### PR TITLE
Datepicker: Use api naming before/after

### DIFF
--- a/client/components/calendar/index.js
+++ b/client/components/calendar/index.js
@@ -34,11 +34,11 @@ class DateRange extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { start, end } = props;
+		const { after, before } = props;
 		this.state = {
 			focusedInput: START_DATE,
-			startText: start ? start.format( shortDateFormat ) : '',
-			endText: end ? end.format( shortDateFormat ) : '',
+			afterText: after ? after.format( shortDateFormat ) : '',
+			beforeText: before ? before.format( shortDateFormat ) : '',
 		};
 
 		this.onDatesChange = this.onDatesChange.bind( this );
@@ -49,12 +49,12 @@ class DateRange extends Component {
 
 	onDatesChange( { startDate, endDate } ) {
 		this.setState( {
-			startText: startDate ? startDate.format( shortDateFormat ) : '',
-			endText: endDate ? endDate.format( shortDateFormat ) : '',
+			afterText: startDate ? startDate.format( shortDateFormat ) : '',
+			beforeText: endDate ? endDate.format( shortDateFormat ) : '',
 		} );
 		this.props.onSelect( {
-			start: startDate,
-			end: endDate,
+			after: startDate,
+			before: endDate,
 		} );
 	}
 
@@ -66,15 +66,12 @@ class DateRange extends Component {
 
 	onInputChange( input, event ) {
 		const value = event.target.value;
-		this.setState( { [ input ]: value } );
+		this.setState( { [ input + 'Text' ]: value } );
 		const date = toMoment( shortDateFormat, value );
 		if ( date ) {
-			const match = input.match( /.*(?=Text)/ );
-			if ( match ) {
-				this.props.onSelect( {
-					[ match[ 0 ] ]: date,
-				} );
-			}
+			this.props.onSelect( {
+				[ input ]: date,
+			} );
 		}
 	}
 
@@ -95,22 +92,22 @@ class DateRange extends Component {
 	}
 
 	render() {
-		const { focusedInput, startText, endText } = this.state;
-		const { start, end } = this.props;
+		const { focusedInput, afterText, beforeText } = this.state;
+		const { after, before } = this.props;
 		const isOutsideRange = this.getOutsideRange();
 		const isMobile = isMobileViewport();
 		return (
 			<Fragment>
 				<div className="woocommerce-date-picker__date-inputs">
 					<input
-						value={ startText }
+						value={ afterText }
 						type="text"
-						onChange={ partial( this.onInputChange, 'startText' ) }
+						onChange={ partial( this.onInputChange, 'after' ) }
 						aria-label={ __( 'Start Date', 'woo-dash' ) }
-						id="start-date-string"
-						aria-describedby="start-date-string-message"
+						id="after-date-string"
+						aria-describedby="after-date-string-message"
 					/>
-					<p className="screen-reader-text" id="start-date-string-message">
+					<p className="screen-reader-text" id="after-date-string-message">
 						{ sprintf(
 							__(
 								"Date input describing a selected date range's start date in format %s",
@@ -121,14 +118,14 @@ class DateRange extends Component {
 					</p>
 					<span>{ __( 'to', 'woo-dash' ) }</span>
 					<input
-						value={ endText }
+						value={ beforeText }
 						type="text"
-						onChange={ partial( this.onInputChange, 'endText' ) }
+						onChange={ partial( this.onInputChange, 'before' ) }
 						aria-label={ __( 'End Date', 'woo-dash' ) }
-						id="end-date-string"
-						aria-describedby="end-date-string-message"
+						id="before-date-string"
+						aria-describedby="before-date-string-message"
 					/>
-					<p className="screen-reader-text" id="start-date-string-message">
+					<p className="screen-reader-text" id="before-date-string-message">
 						{ sprintf(
 							__(
 								"Date input describing a selected date range's end date in format %s",
@@ -147,10 +144,10 @@ class DateRange extends Component {
 						onDatesChange={ this.onDatesChange }
 						onFocusChange={ this.onFocusChange }
 						focusedInput={ focusedInput }
-						startDate={ start }
+						startDate={ after }
 						startDateId={ START_DATE }
 						startDatePlaceholderText={ 'Start Date' }
-						endDate={ end }
+						endDate={ before }
 						endDateId={ END_DATE }
 						endDatePlaceholderText={ 'End Date' }
 						orientation={ 'horizontal' }
@@ -159,7 +156,7 @@ class DateRange extends Component {
 						minimumNights={ 0 }
 						hideKeyboardShortcutsPanel
 						noBorder
-						initialVisibleMonth={ () => start || moment() }
+						initialVisibleMonth={ () => after || moment() }
 						phrases={ phrases }
 					/>
 				</div>
@@ -169,8 +166,8 @@ class DateRange extends Component {
 }
 
 DateRange.propTypes = {
-	start: PropTypes.object,
-	end: PropTypes.object,
+	after: PropTypes.object,
+	before: PropTypes.object,
 	onSelect: PropTypes.func.isRequired,
 	inValidDays: PropTypes.oneOfType( [
 		PropTypes.oneOf( [ 'past', 'future', 'none' ] ),

--- a/client/components/date-picker/content.js
+++ b/client/components/date-picker/content.js
@@ -38,8 +38,8 @@ class DatePickerContent extends Component {
 		const {
 			period,
 			compare,
-			start,
-			end,
+			after,
+			before,
 			onSelect,
 			onClose,
 			getUpdatePath,
@@ -83,8 +83,8 @@ class DatePickerContent extends Component {
 								) }
 								{ selectedTab === 'custom' && (
 									<DateRange
-										start={ start }
-										end={ end }
+										after={ after }
+										before={ before }
 										onSelect={ onSelect }
 										inValidDays="future"
 									/>

--- a/client/components/date-picker/index.js
+++ b/client/components/date-picker/index.js
@@ -29,12 +29,12 @@ class DatePicker extends Component {
 		this.setState( this.addQueryDefaults( nextProps.query ) );
 	}
 
-	addQueryDefaults( { period, compare, start, end } ) {
+	addQueryDefaults( { period, compare, after, before } ) {
 		return {
 			period: period || 'today',
 			compare: compare || 'previous_period',
-			start: start ? moment( start ) : null,
-			end: end ? moment( end ) : null,
+			after: after ? moment( after ) : null,
+			before: before ? moment( before ) : null,
 		};
 	}
 
@@ -43,22 +43,22 @@ class DatePicker extends Component {
 	}
 
 	getOtherQueries( query ) {
-		const { period, compare, start, end, ...otherQueries } = query; // eslint-disable-line no-unused-vars
+		const { period, compare, after, before, ...otherQueries } = query; // eslint-disable-line no-unused-vars
 		return otherQueries;
 	}
 
 	getUpdatePath( selectedTab ) {
 		const { path, query } = this.props;
 		const otherQueries = this.getOtherQueries( query );
-		const { period, compare, start, end } = this.state;
+		const { period, compare, after, before } = this.state;
 		const data = {
 			period: 'custom' === selectedTab ? 'custom' : period,
 			compare,
 		};
 		if ( 'custom' === selectedTab ) {
 			Object.assign( data, {
-				start: start ? start.format( isoDateFormat ) : '',
-				end: end ? end.format( isoDateFormat ) : '',
+				after: after ? after.format( isoDateFormat ) : '',
+				before: before ? before.format( isoDateFormat ) : '',
 			} );
 		}
 		const queryString = stringifyQueryObject( Object.assign( otherQueries, data ) );
@@ -81,15 +81,15 @@ class DatePicker extends Component {
 	}
 
 	isValidSelection( selectedTab ) {
-		const { compare, start, end } = this.state;
+		const { compare, after, before } = this.state;
 		if ( 'custom' === selectedTab ) {
-			return compare && start && end;
+			return compare && after && before;
 		}
 		return true;
 	}
 
 	render() {
-		const { period, compare, start, end } = this.state;
+		const { period, compare, after, before } = this.state;
 		return (
 			<Dropdown
 				className="woocommerce-date-picker"
@@ -109,8 +109,8 @@ class DatePicker extends Component {
 					<DatePickerContent
 						period={ period }
 						compare={ compare }
-						start={ start }
-						end={ end }
+						after={ after }
+						before={ before }
 						onSelect={ this.select }
 						onClose={ onClose }
 						getUpdatePath={ this.getUpdatePath }


### PR DESCRIPTION
The datepicker was using `start` and `end`. These changes reflect the api's use of `after` and `before`.

### Notes
Naming of variables in the calculations of primary and secondary ranges were left as is, eg `primaryStart` and `secondaryEnd` because I think it reads easier. The interface for `getCurrentDates` does reflect the updated names.

## Testing

1. Go to `/wp-admin/admin.php?page=woodash#/analytics`
2. Make sure the datepicker works as expected and throws no errors
3. Ensure the url reflects the updated names when choosing custom dates

Fixes https://github.com/woocommerce/wc-admin/issues/130