### PR TITLE
Remove foxhound globals from eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,9 +10,6 @@
         "node": true
     },
     "globals": {
-        "FoxhoundData": true,
-        "FoxhoundMenu": true,
-        "FoxhoundSettings": true,
         "jQuery": true,
         "wp": true,
         "wpApiSettings": true


### PR DESCRIPTION
Fix #22 – I accidentally left some configuration from Foxhound in the .eslintrc when I imported the settings 🙃 This PR removes them, since they're not used in this project.

For future reference, if we add any globals for passing server-side config, we'll end up defining them here.