### PR TITLE
WordPress notice fixes for JP JITM messages and other notice types

### DIFF
--- a/client/components/header/wordpress-notices.js
+++ b/client/components/header/wordpress-notices.js
@@ -24,14 +24,21 @@ class WordPressNotices extends Component {
 
 	componentDidMount() {
 		const notices = document.getElementById( 'wpadmin-notice-list' );
-		const count = notices.getElementsByClassName( 'notice' ).length;
+		let count = notices.children.length - 1; // Subtract 1 for the wp-header-end div, used to show notices
 		const noticesOpen = notices.classList.contains( 'woocommerce__admin-notice-list-show' );
+		const primary = document.getElementById( 'woocommerce-layout__primary' );
+
+		// Move JITM notices out of the wp toggle
+		const jitmPlaceholder = notices.getElementsByClassName( 'jetpack-jitm-message' );
+		if ( jitmPlaceholder.length > 0 ) {
+			count = count - 1; // Container div
+			primary.insertAdjacentElement( 'afterbegin', jitmPlaceholder[ 0 ] );
+		}
 
 		// See https://reactjs.org/docs/react-component.html#componentdidmount
 		this.setState( { count, notices, noticesOpen } ); // eslint-disable-line react/no-did-mount-set-state
 
 		// Move WordPress notifications into the main WooDash body
-		const primary = document.getElementById( 'woocommerce-layout__primary' );
 		primary.insertAdjacentElement( 'afterbegin', notices );
 	}
 


### PR DESCRIPTION
While working on https://github.com/woocommerce/woo-dash/pull/110, I noticed a couple issues with our notice approach.

First of all, only notices with the `.notice` CSS class were counted. WooCommerce helper, bookings, and other extensions use a `woocommerce-message` class, because who needs consistency. This updates the code to use child nodes to count notices.

In addition, Jetpack has a "just in time message" (JITM) feature that spits out a place holder div into the notice area. "Relevant" messages are then interjected after an API call. I'm opting to just move these out of the notice area and not count them as WP notices. Ideally this will only be a problem right now, as we can work with the Jetpack team to use our WooCommerce new notice system instead of JITM messages abusing the notice system on WC pages.

To Test:

* Verify notices display correctly. You can use something like https://gist.github.com/justinshreve/25392f3bb22492731d056a1dbc0e786f (and try changing class names to make sure it still shows up).
* Open `class.jetpack-jitm.php` and edit `ajax_message`. Use the following to get a JITM message to display on the main dashboard page:

```			
data-message-path="wp:edit-shop_order:admin_notices"
data-query="post_type%3Dshop_order"
data-redirect="%2Fwp-admin%2Fedit.php%3Fpost_type%3Dshop_order"
```
* Verify the JITM message loads, but not behind the notice toggle.