### PR TITLE
Fade in activity panel tabs during page transition

### DIFF
--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -107,6 +107,20 @@
 			padding-top: 60px;
 		}
 	}
+
+	@keyframes isLoaded {
+		0% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
+
+	.woocommerce-layout__activity-panel-tabs {
+		animation: isLoaded;
+		animation-duration: 2000ms;
+	}
 }
 
 .woocommerce-layout * {


### PR DESCRIPTION
Closes #190, #227.

In place of #228 ("Add button placeholders on classic page load"), it was decided in #227 to use a simple fade-in for the buttons. See https://cloudup.com/cIKQIKdxMTH for an example.

This PR adds the animation to `woocommerce-layout__activity-panel-tabs` under the embedded/classic CSS rules.

To Test:
* Go between classic WooCommerce pages, and verify you see the fade-in animation.