### PR TITLE
Implement updated activity panel tab design (part 1)

### DIFF
--- a/client/layout/activity-panel/activity-card/style.scss
+++ b/client/layout/activity-panel/activity-card/style.scss
@@ -2,7 +2,6 @@
 
 .woocommerce-activity-card {
 	background: $white;
-	border: 1px solid $gray;
 	margin-bottom: $spacing * 2;
 }
 

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -2,101 +2,169 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
+import { IconButton } from '@wordpress/components';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Count from 'components/count';
-import { H, Section } from 'layout/section';
+import './style.scss';
+import { Section } from 'layout/section';
 import OrdersList from './orders';
+import WordPressNotices from './wordpress-notices';
 
 class ActivityPanel extends Component {
 	constructor() {
 		super( ...arguments );
 		this.togglePanel = this.togglePanel.bind( this );
+		this.toggleMobile = this.toggleMobile.bind( this );
+		this.renderTab = this.renderTab.bind( this );
 		this.state = {
-			isOpen: false,
+			isPanelOpen: false,
+			mobileOpen: false,
 			currentTab: '',
 		};
 	}
 
 	togglePanel( tabName ) {
-		const { currentTab } = this.state;
-		if ( tabName === this.state.currentTab || '' === currentTab ) {
+		// The WordPress Notices tab is handled differently, since they are displayed inline, so the panel should be closed,
+		// Close behavior of the expanded notices is based on current tab.
+		if ( 'wpnotices' === tabName ) {
 			this.setState( state => ( {
-				isOpen: ! state.isOpen,
-				currentTab: state.isOpen ? '' : tabName,
+				currentTab: 'wpnotices' === state.currentTab ? '' : tabName,
+				mobileOpen: 'wpnotices' !== state.currentTab,
+				isPanelOpen: false,
 			} ) );
 			return;
 		}
 
-		this.setState( { currentTab: tabName } );
+		this.setState( state => {
+			if (
+				tabName === state.currentTab ||
+				'' === state.currentTab ||
+				'wpnotices' === state.currentTab
+			) {
+				return {
+					isPanelOpen: ! state.isPanelOpen,
+					currentTab: state.isPanelOpen ? '' : tabName,
+					mobileOpen: ! state.isPanelOpen,
+				};
+			}
+			return { currentTab: tabName };
+		} );
 	}
 
+	// On smaller screen, the panel buttons are hidden behind a toggle.
+	toggleMobile() {
+		this.setState( state => ( {
+			mobileOpen: ! state.mobileOpen,
+			currentTab: state.mobileOpen ? '' : 'inbox',
+			isPanelOpen: ! state.mobileOpen,
+		} ) );
+	}
+
+	// TODO Replace with correct icons
 	getTabs() {
 		return [
 			{
-				name: 'orders',
-				title: (
-					<span>
-						{ __( 'Orders', 'woo-dash' ) }{' '}
-						<Count count={ 1 } label={ sprintf( __( '%d Unfulfilled', 'woo-dash' ), 3 ) } />
-					</span>
-				),
-				className: 'woocommerce-layout__activity-panel-tab',
+				name: 'inbox',
+				title: __( 'Inbox', 'woo-dash' ),
+				icon: <Gridicon icon="mail" />,
 			},
 			{
-				name: 'reviews',
-				title: (
-					<span>
-						{ __( 'Reviews', 'woo-dash' ) } <Count count={ 7 } />
-					</span>
-				),
-				className: 'woocommerce-layout__activity-panel-tab',
+				name: 'orders',
+				title: __( 'Orders', 'woo-dash' ),
+				icon: <Gridicon icon="pages" />,
 			},
 			{
 				name: 'stock',
-				title: <span>{ __( 'Stock', 'woo-dash' ) }</span>,
-				className: 'woocommerce-layout__activity-panel-tab',
+				title: __( 'Stock', 'woo-dash' ),
+				icon: <Gridicon icon="clipboard" />,
+			},
+			{
+				name: 'reviews',
+				title: __( 'Reviews', 'woo-dash' ),
+				icon: <Gridicon icon="star" />,
 			},
 		];
 	}
 
-	renderPanel( tab ) {
-		switch ( tab ) {
-			case 'orders':
-				return <OrdersList />;
-			default:
-				return <p>Coming soon…</p>;
+	renderPanel() {
+		const { isPanelOpen, currentTab } = this.state;
+
+		if ( ! isPanelOpen ) {
+			return null;
 		}
+
+		let panelContent;
+
+		switch ( currentTab ) {
+			case 'orders':
+				panelContent = <OrdersList />;
+				break;
+			default:
+				panelContent = <p>Coming soon…</p>;
+		}
+
+		return (
+			<Section component="div" className="woocommerce-layout__activity-panel-content">
+				{ panelContent }
+			</Section>
+		);
+	}
+
+	renderTab( tab ) {
+		const { currentTab } = this.state;
+		const className = classnames( 'woocommerce-layout__activity-panel-tab', {
+			'is-active': tab.name === currentTab,
+		} );
+
+		return (
+			<IconButton
+				key={ tab.name }
+				className={ className }
+				onClick={ partial( this.togglePanel, tab.name ) }
+				icon={ tab.icon }
+			>
+				{ tab.title }
+			</IconButton>
+		);
 	}
 
 	render() {
-		const { isOpen } = this.state;
 		const tabs = this.getTabs();
+		const { currentTab, mobileOpen } = this.state;
 
+		const panelClasses = classnames( 'woocommerce-layout__activity-panel', {
+			'is-mobile-open': this.state.mobileOpen,
+		} );
+
+		// TODO Replace the mobile toggle with the Woo bubble Gridicon once it has been added.
 		return (
-			<TabPanel
-				className="woocommerce-layout__activity-panel-tabs"
-				activeClass="is-active"
-				tabs={ tabs }
-				onSelect={ this.togglePanel }
-			>
-				{ selectedTabName => {
-					if ( ! isOpen ) {
-						return null;
-					}
-					return (
-						<Section component="div" className="woocommerce-layout__activity-panel-content">
-							<H>Section: { selectedTabName }</H>
-							{ this.renderPanel( selectedTabName ) }
-						</Section>
-					);
-				} }
-			</TabPanel>
+			<Fragment>
+				<IconButton
+					onClick={ this.toggleMobile }
+					icon={ mobileOpen ? <Gridicon icon="cross-small" /> : 'admin-generic' }
+					label={ __( 'View Activity Panel' ) }
+					aria-expanded={ mobileOpen }
+					tooltip={ false }
+					className="woocommerce-layout__activity-panel-mobile-toggle"
+				/>
+				<div className={ panelClasses }>
+					<div className="woocommerce-layout__activity-panel-tabs">
+						{ tabs && tabs.map( this.renderTab ) }
+						<WordPressNotices
+							showNotices={ 'wpnotices' === currentTab }
+							togglePanel={ this.togglePanel }
+						/>
+					</div>
+					{ this.renderPanel() }
+				</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -1,0 +1,121 @@
+/** @format */
+
+.woocommerce-layout__activity-panel {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-end;
+	position: fixed;
+	top: 30px;
+	right: 0;
+	max-width: 400px;
+	height: 81px;
+
+	@include breakpoint( '782px-1100px' ) {
+		max-width: 280px;
+		height: 61px;
+	}
+
+	@include breakpoint( '<782px' ) {
+		position: fixed;
+		top: 93px;
+		background: #fff;
+		min-width: 100%;
+		height: 50px;
+		display: none;
+	}
+
+	&.is-mobile-open {
+		display: flex;
+		align-items: flex-end;
+	}
+}
+
+.woocommerce-layout__activity-panel-tabs {
+	width: 100%;
+	display: flex;
+
+	@include breakpoint( '782px-1100px' ) {
+		height: 60px;
+	}
+
+	@include breakpoint( '>1100px' ) {
+		height: 80px;
+	}
+
+	.dashicon,
+	.gridicon {
+		width: 100%;
+	}
+
+	svg {
+		width: 18px;
+		height: 18px;
+
+		@include breakpoint( '>1100px' ) {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
+	.components-icon-button {
+		display: initial;
+		text-indent: 0px;
+	}
+
+	.woocommerce-layout__activity-panel-tab {
+		border: none;
+		outline: none;
+		cursor: pointer;
+		background-color: transparent;
+		padding: 0.5em 0.5em 9px 0.5em;
+		color: $gray-darken-30;
+		width: 100%;
+
+		&.is-active {
+			color: $gray-darken-40;
+			border-bottom: 3px solid $woocommerce;
+		}
+
+		&:hover,
+		&:focus,
+		&.components-button:not(:disabled):not([aria-disabled='true']):hover,
+		&.components-button:not(:disabled):not([aria-disabled='true']):focus {
+			background-color: $core-light-gray-200;
+			box-shadow: none;
+		}
+
+		font-size: 11px;
+		@include breakpoint( '>1100px' ) {
+			font-size: 13px;
+		}
+	}
+}
+
+.woocommerce-layout__activity-panel-mobile-toggle {
+	margin-right: 10px;
+	@include breakpoint( '>782px' ) {
+		display: none;
+	}
+}
+
+.woocommerce-layout__activity-panel-content {
+	height: calc(100vh - 80px);
+	min-height: calc(100vh - 80px);
+	background: $gray;
+	width: 510px;
+	position: fixed;
+	right: 0px;
+	top: 92px;
+	z-index: 1000;
+	overflow-x: hidden;
+	overflow-y: scroll;
+
+	@include breakpoint( '>1100px' ) {
+		top: 112px;
+	}
+
+	@include breakpoint( '<782px' ) {
+		top: 143px;
+		width: 100%;
+	}
+}

--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -14,7 +14,6 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 import ActivityPanel from '../activity-panel';
-import WordPressNotices from './wordpress-notices';
 
 const Header = ( { sections, isEmbedded } ) => {
 	const _sections = isArray( sections ) ? sections : [ sections ];
@@ -51,10 +50,7 @@ const Header = ( { sections, isEmbedded } ) => {
 					return <span key={ i }>{ sectionPiece }</span>;
 				} ) }
 			</h1>
-			<div className="woocommerce-layout__header-panel">
-				<ActivityPanel />
-				<WordPressNotices />
-			</div>
+			<ActivityPanel />
 		</div>
 	);
 };

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -10,11 +10,20 @@
 	background: $white;
 	border-bottom: 1px solid $gray;
 	padding: 2px 2px 2px 12px;
-	height: 81px;
+	height: 80px;
 	position: fixed;
 	width: 100%;
 	top: 32px;
 	z-index: 1000;
+
+	@include breakpoint( '<782px' ) {
+		top: 46px;
+		height: 47px;
+	}
+
+	@include breakpoint( '782px-1100px' ) {
+		height: 60px;
+	}
 
 	.woocommerce-layout__header-breadcrumbs {
 		font-size: 13px;
@@ -28,13 +37,4 @@
 			margin: 0 2px 0 2px;
 		}
 	}
-}
-
-.woocommerce-layout__header-panel {
-	display: flex;
-	flex-direction: row;
-	align-items: baseline;
-	position: fixed;
-	top: 30px;
-	right: 32px;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -4,14 +4,13 @@
 	padding: 0;
 }
 
-.woocommerce-header {
-	min-height: 81px;
-	margin: 0;
-	padding: 8px 16px 8px 16px;
-}
-
 .woocommerce-layout__primary {
-	margin: 81px 0 0 $spacing;
+	margin: 80px 0 0 $spacing;
+
+	@include breakpoint( '>1100px' ) {
+		margin-top: 100px;
+	}
+
 	.woocommerce-layout__main {
 		margin: 0 auto;
 		max-width: 640px;
@@ -21,46 +20,6 @@
 .woocommerce-layout .woocommerce-layout__main {
 	padding-right: $spacing;
 	max-width: 1100px;
-}
-
-.woocommerce-layout__activity-panel-tabs {
-	.components-tab-panel__tabs {
-		display: grid;
-		grid-template-columns: 1fr 1fr 1fr;
-		grid-column-gap: 5px;
-		padding: 2em 2em 0;
-		background-color: transparent;
-	}
-
-	.woocommerce-layout__activity-panel-tab {
-		border: none;
-		outline: none;
-		cursor: pointer;
-		background-color: transparent;
-		padding: 1em 0.5em;
-		color: $gray-darken-30;
-
-		&.is-active {
-			color: $gray-darken-40;
-		}
-
-		h2 {
-			font-size: 1.2em;
-		}
-	}
-}
-
-.woocommerce-layout__activity-panel-content {
-	height: calc(100vh - 81px);
-	min-height: calc(100vh - 81px);
-	background: $gray;
-	width: 515px;
-	position: fixed;
-	right: 0px;
-	top: 113px;
-	z-index: 1000;
-	overflow-x: hidden;
-	overflow-y: scroll;
 }
 
 // @TODO remove this?

--- a/client/stylesheets/_breakpoints.scss
+++ b/client/stylesheets/_breakpoints.scss
@@ -5,7 +5,7 @@
 
 // Think very carefully before adding a new breakpoint.
 // The list below is based on wp-admin's main breakpoints
-$breakpoints: 400px, 600px, 782px, 960px, 1100px;
+$breakpoints: 320px, 400px, 600px, 782px, 960px, 1100px;
 
 @mixin breakpoint( $sizes... ) {
 	@each $size in $sizes {

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -22,6 +22,9 @@ $valid-green: #4ab866;
 $error-red: #d94f4f;
 $woocommerce: #95588a;
 
+// Core Colors
+$core-light-gray-200: #f3f4f5;
+
 // Until we create a separate variables partial
 $spacing: 16px;
 

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -77,7 +77,15 @@
 
 	.woocommerce-layout__primary {
 		margin: 0;
-		padding-top: 81px;
+		padding-top: 80px;
+
+		@include breakpoint( '782px-1100px' ) {
+			padding-top: 60px;
+		}
+
+		&.is-embed-loading {
+			display: none;
+		}
 	}
 }
 
@@ -94,18 +102,41 @@
 .woocommerce-layout__notice-list-show {
 	opacity: 1;
 	height: auto;
-	transition: all 1s ease-in-out;
-	margin-top: 0px;
+	transition: opacity 1s ease-in-out;
+	margin-top: 100px;
 
 	&.has-screen-meta-links {
 		display: inline-block;
 		width: 100%;
 	}
+
+	@include breakpoint( '<782px' ) {
+		margin-top: 115px;
+	}
 }
 
-#woocommerce-embedded-root {
-	@include breakpoint( '<600px' ) {
-		margin-top: 46px;
+.woocommerce-embed-page {
+	.woocommerce-layout__notice-list-show {
+		margin-top: 10px;
+		margin-bottom: 16px;
+
+		@include breakpoint( '<600px' ) {
+			margin-top: 80px;
+			margin-bottom: -16px;
+		}
+
+		@include breakpoint( '600px-782px' ) {
+			margin-top: 32px;
+		}
+	}
+
+	.woocommerce-layout__notice-list-hide {
+		height: auto;
+		margin-top: -50px;
+
+		@include breakpoint( '<782px' ) {
+			margin-top: -100px;
+		}
 	}
 }
 
@@ -115,7 +146,7 @@
 }
 
 #wp__notice-list {
-	padding: 10px;
+	padding-right: 20px;
 }
 
 .woocommerce-layout__notice-list .jitm-card {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -218,14 +218,14 @@ function woocommerce_embed_page_header() {
 	?>
 	<div id="woocommerce-embedded-root">
 		<div class="woocommerce-layout">
-			<div class="woocommerce-layout__header is-loading">
+			<div class="woocommerce-layout__header is-embed-loading">
 				<h1 class="woocommerce-layout__header-breadcrumbs">
 					<span><a href="<?php echo esc_url( admin_url( 'admin.php?page=woodash#/' ) ); ?>">WooCommerce</a></span>
 					<span><?php echo $breadcrumbs; ?></span>
 				</h1>
 			</div>
 		</div>
-		<div class="woocommerce-layout__primary" id="woocommerce-layout__primary">
+		<div class="woocommerce-layout__primary is-embed-loading" id="woocommerce-layout__primary">
 			<div id="woocommerce-layout__notice-list" class="woocommerce-layout__notice-list"></div>
 		</div>
 	</div>


### PR DESCRIPTION
See #90.

There are a few todos left, so I'm leaving the "Needs Design" label off for now. I'll request design feedback on the next PR in the series which should finish implementing the new activity panel tab design and related design treatments, and I can fix issues there. I'm putting this one up since it's already quite a few lines deep and is an improvement over what we have now.

This PR implements the mobile behavior and layout and various screen sizes, new style tabs, and updated placement/width of the panel.

<img width="1037" alt="screen shot 2018-06-28 at 12 43 39 pm" src="https://user-images.githubusercontent.com/689165/42048962-a352e2cc-7ad2-11e8-896d-ca60b9522c67.png">

<img width="1031" alt="screen shot 2018-06-28 at 12 43 00 pm" src="https://user-images.githubusercontent.com/689165/42048967-a8cc0170-7ad2-11e8-9c04-8c4bb9c6d8c8.png">

<img width="837" alt="screen shot 2018-06-28 at 12 42 50 pm" src="https://user-images.githubusercontent.com/689165/42048982-b09d0b56-7ad2-11e8-94e8-08a620d63a17.png">


Todos left:
* Unread bubble
* Some kind of loading indicator for the buttons when loading an embedded/classic page
* Header shadow on scroll
* Minor style updates: Woo icon instead of generic cog, spacing updates.
* Updated panel design

To Test:
* Load up this branch
* Visit any wc-admin page and test the different buttons. Test the notice behavior.
* Visit a classic WC page and test the behavior there.