### PR TITLE
Update `react-world-flags` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "8"
-before_install:
-  - git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 script:
   - npm run lint
   - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -13966,12 +13966,12 @@
       }
     },
     "react-world-flags": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/react-world-flags/-/react-world-flags-1.2.3.tgz",
-      "integrity": "sha512-kdjqTBDjpYfNUwoOi2iX1Oeqwb8GQjMoyvoaP27mQuAK2VRcRo4TpCoXZ/hBT2/tRuVmec7zSAABnijN16D92Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-world-flags/-/react-world-flags-1.2.4.tgz",
+      "integrity": "sha512-7WVe6w8SsKo3ySnzZHEZaqBogizU/u952YeQF19AyQ2EItxb4xzgBkUaMuSEXa8AxpK0id/hvJslNhSYdIWMMg==",
       "dev": true,
       "requires": {
-        "svg-country-flags": "git+ssh://git@github.com/hjnilsson/country-flags.git#43451d226fcd9946d9db78aed470a18a81b4d2c6",
+        "svg-country-flags": "^1.2.3",
         "world-countries": "^2.0.0"
       }
     },
@@ -15575,8 +15575,8 @@
       "dev": true
     },
     "svg-country-flags": {
-      "version": "git+ssh://git@github.com/hjnilsson/country-flags.git#43451d226fcd9946d9db78aed470a18a81b4d2c6",
-      "from": "git+ssh://git@github.com/hjnilsson/country-flags.git#43451d226fcd9946d9db78aed470a18a81b4d2c6",
+      "version": "1.2.3",
+      "resolved": "git://github.com/hjnilsson/country-flags.git#43451d226fcd9946d9db78aed470a18a81b4d2c6",
       "dev": true
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-click-outside": "2.3.1",
     "react-dom": "^16.3.2",
     "react-router-dom": "^4.2.2",
-    "react-world-flags": "^1.2.3",
+    "react-world-flags": "^1.2.4",
     "readline-sync": "^1.4.9",
     "sass-loader": "^7.0.1",
     "style-loader": "^0.21.0",


### PR DESCRIPTION
This PR updates `react-world-flags` to v 1.2.4 to get rid of the `git+ssh` URL, which causes issues on machines without github SSH keys set up - like on Travis. This also removes the git config workaround for the issue.

**To test**

- Check that travis tests install & pass
- Make sure @LevinMedia can install the project 😁 