### PR TITLE
Add Gutenberg prereq to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a feature plugin for a modern, javascript-driven dashboard for WooCommer
 
 ## Prerequisites
 
-[Gutenberg](https://wordpress.org/plugins/gutenberg/) should be installed prior to activating the WooCommerce Dashboard feature plugin.
+[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Dashboard feature plugin.
 
 ## Development
 


### PR DESCRIPTION
I installed `woo-dash` without Gutenberg installed and ended up getting a fatal error. We should probably fix that as well/handle that better, but if we are going to rely on Gutenberg for the feature plugin we should mention it in the README.