### PR TITLE
Infinite loop from calling setState in D3 componentDidUpdate

### DIFF
--- a/client/components/d3/base/index.js
+++ b/client/components/d3/base/index.js
@@ -8,6 +8,7 @@ import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { select as d3Select } from 'd3-selection';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,9 +28,11 @@ class D3Base extends Component {
 		this.updateParams();
 	}
 
-	componentDidUpdate() {
-		this.updateParams( this.props );
-		this.draw();
+	componentDidUpdate( prevProps ) {
+		if ( ! isEqual( prevProps, this.props ) ) {
+			this.updateParams( this.props );
+			this.draw();
+		}
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
#120 introduced an infinite loop by calling `setState` from `componentDidUpdate` without any conditions. `setState` would update the components state which would then run `componentDidUpdate` again. 

This PR adds a check to compare the prop objects. It would probably be better to check for specific props, but I'm unsure of what those are at the moment with digging in further and this breaks master and my rebased branches at the moment. cc @greenafrican who might want to update the behavior here.

`Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

To Test:
* Without this branch, notice the warnings in the console. Other JS also breaks
* Apply this branch and notice no warnings.