### PR TITLE
Fix warning: update compose import

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment, compose } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import moment from 'moment';


### PR DESCRIPTION
As of Gutenberg 3.3, `compose` is in its own package, and element.compose is deprecated. This is causing a warning on dev sites:

```
wp.element.compose is deprecated and will be removed in 3.5. Please use wp.compose.compose instead.`
```

This PR updates the orders report to use the right `compose`.