### PR TITLE
Pagination: Fix page input bug.

### DIFF
--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -57,7 +57,7 @@ class Pagination extends Component {
 		const { onPageChange } = this.props;
 		const newPage = parseInt( event.target.value, 10 );
 
-		if ( isFinite( newPage ) ) {
+		if ( isFinite( newPage ) && this.pageCount && this.pageCount >= newPage ) {
 			onPageChange( newPage );
 		}
 	}

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -26,25 +26,12 @@ function keyListener( methodToCall, event ) {
 class Pagination extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = {
-			pageInputValue: props.page,
-		};
 
 		this.previousPage = this.previousPage.bind( this );
 		this.nextPage = this.nextPage.bind( this );
-		this.selectPage = this.selectPage.bind( this );
 		this.selectPageListener = keyListener.bind( this, 'selectPage' );
 		this.onPageValueChange = this.onPageValueChange.bind( this );
 		this.perPageChange = this.perPageChange.bind( this );
-	}
-
-	static getDerivedStateFromProps( props, state ) {
-		if ( props.page !== state.pageInputValue ) {
-			return {
-				pageInputValue: props.page,
-			};
-		}
-		return null;
 	}
 
 	previousPage( event ) {
@@ -65,15 +52,6 @@ class Pagination extends Component {
 		onPageChange( page + 1 );
 	}
 
-	selectPage( event ) {
-		event.stopPropagation();
-		const { onPageChange } = this.props;
-		if ( this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount ) {
-			return;
-		}
-		onPageChange( parseInt( this.state.pageInputValue ) );
-	}
-
 	perPageChange( perPage ) {
 		const { onPerPageChange, onPageChange, total, page } = this.props;
 		onPerPageChange( parseInt( perPage ) );
@@ -84,7 +62,8 @@ class Pagination extends Component {
 	}
 
 	onPageValueChange( event ) {
-		this.setState( { pageInputValue: event.target.value } );
+		const { onPageChange } = this.props;
+		onPageChange( parseInt( event.target.value ) );
 	}
 
 	renderPageArrows() {
@@ -134,7 +113,8 @@ class Pagination extends Component {
 	}
 
 	renderPagePicker() {
-		const isError = this.state.pageInputValue < 1 || this.state.pageInputValue > this.pageCount;
+		const { page } = this.props;
+		const isError = page < 1 || page > this.pageCount;
 		const inputClass = classNames( 'woocommerce-pagination__page-picker-input', {
 			'has-error': isError,
 		} );
@@ -151,8 +131,7 @@ class Pagination extends Component {
 						type="number"
 						onChange={ this.onPageValueChange }
 						onKeyDown={ this.selectPageListener }
-						onBlur={ this.selectPage }
-						value={ this.state.pageInputValue }
+						value={ page }
 						min={ 1 }
 						max={ this.pageCount }
 					/>

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -8,20 +8,12 @@ import { Component } from '@wordpress/element';
 import { IconButton, SelectControl } from '@wordpress/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { noop, uniqueId } from 'lodash';
+import { isFinite, noop, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-
-function keyListener( methodToCall, event ) {
-	switch ( event.key ) {
-		case 'Enter':
-			this[ methodToCall ]( event );
-			break;
-	}
-}
 
 class Pagination extends Component {
 	constructor( props ) {
@@ -29,9 +21,9 @@ class Pagination extends Component {
 
 		this.previousPage = this.previousPage.bind( this );
 		this.nextPage = this.nextPage.bind( this );
-		this.selectPageListener = keyListener.bind( this, 'selectPage' );
 		this.onPageValueChange = this.onPageValueChange.bind( this );
 		this.perPageChange = this.perPageChange.bind( this );
+		this.selectInputValue = this.selectInputValue.bind( this );
 	}
 
 	previousPage( event ) {
@@ -63,7 +55,15 @@ class Pagination extends Component {
 
 	onPageValueChange( event ) {
 		const { onPageChange } = this.props;
-		onPageChange( parseInt( event.target.value ) );
+		const newPage = parseInt( event.target.value, 10 );
+
+		if ( isFinite( newPage ) ) {
+			onPageChange( newPage );
+		}
+	}
+
+	selectInputValue( event ) {
+		event.target.select();
 	}
 
 	renderPageArrows() {
@@ -129,8 +129,8 @@ class Pagination extends Component {
 						className={ inputClass }
 						aria-invalid={ isError }
 						type="number"
+						onClick={ this.selectInputValue }
 						onChange={ this.onPageValueChange }
-						onKeyDown={ this.selectPageListener }
 						value={ page }
 						min={ 1 }
 						max={ this.pageCount }


### PR DESCRIPTION
While testing out #251 - I noticed that the page input field was not changing when I attempted to update the page manually. Using the arrows to toggle next/previous worked fine, but inputing a number or using the up/down arrows within the field did not update the page.

It seems there was a bit of a mish-mash of the page number being controlled from the parent component, and updated via `props.onPageChange`, and a value for page being tracked in component `state`. Since we want to persist report params in the URL, I opted to fix the bug here by moving all usage out of `state` and into using `props.onPageChange`.

__To Test__
- Open up `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
- Verify you can change pages by using the < > arrows, and the page number should update in the URL, the label next to the arrows, and the input field itself.
- Update the page number using the input field. Verify all is updated as expected.