### PR TITLE
SummaryNumber: Switch to dropdown display on small screens

### DIFF
--- a/client/components/calendar/index.js
+++ b/client/components/calendar/index.js
@@ -18,14 +18,11 @@ import 'react-dates/lib/css/_datepicker.css';
 /**
  * Internal dependencies
  */
-import { validateDateInputForRange } from 'lib/date';
 import DateInput from './input';
+import { isMobileViewport } from 'lib/ui';
 import phrases from './phrases';
+import { validateDateInputForRange } from 'lib/date';
 import './style.scss';
-
-// 782px is the width designated by Gutenberg's `</ Popover>` component.
-// * https://github.com/WordPress/gutenberg/blob/c8f8806d4465a83c1a0bc62d5c61377b56fa7214/components/popover/utils.js#L6
-const isMobileViewport = () => window.innerWidth < 782;
 
 class DateRange extends Component {
 	constructor( props ) {

--- a/client/components/summary/README.md
+++ b/client/components/summary/README.md
@@ -30,6 +30,7 @@ render: function() {
 * `value` (required): A string or number value to display - a string is allowed so we can accept currency formatting.
 * `href` (required): An internal link to the report focused on this number.
 * `delta`: A number to represent the percentage change since the last comparison period - positive numbers will show a green up arrow, negative numbers will show a red down arrow. If omitted, no change value will display.
+* `onToggle`: A function used to switch the given SummaryNumber to a button, and called on click.
 * `prevLabel`: A string description of the previous value's timeframe, ex "Previous Year:". Defaults to "Previous Period:".
 * `prevValue`: A string or number value to display - a string is allowed so we can accept currency formatting. If omitted, this section won't display.
 * `selected`: A boolean used to show a highlight style on this number. Defaults to false.

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -60,6 +60,7 @@ const SummaryList = ( { children, label } ) => {
 		<Dropdown
 			className="woocommerce-summary"
 			position="bottom"
+			headerTitle={ label }
 			expandOnMobile
 			renderToggle={ ( { onToggle } ) => cloneElement( selected, { onToggle } ) }
 			renderContent={ () => menu }

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -4,12 +4,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { NavigableMenu } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { isMobileViewport } from 'lib/ui';
 import './style.scss';
 
 const SummaryList = ( { children, label } ) => {
@@ -27,12 +29,21 @@ const SummaryList = ( { children, label } ) => {
 
 	const instanceId = uniqueId( 'woocommerce-summary-helptext-' );
 	return (
-		<nav aria-label={ label } aria-describedby={ instanceId }>
+		<NavigableMenu
+			aria-label={ label }
+			aria-describedby={ instanceId }
+			orientation={ isMobileViewport() ? 'vertical' : 'horizontal' }
+			stopNavigationEvents
+		>
 			<p id={ instanceId } className="screen-reader-text">
-				{ __( 'View the report for the selected data point.', 'wc-admin' ) }
+				{ __(
+					'List of data points available for filtering. Use arrow keys to cycle through ' +
+						'the list. Click a data point for a detailed report.',
+					'wc-admin'
+				) }
 			</p>
 			<ul className={ classes }>{ children }</ul>
-		</nav>
+		</NavigableMenu>
 	);
 };
 

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -12,18 +12,20 @@ import { uniqueId } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isMobileViewport } from 'lib/ui';
+import { isMobileViewport, isTabletViewport } from 'lib/ui';
 import './style.scss';
 
 const SummaryList = ( { children, label } ) => {
 	if ( ! label ) {
 		label = __( 'Performance Indicators', 'wc-admin' );
 	}
+	const isDropdownBreakpoint = isTabletViewport() || isMobileViewport();
+
 	// We default to "one" because we can't have empty children.
 	const itemCount = Children.count( children ) || 1;
 	const hasItemsClass = itemCount < 10 ? `has-${ itemCount }-items` : 'has-10-items';
 	const classes = classnames( 'woocommerce-summary', {
-		[ hasItemsClass ]: ! isMobileViewport(),
+		[ hasItemsClass ]: ! isDropdownBreakpoint,
 	} );
 
 	const instanceId = uniqueId( 'woocommerce-summary-helptext-' );
@@ -31,7 +33,7 @@ const SummaryList = ( { children, label } ) => {
 		<NavigableMenu
 			aria-label={ label }
 			aria-describedby={ instanceId }
-			orientation={ isMobileViewport() ? 'vertical' : 'horizontal' }
+			orientation={ isDropdownBreakpoint ? 'vertical' : 'horizontal' }
 			stopNavigationEvents
 		>
 			<p id={ instanceId } className="screen-reader-text">
@@ -46,7 +48,7 @@ const SummaryList = ( { children, label } ) => {
 	);
 
 	// On large screens, or if there are not multiple SummaryNumbers, we'll display the plain list.
-	if ( ! isMobileViewport() || itemCount < 2 ) {
+	if ( ! isDropdownBreakpoint || itemCount < 2 ) {
 		return menu;
 	}
 

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -3,9 +3,9 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
-import { IconButton } from '@wordpress/components';
 import { isUndefined } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -45,11 +45,16 @@ const SummaryNumber = ( {
 		screenReaderLabel = sprintf( __( 'No change from %s', 'wc-admin' ), prevLabel );
 	}
 
-	const Container = onToggle ? 'div' : Link;
-	const containerProps = { className: classes };
+	const Container = onToggle ? Button : Link;
+	const containerProps = {
+		className: classes,
+		'aria-current': selected ? 'page' : null,
+	};
 	if ( ! onToggle ) {
 		containerProps.href = href;
 		containerProps.role = 'menuitem';
+	} else {
+		containerProps.onClick = onToggle;
 	}
 
 	return (
@@ -79,12 +84,7 @@ const SummaryNumber = ( {
 				</span>
 
 				{ onToggle ? (
-					<IconButton
-						className="woocommerce-summary__toggle-button"
-						onClick={ onToggle }
-						icon={ <Gridicon icon="chevron-down" size={ 36 } /> }
-						label={ __( 'Open data point list', 'wc-admin' ) }
-					/>
+					<Gridicon className="woocommerce-summary__toggle" icon="chevron-down" size={ 36 } />
 				) : null }
 			</Container>
 		</li>

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -5,6 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
+import { IconButton } from '@wordpress/components';
 import { isUndefined } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -17,12 +18,16 @@ const SummaryNumber = ( {
 	delta,
 	href,
 	label,
+	onToggle,
 	prevLabel,
 	prevValue,
 	reverseTrend,
 	selected,
 	value,
 } ) => {
+	const liClasses = classnames( 'woocommerce-summary__item-container', {
+		'is-dropdown-button': onToggle,
+	} );
 	const classes = classnames( 'woocommerce-summary__item', {
 		'is-selected': selected,
 		'is-good-trend': reverseTrend ? delta < 0 : delta > 0,
@@ -40,9 +45,11 @@ const SummaryNumber = ( {
 		screenReaderLabel = sprintf( __( 'No change from %s', 'wc-admin' ), prevLabel );
 	}
 
+	const Container = onToggle ? 'div' : Link;
+
 	return (
-		<li className="woocommerce-summary__item-container">
-			<Link className={ classes } href={ href } role="menuitem">
+		<li className={ liClasses }>
+			<Container className={ classes } href={ href } role="menuitem">
 				<span className="woocommerce-summary__item-label">{ label }</span>
 
 				<span className="woocommerce-summary__item-data">
@@ -65,7 +72,16 @@ const SummaryNumber = ( {
 				<span className="woocommerce-summary__item-prev-value">
 					{ ! isUndefined( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
 				</span>
-			</Link>
+
+				{ onToggle ? (
+					<IconButton
+						className="woocommerce-summary__toggle-button"
+						onClick={ onToggle }
+						icon={ <Gridicon icon="chevron-down" size={ 36 } /> }
+						label={ __( 'Open data point list', 'wc-admin' ) }
+					/>
+				) : null }
+			</Container>
 		</li>
 	);
 };
@@ -74,6 +90,7 @@ SummaryNumber.propTypes = {
 	delta: PropTypes.number,
 	href: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
+	onToggle: PropTypes.func,
 	prevLabel: PropTypes.string,
 	prevValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 	reverseTrend: PropTypes.bool,

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -84,7 +84,7 @@ const SummaryNumber = ( {
 				</span>
 
 				{ onToggle ? (
-					<Gridicon className="woocommerce-summary__toggle" icon="chevron-down" size={ 36 } />
+					<Gridicon className="woocommerce-summary__toggle" icon="chevron-down" size={ 24 } />
 				) : null }
 			</Container>
 		</li>

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -46,10 +46,15 @@ const SummaryNumber = ( {
 	}
 
 	const Container = onToggle ? 'div' : Link;
+	const containerProps = { className: classes };
+	if ( ! onToggle ) {
+		containerProps.href = href;
+		containerProps.role = 'menuitem';
+	}
 
 	return (
 		<li className={ liClasses }>
-			<Container className={ classes } href={ href } role="menuitem">
+			<Container { ...containerProps }>
 				<span className="woocommerce-summary__item-label">{ label }</span>
 
 				<span className="woocommerce-summary__item-data">

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -42,7 +42,7 @@ const SummaryNumber = ( {
 
 	return (
 		<li className="woocommerce-summary__item-container">
-			<Link className={ classes } href={ href }>
+			<Link className={ classes } href={ href } role="menuitem">
 				<span className="woocommerce-summary__item-label">{ label }</span>
 
 				<span className="woocommerce-summary__item-data">

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -195,7 +195,10 @@ $inner-border: $core-grey-light-500;
 		position: relative;
 		width: 100%;
 		padding-right: 2 * $gap + 24px;
-		border-right: none;
+
+		@include breakpoint( '<782px' ) {
+			border-right: none;
+		}
 	}
 
 	.woocommerce-summary__item-label {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -143,12 +143,6 @@ $inner-border: $core-grey-light-500;
 		.components-button {
 			text-align: left;
 		}
-
-		.woocommerce-summary__item {
-			width: 100%;
-			position: relative;
-			@include wrap-contents;
-		}
 	}
 }
 
@@ -170,7 +164,8 @@ $inner-border: $core-grey-light-500;
 	}
 
 	&:focus {
-		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black;
+		// !important to override button styles
+		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black !important;
 	}
 
 	&.is-selected {
@@ -178,8 +173,15 @@ $inner-border: $core-grey-light-500;
 		height: calc(100% + 1px); // Hack to avoid double border
 
 		&:focus {
-			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce;
+			// !important to override button styles
+			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce !important;
 		}
+	}
+
+	.is-dropdown-button & {
+		width: 100%;
+		padding-right: 2 * $gap + 24px;
+		position: relative;
 	}
 
 	.woocommerce-summary__item-label {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -125,6 +125,19 @@ $inner-border: $core-grey-light-500;
 			}
 		}
 	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-summary__item-container:only-child {
+			margin-left: -16px;
+			margin-right: -16px;
+			width: auto;
+
+			& .woocommerce-summary__item {
+				// Remove the border when the button is edge-to-edge
+				border-right: none;
+			}
+		}
+	}
 }
 
 .woocommerce-summary__item-container {
@@ -179,9 +192,10 @@ $inner-border: $core-grey-light-500;
 	}
 
 	.is-dropdown-button & {
+		position: relative;
 		width: 100%;
 		padding-right: 2 * $gap + 24px;
-		position: relative;
+		border-right: none;
 	}
 
 	.woocommerce-summary__item-label {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -266,7 +266,7 @@ $inner-border: $core-grey-light-500;
 
 	.woocommerce-summary__toggle {
 		position: absolute;
-		top: 50px;
+		top: 44px;
 		right: $gap;
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -38,12 +38,21 @@ $inner-border: $core-grey-light-500;
 }
 
 .woocommerce-summary {
+	margin: $gap 0;
 	display: grid;
 	border-width: 1px 0 0 1px;
 	border-style: solid;
 	border-color: $outer-border;
 	background-color: $core-grey-light-300;
 	box-shadow: inset -1px -1px 0 $outer-border;
+
+	.components-popover__content & {
+		max-height: 100%;
+		margin-top: 0;
+		margin-bottom: 0;
+		overflow-y: scroll;
+		border: none;
+	}
 
 	.woocommerce-summary__item-data {
 		display: flex;
@@ -125,6 +134,18 @@ $inner-border: $core-grey-light-500;
 	&:last-of-type .woocommerce-summary__item {
 		// Make sure the last item always uses the outer-border color.
 		border-right-color: $outer-border !important;
+	}
+
+	&.is-dropdown-button {
+		padding: 0;
+		text-align: left;
+		list-style: none;
+
+		.woocommerce-summary__item {
+			width: 100%;
+			position: relative;
+			@include wrap-contents;
+		}
 	}
 }
 
@@ -219,6 +240,12 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-prev-value {
 		@include font-size( 13 );
 		color: $core-grey-dark-500;
+	}
+
+	.woocommerce-summary__toggle-button {
+		position: absolute;
+		top: 50px;
+		right: $gap;
 	}
 }
 

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -138,8 +138,11 @@ $inner-border: $core-grey-light-500;
 
 	&.is-dropdown-button {
 		padding: 0;
-		text-align: left;
 		list-style: none;
+
+		.components-button {
+			text-align: left;
+		}
 
 		.woocommerce-summary__item {
 			width: 100%;
@@ -242,7 +245,7 @@ $inner-border: $core-grey-light-500;
 		color: $core-grey-dark-500;
 	}
 
-	.woocommerce-summary__toggle-button {
+	.woocommerce-summary__toggle {
 		position: absolute;
 		top: 50px;
 		right: $gap;

--- a/client/lib/ui.js
+++ b/client/lib/ui.js
@@ -3,5 +3,10 @@
 // 782px is the width designated by Gutenberg's `</ Popover>` component.
 // * https://github.com/WordPress/gutenberg/blob/c8f8806d4465a83c1a0bc62d5c61377b56fa7214/components/popover/utils.js#L6
 export function isMobileViewport() {
-	return window.innerWidth < 782;
+	return window.innerWidth <= 782;
+}
+
+// Most screens at 1100px or lower are tablets
+export function isTabletViewport() {
+	return window.innerWidth > 782 && window.innerWidth <= 1100;
 }

--- a/client/lib/ui.js
+++ b/client/lib/ui.js
@@ -1,0 +1,7 @@
+/** @format */
+
+// 782px is the width designated by Gutenberg's `</ Popover>` component.
+// * https://github.com/WordPress/gutenberg/blob/c8f8806d4465a83c1a0bc62d5c61377b56fa7214/components/popover/utils.js#L6
+export function isMobileViewport() {
+	return window.innerWidth < 782;
+}


### PR DESCRIPTION
Fixes #131 – This PR adds logic to collapse 2 or more SummaryNumbers into a dropdown/popover on screens smaller than 782px wide.

<img width="484" alt="screen shot 2018-07-31 at 6 21 44 pm" src="https://user-images.githubusercontent.com/541093/43532329-cddc3116-957f-11e8-91a8-ed9a3ec8c25c.png">
<img width="512" alt="screen shot 2018-07-31 at 6 21 55 pm" src="https://user-images.githubusercontent.com/541093/43532330-cdfa16ea-957f-11e8-86a6-accc52f2d4a6.png">

This also updates the semantics of the SummaryList component to use a NavigableMenu, which lets the user move through the list with either arrow keys or tab. I also moved the `isMobileViewport` function into a new file, `lib/ui`. In the future we might want to rethink this so that we can re-render the screens automatically as the browser resizes.

To test

- Shrink your browser (or test on a phone)
- Go to `/wp-admin/admin.php?page=wc-admin#/analytics/test`
- Check that the SummaryNumbers display as expected
- Open a dropdown, it'll take over the screen 
- Click an item, it should take you to the parent analytics page