### PR TITLE
Add languages directory and README.

### DIFF
--- a/languages/README.md
+++ b/languages/README.md
@@ -1,0 +1,10 @@
+Languages
+=========
+
+The generated POT template file is not included in this repository. To create this file locally, follow instructions from [README.md](https://github.com/woocommerce/woo-dash/blob/master/README.md) to install the project, then run the following command:
+
+```
+npm run build
+```
+
+After the build completes, you'll find a `woo-dash.pot` strings file in this directory.


### PR DESCRIPTION
This PR adds in a languages directory where .pot files will eventually be output during the build process. Without this directory present, the build process was failing for me on ubuntu.