### PR TITLE
Fix Masterbar/Notifcation Panel Conflicts

### DIFF
--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -32,3 +32,49 @@
 #wpfooter {
 	display: none;
 }
+
+// Temporary fix for compability with the Jetpack masterbar
+// See https://github.com/Automattic/jetpack/issues/9608
+// !important rules overwrite some existing !important rules
+.jetpack-masterbar {
+	@include breakpoint( '<782px' ) {
+		&.wp-admin .wrap h1 {
+			padding-left: 0;
+		}
+
+		#wpadminbar li.menupop.my-sites {
+			margin-left: 55px;
+		}
+
+		#wpadminbar #wp-admin-bar-menu-toggle {
+			top: -5px;
+			left: -5px;
+			width: 60px;
+
+			.ab-icon:before {
+				color: $white;
+			}
+
+			a {
+				padding: 0 8px 4px 8px !important;
+			}
+
+			a:hover {
+				background: #333;
+			}
+		}
+
+		.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
+			left: -5px;
+			width: 60px;
+
+			.ab-icon:before {
+				color: $white !important;
+			}
+
+			a {
+				background: #333;
+			}
+		}
+	}
+}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -37,6 +37,14 @@ function woo_dash_register_script() {
 		"jQuery( '#toplevel_page_woodash a' ).attr( 'href', 'admin.php?page=woodash#/' );",
 		'before'
 	);
+
+	// Resets lodash to wp-admin's version of lodash
+	wp_add_inline_script(
+		WOO_DASH_APP,
+		'_.noConflict();',
+		'after'
+	);
+
 }
 add_action( 'init', 'woo_dash_register_script' );
 


### PR DESCRIPTION
Fixes #72.

There are two compatibility issues with Jetpack:

**The notifications bar does not open properly.**

This is because of lodash version differences, and explains the JS error we've been seeing in the console.

<img width="574" alt="screen shot 2018-05-22 at 11 47 03 am" src="https://user-images.githubusercontent.com/689165/40378050-6cbb3fe0-5dc0-11e8-8c0a-f7c3744d061c.png">


The fix is to call `noConflict` after our JS, so wp-admin can go back to using the correct version.

You can verify this is happening by applying this branch and calling `console.log( _.VERSION );` within a component, and then adding a `console.log( _.VERSION );` after the `noConflict` line below.

**Masterbar Menu CSS issues when using the WordPress.com toolbar.**

If you enable the WordPress.com toolbar (`Jetpack > Settings > Enable the WordPress.com Toolbar`), the menu icon doesn't display properly on smaller screen sizes. This is actually an issue on all wp-admin pages. I've logged an issue in the Jetpack repo: https://github.com/Automattic/jetpack/issues/9608. It looks like the masterbar uses CSS from both WordPress.com and Jetpack, so multiple patches need to be created/tested/merged. I can help with this, but in the meantime I've adde some CSS to fix it on our pages.

<img width="699" alt="screen shot 2018-05-22 at 12 58 59 pm" src="https://user-images.githubusercontent.com/689165/40378239-f707185e-5dc0-11e8-8eec-c4a9b22ee605.png">

To Test:
* Load any woo-dash page and verify you can open the notifications panel.
* Enable `Jetpack > Settings > Enable the WordPress.com Toolbar`.
* Make your screen size smaller than 782px.
* Verify the menu icon correctly displays in the admin bar.

cc @LevinMedia 