### PR TITLE
Add Gravatar Component

### DIFF
--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -1,0 +1,28 @@
+Gravatar
+============
+
+Use `Gravatar` to display a user's Gravatar.
+
+## How to use:
+
+```jsx
+import { Gravatar } from 'components/gravatar';
+
+render: function() {
+  return (
+    <Gravatar
+		user="email@example.org"
+		size={ 48 }
+	/>
+  );
+}
+```
+
+## Props
+
+* `user`: The address to hash for displaying a Gravatar. Can be an email address or WP-API user object.
+* `size`: Default 60. The size of Gravatar to request.
+* `alt`: Text to display as the image alt attribute.
+* `title`: Text to use for the image's title
+* `fallback`: Default `mp`. Gravatar default fallback mode. See https://en.gravatar.com/site/implement/images/.
+* `className`: Additional CSS classes.

--- a/client/components/gravatar/index.js
+++ b/client/components/gravatar/index.js
@@ -1,0 +1,76 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { parse, stringify } from 'qs';
+import PropTypes from 'prop-types';
+import url from 'url';
+import { isString } from 'lodash';
+import crypto from 'crypto';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Gravatar = ( { alt, title, size, user, className } ) => {
+	const classes = classnames( 'woocommerce-gravatar', className, {
+		'is-placeholder': ! user,
+	} );
+
+	const getResizedImageURL = imageURL => {
+		const parsedURL = url.parse( imageURL );
+		const query = parse( parsedURL.query );
+
+		query.s = size;
+		query.d = 'mp';
+
+		parsedURL.search = stringify( query );
+		return url.format( parsedURL );
+	};
+
+	const getAvatarURLFromEmail = email => {
+		return (
+			'https://www.gravatar.com/avatar/' +
+			crypto
+				.createHash( 'md5' )
+				.update( email )
+				.digest( 'hex' )
+		);
+	};
+
+	const altText = alt || ( user && ( user.display_name || user.name ) ) || '';
+
+	let avatarURL = 'https://www.gravatar.com/avatar/0?s=' + size + '&d=mp';
+	if ( user ) {
+		avatarURL = getResizedImageURL(
+			isString( user ) ? getAvatarURLFromEmail( user ) : user.avatar_URLs[ 96 ]
+		);
+	}
+
+	return (
+		<img
+			alt={ altText }
+			title={ title }
+			className={ classes }
+			src={ avatarURL }
+			width={ size }
+			height={ size }
+		/>
+	);
+};
+
+Gravatar.propTypes = {
+	user: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
+	alt: PropTypes.string,
+	title: PropTypes.string,
+	size: PropTypes.number,
+	className: PropTypes.string,
+};
+
+Gravatar.defaultProps = {
+	size: 60,
+};
+
+export default Gravatar;

--- a/client/components/gravatar/style.scss
+++ b/client/components/gravatar/style.scss
@@ -1,0 +1,5 @@
+/** @format */
+
+.woocommerce-gravatar {
+	border-radius: 50%;
+}

--- a/client/components/gravatar/test/index.js
+++ b/client/components/gravatar/test/index.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from '../';
+
+describe( 'Gravatar', () => {
+	test( 'should fallback to default mystery person Gravatar', () => {
+		const gravatar = shallow( <Gravatar /> );
+		expect( gravatar.prop( 'src' ) ).toBe( 'https://www.gravatar.com/avatar/0?s=60&d=mp' );
+	} );
+
+	test( 'should return a resized avatar from a user object', () => {
+		const user = {
+			avatar_URLs: {
+				24: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=24',
+				48: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=48',
+				96: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=96',
+			},
+		};
+		const gravatar = shallow( <Gravatar user={ user } /> );
+		expect( gravatar.prop( 'src' ) ).toBe(
+			'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=60&d=mp'
+		);
+	} );
+
+	test( 'should return an avatar from an email address', () => {
+		const gravatar = shallow( <Gravatar user="test@example.com" /> );
+		expect( gravatar.prop( 'src' ) ).toBe(
+			'https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=60&d=mp'
+		);
+	} );
+
+	test( 'should return a resized image when passed a size', () => {
+		const gravatar = shallow( <Gravatar user="test@example.com" size={ 40 } /> );
+		expect( gravatar.prop( 'src' ) ).toBe(
+			'https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=40&d=mp'
+		);
+		expect( gravatar.prop( 'width' ) ).toBe( 40 );
+		expect( gravatar.prop( 'height' ) ).toBe( 40 );
+	} );
+
+	test( 'should return an alt attribute', () => {
+		const gravatar = shallow( <Gravatar alt="test" /> );
+		expect( gravatar.prop( 'alt' ) ).toBe( 'test' );
+	} );
+	test( 'should return an alt attribute from a user name', () => {
+		const user = {
+			avatar_URLs: {
+				24: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=24',
+				48: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=48',
+				96: 'https://www.gravatar.com/avatar/098f6bcd4621d373cade4e832627b4f6?s=96',
+			},
+			display_name: 'Justin',
+			name: 'Justin',
+		};
+		const gravatar = shallow( <Gravatar user={ user } /> );
+		expect( gravatar.prop( 'alt' ) ).toBe( 'Justin' );
+	} );
+} );

--- a/client/layout/activity-panel/orders.js
+++ b/client/layout/activity-panel/orders.js
@@ -16,6 +16,7 @@ import ActivityHeader from './activity-header';
 import { EllipsisMenu, MenuTitle, MenuItem } from 'components/ellipsis-menu';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';
+import Gravatar from 'components/gravatar';
 import { Section } from 'layout/section';
 
 function OrdersPanel( { orders } ) {
@@ -55,6 +56,7 @@ function OrdersPanel( { orders } ) {
 								icon={ <Dashicon icon="format-aside" /> }
 								date={ order.date_created }
 							>
+								<Gravatar user={ address.email } />
 								<div>{ sprintf( __( '%s placed order #%d', 'wc-admin' ), name, order.id ) }</div>
 								<div>
 									<span>


### PR DESCRIPTION
Closes #147.

This PR adds a `<Gravatar />` component. It accepts an email address (for use in the orders screen) or a WP-API user object for displaying avatars in those contexts. It will return the mystery person as a fallback. Display wise, a rounded avatar is displayed in the orders activity panel. This PR also adds a few component tests around the resizing and use of user object.

<img width="259" alt="screen shot 2018-07-11 at 11 03 12 am" src="https://user-images.githubusercontent.com/689165/42581398-a822b912-84fa-11e8-8071-862437a7241f.png">

To Test:
* Run `npm run test` and make sure all tests pass.
* Open the orders activity panel and verify you can see an avatar for the order, or the mystery person.