### PR TITLE
Check for Gutenberg & WooCommerce before loading the plugin files

### DIFF
--- a/woo-dash.php
+++ b/woo-dash.php
@@ -33,8 +33,7 @@ function woo_dash_plugins_notice() {
  */
 function woo_dash_plugins_loaded() {
 	if (
-		! defined( 'GUTENBERG_DEVELOPMENT_MODE' ) ||
-		! defined( 'GUTENBERG_VERSION' ) ||
+		! ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' ) ) ||
 		! class_exists( 'WooCommerce' )
 	) {
 		add_action( 'admin_notices', 'woo_dash_plugins_notice' );


### PR DESCRIPTION
This PR updates the code that sets up the plugin, adding in a check for Gutenberg and WooCommerce. If neither are detected, we show an undismissable notice saying that both are required, and we don't load any dashboard code (this also prevents the fatal error when gutenberg is missing, #1 )

![screen shot 2018-05-03 at 2 00 51 pm](https://user-images.githubusercontent.com/541093/39594371-88c988ee-4eda-11e8-8869-803ddab6ebc2.png)

To test

- Deactivate and/or delete Gutenberg or WooCommerce
- You should see the notice, and no WC Dashboard in the sidebar
- Reactivate both plugins
- Notice goes away, and WC Dashboard is in the sidebar again