### PR TITLE
Add ActivityHeader & implement panel styles

### DIFF
--- a/client/components/segmented-selection/style.scss
+++ b/client/components/segmented-selection/style.scss
@@ -23,7 +23,7 @@
 	height: 100%;
 
 	&:active {
-		background-color: $core-grey-light-300;
+		background-color: $core-grey-light-200;
 	}
 
 	&:hover {
@@ -37,7 +37,7 @@
 	left: -9999px;
 
 	&:active + label .woocommerce-segmented-selection__label {
-		background-color: $core-grey-light-300;
+		background-color: $core-grey-light-200;
 	}
 
 	&:checked + label .woocommerce-segmented-selection__label {

--- a/client/layout/activity-panel/activity-header/README.md
+++ b/client/layout/activity-panel/activity-header/README.md
@@ -1,0 +1,24 @@
+ActivityHeader
+============
+
+A component designed for use in the activity panel. It returns a title and can optionally also include a component like dropdown or Ellipsis menu.
+
+## How to use:
+
+```jsx
+import ActivityHeader from 'components/activity-header';
+
+render: function() {
+  return (
+    <ActivityHeader
+      title="Orders"
+    />
+  );
+}
+```
+
+## Props
+
+* `title`: A title for this card (required).
+* `className`: Additional class names.
+* `menu`: A dropdown menu (EllipsisMenu) shown at the top-right of the card.

--- a/client/layout/activity-panel/activity-header/index.js
+++ b/client/layout/activity-panel/activity-header/index.js
@@ -1,0 +1,38 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { EllipsisMenu } from 'components/ellipsis-menu';
+import { H } from 'layout/section';
+
+class ActivityHeader extends Component {
+	render() {
+		const { title, className, menu } = this.props;
+		const cardClassName = classnames( 'woocommerce-layout__activity-panel-header', className );
+
+		return (
+			<div className={ cardClassName }>
+				<H className="woocommerce-layout__activity-panel-header-title">{ title }</H>
+				{ menu && <div className="woocommerce-layout__activity-panel-header-menu">{ menu }</div> }
+			</div>
+		);
+	}
+}
+
+ActivityHeader.propTypes = {
+	className: PropTypes.string,
+	title: PropTypes.string.isRequired,
+	menu: PropTypes.shape( {
+		type: PropTypes.oneOf( [ EllipsisMenu ] ),
+	} ),
+};
+
+export default ActivityHeader;

--- a/client/layout/activity-panel/activity-header/style.scss
+++ b/client/layout/activity-panel/activity-header/style.scss
@@ -1,0 +1,29 @@
+/** @format */
+
+.woocommerce-layout__activity-panel-header {
+	height: 50px;
+	background: $core-grey-light-500;
+	padding: 16px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	@include breakpoint( '>782px' ) {
+		padding: 16px 24px 16px 24px;
+	}
+
+	h3 {
+		font-size: 13px;
+		font-weight: 600;
+		line-height: 16px;
+		margin: 0;
+		padding: 0;
+	}
+
+	.woocommerce-ellipsis-menu__toggle.components-button:not(:disabled):not([aria-disabled='true']):focus,
+	.woocommerce-ellipsis-menu__toggle.components-button:not(:disabled):not([aria-disabled='true']):hover {
+		box-shadow: none;
+		border-radius: 10px;
+		background: $core-grey-light-700;
+	}
+}

--- a/client/layout/activity-panel/inbox.js
+++ b/client/layout/activity-panel/inbox.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ActivityHeader from './activity-header';
+
+class InboxPanel extends Component {
+	render() {
+		return <ActivityHeader title={ __( 'Inbox', 'woo-dash' ) } />;
+	}
+}
+
+export default InboxPanel;

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -14,6 +14,7 @@ import { partial } from 'lodash';
  * Internal dependencies
  */
 import './style.scss';
+import ActivityPanelToggleBubble from './toggle-bubble';
 import { Section } from 'layout/section';
 import OrdersList from './orders';
 import WordPressNotices from './wordpress-notices';
@@ -171,7 +172,7 @@ class ActivityPanel extends Component {
 			<div id="woocommerce-activity-panel">
 				<IconButton
 					onClick={ this.toggleMobile }
-					icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <Gridicon icon="cog" /> }
+					icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <ActivityPanelToggleBubble /> }
 					label={ mobileOpen ? __( 'Close Activity Panel' ) : __( 'View Activity Panel' ) }
 					aria-expanded={ mobileOpen }
 					tooltip={ false }

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -16,7 +16,10 @@ import { partial } from 'lodash';
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
 import { Section } from 'layout/section';
-import OrdersList from './orders';
+import InboxPanel from './inbox';
+import OrdersPanel from './orders';
+import StockPanel from './stock';
+import ReviewsPanel from './reviews';
 import WordPressNotices from './wordpress-notices';
 
 class ActivityPanel extends Component {
@@ -109,10 +112,16 @@ class ActivityPanel extends Component {
 
 	getPanelContent( tab ) {
 		switch ( tab ) {
+			case 'inbox':
+				return <InboxPanel />;
 			case 'orders':
-				return <OrdersList />;
+				return <OrdersPanel />;
+			case 'stock':
+				return <StockPanel />;
+			case 'reviews':
+				return <ReviewsPanel />;
 			default:
-				return <p>Coming soon…</p>;
+				return null;
 		}
 	}
 

--- a/client/layout/activity-panel/orders.js
+++ b/client/layout/activity-panel/orders.js
@@ -6,6 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { compose, Fragment } from '@wordpress/element';
 import { Dashicon, withAPIData } from '@wordpress/components';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ function OrdersPanel( { orders } ) {
 	const menu = (
 		<EllipsisMenu label="Demo Menu">
 			<MenuTitle>Test</MenuTitle>
-			<MenuItem>Test</MenuItem>
+			<MenuItem onInvoke={ noop }>Test</MenuItem>
 		</EllipsisMenu>
 	);
 

--- a/client/layout/activity-panel/orders.js
+++ b/client/layout/activity-panel/orders.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 import { Dashicon, withAPIData } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -11,64 +11,76 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ActivityCard from './activity-card';
+import ActivityHeader from './activity-header';
+import { EllipsisMenu, MenuTitle, MenuItem } from 'components/ellipsis-menu';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';
 import { Section } from 'layout/section';
 
-function OrdersList( { orders } ) {
+function OrdersPanel( { orders } ) {
 	const { data = [], isLoading } = orders;
 
+	const menu = (
+		<EllipsisMenu label="Demo Menu">
+			<MenuTitle>Test</MenuTitle>
+			<MenuItem>Test</MenuItem>
+		</EllipsisMenu>
+	);
+
 	return (
-		<Section>
-			{ isLoading ? (
-				<p>Loading</p>
-			) : (
-				data.map( ( order, i ) => {
-					// We want the billing address, but shipping can be used as a fallback.
-					const address = { ...order.shipping, ...order.billing };
-					const name = `${ address.first_name } ${ address.last_name }`;
-					const productsCount = order.line_items.reduce(
-						( total, line ) => total + line.quantity,
-						0
-					);
+		<Fragment>
+			<ActivityHeader title={ __( 'Orders', 'woo-dash' ) } menu={ menu } />
+			<Section>
+				{ isLoading ? (
+					<p>Loading</p>
+				) : (
+					data.map( ( order, i ) => {
+						// We want the billing address, but shipping can be used as a fallback.
+						const address = { ...order.shipping, ...order.billing };
+						const name = `${ address.first_name } ${ address.last_name }`;
+						const productsCount = order.line_items.reduce(
+							( total, line ) => total + line.quantity,
+							0
+						);
 
-					const total = order.total;
-					const refundValue = getOrderRefundTotal( order );
-					const remainingTotal = getCurrencyFormatDecimal( order.total ) + refundValue;
+						const total = order.total;
+						const refundValue = getOrderRefundTotal( order );
+						const remainingTotal = getCurrencyFormatDecimal( order.total ) + refundValue;
 
-					return (
-						<ActivityCard
-							key={ i }
-							label={ __( 'Order', 'woo-dash' ) }
-							icon={ <Dashicon icon="format-aside" /> }
-							date={ order.date_created }
-						>
-							<div>{ sprintf( __( '%s placed order #%d', 'woo-dash' ), name, order.id ) }</div>
-							<div>
-								<span>
-									{ sprintf(
-										_n( '%d product', '%d products', productsCount, 'woo-dash' ),
-										productsCount
-									) }
-								</span>{' '}
-								{ refundValue ? (
+						return (
+							<ActivityCard
+								key={ i }
+								label={ __( 'Order', 'woo-dash' ) }
+								icon={ <Dashicon icon="format-aside" /> }
+								date={ order.date_created }
+							>
+								<div>{ sprintf( __( '%s placed order #%d', 'woo-dash' ), name, order.id ) }</div>
+								<div>
 									<span>
-										<s>{ formatCurrency( total, order.currency ) }</s>{' '}
-										{ formatCurrency( remainingTotal, order.currency ) }
-									</span>
-								) : (
-									<span>{ formatCurrency( total, order.currency ) }</span>
-								) }
-							</div>
-						</ActivityCard>
-					);
-				} )
-			) }
-		</Section>
+										{ sprintf(
+											_n( '%d product', '%d products', productsCount, 'woo-dash' ),
+											productsCount
+										) }
+									</span>{' '}
+									{ refundValue ? (
+										<span>
+											<s>{ formatCurrency( total, order.currency ) }</s>{' '}
+											{ formatCurrency( remainingTotal, order.currency ) }
+										</span>
+									) : (
+										<span>{ formatCurrency( total, order.currency ) }</span>
+									) }
+								</div>
+							</ActivityCard>
+						);
+					} )
+				) }
+			</Section>
+		</Fragment>
 	);
 }
 
-OrdersList.propTypes = {
+OrdersPanel.propTypes = {
 	orders: PropTypes.object.isRequired,
 };
 
@@ -76,4 +88,4 @@ export default compose( [
 	withAPIData( () => ( {
 		orders: '/wc/v3/orders',
 	} ) ),
-] )( OrdersList );
+] )( OrdersPanel );

--- a/client/layout/activity-panel/reviews.js
+++ b/client/layout/activity-panel/reviews.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ActivityHeader from './activity-header';
+
+class ReviewsPanel extends Component {
+	render() {
+		return <ActivityHeader title={ __( 'Reviews', 'woo-dash' ) } />;
+	}
+}
+
+export default ReviewsPanel;

--- a/client/layout/activity-panel/stock.js
+++ b/client/layout/activity-panel/stock.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ActivityHeader from './activity-header';
+
+class StockPanel extends Component {
+	render() {
+		return <ActivityHeader title={ __( 'Stock', 'woo-dash' ) } />;
+	}
+}
+
+export default StockPanel;

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -5,7 +5,6 @@
 	flex-direction: row;
 	align-items: center;
 	position: fixed;
-	top: 31px;
 	right: 0;
 	height: 80px;
 
@@ -14,7 +13,7 @@
 		background: #fff;
 		margin: 0;
 		padding: 0;
-		top: 10px;
+		top: -3px;
 		width: 100vw;
 		display: none;
 		height: 60px;
@@ -173,7 +172,8 @@
 .woocommerce-layout__activity-panel-wrapper {
 	height: calc(100vh - 80px);
 	min-height: calc(100vh - 80px);
-	background: $gray;
+	background: $core-grey-light-200;
+	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	width: 0px;
 	@include activity-panel-slide();
 	position: fixed;

--- a/client/layout/activity-panel/toggle-bubble.js
+++ b/client/layout/activity-panel/toggle-bubble.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+const ActivityPanelToggleBubble = ( { height = 24, width = 24 } ) => {
+	/* eslint-disable max-len */
+	return (
+		<svg
+			className="woocommerce-layout__activity-panel-toggle-bubble"
+			height={ height }
+			width={ width }
+			viewBox="0 0 24 24"
+		>
+			<path d="M18.9 2H5.1C3.4 2 2 3.4 2 5.1v10.7C2 17.6 3.4 19 5.1 19H9l6 3-1-3h4.9c1.7 0 3.1-1.4 3.1-3.1V5.1C22 3.4 20.6 2 18.9 2zm-1.5 4.5c-.4.8-.8 2.1-1 3.9-.3 1.8-.4 3.1-.3 4.1 0 .3 0 .5-.1.7-.1.2-.3.4-.6.4s-.6-.1-.9-.4c-1-1-1.8-2.6-2.4-4.6-.7 1.4-1.2 2.4-1.6 3.1-.6 1.2-1.2 1.8-1.6 1.9-.3 0-.5-.2-.8-.7-.5-1.4-1.1-4.2-1.7-8.2 0-.3 0-.5.2-.7.1-.2.4-.3.7-.4.5 0 .9.2.9.8.3 2.3.7 4.2 1.1 5.7l2.4-4.5c.2-.4.4-.6.8-.6.5 0 .8.3.9.9.3 1.4.6 2.6 1 3.7.3-2.7.8-4.7 1.4-5.9.2-.3.4-.5.7-.5.2 0 .5.1.7.2.2.2.3.4.3.6 0 .2 0 .4-.1.5z" />
+		</svg>
+	);
+	/* eslint-enable max-len */
+};
+
+ActivityPanelToggleBubble.propTypes = {
+	height: PropTypes.number,
+	width: PropTypes.number,
+};
+
+export default ActivityPanelToggleBubble;

--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -3,11 +3,14 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/utils';
 import { Fill } from 'react-slot-fill';
 import { isArray } from 'lodash';
 import Link from 'components/link';
 import PropTypes from 'prop-types';
+import ReactDom from 'react-dom';
 
 /**
  * Internal dependencies
@@ -15,45 +18,87 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import ActivityPanel from '../activity-panel';
 
-const Header = ( { sections, isEmbedded } ) => {
-	const _sections = isArray( sections ) ? sections : [ sections ];
+class Header extends Component {
+	constructor() {
+		super();
+		this.state = {
+			isScrolled: false,
+		};
 
-	const documentTitle = _sections
-		.map( section => {
-			return isArray( section ) ? section[ 1 ] : section;
-		} )
-		.reverse()
-		.join( ' &lsaquo; ' );
+		this.onWindowScroll = this.onWindowScroll.bind( this );
+		this.updateIsScrolled = this.updateIsScrolled.bind( this );
+	}
 
-	document.title = decodeEntities(
-		sprintf(
-			__( '%1$s &lsaquo; %2$s &#8212; WooCommerce', 'woo-dash' ),
-			documentTitle,
-			wpApiSettings.schema.name
-		)
-	);
+	componentDidMount() {
+		this.threshold = ReactDom.findDOMNode( this ).offsetTop;
+		window.addEventListener( 'scroll', this.onWindowScroll );
+		this.updateIsScrolled();
+	}
 
-	return (
-		<div className="woocommerce-layout__header">
-			<h1 className="woocommerce-layout__header-breadcrumbs">
-				<span>
-					<Link to="/">WooCommerce</Link>
-				</span>
-				{ _sections.map( ( section, i ) => {
-					const sectionPiece = isArray( section ) ? (
-						<Link to={ section[ 0 ] } wpAdmin={ isEmbedded }>
-							{ section[ 1 ] }
-						</Link>
-					) : (
-						section
-					);
-					return <span key={ i }>{ sectionPiece }</span>;
-				} ) }
-			</h1>
-			<ActivityPanel />
-		</div>
-	);
-};
+	componentWillUnmount() {
+		window.removeEventListener( 'scroll', this.onWindowScroll );
+		window.cancelAnimationFrame( this.handle );
+	}
+
+	onWindowScroll() {
+		this.handle = window.requestAnimationFrame( this.updateIsScrolled );
+	}
+
+	updateIsScrolled() {
+		const isScrolled = window.pageYOffset > this.threshold - 20;
+		if ( isScrolled !== this.state.isScrolled ) {
+			this.setState( {
+				isScrolled: isScrolled,
+			} );
+		}
+	}
+
+	render() {
+		const { sections, isEmbedded } = this.props;
+		const { isScrolled } = this.state;
+		const _sections = isArray( sections ) ? sections : [ sections ];
+
+		const documentTitle = _sections
+			.map( section => {
+				return isArray( section ) ? section[ 1 ] : section;
+			} )
+			.reverse()
+			.join( ' &lsaquo; ' );
+
+		document.title = decodeEntities(
+			sprintf(
+				__( '%1$s &lsaquo; %2$s &#8212; WooCommerce', 'woo-dash' ),
+				documentTitle,
+				wpApiSettings.schema.name
+			)
+		);
+
+		const className = classnames( 'woocommerce-layout__header', {
+			'is-scrolled': isScrolled,
+		} );
+
+		return (
+			<div className={ className }>
+				<h1 className="woocommerce-layout__header-breadcrumbs">
+					<span>
+						<Link to="/">WooCommerce</Link>
+					</span>
+					{ _sections.map( ( section, i ) => {
+						const sectionPiece = isArray( section ) ? (
+							<Link to={ section[ 0 ] } wpAdmin={ isEmbedded }>
+								{ section[ 1 ] }
+							</Link>
+						) : (
+							section
+						);
+						return <span key={ i }>{ sectionPiece }</span>;
+					} ) }
+				</h1>
+				<ActivityPanel />
+			</div>
+		);
+	}
+}
 
 Header.propTypes = {
 	sections: PropTypes.node.isRequired,

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -7,13 +7,17 @@
 	flex-direction: row;
 	box-sizing: border-box;
 	background: $white;
-	border-bottom: 1px solid $gray;
+	border-bottom: 1px solid $white;
 	padding: 0px;
 	height: 80px;
 	position: fixed;
 	width: 100%;
 	top: 32px;
 	z-index: 1000;
+
+	&.is-scrolled {
+		box-shadow: 0 6px 6px 0 rgba(85, 93, 102, 0.3);
+	}
 
 	@include breakpoint( '<782px' ) {
 		top: 46px;
@@ -29,17 +33,23 @@
 		font-size: 13px;
 		font-weight: normal;
 		padding: 0px;
-		margin-left: $spacing;
 		flex: 1 auto;
-
 		padding-top: 8px;
+		height: 50px;
+		background: $white;
 
 		@include breakpoint( '782px-1100px' ) {
 			padding-top: 16px;
+			height: auto;
 		}
 
 		@include breakpoint( '>1100px' ) {
 			padding-top: 24px;
+			height: auto;
+		}
+
+		span:first-child {
+			padding-left: $spacing;
 		}
 
 		span + span::before {

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -14,7 +14,7 @@ $gray-light-10: lighten($gray, 10%);
 // Greys
 $core-grey-light-100: #f8f9f9;
 $core-grey-light-200: #f3f4f5;
-$core-grey-light-300: #f3f4f5; // same as 200? By accident?
+$core-grey-light-300: #edeff0;
 $core-grey-light-500: #e2e4e7;
 $core-grey-light-700: #ccd0d4;
 $core-grey-dark-500: #555d66;

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -177,6 +177,13 @@
 	}
 }
 
+@include breakpoint( '<600px' ) {
+	#wpadminbar,
+	.jetpack-masterbar #wpadminbar {
+		position: fixed;
+	}
+}
+
 // Temporary fix for compability with the Jetpack masterbar
 // See https://github.com/Automattic/jetpack/issues/9608
 // !important rules overwrite some existing !important rules

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -87,6 +87,12 @@
 			display: none;
 		}
 	}
+
+	.woocommerce-layout__activity-panel {
+		@include breakpoint( '<782px' ) {
+			top: -20px;
+		}
+	}
 }
 
 .woocommerce-layout * {
@@ -156,6 +162,19 @@
 
 #wpfooter {
 	display: none;
+}
+
+.wp-responsive-open {
+	.woocommerce-layout__header {
+		margin-left: 2px;
+	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-layout__activity-panel-wrapper.is-open,
+		.woocommerce-layout__activity-panel-tabs {
+			width: calc(100vw - 190px);
+		}
+	}
 }
 
 // Temporary fix for compability with the Jetpack masterbar

--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,24 +6084,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6111,12 +6115,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -6125,34 +6131,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6161,25 +6173,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6188,13 +6204,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6210,7 +6228,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6224,13 +6243,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6239,7 +6260,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6248,7 +6270,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6258,18 +6281,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -6277,13 +6303,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -6291,12 +6319,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1",
@@ -6305,7 +6335,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6314,7 +6345,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6322,13 +6354,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6339,7 +6373,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6357,7 +6392,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6367,13 +6403,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6383,7 +6421,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6395,18 +6434,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -6414,19 +6456,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6436,19 +6481,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6460,7 +6508,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -6468,7 +6517,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6483,7 +6533,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6492,42 +6543,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -6537,7 +6595,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6546,7 +6605,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -6554,13 +6614,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6575,13 +6637,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6590,12 +6654,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }


### PR DESCRIPTION
This PR makes the following improvements:

* A shadow is now displayed on scroll for the header, per p1530048782000409-slack-woo-dash.
* Basic panel styles are now implemented (shadow, colors, etc)
* The Woo Bubble icon is now used for the mobile menu
* Fixes mobile styles when the responsive wp-admin menu is open
* The ActivityHeader component is implemented, and shell pages have been created for the other panels.
* It also fixes a duplicate CSS color definition `$core-grey-light-300` and `$core-grey-light-200`.

Closes #112.

---

Open orders panel with menu:

<img width="1061" alt="screen shot 2018-07-06 at 11 04 04 am" src="https://user-images.githubusercontent.com/689165/42386535-c92dac8e-810d-11e8-8a67-cc48ad1d1ee0.png">

Scrolling main content:

<img width="1083" alt="screen shot 2018-07-06 at 11 04 21 am" src="https://user-images.githubusercontent.com/689165/42386546-d08b39b0-810d-11e8-90ee-32b772523a09.png">

Mobile panel:

<img width="767" alt="screen shot 2018-07-06 at 11 05 06 am" src="https://user-images.githubusercontent.com/689165/42386587-eadcdf1c-810d-11e8-9425-1a674ee6fb85.png">

