### PR TITLE
Fix PHP Notices for users without store management capabilities

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -59,6 +59,10 @@ add_action( 'admin_menu', 'woo_dash_register_pages' );
  */
 function woo_dash_link_structure() {
 	global $submenu;
+	// User does not have capabilites to see the submenu
+	if ( ! current_user_can( 'manage_woocommerce' ) ) {
+		return;
+	}
 
 	$woodash_key = null;
 	foreach ( $submenu['woocommerce'] as $submenu_key => $submenu_item ) {


### PR DESCRIPTION
While testing something else, I noticed we flag some warning/notices when the current user doesn't have WooCommerce management capabilities

```
PHP Notice:  Undefined index: woocommerce in woo-dash/lib/admin.php on line 64
PHP Warning:  Invalid argument supplied for foreach() in woo-dash/lib/admin.php on line 64
```

This PR adds a `manage_woocommerce` capability check before proceeding with the menu manipulation. We could alternately directly check for `isset( $submenu['woocommerce'] )`, but IMO this makes it more clear _why_ `$submenu['woocommerce']` might not be set.

**To test:**

- Display warnings/notices with `define( 'WP_DEBUG', true );`
- Log into a user that doesn't have manage capabilities - an editor, author, etc
- Load any admin page, you should not see any notices/warnings.