### PR TITLE
Fix CSS reset duplication

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -12,6 +12,7 @@ import { pick, find } from 'lodash';
 /**
  * Internal dependencies
  */
+import './stylesheets/_wpadmin-reset.scss';
 import Analytics from './analytics';
 import AnalyticsReport from './analytics/report';
 import Dashboard from './dashboard';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,7 @@ const webpackConfig = {
 							loader: 'sass-loader',
 							query: {
 								includePaths: [ 'client/stylesheets' ],
-								data: '@import "_colors"; @import "_breakpoints"; @import "_wpadmin-reset";',
+								data: '@import "_colors"; @import "_breakpoints";',
 							},
 						},
 					],


### PR DESCRIPTION
Fixes #55.

Instead of importing the reset CSS via webpack, this PR just loads it from the main client entry point.

To Test:
* Inspect the build CSS file, and make sure `.woocommerce-page #wpcontent` only shows up once.