### PR TITLE
Update Store Performance Widget Header

### DIFF
--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -20,6 +20,6 @@ render: function() {
 ## Props
 
 * `title` (required): The title to use for this card.
-* `action`: One "primary" action for this card, appears in the card header
+* `action`: One "primary" action for this card, appears in the card header.
 * `className`: You can add classes to the card container.
-* `menu`: An EllipsisMenu, with filters used to control the content visible in this card
+* `settings`: An EllipsisMenu, with filters used to control the content visible in this card, or a Tab component with a list of tabs.

--- a/client/components/card/index.js
+++ b/client/components/card/index.js
@@ -4,6 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import classnames from 'classnames';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 /**
@@ -11,12 +12,14 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 import { EllipsisMenu } from '../ellipsis-menu';
+import Tabs from '../tabs';
 
 class Card extends Component {
 	render() {
-		const { action, children, menu, title } = this.props;
+		const { action, children, settings, title } = this.props;
 		const className = classnames( 'woo-dash__card', this.props.className, {
-			'has-menu': !! menu,
+			'has-menu': !! settings && settings.type === EllipsisMenu,
+			'has-tabs': !! settings && settings.type === Tabs,
 			'has-action': !! action,
 		} );
 		return (
@@ -24,7 +27,7 @@ class Card extends Component {
 				<div className="woo-dash__card-header">
 					<h2 className="woo-dash__card-title">{ title }</h2>
 					{ action && <div className="woo-dash__card-action">{ action }</div> }
-					{ menu && <div className="woo-dash__card-menu">{ menu }</div> }
+					{ settings && <div className="woo-dash__card-settings">{ settings }</div> }
 				</div>
 				<div className="woo-dash__card-body">{ children }</div>
 			</div>
@@ -35,10 +38,15 @@ class Card extends Component {
 Card.propTypes = {
 	action: PropTypes.node,
 	className: PropTypes.string,
-	menu: PropTypes.shape( {
-		type: PropTypes.oneOf( [ EllipsisMenu ] ),
+	settings: PropTypes.shape( {
+		type: PropTypes.oneOf( [ EllipsisMenu, Tabs ] ),
 	} ),
-	title: PropTypes.string.isRequired,
+	title: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.shape( {
+			type: PropTypes.oneOf( [ Link ] ),
+		} ),
+	] ).isRequired,
 };
 
 export default Card;

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -11,6 +11,7 @@
 	border-bottom: 1px solid $gray;
 	display: grid;
 	align-items: center;
+	height: 60px;
 
 	.has-action & {
 		grid-template-columns: 1fr 1fr;
@@ -20,8 +21,16 @@
 		grid-template-columns: 1fr 50px;
 	}
 
+	.has-tabs & {
+		grid-template-columns: 1fr auto;
+	}
+
 	.has-menu.has-action & {
 		grid-template-columns: 1fr 1fr 50px;
+	}
+
+	.has-tabs.has-action & {
+		grid-template-columns: 1fr 125px auto;
 	}
 
 	h2 {
@@ -29,8 +38,50 @@
 	}
 }
 
+.woo-dash__card.has-tabs {
+	h2 {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		padding-bottom: 20px;
+	}
+
+	.woo-dash__tabs-item {
+		padding-bottom: 20px;
+	}
+}
+
+@include breakpoint( '<600px' ) {
+	.woo-dash__card-header {
+		grid-template-columns: unset;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.woo-dash__card.has-tabs {
+		h2 {
+			overflow: visible;
+			padding-bottom: 0px;
+			margin-top: -14px;
+		}
+
+		.woo-dash__tabs-item {
+			padding-bottom: 8px;
+		}
+	}
+
+	.woo-dash__card-settings {
+		margin-top: 8px;
+	}
+
+	.woo-dash__card-action {
+		position: absolute;
+		right: 5px;
+	}
+}
+
 .woo-dash__card-action,
-.woo-dash__card-menu {
+.woo-dash__card-settings {
 	text-align: right;
 }
 

--- a/client/components/tabs/README.md
+++ b/client/components/tabs/README.md
@@ -1,0 +1,36 @@
+Tabs & TabItem
+===
+
+`Tabs` is a basic component that outputs a list of tabs, usually to be used with a `Card` component. It is made up of multiple `TabItem` components.
+
+## Usage
+
+```jsx
+const Tabs = () => {
+	return (
+		<Tabs selectedTab={ period } onSelect={ this.selectPeriod }>
+			<TabItem name="day">Today</TabItem>
+			<TabItem name="week">This Week</TabItem>
+			<TabItem name="month">This Month</TabItem>
+		</Tabs>
+	);
+}
+```
+
+### Tab Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`className` | `string` | none | Additional classNames
+`selectedTab` | `string` | none | The name of the selected tab.
+`onSelect` | `function` | noop | Callback to be executed after selection
+
+### Tab Props
+
+Required props are marked with `*`.
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`name`* | `string` | none | Name to identify the tab.
+
+All other props are automatically passed down by `Tabs`.

--- a/client/components/tabs/index.js
+++ b/client/components/tabs/index.js
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component, cloneElement } from '@wordpress/element';
+import { NavigableMenu } from '@wordpress/components';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class Tabs extends Component {
+	getChildren() {
+		return this.props.children.map(
+			function( child ) {
+				if ( ! child ) {
+					return null;
+				}
+				const passProps = {
+					onClick: event => {
+						event.preventDefault();
+						this.props.onSelect( child.props.name );
+					},
+					key: child.props.name,
+					selected: this.props.selectedTab === child.props.name,
+				};
+				return cloneElement( child, passProps );
+			}.bind( this )
+		);
+	}
+
+	render() {
+		const { className } = this.props;
+		const children = this.getChildren();
+		const classNames = classnames( 'woo-dash__tabs', className );
+
+		return (
+			<NavigableMenu className={ classNames } role="tablist" orientation="horizontal">
+				{ children }
+			</NavigableMenu>
+		);
+	}
+}
+
+Tabs.propTypes = {
+	className: PropTypes.string,
+	selectedTab: PropTypes.string,
+	onSelect: PropTypes.func,
+};
+
+Tabs.defaultProps = {
+	onSelect: noop,
+};
+
+export default Tabs;

--- a/client/components/tabs/item.js
+++ b/client/components/tabs/item.js
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class TabItem extends Component {
+	render() {
+		const { onClick, children, selected, name } = this.props;
+		const classNames = classnames( 'woo-dash__tabs-item', {
+			'is-selected': selected,
+		} );
+		return (
+			<button
+				role="tab"
+				name={ name }
+				className={ classNames }
+				tabIndex={ selected ? null : -1 }
+				aria-selected={ selected }
+				onClick={ onClick }
+			>
+				{ children }
+			</button>
+		);
+	}
+}
+
+TabItem.propTypes = {
+	name: PropTypes.string,
+	onClick: PropTypes.func,
+	children: PropTypes.node,
+	selected: PropTypes.bool,
+};
+
+export default TabItem;

--- a/client/components/tabs/style.scss
+++ b/client/components/tabs/style.scss
@@ -1,0 +1,19 @@
+/** @format */
+
+.woo-dash__tabs-item {
+	font-weight: 500;
+	border: 0;
+	cursor: pointer;
+	padding: 0;
+	margin-left: 16px;
+
+	&:focus {
+		outline: none;
+		border-bottom: 3px solid $purple-light-30;
+	}
+
+	&.is-selected {
+		border-bottom: 3px solid $purple;
+		color: $gray-text;
+	}
+}

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,14 +10,14 @@ import { Component, Fragment } from '@wordpress/element';
  */
 import Agenda from './widgets/agenda';
 import Header from 'components/header';
-import Numbers from './numbers';
+import Performance from './widgets/performance';
 
 export default class Dashboard extends Component {
 	render() {
 		return (
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'woo-dash' ) ] } />
-				<Numbers />
+				<Performance />
 				<Agenda />
 			</Fragment>
 		);

--- a/client/dashboard/widgets/performance/index.js
+++ b/client/dashboard/widgets/performance/index.js
@@ -3,25 +3,29 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button, ToggleControl, withAPIData } from '@wordpress/components';
+import { Button, withAPIData } from '@wordpress/components';
 import { Component, compose } from '@wordpress/element';
+import { Link } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
-import { EllipsisMenu, MenuItem, MenuTitle } from 'components/ellipsis-menu';
+import Tabs from 'components/tabs';
+import TabItem from 'components/tabs/item';
 
-class WidgetNumbers extends Component {
+class Performance extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
 			showCustomers: true,
 			showProducts: true,
 			showOrders: true,
+			period: 'day',
 		};
 
 		this.toggle = this.toggle.bind( this );
+		this.selectPeriod = this.selectPeriod.bind( this );
 	}
 
 	toggle( type ) {
@@ -30,32 +34,19 @@ class WidgetNumbers extends Component {
 		};
 	}
 
-	renderMenu() {
+	selectPeriod( period ) {
+		this.setState( () => ( { period } ) );
+		// TODO Update charts based on new time period.
+	}
+
+	renderTabPanel() {
+		const { period } = this.state;
 		return (
-			<EllipsisMenu label={ __( 'Choose which analytics to display', 'woo-dash' ) }>
-				<MenuTitle>{ __( 'Display Stats:', 'woo-dash' ) }</MenuTitle>
-				<MenuItem onInvoke={ this.toggle( 'showCustomers' ) }>
-					<ToggleControl
-						label={ __( 'Show Customers', 'woo-dash' ) }
-						checked={ this.state.showCustomers }
-						onChange={ this.toggle( 'showCustomers' ) }
-					/>
-				</MenuItem>
-				<MenuItem onInvoke={ this.toggle( 'showProducts' ) }>
-					<ToggleControl
-						label={ __( 'Show Products', 'woo-dash' ) }
-						checked={ this.state.showProducts }
-						onChange={ this.toggle( 'showProducts' ) }
-					/>
-				</MenuItem>
-				<MenuItem onInvoke={ this.toggle( 'showOrders' ) }>
-					<ToggleControl
-						label={ __( 'Show Orders', 'woo-dash' ) }
-						checked={ this.state.showOrders }
-						onChange={ this.toggle( 'showOrders' ) }
-					/>
-				</MenuItem>
-			</EllipsisMenu>
+			<Tabs selectedTab={ period } onSelect={ this.selectPeriod }>
+				<TabItem name="day">Today</TabItem>
+				<TabItem name="week">This Week</TabItem>
+				<TabItem name="month">This Month</TabItem>
+			</Tabs>
 		);
 	}
 
@@ -65,8 +56,9 @@ class WidgetNumbers extends Component {
 		const totalProducts = ( products.data && products.data.length ) || 0;
 		const { showCustomers, showProducts, showOrders } = this.state;
 
+		// TODO Chart display.
 		return (
-			<Card title={ __( 'Store Performance', 'woo-dash' ) } menu={ this.renderMenu() }>
+			<Card title={ ( <Link to="/analytics">{ __( 'Store Performance', 'woo-dash' ) }</Link> ) } settings={ this.renderTabPanel() }>
 				<div className="woo-dash__widget">
 					{ showCustomers && (
 						<div className="woo-dash__widget-item">
@@ -105,4 +97,4 @@ export default compose( [
 		orders: '/wc/v2/orders?status=processing',
 		products: '/wc/v2/products',
 	} ) ),
-] )( WidgetNumbers );
+] )( Performance );

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -16,3 +16,10 @@ $wp-admin-background: #f1f1f1;
 
 // Black
 $black: #24292d; // same as wp-admin sidebar
+
+// Purples
+$purple: #965889;
+$purple-light-10: lighten($purple, 10%);
+$purple-light-20: lighten($purple, 20%);
+$purple-light-30: lighten($purple, 30%);
+$purple-light-40: lighten($purple, 40%);


### PR DESCRIPTION
Closes #80.

This PR updates the Store Performance widget header based on the notes and design notes in #80:

* Remove ellipsis menu from header
* Link Block title to Analytics Overview page
* Implement tabs for period (today, this week, this month) 

It adds support to `<Card />` for Linked titles, and support for a list of Tabs (using a new simple component wrapped around Gutenberg) instead of a menu. It also does some mobile styling and some basic color styling based on the hi-fi preview, though I imagine these will evolve over time and we can update/make more design changes as they become available.

It also renames the widget from Numbers to Performance.

I left on the ‘external gridicon’ request for now since that is not an external link, and the final design of the linked header is still being worked on.