### PR TITLE
Fix WP Notices Tabbing

### DIFF
--- a/client/stylesheets/_wpadmin-reset.scss
+++ b/client/stylesheets/_wpadmin-reset.scss
@@ -141,16 +141,24 @@
 }
 
 .woocommerce-layout__notice-list-hide {
-	opacity: 0;
-	height: 0;
-	overflow: hidden;
+	display: none;
+}
+
+@keyframes slideDown {
+	0% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+	100% {
+		transform: translateY(0);
+		opacity: 1;
+	}
 }
 
 .woocommerce-layout__notice-list-show {
-	opacity: 1;
-	height: auto;
-	transition: opacity 1s ease-in-out;
 	margin-top: 100px;
+	animation: slideDown;
+	animation-duration: 1s;
 
 	&.has-screen-meta-links {
 		display: inline-block;


### PR DESCRIPTION
Right now, you can still tab through notices even if they are hidden. This messes up keyboard navigation because you'll jump from a closed activity panel, to X number of notices, and then dashboard content.

Using `display: none` should solve the issue. When open, you can still tab through the notices. I've also updated the animation here to make it a bit smoother (and because the existing `transition` doesn't work when moving from display: none`).

To Test:
* Make sure you have some notices present (https://gist.github.com/justinshreve/25392f3bb22492731d056a1dbc0e786f)
* Tab through the elements on the page, verify you go from the activity panel to the next element, and not an invisible notice.