### PR TITLE
Table: Add "required"/"sortable" meta to headers/columns

### DIFF
--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -63,15 +63,55 @@ class RevenueReport extends Component {
 
 	getHeadersContent() {
 		return [
-			__( 'Select', 'wc-admin' ),
-			__( 'Date', 'wc-admin' ),
-			__( 'Orders', 'wc-admin' ),
-			__( 'Gross Revenue', 'wc-admin' ),
-			__( 'Refunds', 'wc-admin' ),
-			__( 'Coupons', 'wc-admin' ),
-			__( 'Taxes', 'wc-admin' ),
-			__( 'Shipping', 'wc-admin' ),
-			__( 'Net Revenue', 'wc-admin' ),
+			{
+				label: __( 'Date', 'wc-admin' ),
+				key: 'date_start',
+				required: true,
+				defaultSort: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Gross Revenue', 'wc-admin' ),
+				key: 'gross_revenue',
+				required: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Refunds', 'wc-admin' ),
+				key: 'refunds',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Coupons', 'wc-admin' ),
+				key: 'coupons',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Taxes', 'wc-admin' ),
+				key: 'taxes',
+				required: false,
+				isSortable: false, // For example
+			},
+			{
+				label: __( 'Shipping', 'wc-admin' ),
+				key: 'shipping',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Net Revenue', 'wc-admin' ),
+				key: 'net_revenue',
+				required: false,
+				isSortable: true,
+			},
 		];
 	}
 
@@ -95,10 +135,6 @@ class RevenueReport extends Component {
 				</a>
 			);
 			return [
-				{
-					display: <input type="checkbox" />,
-					value: false,
-				},
 				{
 					display: formatDate( 'm/d/Y', row.date_start ),
 					value: row.date_start,
@@ -207,7 +243,6 @@ class RevenueReport extends Component {
 				<TableCard
 					title={ __( 'Revenue Last Week', 'wc-admin' ) }
 					rows={ rows }
-					rowHeader={ 1 }
 					headers={ headers }
 					onClickDownload={ noop }
 					onQueryChange={ this.onQueryChange }

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -54,11 +54,17 @@ class RevenueReport extends Component {
 
 	/**
 	 * This function returns an event handler for the given `param`
+	 * @todo Move handling of this to a library?
 	 * @param {string} param The parameter in the querystring which should be updated (ex `page`, `per_page`)
 	 * @return {function} A callback which will update `param` to the passed value when called.
 	 */
 	onQueryChange( param ) {
-		return value => updateQueryString( { [ param ]: value } );
+		switch ( param ) {
+			case 'sort':
+				return ( key, dir ) => updateQueryString( { order_by: key, order: dir } );
+			default:
+				return value => updateQueryString( { [ param ]: value } );
+		}
 	}
 
 	getHeadersContent() {

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -61,7 +61,7 @@ class RevenueReport extends Component {
 	onQueryChange( param ) {
 		switch ( param ) {
 			case 'sort':
-				return ( key, dir ) => updateQueryString( { order_by: key, order: dir } );
+				return ( key, dir ) => updateQueryString( { orderby: key, order: dir } );
 			default:
 				return value => updateQueryString( { [ param ]: value } );
 		}

--- a/client/components/table/README.md
+++ b/client/components/table/README.md
@@ -51,7 +51,7 @@ render: function() {
 * `headers`: An array of column headers, as objects with the following properties:
   * `headers[].defaultSort`: Boolean, true if this column is the default for sorting. Only one column should have this set.
   * `headers[].isSortable`: Boolean, true if this column is sortable.
-  * `headers[].key`: The API parameter name for this column, passed to `order_by` when sorting via API.
+  * `headers[].key`: The API parameter name for this column, passed to `orderby` when sorting via API.
   * `headers[].label`: The display label for this column.
   * `headers[].required`: Boolean, true if this column should always display in the table (not shown in toggle-able list).
 * `onSort`: A function called when sortable table headers are clicked, gets the `header.key` as argument.

--- a/client/components/table/README.md
+++ b/client/components/table/README.md
@@ -32,12 +32,12 @@ render: function() {
 
 ### `TableCard` props
 
-* `headers`: An array of column headers
+* `headers`: An array of column headers (see `Table` props).
 * `onQueryChange`: A function which returns a callback function to update the query string for a given `param`.
 * `onClickDownload`: A callback function which handles then "download" button press. Optional, if not used, the button won't appear.
 * `query`: An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
-* `rows` (required): An array of arrays of display/value object pairs. `display` is used for rendering, strings or elements are best here. `value` is used for sorting, and should be a string or number. A column with `false` value will not be sortable.
-* `rowHeader`: Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col is checkboxes, for example). Set to false to disable row headers.
+* `rows` (required): An array of arrays of display/value object pairs (see `Table` props).
+* `rowHeader`: Which column should be the row header, defaults to the first item (`0`) (see `Table` props).
 * `summary`: An array of objects with `label` & `value` properties, which display in a line under the table. Optional, can be left off to show no summary.
 * `title` (required): The title used in the card header, also used as the caption for the content in this table
 
@@ -48,8 +48,14 @@ render: function() {
 
 * `caption` (required): A label for the content in this table
 * `className`: Optional additional classes
-* `headers`: An array of column headers
-* `rows` (required): An array of arrays of renderable elements, strings or numbers are best for sorting
+* `headers`: An array of column headers, as objects with the following properties:
+  * `headers[].defaultSort`: Boolean, true if this column is the default for sorting. Only one column should have this set.
+  * `headers[].isSortable`: Boolean, true if this column is sortable.
+  * `headers[].key`: The API parameter name for this column, passed to `order_by` when sorting via API.
+  * `headers[].label`: The display label for this column.
+  * `headers[].required`: Boolean, true if this column should always display in the table (not shown in toggle-able list).
+* `onSort`: A function called when sortable table headers are clicked, gets the `header.key` as argument.
+* `rows` (required): An array of arrays of display/value object pairs. `display` is used for rendering, strings or elements are best here. `value` is used for sorting, and should be a string or number. A column with `false` value will not be sortable.
 * `rowHeader`: Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col is checkboxes, for example). Set to false to disable row headers.
 
 ### `TableSummary` props

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -84,7 +84,7 @@ class TableCard extends Component {
 					headers={ headers }
 					rowHeader={ rowHeader }
 					caption={ title }
-					sort={ query.order_by }
+					query={ query }
 					onSort={ onQueryChange( 'order_by' ) }
 				/>
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton, ToggleControl } from '@wordpress/components';
-import { fill, isArray, first, noop } from 'lodash';
+import { fill, find, findIndex, first, isArray, noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -27,10 +27,22 @@ class TableCard extends Component {
 		this.toggleCols = this.toggleCols.bind( this );
 	}
 
-	toggleCols( col ) {
+	toggleCols( selected ) {
+		const { headers, query, onQueryChange } = this.props;
 		return () => {
+			// Handle hiding a sorted column
+			if ( query.order_by ) {
+				const sortBy = findIndex( headers, { key: query.order_by } );
+				if ( sortBy === selected ) {
+					const defaultSort = find( headers, { defaultSort: true } );
+					onQueryChange( 'sort' )( defaultSort.key, 'desc' );
+				}
+			}
+
 			this.setState( prevState => ( {
-				showCols: prevState.showCols.map( ( toggled, i ) => ( col === i ? ! toggled : toggled ) ),
+				showCols: prevState.showCols.map(
+					( toggled, i ) => ( selected === i ? ! toggled : toggled )
+				),
 			} ) );
 		};
 	}

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -31,8 +31,8 @@ class TableCard extends Component {
 		const { headers, query, onQueryChange } = this.props;
 		return () => {
 			// Handle hiding a sorted column
-			if ( query.order_by ) {
-				const sortBy = findIndex( headers, { key: query.order_by } );
+			if ( query.orderby ) {
+				const sortBy = findIndex( headers, { key: query.orderby } );
 				if ( sortBy === selected ) {
 					const defaultSort = find( headers, { defaultSort: true } ) || first( headers ) || {};
 					onQueryChange( 'sort' )( defaultSort.key, 'desc' );

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -66,15 +66,20 @@ class TableCard extends Component {
 				menu={
 					<EllipsisMenu label={ __( 'Choose which values to display', 'wc-admin' ) }>
 						<MenuTitle>{ __( 'Columns:', 'wc-admin' ) }</MenuTitle>
-						{ allHeaders.map( ( label, i ) => (
-							<MenuItem key={ i } onInvoke={ this.toggleCols( i ) }>
-								<ToggleControl
-									label={ label }
-									checked={ !! showCols[ i ] }
-									onChange={ this.toggleCols( i ) }
-								/>
-							</MenuItem>
-						) ) }
+						{ allHeaders.map( ( { label, required }, i ) => {
+							if ( required ) {
+								return null;
+							}
+							return (
+								<MenuItem key={ i } onInvoke={ this.toggleCols( i ) }>
+									<ToggleControl
+										label={ label }
+										checked={ !! showCols[ i ] }
+										onChange={ this.toggleCols( i ) }
+									/>
+								</MenuItem>
+							);
+						} ) }
 					</EllipsisMenu>
 				}
 			>

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -90,7 +90,7 @@ class TableCard extends Component {
 					rowHeader={ rowHeader }
 					caption={ title }
 					query={ query }
-					onSort={ onQueryChange( 'order_by' ) }
+					onSort={ onQueryChange( 'sort' ) }
 				/>
 
 				{ summary && <TableSummary data={ summary } /> }

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -103,7 +103,15 @@ class TableCard extends Component {
 }
 
 TableCard.propTypes = {
-	headers: PropTypes.arrayOf( PropTypes.node ),
+	headers: PropTypes.arrayOf(
+		PropTypes.shape( {
+			defaultSort: PropTypes.bool,
+			isSortable: PropTypes.bool,
+			key: PropTypes.string,
+			label: PropTypes.string,
+			required: PropTypes.bool,
+		} )
+	),
 	onQueryChange: PropTypes.func,
 	onClickDownload: PropTypes.func,
 	query: PropTypes.object,

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -34,7 +34,7 @@ class TableCard extends Component {
 			if ( query.order_by ) {
 				const sortBy = findIndex( headers, { key: query.order_by } );
 				if ( sortBy === selected ) {
-					const defaultSort = find( headers, { defaultSort: true } );
+					const defaultSort = find( headers, { defaultSort: true } ) || first( headers ) || {};
 					onQueryChange( 'sort' )( defaultSort.key, 'desc' );
 				}
 			}

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -110,7 +110,7 @@ class Table extends Component {
 											<Fragment>
 												<IconButton
 													icon={
-														sortedBy === key && sortDir !== ASC ? (
+														sortedBy === key && sortDir === ASC ? (
 															<Gridicon size={ 18 } icon="chevron-up" />
 														) : (
 															<Gridicon size={ 18 } icon="chevron-down" />

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -100,6 +100,7 @@ class Table extends Component {
 						<tr>
 							{ headers.map( ( header, i ) => {
 								const isSortable = this.isColSortable( i );
+								const { label } = header;
 								return (
 									<th
 										role="columnheader"
@@ -122,16 +123,16 @@ class Table extends Component {
 												}
 												label={
 													sortDir !== ASC
-														? sprintf( __( 'Sort by %s in ascending order', 'wc-admin' ), header )
-														: sprintf( __( 'Sort by %s in descending order', 'wc-admin' ), header )
+														? sprintf( __( 'Sort by %s in ascending order', 'wc-admin' ), label )
+														: sprintf( __( 'Sort by %s in descending order', 'wc-admin' ), label )
 												}
 												onClick={ () => this.sortBy( i ) }
 												isDefault
 											>
-												{ header }
+												{ label }
 											</IconButton>
 										) : (
-											header
+											label
 										) }
 									</th>
 								);
@@ -163,7 +164,15 @@ class Table extends Component {
 Table.propTypes = {
 	caption: PropTypes.string.isRequired,
 	className: PropTypes.string,
-	headers: PropTypes.arrayOf( PropTypes.node ),
+	headers: PropTypes.arrayOf(
+		PropTypes.shape( {
+			defaultSort: PropTypes.bool,
+			isSortable: PropTypes.bool,
+			key: PropTypes.string,
+			label: PropTypes.string,
+			required: PropTypes.bool,
+		} )
+	),
 	rows: PropTypes.arrayOf(
 		PropTypes.arrayOf(
 			PropTypes.shape( {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -110,7 +110,7 @@ class Table extends Component {
 											<Fragment>
 												<IconButton
 													icon={
-														sortDir === ASC ? (
+														sortedBy === key && sortDir !== ASC ? (
 															<Gridicon size={ 18 } icon="chevron-up" />
 														) : (
 															<Gridicon size={ 18 } icon="chevron-down" />

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -52,7 +52,7 @@ class Table extends Component {
 		const { headers, query } = this.props;
 		return () => {
 			const currentKey =
-				query.order_by || get( find( headers, { defaultSort: true } ), 'key', false );
+				query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
 			const currentDir = query.order || DESC;
 			let dir = DESC;
 			if ( key === currentKey ) {
@@ -66,7 +66,7 @@ class Table extends Component {
 		const { caption, classNames, headers, query, rowHeader } = this.props;
 		const { rows, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames );
-		const sortedBy = query.order_by || get( find( headers, { defaultSort: true } ), 'key', false );
+		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
 		const sortDir = query.order || DESC;
 
 		return (

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import { Component, createRef, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import { IconButton } from '@wordpress/components';
 import { find, get, isEqual, noop, uniqueId } from 'lodash';
@@ -24,6 +24,7 @@ class Table extends Component {
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
+		this.headersID = uniqueId( 'header-' );
 		this.captionID = uniqueId( 'caption-' );
 	}
 
@@ -106,20 +107,25 @@ class Table extends Component {
 								return (
 									<th role="columnheader" scope="col" key={ i } { ...thProps }>
 										{ isSortable ? (
-											<IconButton
-												icon={
-													sortDir === ASC ? (
-														<Gridicon size={ 18 } icon="chevron-up" />
-													) : (
-														<Gridicon size={ 18 } icon="chevron-down" />
-													)
-												}
-												label={ iconLabel }
-												onClick={ this.sortBy( key ) }
-												isDefault
-											>
-												{ label }
-											</IconButton>
+											<Fragment>
+												<IconButton
+													icon={
+														sortDir === ASC ? (
+															<Gridicon size={ 18 } icon="chevron-up" />
+														) : (
+															<Gridicon size={ 18 } icon="chevron-down" />
+														)
+													}
+													aria-describedby={ `${ this.headersID }-${ i }` }
+													onClick={ this.sortBy( key ) }
+													isDefault
+												>
+													{ label }
+												</IconButton>
+												<span className="screen-reader-text" id={ `${ this.headersID }-${ i }` }>
+													{ iconLabel }
+												</span>
+											</Fragment>
 										) : (
 											label
 										) }

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -6,11 +6,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { IconButton } from '@wordpress/components';
+import { find, get, isEqual, noop, uniqueId } from 'lodash';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
-import { isEqual, uniqueId, noop } from 'lodash';
 
-const ASC = 'ascending';
+const ASC = 'asc';
+// const DESC = 'desc';
 
 const getDisplay = cell => cell.display || null;
 
@@ -51,9 +52,11 @@ class Table extends Component {
 	}
 
 	render() {
-		const { caption, classNames, headers, rowHeader } = this.props;
-		const { rows, sortedBy, sortDir, tabIndex } = this.state;
+		const { caption, classNames, headers, query, rowHeader } = this.props;
+		const { rows, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames );
+		const sortedBy = query.order_by || get( find( headers, { defaultSort: true } ), 'key', false );
+		const sortDir = ASC; // @todo bring back asc/desc
 
 		return (
 			<div
@@ -75,7 +78,7 @@ class Table extends Component {
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
 										'is-sortable': isSortable,
-										'is-sorted': sortedBy === i,
+										'is-sorted': sortedBy === key,
 									} ),
 								};
 								if ( isSortable ) {
@@ -145,6 +148,7 @@ Table.propTypes = {
 		} )
 	),
 	onSort: PropTypes.func,
+	query: PropTypes.object,
 	rows: PropTypes.arrayOf(
 		PropTypes.arrayOf(
 			PropTypes.shape( {
@@ -159,6 +163,7 @@ Table.propTypes = {
 Table.defaultProps = {
 	headers: [],
 	onSort: noop,
+	query: {},
 	rowHeader: 0,
 };
 


### PR DESCRIPTION
This PR fixes #271, and sets up the framework for #266. We switch to a new `headers` format, now an array of objects, with these properties:

* `defaultSort`: Boolean, true if this column is the default for sorting. Only one column should have this set.
* `isSortable`: Boolean, true if this column is sortable.
* `key`: The API parameter name for this column, passed to `order_by` when sorting via API.
* `label`: The display label for this column.
* `required`: Boolean, true if this column should always display in the table (not shown in toggle-able list).

This also changes the sorting behavior to update a query param, since we'll want to fetch the sorted list from the server (previously we only sorted the current page of results). Due to the way the current demo data is fetched, sorting this makes no change to the table rows - you'll want to watch the query string.

Columns marked `required` are excluded from the toggle, and if a column that is currently being used to sort the table is hidden, we re-sort the table by the given `defaultSort` item (or the first col, if no default is used).

There should be no visual changes.

**To test**

- View the demo: `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
- Column headers should appear as expected
- Try clicking a col header to sort
- Check that it updates the query string
- Check that the arrows correctly reflect the right state
  - When sorting by a column, the arrow should always appear and should point down if `order=desc`, and up if `order=asc`.
  - All other sortable columns should have arrows on hover, and they will always point down (the default when switching to a new col is to sort descending)
  - Unsortable cols will not have hover states (Taxes, in the demo)
- Reload the page with a query string, ex `/analytics/revenue?order=desc&order_by=refunds`
- Check that Refunds is styled as the "sorted" column
- Try toggling columns by opening the ellipsis menu
- Date and Gross Revenue should not appear in the menu
- Toggle all available columns off
- Date and Gross Revenue should remain
- Turn columns back on, and sort by any other columns, ex Refunds
- Turn off Refunds column, sorting should switch to the Date column