### PR TITLE
SummaryNumber Component: Update to latest hifi design

### DIFF
--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -22,7 +22,6 @@ export default class extends Component {
 					] }
 				/>
 				<h2>One Data Point</h2>
-				<p>Should be full width</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -34,7 +33,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Two Data Points</h2>
-				<p>Should be 2-up</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -53,7 +51,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Three Data Points</h2>
-				<p>Should be 3-up</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -78,7 +75,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Four Data Points</h2>
-				<p>Should be 4-up, percentage wrapped on lt 1365</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -109,7 +105,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Five Data Points</h2>
-				<p>Should be 5-up, percentage wrapped</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -146,7 +141,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Six Data Points</h2>
-				<p>On lt 1365, do 3-up percentage one line, 1365+ be 6-up, percentage wrapped</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -189,7 +183,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Seven Data Points</h2>
-				<p>4-up x 2</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -238,7 +231,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Eight Data Points</h2>
-				<p>4-up x 2</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -293,7 +285,6 @@ export default class extends Component {
 				</SummaryList>
 
 				<h2>Nine Data Points</h2>
-				<p>3-up x 3; 5-up</p>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
@@ -353,8 +344,7 @@ export default class extends Component {
 					/>
 				</SummaryList>
 
-				<h2>Ten Data Points</h2>
-				<p>4-up x 3; 5-up</p>
+				<h2>Ten or More Data Points</h2>
 				<SummaryList>
 					<SummaryNumber
 						label={ __( 'Gross Revenue', 'wc-admin' ) }

--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -47,6 +47,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 				</SummaryList>
@@ -65,6 +66,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -89,6 +91,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -119,6 +122,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -155,6 +159,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -197,6 +202,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -245,6 +251,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -299,6 +306,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
+						reverseTrend
 						selected
 					/>
 					<SummaryNumber
@@ -359,7 +367,7 @@ export default class extends Component {
 						value={ '$24.00' }
 						prevValue={ '$26.40' }
 						delta={ -10 }
-						selected
+						reverseTrend
 					/>
 					<SummaryNumber
 						label={ __( 'Coupons', 'wc-admin' ) }
@@ -378,6 +386,7 @@ export default class extends Component {
 						value={ '$25.00' }
 						prevValue={ '$30.00' }
 						delta={ -20 }
+						selected
 					/>
 					<SummaryNumber
 						label={ __( 'Shipping', 'wc-admin' ) }

--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -90,12 +90,7 @@ export default class extends Component {
 						reverseTrend
 						selected
 					/>
-					<SummaryNumber
-						label={ __( 'Coupons', 'wc-admin' ) }
-						value={ '$40.00' }
-						prevValue={ '$40.00' }
-						delta={ 0 }
-					/>
+					<SummaryNumber label={ __( 'Coupons', 'wc-admin' ) } value={ '$45.00' } />
 					<SummaryNumber
 						label={ __( 'Taxes', 'wc-admin' ) }
 						value={ '$84.73' }

--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -29,6 +29,7 @@ export default class extends Component {
 						value={ '$829.40' }
 						prevValue={ '$785.90' }
 						delta={ 5.5 }
+						selected
 					/>
 				</SummaryList>
 
@@ -393,7 +394,7 @@ export default class extends Component {
 					<SummaryNumber
 						label={ __( 'Taxes', 'wc-admin' ) }
 						value={ '$84.73' }
-						prevValue={ '$92.30' }
+						prevValue={ '$304,803,048.30' }
 						delta={ -8.9 }
 					/>
 					<SummaryNumber

--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -21,20 +21,393 @@ export default class extends Component {
 						__( 'Report Title', 'wc-admin' ),
 					] }
 				/>
+				<h2>One Data Point</h2>
+				<p>Should be full width</p>
 				<SummaryList>
 					<SummaryNumber
-						value={ '$829.40' }
 						label={ __( 'Gross Revenue', 'wc-admin' ) }
-						delta={ 29 }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+				</SummaryList>
+
+				<h2>Two Data Points</h2>
+				<p>Should be 2-up</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
 					/>
 					<SummaryNumber
-						value={ '$24.00' }
 						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
 						delta={ -10 }
 						selected
 					/>
-					<SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'wc-admin' ) } delta={ 15 } />
-					<SummaryNumber value={ '$66.39' } label={ __( 'Tax', 'wc-admin' ) } />
+				</SummaryList>
+
+				<h2>Three Data Points</h2>
+				<p>Should be 3-up</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+				</SummaryList>
+
+				<h2>Four Data Points</h2>
+				<p>Should be 4-up, percentage wrapped on lt 1365</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+				</SummaryList>
+
+				<h2>Five Data Points</h2>
+				<p>Should be 5-up, percentage wrapped</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+				</SummaryList>
+
+				<h2>Six Data Points</h2>
+				<p>On lt 1365, do 3-up percentage one line, 1365+ be 6-up, percentage wrapped</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Shipping', 'wc-admin' ) }
+						value={ '$75.00' }
+						prevValue={ '$60.00' }
+						delta={ 25 }
+					/>
+				</SummaryList>
+
+				<h2>Seven Data Points</h2>
+				<p>4-up x 2</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Shipping', 'wc-admin' ) }
+						value={ '$75.00' }
+						prevValue={ '$60.00' }
+						delta={ 25 }
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+				</SummaryList>
+
+				<h2>Eight Data Points</h2>
+				<p>4-up x 2</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Shipping', 'wc-admin' ) }
+						value={ '$75.00' }
+						prevValue={ '$60.00' }
+						delta={ 25 }
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+				</SummaryList>
+
+				<h2>Nine Data Points</h2>
+				<p>3-up x 3; 5-up</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Shipping', 'wc-admin' ) }
+						value={ '$75.00' }
+						prevValue={ '$60.00' }
+						delta={ 25 }
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+				</SummaryList>
+
+				<h2>Ten Data Points</h2>
+				<p>4-up x 3; 5-up</p>
+				<SummaryList>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
+					<SummaryNumber
+						label={ __( 'Refunds', 'wc-admin' ) }
+						value={ '$24.00' }
+						prevValue={ '$26.40' }
+						delta={ -10 }
+						selected
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Shipping', 'wc-admin' ) }
+						value={ '$75.00' }
+						prevValue={ '$60.00' }
+						delta={ 25 }
+					/>
+					<SummaryNumber
+						label={ __( 'Coupons', 'wc-admin' ) }
+						value={ '$40.00' }
+						prevValue={ '$40.00' }
+						delta={ 0 }
+					/>
+					<SummaryNumber
+						label={ __( 'Taxes', 'wc-admin' ) }
+						value={ '$84.73' }
+						prevValue={ '$92.30' }
+						delta={ -8.9 }
+					/>
+					<SummaryNumber
+						label={ __( 'Average Order Value', 'wc-admin' ) }
+						value={ '$25.00' }
+						prevValue={ '$30.00' }
+						delta={ -20 }
+					/>
+					<SummaryNumber
+						label={ __( 'Gross Revenue', 'wc-admin' ) }
+						value={ '$829.40' }
+						prevValue={ '$785.90' }
+						delta={ 5.5 }
+					/>
 				</SummaryList>
 			</Fragment>
 		);

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -3,12 +3,12 @@
 .woocommerce-card {
 	margin-bottom: 20px;
 	background: white;
-	border: 1px solid $gray;
+	border: 1px solid $core-grey-light-700;
 }
 
 .woocommerce-card__header {
 	padding: 16px;
-	border-bottom: 1px solid $gray;
+	border-bottom: 1px solid $core-grey-light-700;
 	display: grid;
 	align-items: center;
 

--- a/client/components/summary/README.md
+++ b/client/components/summary/README.md
@@ -28,6 +28,7 @@ render: function() {
 
 * `label` (required): A string description of this value, ex "Revenue", or "New Customers"
 * `value` (required): A string or number value to display - a string is allowed so we can accept currency formatting.
+* `href` (required): An internal link to the report focused on this number.
 * `delta`: A number to represent the percentage change since the last comparison period - positive numbers will show a green up arrow, negative numbers will show a red down arrow. If omitted, no change value will display.
 * `prevLabel`: A string description of the previous value's timeframe, ex "Previous Year:". Defaults to "Previous Period:".
 * `prevValue`: A string or number value to display - a string is allowed so we can accept currency formatting. If omitted, this section won't display.

--- a/client/components/summary/README.md
+++ b/client/components/summary/README.md
@@ -11,9 +11,9 @@ import { SummaryList, SummaryNumber } from 'components/summary';
 render: function() {
   return (
     <SummaryList>
-      <SummaryNumber value={ '$829.40' } label={ __( 'Gross Revenue', 'wc-admin' ) } delta={ 29 } />
-      <SummaryNumber value={ '$24.00' } label={ __( 'Refunds', 'wc-admin' ) } delta={ -10 } selected />
-      <SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'wc-admin' ) } />
+      <SummaryNumber value={ '$829.40' } label={ __( 'Gross Revenue', 'wc-admin' ) } delta={ 29 } href="/analytics/report" />
+      <SummaryNumber value={ '$24.00' } label={ __( 'Refunds', 'wc-admin' ) } delta={ -10 } href="/analytics/report" selected />
+      <SummaryNumber value={ '$49.90' } label={ __( 'Coupons', 'wc-admin' ) } href="/analytics/report" />
     </SummaryList>
   );
 }

--- a/client/components/summary/README.md
+++ b/client/components/summary/README.md
@@ -29,5 +29,7 @@ render: function() {
 * `label` (required): A string description of this value, ex "Revenue", or "New Customers"
 * `value` (required): A string or number value to display - a string is allowed so we can accept currency formatting.
 * `delta`: A number to represent the percentage change since the last comparison period - positive numbers will show a green up arrow, negative numbers will show a red down arrow. If omitted, no change value will display.
-* `context`: A string label for the comparison period.
-* `selected`: A boolean used to show a highlight style on this number.
+* `prevLabel`: A string description of the previous value's timeframe, ex "Previous Year:". Defaults to "Previous Period:".
+* `prevValue`: A string or number value to display - a string is allowed so we can accept currency formatting. If omitted, this section won't display.
+* `selected`: A boolean used to show a highlight style on this number. Defaults to false.
+* `reverseTrend`: A boolean used to indicate that a negative delta is "good", and should be styled like a positive (and vice-versa). Defaults to false.

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -5,6 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,8 +25,12 @@ const SummaryList = ( { children, label } ) => {
 	}
 	const classes = classnames( 'woocommerce-summary', hasItemsClass );
 
+	const instanceId = uniqueId( 'woocommerce-summary-helptext-' );
 	return (
-		<nav aria-label={ label }>
+		<nav aria-label={ label } aria-describedby={ instanceId }>
+			<p id={ instanceId } className="screen-reader-text">
+				{ __( 'View the report for the selected data point.', 'wc-admin' ) }
+			</p>
 			<ul className={ classes }>{ children }</ul>
 		</nav>
 	);

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -25,9 +25,9 @@ const SummaryList = ( { children, label } ) => {
 	const classes = classnames( 'woocommerce-summary', hasItemsClass );
 
 	return (
-		<ul className={ classes } aria-label={ label }>
-			{ children }
-		</ul>
+		<nav aria-label={ label }>
+			<ul className={ classes }>{ children }</ul>
+		</nav>
 	);
 };
 

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
@@ -14,8 +15,12 @@ const SummaryList = ( { children, label } ) => {
 	if ( ! label ) {
 		label = __( 'Performance Indicators', 'wc-admin' );
 	}
+	const hasItemsClass =
+		children && children.length ? `has-${ children.length }-items` : 'has-one-item';
+	const classes = classnames( 'woocommerce-summary', hasItemsClass );
+
 	return (
-		<ul className="woocommerce-summary" aria-label={ label }>
+		<ul className={ classes } aria-label={ label }>
 			{ children }
 		</ul>
 	);

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -19,7 +19,8 @@ const SummaryList = ( { children, label } ) => {
 	// it's not an array and .length is undefined.
 	let hasItemsClass = 'has-one-item';
 	if ( children && children.length ) {
-		hasItemsClass = children.length < 10 ? `has-${ children.length }-items` : 'has-10-items';
+		const length = children.filter( Boolean ).length;
+		hasItemsClass = length < 10 ? `has-${ length }-items` : 'has-10-items';
 	}
 	const classes = classnames( 'woocommerce-summary', hasItemsClass );
 

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -15,8 +15,12 @@ const SummaryList = ( { children, label } ) => {
 	if ( ! label ) {
 		label = __( 'Performance Indicators', 'wc-admin' );
 	}
-	const hasItemsClass =
-		children && children.length ? `has-${ children.length }-items` : 'has-one-item';
+	// We default to "one" because we can't have empty children. If `children` is just one item,
+	// it's not an array and .length is undefined.
+	let hasItemsClass = 'has-one-item';
+	if ( children && children.length ) {
+		hasItemsClass = children.length < 10 ? `has-${ children.length }-items` : 'has-10-items';
+	}
 	const classes = classnames( 'woocommerce-summary', hasItemsClass );
 
 	return (

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -4,14 +4,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { Dashicon } from '@wordpress/components';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const SummaryNumber = ( { context, delta, label, selected, value } ) => {
-	if ( ! context ) {
-		context = __( 'vs Previous Period', 'wc-admin' );
-	}
-
+const SummaryNumber = ( { delta, label, prevLabel, prevValue, selected, value } ) => {
 	const classes = classnames( 'woocommerce-summary__item', {
 		'is-selected': selected,
 	} );
@@ -19,17 +15,26 @@ const SummaryNumber = ( { context, delta, label, selected, value } ) => {
 	return (
 		<li className={ classes }>
 			<span className="woocommerce-summary__item-label">{ label }</span>
-			<span className="woocommerce-summary__item-value">{ value }</span>
-			{ delta && (
-				<span className="woocommerce-summary__item-delta">
-					<Dashicon
-						className="woocommerce-summary__item-delta-icon"
-						icon={ delta > 0 ? 'arrow-up-alt' : 'arrow-down-alt' }
-					/>
-					<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
-					<span className="woocommerce-summary__item-delta-label">{ context }</span>
-				</span>
-			) }
+
+			<span className="woocommerce-summary__item-data">
+				<span className="woocommerce-summary__item-value">{ value }</span>
+				{ delta ? (
+					<span className="woocommerce-summary__item-delta">
+						<Gridicon
+							className="woocommerce-summary__item-delta-icon"
+							icon={ delta > 0 ? 'arrow-up' : 'arrow-down' }
+						/>
+						<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
+					</span>
+				) : (
+					<span className="woocommerce-summary__item-delta">
+						<Gridicon className="woocommerce-summary__item-delta-icon" icon="minus" />
+						<span className="woocommerce-summary__item-delta-value">0%</span>
+					</span>
+				) }
+			</span>
+			{ prevLabel && <span className="woocommerce-summary__item-prev-label">{ prevLabel }</span> }
+			{ prevValue && <span className="woocommerce-summary__item-prev-value">{ prevValue }</span> }
 		</li>
 	);
 };
@@ -38,8 +43,14 @@ SummaryNumber.propTypes = {
 	context: PropTypes.string,
 	delta: PropTypes.number,
 	label: PropTypes.string.isRequired,
+	prevLabel: PropTypes.string,
+	prevValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 	selected: PropTypes.bool,
 	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
+};
+
+SummaryNumber.defaultProps = {
+	prevLabel: __( 'Previous Period', 'wc-admin' ),
 };
 
 export default SummaryNumber;

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -33,9 +33,13 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 					</span>
 				) }
 			</span>
-			{ prevValue && <span className="woocommerce-summary__item-prev-label">{ prevLabel }</span> }
-			{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
-			{ prevValue && <span className="woocommerce-summary__item-prev-value">{ prevValue }</span> }
+			{ ! isUndefined( prevValue ) && (
+				<span className="woocommerce-summary__item-prev">
+					<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
+					{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
+					<span className="woocommerce-summary__item-prev-value">{ prevValue }</span>
+				</span>
+			) }
 		</li>
 	);
 };

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -7,9 +7,11 @@ import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
-const SummaryNumber = ( { delta, label, prevLabel, prevValue, selected, value } ) => {
+const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, selected, value } ) => {
 	const classes = classnames( 'woocommerce-summary__item', {
 		'is-selected': selected,
+		'is-good-trend': reverseTrend ? delta < 0 : delta > 0,
+		'is-bad-trend': reverseTrend ? delta > 0 : delta < 0,
 	} );
 
 	return (
@@ -47,11 +49,13 @@ SummaryNumber.propTypes = {
 	prevLabel: PropTypes.string,
 	prevValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 	selected: PropTypes.bool,
+	reverseTrend: PropTypes.bool,
 	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
 };
 
 SummaryNumber.defaultProps = {
 	prevLabel: __( 'Previous Period:', 'wc-admin' ),
+	reverseTrend: false,
 };
 
 export default SummaryNumber;

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -34,6 +34,7 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, selected, value } 
 				) }
 			</span>
 			{ prevLabel && <span className="woocommerce-summary__item-prev-label">{ prevLabel }</span> }
+			{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
 			{ prevValue && <span className="woocommerce-summary__item-prev-value">{ prevValue }</span> }
 		</li>
 	);
@@ -50,7 +51,7 @@ SummaryNumber.propTypes = {
 };
 
 SummaryNumber.defaultProps = {
-	prevLabel: __( 'Previous Period', 'wc-admin' ),
+	prevLabel: __( 'Previous Period:', 'wc-admin' ),
 };
 
 export default SummaryNumber;

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -5,6 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
+import { isUndefined } from 'lodash';
 import PropTypes from 'prop-types';
 
 const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, selected, value } ) => {
@@ -14,28 +15,25 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 		'is-bad-trend': reverseTrend ? delta > 0 : delta < 0,
 	} );
 
+	let icon = delta > 0 ? 'arrow-up' : 'arrow-down';
+	if ( delta === 0 ) {
+		icon = 'minus';
+	}
+
 	return (
 		<li className={ classes }>
 			<span className="woocommerce-summary__item-label">{ label }</span>
 
 			<span className="woocommerce-summary__item-data">
 				<span className="woocommerce-summary__item-value">{ value }</span>
-				{ delta ? (
+				{ ! isUndefined( delta ) && (
 					<span className="woocommerce-summary__item-delta">
-						<Gridicon
-							className="woocommerce-summary__item-delta-icon"
-							icon={ delta > 0 ? 'arrow-up' : 'arrow-down' }
-						/>
+						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } />
 						<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
-					</span>
-				) : (
-					<span className="woocommerce-summary__item-delta">
-						<Gridicon className="woocommerce-summary__item-delta-icon" icon="minus" />
-						<span className="woocommerce-summary__item-delta-value">0%</span>
 					</span>
 				) }
 			</span>
-			{ prevLabel && <span className="woocommerce-summary__item-prev-label">{ prevLabel }</span> }
+			{ prevValue && <span className="woocommerce-summary__item-prev-label">{ prevLabel }</span> }
 			{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
 			{ prevValue && <span className="woocommerce-summary__item-prev-value">{ prevValue }</span> }
 		</li>
@@ -43,19 +41,19 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 };
 
 SummaryNumber.propTypes = {
-	context: PropTypes.string,
 	delta: PropTypes.number,
 	label: PropTypes.string.isRequired,
 	prevLabel: PropTypes.string,
 	prevValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	selected: PropTypes.bool,
 	reverseTrend: PropTypes.bool,
+	selected: PropTypes.bool,
 	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
 };
 
 SummaryNumber.defaultProps = {
 	prevLabel: __( 'Previous Period:', 'wc-admin' ),
 	reverseTrend: false,
+	selected: false,
 };
 
 export default SummaryNumber;

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -8,7 +8,21 @@ import Gridicon from 'gridicons';
 import { isUndefined } from 'lodash';
 import PropTypes from 'prop-types';
 
-const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, selected, value } ) => {
+/**
+ * External dependencies
+ */
+import Link from 'components/link';
+
+const SummaryNumber = ( {
+	delta,
+	href,
+	label,
+	prevLabel,
+	prevValue,
+	reverseTrend,
+	selected,
+	value,
+} ) => {
 	const classes = classnames( 'woocommerce-summary__item', {
 		'is-selected': selected,
 		'is-good-trend': reverseTrend ? delta < 0 : delta > 0,
@@ -16,37 +30,49 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 	} );
 
 	let icon = delta > 0 ? 'arrow-up' : 'arrow-down';
+	let screenReaderLabel =
+		delta > 0
+			? sprintf( __( 'Up %d%% from %s', 'wc-admin' ), delta, prevLabel )
+			: sprintf( __( 'Down %d%% from %s', 'wc-admin' ), Math.abs( delta ), prevLabel );
 	if ( ! delta ) {
 		// delta is zero or falsey
 		icon = 'arrow-right';
+		screenReaderLabel = sprintf( __( 'No change from %s', 'wc-admin' ), prevLabel );
 	}
 
 	return (
-		<li className={ classes }>
-			<span className="woocommerce-summary__item-label">{ label }</span>
+		<li className="woocommerce-summary__item-container">
+			<Link className={ classes } href={ href }>
+				<span className="woocommerce-summary__item-label">{ label }</span>
 
-			<span className="woocommerce-summary__item-data">
-				<span className="woocommerce-summary__item-value">{ value }</span>
-				<span className="woocommerce-summary__item-delta">
-					<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
-					<span className="woocommerce-summary__item-delta-value">
-						{ ! isUndefined( delta )
-							? sprintf( __( '%d%%', 'wc-admin' ), delta )
-							: __( 'N/A', 'wc-admin' ) }
-					</span>
+				<span className="woocommerce-summary__item-data">
+					<span className="woocommerce-summary__item-value">{ value }</span>
+					<div
+						className="woocommerce-summary__item-delta"
+						role="presentation"
+						aria-label={ screenReaderLabel }
+					>
+						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
+						<span className="woocommerce-summary__item-delta-value">
+							{ ! isUndefined( delta )
+								? sprintf( __( '%d%%', 'wc-admin' ), delta )
+								: __( 'N/A', 'wc-admin' ) }
+						</span>
+					</div>
 				</span>
-			</span>
-			<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
-			{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
-			<span className="woocommerce-summary__item-prev-value">
-				{ ! isUndefined( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
-			</span>
+				<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
+				{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
+				<span className="woocommerce-summary__item-prev-value">
+					{ ! isUndefined( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
+				</span>
+			</Link>
 		</li>
 	);
 };
 
 SummaryNumber.propTypes = {
 	delta: PropTypes.number,
+	href: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	prevLabel: PropTypes.string,
 	prevValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
@@ -56,6 +82,7 @@ SummaryNumber.propTypes = {
 };
 
 SummaryNumber.defaultProps = {
+	href: '/analytics',
 	prevLabel: __( 'Previous Period:', 'wc-admin' ),
 	reverseTrend: false,
 	selected: false,

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { isUndefined } from 'lodash';
@@ -16,7 +16,8 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 	} );
 
 	let icon = delta > 0 ? 'arrow-up' : 'arrow-down';
-	if ( delta === 0 ) {
+	if ( ! delta ) {
+		// delta is zero or falsey
 		icon = 'arrow-right';
 	}
 
@@ -26,20 +27,20 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 
 			<span className="woocommerce-summary__item-data">
 				<span className="woocommerce-summary__item-value">{ value }</span>
-				{ ! isUndefined( delta ) && (
-					<span className="woocommerce-summary__item-delta">
-						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
-						<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
+				<span className="woocommerce-summary__item-delta">
+					<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
+					<span className="woocommerce-summary__item-delta-value">
+						{ ! isUndefined( delta )
+							? sprintf( __( '%d%%', 'wc-admin' ), delta )
+							: __( 'N/A', 'wc-admin' ) }
 					</span>
-				) }
-			</span>
-			{ ! isUndefined( prevValue ) && (
-				<span className="woocommerce-summary__item-prev">
-					<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
-					{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
-					<span className="woocommerce-summary__item-prev-value">{ prevValue }</span>
 				</span>
-			) }
+			</span>
+			<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
+			{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
+			<span className="woocommerce-summary__item-prev-value">
+				{ ! isUndefined( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
+			</span>
 		</li>
 	);
 };

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -17,7 +17,7 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 
 	let icon = delta > 0 ? 'arrow-up' : 'arrow-down';
 	if ( delta === 0 ) {
-		icon = 'minus';
+		icon = 'arrow-right';
 	}
 
 	return (
@@ -28,7 +28,7 @@ const SummaryNumber = ( { delta, label, prevLabel, prevValue, reverseTrend, sele
 				<span className="woocommerce-summary__item-value">{ value }</span>
 				{ ! isUndefined( delta ) && (
 					<span className="woocommerce-summary__item-delta">
-						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } />
+						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
 						<span className="woocommerce-summary__item-delta-value">{ delta }%</span>
 					</span>
 				) }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -109,13 +109,31 @@ $inner-border: $core-grey-light-500;
 	}
 }
 
-.woocommerce-summary__item {
+.woocommerce-summary__item-container {
 	margin-bottom: 0;
-	padding: $spacing;
 	width: 100%;
-	background: $core-grey-light-100;
+}
+
+.woocommerce-summary__item {
+	display: block;
+	height: 100%;
+	padding: $spacing;
+	background-color: $core-grey-light-100;
 	border-bottom: 1px solid $outer-border;
 	border-right: 1px solid $inner-border;
+	text-decoration: none;
+
+	&:hover {
+		background-color: $core-grey-light-200;
+	}
+
+	&:active {
+		background-color: $core-grey-light-300;
+	}
+
+	&:focus {
+		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black;
+	}
 
 	&:last-of-type {
 		// Make sure the last item always uses the outer-border color.
@@ -124,8 +142,13 @@ $inner-border: $core-grey-light-500;
 
 	&.is-selected {
 		margin-top: -1px;
+		height: calc(100% + 1px); // Hack to avoid double border
 		background: $white;
 		box-shadow: inset 0 4px 0 $woocommerce;
+
+		&:focus {
+			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce;
+		}
 	}
 
 	.woocommerce-summary__item-label {
@@ -189,6 +212,14 @@ $inner-border: $core-grey-light-500;
 
 	.woocommerce-summary__item {
 		background-color: $white;
+
+		&:hover {
+			background-color: $core-grey-light-200;
+		}
+
+		&:active {
+			background-color: $core-grey-light-300;
+		}
 	}
 
 	.woocommerce-summary__item.is-selected {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -1,10 +1,16 @@
 /** @format */
 
+// Set up some local color variables to make the CSS more clear
+$outer-border: $core-grey-light-700;
+$inner-border: $core-grey-light-500;
+
 .woocommerce-summary {
 	display: grid;
-	border-width: 0 1px 1px 1px;
+	border-width: 1px 0 0 1px;
 	border-style: solid;
-	border-color: $core-grey-light-700;
+	border-color: $outer-border;
+	background-color: $core-grey-light-300;
+	box-shadow: inset -1px -1px 0 $outer-border;
 
 	.woocommerce-summary__item-data {
 		display: flex;
@@ -28,23 +34,38 @@
 
 	&.has-2-items {
 		grid-template-columns: repeat(2, 1fr);
+
+		.woocommerce-summary__item:nth-of-type(2n) {
+			border-right-color: $outer-border;
+		}
 	}
 
-	&.has-3-items,
-	&.has-9-items {
+	&.has-3-items {
 		grid-template-columns: repeat(3, 1fr);
+
+		.woocommerce-summary__item:nth-of-type(3n) {
+			border-right-color: $outer-border;
+		}
 	}
 
 	&.has-4-items,
 	&.has-7-items,
 	&.has-8-items {
 		grid-template-columns: repeat(4, 1fr);
+
+		.woocommerce-summary__item:nth-of-type(4n) {
+			border-right-color: $outer-border;
+		}
 	}
 
 	&.has-5-items,
 	&.has-9-items,
 	&.has-10-items {
 		grid-template-columns: repeat(5, 1fr);
+
+		.woocommerce-summary__item:nth-of-type(5n) {
+			border-right-color: $outer-border;
+		}
 
 		.woocommerce-summary__item-value,
 		.woocommerce-summary__item-delta {
@@ -54,6 +75,10 @@
 
 	&.has-6-items {
 		grid-template-columns: repeat(6, 1fr);
+
+		.woocommerce-summary__item:nth-of-type(6n) {
+			border-right-color: $outer-border;
+		}
 
 		.woocommerce-summary__item-value,
 		.woocommerce-summary__item-delta {
@@ -71,17 +96,13 @@
 			}
 		}
 
-		&.has-6-items {
-			grid-template-columns: repeat(3, 1fr);
-
-			.woocommerce-summary__item-value,
-			.woocommerce-summary__item-delta {
-				min-width: auto;
-			}
-		}
-
+		&.has-6-items,
 		&.has-9-items {
 			grid-template-columns: repeat(3, 1fr);
+
+			.woocommerce-summary__item:nth-of-type(3n) {
+				border-right-color: $outer-border;
+			}
 
 			.woocommerce-summary__item-value,
 			.woocommerce-summary__item-delta {
@@ -91,6 +112,17 @@
 
 		&.has-10-items {
 			grid-template-columns: repeat(4, 1fr);
+
+			.woocommerce-summary__item:nth-of-type(4n) {
+				border-right-color: $outer-border;
+			}
+		}
+
+		&.has-9-items,
+		&.has-10-items {
+			.woocommerce-summary__item:nth-of-type(5n) {
+				border-right-color: $inner-border;
+			}
 		}
 	}
 }
@@ -100,8 +132,13 @@
 	padding: $spacing;
 	width: 100%;
 	background: $core-grey-light-100;
-	border-top: 1px solid $core-grey-light-700;
-	border-left: 1px solid $core-grey-light-500;
+	border-bottom: 1px solid $outer-border;
+	border-right: 1px solid $inner-border;
+
+	&:last-of-type {
+		// Make sure the last item always uses the outer-border color.
+		border-right-color: $outer-border !important;
+	}
 
 	&.is-selected {
 		background: $white;

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -109,9 +109,7 @@
 		border-top: none;
 	}
 
-	.woocommerce-summary__item-label,
-	.woocommerce-summary__item-prev-label,
-	.woocommerce-summary__item-prev-value {
+	.woocommerce-summary__item-label {
 		display: block;
 	}
 
@@ -148,6 +146,10 @@
 		&.gridicons-arrow-down {
 			transform: rotate(-45deg);
 		}
+	}
+
+	.woocommerce-summary__item-prev-label {
+		margin-right: $gap-smallest;
 	}
 
 	.woocommerce-summary__item-prev-label,

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -151,6 +151,14 @@ $inner-border: $core-grey-light-500;
 		color: $woocommerce;
 	}
 
+	&.is-good-trend .woocommerce-summary__item-delta {
+		color: $valid-green;
+	}
+
+	&.is-bad-trend .woocommerce-summary__item-delta {
+		color: $error-red;
+	}
+
 	.woocommerce-summary__item-delta-icon {
 		vertical-align: middle;
 		margin-right: 3px;

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -122,9 +122,9 @@ $inner-border: $core-grey-light-500;
 	}
 
 	&.is-selected {
+		margin-top: -1px;
 		background: $white;
 		box-shadow: inset 0 4px 0 $woocommerce;
-		border-top: none;
 	}
 
 	.woocommerce-summary__item-label {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -37,7 +37,8 @@ $inner-border: $core-grey-light-500;
 		flex-wrap: none;
 	}
 
-	&.has-one-item {
+	&.has-one-item,
+	&.has-1-items {
 		grid-template-columns: 1fr;
 	}
 

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -2,17 +2,96 @@
 
 .woocommerce-summary {
 	display: grid;
-	grid-template-columns: repeat(4, 1fr);
-	border-width: 0 1px 1px 0;
+	border-width: 0 1px 1px 1px;
 	border-style: solid;
-	border-color: #e5e8ec;
+	border-color: $core-grey-light-700;
 
-	@include breakpoint( '<600px' ) {
+	.woocommerce-summary__item-data {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.woocommerce-summary__item-value,
+	.woocommerce-summary__item-delta {
+		flex: 1 0 auto;
+	}
+
+	.woocommerce-summary__item-delta {
+		flex: 0;
+		display: flex;
+		flex-wrap: none;
+	}
+
+	&.has-one-item {
+		grid-template-columns: 1fr;
+	}
+
+	&.has-2-items {
 		grid-template-columns: repeat(2, 1fr);
 	}
 
-	@include breakpoint( '<400px' ) {
-		grid-template-columns: 1fr;
+	&.has-3-items,
+	&.has-9-items {
+		grid-template-columns: repeat(3, 1fr);
+	}
+
+	&.has-4-items,
+	&.has-7-items,
+	&.has-8-items {
+		grid-template-columns: repeat(4, 1fr);
+	}
+
+	&.has-5-items,
+	&.has-9-items,
+	&.has-10-items {
+		grid-template-columns: repeat(5, 1fr);
+
+		.woocommerce-summary__item-value,
+		.woocommerce-summary__item-delta {
+			min-width: 100%;
+		}
+	}
+
+	&.has-6-items {
+		grid-template-columns: repeat(6, 1fr);
+
+		.woocommerce-summary__item-value,
+		.woocommerce-summary__item-delta {
+			min-width: 100%;
+		}
+	}
+
+	@include breakpoint( '<1365px' ) {
+		&.has-4-items,
+		&.has-7-items,
+		&.has-8-items {
+			.woocommerce-summary__item-value,
+			.woocommerce-summary__item-delta {
+				min-width: 100%;
+			}
+		}
+
+		&.has-6-items {
+			grid-template-columns: repeat(3, 1fr);
+
+			.woocommerce-summary__item-value,
+			.woocommerce-summary__item-delta {
+				min-width: auto;
+			}
+		}
+
+		&.has-9-items {
+			grid-template-columns: repeat(3, 1fr);
+
+			.woocommerce-summary__item-value,
+			.woocommerce-summary__item-delta {
+				min-width: auto;
+			}
+		}
+
+		&.has-10-items {
+			grid-template-columns: repeat(4, 1fr);
+		}
 	}
 }
 
@@ -20,53 +99,60 @@
 	margin-bottom: 0;
 	padding: $spacing;
 	width: 100%;
-	background: $white;
-	border-width: 1px 0 0 1px;
-	border-style: solid;
-	border-color: #e5e8ec;
+	background: $core-grey-light-100;
+	border-top: 1px solid $core-grey-light-700;
+	border-left: 1px solid $core-grey-light-500;
 
 	&.is-selected {
-		border-top: 0;
-		background: #f8f9fa;
+		background: $white;
 		box-shadow: inset 0 4px 0 $woocommerce;
+		border-top: none;
 	}
 
 	.woocommerce-summary__item-label,
-	.woocommerce-summary__item-value,
-	.woocommerce-summary__item-delta {
+	.woocommerce-summary__item-prev-label,
+	.woocommerce-summary__item-prev-value {
 		display: block;
 	}
 
 	.woocommerce-summary__item-label {
-		margin-bottom: $spacing/2;
+		margin-bottom: $gap;
+		@include font-size( 11 );
+		text-transform: uppercase;
+		color: $core-grey-dark-300;
 	}
 
 	.woocommerce-summary__item-value {
-		@include font-size( 24 );
-		margin-bottom: $spacing;
+		margin-bottom: $gap-smallest;
+		@include font-size( 18 );
+		font-weight: 600;
+		color: $core-grey-dark-900;
 	}
 
 	.woocommerce-summary__item-delta {
-		@include font-size( 11 );
+		margin-bottom: $gap-small;
+		@include font-size( 18 );
+		color: $woocommerce;
 	}
 
 	.woocommerce-summary__item-delta-icon {
 		vertical-align: middle;
 		margin-right: 3px;
 		margin-top: -3px;
+		fill: currentColor;
 
-		&.dashicons-arrow-up-alt {
+		&.gridicons-arrow-up {
 			transform: rotate(45deg);
-			fill: $valid-green;
 		}
 
-		&.dashicons-arrow-down-alt {
+		&.gridicons-arrow-down {
 			transform: rotate(-45deg);
-			fill: $error-red;
 		}
 	}
 
-	.woocommerce-summary__item-delta-label {
-		margin-left: 5px;
+	.woocommerce-summary__item-prev-label,
+	.woocommerce-summary__item-prev-value {
+		@include font-size( 13 );
+		color: $core-grey-dark-500;
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -143,8 +143,6 @@ $inner-border: $core-grey-light-500;
 	&.is-selected {
 		margin-top: -1px;
 		height: calc(100% + 1px); // Hack to avoid double border
-		background: $white;
-		box-shadow: inset 0 4px 0 $woocommerce;
 
 		&:focus {
 			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce;
@@ -153,9 +151,6 @@ $inner-border: $core-grey-light-500;
 
 	.woocommerce-summary__item-label {
 		display: block;
-	}
-
-	.woocommerce-summary__item-label {
 		margin-bottom: $gap;
 		@include font-size( 11 );
 		text-transform: uppercase;
@@ -165,14 +160,28 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-value {
 		margin-bottom: $gap-smallest;
 		@include font-size( 18 );
-		font-weight: 600;
+		font-weight: 500;
 		color: $core-grey-dark-900;
 	}
 
 	.woocommerce-summary__item-delta {
 		margin-bottom: $gap-small;
 		@include font-size( 18 );
+		font-weight: 300;
 		color: $core-grey-dark-500;
+	}
+
+	&.is-selected {
+		background: $white;
+		box-shadow: inset 0 4px 0 $woocommerce;
+
+		.woocommerce-summary__item-value {
+			font-weight: 600;
+		}
+
+		.woocommerce-summary__item-delta {
+			font-weight: 400;
+		}
 	}
 
 	&.is-good-trend .woocommerce-summary__item-delta {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -149,7 +149,7 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-delta {
 		margin-bottom: $gap-small;
 		@include font-size( 18 );
-		color: $woocommerce;
+		color: $core-grey-dark-500;
 	}
 
 	&.is-good-trend .woocommerce-summary__item-delta {
@@ -163,7 +163,6 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-delta-icon {
 		vertical-align: middle;
 		margin-right: 3px;
-		margin-top: -3px;
 		fill: currentColor;
 
 		&.gridicons-arrow-up {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -13,6 +13,30 @@ $inner-border: $core-grey-light-500;
 	}
 }
 
+@mixin wrap-contents() {
+	.woocommerce-summary__item-value,
+	.woocommerce-summary__item-delta {
+		min-width: 100%;
+	}
+
+	.woocommerce-summary__item-prev-label,
+	.woocommerce-summary__item-prev-value {
+		display: block;
+	}
+}
+
+@mixin reset-wrap() {
+	.woocommerce-summary__item-value,
+	.woocommerce-summary__item-delta {
+		min-width: auto;
+	}
+
+	.woocommerce-summary__item-prev-label,
+	.woocommerce-summary__item-prev-value {
+		display: inline;
+	}
+}
+
 .woocommerce-summary {
 	display: grid;
 	border-width: 1px 0 0 1px;
@@ -60,40 +84,25 @@ $inner-border: $core-grey-light-500;
 	&.has-9-items,
 	&.has-10-items {
 		@include make-cols( 5 );
-
-		.woocommerce-summary__item-value,
-		.woocommerce-summary__item-delta {
-			min-width: 100%;
-		}
+		@include wrap-contents;
 	}
 
 	&.has-6-items {
 		@include make-cols( 6 );
-
-		.woocommerce-summary__item-value,
-		.woocommerce-summary__item-delta {
-			min-width: 100%;
-		}
+		@include wrap-contents;
 	}
 
 	@include breakpoint( '<1365px' ) {
 		&.has-4-items,
 		&.has-7-items,
 		&.has-8-items {
-			.woocommerce-summary__item-value,
-			.woocommerce-summary__item-delta {
-				min-width: 100%;
-			}
+			@include wrap-contents;
 		}
 
 		&.has-6-items,
 		&.has-9-items {
 			@include make-cols( 3 );
-
-			.woocommerce-summary__item-value,
-			.woocommerce-summary__item-delta {
-				min-width: auto;
-			}
+			@include reset-wrap;
 		}
 
 		&.has-10-items {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -174,10 +174,6 @@ $inner-border: $core-grey-light-500;
 		}
 	}
 
-	.woocommerce-summary__item-prev-label {
-		margin-right: $gap-smallest;
-	}
-
 	.woocommerce-summary__item-prev-label,
 	.woocommerce-summary__item-prev-value {
 		@include font-size( 13 );

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -4,6 +4,15 @@
 $outer-border: $core-grey-light-700;
 $inner-border: $core-grey-light-500;
 
+// A local mixin to generate the grid template and border logic
+@mixin make-cols( $i ) {
+	grid-template-columns: repeat($i, 1fr);
+
+	.woocommerce-summary__item:nth-of-type(#{$i}n) {
+		border-right-color: $outer-border;
+	}
+}
+
 .woocommerce-summary {
 	display: grid;
 	border-width: 1px 0 0 1px;
@@ -33,39 +42,23 @@ $inner-border: $core-grey-light-500;
 	}
 
 	&.has-2-items {
-		grid-template-columns: repeat(2, 1fr);
-
-		.woocommerce-summary__item:nth-of-type(2n) {
-			border-right-color: $outer-border;
-		}
+		@include make-cols( 2 );
 	}
 
 	&.has-3-items {
-		grid-template-columns: repeat(3, 1fr);
-
-		.woocommerce-summary__item:nth-of-type(3n) {
-			border-right-color: $outer-border;
-		}
+		@include make-cols( 3 );
 	}
 
 	&.has-4-items,
 	&.has-7-items,
 	&.has-8-items {
-		grid-template-columns: repeat(4, 1fr);
-
-		.woocommerce-summary__item:nth-of-type(4n) {
-			border-right-color: $outer-border;
-		}
+		@include make-cols( 4 );
 	}
 
 	&.has-5-items,
 	&.has-9-items,
 	&.has-10-items {
-		grid-template-columns: repeat(5, 1fr);
-
-		.woocommerce-summary__item:nth-of-type(5n) {
-			border-right-color: $outer-border;
-		}
+		@include make-cols( 5 );
 
 		.woocommerce-summary__item-value,
 		.woocommerce-summary__item-delta {
@@ -74,11 +67,7 @@ $inner-border: $core-grey-light-500;
 	}
 
 	&.has-6-items {
-		grid-template-columns: repeat(6, 1fr);
-
-		.woocommerce-summary__item:nth-of-type(6n) {
-			border-right-color: $outer-border;
-		}
+		@include make-cols( 6 );
 
 		.woocommerce-summary__item-value,
 		.woocommerce-summary__item-delta {
@@ -98,11 +87,7 @@ $inner-border: $core-grey-light-500;
 
 		&.has-6-items,
 		&.has-9-items {
-			grid-template-columns: repeat(3, 1fr);
-
-			.woocommerce-summary__item:nth-of-type(3n) {
-				border-right-color: $outer-border;
-			}
+			@include make-cols( 3 );
 
 			.woocommerce-summary__item-value,
 			.woocommerce-summary__item-delta {
@@ -111,11 +96,7 @@ $inner-border: $core-grey-light-500;
 		}
 
 		&.has-10-items {
-			grid-template-columns: repeat(4, 1fr);
-
-			.woocommerce-summary__item:nth-of-type(4n) {
-				border-right-color: $outer-border;
-			}
+			@include make-cols( 4 );
 		}
 
 		&.has-9-items,

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -180,3 +180,19 @@ $inner-border: $core-grey-light-500;
 		color: $core-grey-dark-500;
 	}
 }
+
+.woocommerce-card {
+	.woocommerce-summary {
+		background-color: $core-grey-light-100;
+		border: none;
+	}
+
+	.woocommerce-summary__item {
+		background-color: $white;
+	}
+
+	.woocommerce-summary__item.is-selected {
+		margin-top: 0;
+		box-shadow: none;
+	}
+}

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -8,7 +8,7 @@ $inner-border: $core-grey-light-500;
 @mixin make-cols( $i ) {
 	grid-template-columns: repeat($i, 1fr);
 
-	.woocommerce-summary__item:nth-of-type(#{$i}n) {
+	.woocommerce-summary__item-container:nth-of-type(#{$i}n) .woocommerce-summary__item {
 		border-right-color: $outer-border;
 	}
 }
@@ -102,7 +102,7 @@ $inner-border: $core-grey-light-500;
 
 		&.has-9-items,
 		&.has-10-items {
-			.woocommerce-summary__item:nth-of-type(5n) {
+			.woocommerce-summary__item-container:nth-of-type(5n) .woocommerce-summary__item {
 				border-right-color: $inner-border;
 			}
 		}
@@ -112,6 +112,11 @@ $inner-border: $core-grey-light-500;
 .woocommerce-summary__item-container {
 	margin-bottom: 0;
 	width: 100%;
+
+	&:last-of-type .woocommerce-summary__item {
+		// Make sure the last item always uses the outer-border color.
+		border-right-color: $outer-border !important;
+	}
 }
 
 .woocommerce-summary__item {
@@ -133,11 +138,6 @@ $inner-border: $core-grey-light-500;
 
 	&:focus {
 		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black;
-	}
-
-	&:last-of-type {
-		// Make sure the last item always uses the outer-border color.
-		border-right-color: $outer-border !important;
 	}
 
 	&.is-selected {

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -76,17 +76,30 @@ class StorePerformance extends Component {
 			>
 				<SummaryList>
 					{ showCustomers && (
-						<SummaryNumber value={ '2' } label={ __( 'New Customers', 'wc-admin' ) } delta={ 15 } />
+						<SummaryNumber
+							label={ __( 'New Customers', 'wc-admin' ) }
+							value={ '2' }
+							prevLabel={ __( 'Previous Week:', 'wc-admin' ) }
+							prevValue={ 3 }
+							delta={ -33 }
+						/>
 					) }
 					{ showProducts && (
-						<SummaryNumber value={ totalProducts } label={ __( 'Total Products', 'wc-admin' ) } />
+						<SummaryNumber
+							label={ __( 'Total Products', 'wc-admin' ) }
+							value={ totalProducts }
+							prevLabel={ __( 'Previous Week:', 'wc-admin' ) }
+							prevValue={ totalProducts }
+							delta={ 0 }
+						/>
 					) }
 					{ showOrders && (
 						<SummaryNumber
-							value={ totalOrders }
-							selected
 							label={ __( 'Total Orders', 'wc-admin' ) }
-							delta={ -6 }
+							value={ totalOrders }
+							prevLabel={ __( 'Previous Week:', 'wc-admin' ) }
+							prevValue={ totalOrders }
+							delta={ 0 }
 						/>
 					) }
 				</SummaryList>
@@ -97,7 +110,7 @@ class StorePerformance extends Component {
 
 export default compose( [
 	withAPIData( () => ( {
-		orders: '/wc/v2/orders?status=processing',
-		products: '/wc/v2/products',
+		orders: '/wc/v3/orders?status=processing',
+		products: '/wc/v3/products',
 	} ) ),
 ] )( StorePerformance );

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -4,6 +4,10 @@
 	border-bottom: 0;
 	border-right: 0;
 
+	.woocommerce-card__header {
+		border-right: 1px solid $core-grey-light-700;
+	}
+
 	.woocommerce-card__body {
 		padding: 0;
 	}

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -1,17 +1,14 @@
 /** @format */
 
 .woocommerce-dashboard__store-performance {
+	border-bottom: 0;
+	border-right: 0;
+
 	.woocommerce-card__body {
 		padding: 0;
 	}
 
 	.woocommerce-summary {
 		margin: 0;
-		border-top: 0px;
-		border-bottom: 0px;
-
-		.woocommerce-summary__item {
-			border-width: 0 1px 0 0;
-		}
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -5,21 +5,16 @@
 }
 
 .woocommerce-layout__primary {
-	margin: 80px 0 0 $spacing;
+	margin: 80px 0 0 $gutter;
 
 	@include breakpoint( '>1100px' ) {
 		margin-top: 100px;
 	}
-
-	.woocommerce-layout__main {
-		margin: 0 auto;
-		max-width: 640px;
-	}
 }
 
 .woocommerce-layout .woocommerce-layout__main {
-	padding-right: $spacing;
-	max-width: 1100px;
+	padding-right: $gutter;
+	max-width: 100%;
 }
 
 // @TODO remove this?

--- a/client/stylesheets/_breakpoints.scss
+++ b/client/stylesheets/_breakpoints.scss
@@ -5,7 +5,7 @@
 
 // Think very carefully before adding a new breakpoint.
 // The list below is based on wp-admin's main breakpoints
-$breakpoints: 320px, 400px, 600px, 782px, 960px, 1100px;
+$breakpoints: 320px, 400px, 600px, 782px, 960px, 1100px, 1365px;
 
 @mixin breakpoint( $sizes... ) {
 	@each $size in $sizes {


### PR DESCRIPTION
See #131 - this PR adds a previous value/label to each SummaryNumber, and updates the design to match the updated hifi designs. This also adds in the ability to link off to a report by adding a required `href` prop to the SummaryNumber.

The smaller screen dropdown functionality will come in a later PR, as that will be much more complex.

**Demo on 1440px wide:**

<img width="572" alt="large-screen-one" src="https://user-images.githubusercontent.com/541093/43209619-1972bac6-8ffb-11e8-9ba4-3f02d271ec13.png">
<img width="948" alt="large-screen-two" src="https://user-images.githubusercontent.com/541093/43209620-19837cda-8ffb-11e8-833f-a4cdd5ac5879.png">

**Demo on 1024px wide:**

<img width="629" alt="med-screen-two" src="https://user-images.githubusercontent.com/541093/43209626-1d7f31bc-8ffb-11e8-9961-5865a2b4c12d.png">

**Demo in a card**

<img width="844" alt="screen shot 2018-07-25 at 11 09 03 am" src="https://user-images.githubusercontent.com/541093/43209650-2da87684-8ffb-11e8-9818-273243ad68a2.png">

**Demo of interactive states**

(top left is active/pressed, middle is selected, top right is hovered, bottom left is unselected + focused)
<img width="791" alt="screen shot 2018-07-25 at 1 30 50 pm" src="https://user-images.githubusercontent.com/541093/43217250-1d832e34-900f-11e8-956d-647cd111f901.png">

(right is a selected + focused item)
<img width="790" alt="screen shot 2018-07-25 at 1 31 04 pm" src="https://user-images.githubusercontent.com/541093/43217251-1d8ed928-900f-11e8-8a3b-9445db51efc2.png">

Don't be scared off by the `+676 lines`, 374 of that is creating an extensive demo page with lots of different number combos 😁

To test:

- Look at the example report `/wp-admin/admin.php?page=wc-admin#/analytics/test`
- Check that all SummaryNumbers appear as expected on screens larger than 783px (have not addressed the dropdowns yet)
- Specific "edge cases":
  - The 2nd item in most cases is "selected", the exception is in "Ten or More Data Points" where it's the 5th item to show selection on the second line.
  - The 3rd item in most cases has a delta of 0
  - In "Four Data Points", the 3rd item has no previous value or delta
  - In "Ten or More Data Points", the 8th item has a ridiculously large previous value
- Mouse or keyboard over them to check on the interactive states
- Check the same for the SummaryNumber card on the dashboard
- Try using VoiceOver to interact with the SummaryNumbers – I've called this a navigation menu, since they link off to specific reports/charts. You should be able to target and click on a summary number

**Note** All the summary numbers go to a default link of `/analytics`, because a) I don't know what these should link to, and b) I really didn't want to update every single demo `SummaryNumber` 😆