### PR TITLE
Date: Load locale data to moment

### DIFF
--- a/client/components/calendar/index.js
+++ b/client/components/calendar/index.js
@@ -158,6 +158,7 @@ class DateRange extends Component {
 						noBorder
 						initialVisibleMonth={ () => after || moment() }
 						phrases={ phrases }
+						firstDayOfWeek={ Number( wcSettings.date.dow ) }
 					/>
 				</div>
 			</Fragment>

--- a/client/lib/currency/index.js
+++ b/client/lib/currency/index.js
@@ -13,7 +13,7 @@ import { get, isNaN } from 'lodash';
  * @returns {?String}                  A formatted string.
  */
 export function formatCurrency( number, currency ) {
-	const locale = wcSettings.locale || 'en-US'; // Default so we don't break.
+	const locale = wcSettings.siteLocale || 'en-US'; // Default so we don't break.
 
 	// default to wcSettings if currency is not passed in
 	if ( ! currency ) {

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -5,6 +5,7 @@
 import moment from 'moment';
 import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
+import { getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -238,3 +239,37 @@ export const getCurrentDates = ( { period, compare, after, before } ) => {
 		},
 	};
 };
+
+export function loadLocaleData() {
+	const { date } = wcSettings;
+	const settings = getSettings();
+	const userLocale = settings.l10n.locale;
+	const { weekdaysShort } = settings.l10n;
+
+	// Keep the default Momentjs English settings for any English
+	if ( ! userLocale.match( /en_/ ) ) {
+		moment.updateLocale( userLocale, {
+			longDateFormat: {
+				L: __( 'MM/DD/YYYY', 'woo-dash' ),
+				LL: __( 'MMMM D, YYYY', 'woo-dash' ),
+				LLL: __( 'D MMMM YYYY LT', 'woo-dash' ),
+				LLLL: __( 'dddd, D MMMM YYYY LT', 'woo-dash' ),
+				LT: __( 'HH:mm', 'woo-dash' ),
+			},
+			calendar: {
+				lastDay: __( '[Yesterday at] LT', 'woo-dash' ),
+				lastWeek: __( '[Last] dddd [at] LT', 'woo-dash' ),
+				nextDay: __( '[Tomorrow at] LT', 'woo-dash' ),
+				nextWeek: __( 'dddd [at] LT', 'woo-dash' ),
+				sameDay: __( '[Today at] LT', 'woo-dash' ),
+				sameElse: __( 'L', 'woo-dash' ),
+			},
+			week: {
+				dow: Number( date.dow ),
+			},
+			weekdaysMin: weekdaysShort,
+		} );
+	}
+}
+
+loadLocaleData();

--- a/client/lib/date/test/index.js
+++ b/client/lib/date/test/index.js
@@ -3,11 +3,12 @@
  * External dependencies
  */
 import moment from 'moment';
+import { setSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
-import { toMoment, getLastPeriod, getCurrentPeriod, getRangeLabel } from 'lib/date';
+import { toMoment, getLastPeriod, getCurrentPeriod, getRangeLabel, loadLocaleData } from 'lib/date';
 
 describe( 'toMoment', () => {
 	it( 'should pass through a valid Moment object as an argument', () => {
@@ -416,5 +417,129 @@ describe( 'getRangeLabel', () => {
 	it( 'should return correct string for dates in different years', () => {
 		const label = getRangeLabel( moment( '2017-04-01' ), moment( '2018-05-15' ) );
 		expect( label ).toBe( 'Apr 1, 2017 - May 15, 2018' );
+	} );
+} );
+
+describe( 'loadLocaleData', () => {
+	beforeEach( () => {
+		// Reset to default settings
+		setSettings( {
+			l10n: {
+				locale: 'en_US',
+				months: [
+					'January',
+					'February',
+					'March',
+					'April',
+					'May',
+					'June',
+					'July',
+					'August',
+					'September',
+					'October',
+					'November',
+					'December',
+				],
+				monthsShort: [
+					'Jan',
+					'Feb',
+					'Mar',
+					'Apr',
+					'May',
+					'Jun',
+					'Jul',
+					'Aug',
+					'Sep',
+					'Oct',
+					'Nov',
+					'Dec',
+				],
+				weekdays: [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ],
+				weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+				meridiem: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM' },
+				relative: { future: ' % s from now', past: '% s ago' },
+			},
+			formats: {
+				time: 'g: i a',
+				date: 'F j, Y',
+				datetime: 'F j, Y g: i a',
+			},
+			timezone: { offset: '0', string: '' },
+		} );
+
+		wcSettings = {
+			adminUrl: 'https://vagrant.local/wp/wp-admin/',
+			locale: 'en-US',
+			currency: { code: 'USD', precision: 2, symbol: '&#36;' },
+			date: {
+				dow: 0,
+			},
+		};
+	} );
+
+	function setToFrancais() {
+		setSettings( {
+			l10n: {
+				locale: 'fr_FR',
+				months: [
+					'janvier',
+					'f\u00e9vrier',
+					'mars',
+					'avril',
+					'mai',
+					'juin',
+					'juillet',
+					'ao\u00fbt',
+					'septembre',
+					'octobre',
+					'novembre',
+					'd\u00e9cembre',
+				],
+				monthsShort: [
+					'Jan',
+					'F\u00e9v',
+					'Mar',
+					'Avr',
+					'Mai',
+					'Juin',
+					'Juil',
+					'Ao\u00fbt',
+					'Sep',
+					'Oct',
+					'Nov',
+					'D\u00e9c',
+				],
+				weekdays: [ 'dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi' ],
+				weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
+				meridiem: { am: ' ', pm: ' ', AM: ' ', PM: ' ' },
+				relative: { future: '%s \u00e0 partir de maintenant', past: 'Il y a %s' },
+			},
+			formats: { time: 'g:i a', date: 'F j, Y', datetime: 'j F Y G \\h i \\m\\i\\n' },
+			timezone: { offset: '0', string: '' },
+		} );
+	}
+
+	it( 'should leave default momentjs data unchanged for english languages', () => {
+		loadLocaleData();
+		expect( moment.locale() ).toBe( 'en' );
+	} );
+
+	it( "should load french data on user locale 'fr-FR'", () => {
+		setToFrancais();
+		loadLocaleData();
+		expect( moment.months()[ 0 ] ).toBe( 'janvier' );
+	} );
+
+	it( "should load translated longDateFormats on user locale 'fr-FR'", () => {
+		setToFrancais();
+		loadLocaleData();
+		expect( moment.localeData()._longDateFormat.LL ).not.toBe( 'F j, Y' );
+	} );
+
+	it( "should load start of week on user locale 'fr-FR'", () => {
+		setToFrancais();
+		wcSettings.date.dow = 5;
+		loadLocaleData();
+		expect( moment.localeData()._week.dow ).toBe( 5 );
 	} );
 } );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -41,8 +41,11 @@ function woo_dash_register_script() {
 	$settings = array(
 		'adminUrl'           => admin_url(),
 		'embedBreadcrumbs'   => woo_dash_get_embed_breadcrumbs(),
-		'locale'   => esc_attr( get_bloginfo( 'language' ) ),
+		'siteLocale'   => esc_attr( get_bloginfo( 'language' ) ),
 		'currency'  => woo_dash_currency_settings(),
+		'date' => array(
+			'dow' => get_option( 'start_of_week', 0 ),
+		),
 	);
 
 	wp_add_inline_script(

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -37,6 +37,9 @@ global.wcSettings = {
 	adminUrl: 'https://vagrant.local/wp/wp-admin/',
 	locale: 'en-US',
 	currency: { code: 'USD', precision: 2, symbol: '&#36;' },
+	date: {
+		dow: 0,
+	},
 };
 
 Object.defineProperty( global.wp, 'date', {


### PR DESCRIPTION
Load `i18n` data from Gutenberg into momentjs so that names of months, days, and other data is available:

```js
moment().format( 'D MMMM YYYY' );
// "4 juillet 2018" 🇺🇸
```

## Testing

1. Change your language to something other than english. Also change the setting for first day of the week.
2. Head to `/wp-admin/admin.php?page=woodash#/analytics`
2. See the new dates reflected in the datepicker launcher. **NB:** The strings, eg "Today", and formats have yet to be translated, so they will still be `en-us`.
![screen shot 2018-07-04 at 2 06 00 pm](https://user-images.githubusercontent.com/1922453/42253012-bcbcbb78-7f93-11e8-8c91-23135b2f1e0a.png)
4. Open the datepicker and go to custom date picker tab. See the updated month, days, and the calender should reflect the first day of the week chosen in Step 1.
![screen shot 2018-07-04 at 2 20 38 pm](https://user-images.githubusercontent.com/1922453/42253352-81f14d4a-7f95-11e8-9f46-e8154e00fb0a.png)

## locale v locale
Gutenberg's locale is from [get_user_locale](https://developer.wordpress.org/reference/functions/get_user_locale/) so that makes sense to use for setting Moment data. `wcSettings` locale is from [get_bloginfo](https://developer.wordpress.org/reference/functions/get_bloginfo/) which makes more sense for currency. So I renamed `wcSettings.locale` to `wcSettings.siteLocale`.

Fixes https://github.com/woocommerce/wc-admin/issues/135