### PR TITLE
Activity Panel: Add loading placeholder for ActivityCard, using Inbox as demo

### DIFF
--- a/client/layout/activity-panel/activity-card/README.md
+++ b/client/layout/activity-panel/activity-card/README.md
@@ -6,7 +6,7 @@ A card designed for use in the activity panel. This is a very structured compone
 ## How to use:
 
 ```jsx
-import ActivityCard from 'components/activity-card';
+import { ActivityCard } from 'components/activity-card';
 
 render: function() {
   return (

--- a/client/layout/activity-panel/activity-card/README.md
+++ b/client/layout/activity-panel/activity-card/README.md
@@ -33,3 +33,31 @@ render: function() {
 * `date`: The timestamp associated with this activity.
 * `icon`: An icon or avatar used to identify this activity. Defaults to Gridicon "notice-outline".
 * `unread`: If this prop is present, the card has a small red bubble indicating an "unread" item. Defaults to false.
+
+ActivityCardPlaceholder
+=======================
+
+This component is similar to `ActivityCard` in output, but renders no real content, just loading placeholders. This is also hidden from any interaction with screen readers using `aria-hidden`.
+
+It does expect `children`, which should be spans with class `is-placeholder`. This will let you define how many lines of placeholder content you want to show.
+
+## How to use:
+
+```jsx
+import { ActivityCardPlaceholder } from 'components/activity-card';
+
+render: function() {
+  return (
+    <ActivityCardPlaceholder hasDate>
+      <span className="is-placeholder" />
+    </ActivityCardPlaceholder>
+  );
+}
+```
+
+## Props
+
+* `children`: Content used in the body of the action card (required).
+* `hasAction`: Boolean. If true, shows a placeholder block for an action. Default false.
+* `hasDate`: Boolean. If true, shows a placeholder block for the date. Default false.
+* `hasSubtitle`: Boolean. If true, shows a placeholder block for the subtitle. Default false.

--- a/client/layout/activity-panel/activity-card/README.md
+++ b/client/layout/activity-panel/activity-card/README.md
@@ -39,8 +39,6 @@ ActivityCardPlaceholder
 
 This component is similar to `ActivityCard` in output, but renders no real content, just loading placeholders. This is also hidden from any interaction with screen readers using `aria-hidden`.
 
-It does expect `children`, which should be spans with class `is-placeholder`. This will let you define how many lines of placeholder content you want to show.
-
 ## How to use:
 
 ```jsx
@@ -48,16 +46,14 @@ import { ActivityCardPlaceholder } from 'components/activity-card';
 
 render: function() {
   return (
-    <ActivityCardPlaceholder hasDate>
-      <span className="is-placeholder" />
-    </ActivityCardPlaceholder>
+    <ActivityCardPlaceholder hasDate />
   );
 }
 ```
 
 ## Props
 
-* `children`: Content used in the body of the action card (required).
 * `hasAction`: Boolean. If true, shows a placeholder block for an action. Default false.
 * `hasDate`: Boolean. If true, shows a placeholder block for the date. Default false.
 * `hasSubtitle`: Boolean. If true, shows a placeholder block for the subtitle. Default false.
+* `lines`: Number. How many lines of placeholder content we should show. Default 1.

--- a/client/layout/activity-panel/activity-card/index.js
+++ b/client/layout/activity-panel/activity-card/index.js
@@ -61,4 +61,5 @@ ActivityCard.defaultProps = {
 	unread: false,
 };
 
-export default ActivityCard;
+export { ActivityCard };
+export { default as ActivityCardPlaceholder } from './placeholder';

--- a/client/layout/activity-panel/activity-card/placeholder.js
+++ b/client/layout/activity-panel/activity-card/placeholder.js
@@ -5,10 +5,11 @@
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { range } from 'lodash';
 
 class ActivityCardPlaceholder extends Component {
 	render() {
-		const { className, children, hasAction, hasDate, hasSubtitle } = this.props;
+		const { className, hasAction, hasDate, hasSubtitle, lines } = this.props;
 		const cardClassName = classnames( 'woocommerce-activity-card is-loading', className );
 
 		return (
@@ -25,7 +26,9 @@ class ActivityCardPlaceholder extends Component {
 						</div>
 					) }
 				</div>
-				<div className="woocommerce-activity-card__body">{ children }</div>
+				<div className="woocommerce-activity-card__body">
+					{ range( lines ).map( i => <span className="is-placeholder" key={ i } /> ) }
+				</div>
 				{ hasAction && (
 					<div className="woocommerce-activity-card__actions">
 						<span className="is-placeholder" />
@@ -38,16 +41,17 @@ class ActivityCardPlaceholder extends Component {
 
 ActivityCardPlaceholder.propTypes = {
 	className: PropTypes.string,
-	children: PropTypes.node.isRequired,
 	hasAction: PropTypes.bool,
 	hasDate: PropTypes.bool,
 	hasSubtitle: PropTypes.bool,
+	lines: PropTypes.number,
 };
 
 ActivityCardPlaceholder.defaultProps = {
 	hasAction: false,
 	hasDate: false,
 	hasSubtitle: false,
+	lines: 1,
 };
 
 export default ActivityCardPlaceholder;

--- a/client/layout/activity-panel/activity-card/placeholder.js
+++ b/client/layout/activity-panel/activity-card/placeholder.js
@@ -1,0 +1,53 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+class ActivityCardPlaceholder extends Component {
+	render() {
+		const { className, children, hasAction, hasDate, hasSubtitle } = this.props;
+		const cardClassName = classnames( 'woocommerce-activity-card is-loading', className );
+
+		return (
+			<div className={ cardClassName } aria-hidden>
+				<span className="woocommerce-activity-card__icon">
+					<span className="is-placeholder" />
+				</span>
+				<div className="woocommerce-activity-card__header">
+					<div className="woocommerce-activity-card__title is-placeholder" />
+					{ hasSubtitle && <div className="woocommerce-activity-card__subtitle is-placeholder" /> }
+					{ hasDate && (
+						<div className="woocommerce-activity-card__date">
+							<span className="is-placeholder" />
+						</div>
+					) }
+				</div>
+				<div className="woocommerce-activity-card__body">{ children }</div>
+				{ hasAction && (
+					<div className="woocommerce-activity-card__actions">
+						<span className="is-placeholder" />
+					</div>
+				) }
+			</div>
+		);
+	}
+}
+
+ActivityCardPlaceholder.propTypes = {
+	className: PropTypes.string,
+	children: PropTypes.node.isRequired,
+	hasAction: PropTypes.bool,
+	hasDate: PropTypes.bool,
+	hasSubtitle: PropTypes.bool,
+};
+
+ActivityCardPlaceholder.defaultProps = {
+	hasAction: false,
+	hasDate: false,
+	hasSubtitle: false,
+};
+
+export default ActivityCardPlaceholder;

--- a/client/layout/activity-panel/activity-card/style.scss
+++ b/client/layout/activity-panel/activity-card/style.scss
@@ -74,3 +74,55 @@
 		margin-left: 0.5em;
 	}
 }
+
+.woocommerce-activity-card.is-loading {
+	.is-placeholder {
+		@include placeholder();
+		display: inline-block;
+		height: 16px;
+	}
+
+	.woocommerce-activity-card__title {
+		width: 80%;
+	}
+
+	.woocommerce-activity-card__subtitle {
+		margin-top: $gap-smallest;
+	}
+
+	.woocommerce-activity-card__date {
+		width: 100%;
+		text-align: right;
+
+		.is-placeholder {
+			// Fixed width for a fake date
+			width: 68px;
+		}
+	}
+
+	.woocommerce-activity-card__icon {
+		margin-right: $gutter;
+
+		.is-placeholder {
+			height: 48px;
+			width: 48px;
+		}
+	}
+
+	.woocommerce-activity-card__body .is-placeholder {
+		width: 100%;
+		margin-bottom: $gap-smallest;
+
+		&:last-of-type {
+			width: 65%;
+			margin-bottom: 0;
+		}
+	}
+
+	.woocommerce-activity-card__actions {
+		.is-placeholder {
+			width: 91px;
+			height: 34px;
+		}
+	}
+}

--- a/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
+++ b/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
@@ -24,6 +24,7 @@ exports[`ActivityCardPlaceholder should render a card placeholder with action pl
   >
     <span
       className="is-placeholder"
+      key="0"
     />
   </div>
   <div
@@ -70,6 +71,7 @@ exports[`ActivityCardPlaceholder should render a card placeholder with all optio
   >
     <span
       className="is-placeholder"
+      key="0"
     />
   </div>
   <div
@@ -113,6 +115,45 @@ exports[`ActivityCardPlaceholder should render a card placeholder with date plac
   >
     <span
       className="is-placeholder"
+      key="0"
+    />
+  </div>
+</div>
+`;
+
+exports[`ActivityCardPlaceholder should render a card placeholder with multiple lines of content 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+      key="0"
+    />
+    <span
+      className="is-placeholder"
+      key="1"
+    />
+    <span
+      className="is-placeholder"
+      key="2"
     />
   </div>
 </div>
@@ -145,6 +186,7 @@ exports[`ActivityCardPlaceholder should render a card placeholder with subtitle 
   >
     <span
       className="is-placeholder"
+      key="0"
     />
   </div>
 </div>
@@ -174,6 +216,7 @@ exports[`ActivityCardPlaceholder should render a default placeholder 1`] = `
   >
     <span
       className="is-placeholder"
+      key="0"
     />
   </div>
 </div>

--- a/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
+++ b/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
@@ -159,6 +159,31 @@ exports[`ActivityCardPlaceholder should render a card placeholder with multiple 
 </div>
 `;
 
+exports[`ActivityCardPlaceholder should render a card placeholder with no content 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  />
+</div>
+`;
+
 exports[`ActivityCardPlaceholder should render a card placeholder with subtitle placeholder 1`] = `
 <div
   aria-hidden={true}

--- a/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
+++ b/client/layout/activity-panel/activity-card/test/__snapshots__/placeholder.js.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActivityCardPlaceholder should render a card placeholder with action placeholder 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__actions"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`ActivityCardPlaceholder should render a card placeholder with all optional placeholder 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+    <div
+      className="woocommerce-activity-card__subtitle is-placeholder"
+    />
+    <div
+      className="woocommerce-activity-card__date"
+    >
+      <span
+        className="is-placeholder"
+      />
+    </div>
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__actions"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`ActivityCardPlaceholder should render a card placeholder with date placeholder 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+    <div
+      className="woocommerce-activity-card__date"
+    >
+      <span
+        className="is-placeholder"
+      />
+    </div>
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`ActivityCardPlaceholder should render a card placeholder with subtitle placeholder 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+    <div
+      className="woocommerce-activity-card__subtitle is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`ActivityCardPlaceholder should render a default placeholder 1`] = `
+<div
+  aria-hidden={true}
+  className="woocommerce-activity-card is-loading"
+>
+  <span
+    className="woocommerce-activity-card__icon"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </span>
+  <div
+    className="woocommerce-activity-card__header"
+  >
+    <div
+      className="woocommerce-activity-card__title is-placeholder"
+    />
+  </div>
+  <div
+    className="woocommerce-activity-card__body"
+  >
+    <span
+      className="is-placeholder"
+    />
+  </div>
+</div>
+`;

--- a/client/layout/activity-panel/activity-card/test/index.js
+++ b/client/layout/activity-panel/activity-card/test/index.js
@@ -9,7 +9,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import ActivityCard from '../';
+import { ActivityCard } from '../';
 import Gravatar from 'components/gravatar';
 
 describe( 'ActivityCard', () => {

--- a/client/layout/activity-panel/activity-card/test/placeholder.js
+++ b/client/layout/activity-panel/activity-card/test/placeholder.js
@@ -1,0 +1,57 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { ActivityCardPlaceholder } from '../';
+
+describe( 'ActivityCardPlaceholder', () => {
+	test( 'should render a default placeholder', () => {
+		const card = shallow(
+			<ActivityCardPlaceholder>
+				<span className="is-placeholder" />
+			</ActivityCardPlaceholder>
+		);
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a card placeholder with subtitle placeholder', () => {
+		const card = shallow(
+			<ActivityCardPlaceholder hasSubtitle>
+				<span className="is-placeholder" />
+			</ActivityCardPlaceholder>
+		);
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a card placeholder with date placeholder', () => {
+		const card = shallow(
+			<ActivityCardPlaceholder hasDate>
+				<span className="is-placeholder" />
+			</ActivityCardPlaceholder>
+		);
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a card placeholder with action placeholder', () => {
+		const card = shallow(
+			<ActivityCardPlaceholder hasAction>
+				<span className="is-placeholder" />
+			</ActivityCardPlaceholder>
+		);
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a card placeholder with all optional placeholder', () => {
+		const card = shallow(
+			<ActivityCardPlaceholder hasAction hasDate hasSubtitle>
+				<span className="is-placeholder" />
+			</ActivityCardPlaceholder>
+		);
+		expect( card ).toMatchSnapshot();
+	} );
+} );

--- a/client/layout/activity-panel/activity-card/test/placeholder.js
+++ b/client/layout/activity-panel/activity-card/test/placeholder.js
@@ -11,47 +11,32 @@ import { ActivityCardPlaceholder } from '../';
 
 describe( 'ActivityCardPlaceholder', () => {
 	test( 'should render a default placeholder', () => {
-		const card = shallow(
-			<ActivityCardPlaceholder>
-				<span className="is-placeholder" />
-			</ActivityCardPlaceholder>
-		);
+		const card = shallow( <ActivityCardPlaceholder /> );
 		expect( card ).toMatchSnapshot();
 	} );
 
 	test( 'should render a card placeholder with subtitle placeholder', () => {
-		const card = shallow(
-			<ActivityCardPlaceholder hasSubtitle>
-				<span className="is-placeholder" />
-			</ActivityCardPlaceholder>
-		);
+		const card = shallow( <ActivityCardPlaceholder hasSubtitle /> );
 		expect( card ).toMatchSnapshot();
 	} );
 
 	test( 'should render a card placeholder with date placeholder', () => {
-		const card = shallow(
-			<ActivityCardPlaceholder hasDate>
-				<span className="is-placeholder" />
-			</ActivityCardPlaceholder>
-		);
+		const card = shallow( <ActivityCardPlaceholder hasDate /> );
 		expect( card ).toMatchSnapshot();
 	} );
 
 	test( 'should render a card placeholder with action placeholder', () => {
-		const card = shallow(
-			<ActivityCardPlaceholder hasAction>
-				<span className="is-placeholder" />
-			</ActivityCardPlaceholder>
-		);
+		const card = shallow( <ActivityCardPlaceholder hasAction /> );
 		expect( card ).toMatchSnapshot();
 	} );
 
 	test( 'should render a card placeholder with all optional placeholder', () => {
-		const card = shallow(
-			<ActivityCardPlaceholder hasAction hasDate hasSubtitle>
-				<span className="is-placeholder" />
-			</ActivityCardPlaceholder>
-		);
+		const card = shallow( <ActivityCardPlaceholder hasAction hasDate hasSubtitle /> );
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a card placeholder with multiple lines of content', () => {
+		const card = shallow( <ActivityCardPlaceholder lines={ 3 } /> );
 		expect( card ).toMatchSnapshot();
 	} );
 } );

--- a/client/layout/activity-panel/activity-card/test/placeholder.js
+++ b/client/layout/activity-panel/activity-card/test/placeholder.js
@@ -39,4 +39,9 @@ describe( 'ActivityCardPlaceholder', () => {
 		const card = shallow( <ActivityCardPlaceholder lines={ 3 } /> );
 		expect( card ).toMatchSnapshot();
 	} );
+
+	test( 'should render a card placeholder with no content', () => {
+		const card = shallow( <ActivityCardPlaceholder lines={ 0 } /> );
+		expect( card ).toMatchSnapshot();
+	} );
 } );

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import Gridicon from 'gridicons';
 
@@ -11,36 +12,96 @@ import Gridicon from 'gridicons';
  */
 import ActivityCard from '../activity-card';
 import ActivityHeader from '../activity-header';
+import { getAdminLink } from 'lib/nav-utils';
 import { Section } from 'layout/section';
 
+const demoNotices = [
+	{
+		id: 1,
+		type: 'informational',
+		title: __( 'Accept Apple Pay using Stripe', 'wc-admin' ),
+		content: __(
+			'Your Stripe payment gateway now allows your customers to pay using Apple Pay.',
+			'wc-admin'
+		),
+		icon: 'customize',
+		status: 'unread',
+		source: 'woocommerce-core',
+		date_created: '2018-07-12T16:23:08Z',
+	},
+	{
+		id: 2,
+		type: 'warning',
+		title: __( 'Extension subscription expired', 'wc-admin' ),
+		content: __(
+			'Your subscription for WooCommerce Subscriptions expired on Jun 7th 2018.',
+			'wc-admin'
+		),
+		icon: 'notice-outline',
+		status: 'read',
+		source: 'woocommerce-core',
+		date_created: '2018-07-11T02:49:00Z',
+	},
+	{
+		id: 3,
+		type: 'informational',
+		title: __( 'Looking for the Store Notice setting?', 'wc-admin' ),
+		content: __( 'It can now be found in the customizer.', 'wc-admin' ),
+		icon: 'info-outline',
+		status: 'read',
+		source: 'woocommerce-core',
+		date_created: '2018-07-10T02:49:00Z',
+		actions: [
+			{
+				id: 1,
+				name: 'store-customizer-setting',
+				label: 'Open Customizer',
+				// @todo What format will links be? Should they default to external/full URLs?
+				// Full URLs that are wc-admin links will force a page refresh though…
+				url: getAdminLink( 'customize.php?autofocus%5Bpanel%5D=woocommerce' ),
+			},
+		],
+	},
+];
+
 class InboxPanel extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			notices: demoNotices,
+		};
+	}
+
 	render() {
+		const { notices = [] } = this.state;
+		const getButtonsFromActions = actions => {
+			if ( ! actions ) {
+				return [];
+			}
+			return actions.map( action => (
+				<Button isDefault href={ action.url }>
+					{ action.label }
+				</Button>
+			) );
+		};
+
 		return (
 			<Fragment>
 				<ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />
 				<Section>
-					<ActivityCard
-						className="woocommerce-inbox-activity-card"
-						title={ __( 'Accept Apple Pay using Stripe', 'wc-admin' ) }
-						date={ '2018-07-12T16:23:08Z' }
-						icon={ <Gridicon icon="customize" size={ 48 } /> }
-						unread
-					>
-						{ __(
-							'Your Stripe payment gateway now allows your customers to pay using Apple Pay.',
-							'wc-admin'
-						) }
-					</ActivityCard>
-					<ActivityCard
-						className="woocommerce-inbox-activity-card"
-						title={ __( 'Extension subscription expired', 'wc-admin' ) }
-						date={ '2018-07-11T02:49:00Z' }
-					>
-						{ __(
-							'Your subscription for WooCommerce Subscriptions expired on Jun 7th 2018.',
-							'wc-admin'
-						) }
-					</ActivityCard>
+					{ notices.map( note => (
+						<ActivityCard
+							key={ note.id }
+							className="woocommerce-inbox-activity-card"
+							title={ note.title }
+							date={ note.date_created }
+							icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
+							unread={ 'unread' === note.status }
+							actions={ getButtonsFromActions( note.actions ) }
+						>
+							{ note.content }
+						</ActivityCard>
+					) ) }
 				</Section>
 			</Fragment>
 		);

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -68,12 +68,20 @@ class InboxPanel extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			notices: demoNotices,
+			loading: true,
+			notices: [],
 		};
+
+		setTimeout( () => {
+			this.setState( {
+				loading: false,
+				notices: demoNotices,
+			} );
+		}, 5000 );
 	}
 
 	render() {
-		const { notices = [] } = this.state;
+		const { loading = true, notices = [] } = this.state;
 		const getButtonsFromActions = actions => {
 			if ( ! actions ) {
 				return [];
@@ -89,19 +97,21 @@ class InboxPanel extends Component {
 			<Fragment>
 				<ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />
 				<Section>
-					{ notices.map( note => (
-						<ActivityCard
-							key={ note.id }
-							className="woocommerce-inbox-activity-card"
-							title={ note.title }
-							date={ note.date_created }
-							icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-							unread={ 'unread' === note.status }
-							actions={ getButtonsFromActions( note.actions ) }
-						>
-							{ note.content }
-						</ActivityCard>
-					) ) }
+					{ loading
+						? 'Loading'
+						: notices.map( note => (
+								<ActivityCard
+									key={ note.id }
+									className="woocommerce-inbox-activity-card"
+									title={ note.title }
+									date={ note.date_created }
+									icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
+									unread={ 'unread' === note.status }
+									actions={ getButtonsFromActions( note.actions ) }
+								>
+									{ note.content }
+								</ActivityCard>
+							) ) }
 				</Section>
 			</Fragment>
 		);

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -10,8 +10,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import ActivityCard from '../activity-card';
-import ActivityCardPlaceholder from '../activity-card/placeholder';
+import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
 import { getAdminLink } from 'lib/nav-utils';
 import { Section } from 'layout/section';

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -71,13 +71,19 @@ class InboxPanel extends Component {
 			loading: true,
 			notices: [],
 		};
+	}
 
-		setTimeout( () => {
+	componentDidMount() {
+		this.interval = setTimeout( () => {
 			this.setState( {
 				loading: false,
 				notices: demoNotices,
 			} );
 		}, 5000 );
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.interval );
 	}
 
 	render() {

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import ActivityCard from '../activity-card';
+import ActivityCardPlaceholder from '../activity-card/placeholder';
 import ActivityHeader from '../activity-header';
 import { getAdminLink } from 'lib/nav-utils';
 import { Section } from 'layout/section';
@@ -97,21 +98,26 @@ class InboxPanel extends Component {
 			<Fragment>
 				<ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />
 				<Section>
-					{ loading
-						? 'Loading'
-						: notices.map( note => (
-								<ActivityCard
-									key={ note.id }
-									className="woocommerce-inbox-activity-card"
-									title={ note.title }
-									date={ note.date_created }
-									icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-									unread={ 'unread' === note.status }
-									actions={ getButtonsFromActions( note.actions ) }
-								>
-									{ note.content }
-								</ActivityCard>
-							) ) }
+					{ loading ? (
+						<ActivityCardPlaceholder className="woocommerce-inbox-activity-card" hasAction hasDate>
+							<span className="is-placeholder" />
+							<span className="is-placeholder" />
+						</ActivityCardPlaceholder>
+					) : (
+						notices.map( note => (
+							<ActivityCard
+								key={ note.id }
+								className="woocommerce-inbox-activity-card"
+								title={ note.title }
+								date={ note.date_created }
+								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
+								unread={ 'unread' === note.status }
+								actions={ getButtonsFromActions( note.actions ) }
+							>
+								{ note.content }
+							</ActivityCard>
+						) )
+					) }
 				</Section>
 			</Fragment>
 		);

--- a/client/layout/activity-panel/panels/inbox.js
+++ b/client/layout/activity-panel/panels/inbox.js
@@ -98,10 +98,12 @@ class InboxPanel extends Component {
 				<ActivityHeader title={ __( 'Inbox', 'wc-admin' ) } />
 				<Section>
 					{ loading ? (
-						<ActivityCardPlaceholder className="woocommerce-inbox-activity-card" hasAction hasDate>
-							<span className="is-placeholder" />
-							<span className="is-placeholder" />
-						</ActivityCardPlaceholder>
+						<ActivityCardPlaceholder
+							className="woocommerce-inbox-activity-card"
+							hasAction
+							hasDate
+							lines={ 2 }
+						/>
 					) : (
 						notices.map( note => (
 							<ActivityCard

--- a/client/layout/activity-panel/panels/orders.js
+++ b/client/layout/activity-panel/panels/orders.js
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import ActivityCard from '../activity-card';
+import { ActivityCard } from '../activity-card';
 import ActivityHeader from '../activity-header';
 import ActivityOutboundLink from '../activity-outbound-link';
 import { EllipsisMenu, MenuTitle, MenuItem } from 'components/ellipsis-menu';

--- a/client/stylesheets/_mixins.scss
+++ b/client/stylesheets/_mixins.scss
@@ -1,3 +1,5 @@
+/** @format */
+
 // Rem output with px fallback
 @mixin font-size($sizeValue: 16, $lineHeight: false ) {
 	font-size: $sizeValue + px;
@@ -12,5 +14,16 @@
 	&:active,
 	&:focus {
 		@content;
+	}
+}
+
+// Adds animation to placeholder section
+@mixin placeholder( $lighten-percentage: 30% ) {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background-color: $core-grey-light-500;
+	color: transparent;
+
+	&:after {
+		content: '\00a0';
 	}
 }

--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -10,6 +10,19 @@
 	}
 }
 
+// Set up animation
+@keyframes loading-fade {
+	0% {
+		opacity: 0.7;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.7;
+	}
+}
+
 // css resets some wp-admin specific rules so that the app fits better in the extension container
 .woocommerce-page {
 	.wrap {


### PR DESCRIPTION
Fixes #155 (kind of) - This adds a new component `ActivityCardPlaceholder`, that should be used to indicate the loading state of an activity panel. It should be globally usable across Inbox, Orders, Reviews, and Stock; though this PR only adds it to Inbox (by way of a fake "API request" using `setTimeout`)

The new `ActivityCardPlaceholder` expects children placeholder elements (which lets you define the number of lines in a placeholder), and then has a few flags for turning on other placeholder elements.

Example for Inbox – `hasDate` and `hasAction`:

<img width="510" alt="inbox" src="https://user-images.githubusercontent.com/541093/42828463-8e48f2f2-89b6-11e8-8c35-94aeb467399b.png">

Example for Orders – `hasDate`, `hasAction`, and `hasSubtitle`:

<img width="510" alt="orders" src="https://user-images.githubusercontent.com/541093/42828462-8e3012b4-89b6-11e8-9574-98b7a71e0584.png">

Example for Reviews – `hasDate`, `hasAction`, and `hasSubtitle` (with some extra styling of placeholder widths):

<img width="510" alt="reviews" src="https://user-images.githubusercontent.com/541093/42828461-8e1acc1a-89b6-11e8-9329-3103e7a0b9d2.png">

Stock will need another pass for the ActivityCard in general, since `children` is required in both ActivityCard and ActivityCardPlaceholder, but stock doesn't have anything in the "children" location.

This PR also updates [the README](https://github.com/woocommerce/wc-admin/blob/update/activity-panel-inbox-loading/client/layout/activity-panel/activity-card/README.md), and adds tests for the placeholder component.

**To test**

- Load up any Woo page
- Click `Inbox`, you should see the loading placeholder for 5 seconds before the "real" content is loaded.