### PR TITLE
SummaryNumber: Update style of dropdown on smaller screens

### DIFF
--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -63,7 +63,7 @@ const SummaryList = ( { children, label } ) => {
 			className="woocommerce-summary"
 			position="bottom"
 			headerTitle={ label }
-			renderToggle={ ( { onToggle } ) => cloneElement( selected, { onToggle } ) }
+			renderToggle={ ( { isOpen, onToggle } ) => cloneElement( selected, { onToggle, isOpen } ) }
 			renderContent={ () => menu }
 		/>
 	);

--- a/client/components/summary/index.js
+++ b/client/components/summary/index.js
@@ -63,7 +63,6 @@ const SummaryList = ( { children, label } ) => {
 			className="woocommerce-summary"
 			position="bottom"
 			headerTitle={ label }
-			expandOnMobile
 			renderToggle={ ( { onToggle } ) => cloneElement( selected, { onToggle } ) }
 			renderContent={ () => menu }
 		/>

--- a/client/components/summary/item.js
+++ b/client/components/summary/item.js
@@ -17,6 +17,7 @@ import Link from 'components/link';
 const SummaryNumber = ( {
 	delta,
 	href,
+	isOpen,
 	label,
 	onToggle,
 	prevLabel,
@@ -27,6 +28,7 @@ const SummaryNumber = ( {
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
 		'is-dropdown-button': onToggle,
+		'is-dropdown-expanded': isOpen,
 	} );
 	const classes = classnames( 'woocommerce-summary__item', {
 		'is-selected': selected,
@@ -55,6 +57,7 @@ const SummaryNumber = ( {
 		containerProps.role = 'menuitem';
 	} else {
 		containerProps.onClick = onToggle;
+		containerProps[ 'aria-expanded' ] = isOpen;
 	}
 
 	return (
@@ -94,6 +97,7 @@ const SummaryNumber = ( {
 SummaryNumber.propTypes = {
 	delta: PropTypes.number,
 	href: PropTypes.string.isRequired,
+	isOpen: PropTypes.bool,
 	label: PropTypes.string.isRequired,
 	onToggle: PropTypes.func,
 	prevLabel: PropTypes.string,
@@ -105,6 +109,7 @@ SummaryNumber.propTypes = {
 
 SummaryNumber.defaultProps = {
 	href: '/analytics',
+	isOpen: false,
 	prevLabel: __( 'Previous Period:', 'wc-admin' ),
 	reverseTrend: false,
 	selected: false,

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -318,11 +318,12 @@ $inner-border: $core-grey-light-500;
 		position: absolute;
 		top: 44px;
 		right: $gap;
+		transition: transform ease 0.2s;
 	}
 
 	.is-dropdown-expanded & {
 		.woocommerce-summary__toggle {
-			transform: rotate(180deg);
+			transform: rotate(-180deg);
 		}
 	}
 

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -319,6 +319,12 @@ $inner-border: $core-grey-light-500;
 		top: 44px;
 		right: $gap;
 	}
+
+	.is-dropdown-expanded & {
+		.woocommerce-summary__toggle {
+			transform: rotate( 180deg );
+		}
+	}
 }
 
 .woocommerce-card {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -322,7 +322,24 @@ $inner-border: $core-grey-light-500;
 
 	.is-dropdown-expanded & {
 		.woocommerce-summary__toggle {
-			transform: rotate( 180deg );
+			transform: rotate(180deg);
+		}
+	}
+
+	.components-popover__content & {
+		.woocommerce-summary__item-label {
+			margin-bottom: 0;
+		}
+
+		.woocommerce-summary__item-value,
+		.woocommerce-summary__item-delta {
+			@include font-size( 13 );
+			margin-bottom: 0;
+		}
+
+		.woocommerce-summary__item-prev-label,
+		.woocommerce-summary__item-prev-value {
+			@include font-size( 11 );
 		}
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -46,6 +46,39 @@ $inner-border: $core-grey-light-500;
 	background-color: $core-grey-light-300;
 	box-shadow: inset -1px -1px 0 $outer-border;
 
+	// Specificity
+	.components-popover.components-popover {
+		// !important to override element-level styles
+		position: static !important;
+		top: auto !important;
+		left: auto !important;
+		right: auto !important;
+		bottom: auto !important;
+		margin-top: 0 !important;
+		margin-left: 0;
+
+		.components-popover__header {
+			display: none;
+		}
+
+		.components-popover__content {
+			position: static;
+			left: auto;
+			right: auto;
+			margin: 0;
+			width: 100%;
+			max-width: 100% !important;
+			max-height: 100% !important;
+			box-shadow: none;
+			border: none;
+			transform: none;
+
+			.woocommerce-summary__item.is-selected {
+				display: none;
+			}
+		}
+	}
+
 	.components-popover__content & {
 		max-height: 100%;
 		margin-top: 0;
@@ -126,15 +159,32 @@ $inner-border: $core-grey-light-500;
 		}
 	}
 
+	@include breakpoint( '<1100px' ) {
+		.woocommerce-summary__item {
+			// One-col layout for all items means right border is always "outer"
+			border-right-color: $outer-border;
+		}
+	}
+
 	@include breakpoint( '<782px' ) {
+		.woocommerce-summary__item-container.is-dropdown-button,
 		.woocommerce-summary__item-container:only-child {
 			margin-left: -16px;
 			margin-right: -16px;
 			width: auto;
 
-			& .woocommerce-summary__item {
+			.woocommerce-summary__item {
 				// Remove the border when the button is edge-to-edge
 				border-right: none;
+			}
+		}
+		.components-popover.components-popover {
+			margin-left: -16px;
+			margin-right: -16px;
+
+			.woocommerce-summary__item-container {
+				margin-left: 0;
+				margin-right: 0;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #273 – the SummaryNumber dropdown should not take over the entire screen. I was able to update the look of the popover with just CSS 🎉 It now looks like this:

<img width="748" alt="screen shot 2018-08-09 at 2 35 30 pm" src="https://user-images.githubusercontent.com/541093/43918711-d0bf0dbe-9be1-11e8-932a-89b048b640e2.png">

I've hidden the currently-selected item in the dropdown, otherwise it would appear twice (at the top of the list & again in the list itself). Focus styling still works the same way, focus is directed to the first item in the list (we can't change that), and arrow & tab keys can navigate through the list. Clicking outside of the dropdown, or hitting escape, will close the dropdown.

**To test**

- Check out the SummaryNumber demo page, `/wp-admin/admin.php?page=wc-admin#/analytics/test`
  - On less than 1100px, the SummaryNumber switches to the dropdown, clicking it should unfold a list of numbers, still with padding around the container
  - On less than 783px, the SummaryNumber button & dropdown switch to an edge-to-edge design
- Check the SummaryNumber in "real use" on the Revenue report `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
- Check the non-dropdown version of the SummaryNumber on the dashboard (nothing should change here)