### PR TITLE
Orders Panel: Add default prop object.

### DIFF
--- a/client/layout/activity-panel/panels/orders.js
+++ b/client/layout/activity-panel/panels/orders.js
@@ -111,4 +111,11 @@ OrdersPanel.propTypes = {
 	orders: PropTypes.object.isRequired,
 };
 
+OrdersPanel.defaultProps = {
+	orders: {
+		data: [],
+		isLoading: false,
+	},
+};
+
 export default OrdersPanel;


### PR DESCRIPTION
I believe I may have introduced this regression when I removed the usage of `withAPIData` last week in #267 - but currently when you attempt to open the Orders Activity Panel on `master` there is an exception.

The fix here was to add a default prop object to prevent the error from happening, but this can, and likely will be refactored as we hook up the data layer to this component.

__To Test__
- Open up wc-admin
- Expand the orders panel and verify no exceptions occur in the console