### PR TITLE
Add ProductImage Component

### DIFF
--- a/client/components/product-image/README.md
+++ b/client/components/product-image/README.md
@@ -1,0 +1,32 @@
+ProductImage
+============
+
+Use `ProductImage` to display a product's featured image. If no image can be found, a placeholder matching the front-end image placeholder will be displayed.
+
+## How to use:
+
+```jsx
+import ProductImage from 'components/product-image';
+
+render: function() {
+  return (
+	<div>
+		<ProductImage product={ null } />
+		<ProductImage product={ { images: [] } } />
+		<ProductImage product={ { images: [
+			{
+				src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
+			},
+		] } } />
+	</div>
+  );
+}
+```
+
+## Props
+
+* `product`: Product object. The image to display will be pulled from `product.images`. See https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties
+* `width`: Default 60. The width of image to display.
+* `height`: Default 60. The height of image to display.
+* `alt`: Text to use as the image alt attribute.
+* `className`: Additional CSS classes.

--- a/client/components/product-image/index.js
+++ b/client/components/product-image/index.js
@@ -15,6 +15,7 @@ const ProductImage = ( { product, alt, width, height, className, ...props } ) =>
 	// The first returned image from the API is the featured/product image.
 	const productImage = product && product.images && product.images[ 0 ];
 	const src = ( productImage && productImage.src ) || false;
+	const altText = alt || ( productImage && productImage.alt ) || '';
 
 	const classes = classnames( 'woocommerce-product-image', className, {
 		'is-placeholder': ! src,
@@ -26,7 +27,7 @@ const ProductImage = ( { product, alt, width, height, className, ...props } ) =>
 			src={ src || wcSettings.wcAssetUrl + 'images/placeholder.png' }
 			width={ width }
 			height={ height }
-			alt={ alt }
+			alt={ altText }
 			{ ...props }
 		/>
 	);
@@ -44,7 +45,6 @@ ProductImage.defaultProps = {
 	width: 60,
 	height: 60,
 	className: '',
-	alt: '',
 };
 
 export default ProductImage;

--- a/client/components/product-image/index.js
+++ b/client/components/product-image/index.js
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const ProductImage = ( { product, alt, width, height, className, ...props } ) => {
+	// The first returned image from the API is the featured/product image.
+	const productImage = product && product.images && product.images[ 0 ];
+	const src = ( productImage && productImage.src ) || false;
+
+	const classes = classnames( 'woocommerce-product-image', className, {
+		'is-placeholder': ! src,
+	} );
+
+	return (
+		<img
+			className={ classes }
+			src={ src || wcSettings.wcAssetUrl + 'images/placeholder.png' }
+			width={ width }
+			height={ height }
+			alt={ alt }
+			{ ...props }
+		/>
+	);
+};
+
+ProductImage.propTypes = {
+	width: PropTypes.number,
+	height: PropTypes.number,
+	className: PropTypes.string,
+	product: PropTypes.object,
+	alt: PropTypes.string,
+};
+
+ProductImage.defaultProps = {
+	width: 60,
+	height: 60,
+	className: '',
+	alt: '',
+};
+
+export default ProductImage;

--- a/client/components/product-image/style.scss
+++ b/client/components/product-image/style.scss
@@ -1,0 +1,5 @@
+/** @format */
+
+.woocommerce-product-image {
+	border-radius: 50%;
+}

--- a/client/components/product-image/test/__snapshots__/index.js.snap
+++ b/client/components/product-image/test/__snapshots__/index.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductImage should render a placeholder image if no product images are found 1`] = `
+<img
+  alt=""
+  className="woocommerce-product-image is-placeholder"
+  height={60}
+  src="https://woocommerce.com/wp-content/plugins/woocommerce/assets/images/placeholder.png"
+  width={60}
+/>
+`;
+
+exports[`ProductImage should render a product image 1`] = `
+<img
+  alt=""
+  className="woocommerce-product-image"
+  height={60}
+  src="https://i.cloudup.com/pt4DjwRB84-3000x3000.png"
+  width={60}
+/>
+`;

--- a/client/components/product-image/test/__snapshots__/index.js.snap
+++ b/client/components/product-image/test/__snapshots__/index.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProductImage should fallback to empty alt attribute if not passed via prop or product object 1`] = `
+<img
+  alt=""
+  className="woocommerce-product-image"
+  height={60}
+  src="https://i.cloudup.com/pt4DjwRB84-3000x3000.png"
+  width={60}
+/>
+`;
+
+exports[`ProductImage should fallback to product alt text 1`] = `
+<img
+  alt="hello world"
+  className="woocommerce-product-image"
+  height={60}
+  src="https://i.cloudup.com/pt4DjwRB84-3000x3000.png"
+  width={60}
+/>
+`;
+
 exports[`ProductImage should render a placeholder image if no product images are found 1`] = `
 <img
   alt=""
@@ -16,6 +36,16 @@ exports[`ProductImage should render a product image 1`] = `
   className="woocommerce-product-image"
   height={60}
   src="https://i.cloudup.com/pt4DjwRB84-3000x3000.png"
+  width={60}
+/>
+`;
+
+exports[`ProductImage should render the passed alt prop 1`] = `
+<img
+  alt="testing"
+  className="woocommerce-product-image is-placeholder"
+  height={60}
+  src="undefinedimages/placeholder.png"
   width={60}
 />
 `;

--- a/client/components/product-image/test/index.js
+++ b/client/components/product-image/test/index.js
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import ProductImage from '../';
+
+describe( 'ProductImage', () => {
+	test( 'should have correct alt text', () => {
+		const image = <ProductImage alt="testing" />;
+		expect( image.props.alt ).toBe( 'testing' );
+	} );
+
+	test( 'should have the correct width and height', () => {
+		const image = <ProductImage width={ 30 } height={ 30 } />;
+		expect( image.props.width ).toBe( 30 );
+		expect( image.props.height ).toBe( 30 );
+	} );
+
+	test( 'should render a product image', () => {
+		const product = {
+			name: 'Test Product',
+			images: [
+				{
+					src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
+				},
+			],
+		};
+		const card = shallow( <ProductImage product={ product } /> );
+		expect( card ).toMatchSnapshot();
+	} );
+
+	test( 'should render a placeholder image if no product images are found', () => {
+		global.wcSettings.wcAssetUrl = 'https://woocommerce.com/wp-content/plugins/woocommerce/assets/';
+		const product = {
+			name: 'Test Product',
+		};
+		const card = shallow( <ProductImage product={ product } /> );
+		expect( card ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/product-image/test/index.js
+++ b/client/components/product-image/test/index.js
@@ -10,9 +10,36 @@ import { shallow } from 'enzyme';
 import ProductImage from '../';
 
 describe( 'ProductImage', () => {
-	test( 'should have correct alt text', () => {
-		const image = <ProductImage alt="testing" />;
-		expect( image.props.alt ).toBe( 'testing' );
+	test( 'should render the passed alt prop', () => {
+		const image = shallow( <ProductImage alt="testing" /> );
+		expect( image ).toMatchSnapshot();
+	} );
+
+	test( 'should fallback to product alt text', () => {
+		const product = {
+			name: 'Test Product',
+			images: [
+				{
+					src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
+					alt: 'hello world',
+				},
+			],
+		};
+		const image = shallow( <ProductImage product={ product } /> );
+		expect( image ).toMatchSnapshot();
+	} );
+
+	test( 'should fallback to empty alt attribute if not passed via prop or product object', () => {
+		const product = {
+			name: 'Test Product',
+			images: [
+				{
+					src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
+				},
+			],
+		};
+		const image = shallow( <ProductImage product={ product } /> );
+		expect( image ).toMatchSnapshot();
 	} );
 
 	test( 'should have the correct width and height', () => {
@@ -30,8 +57,8 @@ describe( 'ProductImage', () => {
 				},
 			],
 		};
-		const card = shallow( <ProductImage product={ product } /> );
-		expect( card ).toMatchSnapshot();
+		const image = shallow( <ProductImage product={ product } /> );
+		expect( image ).toMatchSnapshot();
 	} );
 
 	test( 'should render a placeholder image if no product images are found', () => {
@@ -39,7 +66,7 @@ describe( 'ProductImage', () => {
 		const product = {
 			name: 'Test Product',
 		};
-		const card = shallow( <ProductImage product={ product } /> );
-		expect( card ).toMatchSnapshot();
+		const image = shallow( <ProductImage product={ product } /> );
+		expect( image ).toMatchSnapshot();
 	} );
 } );

--- a/client/layout/activity-panel/panels/reviews.js
+++ b/client/layout/activity-panel/panels/reviews.js
@@ -3,16 +3,32 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import ActivityHeader from '../activity-header';
+import ProductImage from 'components/product-image';
 
 class ReviewsPanel extends Component {
 	render() {
-		return <ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />;
+		return (
+			<Fragment>
+				<ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />
+				<ProductImage product={ null } />
+				<ProductImage product={ { images: [] } } />
+				<ProductImage
+					product={ {
+						images: [
+							{
+								src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
+							},
+						],
+					} }
+				/>
+			</Fragment>
+		);
 	}
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -42,6 +42,7 @@ function wc_admin_register_script() {
 	// Settings and variables can be passed here for access in the app
 	$settings = array(
 		'adminUrl'           => admin_url(),
+		'wcAssetUrl'         => plugins_url( 'assets/', WC_PLUGIN_FILE ),
 		'embedBreadcrumbs'   => wc_admin_get_embed_breadcrumbs(),
 		'siteLocale'         => esc_attr( get_bloginfo( 'language' ) ),
 		'currency'           => wc_admin_currency_settings(),


### PR DESCRIPTION
This PR adds a new `ProductImage` component. Closes #202.

It accepts a product object, and will return an image tag with the featured image, or a placeholder image. The placeholder image returned is the one shipped with WooCommerce.

I've added a couple static examples to the review panel for now.

To Test:
* Run `npm test` and make sure all tests pass.
* Open the review panel. You should see two placeholder rounded images, and one rendered product image.

<img width="261" alt="screen shot 2018-07-19 at 1 36 25 pm" src="https://user-images.githubusercontent.com/689165/42960062-c151461a-8b58-11e8-8443-e64e2bcb209f.png">
