### PR TITLE
Use Swagger API data on Revenue Report

### DIFF
--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import Card from 'components/card';
 import DatePicker from 'components/date-picker';
 import { getAdminLink, updateQueryString } from 'lib/nav-utils';
-import { getCurrencyFormatString } from 'lib/currency';
+import { getCurrencyFormatString, formatCurrency } from 'lib/currency';
 import { getReportData } from 'lib/swagger';
 import Header from 'components/header';
 import { SummaryList, SummaryNumber } from 'components/summary';
@@ -110,22 +110,25 @@ class RevenueReport extends Component {
 
 				<SummaryList>
 					<SummaryNumber
-						value={ summaryStats.gross_revenue }
+						value={ formatCurrency( summaryStats.gross_revenue ) }
 						label={ __( 'Gross Revenue', 'woo-dash' ) }
 						delta={ 29 }
 					/>
 					<SummaryNumber
-						value={ summaryStats.refunds }
+						value={ formatCurrency( summaryStats.refunds ) }
 						label={ __( 'Refunds', 'woo-dash' ) }
 						delta={ -10 }
 						selected
 					/>
 					<SummaryNumber
-						value={ summaryStats.coupons }
+						value={ formatCurrency( summaryStats.coupons ) }
 						label={ __( 'Coupons', 'woo-dash' ) }
 						delta={ 15 }
 					/>
-					<SummaryNumber value={ summaryStats.taxes } label={ __( 'Taxes', 'woo-dash' ) } />
+					<SummaryNumber
+						value={ formatCurrency( summaryStats.taxes ) }
+						label={ __( 'Taxes', 'woo-dash' ) }
+					/>
 				</SummaryList>
 
 				<Card title={ __( 'Gross Revenue' ) }>

--- a/client/lib/currency/index.js
+++ b/client/lib/currency/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isNaN } from 'lodash';
+import { get, isNaN } from 'lodash';
 
 /**
  * Formats money with a given currency code. Uses site's current locale for symbol formatting
@@ -14,6 +14,11 @@ import { isNaN } from 'lodash';
  */
 export function formatCurrency( number, currency ) {
 	const locale = wcSettings.locale || 'en-US'; // Default so we don't break.
+
+	// default to wcSettings if currency is not passed in
+	if ( ! currency ) {
+		currency = get( wcSettings, 'currency.code', 'USD' );
+	}
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}

--- a/client/lib/currency/test/index.js
+++ b/client/lib/currency/test/index.js
@@ -5,6 +5,11 @@
 import { formatCurrency, getCurrencyFormatDecimal, getCurrencyFormatString } from '../index';
 
 describe( 'formatCurrency', () => {
+	it( 'should default to wcSettings or USD when currency not passed in', () => {
+		expect( formatCurrency( 9.99 ) ).toBe( '$9.99' );
+		expect( formatCurrency( 30 ) ).toBe( '$30.00' );
+	} );
+
 	it( 'should round a number to 2 decimal places in USD', () => {
 		expect( formatCurrency( 9.49258, 'USD' ) ).toBe( '$9.49' );
 		expect( formatCurrency( 30, 'USD' ) ).toBe( '$30.00' );

--- a/client/lib/swagger.js
+++ b/client/lib/swagger.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import qs from 'qs';
+
+export function getReportData( report, args ) {
+	const baseSwaggerUrl = 'https://virtserver.swaggerhub.com/peterfabian/wc-v3-api/1.0.0/reports/';
+	const params = args ? '?' + qs.stringify( args ) : '';
+	return fetch( `${ baseSwaggerUrl }${ report }${ params }`, {
+		headers: {
+			accept: 'application/json',
+		},
+	} );
+}


### PR DESCRIPTION
This branch is part of #98 and utilizes the new swagger mock endpoints on the Revenue Report to verify the format/structure of the response will work. Much of this code will be removed as we implement the real `v3` stat endpoints, but until those are ready - this will allow us to pull test data from the mock swagger endpoints for use in developing the reports.

![revenue-report](https://user-images.githubusercontent.com/22080/41942758-861db8b8-7955-11e8-8184-ec91c2e30006.png)

__Caveats__
The swagger endpoints return the same data set regardless of arguments passed, so doing certain things like responding to the date picker changes, or interval changes will not result in an update of the data. This is more about verifying the response format contains all the bits and bobs needed to build the reports.

__To Test__
- Visit `/wp-admin/admin.php?page=woodash#/analytics/revenue` on your test site
- Verify numbers show up in the Summary and Table area ( yes there is only one record / interval returned by swagger and thus only one shown in the table )
- I also added a new test case to `formatCurrency` so we can utilize it without passing in a currency, and it will default to the store currency - so please verify that `npm test` is all green for you on this branch ( reminds myself to setup CI on this project )

__Other Notes__
While working on this I hit a bit of a bug with the `<Table />` component because it grabs `rows` from the props on first load, but does not subsequently update when new props are sent down with new data. So since the data wasn't available on first render ( swagger request was in-flight ) the row was never rendered.

I tried to do some hacking with `componentWillReceiveProps` on the `<Table />` component but of course that is being deprecated - I will create an issue for this as the Table component will need to be able to re-render when a new set of row data is passed down from pagination changes and other events.