### PR TITLE
Header: Set z-index greater than popover

### DIFF
--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -13,7 +13,7 @@
 	position: fixed;
 	width: 100%;
 	top: 32px;
-	z-index: 1000;
+	z-index: 99999; /* component-popover is 99990 */
 
 	&.is-scrolled {
 		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);


### PR DESCRIPTION
Fixes #252 

I was unable to reproduce the other issue summarized in 252, so this fix is soley for the z-index problem of the popover and navigation header.

__To Test__
- Open up the revenue report
- Expand the date picker
- Scroll down and verify the picker popover is shown _behind_ the navigation header