### PR TITLE
Analytics: Add support for additional reports

### DIFF
--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Header from 'components/header';
+import { SummaryList, SummaryNumber } from 'components/summary';
+
+export default class extends Component {
+	render() {
+		return (
+			<Fragment>
+				<Header
+					sections={ [
+						[ '/analytics', __( 'Analytics', 'woo-dash' ) ],
+						__( 'Report Title', 'woo-dash' ),
+					] }
+				/>
+				<SummaryList>
+					<SummaryNumber
+						value={ '$829.40' }
+						label={ __( 'Gross Revenue', 'woo-dash' ) }
+						delta={ 29 }
+					/>
+					<SummaryNumber
+						value={ '$24.00' }
+						label={ __( 'Refunds', 'woo-dash' ) }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } delta={ 15 } />
+					<SummaryNumber value={ '$66.39' } label={ __( 'Tax', 'woo-dash' ) } />
+				</SummaryList>
+			</Fragment>
+		);
+	}
+}

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -2,41 +2,31 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import Header from 'components/header';
-import { SummaryList, SummaryNumber } from 'components/summary';
+import ExampleReport from './example';
+import RevenueReport from './revenue';
 
-export default class extends Component {
+class Report extends Component {
 	render() {
-		return (
-			<Fragment>
-				<Header
-					sections={ [
-						[ '/analytics', __( 'Analytics', 'woo-dash' ) ],
-						__( 'Report Title', 'woo-dash' ),
-					] }
-				/>
-				<SummaryList>
-					<SummaryNumber
-						value={ '$829.40' }
-						label={ __( 'Gross Revenue', 'woo-dash' ) }
-						delta={ 29 }
-					/>
-					<SummaryNumber
-						value={ '$24.00' }
-						label={ __( 'Refunds', 'woo-dash' ) }
-						delta={ -10 }
-						selected
-					/>
-					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } delta={ 15 } />
-					<SummaryNumber value={ '$66.39' } label={ __( 'Tax', 'woo-dash' ) } />
-				</SummaryList>
-			</Fragment>
-		);
+		const { params } = this.props;
+		switch ( params.report ) {
+			case 'revenue':
+				return <RevenueReport { ...this.props } />;
+			default:
+				return <ExampleReport />;
+		}
 	}
 }
+
+Report.propTypes = {
+	params: PropTypes.object.isRequired,
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object.isRequired,
+};
+
+export default Report;

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -1,0 +1,55 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import DatePicker from 'components/date-picker';
+import Header from 'components/header';
+import { SummaryList, SummaryNumber } from 'components/summary';
+
+class RevenueReport extends Component {
+	render() {
+		const { path, query } = this.props;
+		return (
+			<Fragment>
+				<Header
+					sections={ [
+						[ '/analytics', __( 'Analytics', 'woo-dash' ) ],
+						__( 'Revenue', 'woo-dash' ),
+					] }
+				/>
+				<DatePicker query={ query } path={ path } />
+
+				<SummaryList>
+					<SummaryNumber
+						value={ '$829.40' }
+						label={ __( 'Gross Revenue', 'woo-dash' ) }
+						delta={ 29 }
+					/>
+					<SummaryNumber
+						value={ '$24.00' }
+						label={ __( 'Refunds', 'woo-dash' ) }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } delta={ 15 } />
+					<SummaryNumber value={ '$66.39' } label={ __( 'Taxes', 'woo-dash' ) } />
+				</SummaryList>
+			</Fragment>
+		);
+	}
+}
+
+RevenueReport.propTypes = {
+	params: PropTypes.object.isRequired,
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object.isRequired,
+};
+
+export default RevenueReport;

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -48,6 +48,15 @@ function woo_dash_register_pages(){
 		'woodash#/analytics/test',
 		'woo_dash_page'
 	);
+
+	add_submenu_page(
+		'woodash#/analytics',
+		__( 'Revenue', 'woo-dash' ),
+		__( 'Revenue', 'woo-dash' ),
+		'manage_options',
+		'woodash#/analytics/revenue',
+		'woo_dash_page'
+	);
 }
 add_action( 'admin_menu', 'woo_dash_register_pages' );
 


### PR DESCRIPTION
This branch is for #97 - and it seeks to support rendering different report components based upon the `:report` param from the route.

![revenue-report](https://user-images.githubusercontent.com/22080/41436141-a403e89a-6fd5-11e8-9b41-b345e330e996.png)

I have taken the existing example report and moved it to the aptly named `example.js` - which can still be a sandbox of sorts while we develop new components for reports, but I have also created `RevenueReport` for our first _legit_ report!

__To Test__
- Expand the _Analytics_ section in your wp-admin sidebar, click "Revenue"
- Verify the Revenue report renders, and the breadcrumbs are correct.

__Questions__
- Should the date picker component live in the root report component? I thought there could potentially be some reports that are not date based ( i.e. customer-esque reports ) so opted to inclued it in the report itself.
- Does this folder structure make sense? Or should we have a folder for each singular report?