### PR TITLE
PHPUnit: Update setup to ensure Gutenberg is loaded

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
@@ -6,9 +6,11 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	verbose="true"
+	syntaxCheck="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="Woo Dash Test Suite">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+	require dirname( dirname( dirname( __FILE__ ) ) ) . '/gutenberg/gutenberg.php';
 	require dirname( dirname( __FILE__ ) ) . '/woo-dash.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );


### PR DESCRIPTION
This PR updates the PHPUnit setup so that we load gutenberg into the tests. If we don't, we get an error about `gutenberg_get_jed_locale_data` being undefined.

You can now run `phpunit` to test our sample test 🙂 