### PR TITLE
Add Collapsed Review View

### DIFF
--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -11,7 +11,6 @@
 
 	.woocommerce-split-button__main-action,
 	.woocommerce-split-button__menu-toggle {
-		padding: ($gap-smallest * 2) $gap-large ($gap-smallest * 2) $gap-small;
 		line-height: 26px;
 		height: 42px;
 		border-radius: 3px;
@@ -26,16 +25,19 @@
 	}
 
 	.woocommerce-split-button__main-action {
-		padding: $gap-small;
+		padding: 0 $gap-small;
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 		border-right: 0;
+		height: 32px;
 	}
 
 	.woocommerce-split-button__menu-toggle {
 		border-top-left-radius: 0;
 		border-bottom-left-radius: 0;
-		padding: $gap-smallest * 2;
+		padding: $gap-smallest;
+		height: 32px;
+		width: 32px;
 	}
 
 	.woocommerce-split-button__menu-popover.is-mobile {
@@ -69,7 +71,7 @@
 		}
 
 		.woocommerce-split-button__main-action {
-			padding: ($gap-smallest * 2) $gap-large ($gap-smallest * 2) $gap-small;
+			padding: 0 $gap-large 0 $gap-small;
 		}
 	}
 
@@ -106,6 +108,8 @@
 
 	.dashicons-arrow-down {
 		fill: $core-grey-dark-500;
+		height: 20px;
+		width: 20px;
 	}
 
 	.woocommerce-split-button__menu-toggle.is-active,

--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -69,10 +69,6 @@
 		.woocommerce-split-button__main-action.components-button .dashicon {
 			margin-right: $gap-smallest * 2;
 		}
-
-		.woocommerce-split-button__main-action {
-			padding: 0 $gap-large 0 $gap-small;
-		}
 	}
 
 	.woocommerce-split-button__menu-wrapper {

--- a/client/layout/activity-panel/activity-card/index.js
+++ b/client/layout/activity-panel/activity-card/index.js
@@ -52,7 +52,7 @@ ActivityCard.propTypes = {
 	date: PropTypes.string,
 	icon: PropTypes.node,
 	subtitle: PropTypes.node,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ).isRequired,
 	unread: PropTypes.bool,
 };
 

--- a/client/layout/activity-panel/activity-card/style.scss
+++ b/client/layout/activity-panel/activity-card/style.scss
@@ -46,11 +46,17 @@
 .woocommerce-activity-card__header {
 	margin-bottom: $gap;
 	display: flex;
-	flex-direction: column-reverse;
+	flex-direction: column;
+
+	a {
+		color: $woocommerce;
+		text-decoration: none;
+	}
 
 	.woocommerce-activity-card__title {
 		margin: 0;
 		@include font-size( 13 );
+		order: 2;
 	}
 
 	.woocommerce-activity-card__date {
@@ -58,6 +64,11 @@
 		text-transform: uppercase;
 		@include font-size( 11 );
 		margin-bottom: $gap-small;
+		order: 1;
+	}
+
+	.woocommerce-activity-card__subtitle {
+		order: 3;
 	}
 
 	@include breakpoint( '>782px' ) {

--- a/client/layout/activity-panel/panels/reviews.js
+++ b/client/layout/activity-panel/panels/reviews.js
@@ -2,101 +2,167 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import Gridicon from 'gridicons';
+import interpolateComponents from 'interpolate-components';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
+import Gravatar from 'components/gravatar';
+import Link from 'components/link';
+import ProductImage from 'components/product-image';
+import { ReviewRating } from 'components/rating';
+import { Section } from 'layout/section';
 import SplitButton from 'components/split-button';
 
+// TODO Pull proper data from the API
+const demoReviews = [
+	{
+		id: 1,
+		product_id: 1,
+		reviewer: 'Justin Shreve',
+		reviewer_email: 'justin@automattic.com',
+		rating: 3,
+		verified: true,
+		review:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque finibus hendrerit finibus.' +
+			'Integer tristique turpis a aliquam aliquam. Phasellus sapien lectus, sodales in sagittis nec, placerat a augue.',
+		status: 'pending',
+		date_created: '2018-07-10T02:49:00Z',
+	},
+];
+
+const demoProducts = [
+	{
+		id: 1,
+		name: 'WordPress Shirt',
+		permalink: '#',
+		images: [
+			{
+				id: 1,
+				src: 'https://cldup.com/5QyaPgyfFo-3000x3000.png',
+			},
+		],
+	},
+];
+
 class ReviewsPanel extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			loading: true,
+			reviews: [],
+		};
+	}
+
+	componentDidMount() {
+		this.interval = setTimeout( () => {
+			this.setState( {
+				loading: false,
+				reviews: demoReviews,
+			} );
+		}, 5000 );
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.interval );
+	}
+
+	renderReview( review ) {
+		const product = demoProducts[ 0 ];
+
+		const title = interpolateComponents( {
+			mixedString: sprintf(
+				__(
+					'{{productLink}}%s{{/productLink}} reviewed by {{authorLink}}%s{{/authorLink}}',
+					'wc-admin'
+				),
+				product.name,
+				review.reviewer
+			),
+			components: {
+				productLink: <Link href={ product.permalink } type="external" />,
+				authorLink: <Link href={ 'mailto:' + review.reviewer_email } type="external" />,
+			},
+		} );
+
+		const subtitle = (
+			<Fragment>
+				<ReviewRating review={ review } />
+				{ review.verified && (
+					<span className="woocommerce-review-activity-card__verified">
+						<Gridicon icon="checkmark" size={ 18 } />
+						{ __( 'Verified customer', 'wc-admin' ) }
+					</span>
+				) }
+			</Fragment>
+		);
+
+		const icon = (
+			<div className="woocommerce-review-activity-card__image-overlay">
+				<Gravatar user={ review.reviewer_email } size={ 24 } />
+				<ProductImage product={ product } />
+			</div>
+		);
+
+		const cardActions = () => {
+			const mainLabel =
+				'approved' === review.status ? __( 'Unapprove', 'wc-admin' ) : __( 'Approve', 'wc-admin' );
+			return (
+				<SplitButton
+					mainLabel={ mainLabel }
+					menuLabel={ __( 'Select an action', 'wc-admin' ) }
+					onClick={ noop }
+					controls={ [
+						{
+							label: __( 'Reply', 'wc-admin' ),
+							onClick: noop,
+						},
+						{
+							label: __( 'Spam', 'wc-admin' ),
+							onClick: noop,
+						},
+						{
+							label: __( 'Trash', 'wc-admin' ),
+							onClick: noop,
+						},
+					] }
+				/>
+			);
+		};
+
+		return (
+			<ActivityCard
+				className="woocommerce-review-activity-card"
+				key={ review.id }
+				title={ title }
+				subtitle={ subtitle }
+				date={ review.date_created }
+				icon={ icon }
+				actions={ cardActions() }
+			>
+				{ review.review }
+			</ActivityCard>
+		);
+	}
+
 	render() {
+		const { loading = true, reviews = [] } = this.state;
 		return (
 			<Fragment>
 				<ActivityHeader title={ __( 'Reviews', 'wc-admin' ) } />
-
-				<SplitButton
-					isPrimary
-					mainLabel="Primary Button"
-					menuLabel="Select an action"
-					onClick={ () => alert( 'Primary Main Action clicked' ) }
-					controls={ [
-						{
-							label: 'Up',
-							onClick: () => alert( 'Primary Up clicked' ),
-						},
-						{
-							label: 'Right',
-							onClick: () => alert( 'Primary Right clicked' ),
-						},
-						{
-							label: 'Down',
-							icon: <Gridicon icon="arrow-down" />,
-							onClick: () => alert( 'Primary Down clicked' ),
-						},
-						{
-							label: 'Left',
-							icon: <Gridicon icon="arrow-left" />,
-							onClick: () => alert( 'Primary Left clicked' ),
-						},
-					] }
-				/>
-
-				<SplitButton
-					mainIcon={ <Gridicon icon="pencil" /> }
-					mainLabel="Secondary Button"
-					menuLabel="Select an action"
-					onClick={ () => alert( 'Secondary Main Action clicked' ) }
-					controls={ [
-						{
-							label: 'Up',
-							icon: <Gridicon icon="arrow-up" />,
-							onClick: () => alert( 'Secondary Up clicked' ),
-						},
-						{
-							label: 'Right',
-							onClick: () => alert( 'Secondary Right clicked' ),
-						},
-						{
-							label: 'Down',
-							icon: <Gridicon icon="arrow-down" />,
-							onClick: () => alert( 'Secondary Down clicked' ),
-						},
-						{
-							icon: <Gridicon icon="arrow-left" />,
-							onClick: () => alert( 'Secondary Left clicked' ),
-						},
-					] }
-				/>
-
-				<SplitButton
-					mainIcon={ <Gridicon icon="pencil" /> }
-					menuLabel="Select an action"
-					onClick={ () => alert( 'Icon Only Action clicked' ) }
-					controls={ [
-						{
-							label: 'Up',
-							icon: <Gridicon icon="arrow-up" />,
-							onClick: () => alert( 'Icon Only Up clicked' ),
-						},
-						{
-							label: 'Right',
-							onClick: () => alert( 'Icon Only Right clicked' ),
-						},
-						{
-							label: 'Down',
-							icon: <Gridicon icon="arrow-down" />,
-							onClick: () => alert( 'Icon Only Down clicked' ),
-						},
-						{
-							icon: <Gridicon icon="arrow-left" />,
-							onClick: () => alert( 'Icon Only Left clicked' ),
-						},
-					] }
-				/>
+				<Section>
+					{ loading ? (
+						<ActivityCardPlaceholder hasAction hasSubtitle hasDate lines={ 2 } />
+					) : (
+						reviews.map( this.renderReview )
+					) }
+				</Section>
 			</Fragment>
 		);
 	}

--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -267,3 +267,48 @@
 		margin-bottom: $gap-small;
 	}
 }
+
+.woocommerce-review-activity-card {
+	.woocommerce-review-activity-card__verified {
+		margin-left: $gap-small;
+		display: inline-flex;
+		position: relative;
+		top: $gap-smallest;
+		color: $valid-green;
+		@include font-size( 12 );
+
+		.gridicon {
+			margin-right: $gap-smallest;
+			fill: $valid-green;
+		}
+	}
+
+	.woocommerce-review-activity-card__image-overlay {
+		margin-left: -$gap-large;
+		img.woocommerce-gravatar {
+			left: $gap-large;
+			position: relative;
+			top: -42px;
+			border: 2px solid $white;
+		}
+	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-review-activity-card__image-overlay {
+			margin-top: $gap-smallest;
+		}
+
+		.woocommerce-activity-card__icon img.woocommerce-gravatar {
+			margin-left: 0;
+			width: 18px;
+			height: 18px;
+			left: 32px;
+			top: -28px;
+		}
+
+		.woocommerce-activity-card__icon img.woocommerce-product-image {
+			width: 38px;
+			height: 38px;
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7941,6 +7941,17 @@
         }
       }
     },
+    "interpolate-components": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.1.tgz",
+      "integrity": "sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=",
+      "dev": true,
+      "requires": {
+        "react": "^0.14.3 || ^15.1.0 || ^16.0.0",
+        "react-addons-create-fragment": "^0.14.3 || ^15.1.0",
+        "react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
+      }
+    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -15265,6 +15276,17 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-addons-create-fragment": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
+      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.4",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.0"
       }
     },
     "react-addons-shallow-compare": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "grunt-wp-i18n": "^1.0.2",
     "history": "^4.7.2",
     "husky": "^0.14.3",
+    "interpolate-components": "1.1.1",
     "node-sass": "^4.9.0",
     "postcss-loader": "^2.1.6",
     "prettier": "github:automattic/calypso-prettier#c56b4251",


### PR DESCRIPTION
This PR adds the collapsed card view and loading state view for reviews. It is not hooked up to an API yet (review endpoint has not been merged), so it uses the same loading trick as the Inbox tab. The actions also do nothing yet.

It also introduces a new package `interpolate-components` (https://github.com/Automattic/interpolate-components) that allows us to use components in translated strings.

Closes #205.

Mobile:

<img width="602" alt="screen shot 2018-07-26 at 2 48 19 pm" src="https://user-images.githubusercontent.com/689165/43282508-5411cbd8-90e4-11e8-97f9-d86190b43b0e.png">

<img width="505" alt="screen shot 2018-07-26 at 2 48 03 pm" src="https://user-images.githubusercontent.com/689165/43282515-581de19e-90e4-11e8-9cc6-e98aa6e4da00.png">

Desktop:

<img width="551" alt="screen shot 2018-07-26 at 2 48 48 pm" src="https://user-images.githubusercontent.com/689165/43282544-6b9381e8-90e4-11e8-9de2-e2fd7487d5dc.png">

<img width="531" alt="screen shot 2018-07-26 at 2 48 27 pm" src="https://user-images.githubusercontent.com/689165/43282554-71ac4844-90e4-11e8-8ea0-a88f4d3053d5.png">

To Test:
* Load up the reviews panel and verify everything looks OK.