### PR TITLE
Table: Update style to match design

### DIFF
--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -87,36 +87,42 @@ class RevenueReport extends Component {
 				key: 'gross_revenue',
 				required: true,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Refunds', 'wc-admin' ),
 				key: 'refunds',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Coupons', 'wc-admin' ),
 				key: 'coupons',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Taxes', 'wc-admin' ),
 				key: 'taxes',
 				required: false,
 				isSortable: false, // For example
+				isNumeric: true,
 			},
 			{
 				label: __( 'Shipping', 'wc-admin' ),
 				key: 'shipping',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Net Revenue', 'wc-admin' ),
 				key: 'net_revenue',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 		];
 	}

--- a/client/components/filter-picker/style.scss
+++ b/client/components/filter-picker/style.scss
@@ -74,30 +74,33 @@
 			}
 		}
 	}
-}
 
-.woocommerce-filter-picker__content-list-item-btn {
-	padding: 1em 1em 1em 3em;
-	display: block;
-	width: 100%;
-	text-align: left;
-	background-color: $core-grey-light-100;
-	color: $core-grey-dark-500;
-	position: relative;
-
-	&:hover {
-		background-color: $core-grey-light-200;
-		color: $core-grey-dark-500;
-	}
-
-	&.components-button:not(:disabled):not([aria-disabled='true']):focus {
+	.woocommerce-filter-picker__content-list-item-btn {
+		position: relative;
+		display: block;
+		width: 100%;
+		padding: 1em 1em 1em 3em;
 		background-color: $core-grey-light-100;
-	}
+		text-align: left;
 
-	.dashicon {
-		position: absolute;
-		left: 1em;
-		top: 50%;
-		transform: translate(0, -50%);
+		&.components-button {
+			color: $core-grey-dark-500;
+		}
+
+		&:hover {
+			background-color: $core-grey-light-200;
+			color: $core-grey-dark-500;
+		}
+
+		&.components-button:not(:disabled):not([aria-disabled='true']):focus {
+			background-color: $core-grey-light-100;
+		}
+
+		.dashicon {
+			position: absolute;
+			left: 1em;
+			top: 50%;
+			transform: translate(0, -50%);
+		}
 	}
 }

--- a/client/components/table/README.md
+++ b/client/components/table/README.md
@@ -50,6 +50,7 @@ render: function() {
 * `className`: Optional additional classes
 * `headers`: An array of column headers, as objects with the following properties:
   * `headers[].defaultSort`: Boolean, true if this column is the default for sorting. Only one column should have this set.
+  * `headers[].isNumeric`: Boolean, true if this column is a number value.
   * `headers[].isSortable`: Boolean, true if this column is sortable.
   * `headers[].key`: The API parameter name for this column, passed to `orderby` when sorting via API.
   * `headers[].label`: The display label for this column.

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -37,6 +37,16 @@
 	padding: $gap $gap-large;
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;
+
+	a {
+		display: block;
+		margin: ($gap*-1) ($gap-large*-1);
+		padding: $gap $gap-large;
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
 }
 
 .woocommerce-table__header,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -25,6 +25,11 @@
 		border-collapse: collapse;
 		width: 100%;
 	}
+
+	tr:hover,
+	tr:focus-within {
+		background-color: $core-grey-light-200;
+	}
 }
 
 .woocommerce-table__header,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -43,6 +43,11 @@
 		margin: ($gap*-1) ($gap-large*-1);
 		padding: $gap $gap-large;
 
+		&:hover,
+		&:focus {
+			color: $woocommerce-700;
+		}
+
 		&:focus {
 			box-shadow: none;
 		}

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -52,6 +52,14 @@
 			box-shadow: none;
 		}
 	}
+
+	&.is-numeric {
+		text-align: right;
+
+		button {
+			justify-content: flex-end;
+		}
+	}
 }
 
 .woocommerce-table__header,
@@ -70,9 +78,9 @@ th.woocommerce-table__item {
 	}
 
 	.components-button.is-button {
-		padding: $gap-smaller $gap $gap-smaller 0;
 		height: auto;
 		width: 100%;
+		padding: $gap-smaller $gap-large $gap-smaller 0;
 		vertical-align: middle;
 		line-height: 1;
 		border: none;

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -85,11 +85,12 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { isSortable, key, label } = header;
+								const { isSortable, isNumeric, key, label } = header;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
 										'is-sortable': isSortable,
 										'is-sorted': sortedBy === key,
+										'is-numeric': isNumeric,
 									} ),
 								};
 								if ( isSortable ) {
@@ -135,18 +136,18 @@ class Table extends Component {
 						</tr>
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
-								{ row.map(
-									( cell, j ) =>
-										rowHeader === j ? (
-											<th scope="row" key={ j } className="woocommerce-table__item">
-												{ getDisplay( cell ) }
-											</th>
-										) : (
-											<td key={ j } className="woocommerce-table__item">
-												{ getDisplay( cell ) }
-											</td>
-										)
-								) }
+								{ row.map( ( cell, j ) => {
+									const { isNumeric } = headers[ j ];
+									const Cell = rowHeader === j ? 'th' : 'td';
+									const cellClasses = classnames( 'woocommerce-table__item', {
+										'is-numeric': isNumeric,
+									} );
+									return (
+										<Cell scope="row" key={ j } className={ cellClasses }>
+											{ getDisplay( cell ) }
+										</Cell>
+									);
+								} ) }
 							</tr>
 						) ) }
 					</tbody>

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -29,3 +29,24 @@
 		opacity: 0.7;
 	}
 }
+
+.woocommerce-layout {
+	a:link,
+	a:visited,
+	.components-button.is-link {
+		color: $woocommerce-500;
+	}
+
+	a:hover,
+	a:active,
+	a:focus,
+	.components-button.is-link:hover,
+	.components-button.is-link:active,
+	.components-button.is-link:focus {
+		color: $woocommerce-400;
+	}
+
+	a:focus {
+		box-shadow: 0 0 0 1px $woocommerce-300, 0 0 2px 1px rgba($woocommerce-300, 0.8);
+	}
+}


### PR DESCRIPTION
Fixes #286 & also addresses some of #119 

✅ Adds the hover state for table rows (also activated by focusing on an element inside the table row)
✅ Adds a default link state for all links in the app - guess at colors, waiting for answer on #119
✅ Expands padding of links in cells to cover the entire cell
✅ Numeric columns are right-aligned

![report-table](https://user-images.githubusercontent.com/541093/43971833-8c519614-9ca0-11e8-8bc0-d2013aafc4c5.png)

I've guessed at the link colors- the base purple, with a lighter color for hover states. I needed to update the filter picker, since it had specificity issues with the text color. I also switched the hover/focus color for the table to a darker color, since the lighter purple against the light grey didn't have a high enough contrast.

**To test**

- Check that the table looks good: `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`