### PR TITLE
Update Card Header Styles

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -7,7 +7,7 @@
 }
 
 .woocommerce-card__header {
-	padding: 20px;
+	padding: 16px;
 	border-bottom: 1px solid $gray;
 	display: grid;
 	align-items: center;
@@ -17,11 +17,11 @@
 	}
 
 	.has-menu & {
-		grid-template-columns: 1fr 50px;
+		grid-template-columns: 1fr 24px;
 	}
 
 	.has-menu.has-action & {
-		grid-template-columns: 1fr 1fr 50px;
+		grid-template-columns: 1fr 1fr 48px;
 	}
 
 	h2 {
@@ -36,4 +36,13 @@
 
 .woocommerce-card__body {
 	padding: 20px;
+}
+
+.woocommerce-ellipsis-menu__toggle {
+	padding: 0;
+}
+
+.woocommerce-card__title {
+	font-size: 16px;
+	font-weight: 600;
 }

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -26,6 +26,7 @@
 
 	h2 {
 		margin: 0;
+		padding: 1px 0;
 	}
 }
 


### PR DESCRIPTION
This branch fixes #132 ( please disregard my poorly named branch 🤦‍♂️ ) - this is just a quick CSS update to bring the `<Card />` component css in-line with the HiFi design.

__Before__
![card-before](https://user-images.githubusercontent.com/22080/42002727-29acd03c-7a1d-11e8-93d1-689f9b5eb609.png)

__After__
![card-after](https://user-images.githubusercontent.com/22080/42002735-2f65c696-7a1d-11e8-92cf-be56bb02285c.png)

__Test__
Visit /wp-admin/admin.php?page=woodash#/ and verify all looks well