### PR TITLE
Add a label to Count to add context for screen reader users

### DIFF
--- a/client/components/count/README.md
+++ b/client/components/count/README.md
@@ -22,4 +22,4 @@ export default function myCount() {
 Name | Type | Default | Description
 --- | --- | --- | ---
 `count`* | `number` | none | Value of the number to be displayed
-`label` | `string` | "Total 4" | A translated label with the number in context, used for screen readers
+`label` | `string` | "Total {props.count}" | A translated label with the number in context, used for screen readers

--- a/client/components/count/README.md
+++ b/client/components/count/README.md
@@ -22,4 +22,4 @@ export default function myCount() {
 Name | Type | Default | Description
 --- | --- | --- | ---
 `count`* | `number` | none | Value of the number to be displayed
-
+`label` | `string` | "Total" | Label for this number, read by screen readers (hidden visually)

--- a/client/components/count/README.md
+++ b/client/components/count/README.md
@@ -22,4 +22,4 @@ export default function myCount() {
 Name | Type | Default | Description
 --- | --- | --- | ---
 `count`* | `number` | none | Value of the number to be displayed
-`label` | `string` | "Total" | Label for this number, read by screen readers (hidden visually)
+`label` | `string` | "Total 4" | A translated label with the number in context, used for screen readers

--- a/client/components/count/index.js
+++ b/client/components/count/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 /**
  * Internal dependencies
@@ -10,9 +10,13 @@ import PropTypes from 'prop-types';
 import './style.scss';
 
 const Count = ( { count, label } ) => {
+	if ( ! label ) {
+		label = sprintf( __( 'Total %d', 'woo-dash' ), count );
+	}
+
 	return (
-		<span className="woocommerce-count">
-			<span className="screen-reader-text">{ label }</span> { count }
+		<span className="woocommerce-count" aria-label={ label }>
+			{ count }
 		</span>
 	);
 };
@@ -23,7 +27,7 @@ Count.propTypes = {
 };
 
 Count.defaultProps = {
-	label: __( 'Total', 'woo-dash' ),
+	label: '',
 };
 
 export default Count;

--- a/client/components/count/index.js
+++ b/client/components/count/index.js
@@ -2,18 +2,28 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-const Count = ( { count } ) => {
-	return <span className="woocommerce-count">{ count }</span>;
+const Count = ( { count, label } ) => {
+	return (
+		<span className="woocommerce-count">
+			<span className="screen-reader-text">{ label }</span> { count }
+		</span>
+	);
 };
 
 Count.propTypes = {
 	count: PropTypes.number.isRequired,
+	label: PropTypes.string,
+};
+
+Count.defaultProps = {
+	label: __( 'Total', 'woo-dash' ),
 };
 
 export default Count;

--- a/client/layout/sidebar/index.js
+++ b/client/layout/sidebar/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { IconButton, TabPanel } from '@wordpress/components';
@@ -32,7 +32,8 @@ class Sidebar extends Component {
 				name: 'orders',
 				title: (
 					<span>
-						{ __( 'Orders', 'woo-dash' ) } <Count count={ 1 } />
+						{ __( 'Orders', 'woo-dash' ) }{' '}
+						<Count count={ 1 } label={ sprintf( __( '%d Unfulfilled', 'woo-dash' ), 3 ) } />
 					</span>
 				),
 				className: 'woocommerce-layout__sidebar-tab',


### PR DESCRIPTION
This PR adds a new prop to Count, `label`. This adds an `aria-label` to the count with the content of `label`, which defaults to "Total [count]", just to add some more context for screen reader users. This should not change the visual aspect of the Count bubble.

<img width="320" alt="screen shot 2018-05-31 at 1 04 57 pm" src="https://user-images.githubusercontent.com/541093/40796495-3cad5fee-64d3-11e8-98b4-c3103587d356.png">

Before, screen readers would say "Reviews 7, tab, 3 of 3", and it's not clear what the 7 is. The addition of "total" at least makes this "Reviews Total 7, tab, 3 of 3". By adding this as a prop, too, we can customize it - for example, [the Orders `Count` now reads "Orders 3 Unfulfilled, tab, 2 of 3".](https://github.com/woocommerce/woo-dash/pull/102/files#diff-8097f272fa354618a1a10dd825ce339fR36)

~The number isn't in the context of the string, so translators can't change it if it doesn't make sense. I think the trade off here is fine (better to have some odd context than none).~ Not an issue anymore 🎉 

**To test**

- Build the branch
- Try using VoiceOver + Safari to navigate tabs, you should hear the word total - ex, "Reviews total 7"
- You can also just inspect element on a tab, and you should see the aria-label attribute with Total 7.
- Is total a good default term?

Note, this PR is built on #99, not master.