### PR TITLE
Layout: Add the 40px side gutters on 1100px+ screens

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -3,9 +3,19 @@
 .woocommerce-dashboard__columns {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
-	grid-column-gap: $gutter;
+	grid-column-gap: $gap-large;
 
 	@include breakpoint( '<1100px' ) {
 		grid-template-columns: 1fr;
 	}
+}
+
+.woocommerce-dashboard__widget {
+	display: flex;
+	align-items: center;
+	text-align: center;
+}
+
+.woocommerce-dashboard__widget-item {
+	flex: 1;
 }

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -6,7 +6,6 @@
 	justify-content: space-between;
 	flex-direction: row;
 	box-sizing: border-box;
-	background: $white;
 	border-bottom: 1px solid $white;
 	padding: 0px;
 	height: 80px;
@@ -32,7 +31,7 @@
 	.woocommerce-layout__header-breadcrumbs {
 		font-size: 13px;
 		font-weight: normal;
-		padding: 0px;
+		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
 		height: 50px;
 		line-height: 50px;
@@ -46,10 +45,6 @@
 		@include breakpoint( '>1100px' ) {
 			height: 80px;
 			line-height: 80px;
-		}
-
-		span:first-child {
-			padding-left: $spacing;
 		}
 
 		span + span::before {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -5,7 +5,7 @@
 }
 
 .woocommerce-layout__primary {
-	margin: 80px 0 0 $gutter;
+	margin: 80px 0 0 $gutter-large;
 
 	@include breakpoint( '>1100px' ) {
 		margin-top: 100px;
@@ -13,17 +13,6 @@
 }
 
 .woocommerce-layout .woocommerce-layout__main {
-	padding-right: $gutter;
+	padding-right: $gutter-large;
 	max-width: 100%;
-}
-
-// @TODO remove this?
-.woocommerce-dashboard__widget {
-	display: flex;
-	align-items: center;
-	text-align: center;
-}
-
-.woocommerce-dashboard__widget-item {
-	flex: 1;
 }

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -1,7 +1,9 @@
 /** @format */
 
 $gutter: var(--main-gap);
+$gutter-large: var(--large-gap);
 
+$gap-largest: 40px;
 $gap-large: 24px;
 $gap: 16px;
 $gap-small: 12px;

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -2,10 +2,17 @@
 
 // By using CSS variables, we can switch the spacing rhythm using a single media query.
 :root {
+	--large-gap: 40px;
 	--main-gap: 24px;
+}
+@media (max-width: 1100px) {
+	:root {
+		--large-gap: 24px;
+	}
 }
 @media (max-width: 782px) {
 	:root {
+		--large-gap: 16px;
 		--main-gap: 16px;
 	}
 }


### PR DESCRIPTION
I noticed in the mockup for #279 that the side gutters should actually be 40px on screens wider than 1100px:

![screen shot 2018-08-08 at 3 35 08 pm](https://user-images.githubusercontent.com/541093/43860099-ad6f383c-9b20-11e8-85a1-07d777d76db5.png)

I've added a new `$gutter-large` variable, which is also responsive, so we can use this for the side gutters. `$gutter` can still be used for responsive padding inside cards (the `ActivityCard` does this). The new variable updates to 40px at 1100px, so the two compare like this:

| Screen | `$gutter` | `$gutter-large` |
| ------ | --------- | --------------- |
| &lt; 783 | 16px | 16px |
| 783-1100 | 24px | 24px |
| 1101-1365 | 24px | 40px |
| &gt; 1365 | 24px | 40px |

I also moved some dashboard-specific styles into the new dashboard scss file, and moved the header padding on to the container, rather than the `first-child` selector.

To test:

- Check that the space around the main content is 40px at 1100+ & drops to 24px at <1100.
- Check that this didn't affect spacing in any other places