### PR TITLE
Add SplitButton Component

### DIFF
--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -1,0 +1,77 @@
+SplitButton
+============
+
+A component for displaying a button with a main action plus a secondary set of actions behind a menu toggle.
+
+## How to use:
+
+```jsx
+import SplitButton from 'components/split-button';
+
+render: function() {
+  return (
+	<div>
+		<SplitButton
+			isPrimary
+			mainLabel="Primary Button"
+			menuLabel="Select an action"
+			onClick={ () => alert( 'Primary Main Action clicked' ) }
+			controls={ [
+				{
+					label: 'Up',
+					onClick: () => alert( 'Primary Up clicked' ),
+				},
+				{
+					label: 'Right',
+					onClick: () => alert( 'Primary Right clicked' ),
+				},
+				{
+					label: 'Down',
+					icon: <Gridicon icon="arrow-down" />,
+					onClick: () => alert( 'Primary Down clicked' ),
+				},
+				{
+					label: 'Left',
+					icon: <Gridicon icon="arrow-left" />,
+					onClick: () => alert( 'Primary Left clicked' ),
+				},
+			] }
+				/>
+		<SplitButton
+			mainIcon={ <Gridicon icon="pencil" /> }
+			menuLabel="Select an action"
+			onClick={ () => alert( 'Icon Only Action clicked' ) }
+			controls={ [
+				{
+					label: 'Up',
+					icon: <Gridicon icon="arrow-up" />,
+					onClick: () => alert( 'Icon Only Up clicked' ),
+				},
+				{
+					label: 'Right',
+					onClick: () => alert( 'Icon Only Right clicked' ),
+				},
+				{
+					label: 'Down',
+					icon: <Gridicon icon="arrow-down" />,
+					onClick: () => alert( 'Icon Only Down clicked' ),
+				},
+				{
+					icon: <Gridicon icon="arrow-left" />,
+					onClick: () => alert( 'Icon Only Left clicked' ),
+				},
+			] }
+		/>
+	</div>
+  );
+}
+```
+## Props
+
+* `isPrimary`: Default false. Whether the button is styled as a primary button.
+* `mainIcon`: Icon for the main button.
+* `mainLabel`: Label for the main button.
+* `onClick`: Function to activate when the the main button is clicked.
+* `menuLabel`: Label to display for the menu of actions, used as a heading on the mobile popover and for accessible text.
+* `controls`: An array of additional actions. Accepts additional icon, label, and onClick props.
+* `className`: Additional CSS classes.

--- a/client/components/split-button/index.js
+++ b/client/components/split-button/index.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { Button, IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const SplitButton = ( {
+	isPrimary,
+	mainIcon,
+	mainLabel,
+	onClick,
+	menuLabel,
+	controls,
+	className,
+} ) => {
+	if ( ! controls || ! controls.length ) {
+		return null;
+	}
+
+	const MainButtonComponent = ( mainIcon && IconButton ) || Button;
+	const classes = classnames( 'woocommerce-split-button', className, {
+		'is-primary': isPrimary,
+		'has-label': mainLabel,
+	} );
+
+	return (
+		<div className={ classes }>
+			<MainButtonComponent
+				icon={ mainIcon }
+				className="woocommerce-split-button__main-action"
+				onClick={ onClick }
+			>
+				{ mainLabel }
+			</MainButtonComponent>
+			<Dropdown
+				className="woocommerce-split-button__menu"
+				position="bottom left"
+				contentClassName="woocommerce-split-button__menu-popover"
+				expandOnMobile
+				headerTitle={ menuLabel }
+				renderToggle={ ( { isOpen, onToggle } ) => {
+					return (
+						<IconButton
+							icon={ isOpen ? 'arrow-up' : 'arrow-down' }
+							className={ classnames( 'woocommerce-split-button__menu-toggle', {
+								'is-active': isOpen,
+							} ) }
+							onClick={ onToggle }
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							label={ menuLabel }
+							tooltip={ menuLabel }
+						/>
+					);
+				} }
+				renderContent={ ( { onClose } ) => {
+					const renderControl = ( control, index ) => {
+						const ButtonComponent = ( control.icon && IconButton ) || Button;
+						return (
+							<ButtonComponent
+								key={ index }
+								onClick={ event => {
+									event.stopPropagation();
+									onClose();
+									if ( control.onClick ) {
+										control.onClick();
+									}
+								} }
+								className="woocommerce-split-button__menu-item"
+								icon={ control.icon || '' }
+								role="menuitem"
+							>
+								{ control.label }
+							</ButtonComponent>
+						);
+					};
+
+					return (
+						<NavigableMenu
+							className="woocommerce-split-button__menu-wrapper"
+							role="menu"
+							aria-label={ menuLabel }
+						>
+							{ controls.map( renderControl ) }
+						</NavigableMenu>
+					);
+				} }
+			/>
+		</div>
+	);
+};
+
+SplitButton.propTypes = {
+	isPrimary: PropTypes.bool,
+	mainIcon: PropTypes.node,
+	mainLabel: PropTypes.string,
+	onClick: PropTypes.func,
+	menuLabel: PropTypes.string,
+	controls: PropTypes.arrayOf(
+		PropTypes.shape( {
+			icon: PropTypes.node,
+			label: PropTypes.string,
+			onClick: PropTypes.func,
+		} )
+	).isRequired,
+	className: PropTypes.string,
+};
+
+SplitButton.defaultProps = {
+	isPrimary: false,
+	onClick: noop,
+};
+
+export default SplitButton;

--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -11,7 +11,7 @@
 
 	.woocommerce-split-button__main-action,
 	.woocommerce-split-button__menu-toggle {
-		padding: ($gap-smallest * 2) $gap-large($gap-smallest * 2) $gap-small;
+		padding: ($gap-smallest * 2) $gap-large ($gap-smallest * 2) $gap-small;
 		line-height: 26px;
 		height: 42px;
 		border-radius: 3px;
@@ -52,8 +52,8 @@
 	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus,
 	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus {
 		background-color: $button-hover;
-		box-shadow: inset 0 -1px 0 $core-grey-dark-300;
 		border: 1px solid $core-grey-dark-500;
+		box-shadow: inset 0 -1px 0 $core-grey-dark-300, 0 0 0 2px #bfe7f3;
 	}
 
 	.woocommerce-split-button__main-action.components-button .gridicon,
@@ -126,24 +126,24 @@
 	.woocommerce-split-button__menu-toggle {
 		background: $woocommerce;
 		color: $white;
-		border-color: $woocommerce-darker;
-		box-shadow: inset 0 -1px 0 $woocommerce-darker;
+		border-color: $woocommerce-600;
+		box-shadow: inset 0 -1px 0 $woocommerce-600;
 	}
 
 	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover,
 	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
 		color: $white;
-		background-color: lighten($woocommerce, 5%);
-		border-color: darken($woocommerce-darker, 5%);
-		box-shadow: inset 0 -1px 0 darken($woocommerce-darker, 5%);
+		background-color: $woocommerce-600;
+		border-color: $woocommerce-700;
+		box-shadow: inset 0 -1px 0 $woocommerce-700;
 	}
 
 	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus,
 	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus {
 		color: $white;
-		background-color: lighten($woocommerce, 5%);
-		box-shadow: inset 0 -1px 0 darken($woocommerce-darker, 5%);
-		border-color: darken($woocommerce-darker, 5%);
+		background-color: $woocommerce-600;
+		box-shadow: inset 0 -1px 0 $woocommerce-700, 0 0 0 2px $woocommerce-100;
+		border: 1px solid $woocommerce-700;
 	}
 
 	.dashicons-arrow-down {

--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -1,0 +1,152 @@
+/** @format */
+
+.woocommerce-split-button {
+	display: flex;
+	align-items: center;
+	padding: $gap-smallest 0px $gap-smallest 0px;
+
+	.woocommerce-split-button__menu {
+		padding: 0;
+	}
+
+	.woocommerce-split-button__main-action,
+	.woocommerce-split-button__menu-toggle {
+		padding: ($gap-smallest * 2) $gap-large($gap-smallest * 2) $gap-small;
+		line-height: 26px;
+		height: 42px;
+		border-radius: 3px;
+		white-space: nowrap;
+		border-width: 1px;
+		border-style: solid;
+		color: $core-grey-dark-500;
+		border-color: $core-grey-light-800;
+		background: $core-grey-light-200;
+		box-shadow: inset 0 -1px 0 $core-grey-light-800;
+		vertical-align: top;
+	}
+
+	.woocommerce-split-button__main-action {
+		padding: $gap-small;
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		border-right: 0;
+	}
+
+	.woocommerce-split-button__menu-toggle {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+		padding: $gap-smallest * 2;
+	}
+
+	.woocommerce-split-button__menu-popover.is-mobile {
+		top: 46px;
+	}
+
+	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover,
+	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
+		background-color: $button-hover;
+		border-color: $core-grey-dark-200;
+		box-shadow: inset 0 -1px 0 $core-grey-light-800;
+	}
+
+	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus,
+	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus {
+		background-color: $button-hover;
+		box-shadow: inset 0 -1px 0 $core-grey-dark-300;
+		border: 1px solid $core-grey-dark-500;
+	}
+
+	.woocommerce-split-button__main-action.components-button .gridicon,
+	.woocommerce-split-button__main-action.components-button .dashicon {
+		width: 18px;
+		height: 18px;
+	}
+
+	&.has-label {
+		.woocommerce-split-button__main-action.components-button .gridicon,
+		.woocommerce-split-button__main-action.components-button .dashicon {
+			margin-right: $gap-smallest * 2;
+		}
+
+		.woocommerce-split-button__main-action {
+			padding: ($gap-smallest * 2) $gap-large ($gap-smallest * 2) $gap-small;
+		}
+	}
+
+	.woocommerce-split-button__menu-wrapper {
+		width: 100%;
+		padding: $gap-smallest;
+
+		.components-button,
+		.components-icon-button {
+			color: $core-grey-dark-500;
+			margin-top: $gap-smallest;
+			margin-bottom: $gap-smallest;
+		}
+
+		.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
+			background-color: $white;
+			color: $black;
+			box-shadow: inset 0 0 0 1px $core-grey-light-500, inset 0 0 0 2px $white,
+				0 1px 1px rgba(25, 30, 35, 0.2);
+		}
+	}
+
+	.woocommerce-split-button__menu-item {
+		width: 100%;
+		padding: $gap-smallest;
+		border-radius: 0;
+		outline: none;
+		cursor: pointer;
+
+		.dashicon {
+			margin-right: $gap-smallest * 2;
+		}
+	}
+
+	.dashicons-arrow-down {
+		fill: $core-grey-dark-500;
+	}
+
+	.woocommerce-split-button__menu-toggle.is-active,
+	.woocommerce-split-button__menu-toggle.is-active:hover,
+	.woocommerce-split-button__menu-toggle.is-active > svg,
+	.woocommerce-split-button__menu-toggle.is-active:hover > svg {
+		background: initial;
+	}
+
+	.woocommerce-split-button__menu-toggle.is-active,
+	.woocommerce-split-button__menu-toggle.is-active:hover {
+		border-color: $core-grey-light-800;
+	}
+}
+
+.woocommerce-split-button.is-primary {
+	.woocommerce-split-button__main-action,
+	.woocommerce-split-button__menu-toggle {
+		background: $woocommerce;
+		color: $white;
+		border-color: $woocommerce-darker;
+		box-shadow: inset 0 -1px 0 $woocommerce-darker;
+	}
+
+	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover,
+	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
+		color: $white;
+		background-color: lighten($woocommerce, 5%);
+		border-color: darken($woocommerce-darker, 5%);
+		box-shadow: inset 0 -1px 0 darken($woocommerce-darker, 5%);
+	}
+
+	.woocommerce-split-button__menu-toggle.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus,
+	.woocommerce-split-button__main-action.components-button:not(:disabled):not([aria-disabled='true']):not(.is-default):focus {
+		color: $white;
+		background-color: lighten($woocommerce, 5%);
+		box-shadow: inset 0 -1px 0 darken($woocommerce-darker, 5%);
+		border-color: darken($woocommerce-darker, 5%);
+	}
+
+	.dashicons-arrow-down {
+		fill: $white;
+	}
+}

--- a/client/layout/activity-panel/activity-outbound-link/style.scss
+++ b/client/layout/activity-panel/activity-outbound-link/style.scss
@@ -26,7 +26,7 @@
 
 	&:active {
 		background: $core-grey-light-100;
-		color: $woocommerce-darker;
+		color: $woocommerce-700;
 	}
 
 	&:focus {
@@ -46,7 +46,7 @@
 	&:active {
 		.gridicon {
 			display: initial;
-			color: $woocommerce-darker;
+			color: $woocommerce-700;
 		}
 	}
 }

--- a/client/layout/activity-panel/panels/reviews.js
+++ b/client/layout/activity-panel/panels/reviews.js
@@ -4,68 +4,99 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import ActivityHeader from '../activity-header';
-import ProductImage from 'components/product-image';
-import { ProductRating, ReviewRating, Rating } from 'components/rating';
+import SplitButton from 'components/split-button';
 
 class ReviewsPanel extends Component {
 	render() {
 		return (
 			<Fragment>
 				<ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />
-				<ProductImage product={ null } />
-				<ProductImage product={ { images: [] } } />
-				<ProductImage
-					product={ {
-						images: [
-							{
-								src: 'https://i.cloudup.com/pt4DjwRB84-3000x3000.png',
-							},
-						],
-					} }
+
+				<SplitButton
+					isPrimary
+					mainLabel="Primary Button"
+					menuLabel="Select an action"
+					onClick={ () => alert( 'Primary Main Action clicked' ) }
+					controls={ [
+						{
+							label: 'Up',
+							onClick: () => alert( 'Primary Up clicked' ),
+						},
+						{
+							label: 'Right',
+							onClick: () => alert( 'Primary Right clicked' ),
+						},
+						{
+							label: 'Down',
+							icon: <Gridicon icon="arrow-down" />,
+							onClick: () => alert( 'Primary Down clicked' ),
+						},
+						{
+							label: 'Left',
+							icon: <Gridicon icon="arrow-left" />,
+							onClick: () => alert( 'Primary Left clicked' ),
+						},
+					] }
 				/>
-				<div>
-					Rating: <Rating rating={ 4 } totalStars={ 5 } />
-				</div>
-				<div>
-					Rating: <Rating rating={ 2.5 } totalStars={ 6 } />
-				</div>
-				<div>
-					ProductRating:{' '}
-					<ProductRating
-						product={ {
-							average_rating: 2.5,
-						} }
-					/>
-				</div>
-				<div>
-					ProductRating:{' '}
-					<ProductRating
-						product={ {
-							average_rating: 4,
-						} }
-					/>
-				</div>
-				<div>
-					ReviewRating:{' '}
-					<ReviewRating
-						review={ {
-							rating: 4,
-						} }
-					/>
-				</div>
-				<div>
-					ReviewRating:{' '}
-					<ReviewRating
-						review={ {
-							rating: 1.5,
-						} }
-					/>
-				</div>
+
+				<SplitButton
+					mainIcon={ <Gridicon icon="pencil" /> }
+					mainLabel="Secondary Button"
+					menuLabel="Select an action"
+					onClick={ () => alert( 'Secondary Main Action clicked' ) }
+					controls={ [
+						{
+							label: 'Up',
+							icon: <Gridicon icon="arrow-up" />,
+							onClick: () => alert( 'Secondary Up clicked' ),
+						},
+						{
+							label: 'Right',
+							onClick: () => alert( 'Secondary Right clicked' ),
+						},
+						{
+							label: 'Down',
+							icon: <Gridicon icon="arrow-down" />,
+							onClick: () => alert( 'Secondary Down clicked' ),
+						},
+						{
+							icon: <Gridicon icon="arrow-left" />,
+							onClick: () => alert( 'Secondary Left clicked' ),
+						},
+					] }
+				/>
+
+				<SplitButton
+					mainIcon={ <Gridicon icon="pencil" /> }
+					menuLabel="Select an action"
+					onClick={ () => alert( 'Icon Only Action clicked' ) }
+					controls={ [
+						{
+							label: 'Up',
+							icon: <Gridicon icon="arrow-up" />,
+							onClick: () => alert( 'Icon Only Up clicked' ),
+						},
+						{
+							label: 'Right',
+							onClick: () => alert( 'Icon Only Right clicked' ),
+						},
+						{
+							label: 'Down',
+							icon: <Gridicon icon="arrow-down" />,
+							onClick: () => alert( 'Icon Only Down clicked' ),
+						},
+						{
+							icon: <Gridicon icon="arrow-left" />,
+							onClick: () => alert( 'Icon Only Left clicked' ),
+						},
+					] }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -32,6 +32,9 @@ $core-grey-dark-900: #191e23;
 
 $gray-text: $core-grey-dark-500;
 
+// Gutenberg
+$button-hover: #fafafa;
+
 // wp-admin
 $wp-admin-background: #f1f1f1;
 $black: #24292d; // same as wp-admin sidebar

--- a/client/stylesheets/_colors.scss
+++ b/client/stylesheets/_colors.scss
@@ -32,6 +32,12 @@ $core-grey-dark-900: #191e23;
 
 $gray-text: $core-grey-dark-500;
 
+// WooCommerce Purples
+$woocommerce: #95588a;
+$woocommerce-100: #ffd7ff;
+$woocommerce-600: #7c3f71;
+$woocommerce-700: #622557;
+
 // Gutenberg
 $button-hover: #fafafa;
 
@@ -43,8 +49,6 @@ $black: #24292d; // same as wp-admin sidebar
 $valid-green: #4ab866;
 $notice-yellow: #ffb900;
 $error-red: #d94f4f;
-$woocommerce: #95588a;
-$woocommerce-darker: #5b3453;
 $box-shadow-blue: #5b9dd9;
 $core-orange: #ca4a1f;
 


### PR DESCRIPTION
This PR adds a new component, `SplitButton`. There was no existing component in Gutenberg, but there was some prior art with `DropdownMenu`, so I was able to construct a `SplitButton` using existing Gutenberg components.

I've added a couple examples under the review panel. You can have a primary button or secondary theme button.

<img width="259" alt="screen shot 2018-07-24 at 11 20 36 am" src="https://user-images.githubusercontent.com/689165/43148860-256b2920-8f34-11e8-9611-822a8f083794.png">

<img width="374" alt="screen shot 2018-07-24 at 11 20 44 am" src="https://user-images.githubusercontent.com/689165/43148870-289431b4-8f34-11e8-9191-dc847db4037a.png">

I couldn't find any designs for hover/focus states, so for the secondary buttons match Gutenberg's styles. For the primary styles (WooCommerce purple) I am using a lighter version of the purple. This could use some design input.

To Test:
* Open up the reviews panel.
* Confirm you see some `SplitButton` instances.
* Test the menu.
* Test mobile popover behavior.

Closes #200.