### PR TITLE
Hide notices on woo-dash pages

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -8,6 +8,10 @@
 	}
 }
 
+.woo-dashboard__admin-notice-list-hide {
+	display: none;
+}
+
 .woo-dashboard {
 	display: grid;
 	grid-template-columns: auto 300px;

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -1,6 +1,17 @@
 <?php
 
 /**
+ * Returns true if we are on a JS powered admin page.
+ */
+function woo_dash_is_admin_page() {
+	global $hook_suffix;
+	if ( in_array( $hook_suffix, array( 'toplevel_page_woodash' ) ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
  * Register a new menu page for the Dashboard
  */
 function woo_dash_register_page(){
@@ -20,8 +31,8 @@ add_action( 'admin_menu', 'woo_dash_register_page' );
 /**
  * Load the assets on the Dashboard page
  */
-function woo_dash_enqueue_script( $hook ){
-	if ( 'toplevel_page_woodash' !== $hook ) {
+function woo_dash_enqueue_script(){
+	if ( ! woo_dash_is_admin_page() ) {
 		return;
 	}
 
@@ -33,7 +44,7 @@ add_action( 'admin_enqueue_scripts', 'woo_dash_enqueue_script' );
 function woo_dash_admin_body_class( $admin_body_class = '' ) {
 	global $hook_suffix;
 
-	if ( ! in_array( $hook_suffix, array( 'toplevel_page_woodash' ) ) ) {
+	if ( ! woo_dash_is_admin_page() ) {
 		return $admin_body_class;
 	}
 
@@ -43,6 +54,24 @@ function woo_dash_admin_body_class( $admin_body_class = '' ) {
 	return " $admin_body_class ";
 }
 add_filter( 'admin_body_class', 'woo_dash_admin_body_class' );
+
+
+function woo_dash_admin_before_notices() {
+	if ( ! woo_dash_is_admin_page() ) {
+		return;
+	}
+	echo '<div class="woo-dashboard__admin-notice-list-hide">';
+	echo '<div class="wp-header-end"></div>'; // https://github.com/WordPress/WordPress/blob/f6a37e7d39e2534d05b9e542045174498edfe536/wp-admin/js/common.js#L737
+}
+add_action( 'admin_notices', 'woo_dash_admin_before_notices', 0 );
+
+function woo_dash_admin_after_notices() {
+	if ( ! woo_dash_is_admin_page() ) {
+		return;
+	}
+	echo '</div>';
+}
+add_action( 'admin_notices', 'woo_dash_admin_after_notices', PHP_INT_MAX );
 
 
 /**


### PR DESCRIPTION
This PR hides standard WP admin notices (`admin_notices`) on woo-dash pages. This is only a partial solution. See #35, which still needs fully addressed once we have a design for how we actually want to present these.

This uses the solution Kevin came up with for `synchrotron` and https://github.com/WordPress/gutenberg/pull/5590, however it also includes the `wp-header-end` div so all notices are caught (otherwise, some show up under the nearest h1/h2 🤦‍♂️ ).

To Test:
* Add a plugin that shows a notice. If you need one, you can use the following as a plugin:

```
<?php
/*
Plugin Name: Add Test Notice
Description: Adds a test notice.
Author: WooCommerce
Version: 1.0
*/

function test_add_notice() { ?>
	<div class="notice notice-warning is-dismissible">
		<p>
			<strong>Testing notice.</strong>
		</p>
	</div>
<?php }

add_action( 'admin_notices', 'test_add_notice' );
```