### PR TITLE
Datepicker: Validate and handle bad query parameters

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -8,24 +8,34 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import QueryBoundaryError from 'components/query-boundary-error';
 import ExampleReport from './example';
 import RevenueReport from './revenue';
 import ProductsReport from './products';
 import OrdersReport from './orders/';
 
 class Report extends Component {
-	render() {
-		const { params } = this.props;
-		switch ( params.report ) {
+	getReportType( report ) {
+		switch ( report ) {
 			case 'revenue':
-				return <RevenueReport { ...this.props } />;
+				return RevenueReport;
 			case 'products':
-				return <ProductsReport { ...this.props } />;
+				return ProductsReport;
 			case 'orders':
-				return <OrdersReport { ...this.props } />;
+				return OrdersReport;
 			default:
-				return <ExampleReport />;
+				return ExampleReport;
 		}
+	}
+
+	render() {
+		const { params, query, path } = this.props;
+		const ReportType = this.getReportType( params.report );
+		return (
+			<QueryBoundaryError query={ query } path={ path }>
+				<ReportType { ...this.props } />
+			</QueryBoundaryError>
+		);
 	}
 }
 

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -12,12 +12,13 @@ import Header from 'layout/header';
 import DatePicker from 'components/date-picker';
 import FilterPicker from 'components/filter-picker';
 import { filters, filterPaths } from './constants';
+import QueryBoundaryError from 'components/query-boundary-error';
 import './style.scss';
 
 export default class extends Component {
 	render() {
 		const { query, path } = this.props;
-
+		const queryKey = JSON.stringify( query );
 		return (
 			<Fragment>
 				<Header
@@ -26,15 +27,17 @@ export default class extends Component {
 						__( 'Products', 'wc-admin' ),
 					] }
 				/>
-				<div className="woocommerce-products__pickers">
-					<DatePicker query={ query } path={ path } key={ JSON.stringify( query ) } />
-					<FilterPicker
-						query={ query }
-						path={ path }
-						filters={ filters }
-						filterPaths={ filterPaths }
-					/>
-				</div>
+				<QueryBoundaryError query={ query } path={ path } key={ queryKey }>
+					<div className="woocommerce-products__pickers">
+						<DatePicker query={ query } path={ path } key={ queryKey } />
+						<FilterPicker
+							query={ query }
+							path={ path }
+							filters={ filters }
+							filterPaths={ filterPaths }
+						/>
+					</div>
+				</QueryBoundaryError>
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -12,7 +12,6 @@ import Header from 'layout/header';
 import DatePicker from 'components/date-picker';
 import FilterPicker from 'components/filter-picker';
 import { filters, filterPaths } from './constants';
-import QueryBoundaryError from 'components/query-boundary-error';
 import './style.scss';
 
 export default class extends Component {
@@ -27,17 +26,15 @@ export default class extends Component {
 						__( 'Products', 'wc-admin' ),
 					] }
 				/>
-				<QueryBoundaryError query={ query } path={ path } key={ queryKey }>
-					<div className="woocommerce-products__pickers">
-						<DatePicker query={ query } path={ path } key={ queryKey } />
-						<FilterPicker
-							query={ query }
-							path={ path }
-							filters={ filters }
-							filterPaths={ filterPaths }
-						/>
-					</div>
-				</QueryBoundaryError>
+				<div className="woocommerce-products__pickers">
+					<DatePicker query={ query } path={ path } key={ queryKey } />
+					<FilterPicker
+						query={ query }
+						path={ path }
+						filters={ filters }
+						filterPaths={ filterPaths }
+					/>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/components/query-boundary-error/README.md
+++ b/client/components/query-boundary-error/README.md
@@ -1,0 +1,36 @@
+QueryBoundaryError (In Progress)
+============
+
+This component is an [Error Boundary](https://reactjs.org/docs/error-boundaries.html) introduced in React 16 used to catch errors in query parameters that don't make sense and will likely break components downstream. By catching errors, we can choose what to render.
+
+## How to use:
+
+```jsx
+import QueryBoundaryError from 'components/query-boundary-error';
+import { QueryException } from 'components/query-boundary-error/exceptions';
+
+render: function() {
+  return (
+    <QueryBoundaryError key={ window.location.search }>
+      <div>
+      	{ throw new QueryException( { msg: 'Hello World', resetQuery: {}, params: [] } ) }
+      </div>
+    </QueryBoundaryError>
+  );
+}
+```
+
+## `QueryBoundaryError` Props
+
+Required props are marked with `*`.
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`query`* | `object` | none | The query string represented in object form
+`path`* | `string` | none | `path` parameter supplied by React-Router
+`key`| `*` | none |  Force a recalculation or reset of internal state when this key changes. Useful for a url change, for instance
+
+
+## `QueryException`
+
+A function used to describe error thrown and supply details on how to handle the error

--- a/client/components/query-boundary-error/exceptions.js
+++ b/client/components/query-boundary-error/exceptions.js
@@ -1,0 +1,7 @@
+/** @format */
+
+export function QueryException( obj ) {
+	this.msg = obj.msg;
+	this.resetQuery = obj.resetQuery;
+	this.params = obj.params;
+}

--- a/client/components/query-boundary-error/index.js
+++ b/client/components/query-boundary-error/index.js
@@ -2,20 +2,22 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import { Redirect } from 'react-router-dom';
+import { Component, Fragment } from '@wordpress/element';
 import { stringify as stringifyQueryObject } from 'qs';
+import { __ } from '@wordpress/i18n';
 import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { QueryException } from './exceptions';
+import Link from 'components/link';
 
 class QueryBoundaryError extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = { error: null };
+		this.onClick = this.onClick.bind( this );
 	}
 
 	componentDidCatch( error ) {
@@ -24,14 +26,32 @@ class QueryBoundaryError extends Component {
 		}
 	}
 
+	onClick() {
+		this.setState( { error: null } );
+	}
+
 	render() {
-		const { children, path, query } = this.props;
+		const { children, query, path } = this.props;
 		const { error } = this.state;
 		if ( error ) {
+			// @TODO: Move this logic to nav-utils
 			const otherQueries = omit( query, error.params );
 			const queryString = stringifyQueryObject( Object.assign( otherQueries, error.resetQuery ) );
-			const to = `${ path }${ queryString.length ? '?' : '' }${ queryString }`;
-			return <Redirect to={ to } />;
+			const href = `${ path }${ queryString.length ? '?' : '' }${ queryString }`;
+			return (
+				<Fragment>
+					<p>{ __( 'Oops, something went wrong!', 'wc-admin' ) }</p>
+					<p>{ error.msg }</p>
+					<Link
+						href={ href }
+						type="wc-admin"
+						onClick={ this.onClick }
+						className="components-button is-button is-primary"
+					>
+						{ __( 'Back to report', 'wc-admin' ) }
+					</Link>
+				</Fragment>
+			);
 		}
 		return children;
 	}

--- a/client/components/query-boundary-error/index.js
+++ b/client/components/query-boundary-error/index.js
@@ -1,0 +1,40 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Redirect } from 'react-router-dom';
+import { stringify as stringifyQueryObject } from 'qs';
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { QueryException } from './exceptions';
+
+class QueryBoundaryError extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { error: null };
+	}
+
+	componentDidCatch( error ) {
+		if ( error instanceof QueryException ) {
+			this.setState( { error } );
+		}
+	}
+
+	render() {
+		const { children, path, query } = this.props;
+		const { error } = this.state;
+		if ( error ) {
+			const otherQueries = omit( query, error.params );
+			const queryString = stringifyQueryObject( Object.assign( otherQueries, error.resetQuery ) );
+			const to = `${ path }${ queryString.length ? '?' : '' }${ queryString }`;
+			return <Redirect to={ to } />;
+		}
+		return children;
+	}
+}
+
+export default QueryBoundaryError;

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -227,16 +227,17 @@ export const isInvalidDateQuery = ( { period, compare, after, before } ) => {
 	const validCompare = find( compareValues, item => item.value === compare );
 	const resetQuery = {};
 	const params = [ 'period', 'compare', 'before', 'after' ];
+	const invalidParamMessage = __( 'Invalid query parameter', 'wc-admin' );
 
 	if ( period && ! validPeriod ) {
-		return { msg: 'invalid period parameter', resetQuery, params };
+		return { msg: invalidParamMessage, resetQuery, params };
 	}
 	if ( compare && ! validCompare ) {
-		return { msg: 'invalid compare parameter', resetQuery, params };
+		return { msg: invalidParamMessage, resetQuery, params };
 	}
 	if ( validPeriod && validPeriod.value === 'custom' ) {
 		if ( ! before || ! after ) {
-			return { msg: 'invalid date range for custom period', resetQuery, params };
+			return { msg: __( 'Invalid date range for custom period', 'wc-admin' ), resetQuery, params };
 		}
 		const validAfter = validateDateInputForRange( 'after', after, before, after, isoDateFormat );
 		const validBefore = validateDateInputForRange( 'before', before, before, after, isoDateFormat );

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -12,6 +12,7 @@ import { getSettings } from '@wordpress/date';
  */
 import { presetValues } from 'components/date-picker/preset-periods';
 import { compareValues } from 'components/date-picker/compare-periods';
+import { QueryException } from 'components/query-boundary-error/exceptions';
 
 /**
  * DateValue Object
@@ -217,6 +218,42 @@ function getDateValue( period, compare, after, before ) {
 	}
 }
 
+export const isInvalidDateQuery = ( { period, compare, after, before } ) => {
+	if ( ! period && ! compare && ! after && ! before ) {
+		return false;
+	}
+
+	const validPeriod = find( presetValues, item => item.value === period );
+	const validCompare = find( compareValues, item => item.value === compare );
+	const resetQuery = {};
+	const params = [ 'period', 'compare', 'before', 'after' ];
+
+	if ( period && ! validPeriod ) {
+		return { msg: 'invalid period parameter', resetQuery, params };
+	}
+	if ( compare && ! validCompare ) {
+		return { msg: 'invalid compare parameter', resetQuery, params };
+	}
+	if ( validPeriod && validPeriod.value === 'custom' ) {
+		if ( ! before || ! after ) {
+			return { msg: 'invalid date range for custom period', resetQuery, params };
+		}
+		const validAfter = validateDateInputForRange( 'after', after, before, after, isoDateFormat );
+		const validBefore = validateDateInputForRange( 'before', before, before, after, isoDateFormat );
+		if ( validAfter.error ) {
+			return { msg: validAfter.error, resetQuery, params };
+		}
+		if ( validBefore.error ) {
+			return { msg: validBefore.error, resetQuery, params };
+		}
+		return false;
+	}
+	if ( before || after ) {
+		return { msg: null, resetQuery: { period, compare }, params };
+	}
+	return false;
+};
+
 /**
  * Add default date-related parameters to a query object
  *
@@ -227,6 +264,10 @@ function getDateValue( period, compare, after, before ) {
  * @return {DateParams} - date parameters derived from query parameters with added defaults
  */
 export const getDateParamsFromQuery = ( { period, compare, after, before } ) => {
+	const invalidQuery = isInvalidDateQuery( { period, compare, after, before } );
+	if ( invalidQuery ) {
+		throw new QueryException( invalidQuery );
+	}
 	return {
 		period: period || 'today',
 		compare: compare || 'previous_period',


### PR DESCRIPTION
Validate date related query paramters and throw an exception to be handled by a [React Error Boundary](https://reactjs.org/docs/error-boundaries.html) upstream.

For example, an invalid `period` parameter, `?period=not_valid`, will cause an exception to be thrown:

![screen shot 2018-08-02 at 2 48 51 pm](https://user-images.githubusercontent.com/1922453/43559722-4818b7b8-9663-11e8-87c3-acaf48208545.png)

The `QueryBoundaryError` will catch the error and redirect to a working URL.

## In Progress, but input desired
Before I continue, I'd love some input on the following:

1. This code silently redirects to a desirable set of query parameters, which can be fully controlled depending on the type of error. Is this how we'd like to handle this sort of problem? 

2. I'm only catching url query related errors in a specific location, around the date/filter pickers. We could have an all encompassing Error Boundary and use it to redirect or simple print an "Oops, something went wrong" page. Would this make sense for us?

### Test
1. `http://localhost/wp-admin/admin.php?page=wc-admin#/analytics/products`
2. Use the filters (date and to add query parameters
3. Change a date-related parameter to one that doesn't make sense
4. See the error in the console
5. See the page redirect
6. See any unrelated queries remain unchanged