### PR TITLE
Activity Panel: Unread bubble, animations, cleaned up styles/mobile handling

### DIFF
--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -79,6 +79,6 @@
 
 .woocommerce-pagination__page-picker-input.has-error,
 .woocommerce-pagination__page-picker-input.has-error:focus {
-	border-color: $alert-red;
-	box-shadow: 0 0 2px $alert-red;
+	border-color: $error-red;
+	box-shadow: 0 0 2px $error-red;
 }

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -3,40 +3,42 @@
 .woocommerce-layout__activity-panel {
 	display: flex;
 	flex-direction: row;
-	align-items: flex-end;
+	align-items: center;
 	position: fixed;
-	top: 30px;
+	top: 31px;
 	right: 0;
-	max-width: 400px;
-	height: 81px;
+	height: 80px;
+
+	@include breakpoint( '<782px' ) {
+		position: relative;
+		background: #fff;
+		margin: 0;
+		padding: 0;
+		top: auto;
+		display: none;
+		border-top: 1px solid $gray;
+		height: 61px;
+		flex: 1 100%;
+	}
 
 	@include breakpoint( '782px-1100px' ) {
 		max-width: 280px;
-		height: 61px;
+		height: 60px;
 	}
 
-	@include breakpoint( '<782px' ) {
-		position: fixed;
-		top: 93px;
-		background: #fff;
-		min-width: 100%;
-		height: 50px;
-		display: none;
+	@include breakpoint( '>1100px' ) {
+		max-width: 400px;
 	}
 
 	&.is-mobile-open {
 		display: flex;
-		align-items: flex-end;
 	}
 }
 
 .woocommerce-layout__activity-panel-tabs {
 	width: 100%;
 	display: flex;
-
-	@include breakpoint( '782px-1100px' ) {
-		height: 60px;
-	}
+	height: 60px;
 
 	@include breakpoint( '>1100px' ) {
 		height: 80px;
@@ -66,35 +68,89 @@
 		border: none;
 		outline: none;
 		cursor: pointer;
-		background-color: transparent;
-		padding: 0.5em 0.5em 9px 0.5em;
-		color: $gray-darken-30;
+		background-color: $white;
+		color: $core-dark-gray-500;
 		width: 100%;
+		height: 60px;
+		border-bottom: 3px solid $white;
+
+		@include breakpoint( '>1100px' ) {
+			height: 80px;
+		}
 
 		&.is-active {
-			color: $gray-darken-40;
+			color: $core-dark-gray-700;
 			border-bottom: 3px solid $woocommerce;
+			box-shadow: none;
 		}
 
 		&:hover,
-		&:focus,
 		&.components-button:not(:disabled):not([aria-disabled='true']):hover,
+		&:focus,
 		&.components-button:not(:disabled):not([aria-disabled='true']):focus {
 			background-color: $core-light-gray-200;
 			box-shadow: none;
+		}
+
+		&:focus:not(.is-active),
+		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):focus,
+		&:hover:not(.is-active),
+		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):hover {
+			border-bottom: 3px solid $core-light-gray-200;
 		}
 
 		font-size: 11px;
 		@include breakpoint( '>1100px' ) {
 			font-size: 13px;
 		}
+
+		&.has-unread:after,
+		&.woocommerce-layout__activity-panel-tab-wordpress-notices:after {
+			content: ' ';
+			position: absolute;
+			padding: 1px;
+			background: $core-orange;
+			border: 2px solid $white;
+			width: 4px;
+			height: 4px;
+			display: inline-block;
+			border-radius: 50%;
+			top: 10px;
+			left: 50%;
+
+			@include breakpoint( '782px-1100px' ) {
+				top: 8px;
+				right: 18px;
+				left: initial;
+				margin-left: 0;
+			}
+
+			@include breakpoint( '>1100px' ) {
+				top: 16px;
+				right: 28px;
+				left: initial;
+				margin-left: 0;
+			}
+		}
 	}
 }
 
 .woocommerce-layout__activity-panel-mobile-toggle {
 	margin-right: 10px;
+	max-width: 48px;
+	height: 46px;
 	@include breakpoint( '>782px' ) {
 		display: none;
+	}
+}
+
+@keyframes tabSwitch {
+	0%,
+	100% {
+		transform: translateX(0);
+	}
+	50% {
+		transform: translateX(100px);
 	}
 }
 
@@ -102,7 +158,8 @@
 	height: calc(100vh - 80px);
 	min-height: calc(100vh - 80px);
 	background: $gray;
-	width: 510px;
+	width: 0px;
+	transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
 	position: fixed;
 	right: 0px;
 	top: 92px;
@@ -115,7 +172,19 @@
 	}
 
 	@include breakpoint( '<782px' ) {
-		top: 143px;
-		width: 100%;
+		top: 153px;
+	}
+
+	&.is-open {
+		transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+		width: 510px;
+		@include breakpoint( '<782px' ) {
+			width: 100%;
+		}
+	}
+
+	&.is-tab-switch {
+		animation: tabSwitch;
+		animation-duration: 300ms;
 	}
 }

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -14,7 +14,7 @@
 		background: #fff;
 		margin: 0;
 		padding: 0;
-		top: auto;
+		top: 10px;
 		display: none;
 		border-top: 1px solid $gray;
 		height: 61px;
@@ -69,7 +69,7 @@
 		outline: none;
 		cursor: pointer;
 		background-color: $white;
-		color: $core-dark-gray-500;
+		color: $core-grey-dark-500;
 		width: 100%;
 		height: 60px;
 		border-bottom: 3px solid $white;
@@ -79,24 +79,9 @@
 		}
 
 		&.is-active {
-			color: $core-dark-gray-700;
+			color: $core-grey-dark-700;
 			border-bottom: 3px solid $woocommerce;
 			box-shadow: none;
-		}
-
-		&:hover,
-		&.components-button:not(:disabled):not([aria-disabled='true']):hover,
-		&:focus,
-		&.components-button:not(:disabled):not([aria-disabled='true']):focus {
-			background-color: $core-light-gray-200;
-			box-shadow: none;
-		}
-
-		&:focus:not(.is-active),
-		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):focus,
-		&:hover:not(.is-active),
-		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):hover {
-			border-bottom: 3px solid $core-light-gray-200;
 		}
 
 		font-size: 11px;
@@ -132,6 +117,30 @@
 				margin-left: 0;
 			}
 		}
+
+		&:hover,
+		&.components-button:not(:disabled):not([aria-disabled='true']):hover,
+		&:focus,
+		&.components-button:not(:disabled):not([aria-disabled='true']):focus {
+			background-color: $core-grey-light-200;
+			box-shadow: none;
+
+			&.has-unread:after,
+			&.woocommerce-layout__activity-panel-tab-wordpress-notices:after {
+				border-color: $core-grey-light-200;
+			}
+		}
+
+		&:focus:not(.is-active),
+		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):focus,
+		&:hover:not(.is-active),
+		&.components-button:not(.is-active):not(:disabled):not([aria-disabled='true']):hover {
+			border-bottom: 3px solid $core-grey-light-200;
+			&.has-unread:after,
+			&.woocommerce-layout__activity-panel-tab-wordpress-notices:after {
+				border-color: $core-grey-light-200;
+			}
+		}
 	}
 }
 
@@ -139,6 +148,9 @@
 	margin-right: 10px;
 	max-width: 48px;
 	height: 46px;
+	position: fixed;
+	top: 46px;
+	right: 0;
 	@include breakpoint( '>782px' ) {
 		display: none;
 	}
@@ -154,12 +166,16 @@
 	}
 }
 
-.woocommerce-layout__activity-panel-content {
+@mixin activity-panel-slide {
+	transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.woocommerce-layout__activity-panel-wrapper {
 	height: calc(100vh - 80px);
 	min-height: calc(100vh - 80px);
 	background: $gray;
 	width: 0px;
-	transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+	@include activity-panel-slide();
 	position: fixed;
 	right: 0px;
 	top: 92px;
@@ -176,14 +192,14 @@
 	}
 
 	&.is-open {
-		transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+		@include activity-panel-slide();
 		width: 510px;
 		@include breakpoint( '<782px' ) {
 			width: 100%;
 		}
 	}
 
-	&.is-tab-switch {
+	.woocommerce-layout__activity-panel-content {
 		animation: tabSwitch;
 		animation-duration: 300ms;
 	}

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -15,9 +15,9 @@
 		margin: 0;
 		padding: 0;
 		top: 10px;
+		width: 100vw;
 		display: none;
-		border-top: 1px solid $gray;
-		height: 61px;
+		height: 60px;
 		flex: 1 100%;
 	}
 

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -186,6 +186,7 @@ class WordPressNotices extends Component {
 		}
 
 		const className = classnames( 'woocommerce-layout__activity-panel-tab', {
+			'woocommerce-layout__activity-panel-tab-wordpress-notices': true,
 			'is-active': showNotices,
 		} );
 

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -5,11 +5,10 @@
 	display: flex;
 	justify-content: space-between;
 	flex-direction: row;
-	align-items: center;
 	box-sizing: border-box;
 	background: $white;
 	border-bottom: 1px solid $gray;
-	padding: 2px 2px 2px 12px;
+	padding: 0px;
 	height: 80px;
 	position: fixed;
 	width: 100%;
@@ -19,6 +18,7 @@
 	@include breakpoint( '<782px' ) {
 		top: 46px;
 		height: 47px;
+		flex-flow: row wrap;
 	}
 
 	@include breakpoint( '782px-1100px' ) {
@@ -28,13 +28,28 @@
 	.woocommerce-layout__header-breadcrumbs {
 		font-size: 13px;
 		font-weight: normal;
-		padding: 9px 0 4px 0;
-		margin-left: 35px;
+		padding: 0px;
+		margin-left: $spacing;
+		flex: 1 auto;
+
+		padding-top: 8px;
+
+		@include breakpoint( '782px-1100px' ) {
+			padding-top: 16px;
+		}
+
+		@include breakpoint( '>1100px' ) {
+			padding-top: 24px;
+		}
 
 		span + span::before {
 			content: ' / ';
 			color: $gray-text;
 			margin: 0 2px 0 2px;
+		}
+
+		a {
+			color: $woocommerce;
 		}
 	}
 }

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -17,24 +17,18 @@ $core-grey-light-200: #f3f4f5;
 $core-grey-light-300: #f3f4f5; // same as 200? By accident?
 $core-grey-light-500: #e2e4e7;
 $core-grey-light-700: #ccd0d4;
-//$core-grey-dark-500: #E8EAEB;
-$core-grey-dark-500: #3c3d3e; // This seems really light, so I made one up
+$core-grey-dark-500: #555d66;
+$core-grey-dark-700: #32373c;
 
+// wp-admin
 $wp-admin-background: #f1f1f1;
-
-// Black
 $black: #24292d; // same as wp-admin sidebar
 
 // Bright colors
 $valid-green: #4ab866;
 $error-red: #d94f4f;
 $woocommerce: #95588a;
-
-// Core Colors
 $core-orange: #ca4a1f;
-$core-light-gray-200: #f3f4f5;
-$core-dark-gray-500: #555d66;
-$core-dark-gray-700: #32373c;
 
 // Until we create a separate variables partial
 $spacing: 16px;

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -31,12 +31,13 @@ $error-red: #d94f4f;
 $woocommerce: #95588a;
 
 // Core Colors
+$core-orange: #ca4a1f;
 $core-light-gray-200: #f3f4f5;
+$core-dark-gray-500: #555d66;
+$core-dark-gray-700: #32373c;
 
 // Until we create a separate variables partial
 $spacing: 16px;
-
-$alert-red: #d94f4f;
 
 $button: #f0f2f4;
 $button-border: darken($button, 20%);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prettier": "github:automattic/calypso-prettier#c56b4251",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
+    "react-click-outside": "2.3.1",
     "react-dom": "^16.3.2",
     "react-router-dom": "^4.2.2",
     "readline-sync": "^1.4.9",


### PR DESCRIPTION
This PR makes a few more adjustments to the ActivityPanel.

It adds:
* Unread bubbles (static for now)
* Animations
* Cleaned up style/mobile handling

I think the tab portion & animations of the activity panel is ready for some design eyes.

Video in action: https://cloudup.com/cga7sFPEJod

<img width="447" alt="screen shot 2018-07-03 at 6 36 18 pm" src="https://user-images.githubusercontent.com/689165/42247721-07c1937c-7ef0-11e8-969a-a5d2bce9e00d.png">

<img width="718" alt="screen shot 2018-07-03 at 6 36 30 pm" src="https://user-images.githubusercontent.com/689165/42247725-0ab9d1c0-7ef0-11e8-8574-94d32e7708eb.png">


Still to come in future PRs:
* Woo logo instead of cog
* Panel Styles
* Shadow on scroll for header
* Improvements on classic pages

To Test:
* Visit the dashboard. Try opening tabs, switching between them, etc.
* Test different screen sizes. Make sure things look OK.
