### PR TITLE
Overview: Add Columns

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 import Header from 'layout/header';
 import StorePerformance from './store-performance';
 import Chart from 'components/chart';
-import Card from '../components/card';
+import Card from 'components/card';
 
 export default class Dashboard extends Component {
 	render() {
@@ -22,10 +22,10 @@ export default class Dashboard extends Component {
 				<StorePerformance />
 				<Chart />
 				<div className="woocommerce-dashboard__columns">
-					<div className="woocommerce-dashboard__column">
+					<div>
 						<Card title={ __( 'Top Selling Products', 'wc-admin' ) } />
 					</div>
-					<div className="woocommerce-dashboard__column">
+					<div>
 						<Card title={ __( 'Orders', 'wc-admin' ) } />
 					</div>
 				</div>

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -8,9 +8,11 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import Header from 'layout/header';
 import StorePerformance from './store-performance';
 import Chart from 'components/chart';
+import Card from '../components/card';
 
 export default class Dashboard extends Component {
 	render() {
@@ -19,6 +21,14 @@ export default class Dashboard extends Component {
 				<Header sections={ [ __( 'Dashboard', 'wc-admin' ) ] } />
 				<StorePerformance />
 				<Chart />
+				<div className="woocommerce-dashboard__columns">
+					<div className="woocommerce-dashboard__column">
+						<Card title={ __( 'Top Selling Products', 'wc-admin' ) } />
+					</div>
+					<div className="woocommerce-dashboard__column">
+						<Card title={ __( 'Orders', 'wc-admin' ) } />
+					</div>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -23,10 +23,12 @@ export default class Dashboard extends Component {
 				<Chart />
 				<div className="woocommerce-dashboard__columns">
 					<div>
-						<Card title={ __( 'Top Selling Products', 'wc-admin' ) } />
+						<Card title={ __( 'Column 1/1', 'wc-admin' ) } />
+						<Card title={ __( '1/2 Top Selling Products', 'wc-admin' ) } />
 					</div>
 					<div>
-						<Card title={ __( 'Orders', 'wc-admin' ) } />
+						<Card title={ __( 'Column 2/1 Orders', 'wc-admin' ) } />
+						<Card title={ __( 'Column 2/2', 'wc-admin' ) } />
 					</div>
 				</div>
 			</Fragment>

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -1,22 +1,11 @@
 /** @format */
 
 .woocommerce-dashboard__columns {
-	display: flex;
-	flex-direction: row;
-	margin-left: -20px;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-column-gap: $gutter;
 
 	@include breakpoint( '<782px' ) {
-		flex-direction: column;
-	}
-}
-
-.woocommerce-dashboard__column {
-	flex: 1 0 50%;
-	margin-left: 20px;
-	max-width: calc(50% - 20px);
-
-	@include breakpoint( '<782px' ) {
-		flex: 1 0 100%;
-		max-width: calc(100% - 20px);
+		grid-template-columns: 1fr;
 	}
 }

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -5,9 +5,18 @@
 	flex-direction: row;
 	margin-left: -20px;
 
-	.woocommerce-dashboard__column {
-		flex: 1 0 50%;
-		margin-left: 20px;
-		max-width: calc(50% - 20px);
+	@include breakpoint( '<782px' ) {
+		flex-direction: column;
+	}
+}
+
+.woocommerce-dashboard__column {
+	flex: 1 0 50%;
+	margin-left: 20px;
+	max-width: calc(50% - 20px);
+
+	@include breakpoint( '<782px' ) {
+		flex: 1 0 100%;
+		max-width: calc(100% - 20px);
 	}
 }

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -5,7 +5,7 @@
 	grid-template-columns: 1fr 1fr;
 	grid-column-gap: $gutter;
 
-	@include breakpoint( '<782px' ) {
+	@include breakpoint( '<1100px' ) {
 		grid-template-columns: 1fr;
 	}
 }

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -1,0 +1,13 @@
+/** @format */
+
+.woocommerce-dashboard__columns {
+	display: flex;
+	flex-direction: row;
+	margin-left: -20px;
+
+	.woocommerce-dashboard__column {
+		flex: 1 0 50%;
+		margin-left: 20px;
+		max-width: calc(50% - 20px);
+	}
+}


### PR DESCRIPTION
A small PR to get the stage set for #108 - and adding in more blocks to the overview page. For now I have just added two empty cards to show the design working.

![image](https://user-images.githubusercontent.com/22080/43741506-819dded2-9983-11e8-9134-a24ac0116b0f.png)

__To Test__
- Load up the dashboard page and verify the placeholder block/cards look good
- Resize the window and note they collapse to a column at smaller viewports

__Design Questions__
I couldn't find a design with details around when the breakpoint from two columns to a single column should happen, so I went with the 782 breakpoint used elsewhere. Also guessing 20px is the correct padding to have between these columns?