### PR TITLE
Fix key prop warning in FilterPicker

### DIFF
--- a/client/components/filter-picker/index.js
+++ b/client/components/filter-picker/index.js
@@ -158,8 +158,9 @@ class FilterPicker extends Component {
 					) }
 					renderContent={ ( { onClose } ) => (
 						<ul className="woocommerce-filter-picker__content-list" ref={ this.listRef }>
-							{ visibleFilters.map( filter => (
+							{ visibleFilters.map( ( filter, i ) => (
 								<li
+									key={ i }
 									className={ classnames( 'woocommerce-filter-picker__content-list-item', {
 										'is-selected': selectedFilter.value === filter.value,
 									} ) }


### PR DESCRIPTION
There is a key warning inside FilterPicker: `Each child in an array or iterator should have a unique "key" prop`. This tiny PR fixes it.

* Test with this branch to verify you see no prop warning on the `Analytics > Products` page when opening the `Show filter`.