### PR TITLE
Add unread indicator to mobile panel toggle

### DIFF
--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -28,10 +28,12 @@ class ActivityPanel extends Component {
 		this.togglePanel = this.togglePanel.bind( this );
 		this.toggleMobile = this.toggleMobile.bind( this );
 		this.renderTab = this.renderTab.bind( this );
+		this.updateNoticeFlag = this.updateNoticeFlag.bind( this );
 		this.state = {
 			isPanelOpen: false,
 			mobileOpen: false,
 			currentTab: '',
+			hasWordPressNotices: false,
 		};
 	}
 
@@ -80,6 +82,12 @@ class ActivityPanel extends Component {
 		}
 	}
 
+	updateNoticeFlag( noticeCount ) {
+		this.setState( {
+			hasWordPressNotices: noticeCount > 0,
+		} );
+	}
+
 	// TODO Pull in dynamic unread status/count
 	getTabs() {
 		return [
@@ -87,7 +95,7 @@ class ActivityPanel extends Component {
 				name: 'inbox',
 				title: __( 'Inbox', 'wc-admin' ),
 				icon: <Gridicon icon="mail" />,
-				unread: true,
+				unread: false,
 			},
 			{
 				name: 'orders',
@@ -99,13 +107,13 @@ class ActivityPanel extends Component {
 				name: 'stock',
 				title: __( 'Stock', 'wc-admin' ),
 				icon: <Gridicon icon="clipboard" />,
-				unread: true,
+				unread: false,
 			},
 			{
 				name: 'reviews',
 				title: __( 'Reviews', 'wc-admin' ),
 				icon: <Gridicon icon="star" />,
-				unread: true,
+				unread: false,
 			},
 		];
 	}
@@ -187,13 +195,14 @@ class ActivityPanel extends Component {
 
 	render() {
 		const tabs = this.getTabs();
-		const { currentTab, mobileOpen } = this.state;
+		const { currentTab, mobileOpen, hasWordPressNotices } = this.state;
 		const headerId = uniqueId( 'activity-panel-header_' );
 		const panelClasses = classnames( 'woocommerce-layout__activity-panel', {
 			'is-mobile-open': this.state.mobileOpen,
 		} );
 
-		// TODO Replace the mobile toggle with the Woo bubble Gridicon once it has been added.
+		const hasUnread = hasWordPressNotices || tabs.some( tab => tab.unread );
+
 		return (
 			<div>
 				<H id={ headerId } className="screen-reader-text">
@@ -202,7 +211,13 @@ class ActivityPanel extends Component {
 				<Section component="aside" id="woocommerce-activity-panel" aria-labelledby={ headerId }>
 					<IconButton
 						onClick={ this.toggleMobile }
-						icon={ mobileOpen ? <Gridicon icon="cross-small" /> : <ActivityPanelToggleBubble /> }
+						icon={
+							mobileOpen ? (
+								<Gridicon icon="cross-small" />
+							) : (
+								<ActivityPanelToggleBubble hasUnread={ hasUnread } />
+							)
+						}
 						label={
 							mobileOpen
 								? __( 'Close Activity Panel', 'wc-admin' )
@@ -222,6 +237,7 @@ class ActivityPanel extends Component {
 							<WordPressNotices
 								showNotices={ 'wpnotices' === currentTab }
 								togglePanel={ this.togglePanel }
+								onCountUpdate={ this.updateNoticeFlag }
 							/>
 						</NavigableMenu>
 						{ this.renderPanel() }

--- a/client/layout/activity-panel/index.js
+++ b/client/layout/activity-panel/index.js
@@ -95,7 +95,7 @@ class ActivityPanel extends Component {
 				name: 'inbox',
 				title: __( 'Inbox', 'wc-admin' ),
 				icon: <Gridicon icon="mail" />,
-				unread: false,
+				unread: true,
 			},
 			{
 				name: 'orders',
@@ -188,7 +188,10 @@ class ActivityPanel extends Component {
 				onClick={ partial( this.togglePanel, tab.name ) }
 				icon={ tab.icon }
 			>
-				{ tab.title }
+				{ tab.title }{' '}
+				{ tab.unread && (
+					<span className="screen-reader-text">{ __( 'unread activity', 'wc-admin' ) }</span>
+				) }
 			</IconButton>
 		);
 	}
@@ -202,6 +205,9 @@ class ActivityPanel extends Component {
 		} );
 
 		const hasUnread = hasWordPressNotices || tabs.some( tab => tab.unread );
+		const viewLabel = hasUnread
+			? __( 'View Activity Panel, you have unread activity', 'wc-admin' )
+			: __( 'View Activity Panel', 'wc-admin' );
 
 		return (
 			<div>
@@ -218,11 +224,7 @@ class ActivityPanel extends Component {
 								<ActivityPanelToggleBubble hasUnread={ hasUnread } />
 							)
 						}
-						label={
-							mobileOpen
-								? __( 'Close Activity Panel', 'wc-admin' )
-								: __( 'View Activity Panel', 'wc-admin' )
-						}
+						label={ mobileOpen ? __( 'Close Activity Panel', 'wc-admin' ) : viewLabel }
 						aria-expanded={ mobileOpen }
 						tooltip={ false }
 						className="woocommerce-layout__activity-panel-mobile-toggle"

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -155,6 +155,20 @@
 	}
 }
 
+.woocommerce-layout__activity-panel-toggle-bubble.has-unread:after {
+	content: ' ';
+	position: absolute;
+	padding: 1px;
+	background: $core-orange;
+	border: 2px solid white;
+	width: 4px;
+	height: 4px;
+	display: inline-block;
+	border-radius: 50%;
+	top: 6px;
+	right: 4px;
+}
+
 @keyframes tabSwitch {
 	0%,
 	100% {

--- a/client/layout/activity-panel/toggle-bubble.js
+++ b/client/layout/activity-panel/toggle-bubble.js
@@ -3,19 +3,21 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
-const ActivityPanelToggleBubble = ( { height = 24, width = 24 } ) => {
+const ActivityPanelToggleBubble = ( { height = 24, width = 24, hasUnread = false } ) => {
+	const classes = classnames( 'woocommerce-layout__activity-panel-toggle-bubble', {
+		'has-unread': hasUnread,
+	} );
+
 	/* eslint-disable max-len */
 	return (
-		<svg
-			className="woocommerce-layout__activity-panel-toggle-bubble"
-			height={ height }
-			width={ width }
-			viewBox="0 0 24 24"
-		>
-			<path d="M18.9 2H5.1C3.4 2 2 3.4 2 5.1v10.7C2 17.6 3.4 19 5.1 19H9l6 3-1-3h4.9c1.7 0 3.1-1.4 3.1-3.1V5.1C22 3.4 20.6 2 18.9 2zm-1.5 4.5c-.4.8-.8 2.1-1 3.9-.3 1.8-.4 3.1-.3 4.1 0 .3 0 .5-.1.7-.1.2-.3.4-.6.4s-.6-.1-.9-.4c-1-1-1.8-2.6-2.4-4.6-.7 1.4-1.2 2.4-1.6 3.1-.6 1.2-1.2 1.8-1.6 1.9-.3 0-.5-.2-.8-.7-.5-1.4-1.1-4.2-1.7-8.2 0-.3 0-.5.2-.7.1-.2.4-.3.7-.4.5 0 .9.2.9.8.3 2.3.7 4.2 1.1 5.7l2.4-4.5c.2-.4.4-.6.8-.6.5 0 .8.3.9.9.3 1.4.6 2.6 1 3.7.3-2.7.8-4.7 1.4-5.9.2-.3.4-.5.7-.5.2 0 .5.1.7.2.2.2.3.4.3.6 0 .2 0 .4-.1.5z" />
-		</svg>
+		<div className={ classes }>
+			<svg height={ height } width={ width } viewBox="0 0 24 24">
+				<path d="M18.9 2H5.1C3.4 2 2 3.4 2 5.1v10.7C2 17.6 3.4 19 5.1 19H9l6 3-1-3h4.9c1.7 0 3.1-1.4 3.1-3.1V5.1C22 3.4 20.6 2 18.9 2zm-1.5 4.5c-.4.8-.8 2.1-1 3.9-.3 1.8-.4 3.1-.3 4.1 0 .3 0 .5-.1.7-.1.2-.3.4-.6.4s-.6-.1-.9-.4c-1-1-1.8-2.6-2.4-4.6-.7 1.4-1.2 2.4-1.6 3.1-.6 1.2-1.2 1.8-1.6 1.9-.3 0-.5-.2-.8-.7-.5-1.4-1.1-4.2-1.7-8.2 0-.3 0-.5.2-.7.1-.2.4-.3.7-.4.5 0 .9.2.9.8.3 2.3.7 4.2 1.1 5.7l2.4-4.5c.2-.4.4-.6.8-.6.5 0 .8.3.9.9.3 1.4.6 2.6 1 3.7.3-2.7.8-4.7 1.4-5.9.2-.3.4-.5.7-.5.2 0 .5.1.7.2.2.2.3.4.3.6 0 .2 0 .4-.1.5z" />
+			</svg>
+		</div>
 	);
 	/* eslint-enable max-len */
 };
@@ -23,6 +25,7 @@ const ActivityPanelToggleBubble = ( { height = 24, width = 24 } ) => {
 ActivityPanelToggleBubble.propTypes = {
 	height: PropTypes.number,
 	width: PropTypes.number,
+	hasUnread: PropTypes.bool,
 };
 
 export default ActivityPanelToggleBubble;

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -199,7 +199,8 @@ class WordPressNotices extends Component {
 				role="tab"
 				tabIndex={ showNotices ? null : -1 }
 			>
-				{ __( 'Notices', 'wc-admin' ) }
+				{ __( 'Notices', 'wc-admin' ) }{' '}
+				<span className="screen-reader-text">{ __( 'unread activity', 'wc-admin' ) }</span>
 			</IconButton>
 		);
 	}

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
 import { IconButton } from '@wordpress/components';
-import { partial } from 'lodash';
+import { partial, noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 class WordPressNotices extends Component {
@@ -210,6 +210,11 @@ WordPressNotices.propTypes = {
 	showNotices: PropTypes.bool,
 	togglePanel: PropTypes.func,
 	onCountUpdate: PropTypes.func,
+};
+
+WordPressNotices.defaultProps = {
+	togglePanel: noop,
+	onCountUpdate: noop,
 };
 
 export default WordPressNotices;

--- a/client/layout/activity-panel/wordpress-notices.js
+++ b/client/layout/activity-panel/wordpress-notices.js
@@ -3,11 +3,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
+import { IconButton } from '@wordpress/components';
 import { partial } from 'lodash';
-import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
 class WordPressNotices extends Component {
 	constructor() {
@@ -92,6 +93,7 @@ class WordPressNotices extends Component {
 
 		count = count - 1; // Remove 1 for `wp-header-end` which is a child of wp__notice-list
 
+		this.props.onCountUpdate( count );
 		this.setState( { count, notices, noticesOpen, screenMeta, screenLinks } );
 
 		// Move collapsed WordPress notifications into the main wc-admin body
@@ -139,6 +141,7 @@ class WordPressNotices extends Component {
 	updateCount() {
 		const updatedCount = this.state.count - 1;
 		this.setState( { count: updatedCount } );
+		this.props.onCountUpdate( updatedCount );
 
 		if ( updatedCount < 1 ) {
 			this.props.togglePanel( 'wpnotices' ); // Close the panel since all of the notices have been closed.
@@ -201,5 +204,11 @@ class WordPressNotices extends Component {
 		);
 	}
 }
+
+WordPressNotices.propTypes = {
+	showNotices: PropTypes.bool,
+	togglePanel: PropTypes.func,
+	onCountUpdate: PropTypes.func,
+};
 
 export default WordPressNotices;


### PR DESCRIPTION
This PR adds an unread indicator to the mobile toggle, so mobile users can see if the panel contains new items. Closes #198.

@ryelle What would be the best way to announce to screen readers that there are unread items? Just a label on the toggle div? There is also no indication on the desktop tabs if there are unread items so we should add something there too.

To Test:
* Shrink your screen down to mobile sizes
* If you have any WP notices, this branch should should display an orange unread indicator on the Woo bubble. If you dismiss all the notices, the orange circle should go away.
* You can also change the unread flags in `getTabs()` to test.

<img width="70" alt="screen shot 2018-07-17 at 11 28 05 am" src="https://user-images.githubusercontent.com/689165/42827485-80767e26-89b4-11e8-9f01-b5ea16ab5567.png">
 