### PR TITLE
ActivityPanel: Update semantics for screen reader navigation

### DIFF
--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -5,17 +5,17 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import Gridicon from 'gridicons';
 import { IconButton } from '@wordpress/components';
-import { partial } from 'lodash';
+import { partial, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
-import { Section } from 'layout/section';
+import { H, Section } from 'layout/section';
 import InboxPanel from './inbox';
 import OrdersPanel from './orders';
 import StockPanel from './stock';
@@ -132,7 +132,7 @@ class ActivityPanel extends Component {
 		} );
 
 		return (
-			<Section component="div" className={ classNames }>
+			<div className={ classNames }>
 				{ ( isPanelOpen && (
 					<div
 						className="woocommerce-layout__activity-panel-content"
@@ -144,7 +144,7 @@ class ActivityPanel extends Component {
 					</div>
 				) ) ||
 					null }
-			</Section>
+			</div>
 		);
 	}
 
@@ -171,33 +171,38 @@ class ActivityPanel extends Component {
 	render() {
 		const tabs = this.getTabs();
 		const { currentTab, mobileOpen } = this.state;
-
+		const headerId = uniqueId( 'activity-panel-header_' );
 		const panelClasses = classnames( 'woocommerce-layout__activity-panel', {
 			'is-mobile-open': this.state.mobileOpen,
 		} );
 
 		// TODO Replace the mobile toggle with the Woo bubble Gridicon once it has been added.
 		return (
-			<div id="woocommerce-activity-panel">
-				<IconButton
-					onClick={ this.toggleMobile }
-					icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <ActivityPanelToggleBubble /> }
-					label={ mobileOpen ? __( 'Close Activity Panel' ) : __( 'View Activity Panel' ) }
-					aria-expanded={ mobileOpen }
-					tooltip={ false }
-					className="woocommerce-layout__activity-panel-mobile-toggle"
-				/>
-				<div className={ panelClasses }>
-					<div className="woocommerce-layout__activity-panel-tabs" role="tablist">
-						{ tabs && tabs.map( this.renderTab ) }
-						<WordPressNotices
-							showNotices={ 'wpnotices' === currentTab }
-							togglePanel={ this.togglePanel }
-						/>
+			<Fragment>
+				<H id={ headerId } className="screen-reader-text">
+					{ __( 'Store Activity', 'woo-dash' ) }
+				</H>
+				<Section component="aside" id="woocommerce-activity-panel" aria-labelledby={ headerId }>
+					<IconButton
+						onClick={ this.toggleMobile }
+						icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <ActivityPanelToggleBubble /> }
+						label={ mobileOpen ? __( 'Close Activity Panel' ) : __( 'View Activity Panel' ) }
+						aria-expanded={ mobileOpen }
+						tooltip={ false }
+						className="woocommerce-layout__activity-panel-mobile-toggle"
+					/>
+					<div className={ panelClasses }>
+						<div className="woocommerce-layout__activity-panel-tabs" role="tablist">
+							{ tabs && tabs.map( this.renderTab ) }
+							<WordPressNotices
+								showNotices={ 'wpnotices' === currentTab }
+								togglePanel={ this.togglePanel }
+							/>
+						</div>
+						{ this.renderPanel() }
 					</div>
-					{ this.renderPanel() }
-				</div>
-			</div>
+				</Section>
+			</Fragment>
 		);
 	}
 }

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
 import { IconButton } from '@wordpress/components';
 import { partial, uniqueId } from 'lodash';
@@ -178,7 +178,7 @@ class ActivityPanel extends Component {
 
 		// TODO Replace the mobile toggle with the Woo bubble Gridicon once it has been added.
 		return (
-			<Fragment>
+			<div>
 				<H id={ headerId } className="screen-reader-text">
 					{ __( 'Store Activity', 'wc-admin' ) }
 				</H>
@@ -206,7 +206,7 @@ class ActivityPanel extends Component {
 						{ this.renderPanel() }
 					</div>
 				</Section>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -180,13 +180,17 @@ class ActivityPanel extends Component {
 		return (
 			<Fragment>
 				<H id={ headerId } className="screen-reader-text">
-					{ __( 'Store Activity', 'woo-dash' ) }
+					{ __( 'Store Activity', 'wc-admin' ) }
 				</H>
 				<Section component="aside" id="woocommerce-activity-panel" aria-labelledby={ headerId }>
 					<IconButton
 						onClick={ this.toggleMobile }
 						icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <ActivityPanelToggleBubble /> }
-						label={ mobileOpen ? __( 'Close Activity Panel' ) : __( 'View Activity Panel' ) }
+						label={
+							mobileOpen
+								? __( 'Close Activity Panel', 'wc-admin' )
+								: __( 'View Activity Panel', 'wc-admin' )
+						}
 						aria-expanded={ mobileOpen }
 						tooltip={ false }
 						className="woocommerce-layout__activity-panel-mobile-toggle"


### PR DESCRIPTION
This fixes the second issue in #181 -- where we lost some of the semantics of the sidebar in the move to ActivityPanel.

- Move the Section wrap to the top-level of ActivityPanel, rather than just the panel contents.
- Add a heading for the Section, which also fixes the heading hierarchy following it
- Use an `aside` to wrap the entire ActivityPanel, which will expose the whole thing as a “complementary” in landmark nav. By adding the aria-labelledby mapped to the new `H`, we can also give it a name in the landmarks menu.

Example of VoiceOver Landmarks menu:
![screen shot 2018-07-09 at 4 37 08 pm](https://user-images.githubusercontent.com/541093/42475018-611b15fa-8397-11e8-8e87-7677b8de25c7.png)

Example of VoiceOver headings menu:
![screen shot 2018-07-09 at 4 38 22 pm](https://user-images.githubusercontent.com/541093/42475019-612d594a-8397-11e8-98a9-ae07d0868fff.png)

To test:

- View the heading hierarchy, either with VoiceOver or [a tool like WAVE](http://wave.webaim.org/)
- Make sure the heading structure is consistent and does not skip a level
- Check that the activity panel is rendered with an aside, and try using the VoiceOver landmarks menu to navigate to it