### PR TITLE
Gutenberg: move decodeEntities to htmlEntities packages

### DIFF
--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -5,7 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import classnames from 'classnames';
-import { decodeEntities } from '@wordpress/utils';
+import { decodeEntities } from '@wordpress/htmlEntities';
 import { Fill } from 'react-slot-fill';
 import { isArray } from 'lodash';
 import Link from 'components/link';

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -9,7 +9,7 @@
   "moduleDirectories": ["node_modules", "<rootDir>/client"],
   "moduleNameMapper": {
     "@wordpress\\/(blocks|components|editor|data|utils|edit-post|viewport|plugins|core-data)": "<rootDir>/node_modules/gutenberg/$1",
-    "@wordpress\\/(date|element|dom|keycodes|deprecated)$": "<rootDir>/node_modules/gutenberg/packages/$1/src",
+    "@wordpress\\/(date|element|dom|keycodes|deprecated|htmlEntities)$": "<rootDir>/node_modules/gutenberg/packages/$1/src",
     "@wordpress\\/api-request": "<rootDir>/tests/js/mocks/api-request",
     "tinymce": "<rootDir>/tests/js/mocks/tinymce"
   },

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -35,6 +35,7 @@ global.wp = {
 	'dom',
 	'keycodes',
 	'deprecated',
+	'htmlEntities',
 ].forEach( packageName => {
 	Object.defineProperty( global.wp, packageName, {
 		get: () => require( 'gutenberg/packages/' + packageName ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ const gutenbergPackages = [
 	'element',
 	'keycodes',
 	'deprecated',
+	'htmlEntities',
 ];
 
 const wordPressPackages = [


### PR DESCRIPTION
The master branch of Gutenberg moves `decodeEntities` to its packages folder under `/packages/htmlEntities`. This PR reflects that change.

This change is only functional if you are running the master branch of Gutenberg in your dev environment.

**How does everyone configure their environment in regards to Gutenberg?** Master branch? Install from wordpress.org/plugins? Latest tagged release?

I'm curious because we can hold off on pull requests like this if most devs are behind master branch. We could update all at once in this case.

## Test
* Pull the latest from Gutenberg
* Make sure wc-admin loads without errors