### PR TITLE
Datepicker: Refactor Calendar to fully controlled component

### DIFF
--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -38,7 +38,7 @@ export default class extends Component {
 					] }
 				/>
 				<div className="woocommerce-products__pickers">
-					<DatePicker query={ query } path={ path } />
+					<DatePicker query={ query } path={ path } key={ JSON.stringify( query ) } />
 					<FilterPicker
 						query={ query }
 						path={ path }

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -115,7 +115,7 @@ class RevenueReport extends Component {
 						__( 'Revenue', 'wc-admin' ),
 					] }
 				/>
-				<DatePicker query={ query } path={ path } />
+				<DatePicker query={ query } path={ path } key={ JSON.stringify( query ) } />
 
 				<SummaryList>
 					<SummaryNumber

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -6,7 +6,7 @@ Select a range of dates or single dates
 ## Usage
 
 ```jsx
-<DatePicker query={ query } path={ path } />
+<DatePicker query={ query } path={ path } key={ JSON.stringify( query ) } />
 ```
 
 ### Props
@@ -17,6 +17,7 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 `query`* | `object` | none | The query string represented in object form
 `path`* | `string` | none | `path` parameter supplied by React-Router
+`key`| `*` | none |  Force a recalculation or reset of internal state when this key changes. Useful for a url change, for instance
 
 ## URL as the source of truth
 

--- a/client/components/date-picker/content.js
+++ b/client/components/date-picker/content.js
@@ -25,7 +25,7 @@ class DatePickerContent extends Component {
 		this.onTabSelect = this.onTabSelect.bind( this );
 	}
 	onTabSelect( tab ) {
-		const { onSelect, period } = this.props;
+		const { onUpdate, period } = this.props;
 
 		/**
 		 * If the period is `custom` and the user switches tabs to view the presets,
@@ -33,7 +33,7 @@ class DatePickerContent extends Component {
 		 * `custom` value for period will result in no selection.
 		 */
 		if ( 'period' === tab && 'custom' === period ) {
-			onSelect( { period: 'today' } );
+			onUpdate( { period: 'today' } );
 		}
 	}
 
@@ -43,11 +43,17 @@ class DatePickerContent extends Component {
 			compare,
 			after,
 			before,
-			onSelect,
+			onUpdate,
 			onClose,
 			getUpdatePath,
 			isValidSelection,
 			resetCustomValues,
+			focusedInput,
+			afterText,
+			beforeText,
+			afterError,
+			beforeError,
+			shortDateFormat,
 		} = this.props;
 		return (
 			<div>
@@ -83,14 +89,20 @@ class DatePickerContent extends Component {
 						{ selectedTab => (
 							<Fragment>
 								{ selectedTab === 'period' && (
-									<PresetPeriods onSelect={ onSelect } period={ period } />
+									<PresetPeriods onSelect={ onUpdate } period={ period } />
 								) }
 								{ selectedTab === 'custom' && (
 									<DateRange
 										after={ after }
 										before={ before }
-										onSelect={ onSelect }
+										onUpdate={ onUpdate }
 										inValidDays="future"
+										focusedInput={ focusedInput }
+										afterText={ afterText }
+										beforeText={ beforeText }
+										afterError={ afterError }
+										beforeError={ beforeError }
+										shortDateFormat={ shortDateFormat }
 									/>
 								) }
 								<div
@@ -102,7 +114,7 @@ class DatePickerContent extends Component {
 									<H className="woocommerce-date-picker__text">
 										{ __( 'compare to', 'wc-admin' ) }
 									</H>
-									<ComparePeriods onSelect={ onSelect } compare={ compare } />
+									<ComparePeriods onSelect={ onUpdate } compare={ compare } />
 									<div className="woocommerce-date-picker__content-controls-btns">
 										{ selectedTab === 'custom' && (
 											<Button
@@ -147,10 +159,16 @@ class DatePickerContent extends Component {
 DatePickerContent.propTypes = {
 	period: PropTypes.string.isRequired,
 	compare: PropTypes.string.isRequired,
-	onSelect: PropTypes.func.isRequired,
+	onUpdate: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
 	getUpdatePath: PropTypes.func.isRequired,
 	resetCustomValues: PropTypes.func.isRequired,
+	focusedInput: PropTypes.string,
+	afterText: PropTypes.string,
+	beforeText: PropTypes.string,
+	afterError: PropTypes.string,
+	beforeError: PropTypes.string,
+	shortDateFormat: PropTypes.string.isRequired,
 };
 
 export default DatePickerContent;

--- a/client/components/date-picker/index.js
+++ b/client/components/date-picker/index.js
@@ -16,22 +16,35 @@ import DropdownButton from 'components/dropdown-button';
 import DatePickerContent from './content';
 import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
 
+const shortDateFormat = __( 'MM/DD/YYYY', 'wc-admin' );
+
 class DatePicker extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = getDateParamsFromQuery( props.query );
-		this.select = this.select.bind( this );
+		this.state = this.getResetState( props );
+
+		this.update = this.update.bind( this );
 		this.getUpdatePath = this.getUpdatePath.bind( this );
 		this.isValidSelection = this.isValidSelection.bind( this );
 		this.resetCustomValues = this.resetCustomValues.bind( this );
 	}
 
-	// @TODO change this to `getDerivedStateFromProps` in React 16.4
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		this.setState( getDateParamsFromQuery( nextProps.query ) );
+	getResetState( props ) {
+		const { period, compare, before, after } = getDateParamsFromQuery( props.query );
+		return {
+			period,
+			compare,
+			before,
+			after,
+			focusedInput: 'startDate',
+			afterText: after ? after.format( shortDateFormat ) : '',
+			beforeText: before ? before.format( shortDateFormat ) : '',
+			afterError: null,
+			beforeError: null,
+		};
 	}
 
-	select( update ) {
+	update( update ) {
 		this.setState( update );
 	}
 
@@ -78,11 +91,26 @@ class DatePicker extends Component {
 		this.setState( {
 			after: null,
 			before: null,
+			focusedInput: 'startDate',
+			afterText: '',
+			beforeText: '',
+			afterError: null,
+			beforeError: null,
 		} );
 	}
 
 	render() {
-		const { period, compare, after, before } = this.state;
+		const {
+			period,
+			compare,
+			after,
+			before,
+			focusedInput,
+			afterText,
+			beforeText,
+			afterError,
+			beforeError,
+		} = this.state;
 		return (
 			<div className="woocommerce-date-picker">
 				<p>{ __( 'Date Range', 'wc-admin' ) }:</p>
@@ -103,11 +131,17 @@ class DatePicker extends Component {
 							compare={ compare }
 							after={ after }
 							before={ before }
-							onSelect={ this.select }
+							onUpdate={ this.update }
 							onClose={ onClose }
 							getUpdatePath={ this.getUpdatePath }
 							isValidSelection={ this.isValidSelection }
 							resetCustomValues={ this.resetCustomValues }
+							focusedInput={ focusedInput }
+							afterText={ afterText }
+							beforeText={ beforeText }
+							afterError={ afterError }
+							beforeError={ beforeError }
+							shortDateFormat={ shortDateFormat }
 						/>
 					) }
 				/>

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -307,3 +307,51 @@ export function loadLocaleData() {
 }
 
 loadLocaleData();
+
+export const dateValidationMessages = {
+	invalid: __( 'Invalid date', 'wc-admin' ),
+	future: __( 'Select a date in the past', 'wc-admin' ),
+	startAfterEnd: __( 'Start date must be before end date', 'wc-admin' ),
+	endBeforeStart: __( 'Start date must be before end date', 'wc-admin' ),
+};
+
+/**
+ * Validate text input supplied for a date range.
+ *
+ * @param {string} type - Designate begining or end of range, eg `before` or `after`.
+ * @param {string} value - User input value
+ * @param {Moment|null} [before] - If already designated, the before date parameter
+ * @param {Moment|null} [after] - If already designated, the after date parameter
+ * @param {string} format - The expected date format in a user's locale
+ * @return {Object} validatedDate - validated date oject
+ * @param {Moment|null} validatedDate.date - A resulting Moment date object or null, if invalid
+ * @param {string} validatedDate.error - An optional error message if date is invalid
+ */
+export function validateDateInputForRange( type, value, before, after, format ) {
+	const date = toMoment( format, value );
+	if ( ! date ) {
+		return {
+			date: null,
+			error: dateValidationMessages.invalid,
+		};
+	}
+	if ( moment().isBefore( date, 'day' ) ) {
+		return {
+			date: null,
+			error: dateValidationMessages.future,
+		};
+	}
+	if ( 'after' === type && before && date.isAfter( before, 'day' ) ) {
+		return {
+			date: null,
+			error: dateValidationMessages.startAfterEnd,
+		};
+	}
+	if ( 'before' === type && after && date.isBefore( after, 'day' ) ) {
+		return {
+			date: null,
+			error: dateValidationMessages.endBeforeStart,
+		};
+	}
+	return { date };
+}

--- a/client/lib/date/test/index.js
+++ b/client/lib/date/test/index.js
@@ -16,6 +16,8 @@ import {
 	getRangeLabel,
 	loadLocaleData,
 	getCurrentDates,
+	validateDateInputForRange,
+	dateValidationMessages,
 } from 'lib/date';
 
 describe( 'toMoment', () => {
@@ -589,5 +591,79 @@ describe( 'getCurrentDates', () => {
 		// Ensure default compare is `previous_period`
 		expect( yesterday.isSame( currentDates.secondary.after, 'day' ) ).toBe( true );
 		expect( yesterday.isSame( currentDates.secondary.before, 'day' ) ).toBe( true );
+	} );
+} );
+
+describe( 'validateDateInputForRange', () => {
+	const dateFormat = 'YYYY-MM-DD';
+
+	it( 'should return a valid date in Moment object', () => {
+		const validated = validateDateInputForRange( 'after', '2018-04-15', null, null, dateFormat );
+		expect( moment.isMoment( validated.date ) ).toBe( true );
+		expect( validated.error ).toBe( undefined );
+	} );
+
+	it( 'should return a null date on invalid date string', () => {
+		const validated = validateDateInputForRange(
+			'after',
+			'BAd-2018-Date-Format/15/4',
+			null,
+			null,
+			dateFormat
+		);
+		expect( validated.date ).toBe( null );
+		expect( validated.error ).toBe( dateValidationMessages.invalid );
+	} );
+
+	it( 'should return a correct error for a date in the future', () => {
+		const futureDateString = moment()
+			.add( 1, 'months' )
+			.format( dateFormat );
+		const validated = validateDateInputForRange(
+			'after',
+			futureDateString,
+			null,
+			null,
+			dateFormat
+		);
+		expect( validated.date ).toBe( null );
+		expect( validated.error ).toBe( dateValidationMessages.future );
+	} );
+
+	it( 'should return a correct error for start', () => {
+		const futureDateString = moment()
+			.add( 1, 'months' )
+			.format( dateFormat );
+		const validated = validateDateInputForRange(
+			'after',
+			futureDateString,
+			null,
+			null,
+			dateFormat
+		);
+		expect( validated.date ).toBe( null );
+		expect( validated.error ).toBe( dateValidationMessages.future );
+	} );
+
+	it( 'should return a correct error for start after end', () => {
+		const end = moment().subtract( 5, 'months' );
+		const value = end
+			.clone()
+			.add( 1, 'months' )
+			.format( dateFormat );
+		const validated = validateDateInputForRange( 'after', value, end, null, dateFormat );
+		expect( validated.date ).toBe( null );
+		expect( validated.error ).toBe( dateValidationMessages.startAfterEnd );
+	} );
+
+	it( 'should return a correct error for end after start', () => {
+		const start = moment().subtract( 5, 'months' );
+		const value = start
+			.clone()
+			.subtract( 1, 'months' )
+			.format( dateFormat );
+		const validated = validateDateInputForRange( 'before', value, null, start, dateFormat );
+		expect( validated.date ).toBe( null );
+		expect( validated.error ).toBe( dateValidationMessages.endBeforeStart );
 	} );
 } );


### PR DESCRIPTION
The Calendar component had its own state, comprised of text inputs and error messages. This PR moves the state logic up to the date picker, making Calendar a [fully controlled component](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#preferred-solutions).

There was a mis-alignment between the Calendar state and DatePicker state. In particular, the Reset button had effects on both and some comparisons were required in Calendar to guess if the DatePicker state had been reset. This caused odd interactions when resetting. I can now eliminate this faulty code:

```js
componentDidUpdate( prevProps ) {
	const { after, before } = this.props;
	/**
	 * Check if props have been reset. If so, reset internal state. Disabling
	 * eslint here because this setState cannot cause infinte loop
	 */
	/* eslint-disable react/no-did-update-set-state */
	if ( ( prevProps.before || prevProps.after ) && ( null === after && null === before ) ) {
		this.setState( {
			focusedInput: START_DATE,
			afterText: '',
			beforeText: '',
			afterError: null,
			beforeError: null,
		} );
	}
	/* eslint-enable react/no-did-update-set-state */
}
```
## Other changes
* `validateDateInputForRange` was also pulled out to `lib/date` and unit tests added.
* Remove `UNSAFE_componentWillReceiveProps`. 

The nature of this component is such that a reset of internal state needs to happen on every change of the url query parameters. Previously, this was done like in the `UNSAFE` manner:

```js
UNSAFE_componentWillReceiveProps( nextProps ) {
    this.setState( this.getResetState( nextProps ) );
}
```
One option was to use `getDerivedStateFromProps`, but that runs on every update and can introduce problems. Instead I opted for [Fully uncontrolled component with a key](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) to force reset on prop changes.

```js
<DatePicker query={ query } path={ path } key={ JSON.stringify( query ) } />
```

## Test
1. `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2. Make sure the datepicker hasn't regressed
3. Use the "Reset" button at various stages of editing the custom datepicker. Behaviour should be free of irregularities
4. `npm run test`

Depends on https://github.com/woocommerce/wc-admin/pull/235