### PR TITLE
Fix unique key warning for DropdownButton labels

### DIFF
--- a/client/components/dropdown-button/index.js
+++ b/client/components/dropdown-button/index.js
@@ -20,7 +20,7 @@ const DropdownButton = props => {
 	return (
 		<Button className={ buttonClasses } aria-expanded={ isOpen } { ...otherProps }>
 			<div className="woocommerce-dropdown-button__labels">
-				{ labels.map( label => <span>{ label }</span> ) }
+				{ labels.map( ( label, i ) => <span key={ i }>{ label }</span> ) }
 			</div>
 		</Button>
 	);


### PR DESCRIPTION
I'm seeing a warning on master: `Each child in an array or iterator should have a unique "key" prop.` in the `DropdownButton` component.

This PR fixes that by adding a key to each span.

**To test**

- Load a page with the datepicker on it, like `wp-admin/admin.php?page=woodash#/analytics`
- Check that there are no warnings in console