### PR TITLE
Fix ActivityPanel Slide Animation

### DIFF
--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -127,14 +127,15 @@ class ActivityPanel extends Component {
 
 	renderPanel() {
 		const { isPanelOpen, currentTab } = this.state;
-		const classNames = classnames( 'woocommerce-layout__activity-panel-wrapper', {
-			'is-open': isPanelOpen,
-		} );
 
 		const tab = find( this.getTabs(), { name: currentTab } );
 		if ( ! tab ) {
-			return null;
+			return <div className="woocommerce-layout__activity-panel-wrapper" />;
 		}
+
+		const classNames = classnames( 'woocommerce-layout__activity-panel-wrapper', {
+			'is-open': isPanelOpen,
+		} );
 
 		return (
 			<div className={ classNames } tabIndex={ 0 } role="tabpanel" aria-label={ tab.title }>


### PR DESCRIPTION
It looks like we lost the slide animation (that happens on open/close) in a recent commit. This PR adds it back. 

The animation toggles when `is-open` is added/removed from the wrapper div.

To Test:
* Load up this branch and test that the open/close animation works.