### PR TITLE
Activity Panel: Add a "first draft" of Inbox items

### DIFF
--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -16,10 +16,10 @@ import { partial, uniqueId, find } from 'lodash';
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
 import { H, Section } from 'layout/section';
-import InboxPanel from './inbox';
-import OrdersPanel from './orders';
-import StockPanel from './stock';
-import ReviewsPanel from './reviews';
+import InboxPanel from './panels/inbox';
+import OrdersPanel from './panels/orders';
+import StockPanel from './panels/stock';
+import ReviewsPanel from './panels/reviews';
 import WordPressNotices from './wordpress-notices';
 
 class ActivityPanel extends Component {

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -3,16 +3,47 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import ActivityCard from '../activity-card';
 import ActivityHeader from '../activity-header';
+import { Section } from 'layout/section';
 
 class InboxPanel extends Component {
 	render() {
-		return <ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />;
+		return (
+			<Fragment>
+				<ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />
+				<Section>
+					<ActivityCard
+						className="woocommerce-inbox-activity-card"
+						title={ __( 'Accept Apple Pay using Stripe', 'wc-admin' ) }
+						date={ '2018-07-12T16:23:08Z' }
+						icon={ <Gridicon icon="customize" size={ 48 } /> }
+						unread
+					>
+						{ __(
+							'Your Stripe payment gateway now allows your customers to pay using Apple Pay.',
+							'wc-admin'
+						) }
+					</ActivityCard>
+					<ActivityCard
+						className="woocommerce-inbox-activity-card"
+						title={ __( 'Extension subscription expired', 'wc-admin' ) }
+						date={ '2018-07-11T02:49:00Z' }
+					>
+						{ __(
+							'Your subscription for WooCommerce Subscriptions expired on Jun 7th 2018.',
+							'wc-admin'
+						) }
+					</ActivityCard>
+				</Section>
+			</Fragment>
+		);
 	}
 }
 

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -8,7 +8,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import ActivityHeader from './activity-header';
+import ActivityHeader from '../activity-header';
 
 class InboxPanel extends Component {
 	render() {

--- a/client/layout/activity-panel/panels/orders.js
+++ b/client/layout/activity-panel/panels/orders.js
@@ -11,8 +11,8 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import ActivityCard from './activity-card';
-import ActivityHeader from './activity-header';
+import ActivityCard from '../activity-card';
+import ActivityHeader from '../activity-header';
 import { EllipsisMenu, MenuTitle, MenuItem } from 'components/ellipsis-menu';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';

--- a/client/layout/activity-panel/panels/reviews.js
+++ b/client/layout/activity-panel/panels/reviews.js
@@ -8,12 +8,12 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import ActivityHeader from './activity-header';
+import ActivityHeader from '../activity-header';
 
-class StockPanel extends Component {
+class ReviewsPanel extends Component {
 	render() {
-		return <ActivityHeader title={ __( 'Stock', 'wc-admin' ) } />;
+		return <ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />;
 	}
 }
 
-export default StockPanel;
+export default ReviewsPanel;

--- a/client/layout/activity-panel/panels/stock.js
+++ b/client/layout/activity-panel/panels/stock.js
@@ -8,12 +8,12 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import ActivityHeader from './activity-header';
+import ActivityHeader from '../activity-header';
 
-class ReviewsPanel extends Component {
+class StockPanel extends Component {
 	render() {
-		return <ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />;
+		return <ActivityHeader title={ __( 'Stock', 'wc-admin' ) } />;
 	}
 }
 
-export default ReviewsPanel;
+export default StockPanel;

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -227,9 +227,23 @@
 .woocommerce-layout__activity-panel-avatar-flag-overlay {
 	position: relative;
 	top: -$gap-small;
+
 	.woocommerce-flag {
 		position: relative;
 		top: 16px;
 		border: 2px solid $white;
+	}
+}
+
+// Needs the double-class for specificity
+.woocommerce-activity-card.woocommerce-inbox-activity-card {
+	grid-template-columns: 72px 1fr;
+
+	@include breakpoint( '<782px' ) {
+		grid-template-columns: 64px 1fr;
+	}
+
+	.woocommerce-activity-card__header {
+		margin-bottom: $gap-small;
 	}
 }


### PR DESCRIPTION
See #176 - This PR adds some hardcoded items to the Inbox section in the Activity Panel. This is to show how these items would be styled. The first item is "unread".

<img width="531" alt="screen shot 2018-07-16 at 10 59 57 am" src="https://user-images.githubusercontent.com/541093/42766893-97c4a754-88e9-11e8-8e4f-02d79ad79780.png">

I've also moved all the activity panel files into a new folder `/panels`, just to clean up the `activity-panels` folder.

To test

- Make sure cards appear in Inbox section of activity panel
- There is no other functionality here, yet