### PR TITLE
Add $file parameter to woo_dash_dir_path

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -8,7 +8,7 @@ function woo_dash_register_script() {
 		WOO_DASH_APP,
 		woo_dash_url( 'js/index.js' ),
 		[ 'wp-blocks', 'wp-element', 'wp-i18n' ],
-		filemtime( woo_dash_dir_path( '/js/index.js' ) ),
+		filemtime( woo_dash_dir_path( 'js/index.js' ) ),
 		true
 	);
 
@@ -16,7 +16,7 @@ function woo_dash_register_script() {
 		WOO_DASH_APP,
 		woo_dash_url( 'js/style.css' ),
 		[ 'wp-components', 'wp-blocks', 'wp-edit-blocks' ],
-		filemtime( woo_dash_dir_path( '/js/index.js' ) )
+		filemtime( woo_dash_dir_path( 'js/index.js' ) )
 	);
 
 	// Set up the text domain and translations

--- a/lib/common.php
+++ b/lib/common.php
@@ -3,10 +3,12 @@
 /**
  * Retrieves the root plugin path.
  *
+ * @param  string $file Optional relative path of the desired file.
+ *
  * @return string Root path to the gutenberg custom fields plugin.
  */
-function woo_dash_dir_path() {
-	return plugin_dir_path( dirname(__FILE__ ) );
+function woo_dash_dir_path( $file = '' ) {
+	return plugin_dir_path( dirname(__FILE__ ) ) . $file;
 }
 
 /**


### PR DESCRIPTION
`woo_dash_dir_path` was being called with a $file parameter, but not doing anything with it. That means the `filemtime` wasn't being returned for the correct file. This PR adds it as an optional parameter. The removal of the leading forward slash also matches `woo_dash_url`.

To test:
* Make a JS change with `npm run watch` running and refresh the dashboard. Make sure your change is visible. 