### PR TITLE
Expand WP notices with header toggle

### DIFF
--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import './style.scss';
+import WordPressNotices from './wordpress-notices';
 
 const Header = ( { sections, onToggle, isSidebarOpen } ) => {
 	const _sections = isArray( sections ) ? sections : [ sections ];
@@ -48,14 +49,17 @@ const Header = ( { sections, onToggle, isSidebarOpen } ) => {
 					return <span key={ i }>{ sectionPiece }</span>;
 				} ) }
 			</h1>
-			<div className="woocommerce-header__toggle">
-				<IconButton
-					className="woocommerce-header__button"
-					onClick={ onToggle }
-					icon="clock"
-					label={ __( 'Show Sidebar', 'woo-dash' ) }
-					aria-expanded={ isSidebarOpen }
-				/>
+			<div className="woocommerce-header__buttons">
+				<div className="woocommerce-header__toggle">
+					<IconButton
+						className="woocommerce-header__button"
+						onClick={ onToggle }
+						icon="clock"
+						label={ __( 'Show Sidebar', 'woo-dash' ) }
+						aria-expanded={ isSidebarOpen }
+					/>
+				</div>
+				<WordPressNotices />
 			</div>
 		</div>
 	);

--- a/client/components/header/style.scss
+++ b/client/components/header/style.scss
@@ -24,3 +24,9 @@
 		}
 	}
 }
+
+.woocommerce-header__buttons {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}

--- a/client/components/header/wordpress-notices.js
+++ b/client/components/header/wordpress-notices.js
@@ -28,7 +28,7 @@ class WordPressNotices extends Component {
 		const noticesOpen = notices.classList.contains( 'woocommerce__admin-notice-list-show' );
 
 		// See https://reactjs.org/docs/react-component.html#componentdidmount
-		this.setState( Object.assign( {}, { count, notices, noticesOpen } ) ); // eslint-disable-line react/no-did-mount-set-state
+		this.setState( { count, notices, noticesOpen } ); // eslint-disable-line react/no-did-mount-set-state
 
 		// Move WordPress notifications into the main WooDash body
 		const primary = document.getElementById( 'woocommerce-layout__primary' );
@@ -45,12 +45,12 @@ class WordPressNotices extends Component {
 			dismissNotices[ key ].removeEventListener( 'click', this.updateCount );
 		}, this );
 
-		this.setState( Object.assign( {}, { noticesOpen: false, hasEventListeners: false } ) );
+		this.setState( { noticesOpen: false, hasEventListeners: false } );
 		this.hideNotices();
 	}
 
 	updateCount() {
-		this.setState( Object.assign( {}, { count: this.state.count - 1 } ) );
+		this.setState( { count: this.state.count - 1 } );
 	}
 
 	maybeAddDismissEvents() {
@@ -63,7 +63,7 @@ class WordPressNotices extends Component {
 			dismiss[ key ].addEventListener( 'click', this.updateCount );
 		}, this );
 
-		this.setState( Object.assign( {}, { hasEventListeners: true } ) );
+		this.setState( { hasEventListeners: true } );
 	}
 
 	showNotices() {
@@ -84,7 +84,7 @@ class WordPressNotices extends Component {
 			this.maybeAddDismissEvents();
 		}
 
-		this.setState( Object.assign( {}, { noticesOpen: ! noticesOpen } ) );
+		this.setState( { noticesOpen: ! noticesOpen } );
 	}
 
 	render() {

--- a/client/components/header/wordpress-notices.js
+++ b/client/components/header/wordpress-notices.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { forEach } from 'lodash';
+import { IconButton, Dropdown } from '@wordpress/components';
+
+class WordPressNotices extends Component {
+	constructor() {
+		super();
+		this.state = {
+			count: 0,
+			notices: null,
+		};
+	}
+
+	componentDidMount() {
+		const noticeList = document.getElementById( 'wpadmin-notice-list' );
+		const notices = noticeList.getElementsByClassName( 'notice' );
+		const count = notices.length;
+
+		console.log( notices );
+
+		// See https://reactjs.org/docs/react-component.html#componentdidmount
+		/* eslint-disable react/no-did-mount-set-state */
+		this.setState( Object.assign( {}, { notices, count } ) );
+		/* eslint-enable react/no-did-mount-set-state */
+	}
+
+	renderNotices() {
+		let noticeOutput;
+		forEach( this.state.notices, notice => {
+			noticeOutput += ( notice && notice.innerHTML ) || '';
+		} );
+		return <div dangerouslySetInnerHTML={ { __html: noticeOutput } } />;
+	}
+
+	render() {
+		const { count } = this.state;
+		return (
+			<div>
+				<Dropdown
+					position="bottom left"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<IconButton
+							onClick={ onToggle }
+							className="woo-dash__header-button"
+							icon="wordpress-alt"
+							label={ sprintf( __( 'View %d WordPress Notices', 'woo-dash' ), count ) }
+							aria-expanded={ isOpen }
+						/>
+					) }
+					renderContent={ () => this.renderNotices() }
+				/>
+			</div>
+		);
+	}
+}
+
+export default WordPressNotices;

--- a/client/components/header/wordpress-notices.js
+++ b/client/components/header/wordpress-notices.js
@@ -4,8 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { forEach } from 'lodash';
-import { IconButton, Dropdown } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 
 class WordPressNotices extends Component {
 	constructor() {
@@ -13,48 +12,95 @@ class WordPressNotices extends Component {
 		this.state = {
 			count: 0,
 			notices: null,
+			noticesOpen: false,
+			hasEventListeners: false,
 		};
+
+		this.onToggle = this.onToggle.bind( this );
+		this.updateCount = this.updateCount.bind( this );
+		this.showNotices = this.showNotices.bind( this );
+		this.hideNotices = this.hideNotices.bind( this );
 	}
 
 	componentDidMount() {
-		const noticeList = document.getElementById( 'wpadmin-notice-list' );
-		const notices = noticeList.getElementsByClassName( 'notice' );
-		const count = notices.length;
-
-		console.log( notices );
+		const notices = document.getElementById( 'wpadmin-notice-list' );
+		const count = notices.getElementsByClassName( 'notice' ).length;
+		const noticesOpen = notices.classList.contains( 'woocommerce__admin-notice-list-show' );
 
 		// See https://reactjs.org/docs/react-component.html#componentdidmount
-		/* eslint-disable react/no-did-mount-set-state */
-		this.setState( Object.assign( {}, { notices, count } ) );
-		/* eslint-enable react/no-did-mount-set-state */
+		this.setState( Object.assign( {}, { count, notices, noticesOpen } ) ); // eslint-disable-line react/no-did-mount-set-state
+
+		// Move WordPress notifications into the main WooDash body
+		const primary = document.getElementById( 'woocommerce-layout__primary' );
+		primary.insertAdjacentElement( 'afterbegin', notices );
 	}
 
-	renderNotices() {
-		let noticeOutput;
-		forEach( this.state.notices, notice => {
-			noticeOutput += ( notice && notice.innerHTML ) || '';
-		} );
-		return <div dangerouslySetInnerHTML={ { __html: noticeOutput } } />;
+	componentWillUnmount() {
+		document
+			.getElementById( 'wpbody-content' )
+			.insertAdjacentElement( 'afterbegin', this.state.notices );
+
+		const dismissNotices = document.getElementsByClassName( 'notice-dismiss' );
+		Object.keys( dismissNotices ).forEach( function( key ) {
+			dismissNotices[ key ].removeEventListener( 'click', this.updateCount );
+		}, this );
+
+		this.setState( Object.assign( {}, { noticesOpen: false, hasEventListeners: false } ) );
+		this.hideNotices();
+	}
+
+	updateCount() {
+		this.setState( Object.assign( {}, { count: this.state.count - 1 } ) );
+	}
+
+	maybeAddDismissEvents() {
+		if ( this.state.hasEventListeners ) {
+			return;
+		}
+
+		const dismiss = document.getElementsByClassName( 'notice-dismiss' );
+		Object.keys( dismiss ).forEach( function( key ) {
+			dismiss[ key ].addEventListener( 'click', this.updateCount );
+		}, this );
+
+		this.setState( Object.assign( {}, { hasEventListeners: true } ) );
+	}
+
+	showNotices() {
+		this.state.notices.className = 'woocommerce__admin-notice-list-show';
+	}
+
+	hideNotices() {
+		this.state.notices.className = 'woocommerce__admin-notice-list-hide';
+	}
+
+	onToggle() {
+		const { noticesOpen } = this.state;
+
+		if ( noticesOpen ) {
+			this.hideNotices();
+		} else {
+			this.showNotices();
+			this.maybeAddDismissEvents();
+		}
+
+		this.setState( Object.assign( {}, { noticesOpen: ! noticesOpen } ) );
 	}
 
 	render() {
-		const { count } = this.state;
+		const { count, noticesOpen } = this.state;
+
+		if ( count < 1 ) {
+			return null;
+		}
+
 		return (
-			<div>
-				<Dropdown
-					position="bottom left"
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<IconButton
-							onClick={ onToggle }
-							className="woo-dash__header-button"
-							icon="wordpress-alt"
-							label={ sprintf( __( 'View %d WordPress Notices', 'woo-dash' ), count ) }
-							aria-expanded={ isOpen }
-						/>
-					) }
-					renderContent={ () => this.renderNotices() }
-				/>
-			</div>
+			<IconButton
+				onClick={ this.onToggle }
+				icon="wordpress-alt"
+				label={ sprintf( __( 'View %d WordPress Notices', 'woo-dash' ), count ) }
+				aria-expanded={ noticesOpen }
+			/>
 		);
 	}
 }

--- a/client/components/header/wordpress-notices.js
+++ b/client/components/header/wordpress-notices.js
@@ -2,9 +2,9 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
+import { sprintf, _n } from '@wordpress/i18n';
 
 class WordPressNotices extends Component {
 	constructor() {
@@ -98,7 +98,10 @@ class WordPressNotices extends Component {
 			<IconButton
 				onClick={ this.onToggle }
 				icon="wordpress-alt"
-				label={ sprintf( __( 'View %d WordPress Notices', 'woo-dash' ), count ) }
+				label={ sprintf(
+					_n( 'View %d WordPress Notice', 'View %d WordPress Notices', count, 'woo-dash' ),
+					count
+				) }
 				aria-expanded={ noticesOpen }
 			/>
 		);

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -45,7 +45,7 @@ class Layout extends Component {
 		return (
 			<div className={ className }>
 				<Slot name="header" fillChildProps={ headerProps } />
-				<div className="woocommerce-layout__primary">
+				<div className="woocommerce-layout__primary" id="woocommerce-layout__primary">
 					<Notices />
 					<div className="woocommerce-layout__main">
 						<Controller { ...this.props } />

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -52,6 +52,19 @@
 
 .woocommerce__admin-notice-list-hide {
 	display: none;
+	opacity: 0;
+	height: 0;
+	overflow: hidden;
+}
+
+.woocommerce__admin-notice-list-show {
+	opacity: 1;
+	height: auto;
+	transition: all 1s ease-in-out;
+}
+
+.wp-header-end {
+	margin: 0;
 }
 
 #wpfooter {

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -51,7 +51,6 @@
 }
 
 .woocommerce__admin-notice-list-hide {
-	display: none;
 	opacity: 0;
 	height: 0;
 	overflow: hidden;

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -115,7 +115,7 @@ function woo_dash_admin_before_notices() {
 	if ( ! woo_dash_is_admin_page() ) {
 		return;
 	}
-	echo '<div class="woocommerce__admin-notice-list-hide">';
+	echo '<div class="woocommerce__admin-notice-list-hide" id="wpadmin-notice-list">';
 	echo '<div class="wp-header-end"></div>'; // https://github.com/WordPress/WordPress/blob/f6a37e7d39e2534d05b9e542045174498edfe536/wp-admin/js/common.js#L737
 }
 add_action( 'admin_notices', 'woo_dash_admin_before_notices', 0 );


### PR DESCRIPTION
See #77.

Per p6riRB-3bd-p2 #comment-3810, this is an attempt at putting WP notices, hidden by default, behind a toggle that will display when there are notices present.

See this for a preview: https://cloudup.com/cUScXAMJH-R

It does some DOM manipulation that doesn't feel great, but if we hope to show these in a nice way to the user, that seems necessary no matter what based on how WP notices work (just HTML dumped into wp-admin -- no array or structure). Considering this a try branch for now incase someone has another idea.

To Test:
* Visit the dash with a WP notice showing, and test the toggle. Test switching pages, and dismissing the notice. 
* If you need a notice to test, you can use this gist: https://gist.github.com/justinshreve/25392f3bb22492731d056a1dbc0e786f