### PR TITLE
Add Summary Number/Performance Tile component

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -9,6 +9,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import Header from 'components/header';
+import { SummaryList, SummaryNumber } from 'components/summary';
 
 export default class extends Component {
 	render() {
@@ -20,7 +21,21 @@ export default class extends Component {
 						__( 'Report Title', 'woo-dash' ),
 					] }
 				/>
-				<div>Report: { this.props.params.report }</div>
+				<SummaryList>
+					<SummaryNumber
+						value={ '$829.40' }
+						label={ __( 'Gross Revenue', 'woo-dash' ) }
+						delta={ 29 }
+					/>
+					<SummaryNumber
+						value={ '$24.00' }
+						label={ __( 'Refunds', 'woo-dash' ) }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } delta={ 15 } />
+					<SummaryNumber value={ '$66.39' } label={ __( 'Tax', 'woo-dash' ) } />
+				</SummaryList>
 			</Fragment>
 		);
 	}

--- a/client/components/summary/README.md
+++ b/client/components/summary/README.md
@@ -1,0 +1,33 @@
+SummaryList & SummaryNumber
+===========================
+
+A list of "summary numbers", performance indicators for a given store. `SummaryList` is a container element for a set of `SummaryNumber`s. Each `SummaryNumber` shows a value, label, and an optional change percentage.
+
+## How to use:
+
+```jsx
+import { SummaryList, SummaryNumber } from 'components/summary';
+
+render: function() {
+  return (
+    <SummaryList>
+      <SummaryNumber value={ '$829.40' } label={ __( 'Gross Revenue', 'woo-dash' ) } delta={ 29 } />
+      <SummaryNumber value={ '$24.00' } label={ __( 'Refunds', 'woo-dash' ) } delta={ -10 } selected />
+      <SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } />
+    </SummaryList>
+  );
+}
+```
+
+## `SummaryList` Props
+
+* `children` (required): A list of `<SummaryNumber />`s
+* `label`: An optional label of this group, read to screen reader users. Defaults to "Performance Indicators".
+
+## `SummaryNumber` Props
+
+* `label` (required): A string description of this value, ex "Revenue", or "New Customers"
+* `value` (required): A string or number value to display - a string is allowed so we can accept currency formatting.
+* `delta`: A number to represent the percentage change since the last comparison period - positive numbers will show a green up arrow, negative numbers will show a red down arrow. If omitted, no change value will display.
+* `context`: A string label for the comparison period.
+* `selected`: A boolean used to show a highlight style on this number.

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -1,0 +1,30 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const SummaryList = ( { children, label } ) => {
+	if ( ! label ) {
+		label = __( 'Performance Indicators', 'woo-dash' );
+	}
+	return (
+		<ul className="woocommerce-summary" aria-label={ label }>
+			{ children }
+		</ul>
+	);
+};
+
+SummaryList.propTypes = {
+	children: PropTypes.node.isRequired,
+	label: PropTypes.string,
+};
+
+export { SummaryList };
+export { default as SummaryNumber } from './item';

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { Dashicon } from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+const SummaryNumber = ( { context, delta, label, selected, value } ) => {
+	if ( ! context ) {
+		context = __( 'vs Previous Period', 'woo-dash' );
+	}
+
+	const classes = classnames( 'woocommerce-summary__item', {
+		'is-selected': selected,
+	} );
+
+	return (
+		<li className={ classes }>
+			<span className="woocommerce-summary__item-label">{ label }</span>
+			<span className="woocommerce-summary__item-value">{ value }</span>
+			{ delta && (
+				<span className="woocommerce-summary__item-delta">
+					<Dashicon
+						className="woocommerce-summary__item-delta-icon"
+						icon={ delta > 0 ? 'arrow-up-alt' : 'arrow-down-alt' }
+					/>
+					<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
+					<span className="woocommerce-summary__item-delta-label">{ context }</span>
+				</span>
+			) }
+		</li>
+	);
+};
+
+SummaryNumber.propTypes = {
+	context: PropTypes.string,
+	delta: PropTypes.number,
+	label: PropTypes.string.isRequired,
+	selected: PropTypes.bool,
+	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
+};
+
+export default SummaryNumber;

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -1,7 +1,19 @@
 /** @format */
 
 .woocommerce-summary {
-	display: flex;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	border-width: 0 1px 1px 0;
+	border-style: solid;
+	border-color: #e5e8ec;
+
+	@include breakpoint( '<600px' ) {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include breakpoint( '<400px' ) {
+		grid-template-columns: 1fr;
+	}
 }
 
 .woocommerce-summary__item {
@@ -9,16 +21,14 @@
 	padding: $spacing;
 	width: 100%;
 	background: $white;
-	border: 1px solid #e5e8ec;
+	border-width: 1px 0 0 1px;
+	border-style: solid;
+	border-color: #e5e8ec;
 
 	&.is-selected {
 		border-top: 0;
 		background: #f8f9fa;
 		box-shadow: inset 0 4px 0 $woocommerce;
-	}
-
-	& + .woocommerce-summary__item {
-		border-left: none;
 	}
 
 	.woocommerce-summary__item-label,

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -1,0 +1,62 @@
+/** @format */
+
+.woocommerce-summary {
+	display: flex;
+}
+
+.woocommerce-summary__item {
+	margin-bottom: 0;
+	padding: $spacing;
+	width: 100%;
+	background: $white;
+	border: 1px solid #e5e8ec;
+
+	&.is-selected {
+		border-top: 0;
+		background: #f8f9fa;
+		box-shadow: inset 0 4px 0 $woocommerce;
+	}
+
+	& + .woocommerce-summary__item {
+		border-left: none;
+	}
+
+	.woocommerce-summary__item-label,
+	.woocommerce-summary__item-value,
+	.woocommerce-summary__item-delta {
+		display: block;
+	}
+
+	.woocommerce-summary__item-label {
+		margin-bottom: $spacing/2;
+	}
+
+	.woocommerce-summary__item-value {
+		@include font-size( 24 );
+		margin-bottom: $spacing;
+	}
+
+	.woocommerce-summary__item-delta {
+		@include font-size( 11 );
+	}
+
+	.woocommerce-summary__item-delta-icon {
+		vertical-align: middle;
+		margin-right: 3px;
+		margin-top: -3px;
+
+		&.dashicons-arrow-up-alt {
+			transform: rotate(45deg);
+			fill: $valid-green;
+		}
+
+		&.dashicons-arrow-down-alt {
+			transform: rotate(-45deg);
+			fill: $error-red;
+		}
+	}
+
+	.woocommerce-summary__item-delta-label {
+		margin-left: 5px;
+	}
+}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -63,6 +63,10 @@
 	@include hidden-sidebar;
 }
 
+.woocommerce-layout.has-hidden-sidebar .woocommerce-layout__main {
+	max-width: 1100px;
+}
+
 .woocommerce-layout__secondary {
 	background: $gray;
 	border-left: 1px solid $gray;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -17,7 +17,7 @@
 }
 
 .woocommerce-layout__primary {
-	margin: 20px 0 0 20px;
+	margin: $spacing 0 0 $spacing;
 
 	.woocommerce-layout__main {
 		margin: 0 auto;
@@ -29,7 +29,7 @@
 	display: grid;
 	grid-template-columns: auto 360px;
 	grid-template-rows: 47px auto;
-	grid-gap: 0 20px;
+	grid-gap: 0 $spacing;
 
 	@include breakpoint( '<782px' ) {
 		display: block;
@@ -64,6 +64,7 @@
 }
 
 .woocommerce-layout.has-hidden-sidebar .woocommerce-layout__main {
+	padding-right: $spacing;
 	max-width: 1100px;
 }
 

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -17,5 +17,10 @@ $wp-admin-background: #f1f1f1;
 // Black
 $black: #24292d; // same as wp-admin sidebar
 
+// Bright colors
+$valid-green: #4ab866;
+$error-red: #d94f4f;
+$woocommerce: #95588a;
+
 // Until we create a separate variables partial
 $spacing: 16px;


### PR DESCRIPTION
Fixes #82; This component is called "Summary Number" in the designs, so I've gone with that naming here. It allows for a labelled number and a percentage change to be displayed in a grid/list format.

![screen shot 2018-06-12 at 2 05 26 pm](https://user-images.githubusercontent.com/541093/41308641-853f0d40-6e4a-11e8-950d-ca3d01ad406b.png)

![screen shot 2018-06-12 at 2 32 16 pm](https://user-images.githubusercontent.com/541093/41309685-733e7d58-6e4d-11e8-97df-36c34e989c10.png)

I've added both a SummaryList and a SummaryNumber component so that the semantics play together for assistive tech users. This PR includes the basic styling from https://github.com/woocommerce/woo-dash/issues/82#issuecomment-396579164, but not the exact text colors- once the hifi styles have been decided, we can create the real color variables and use those.

You can view [more details on the components' README](https://github.com/woocommerce/woo-dash/blob/978e58b0d13320753234409664b3dd4d8191bacc/client/components/summary/README.md).

**To test**

- View the example report link `/wp-admin/admin.php?page=woodash#/analytics/test`
- The blocks should be lined up correctly, 4 per row
- Shrinking the screen should drop the blocks to 2 per row, then 1 per row
- Change the content of the summary numbers if you want, to see how it would be used (eventually it will be used in both a card and on its own)