### PR TITLE
Try a context-aware heading component

### DIFF
--- a/client/components/activity-card/index.js
+++ b/client/components/activity-card/index.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 import { EllipsisMenu } from '../ellipsis-menu';
+import { H, Section } from 'layout/section';
 
 class ActivityCard extends Component {
 	render() {
@@ -23,20 +24,20 @@ class ActivityCard extends Component {
 			<section className={ cardClassName }>
 				<header className="woocommerce-activity-card__header">
 					<span className="woocommerce-activity-card__icon">{ icon }</span>
-					<h3 className="woocommerce-activity-card__label">
+					<H className="woocommerce-activity-card__label">
 						{ label }
 						{ date && (
 							<span className="woocommerce-activity-card__date">
 								– { moment( date ).fromNow() }
 							</span>
 						) }
-					</h3>
+					</H>
 					{ menu && <div className="woocommerce-activity-card__menu">{ menu }</div> }
 				</header>
-				<div className="woocommerce-activity-card__body">
+				<Section className="woocommerce-activity-card__body">
 					<div className="woocommerce-activity-card__content">{ children }</div>
 					{ image && <div className="woocommerce-activity-card__image">{ image }</div> }
-				</div>
+				</Section>
 				{ actions && (
 					<footer className="woocommerce-activity-card__actions">
 						{ actions.map( ( item, i ) => cloneElement( item, { key: i } ) ) }

--- a/client/components/activity-list/orders.js
+++ b/client/components/activity-list/orders.js
@@ -13,12 +13,13 @@ import PropTypes from 'prop-types';
 import ActivityCard from 'components/activity-card';
 import { getCurrencyFormatDecimal, getCurrencyFormatString } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';
+import { Section } from 'layout/section';
 
 function OrdersList( { orders } ) {
 	const { data = [], isLoading } = orders;
 
 	return (
-		<div>
+		<Section>
 			{ isLoading ? (
 				<p>Loading</p>
 			) : (
@@ -63,7 +64,7 @@ function OrdersList( { orders } ) {
 					);
 				} )
 			) }
-		</div>
+		</Section>
 	);
 }
 

--- a/client/components/card/index.js
+++ b/client/components/card/index.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 import { EllipsisMenu } from '../ellipsis-menu';
+import { H, Section } from 'layout/section';
 
 class Card extends Component {
 	render() {
@@ -22,11 +23,11 @@ class Card extends Component {
 		return (
 			<div className={ className }>
 				<div className="woocommerce-card__header">
-					<h2 className="woocommerce-card__title">{ title }</h2>
+					<H className="woocommerce-card__title">{ title }</H>
 					{ action && <div className="woocommerce-card__action">{ action }</div> }
 					{ menu && <div className="woocommerce-card__menu">{ menu }</div> }
 				</div>
-				<div className="woocommerce-card__body">{ children }</div>
+				<Section className="woocommerce-card__body">{ children }</Section>
 			</div>
 		);
 	}

--- a/client/components/date-picker/content.js
+++ b/client/components/date-picker/content.js
@@ -11,49 +11,57 @@ import { Link } from 'react-router-dom';
 /**
  * Internal dependencies
  */
-import PresetPeriods from './preset-periods';
 import ComparePeriods from './compare-periods';
+import { H, Section } from 'layout/section';
+import PresetPeriods from './preset-periods';
 
 class DatePickerContent extends Component {
 	render() {
 		const { period, compare, onSelect, onClose, getUpdatePath } = this.props;
 		return (
 			<Fragment>
-				<h3 className="woocommerce-date-picker__text">{ __( 'select a date range', 'woo-dash' ) }</h3>
-				<TabPanel
-					tabs={ [
-						{
-							name: 'period',
-							title: __( 'Presets', 'woo-dash' ),
-							className: 'woocommerce-date-picker__tab',
-						},
-						{
-							name: 'custom',
-							title: __( 'Custom', 'woo-dash' ),
-							className: 'woocommerce-date-picker__tab',
-						},
-					] }
-					className="woocommerce-date-picker__tabs"
-					activeClass="is-active"
-				>
-					{ selectedTab => (
-						<Fragment>
-							{ selectedTab === 'period' && (
-								<PresetPeriods onSelect={ onSelect } period={ period } />
-							) }
-							{ selectedTab === 'custom' && <div>Custom Date Picker Goes here</div> }
-							<h3 className="woocommerce-date-picker__text">{ __( 'compare to', 'woo-dash' ) }</h3>
-							<ComparePeriods onSelect={ onSelect } compare={ compare } />
-							<Link
-								className="woocommerce-date-picker__update-btn"
-								to={ getUpdatePath( selectedTab ) }
-								onClick={ onClose }
-							>
-								{ __( 'Update', 'woo-dash' ) }
-							</Link>
-						</Fragment>
-					) }
-				</TabPanel>
+				<H className="screen-reader-text" tabIndex="0">
+					{ __( 'Select date range and comparison', 'woo-dash' ) }
+				</H>
+				<Section component={ false }>
+					<H className="woocommerce-date-picker__text">
+						{ __( 'select a date range', 'woo-dash' ) }
+					</H>
+					<TabPanel
+						tabs={ [
+							{
+								name: 'period',
+								title: __( 'Presets', 'woo-dash' ),
+								className: 'woocommerce-date-picker__tab',
+							},
+							{
+								name: 'custom',
+								title: __( 'Custom', 'woo-dash' ),
+								className: 'woocommerce-date-picker__tab',
+							},
+						] }
+						className="woocommerce-date-picker__tabs"
+						activeClass="is-active"
+					>
+						{ selectedTab => (
+							<Fragment>
+								{ selectedTab === 'period' && (
+									<PresetPeriods onSelect={ onSelect } period={ period } />
+								) }
+								{ selectedTab === 'custom' && <div>Custom Date Picker Goes here</div> }
+								<H className="woocommerce-date-picker__text">{ __( 'compare to', 'woo-dash' ) }</H>
+								<ComparePeriods onSelect={ onSelect } compare={ compare } />
+								<Link
+									className="woocommerce-date-picker__update-btn"
+									to={ getUpdatePath( selectedTab ) }
+									onClick={ onClose }
+								>
+									{ __( 'Update', 'woo-dash' ) }
+								</Link>
+							</Fragment>
+						) }
+					</TabPanel>
+				</Section>
 			</Fragment>
 		);
 	}

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -36,7 +36,7 @@ const Header = ( { sections, onToggle, isSidebarOpen } ) => {
 
 	return (
 		<div className="woocommerce-header">
-			<h1>
+			<h1 className="woocommerce-header__breadcrumbs">
 				<span>
 					<Link to="/">WooCommerce</Link>
 				</span>

--- a/client/components/header/style.scss
+++ b/client/components/header/style.scss
@@ -10,7 +10,7 @@
 	background: $white;
 	border-bottom: 1px solid $gray;
 
-	h1 {
+	.woocommerce-header__breadcrumbs {
 		font-size: 13px;
 
 		span {

--- a/client/dashboard/widgets/agenda/header.js
+++ b/client/dashboard/widgets/agenda/header.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Count from 'components/count';
+import { H, Section } from 'layout/section';
 
 class AgendaHeader extends Component {
 	constructor( props ) {
@@ -42,10 +43,10 @@ class AgendaHeader extends Component {
 		return (
 			<a className={ classes } href={ href }>
 				<div className="woocommerce-dashboard__agenda-group-title is-link">
-					<h3>
+					<H className="woocommerce-dashboard__agenda-group-label">
 						{ count && <Count count={ count } /> }
 						{ title }
-					</h3>
+					</H>
 					<span className="woocommerce-dashboard__agenda-group-arrow">
 						<Dashicon icon="arrow-right-alt2" />
 					</span>
@@ -76,16 +77,16 @@ class AgendaHeader extends Component {
 					onClick={ this.toggle }
 					className="woocommerce-dashboard__agenda-group-title is-accordion"
 				>
-					<h3>
+					<H className="woocommerce-dashboard__agenda-group-label">
 						{ count && <Count count={ count } /> }
 						{ title }
-					</h3>
+					</H>
 					<IconButton onClick={ this.toggle } aria-expanded={ isOpened } icon={ icon } />
 				</div>
 
 				{ isOpened &&
 					children && (
-						<div className="woocommerce-dashboard__agenda-group-content">{ children }</div>
+						<Section className="woocommerce-dashboard__agenda-group-content">{ children }</Section>
 					) }
 			</div>
 		);

--- a/client/dashboard/widgets/agenda/style.scss
+++ b/client/dashboard/widgets/agenda/style.scss
@@ -10,7 +10,7 @@
 	text-decoration: none;
 	display: block;
 
-	h3 {
+	.woocommerce-dashboard__agenda-group-label {
 		font-size: 13px;
 		font-weight: normal;
 
@@ -38,7 +38,7 @@
 		cursor: pointer;
 	}
 
-	h3 {
+	.woocommerce-dashboard__agenda-group-label {
 		margin: 0;
 	}
 

--- a/client/layout/README.md
+++ b/client/layout/README.md
@@ -35,3 +35,43 @@ This function returns an array of objects, each describing a page in the app. Th
 ### `<Controller />`
 
 This component pulls out the current page from `getPages`, and renders the container component defined in the object.
+
+## `Section` and `H`
+
+These components are pulled from `layout/section`, and are used to frame out the page content for accessible heading hierarchy. Instead of defining fixed heading levels (`h2`, `h3`, …) you can use `<H />` to create "section headings", which look to the parent `<Section />`s for the appropriate heading level.
+
+For example…
+
+```jsx
+<H>My important title</H>
+<Section>
+	<H>This subtitle</H>
+	<p>Some content</p>
+	<H>Another subtitle</H>
+	<p>More content</p>
+</Section>
+```
+
+will render as
+
+```html
+<h2>My important title</h2>
+<div>
+	<h3>This subtitle</h3>
+	<p>Some content</p>
+	<h3>Another subtitle</h3>
+	<p>More content</p>
+</div>
+```
+
+Note that H starts at level 2, since there should be only 1 `h1` on each page and we set that separately in `<Header />`.
+
+### Props for `<H />`
+
+Any props passed to `H` will pass down to the `h*` element, so be sure to use only valid HTML properties.
+
+### Props for `<Section />`
+
+- `component`: The wrapper component for this section. Optional, defaults to `div`. If passed false, no wrapper is used.
+- `children`: The children inside this section, rendered in the `component`. This increases the context level for the next heading used.
+- `...props`: All other props are passed to the wrapper component, or ignored if `component === false`.

--- a/client/layout/section.js
+++ b/client/layout/section.js
@@ -1,0 +1,36 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+/**
+ * Context container for heading level. We start at 2 because the `h1` is defined in <Header />
+ *
+ * See https://medium.com/@Heydon/managing-heading-levels-in-design-systems-18be9a746fa3
+ */
+const Level = createContext( 2 );
+
+export function Section( { component, children, ...props } ) {
+	const Component = component || 'div';
+	return (
+		<Level.Consumer>
+			{ level => (
+				<Level.Provider value={ level + 1 }>
+					{ false === component ? children : <Component { ...props }>{ children }</Component> }
+				</Level.Provider>
+			) }
+		</Level.Consumer>
+	);
+}
+
+export function H( props ) {
+	return (
+		<Level.Consumer>
+			{ level => {
+				const Heading = 'h' + Math.min( level, 6 );
+				return <Heading { ...props } />;
+			} }
+		</Level.Consumer>
+	);
+}

--- a/client/layout/sidebar/header.js
+++ b/client/layout/sidebar/header.js
@@ -5,12 +5,17 @@
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { H } from 'layout/section';
+
 class SidebarHeader extends Component {
 	render() {
 		const { label } = this.props;
 		return (
 			<div className="woocommerce-layout__sidebar-header">
-				<h3 className="woocommerce-layout__sidebar-header-label">{ label }</h3>
+				<H className="woocommerce-layout__sidebar-header-label">{ label }</H>
 				<div className="woocommerce-layout__sidebar-header-divider" />
 			</div>
 		);

--- a/client/layout/sidebar/index.js
+++ b/client/layout/sidebar/index.js
@@ -4,7 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { IconButton, TabPanel } from '@wordpress/components';
 import { uniqueId } from 'lodash';
 
@@ -14,6 +14,7 @@ import { uniqueId } from 'lodash';
 import './style.scss';
 import ActivityList from 'components/activity-list';
 import Count from 'components/count';
+import { H, Section } from 'layout/section';
 
 class Sidebar extends Component {
 	getTabs() {
@@ -56,9 +57,9 @@ class Sidebar extends Component {
 		return (
 			<aside className={ className } aria-labelledby={ headerId }>
 				<header className="woocommerce-layout__sidebar-top">
-					<h2 className="woocommerce-layout__sidebar-title screen-reader-text" id={ headerId }>
+					<H className="woocommerce-layout__sidebar-title screen-reader-text" id={ headerId }>
 						{ __( 'Store Activity', 'woo-dash' ) }
-					</h2>
+					</H>
 					<div className="woocommerce-layout__sidebar-toggle">
 						<IconButton
 							className="woocommerce-layout__sidebar-button"
@@ -75,10 +76,10 @@ class Sidebar extends Component {
 				>
 					{ selectedTabName => {
 						return (
-							<Fragment>
-								<h3>Section: { selectedTabName }</h3>
+							<Section component={ false }>
+								<H>Section: { selectedTabName }</H>
 								<ActivityList section={ selectedTabName } />
-							</Fragment>
+							</Section>
 						);
 					} }
 				</TabPanel>

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -6,7 +6,7 @@
     "!**/vendor/**",
     "!**/test/**"
   ],
-  "moduleDirectories": ["node_modules"],
+  "moduleDirectories": ["node_modules", "<rootDir>/client"],
   "moduleNameMapper": {
     "@wordpress\\/(blocks|components|date|editor|data|utils|edit-post|viewport|plugins|core-data)": "<rootDir>/node_modules/gutenberg/$1",
     "@wordpress\\/(date|element|dom)$": "<rootDir>/node_modules/gutenberg/packages/$1/src",


### PR DESCRIPTION
In React, we have a component structure, which lets us potentially nest any component inside any other component (a `Card` in a `Card`, for example). Currently we use "fixed" headings, `h2`, `h3`, and we try to keep the components in a coherent hierarchy so that the heading levels are semantic. This PR tries another approach, using [React's Context API](https://reactjs.org/docs/context.html) to keep track of sections and use the correct heading level automatically.

This PR adds two new components, `H` and `Section`. Instead of defining fixed heading levels (`h2`, `h3`, …) you can use `<H />` to create "section headings", which look to the parent `<Section />`s for the appropriate heading level. For example:

```jsx
<H>My important title</H>
<Section>
	<H>This subtitle</H>
	<p>Some content</p>
	<H>Another subtitle</H>
	<p>More content</p>
</Section>
```

will render as

```html
<h2>My important title</h2>
<div>
	<h3>This subtitle</h3>
	<p>Some content</p>
	<h3>Another subtitle</h3>
	<p>More content</p>
</div>
```

This means we can use the same components inside a card, inside the sidebar, etc without worrying about a conflicting header order. The only change necessary will be to remember to style based on className, rather than the element tag itself.

[See the README for more details on props, etc](https://github.com/woocommerce/woo-dash/blob/16af1f81eece206e9015aaf4fe93a14d6d431ecb/client/layout/README.md#section-and-h), or check out [the article that inspired this](https://medium.com/@Heydon/managing-heading-levels-in-design-systems-18be9a746fa3)

**To test**

- Load up the dashboard, check the dashboard & analytics pages
- Inspect the heading levels of the page, either by using [WAVE](http://wave.webaim.org/extension/) or with VoiceOver + Safari
- For VO+Safari, you can turn on VoiceOver, then hit <kbd>ctrl</kbd><kbd>opt</kbd><kbd>U</kbd>, then use the left or right arrow keys to move through the menus provided until you hear "Headings Menu", you should see something like this, and you can check that this is an acceptable outline of the page:

![screen shot 2018-06-18 at 12 39 43 pm](https://user-images.githubusercontent.com/541093/41549722-be1643d2-72f4-11e8-86f5-ae4316decde9.png)
