### PR TITLE
Fixes some display issues on embedded/classic WC pages

### DIFF
--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -15,6 +15,8 @@ class WordPressNotices extends Component {
 		this.state = {
 			count: 0,
 			notices: null,
+			screenLinks: null,
+			screenMeta: null,
 			noticesOpen: false,
 			hasEventListeners: false,
 		};
@@ -67,19 +69,8 @@ class WordPressNotices extends Component {
 	initialize() {
 		const notices = document.getElementById( 'wp__notice-list' );
 		const noticesOpen = notices.classList.contains( 'woocommerce-layout__notice-list-show' );
-
-		// On existing classic WooCommerce pages, screen links like "help" and "screen options" display, and need to be displayed
-		// along side the notifications expansion.
+		const screenMeta = document.getElementById( 'screen-meta' );
 		const screenLinks = document.getElementById( 'screen-meta-links' );
-		if ( screenLinks ) {
-			notices.classList.add( 'has-screen-meta-links' );
-			document
-				.getElementById( 'woocommerce-layout__notice-list' )
-				.insertAdjacentElement( 'beforebegin', document.getElementById( 'screen-meta' ) );
-			document
-				.getElementById( 'woocommerce-layout__notice-list' )
-				.insertAdjacentElement( 'beforebegin', screenLinks );
-		}
 
 		const collapsedTargetArea = document.getElementById( 'woocommerce-layout__notice-list' );
 		const uncollapsedTargetArea =
@@ -101,7 +92,7 @@ class WordPressNotices extends Component {
 
 		count = count - 1; // Remove 1 for `wp-header-end` which is a child of wp__notice-list
 
-		this.setState( { count, notices, noticesOpen } );
+		this.setState( { count, notices, noticesOpen, screenMeta, screenLinks } );
 
 		// Move collapsed WordPress notifications into the main wc-admin body
 		collapsedTargetArea.insertAdjacentElement( 'beforeend', notices );
@@ -168,13 +159,19 @@ class WordPressNotices extends Component {
 	}
 
 	showNotices() {
-		this.state.notices.classList.add( 'woocommerce-layout__notice-list-show' );
-		this.state.notices.classList.remove( 'woocommerce-layout__notice-list-hide' );
+		const { notices, screenLinks, screenMeta } = this.state;
+		notices.classList.add( 'woocommerce-layout__notice-list-show' );
+		notices.classList.remove( 'woocommerce-layout__notice-list-hide' );
+		screenMeta && screenMeta.classList.add( 'is-hidden-by-notices' );
+		screenLinks && screenLinks.classList.add( 'is-hidden-by-notices' );
 	}
 
 	hideNotices() {
-		this.state.notices.classList.add( 'woocommerce-layout__notice-list-hide' );
-		this.state.notices.classList.remove( 'woocommerce-layout__notice-list-show' );
+		const { notices, screenLinks, screenMeta } = this.state;
+		notices.classList.add( 'woocommerce-layout__notice-list-hide' );
+		notices.classList.remove( 'woocommerce-layout__notice-list-show' );
+		screenMeta && screenMeta.classList.remove( 'is-hidden-by-notices' );
+		screenLinks && screenLinks.classList.remove( 'is-hidden-by-notices' );
 	}
 
 	render() {

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -16,12 +16,12 @@
 	z-index: 1000;
 
 	&.is-scrolled {
-		box-shadow: 0 6px 6px 0 rgba(85, 93, 102, 0.3);
+		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);
 	}
 
 	@include breakpoint( '<782px' ) {
 		top: 46px;
-		height: 47px;
+		height: 50px;
 		flex-flow: row wrap;
 	}
 
@@ -34,18 +34,18 @@
 		font-weight: normal;
 		padding: 0px;
 		flex: 1 auto;
-		padding-top: 8px;
 		height: 50px;
+		line-height: 50px;
 		background: $white;
 
 		@include breakpoint( '782px-1100px' ) {
-			padding-top: 16px;
-			height: auto;
+			height: 60px;
+			line-height: 60px;
 		}
 
 		@include breakpoint( '>1100px' ) {
-			padding-top: 24px;
-			height: auto;
+			height: 80px;
+			line-height: 80px;
 		}
 
 		span:first-child {

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -58,7 +58,6 @@
 
 	.wrap {
 		padding: 20px;
-		padding-top: 0;
 	}
 
 	#screen-meta {
@@ -71,8 +70,24 @@
 		padding: 1px 12px;
 	}
 
-	#wpbody-content #wp__notice-list {
-		margin-top: 8px;
+	.woocommerce-layout__header {
+		&.is-scrolled {
+			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
+		}
+
+		.woocommerce-layout__header-breadcrumbs {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
+	/**
+	* Hides screen meta and links when notices are open since the elements get moved around.
+	* The !important overwrites an inline wp-admin style.
+	*/
+	#screen-meta.is-hidden-by-notices,
+	#screen-meta-links.is-hidden-by-notices {
+		display: none !important;
 	}
 
 	.woocommerce-layout__primary {
@@ -81,16 +96,6 @@
 
 		@include breakpoint( '782px-1100px' ) {
 			padding-top: 60px;
-		}
-
-		&.is-embed-loading {
-			display: none;
-		}
-	}
-
-	.woocommerce-layout__activity-panel {
-		@include breakpoint( '<782px' ) {
-			top: -20px;
 		}
 	}
 }
@@ -133,15 +138,6 @@
 
 		@include breakpoint( '600px-782px' ) {
 			margin-top: 32px;
-		}
-	}
-
-	.woocommerce-layout__notice-list-hide {
-		height: auto;
-		margin-top: -50px;
-
-		@include breakpoint( '<782px' ) {
-			margin-top: -100px;
 		}
 	}
 }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -221,7 +221,7 @@ function woocommerce_embed_page_header() {
 			<div class="woocommerce-layout__header is-embed-loading">
 				<h1 class="woocommerce-layout__header-breadcrumbs">
 					<span><a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-admin#/' ) ); ?>">WooCommerce</a></span>
-					<span><?php echo $breadcrumbs; ?></span>
+					<?php echo $breadcrumbs; ?>
 				</h1>
 			</div>
 		</div>


### PR DESCRIPTION
There were a few issues with the header and activity panel on classic WooCommerce pages (embedded mode). Closes #140.

This changes how we were handling the screen meta links. Instead of trying to move them around with hacky JS, we will just hide them when the notices panel is expanded. It also fixes some margins/padding issues, and fixes the WP notices from pushing down content when classic pages are loading.

I started doing some work on placeholders for the icons since they load in slower on classic pages, though these placeholders would display on *every* PHP page transition. I paused on implementing this to think about what we can do. Ideas welcome.

To Test:
* Load up this branch and test loading a couple classic WooCommerce pages.
* Test some actual dashboard/analytics pages.
* Verify things look consistent and normal.