### PR TITLE
Fix Accessibility issues: tabpanel behavior, and reduced motion setting

### DIFF
--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -7,13 +7,9 @@ import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
 import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
-<<<<<<< HEAD
-import { IconButton } from '@wordpress/components';
-import { partial, uniqueId } from 'lodash';
-=======
+
 import { IconButton, NavigableMenu } from '@wordpress/components';
-import { partial } from 'lodash';
->>>>>>> Fix Accessibility issues: tabpanel behavior, and reduced motion setting
+import { partial, uniqueId, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -136,22 +132,26 @@ class ActivityPanel extends Component {
 			'is-open': isPanelOpen,
 		} );
 
+		const tab = find( this.getTabs(), { name: currentTab } );
+		if ( ! tab ) {
+			return null;
+		}
+
 		return (
-			<div className={ classNames }>
+			<Section component="div" className={ classNames } tabindex={ 0 }>
 				{ ( isPanelOpen && (
 					<div
 						className="woocommerce-layout__activity-panel-content"
 						key={ 'activity-panel-' + currentTab }
 						id={ 'activity-panel-' + currentTab }
 						role="tabpanel"
-						tabindex={ 0 }
-						aria-labelledby={ 'activity-panel-tab' + currentTab }
+						aria-label={ tab.title }
 					>
 						{ this.getPanelContent( currentTab ) }
 					</div>
 				) ) ||
 					null }
-			</div>
+			</Section>
 		);
 	}
 

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
 import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
-
 import { IconButton, NavigableMenu } from '@wordpress/components';
 import { partial, uniqueId, find } from 'lodash';
 
@@ -138,20 +137,18 @@ class ActivityPanel extends Component {
 		}
 
 		return (
-			<Section component="div" className={ classNames } tabindex={ 0 }>
+			<div className={ classNames } tabIndex={ 0 } role="tabpanel" aria-label={ tab.title }>
 				{ ( isPanelOpen && (
 					<div
 						className="woocommerce-layout__activity-panel-content"
 						key={ 'activity-panel-' + currentTab }
 						id={ 'activity-panel-' + currentTab }
-						role="tabpanel"
-						aria-label={ tab.title }
 					>
 						{ this.getPanelContent( currentTab ) }
 					</div>
 				) ) ||
 					null }
-			</Section>
+			</div>
 		);
 	}
 
@@ -216,17 +213,17 @@ class ActivityPanel extends Component {
 						className="woocommerce-layout__activity-panel-mobile-toggle"
 					/>
 					<div className={ panelClasses }>
-					<NavigableMenu
-						role="tablist"
-						orientation="horizontal"
-						className="woocommerce-layout__activity-panel-tabs"
-					>
-						{ tabs && tabs.map( this.renderTab ) }
-						<WordPressNotices
-							showNotices={ 'wpnotices' === currentTab }
-							togglePanel={ this.togglePanel }
-						/>
-					</NavigableMenu>
+						<NavigableMenu
+							role="tablist"
+							orientation="horizontal"
+							className="woocommerce-layout__activity-panel-tabs"
+						>
+							{ tabs && tabs.map( this.renderTab ) }
+							<WordPressNotices
+								showNotices={ 'wpnotices' === currentTab }
+								togglePanel={ this.togglePanel }
+							/>
+						</NavigableMenu>
 						{ this.renderPanel() }
 					</div>
 				</Section>

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -7,8 +7,13 @@ import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
 import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
+<<<<<<< HEAD
 import { IconButton } from '@wordpress/components';
 import { partial, uniqueId } from 'lodash';
+=======
+import { IconButton, NavigableMenu } from '@wordpress/components';
+import { partial } from 'lodash';
+>>>>>>> Fix Accessibility issues: tabpanel behavior, and reduced motion setting
 
 /**
  * Internal dependencies
@@ -139,6 +144,8 @@ class ActivityPanel extends Component {
 						key={ 'activity-panel-' + currentTab }
 						id={ 'activity-panel-' + currentTab }
 						role="tabpanel"
+						tabindex={ 0 }
+						aria-labelledby={ 'activity-panel-tab' + currentTab }
 					>
 						{ this.getPanelContent( currentTab ) }
 					</div>
@@ -148,20 +155,33 @@ class ActivityPanel extends Component {
 		);
 	}
 
-	renderTab( tab ) {
-		const { currentTab } = this.state;
+	renderTab( tab, i ) {
+		const { currentTab, isPanelOpen } = this.state;
 		const className = classnames( 'woocommerce-layout__activity-panel-tab', {
 			'is-active': tab.name === currentTab,
 			'has-unread': tab.unread,
 		} );
 
+		const selected = tab.name === currentTab;
+		let tabIndex = -1;
+
+		// Only make this item tabbable if it is the currently selected item, or the panel is closed and the item is the first item (Inbox)
+		// If wpnotices is currently selected, tabindex below should be  -1 and <WordPressNotices /> will become the tabbed element.
+		if ( selected || ( ! isPanelOpen && i === 0 && 'wpnotices' !== currentTab ) ) {
+			tabIndex = null;
+		}
+
 		return (
 			<IconButton
-				key={ tab.name }
+				role="tab"
 				className={ className }
+				tabIndex={ tabIndex }
+				aria-selected={ selected }
+				aria-controls={ 'activity-panel-' + tab.name }
+				key={ 'activity-panel-tab-' + tab.name }
+				id={ 'activity-panel-tab-' + tab.name }
 				onClick={ partial( this.togglePanel, tab.name ) }
 				icon={ tab.icon }
-				aria-controls={ 'activity-panel-' + tab.name }
 			>
 				{ tab.title }
 			</IconButton>
@@ -196,13 +216,17 @@ class ActivityPanel extends Component {
 						className="woocommerce-layout__activity-panel-mobile-toggle"
 					/>
 					<div className={ panelClasses }>
-						<div className="woocommerce-layout__activity-panel-tabs" role="tablist">
-							{ tabs && tabs.map( this.renderTab ) }
-							<WordPressNotices
-								showNotices={ 'wpnotices' === currentTab }
-								togglePanel={ this.togglePanel }
-							/>
-						</div>
+					<NavigableMenu
+						role="tablist"
+						orientation="horizontal"
+						className="woocommerce-layout__activity-panel-tabs"
+					>
+						{ tabs && tabs.map( this.renderTab ) }
+						<WordPressNotices
+							showNotices={ 'wpnotices' === currentTab }
+							togglePanel={ this.togglePanel }
+						/>
+					</NavigableMenu>
 						{ this.renderPanel() }
 					</div>
 				</Section>

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -167,6 +167,9 @@
 
 @mixin activity-panel-slide {
 	transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+	@media screen and (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
 }
 
 .woocommerce-layout__activity-panel-wrapper {
@@ -202,5 +205,9 @@
 	.woocommerce-layout__activity-panel-content {
 		animation: tabSwitch;
 		animation-duration: 300ms;
+
+		@media screen and (prefers-reduced-motion: reduce) {
+			animation: none;
+		}
 	}
 }

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -193,6 +193,7 @@ class WordPressNotices extends Component {
 				className={ className }
 				onClick={ partial( togglePanel, 'wpnotices' ) }
 				icon={ <Gridicon icon="my-sites" /> }
+				tabIndex={ showNotices ? null : -1 }
 			>
 				{ __( 'Notices', 'wc-admin' ) }
 			</IconButton>

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -193,6 +193,7 @@ class WordPressNotices extends Component {
 				className={ className }
 				onClick={ partial( togglePanel, 'wpnotices' ) }
 				icon={ <Gridicon icon="my-sites" /> }
+				role="tab"
 				tabIndex={ showNotices ? null : -1 }
 			>
 				{ __( 'Notices', 'wc-admin' ) }


### PR DESCRIPTION
This PR fixes issues one and three from #181.

* It updates the tablist to use `NavigableMenu` which supports the correct keyboard navigation (with arrows).
* It also stops the animations from running on the panel if the the reduced motion setting is turned on.

To Test:
* Load up the branch and verify that you can still interact with the tabs. Try using your keyboard to navigate between tabbable elements, then try navigating and switching between the activity panel tabs using your arrow keys.
* Go to `System Preferences > Accessibility > Display` and turn on `Reduce motion`. Use a browser like Safari, and confirm that the animations don't occur.