### PR TITLE
fix mouse handlers

### DIFF
--- a/client/components/legend/index.js
+++ b/client/components/legend/index.js
@@ -24,12 +24,12 @@ class Legend extends Component {
 		const d3Color = d3ScaleOrdinal().range( d3Range( 0, 1.1, 100 / ( data.length - 1 ) / 100 ) );
 		const width = data.length <= 2 ? 240 : 320;
 		return (
-			<ul>
+			<ul className="woocommerce-legend">
 				{ data.map( ( row, i ) => (
 					<li
 						id={ row.key }
-						onMouseOver={ handleLegendHover }
-						onMouseOut={ handleLegendHover }
+						onMouseEnter={ handleLegendHover }
+						onMouseLeave={ handleLegendHover }
 						onBlur={ handleLegendHover }
 						onFocus={ handleLegendHover }
 					>

--- a/client/components/legend/style.scss
+++ b/client/components/legend/style.scss
@@ -4,11 +4,14 @@
  * @format
  */
 
+.woocommerce-legend li {
+	margin: 0;
+}
+
 .container {
 	display: block;
 	position: relative;
-	padding-left: 20px;
-	margin-bottom: 12px;
+	padding: 3px 0 3px 20px;
 	cursor: pointer;
 	font-size: 13px;
 	user-select: none;
@@ -69,7 +72,7 @@
 
 .checkmark {
 	position: absolute;
-	top: 3px;
+	top: 6px;
 	left: 0;
 	height: 12px;
 	width: 12px;

--- a/client/dashboard/charts.js
+++ b/client/dashboard/charts.js
@@ -20,9 +20,11 @@ class WidgetCharts extends Component {
 		this.handleLegendHover = this.handleLegendHover.bind( this );
 		this.handleLegendToggle = this.handleLegendToggle.bind( this );
 		this.state = {
-			orderedKeys: this.getOrderedKeys( dummyOrders ).map( d => (
-				{ ...d, visible: true, focus: true }
-			) ),
+			orderedKeys: this.getOrderedKeys( dummyOrders ).map( d => ( {
+				...d,
+				visible: true,
+				focus: true,
+			} ) ),
 		};
 	}
 
@@ -34,7 +36,8 @@ class WidgetCharts extends Component {
 					return accum;
 				}, [] )
 			),
-		].map( key => ( {
+		]
+			.map( key => ( {
 				key,
 				total: data.reduce( ( a, c ) => a + c[ key ], 0 ),
 			} ) )
@@ -52,10 +55,13 @@ class WidgetCharts extends Component {
 
 	handleLegendHover( event ) {
 		this.setState( {
-			orderedKeys: this.state.orderedKeys.map( d => ( {
-				...d,
-				focus: d.key !== event.target.id ? ! d.focus : d.focus,
-			} ) ),
+			orderedKeys: this.state.orderedKeys.map( d => {
+				const enterFocus = d.key === event.target.id ? true : false;
+				return {
+					...d,
+					focus: event.type === 'mouseleave' || event.type === 'blur' ? true : enterFocus,
+				};
+			} ),
 		} );
 	}
 


### PR DESCRIPTION
@greenafrican 

`onMouseOut`  was also wrong because it bubbles, so it was called when moving the mouse to a child element of the `li`. `onMouseLeave` is the right one.

https://developer.mozilla.org/en-US/docs/Web/Events/mouseleave

I made `handleLegendHover` more explicit because something wasn't right. 

How do you test blur? I wasn't able to tab over the legend items so I didn't test it