### PR TITLE
Fix mobile menu and header padding 

### DIFF
--- a/client/stylesheets/_breakpoints.scss
+++ b/client/stylesheets/_breakpoints.scss
@@ -1,7 +1,11 @@
+/** @format */
+
 // Breakpoints
 // Forked from https://github.com/Automattic/wp-calypso/blob/46ae24d8800fb85da6acf057a640e60dac988a38/assets/stylesheets/shared/mixins/_breakpoints.scss
 
-$breakpoints: 480px, 660px, 800px, 960px, 1040px, 1280px, 1400px; // Think very carefully before adding a new breakpoint
+// Think very carefully before adding a new breakpoint.
+// The list below is based on wp-admin's main breakpoints
+$breakpoints: 400px, 600px, 782px, 960px, 1100px;
 
 @mixin breakpoint( $sizes... ) {
 	@each $size in $sizes {

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -11,7 +11,15 @@
 		padding: 0;
 	}
 
-	@media screen and (max-width: 782px) {
+	* {
+		box-sizing: border-box;
+	}
+
+	.menu-top {
+		box-sizing: initial;
+	}
+
+	@include breakpoint( '<782px' ) {
 		// WP breakpoint for mobile menu
 		.wp-responsive-open #wpbody {
 			right: -14.5em;


### PR DESCRIPTION
This tiny CSS PR fixes the display of the menu and header bar when wp-admin's mobile menu is open.

Before:

<img width="356" alt="screen shot 2018-05-15 at 11 24 03 am" src="https://user-images.githubusercontent.com/689165/40066727-c1370d76-5832-11e8-820a-1fbb8a2078d7.png">

After:

<img width="358" alt="screen shot 2018-05-15 at 11 24 37 am" src="https://user-images.githubusercontent.com/689165/40066732-c4cae958-5832-11e8-8a0e-c8dc85de4af4.png">

I'm not using the breakpoint mixin here because this rule needs to target <782px (wp-admin's breakpoint for that menu), and I think this is one of the few CSS rules that will, so I'm not sure if it's worth adding to the list of device breakpoints.

To Test:
* Shrink your screen size.
* Open the mobile menu.
* Verify everything looks OK.
