### PR TITLE
Add Pagination Component

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -2,39 +2,17 @@
 /**
  * External dependencies
  */
-import { Component, Fragment, compose } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { stringify as stringifyQueryObject } from 'qs';
-import { withRouter } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import ExampleReport from './example';
 import RevenueReport from './revenue';
-import Pagination from 'components/pagination';
 
 class Report extends Component {
-	constructor() {
-		super();
-		this.onPageChange = this.onPageChange.bind( this );
-		this.onPerPageChange = this.onPerPageChange.bind( this );
-	}
-	onPageChange( page ) {
-		this.updateLocation( { page } );
-	}
-
-	onPerPageChange( perPage ) {
-		this.updateLocation( { per_page: perPage } );
-	}
-
-	updateLocation( data ) {
-		const { path, query, history } = this.props;
-		const queryString = stringifyQueryObject( Object.assign( query, data ) );
-		history.push( `${ path }?${ queryString }` );
-	}
-
-	renderReport() {
+	render() {
 		const { params } = this.props;
 		switch ( params.report ) {
 			case 'revenue':
@@ -43,31 +21,10 @@ class Report extends Component {
 				return <ExampleReport />;
 		}
 	}
-
-	render() {
-		const { query } = this.props;
-		return (
-			<Fragment>
-				{ this.renderReport() }
-				<Pagination
-					page={ parseInt( query.page ) || 1 }
-					perPage={ parseInt( query.per_page ) || 25 }
-					total={ 5000 }
-					onPageChange={ this.onPageChange }
-					onPerPageChange={ this.onPerPageChange }
-				/>
-			</Fragment>
-		);
-	}
 }
 
 Report.propTypes = {
 	params: PropTypes.object.isRequired,
-	history: PropTypes.shape( {
-		push: PropTypes.func.isRequired,
-	} ),
-	path: PropTypes.string.isRequired,
-	query: PropTypes.object.isRequired,
 };
 
-export default compose( [ withRouter ] )( Report );
+export default Report;

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -2,17 +2,39 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment, compose } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { stringify as stringifyQueryObject } from 'qs';
+import { withRouter } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import ExampleReport from './example';
 import RevenueReport from './revenue';
+import Pagination from 'components/pagination';
 
 class Report extends Component {
-	render() {
+	constructor() {
+		super();
+		this.onPageChange = this.onPageChange.bind( this );
+		this.onPerPageChange = this.onPerPageChange.bind( this );
+	}
+	onPageChange( page ) {
+		this.updateLocation( { page } );
+	}
+
+	onPerPageChange( perPage ) {
+		this.updateLocation( { per_page: perPage } );
+	}
+
+	updateLocation( data ) {
+		const { path, query, history } = this.props;
+		const queryString = stringifyQueryObject( Object.assign( query, data ) );
+		history.push( `${ path }?${ queryString }` );
+	}
+
+	renderReport() {
 		const { params } = this.props;
 		switch ( params.report ) {
 			case 'revenue':
@@ -21,12 +43,31 @@ class Report extends Component {
 				return <ExampleReport />;
 		}
 	}
+
+	render() {
+		const { query } = this.props;
+		return (
+			<Fragment>
+				{ this.renderReport() }
+				<Pagination
+					page={ parseInt( query.page ) || 1 }
+					perPage={ parseInt( query.per_page ) || 25 }
+					total={ 5000 }
+					onPageChange={ this.onPageChange }
+					onPerPageChange={ this.onPerPageChange }
+				/>
+			</Fragment>
+		);
+	}
 }
 
 Report.propTypes = {
 	params: PropTypes.object.isRequired,
+	history: PropTypes.shape( {
+		push: PropTypes.func.isRequired,
+	} ),
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
 
-export default Report;
+export default compose( [ withRouter ] )( Report );

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -12,16 +12,31 @@ import PropTypes from 'prop-types';
  */
 import Card from 'components/card';
 import DatePicker from 'components/date-picker';
-import { getAdminLink } from 'lib/nav-utils';
+import { getAdminLink, updateQueryString } from 'lib/nav-utils';
 import { getCurrencyFormatString } from 'lib/currency';
 import Header from 'components/header';
 import { SummaryList, SummaryNumber } from 'components/summary';
 import Table from 'components/table';
+import Pagination from 'components/pagination';
 
 // Mock data until we fetch from an API
 import rawData from './mock-data';
 
 class RevenueReport extends Component {
+	constructor() {
+		super();
+		this.onPageChange = this.onPageChange.bind( this );
+		this.onPerPageChange = this.onPerPageChange.bind( this );
+	}
+
+	onPageChange( page ) {
+		updateQueryString( { page } );
+	}
+
+	onPerPageChange( perPage ) {
+		updateQueryString( { per_page: perPage } );
+	}
+
 	getRowsContent( data ) {
 		return map( data, ( row, label ) => {
 			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
@@ -83,11 +98,21 @@ class RevenueReport extends Component {
 					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'woo-dash' ) } delta={ 15 } />
 					<SummaryNumber value={ '$66.39' } label={ __( 'Taxes', 'woo-dash' ) } />
 				</SummaryList>
+
 				<Card title={ __( 'Gross Revenue' ) }>
 					<p>Graph here</p>
 					<hr />
 					<Table rows={ rows } headers={ headers } caption={ __( 'Revenue Last Week' ) } />
 				</Card>
+
+				<Pagination
+					page={ parseInt( query.page ) || 1 }
+					perPage={ parseInt( query.per_page ) || 25 }
+					total={ 5000 }
+					onPageChange={ this.onPageChange }
+					onPerPageChange={ this.onPerPageChange }
+				/>
+
 			</Fragment>
 		);
 	}

--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -1,0 +1,31 @@
+Pagination
+============
+
+Use `Pagination` to allow navigation between pages that represent a collection of items. The component allows for selecting a new page and items per page options.
+
+## How to use:
+
+```jsx
+import { Pagination } from 'components/pagination';
+
+render: function() {
+  return (
+    <Pagination
+		page={ this.state.page }
+		perPage={ this.state.perPage }
+		total={ 5000 }
+		onPageChange={ this.onPageChange }
+		onPerPageChange={ this.onPerPageChange }
+	/>
+  );
+}
+```
+
+## Props
+
+* `page` (required): The current page of the collection.
+* `onPageChange`: A function to execute when the page is changed.
+* `perPage` (required): The amount of results that are being displayed per page.
+* `onPerPageChange`: A function to execute when the per page option is changed.
+* `total` (required): The total number of results.
+* `className`: Additional classNames.

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -1,0 +1,212 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { IconButton, SelectControl } from '@wordpress/components';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { noop, uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function keyListener( methodToCall, event ) {
+	switch ( event.key ) {
+		case 'Enter':
+			this[ methodToCall ]( event );
+			break;
+	}
+}
+
+class Pagination extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			pageInputValue: props.page,
+		};
+
+		this.previousPage = this.previousPage.bind( this );
+		this.nextPage = this.nextPage.bind( this );
+		this.selectPage = this.selectPage.bind( this );
+		this.selectPageListner = keyListener.bind( this, 'selectPage' );
+		this.onPageValueChange = this.onPageValueChange.bind( this );
+		this.perPageChange = this.perPageChange.bind( this );
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		if ( props.page !== state.pageInputValue ) {
+			return {
+				pageInputValue: props.page,
+			};
+		}
+		return null;
+	}
+
+	previousPage( event ) {
+		event.stopPropagation();
+		const { page, onPageChange } = this.props;
+		if ( page - 1 < 1 ) {
+			return;
+		}
+		onPageChange( page - 1 );
+	}
+
+	nextPage( event ) {
+		event.stopPropagation();
+		const { page, onPageChange } = this.props;
+		if ( page + 1 > this.pageCount ) {
+			return;
+		}
+		onPageChange( page + 1 );
+	}
+
+	selectPage( event ) {
+		event.stopPropagation();
+		const { onPageChange } = this.props;
+		if ( this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount ) {
+			return;
+		}
+		onPageChange( parseInt( this.state.pageInputValue ) );
+	}
+
+	perPageChange( perPage ) {
+		const { onPerPageChange, onPageChange, total, page } = this.props;
+		onPerPageChange( parseInt( perPage ) );
+		const newMaxPage = Math.ceil( total / parseInt( perPage ) );
+		if ( page > newMaxPage ) {
+			onPageChange( newMaxPage );
+		}
+	}
+
+	onPageValueChange( event ) {
+		this.setState( { pageInputValue: event.target.value } );
+	}
+
+	renderPageArrows() {
+		const { page } = this.props;
+
+		if ( this.pageCount <= 1 ) {
+			return null;
+		}
+
+		const previousLinkClass = classNames( 'woocommerce-pagination__link', {
+			'is-active': page > 1,
+		} );
+
+		const nextLinkClass = classNames( 'woocommerce-pagination__link', {
+			'is-active': page < this.pageCount,
+		} );
+
+		return (
+			<div className="woocommerce-pagination__page-arrows">
+				<span className="woocommerce-pagination__page-arrows-label">
+					{ sprintf( __( 'Page %d of %d', 'woo-dash' ), page, this.pageCount ) }
+				</span>
+				<div className="woocommerce-pagination__page-arrows-buttons">
+					<IconButton
+						className={ previousLinkClass }
+						disabled={ ! ( page > 1 ) }
+						onClick={ this.previousPage }
+						icon="arrow-left"
+						label={ __( 'Previous Page', 'woo-dash' ) }
+						size={ 18 }
+					/>
+					<IconButton
+						className={ nextLinkClass }
+						disabled={ ! ( page < this.pageCount ) }
+						onClick={ this.nextPage }
+						icon="arrow-right"
+						label={ __( 'Next Page', 'woo-dash' ) }
+						size={ 18 }
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	renderPagePicker() {
+		const inputClass = classNames( 'woocommerce-pagination__page-picker-input', {
+			'has-error': this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount,
+		} );
+		const instanceId = uniqueId( 'woocommerce-pagination-page-picker-' );
+		return (
+			<div className="woocommerce-pagination__page-picker">
+				<label htmlFor={ instanceId } className="woocommerce-pagination__page-picker-label">
+					{ __( 'Go to page:', 'woo-dash' ) }
+					<input
+						id={ instanceId }
+						className={ inputClass }
+						type="number"
+						onChange={ this.onPageValueChange }
+						onKeyDown={ this.selectPageListner }
+						onBlur={ this.selectPage }
+						value={ this.state.pageInputValue }
+						min={ 1 }
+						max={ this.pageCount }
+					/>
+				</label>
+			</div>
+		);
+	}
+
+	renderPerPagePicker() {
+		// TODO Replace this with a styleized Select drop-down/control?
+		return (
+			<div className="woocommerce-pagination__per-page-picker">
+				<SelectControl
+					label={ __( 'Rows:', 'woo-dash' ) }
+					value={ this.props.perPage }
+					onChange={ this.perPageChange }
+					options={ [
+						{ value: '25', label: '25' },
+						{ value: '50', label: '50' },
+						{ value: '75', label: '75' },
+						{ value: '100', label: '100' },
+						{ value: '250', label: '250' },
+						{ value: '500', label: '500' },
+					] }
+				/>
+			</div>
+		);
+	}
+
+	render() {
+		const { total, perPage, className } = this.props;
+		this.pageCount = Math.ceil( total / perPage );
+
+		if ( this.pageCount <= 1 ) {
+			return null;
+		}
+
+		const classes = classNames( 'woocommerce-pagination', className );
+
+		return (
+			<div className={ classes }>
+				{ this.renderPageArrows() }
+				{ this.renderPagePicker() }
+				{ this.renderPerPagePicker() }
+			</div>
+		);
+	}
+}
+
+Pagination.propTypes = {
+	page: PropTypes.number.isRequired,
+	onPageChange: PropTypes.func,
+	perPage: PropTypes.number.isRequired,
+	onPerPageChange: PropTypes.func,
+	total: PropTypes.number.isRequired,
+	className: PropTypes.string,
+};
+
+Pagination.defaultProps = {
+	onPageChange: noop,
+	onPerPageChange: noop,
+};
+
+export default Pagination;

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -33,7 +33,7 @@ class Pagination extends Component {
 		this.previousPage = this.previousPage.bind( this );
 		this.nextPage = this.nextPage.bind( this );
 		this.selectPage = this.selectPage.bind( this );
-		this.selectPageListner = keyListener.bind( this, 'selectPage' );
+		this.selectPageListener = keyListener.bind( this, 'selectPage' );
 		this.onPageValueChange = this.onPageValueChange.bind( this );
 		this.perPageChange = this.perPageChange.bind( this );
 	}
@@ -104,7 +104,11 @@ class Pagination extends Component {
 
 		return (
 			<div className="woocommerce-pagination__page-arrows">
-				<span className="woocommerce-pagination__page-arrows-label">
+				<span
+					className="woocommerce-pagination__page-arrows-label"
+					role="status"
+					aria-live="polite"
+				>
 					{ sprintf( __( 'Page %d of %d', 'woo-dash' ), page, this.pageCount ) }
 				</span>
 				<div className="woocommerce-pagination__page-arrows-buttons">
@@ -130,9 +134,11 @@ class Pagination extends Component {
 	}
 
 	renderPagePicker() {
+		const isError = this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount;
 		const inputClass = classNames( 'woocommerce-pagination__page-picker-input', {
-			'has-error': this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount,
+			'has-error': isError,
 		} );
+
 		const instanceId = uniqueId( 'woocommerce-pagination-page-picker-' );
 		return (
 			<div className="woocommerce-pagination__page-picker">
@@ -141,9 +147,10 @@ class Pagination extends Component {
 					<input
 						id={ instanceId }
 						className={ inputClass }
+						aria-invalid={ isError }
 						type="number"
 						onChange={ this.onPageValueChange }
-						onKeyDown={ this.selectPageListner }
+						onKeyDown={ this.selectPageListener }
 						onBlur={ this.selectPage }
 						value={ this.state.pageInputValue }
 						min={ 1 }

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -116,7 +116,7 @@ class Pagination extends Component {
 						className={ previousLinkClass }
 						disabled={ ! ( page > 1 ) }
 						onClick={ this.previousPage }
-						icon="arrow-left"
+						icon="arrow-left-alt2"
 						label={ __( 'Previous Page', 'woo-dash' ) }
 						size={ 18 }
 					/>
@@ -124,7 +124,7 @@ class Pagination extends Component {
 						className={ nextLinkClass }
 						disabled={ ! ( page < this.pageCount ) }
 						onClick={ this.nextPage }
-						icon="arrow-right"
+						icon="arrow-right-alt2"
 						label={ __( 'Next Page', 'woo-dash' ) }
 						size={ 18 }
 					/>
@@ -143,7 +143,7 @@ class Pagination extends Component {
 		return (
 			<div className="woocommerce-pagination__page-picker">
 				<label htmlFor={ instanceId } className="woocommerce-pagination__page-picker-label">
-					{ __( 'Go to page:', 'woo-dash' ) }
+					{ __( 'Go to page', 'woo-dash' ) }
 					<input
 						id={ instanceId }
 						className={ inputClass }
@@ -166,7 +166,7 @@ class Pagination extends Component {
 		return (
 			<div className="woocommerce-pagination__per-page-picker">
 				<SelectControl
-					label={ __( 'Rows:', 'woo-dash' ) }
+					label={ __( 'Rows per page', 'woo-dash' ) }
 					value={ this.props.perPage }
 					onChange={ this.perPageChange }
 					options={ [

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -1,0 +1,71 @@
+/** @format */
+
+.woocommerce-pagination {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	justify-content: center;
+	align-items: center;
+
+	input {
+		border-radius: 4px;
+	}
+}
+
+.woocommerce-pagination__page-arrows {
+	display: flex;
+	flex-direction: row;
+}
+
+.woocommerce-pagination__page-arrows-buttons {
+	display: inline-flex;
+	align-items: baseline;
+	border: 1px solid $gray-light-10;
+	border-radius: 4px;
+	background: $white;
+
+	button:first-child {
+		border-right: 1px solid $gray-light-10;
+	}
+
+	.woocommerce-pagination__link {
+		padding: 4px;
+	}
+}
+
+.woocommerce-pagination__page-arrows-label {
+	margin-top: $spacing / 2;
+	margin-right: $spacing / 2;
+}
+
+.woocommerce-pagination__page-picker {
+	margin-left: $spacing / 2;
+}
+
+.woocommerce-pagination__page-picker-input {
+	margin-left: $spacing / 2;
+	width: 60px;
+}
+
+.woocommerce-pagination__per-page-picker {
+	margin-left: $spacing;
+
+	.components-base-control {
+		margin-bottom: 0;
+	}
+	.components-base-control__field {
+		display: flex;
+		flex-direction: row;
+		align-items: baseline;
+	}
+
+	.components-base-control__label {
+		margin-right: $spacing / 2;
+	}
+}
+
+.woocommerce-pagination__page-picker-input.has-error,
+.woocommerce-pagination__page-picker-input.has-error:focus {
+	border-color: $alert-red;
+	box-shadow: 0 0 2px $alert-red;
+}

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -20,12 +20,21 @@
 .woocommerce-pagination__page-arrows-buttons {
 	display: inline-flex;
 	align-items: baseline;
-	border: 1px solid $gray-light-10;
+	border: 1px solid $button-border;
+	border-bottom: 2px solid $button-border;
 	border-radius: 4px;
-	background: $white;
+	background: $button;
+
+	.components-button:not(:disabled):not([aria-disabled='true']) {
+		color: $black;
+	}
+
+	.components-icon-button:not(:disabled):not([aria-disabled='true']):hover {
+		color: $gray-darken-40;
+	}
 
 	button:first-child {
-		border-right: 1px solid $gray-light-10;
+		border-right: 2px solid darken($button, 10%);
 	}
 
 	.woocommerce-pagination__link {
@@ -48,7 +57,7 @@
 }
 
 .woocommerce-pagination__per-page-picker {
-	margin-left: $spacing;
+	margin-left: $spacing / 2;
 
 	.components-base-control {
 		margin-bottom: 0;
@@ -57,6 +66,10 @@
 		display: flex;
 		flex-direction: row;
 		align-items: baseline;
+	}
+
+	.components-select-control__input {
+		width: 60px;
 	}
 
 	.components-base-control__label {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -42,12 +42,12 @@ const getPages = () => {
 class Controller extends Component {
 	render() {
 		// Pass URL parameters (example :report -> params.report) and query string parameters
-		const { path, params } = this.props.match;
+		const { path, url, params } = this.props.match;
 		const search = this.props.location.search.substring( 1 );
 		const query = parse( search );
 		const page = find( getPages(), { path } );
 		window.wpNavMenuClassChange( page.wpMenu );
-		return createElement( page.container, { params, path, query } );
+		return createElement( page.container, { params, path: url, pathMatch: path, query } );
 	}
 }
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -4,7 +4,7 @@
  */
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
-import { HashRouter as Router, Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
 import { Slot } from 'react-slot-fill';
 import PropTypes from 'prop-types';
 
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import Header from 'components/header';
 import { Controller, getPages } from './controller';
+import history from 'lib/history';
 import Notices from './notices';
 import Sidebar from './sidebar';
 
@@ -68,7 +69,7 @@ Layout.propTypes = {
 export class PageLayout extends Component {
 	render() {
 		return (
-			<Router>
+			<Router history={ history }>
 				<Switch>
 					{ getPages().map( page => {
 						return <Route key={ page.path } path={ page.path } exact component={ Layout } />;

--- a/client/lib/history.js
+++ b/client/lib/history.js
@@ -1,0 +1,10 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { createHashHistory } from 'history';
+
+// See https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
+
+export default createHashHistory();

--- a/client/lib/nav-utils.js
+++ b/client/lib/nav-utils.js
@@ -1,5 +1,11 @@
 /** @format */
 
+/**
+ * External dependencies
+ */
+import history from './history';
+import { parse, stringify as stringifyQueryObject } from 'qs';
+
 /* Returns a string with the site's wp-admin URL appended. JS version of `admin_url`.
  *
  * @param {String} path Relative path.
@@ -7,4 +13,15 @@
  */
 export const getAdminLink = path => {
 	return wcSettings.adminUrl + path;
+};
+
+/* Updates the query parameters of the current page.
+ *
+ * @param {Object} Query parameters to be updated.
+ */
+export const updateQueryString = query => {
+	const path = history.location.pathname;
+	const currentQuery = parse( history.location.search.substring( 1 ) );
+	const queryString = stringifyQueryObject( Object.assign( currentQuery, query ) );
+	history.push( `${ path }?${ queryString }` );
 };

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -24,3 +24,5 @@ $woocommerce: #95588a;
 
 // Until we create a separate variables partial
 $spacing: 16px;
+
+$alert-red: #d94f4f;

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -26,3 +26,6 @@ $woocommerce: #95588a;
 $spacing: 16px;
 
 $alert-red: #d94f4f;
+
+$button: #f0f2f4;
+$button-border: darken($button, 20%);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7526,6 +7526,19 @@
         "sntp": "1.0.9"
       }
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "dev": true,
+      "requires": {
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "grunt": "^1.0.2",
     "grunt-wp-i18n": "^1.0.2",
     "gutenberg": "github:WordPress/gutenberg#v2.9.0",
+    "history": "^4.7.2",
     "husky": "^0.14.3",
     "node-sass": "^4.9.0",
     "prettier": "github:automattic/calypso-prettier#c56b4251",


### PR DESCRIPTION
Closes #93.

This PR adds a new `Pagination` component that allows for selecting the page and number of items per page. It also updates the report route to use the update callbacks to update the query string of the current page.

The only part not implemented in this PR is the styleized dropdown/select from the mock. I'm using `SelectControl` from Gutenberg right now, but we could create a wrapper for the select in a future PR.

My main design question is around the behavior of the "go to" option. Right now I have it only update the current page if you hit "enter" or type and then switch focus out of the input. Should this instead update as the user types with a debounce? Something else? cc @LevinMedia.

<img width="522" alt="screen shot 2018-06-15 at 10 55 57 am" src="https://user-images.githubusercontent.com/689165/41474711-b52e295e-708a-11e8-8a58-343853050fae.png">

To Test:
* `npm install` to make sure the history package is installed
* Visit `http://:site/wp-admin/admin.php?page=woodash#/analytics/revenue`
* Test paging through pages using the arrows
* Test using the "go to page:" selector. There is some validation error so you don't try to go to a page that doesn't exist.
* Test using the number of items dropdown
* Verify the "Page %d of %d" and query strings update when selections are made