### PR TITLE
Add the ability to use withAPIData

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
     "root": true,
     "parser": "babel-eslint",
     "extends": [
-        "wpcalypso/react",
+        "wpcalypso/react"
     ],
     "env": {
         "browser": true,
@@ -15,6 +15,7 @@
         "FoxhoundSettings": true,
         "jQuery": true,
         "wp": true,
+        "wpApiSettings": true
     },
     "rules": {
         "camelcase": 0,
@@ -24,6 +25,6 @@
         "react/react-in-jsx-scope": 0,
         "wpcalypso/import-no-redux-combine-reducers": 0,
         "wpcalypso/jsx-classname-namespace": 0,
-        "wpcalypso/redux-no-bound-selectors": 1,
+        "wpcalypso/redux-no-bound-selectors": 1
     }
 }

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -4,8 +4,8 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Button, withAPIData } from '@wordpress/components';
+import { Component, compose } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -15,6 +15,8 @@ import useFilters from '../use-filters';
 
 class Dashboard extends Component {
 	render() {
+		const { products } = this.props;
+		const totalProducts = products.data && products.data.length || 0;
 		return (
 			<div>
 				<h2>{ applyFilters( 'woodash.example2', __( 'Example Widget', 'woo-dash' ) ) }</h2>
@@ -24,6 +26,9 @@ class Dashboard extends Component {
 					</div>
 					<div className="wd_widget-item">
 						{ sprintf( _n( '%d New Order', '%d New Orders', 10, 'woo-dash' ), 10 ) }
+					</div>
+					<div className="wd_widget-item">
+						{ sprintf( _n( '%d Product', '%d Products', totalProducts, 'woo-dash' ), totalProducts ) }
 					</div>
 					<div className="wd_widget-item">
 						<Button isPrimary href="#">{ __( 'View Orders', 'woo-dash' ) }</Button>
@@ -36,4 +41,9 @@ class Dashboard extends Component {
 	}
 }
 
-export default useFilters( [ 'woodash.example', 'woodash.example2' ] )( Dashboard );
+export default compose( [
+	useFilters( [ 'woodash.example', 'woodash.example2' ] ),
+	withAPIData( () => ( {
+		products: '/wc/v2/products',
+	} ) ),
+] )( Dashboard );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2,8 +2,10 @@
 /**
  * External dependencies
  */
+import { APIProvider } from '@wordpress/components';
 import { createElement, render } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +13,13 @@ import { addFilter } from '@wordpress/hooks';
 import Dashboard from './dashboard';
 
 render(
-	createElement( Dashboard ),
+	createElement( APIProvider, {
+		...wpApiSettings,
+		...pick( wp.api, [
+			'postTypeRestBaseMapping',
+			'taxonomyRestBaseMapping',
+		] ),
+	}, createElement( Dashboard ) ),
 	document.getElementById( 'root' )
 );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -23,6 +23,9 @@ function woo_dash_register_script() {
 	$locale_data = gutenberg_get_jed_locale_data( 'woo-dash' );
 	$content = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "woo-dash" );';
 	wp_add_inline_script( WOO_DASH_APP, $content, 'before' );
+
+	wp_enqueue_script( 'wp-api' );
+	gutenberg_extend_wp_api_backbone_client();
 }
 add_action( 'init', 'woo_dash_register_script' );
 


### PR DESCRIPTION
This PR adds the ability to use `withAPIData` to make API requests to WordPress or WooCommerce endpoints. I need it for my extensions API experiments, but I figured this is useful to get working in general.

To test:
* Go to `http://:site/wp-admin/admin.php?page=woodash` and verify your product count loads correctly. It'll flash 0 at first, since I don't handle loading indicators or anything since this is just a test.