### PR TITLE
Activity Panel Outbound Link

### DIFF
--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -6,7 +6,7 @@ Use `Gravatar` to display a user's Gravatar.
 ## How to use:
 
 ```jsx
-import { Gravatar } from 'components/gravatar';
+import Gravatar from 'components/gravatar';
 
 render: function() {
   return (

--- a/client/components/link/README.md
+++ b/client/components/link/README.md
@@ -1,0 +1,26 @@
+Link
+============
+
+Use `Link` to create a link to another resource. It accepts a type to automatically create wp-admin links, wc-admin links, and external links.
+
+## How to use:
+
+```jsx
+import Link from 'components/link';
+
+render: function() {
+  return (
+	<Link
+		href="edit.php?post_type=shop_coupon"
+		type="wp-admin"
+	>
+		Coupons
+	</Link>
+  );
+}
+```
+
+## Props
+
+* `href` (required): The resource to link to.
+* `type` (required): Type of link. For wp-admin and wc-admin, the correct prefix is appended. Accepts: wc-admin, wp-admin, external.

--- a/client/components/link/index.js
+++ b/client/components/link/index.js
@@ -13,16 +13,24 @@ import { getAdminLink } from 'lib/nav-utils';
 
 class Link extends Component {
 	render() {
-		const { children, to, wpAdmin, ...props } = this.props;
-		if ( this.context.router && ! wpAdmin ) {
+		const { children, href, type, ...props } = this.props;
+		if ( this.context.router && 'wc-admin' === type ) {
 			return (
-				<RouterLink to={ to } { ...props }>
+				<RouterLink to={ href } { ...props }>
 					{ children }
 				</RouterLink>
 			);
 		}
 
-		const path = wpAdmin ? getAdminLink( to ) : getAdminLink( 'admin.php?page=wcadmin#' + to );
+		let path;
+		if ( 'wp-admin' === type ) {
+			path = getAdminLink( href );
+		} else if ( 'external' === type ) {
+			path = href;
+		} else {
+			path = getAdminLink( 'admin.php?page=wc-admin#' + href );
+		}
+
 		return (
 			<a href={ path } { ...props }>
 				{ children }
@@ -32,12 +40,12 @@ class Link extends Component {
 }
 
 Link.propTypes = {
-	to: PropTypes.string,
-	wpAdmin: PropTypes.bool,
+	href: PropTypes.string.isRequired,
+	type: PropTypes.oneOf( [ 'wp-admin', 'wc-admin', 'external' ] ).isRequired,
 };
 
 Link.defaultProps = {
-	wpAdmin: false,
+	type: 'wc-admin',
 };
 
 Link.contextTypes = {

--- a/client/layout/activity-panel/activity-header/README.md
+++ b/client/layout/activity-panel/activity-header/README.md
@@ -6,7 +6,7 @@ A component designed for use in the activity panel. It returns a title and can o
 ## How to use:
 
 ```jsx
-import ActivityHeader from 'components/activity-header';
+import ActivityHeader from 'layout/activity-panel/activity-header';
 
 render: function() {
   return (

--- a/client/layout/activity-panel/activity-outbound-link/README.md
+++ b/client/layout/activity-panel/activity-outbound-link/README.md
@@ -1,0 +1,26 @@
+ActivityPanelOutboundLink
+============
+
+`ActivityPanelOutboundLink` creates a styled link for use in the Activity Panel.
+
+## How to use:
+
+```jsx
+import ActivityOutboundLink from 'layout/activity-panel/activity-outbound-link';
+
+render: function() {
+  return (
+	<ActivityOutboundLink
+		href="edit.php?post_type=shop_coupon"
+		type="wp-admin"
+	>
+		Coupons
+	</ActivityOutboundLink>
+  );
+}
+```
+
+## Props
+
+* `href` (required): The resource to link to.
+* `type` (required): Type of link. For wp-admin and wc-admin, the correct prefix is appended. Accepts: wc-admin, wp-admin, external.

--- a/client/layout/activity-panel/activity-outbound-link/README.md
+++ b/client/layout/activity-panel/activity-outbound-link/README.md
@@ -1,7 +1,7 @@
-ActivityPanelOutboundLink
+ActivityOutboundLink
 ============
 
-`ActivityPanelOutboundLink` creates a styled link for use in the Activity Panel.
+`ActivityOutboundLink` creates a styled link for use in the Activity Panel.
 
 ## How to use:
 

--- a/client/layout/activity-panel/activity-outbound-link/index.js
+++ b/client/layout/activity-panel/activity-outbound-link/index.js
@@ -13,10 +13,11 @@ import Gridicon from 'gridicons';
 import './style.scss';
 import Link from 'components/link';
 
-const ActivityOutboundLink = ( { href, type, className, children } ) => {
+const ActivityOutboundLink = props => {
+	const { href, type, className, children, ...restOfProps } = props;
 	const classes = classnames( 'woocommerce-layout__activity-panel-outbound-link', className );
 	return (
-		<Link href={ href } type={ type } className={ classes }>
+		<Link href={ href } type={ type } className={ classes } { ...restOfProps }>
 			{ children }
 			<Gridicon icon="arrow-right" />
 		</Link>

--- a/client/layout/activity-panel/activity-outbound-link/index.js
+++ b/client/layout/activity-panel/activity-outbound-link/index.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Link from 'components/link';
+
+const ActivityOutboundLink = ( { href, type, className, children } ) => {
+	const classes = classnames( 'woocommerce-layout__activity-panel-outbound-link', className );
+	return (
+		<Link href={ href } type={ type } className={ classes }>
+			{ children }
+			<Gridicon icon="arrow-right" />
+		</Link>
+	);
+};
+
+ActivityOutboundLink.propTypes = {
+	href: PropTypes.string.isRequired,
+	type: PropTypes.oneOf( [ 'wp-admin', 'wc-admin', 'external' ] ).isRequired,
+	className: PropTypes.string,
+};
+
+ActivityOutboundLink.defaultProps = {
+	type: 'wp-admin',
+};
+
+export default ActivityOutboundLink;

--- a/client/layout/activity-panel/activity-outbound-link/style.scss
+++ b/client/layout/activity-panel/activity-outbound-link/style.scss
@@ -1,0 +1,56 @@
+/** @format */
+
+.woocommerce-layout__activity-panel-outbound-link {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	height: 50px;
+	background: $core-grey-light-200;
+	border-bottom: 1px solid $core-grey-light-400;
+	padding: $gap;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 18px;
+	margin: 0;
+	color: $woocommerce;
+	text-decoration: none;
+
+	@include breakpoint( '>782px' ) {
+		padding: $gap $gap-large $gap $gap-large;
+	}
+
+	.gridicon {
+		display: none;
+	}
+
+	&:hover {
+		background: $white;
+		color: $woocommerce;
+	}
+
+	&:active {
+		background: $core-grey-light-100;
+		color: $woocommerce-darker;
+	}
+
+	&:focus {
+		color: $woocommerce;
+		background: $core-grey-light-200;
+		box-shadow: inset 0 0 0 1px $box-shadow-blue, inset 0 0 0 2px #fff;
+	}
+
+	&:hover,
+	&:focus {
+		.gridicon {
+			display: initial;
+			color: $woocommerce;
+		}
+	}
+
+	&:active {
+		.gridicon {
+			display: initial;
+			color: $woocommerce-darker;
+		}
+	}
+}

--- a/client/layout/activity-panel/activity-outbound-link/style.scss
+++ b/client/layout/activity-panel/activity-outbound-link/style.scss
@@ -7,17 +7,13 @@
 	height: 50px;
 	background: $core-grey-light-200;
 	border-bottom: 1px solid $core-grey-light-400;
-	padding: $gap;
+	padding: $gap $gutter;
 	font-size: 13px;
 	font-weight: 500;
 	line-height: 18px;
 	margin: 0;
 	color: $woocommerce;
 	text-decoration: none;
-
-	@include breakpoint( '>782px' ) {
-		padding: $gap $gap-large $gap $gap-large;
-	}
 
 	.gridicon {
 		display: none;

--- a/client/layout/activity-panel/panels/orders.js
+++ b/client/layout/activity-panel/panels/orders.js
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
  */
 import ActivityCard from '../activity-card';
 import ActivityHeader from '../activity-header';
+import ActivityOutboundLink from '../activity-outbound-link';
 import { EllipsisMenu, MenuTitle, MenuItem } from 'components/ellipsis-menu';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';
@@ -46,18 +47,19 @@ function OrdersPanel( { orders } ) {
 				{ isLoading ? (
 					<p>Loading</p>
 				) : (
-					data.map( ( order, i ) => {
-						// We want the billing address, but shipping can be used as a fallback.
-						const address = { ...order.shipping, ...order.billing };
-						const name = `${ address.first_name } ${ address.last_name }`;
-						const productsCount = order.line_items.reduce(
-							( total, line ) => total + line.quantity,
-							0
-						);
+					<Fragment>
+						{ data.map( ( order, i ) => {
+							// We want the billing address, but shipping can be used as a fallback.
+							const address = { ...order.shipping, ...order.billing };
+							const name = `${ address.first_name } ${ address.last_name }`;
+							const productsCount = order.line_items.reduce(
+								( total, line ) => total + line.quantity,
+								0
+							);
 
-						const total = order.total;
-						const refundValue = getOrderRefundTotal( order );
-						const remainingTotal = getCurrencyFormatDecimal( order.total ) + refundValue;
+							const total = order.total;
+							const refundValue = getOrderRefundTotal( order );
+							const remainingTotal = getCurrencyFormatDecimal( order.total ) + refundValue;
 
 						return (
 							<ActivityCard
@@ -92,8 +94,12 @@ function OrdersPanel( { orders } ) {
 							>
 								Pending
 							</ActivityCard>
-						);
-					} )
+							);
+						} ) }
+						<ActivityOutboundLink href={ 'edit.php?post_type=shop_order' }>
+							{ __( 'Manage all orders' ) }
+						</ActivityOutboundLink>
+					</Fragment>
 				) }
 			</Section>
 		</Fragment>

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -185,12 +185,12 @@
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: scroll;
-	padding-bottom: $gap-small * 6;
 
+	// Extra padding is needed at the bottom of the wrapper because of our positioning, height, and overflow rules. Otherwise, some content can get cut off.
+	padding-bottom: $gap-small * 6;
 	@include breakpoint( '782px-1100px' ) {
 		padding-bottom: $gap-small;
 	}
-
 	@include breakpoint( '>1100px' ) {
 		top: 112px;
 		padding-bottom: $gap * 2;

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -185,9 +185,15 @@
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: scroll;
+	padding-bottom: $gap-small * 6;
+
+	@include breakpoint( '782px-1100px' ) {
+		padding-bottom: $gap-small;
+	}
 
 	@include breakpoint( '>1100px' ) {
 		top: 112px;
+		padding-bottom: $gap * 2;
 	}
 
 	@include breakpoint( '<782px' ) {

--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -81,11 +81,11 @@ class Header extends Component {
 			<div className={ className }>
 				<h1 className="woocommerce-layout__header-breadcrumbs">
 					<span>
-						<Link to="/">WooCommerce</Link>
+						<Link href="/">WooCommerce</Link>
 					</span>
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = isArray( section ) ? (
-							<Link to={ section[ 0 ] } wpAdmin={ isEmbedded }>
+							<Link href={ section[ 0 ] } type={ isEmbedded ? 'wp-admin' : 'wc-admin' }>
 								{ section[ 1 ] }
 							</Link>
 						) : (

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -40,6 +40,8 @@ $black: #24292d; // same as wp-admin sidebar
 $valid-green: #4ab866;
 $error-red: #d94f4f;
 $woocommerce: #95588a;
+$woocommerce-darker: #5b3453;
+$box-shadow-blue: #5b9dd9;
 $core-orange: #ca4a1f;
 
 $button: #f0f2f4;


### PR DESCRIPTION
This PR adds a new Activity Panel component for creating a styled outbound link as [seen here](https://automattic.invisionapp.com/d/main#/console/14654690/304742001/inspect).

Closes #194.

It also does some README cleanup/adds a README for the `Link` component, and renames the `<Link>` `to` prop to `href` which feels a bit more natural for this wrapper component.

<img width="521" alt="screen shot 2018-07-16 at 11 56 39 am" src="https://user-images.githubusercontent.com/689165/42769465-318b396a-88f0-11e8-837c-c695f91d9115.png">

<img width="523" alt="screen shot 2018-07-16 at 12 01 59 pm" src="https://user-images.githubusercontent.com/689165/42769471-346cabdc-88f0-11e8-8914-29c0b34e157e.png">

To Test:
* Open up the orders activity panel and scroll to the bottom. You should see an outbound link. Verify the various states and that the link clicks through to the orders page.