### PR TITLE
Remove debug code logging screen ID

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -6,13 +6,11 @@ function wc_admin_register_script() {
 	// Are we displaying the full React app or just embedding the header on a classic screen?
 	$screen_id = wc_admin_get_current_screen_id();
 
-	error_log( $screen_id );
-
 	if ( in_array( $screen_id, wc_admin_get_embed_enabled_screen_ids() ) ) {
-		$js_entry = 'dist/embedded.js';
+		$js_entry  = 'dist/embedded.js';
 		$css_entry = 'dist/css/embedded.css';
 	} else {
-		$js_entry = 'dist/index.js';
+		$js_entry  = 'dist/index.js';
 		$css_entry = 'dist/css/index.css';
 	}
 


### PR DESCRIPTION
I noticed my `debug.log` filling up with this:

```
[24-Jul-2018 16:41:12 UTC] dashboard
[24-Jul-2018 16:41:16 UTC] update-core
[24-Jul-2018 16:43:16 UTC] woocommerce_page_wc-admin
```

It looks like this was added to identify screens for the Activity Panel, but it shouldn't be needed anymore.