### PR TITLE
Component: Fix rows prop in Table

### DIFF
--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -60,8 +60,6 @@ class RevenueReport extends Component {
 
 	getRowsContent( data ) {
 		return map( data, row => {
-			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
-			// we need to know which kind of report this is, and parse the `label` to get this row's date
 			const {
 				coupons,
 				gross_revenue,
@@ -72,6 +70,8 @@ class RevenueReport extends Component {
 				taxes,
 			} = row.subtotals;
 
+			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
+			// we need to know which kind of report this is, and parse the `label` to get this row's date
 			const orderLink = (
 				<a href={ getAdminLink( '/edit.php?post_type=shop_order&w=4&year=2018' ) }>
 					{ orders_count }
@@ -94,7 +94,7 @@ class RevenueReport extends Component {
 		const { path, query } = this.props;
 		const summaryStats = get( this.state.stats, 'totals', {} );
 		const intervalStats = get( this.state.stats, 'intervals', [] );
-		const rows = this.getRowsContent( intervalStats );
+		const rows = this.getRowsContent( intervalStats ) || [];
 
 		const headers = [
 			__( 'Date', 'wc-admin' ),
@@ -143,10 +143,8 @@ class RevenueReport extends Component {
 				<Card title={ __( 'Gross Revenue' ) }>
 					<p>Graph here</p>
 					<hr />
-					{ rows &&
-						rows.length && (
-							<Table rows={ rows } headers={ headers } caption={ __( 'Revenue Last Week' ) } />
-						) }
+					{ /* @todo Switch a placeholder view if we don't have rows */ }
+					<Table rows={ rows } headers={ headers } caption={ __( 'Revenue Last Week' ) } />
 				</Card>
 
 				<Pagination

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -31,6 +31,16 @@ class Table extends Component {
 		this.captionID = uniqueId( 'caption-' );
 	}
 
+	componentDidMount() {
+		const { scrollWidth, clientWidth } = this.container.current;
+		const scrollable = scrollWidth > clientWidth;
+		/* eslint-disable react/no-did-mount-set-state */
+		this.setState( {
+			tabIndex: scrollable ? '0' : null,
+		} );
+		/* eslint-enable react/no-did-mount-set-state */
+	}
+
 	sortBy( col ) {
 		this.setState( prevState => {
 			// Set the sort direction as inverse of current state
@@ -43,16 +53,6 @@ class Table extends Component {
 				sortDir,
 			};
 		} );
-	}
-
-	componentDidMount() {
-		const { scrollWidth, clientWidth } = this.container.current;
-		const scrollable = scrollWidth > clientWidth;
-		/* eslint-disable react/no-did-mount-set-state */
-		this.setState( {
-			tabIndex: scrollable ? '0' : null,
-		} );
-		/* eslint-enable react/no-did-mount-set-state */
 	}
 
 	isColSortable( col ) {

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -7,7 +7,7 @@ import { Component, createRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { IconButton } from '@wordpress/components';
 import PropTypes from 'prop-types';
-import { uniqueId } from 'lodash';
+import { isEqual, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +29,16 @@ class Table extends Component {
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
 		this.captionID = uniqueId( 'caption-' );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! isEqual( this.props.rows, prevProps.rows ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( {
+				rows: this.props.rows,
+			} );
+			/* eslint-enable react/no-did-update-set-state */
+		}
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
Fixes the issue in https://github.com/woocommerce/wc-admin/issues/92#issuecomment-400820748 - the `Table` did not update when parent props changed. This was because we set the rows into state on mount, and then only read from the state on subsequent renders. This PR uses `componentDidUpdate` to check if the rows have changed from the parent, and resets the rows state.

We do have to tell eslint that setting state in `componentDidUpdate` is OK, but it _is_ ok because we do it inside a conditional (preventing an infinite loop).

This will also wipe out any sorting that already exists if more rows are added. We'll probably want to address that in a later PR, maybe pulling out [the sorting here](https://github.com/woocommerce/wc-admin/blob/bf008bced80166d255b037e75e154fc6e261aa7d/client/components/table/index.js#L59-L61) & sorting our row prop before setting it into state.

To test:

- View the revenue report
- It should show the one revenue row in the table as expected
