### PR TITLE
Add Order Status Component

### DIFF
--- a/client/components/order-status/README.md
+++ b/client/components/order-status/README.md
@@ -1,0 +1,23 @@
+OrderStatus
+============
+
+Use `OrderStatus` to display a badge with human-friendly text describing the current order status.
+
+## How to use:
+
+```jsx
+import OrderStatus from 'components/order-status';
+
+render: function() {
+  return (
+	<OrderStatus
+		order={ order }
+	/>
+  );
+}
+```
+
+## Props
+
+* `order` (required): The order to display a status for.
+* `className`: Additional CSS classes.

--- a/client/components/order-status/index.js
+++ b/client/components/order-status/index.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const OrderStatus = ( { order, className } ) => {
+	const { status } = order;
+	const { orderStatuses } = wcSettings;
+	const classes = classnames( 'woocommerce-order-status', className );
+	const indicatorClasses = classnames( 'woocommerce-order-status__indicator', {
+		[ 'is-' + status ]: true,
+	} );
+	const label = orderStatuses[ 'wc-' + status ] || status;
+	return (
+		<div className={ classes }>
+			<span className={ indicatorClasses } />
+			{ label }
+		</div>
+	);
+};
+
+OrderStatus.propTypes = {
+	order: PropTypes.object.isRequired,
+	className: PropTypes.string,
+};
+
+export default OrderStatus;

--- a/client/components/order-status/style.scss
+++ b/client/components/order-status/style.scss
@@ -1,0 +1,26 @@
+/** @format */
+
+.woocommerce-order-status {
+	display: flex;
+	align-items: center;
+}
+
+.woocommerce-order-status__indicator {
+	width: 16px;
+	height: 16px;
+	display: block;
+	background: $core-grey-light-700;
+	margin-right: $gap-smallest * 2;
+	border-radius: 50%;
+	border: 3px solid $core-grey-light-500;
+
+	&.is-processing {
+		background: $valid-green;
+		border-color: lighten($valid-green, 20%);
+	}
+
+	&.is-on-hold {
+		background: $notice-yellow;
+		border-color: lighten($notice-yellow, 20%);
+	}
+}

--- a/client/layout/activity-panel/panels/orders.js
+++ b/client/layout/activity-panel/panels/orders.js
@@ -18,6 +18,7 @@ import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getOrderRefundTotal } from 'lib/order-values';
 import Gravatar from 'components/gravatar';
 import Flag from 'components/flag';
+import OrderStatus from 'components/order-status';
 import { Section } from 'layout/section';
 
 function OrdersPanel( { orders } ) {
@@ -90,7 +91,7 @@ function OrdersPanel( { orders } ) {
 									</Button>
 								}
 							>
-								Pending
+								<OrderStatus order={ order } />
 							</ActivityCard>
 						);
 					} )

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -38,6 +38,7 @@ $black: #24292d; // same as wp-admin sidebar
 
 // Bright colors
 $valid-green: #4ab866;
+$notice-yellow: #ffb900;
 $error-red: #d94f4f;
 $woocommerce: #95588a;
 $core-orange: #ca4a1f;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -43,11 +43,12 @@ function wc_admin_register_script() {
 	$settings = array(
 		'adminUrl'           => admin_url(),
 		'embedBreadcrumbs'   => wc_admin_get_embed_breadcrumbs(),
-		'siteLocale'   => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'  => wc_admin_currency_settings(),
-		'date' => array(
+		'siteLocale'         => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'           => wc_admin_currency_settings(),
+		'date'               => array(
 			'dow' => get_option( 'start_of_week', 0 ),
 		),
+		'orderStatuses'      => wc_get_order_statuses(),
 	);
 
 	wp_add_inline_script(


### PR DESCRIPTION
This PR adds an `OrderStatus` component, to display a badge and label describing the current order status. Closes #148. I'm making this one a normal component since there can be applications outside of the activity panel in the future (like a redesigned orders page).

It injects the orders statuses into `wcSettings`, so any custom order statuses can display their labels correctly in the panel.

To Test:
* Open the order panel with a few orders (a couple different statuses including processing and on-hold would be good) and verify the badges display.

<img width="534" alt="screen shot 2018-07-16 at 1 43 59 pm" src="https://user-images.githubusercontent.com/689165/42774302-592f1798-88ff-11e8-9306-03524917c01d.png">
