### PR TITLE
Add "in progress" banner to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 This is a feature plugin for a modern, javascript-driven WooCommerce Admin experience.
 
+---
+
+:warning: This project is in active development, and is not ready for general use. You can follow the features in development by looking at the [project's issues](https://github.com/woocommerce/wc-admin/issues). **We do not recommend running this on production sites.**
+
+---
+
 ## Prerequisites
 
-[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin. You also need v3 of the WooCommerce REST API via [wc-api-dev](https://github.com/woocommerce/wc-api-dev/) or [the feature branch](https://github.com/woocommerce/woocommerce/tree/feature/rest-api-v3).
+[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin. You also need v3 of the WooCommerce REST API via [wc-api-dev](https://github.com/woocommerce/wc-api-dev/) or [the feature branch of WooCommerce](https://github.com/woocommerce/woocommerce/tree/feature/rest-api-v3).
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin. You also need v3 of the WooCommerce REST API via [wc-api-dev](https://github.com/woocommerce/wc-api-dev/) or [the feature branch of WooCommerce](https://github.com/woocommerce/woocommerce/tree/feature/rest-api-v3).
+[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin. You also need v3 of the WooCommerce REST API, which you can get by installing the feature branch of WooCommerce. [Clone the feature branch from github](https://github.com/woocommerce/woocommerce/tree/feature/rest-api-v3), or [download a zip of WooCommerce](https://github.com/woocommerce/woocommerce/archive/feature/rest-api-v3.zip).
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 


### PR DESCRIPTION
There has been some confusion about the state of this project, how it's confusing to set up and lacks screenshots/docs. This adds a new banner on the readme:

---

:warning: This project is in active development, and is not ready for general use. You can follow the features in development by looking at the [project's issues](https://github.com/woocommerce/wc-admin/issues). **We do not recommend running this on production sites.**

---

[View readme.](https://github.com/woocommerce/wc-admin/blob/update/wip-readme/README.md) I added the note about checking out the issues because we do technically have screenshots there, and we can manage community feedback in issues if needed. I don't want to scare everyone off the project 🙂 