### PR TITLE
Layout: Fix spacing on Card component

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -1,13 +1,13 @@
 /** @format */
 
 .woocommerce-card {
-	margin-bottom: 20px;
+	margin-bottom: $gap-large;
 	background: white;
 	border: 1px solid $core-grey-light-700;
 }
 
 .woocommerce-card__header {
-	padding: 16px;
+	padding: ($gap - 3) $gap;
 	border-bottom: 1px solid $core-grey-light-700;
 	display: grid;
 	align-items: center;
@@ -23,11 +23,6 @@
 	.has-menu.has-action & {
 		grid-template-columns: 1fr 1fr 48px;
 	}
-
-	h2 {
-		margin: 0;
-		padding: 1px 0;
-	}
 }
 
 .woocommerce-card__action,
@@ -36,7 +31,7 @@
 }
 
 .woocommerce-card__body {
-	padding: 20px;
+	padding: $gap;
 }
 
 .woocommerce-ellipsis-menu__toggle {
@@ -44,6 +39,11 @@
 }
 
 .woocommerce-card__title {
-	font-size: 16px;
+	margin: 0;
+	// EllipsisMenu is 24px, so to match we add 6px padding around the
+	// heading text, which we know is 18px from line-height.
+	padding: 3px 0;
+	@include font-size( 15 );
+	line-height: 1.2;
 	font-weight: 600;
 }

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -4,7 +4,7 @@
 	flex-direction: column;
 	justify-content: flex-start;
 	align-items: flex-start;
-	margin: -20px;
+	margin: -$gap;
 	border-top: 1px solid $core-grey-light-200;
 
 	.woocommerce-dashboard__widget-chart-header {


### PR DESCRIPTION
Another small layout fix– The `Card` component was created before the gap/gutter variables, so they're still using a 20px padding. I've updated them to use the right variables, and fixed the magic padding on the card title + added a comment.

**To test**

- Make sure all the cards look OK