### PR TITLE
Try: Proof of concept WooCommerce wp-admin skin

### DIFF
--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -6,7 +6,6 @@
 	align-items: center;
 	position: fixed;
 	right: 0;
-	height: 80px;
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
@@ -16,13 +15,11 @@
 		top: -3px;
 		width: 100vw;
 		display: none;
-		height: 60px;
 		flex: 1 100%;
 	}
 
 	@include breakpoint( '782px-1100px' ) {
 		max-width: 280px;
-		height: 60px;
 	}
 
 	@include breakpoint( '>1100px' ) {
@@ -37,11 +34,7 @@
 .woocommerce-layout__activity-panel-tabs {
 	width: 100%;
 	display: flex;
-	height: 60px;
-
-	@include breakpoint( '>1100px' ) {
-		height: 80px;
-	}
+	height: 47px;
 
 	.dashicon,
 	.gridicon {
@@ -49,13 +42,8 @@
 	}
 
 	svg {
-		width: 18px;
-		height: 18px;
-
-		@include breakpoint( '>1100px' ) {
-			width: 24px;
-			height: 24px;
-		}
+		width: 16px;
+		height: 16px;
 	}
 
 	.components-icon-button {
@@ -67,26 +55,19 @@
 		border: none;
 		outline: none;
 		cursor: pointer;
-		background-color: $white;
-		color: $core-grey-dark-500;
+		background-color: transparent;
+		color: $white;
 		width: 100%;
-		height: 60px;
-		border-bottom: 3px solid $white;
-
-		@include breakpoint( '>1100px' ) {
-			height: 80px;
-		}
+		height: 46px;
+		border-bottom: 3px solid #5b3452;
 
 		&.is-active {
-			color: $core-grey-dark-700;
+			color: $white;
 			border-bottom: 3px solid $woocommerce;
 			box-shadow: none;
 		}
 
 		font-size: 11px;
-		@include breakpoint( '>1100px' ) {
-			font-size: 13px;
-		}
 
 		&.has-unread:after,
 		&.woocommerce-layout__activity-panel-tab-wordpress-notices:after {
@@ -110,8 +91,8 @@
 			}
 
 			@include breakpoint( '>1100px' ) {
-				top: 16px;
-				right: 28px;
+				top: 6px;
+				right: 26px;
 				left: initial;
 				margin-left: 0;
 			}
@@ -187,15 +168,15 @@
 }
 
 .woocommerce-layout__activity-panel-wrapper {
-	height: calc(100vh - 80px);
-	min-height: calc(100vh - 80px);
+	height: calc(100vh - 47px);
+	min-height: calc(100vh - 47px);
 	background: $core-grey-light-200;
 	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	width: 0px;
 	@include activity-panel-slide();
 	position: fixed;
 	right: 0px;
-	top: 92px;
+	top: 46px;
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: scroll;
@@ -206,12 +187,7 @@
 		padding-bottom: $gap-small;
 	}
 	@include breakpoint( '>1100px' ) {
-		top: 112px;
 		padding-bottom: $gap * 2;
-	}
-
-	@include breakpoint( '<782px' ) {
-		top: 153px;
 	}
 
 	&.is-open {

--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -80,9 +80,6 @@ class Header extends Component {
 		return (
 			<div className={ className }>
 				<h1 className="woocommerce-layout__header-breadcrumbs">
-					<span>
-						<Link href="/">WooCommerce</Link>
-					</span>
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = isArray( section ) ? (
 							<Link href={ section[ 0 ] } type={ isEmbedded ? 'wp-admin' : 'wc-admin' }>

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -1,22 +1,17 @@
 /** @format */
 
 .woocommerce-layout__header {
-	background: $white;
+	background: transparent;
 	display: flex;
 	justify-content: space-between;
 	flex-direction: row;
 	box-sizing: border-box;
-	border-bottom: 1px solid $white;
 	padding: 0px;
-	height: 80px;
+	height: 47px;
 	position: fixed;
 	width: 100%;
-	top: 32px;
+	top: 0px;
 	z-index: 99999; /* component-popover is 99990 */
-
-	&.is-scrolled {
-		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);
-	}
 
 	@include breakpoint( '<782px' ) {
 		top: 46px;
@@ -33,28 +28,17 @@
 		font-weight: normal;
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
-		height: 50px;
-		line-height: 50px;
-		background: $white;
-
-		@include breakpoint( '782px-1100px' ) {
-			height: 60px;
-			line-height: 60px;
-		}
-
-		@include breakpoint( '>1100px' ) {
-			height: 80px;
-			line-height: 80px;
-		}
+		line-height: 47px;
+		color: $white;
 
 		span + span::before {
 			content: ' / ';
-			color: $gray-text;
+			color: $white;
 			margin: 0 2px 0 2px;
 		}
 
 		a {
-			color: $woocommerce;
+			color: $white;
 		}
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -5,11 +5,7 @@
 }
 
 .woocommerce-layout__primary {
-	margin: 80px 0 0 $gutter-large;
-
-	@include breakpoint( '>1100px' ) {
-		margin-top: 100px;
-	}
+	margin: $gap-large 0 0 $gutter-large;
 }
 
 .woocommerce-layout .woocommerce-layout__main {

--- a/client/stylesheets/_embedded.scss
+++ b/client/stylesheets/_embedded.scss
@@ -3,6 +3,9 @@
 // Import our wp-admin reset.
 @import './shared/_reset.scss';
 
+// Import wp-admin skin.
+@import './shared/_wp_admin_skin.scss';
+
 // Import any global styles.
 @import './shared/_global.scss';
 

--- a/client/stylesheets/_index.scss
+++ b/client/stylesheets/_index.scss
@@ -3,6 +3,9 @@
 // Import our wp-admin reset.
 @import './shared/_reset.scss';
 
+// Import wp-admin skin.
+@import './shared/_wp_admin_skin.scss';
+
 // Import any global styles.
 @import './shared/_global.scss';
 

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -25,10 +25,6 @@
 	}
 
 	.woocommerce-layout__header {
-		&.is-scrolled {
-			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
-		}
-
 		.woocommerce-layout__header-breadcrumbs {
 			margin-top: 0;
 			margin-bottom: 0;

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -26,21 +26,7 @@
 	}
 
 	.wp-has-current-submenu:after {
-		right: 0;
-		border: 8px solid transparent;
-		content: ' ';
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-		border-right-color: #f1f1f1;
-		top: 0;
-		margin-top: 10px;
-
-		@include breakpoint( '<960px' ) {
-			border-width: 4px;
-			margin-top: 14px;
-		}
+		display: none;
 	}
 }
 

--- a/client/stylesheets/shared/_wp_admin_skin.scss
+++ b/client/stylesheets/shared/_wp_admin_skin.scss
@@ -1,0 +1,551 @@
+/** @format */
+
+body,
+#wp-content-editor-tools {
+	background: #f3f6f8;
+}
+
+#wpwrap {
+	top: 14px;
+	background: #efefef;
+}
+
+#adminmenu #collapse-menu,
+#adminmenu .wp-menu-separator,
+#screen-meta-links,
+.wp-submenu,
+#toplevel_page_jetpack {
+	display: none;
+}
+
+.wp-menu-open .wp-submenu {
+	display: block;
+}
+
+#adminmenuwrap,
+#adminmenuback,
+#adminmenu {
+	background: #e4e4e4;
+}
+
+#adminmenuback {
+	border-right: 1px solid #d9e3ea;
+}
+
+#adminmenu,
+#adminmenuwrap,
+#adminmenuback,
+#adminmenu .wp-submenu {
+	width: 272px;
+}
+
+#adminmenu .wp-has-current-submenu .wp-submenu,
+#adminmenu .opensub .wp-submenu,
+#adminmenu .opensub .wp-submenu:after,
+#adminmenu a.wp-has-current-submenu:focus + .wp-submenu,
+.no-js li.wp-has-current-submenu:hover .wp-submenu {
+	background: #dedede !important;
+}
+
+#adminmenu li.menu-top:hover,
+#adminmenu li.opensub > a.menu-top,
+#adminmenu li > a.menu-top:focus,
+#adminmenu li.wp-menu-open {
+	background: #f3f6f8;
+}
+
+#adminmenu .wp-submenu-head,
+#adminmenu a.menu-top {
+	padding: 5px 0 5px 5px;
+}
+
+#adminmenu .wp-has-current-submenu ul > li > a,
+.folded #adminmenu li.menu-top .wp-submenu > li > a {
+	padding: 7px 12px 7px 46px;
+	font-size: 14px;
+}
+
+#adminmenu .wp-submenu a:hover {
+	background: #fff;
+}
+
+#adminmenu > li.wp-first-item {
+	border-bottom: 1px solid rgba(200, 215, 225, 0.5);
+}
+
+#wpcontent {
+	margin-left: 272px;
+}
+
+#adminmenu {
+	margin-top: 0px;
+}
+
+ul#adminmenu a.wp-has-current-submenu:after,
+ul#adminmenu > li.current > a.current:after,
+#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after {
+	border: none;
+}
+
+#adminmenu .dashicons,
+#adminmenu .dashicons-before:before {
+	width: 24px;
+	height: 24px;
+	font-size: 24px;
+}
+
+#adminmenu a,
+#adminmenu div.wp-menu-image:before {
+	color: #2e4453 !important;
+}
+
+#adminmenu li.current a.menu-top,
+#adminmenu li.wp-has-current-submenu a.wp-has-current-submenu,
+.folded #adminmenu li.current.menu-top,
+.folded #adminmenu li.wp-has-current-submenu {
+	background: #dedede;
+}
+
+#adminmenu div.wp-menu-image.svg {
+	filter: brightness(0.25);
+}
+
+#toplevel_page_plugins div.wp-menu-image.svg,
+#toplevel_page_plugin-install div.wp-menu-image.svg {
+	background-size: 24px auto;
+}
+
+#toplevel_page_plugins div.wp-menu-image.svg {
+	position: relative;
+	left: -2px;
+}
+
+#adminmenu li.wp-menu-open div.wp-menu-image.svg {
+	filter: brightness(100);
+}
+
+#adminmenu li.wp-menu-open div.wp-menu-image:before,
+#adminmenu li.wp-menu-open div.wp-menu-name {
+	color: #2e4453;
+}
+
+#adminmenu div.wp-menu-name {
+	color: #2e4453;
+	font-size: 15px;
+	padding: 9px 0 8px 41px;
+}
+
+#adminmenu li.menu-top {
+	min-height: 46px;
+}
+
+#calypso-sidebar-header {
+	position: fixed;
+	top: 47px;
+	left: 0;
+	width: 272px;
+	height: 70px;
+	background: #fff;
+	z-index: 10000;
+}
+
+#calypso-sidebar-header svg {
+	float: left;
+	position: relative;
+	left: 10px;
+	top: 23px;
+}
+
+#calypso-sidebar-header ul {
+	float: left;
+	position: relative;
+	top: 3px;
+	left: 15px;
+}
+
+#calypso-sidebar-header ul li {
+	margin: 0;
+}
+
+#calypso-sidebar-header ul li#calypso-sitename {
+	font-size: 12px;
+	color: #537994;
+}
+
+#calypso-sidebar-header ul li#calypso-plugins {
+	font-weight: bold;
+	color: #2e4453;
+	font-size: 16px;
+}
+
+@media only screen and (max-width: 960px) {
+	#calypso-sidebar-header {
+		width: 36px;
+	}
+
+	#calypso-sidebar-header ul {
+		display: none;
+	}
+
+	#calypso-sidebar-header svg {
+		left: 6px;
+	}
+
+	#adminmenu a.menu-top {
+		padding-left: 1px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	#calypso-sidebar-header {
+		position: absolute;
+		display: none;
+		width: 190px;
+		top: -14px;
+	}
+
+	.wp-responsive-open #calypso-sidebar-header {
+		display: block;
+	}
+
+	#calypso-sidebar-header ul {
+		display: block;
+	}
+
+	.auto-fold #adminmenu .wp-menu-name {
+		margin-left: 0;
+	}
+
+	.auto-fold #adminmenu {
+		top: -14px;
+	}
+
+	.auto-fold #adminmenu .selected,
+	#adminmenu li.opensub > a.menu-top,
+	#adminmenu li > a.menu-top:focus,
+	#adminmenu li.wp-menu-open {
+		background: #537994 !important;
+	}
+
+	#adminmenu .wp-submenu,
+	.auto-fold #adminmenu .selected .wp-submenu,
+	.auto-fold #adminmenu .wp-menu-open .wp-submenu,
+	#adminmenu a.wp-has-current-submenu:focus + .wp-submenu {
+		background: #f3f6f8 !important;
+	}
+
+	.auto-fold #adminmenu li.selected div.wp-menu-image.svg {
+		filter: brightness(100);
+	}
+
+	.auto-fold #adminmenu li.selected div.wp-menu-image:before,
+	.auto-fold #adminmenu li.selected div.wp-menu-name {
+		color: #fff !important;
+	}
+
+	#wpadminbar .quicklinks > ul > li > a,
+	#wpadminbar .quicklinks > ul > li > .ab-empty-item {
+		padding: 0 15px !important;
+	}
+
+	#wpadminbar li#wp-admin-bar-ab-new-post a {
+		padding: 7px 15px !important;
+	}
+}
+
+@media screen and (max-width: 600px) {
+	#calypso-sidebar-header {
+		top: 46px;
+	}
+
+	.auto-fold #adminmenu {
+		top: 46px;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	#wpadminbar #wp-admin-bar-blog.my-sites > a.ab-item:before {
+		margin-top: 4px !important;
+	}
+
+	#wpadminbar #wp-admin-bar-newdash > a.ab-item:before {
+		margin-top: 6px !important;
+	}
+
+	#wpadminbar ul li#wp-admin-bar-ab-new-post a:before {
+		top: -5px !important;
+		margin-left: -12px !important;
+	}
+}
+
+/* Nav Bar */
+
+.nav-tab-wrapper,
+.wrap h2.nav-tab-wrapper {
+	margin: 10px 0 25px;
+	background: #fff;
+	border: 1px solid rgba(200, 215, 225, 0.5);
+}
+
+.nav-tab {
+	border: none;
+	background: none;
+	font-weight: 400;
+	padding: 3px 13px 12px;
+	color: #0087be;
+}
+
+.nav-tab-active,
+.nav-tab-active:focus,
+.nav-tab-active:focus:active,
+.nav-tab-active:hover {
+	background: transparent;
+	box-shadow: none;
+}
+
+.nav-tab:first-child {
+	margin-left: 0;
+}
+
+.nav-tab-active,
+.nav-tab-active:focus,
+.nav-tab-active:focus:active {
+	border-bottom: 2px solid #2e4453;
+	color: #2e4453;
+}
+
+/* Admin Bar */
+
+#wpadminbar {
+	background: #5b3452;
+	height: 46px;
+}
+
+#wpadminbar .ab-top-menu > li > .ab-item {
+	font-size: 14px;
+}
+
+#wpadminbar * {
+	line-height: 46px;
+}
+
+#wpadminbar .quicklinks a,
+#wpadminbar .quicklinks .ab-empty-item,
+#wpadminbar .shortlink-input {
+	height: 46px;
+}
+
+#wpadminbar .quicklinks > ul > li > a {
+	padding: 0 15px;
+}
+
+#wpadminbar .quicklinks > ul > li.current > a {
+	background: #004967;
+}
+
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
+#wpadminbar .ab-top-menu > li.hover > .ab-item,
+#wpadminbar .ab-top-menu > li.ab-hover > .ab-item {
+	background: transparent !important;
+}
+
+#wpadminbar .ab-top-menu > li.my-sites > .ab-item,
+#wpadminbar .ab-top-menu > li.my-sites.hover > .ab-item,
+#wpadminbar .ab-top-menu > li.my-sites.ab-hover > .ab-item {
+	background: #004967 !important;
+}
+
+#wpadminbar #wp-admin-bar-blog.my-sites > a.ab-item:before,
+#wpadminbar #wp-admin-bar-newdash > a.ab-item:before {
+	margin-top: 12px;
+}
+
+div#wpadminbar .quicklinks > ul > li#wp-admin-bar-notes > a.ab-item span.noticon,
+#wpadminbar > #wp-toolbar span.noticon,
+#wpadminbar #wp-admin-bar-notes .noticon {
+	top: 10px;
+}
+
+#wpadminbar ul li#wp-admin-bar-ab-new-post a {
+	padding: 6px 20px;
+	color: #0087be !important;
+}
+
+#wpadminbar ul li#wp-admin-bar-ab-new-post a span {
+	color: #0087be !important;
+	font-size: 14px !important;
+}
+
+#wpadminbar ul li#wp-admin-bar-ab-new-post a:before,
+#wpadminbar ul li#wp-admin-bar-ab-new-post a:after {
+	filter: brightness(4);
+}
+
+#wpadminbar li#wp-admin-bar-blog.menupop > .ab-sub-wrapper,
+#wpadminbar li#wp-admin-bar-newdash.menupop > .ab-sub-wrapper,
+#wpadminbar li#wp-admin-bar-my-account.menupop > .ab-sub-wrapper {
+	display: none !important;
+}
+
+#wpadminbar li#wp-admin-bar-notes > #wpnt-notes-panel2 {
+	top: 46px;
+}
+
+#wpadminbar .ab-top-menu > li.ab-active > .ab-item,
+#wpadminbar > #wp-toolbar .wpnt-show span.noticon,
+#wpadminbar #wp-admin-bar-notes.wpnt-show .noticon {
+	color: #fff !important;
+}
+
+#wpadminbar .ab-active > a.ab-item:before,
+#wp-admin-bar-notes.active .noticon-bell:before {
+	filter: brightness(100) !important;
+}
+
+/* WP Admin UI Mods */
+
+.wrap {
+	margin: 20px 30px 25px 15px;
+}
+
+@media screen and (max-width: 782px) {
+	.wrap {
+		margin: 10px 18px 10px 7px;
+	}
+}
+
+.subsubsub,
+.wp-filter {
+	margin: 10px 0 25px;
+	background: #fff;
+	border: 1px solid rgba(200, 215, 225, 0.5);
+	width: 100%;
+	box-shadow: none;
+	padding: 0;
+}
+
+.subsubsub a,
+.filter-links li > a {
+	padding: 10px 15px;
+	display: inline-block;
+	font-size: 14px;
+	margin: 0;
+	color: #0073aa;
+	border-bottom: none;
+	outline: none;
+}
+
+.filter-links li > a {
+	padding: 16px;
+}
+
+.subsubsub a.current,
+.filter-links .current {
+	border-bottom: 2px solid #000;
+}
+
+.count {
+	display: inline-block;
+	padding: 1px 6px;
+	border: solid 1px #87a6bc;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: bold;
+	line-height: 14px;
+	color: #537994;
+	text-align: center;
+	margin-left: 2px;
+}
+
+.plugins-php .tablenav .one-page .displaying-num {
+	display: none;
+}
+
+.plugins-php .tablenav {
+	clear: none;
+	float: left;
+	margin-bottom: 15px;
+}
+
+.plugins-php p.search-box {
+	margin-top: 5px;
+}
+
+.wrap .wp-heading-inline + .page-title-action,
+.wrap .add-new-h2,
+.wrap .add-new-h2:active,
+.wrap .page-title-action,
+.wrap .page-title-action:active {
+	background: #00aadc;
+	border-color: #008ab3;
+	color: #fff;
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0 5px 0 0;
+	outline: 0;
+	overflow: hidden;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: middle;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	font-size: 13px;
+	line-height: 21px;
+	border-radius: 4px;
+	padding: 2px 10px 2px;
+	margin-bottom: 2px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+
+.wp-core-ui .button {
+	background: #fff;
+}
+
+.wp-core-ui .button-primary {
+	background: #00aadc;
+	border-color: #008ab3;
+	color: #fff;
+	text-shadow: none;
+}
+
+.wrap .wp-heading-inline + .page-title-action:hover {
+	border-color: #005082;
+}
+
+#adminmenu .awaiting-mod,
+#adminmenu .update-plugins {
+	background-color: #00aadc;
+}
+
+.ui-tabs-nav li,
+.wp-switch-editor {
+	background-color: #e9eff3 !important;
+}
+
+.plugin-card-bottom,
+.alternate,
+.striped > tbody > :nth-child(odd),
+ul.striped > :nth-child(odd),
+.ui-tabs-panel,
+.ui-tabs-nav li.ui-tabs-active,
+.ui-tabs-nav li.ui-tabs-active:hover,
+div.mce-toolbar-grp,
+.html-active .switch-html,
+.tmce-active .switch-tmce,
+#post-status-info,
+.quicktags-toolbar,
+#major-publishing-actions {
+	background-color: #f3f6f8 !important;
+	border-color: #d9e3ea;
+}
+
+.wp-filter .search-form {
+	margin-right: 10px;
+}

--- a/lib/menu.php
+++ b/lib/menu.php
@@ -1,0 +1,65 @@
+<?php
+class WC_Admin_Menu {
+	static $instance = false;
+
+	private function __construct() {
+		add_action( 'wp_loaded', array( $this, 'setup' ) );
+	}
+
+	public static function getInstance() {
+		if ( !self::$instance )
+			self::$instance = new self;
+		
+		return self::$instance;
+	}
+
+	public function setup() {
+		// TODO Only show on WooCommerce pages and WC plugin pages)
+		// TODO Remove WooCommerce Navigation from Main Menu - Only a single WooCommerce link
+		// TODO Only add WC and WC related plugins to the WC-Admin Experience (opt-in)
+		add_action( 'admin_menu', array( $this, 'remove_core_menus' ), 1000000000 );
+		add_action( 'wp_before_admin_bar_render', array( $this, 'modify_masterbar' ), 100000 );
+		
+	}
+
+	public function remove_core_menus() {
+		remove_menu_page( 'index.php' );
+		remove_menu_page( 'jetpack' );
+		remove_menu_page( 'edit.php' );
+		remove_menu_page( 'edit.php?post_type=feedback' );
+		remove_menu_page( 'upload.php' );
+		remove_menu_page( 'edit.php?post_type=page' );
+		remove_menu_page( 'edit-comments.php' );
+		remove_menu_page( 'themes.php' );
+		remove_menu_page( 'plugins.php' );
+		remove_menu_page( 'users.php' );
+		remove_menu_page( 'tools.php' );
+		remove_menu_page( 'link-manager.php' );
+
+		// Core settings pages
+		remove_submenu_page( 'options-general.php', 'options-general.php' ); 
+		remove_submenu_page( 'options-general.php', 'options-writing.php' ); 
+		remove_submenu_page( 'options-general.php', 'options-reading.php' ); 
+		remove_submenu_page( 'options-general.php', 'options-discussion.php' ); 
+		remove_submenu_page( 'options-general.php', 'options-media.php' ); 
+		remove_submenu_page( 'options-general.php', 'options-permalink.php' );
+		remove_submenu_page( 'options-general.php', 'privacy.php' );
+		remove_submenu_page( 'options-general.php', 'sharing' ); 
+	}
+
+	public function modify_masterbar() {
+		global $wp_admin_bar;
+
+		if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+			return false;
+		}
+
+		$nodes = $wp_admin_bar->get_nodes();
+		foreach( $nodes as $node ) {
+			$wp_admin_bar->remove_menu( $node->id );
+		}
+	}
+
+}
+
+$WC_Admin_Menu = WC_Admin_Menu::getInstance();

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -46,6 +46,9 @@ function wc_admin_plugins_loaded() {
 	// Register script files
 	require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 
+	// Update wp-admin navigation
+	require_once dirname( __FILE__ ) . '/lib/menu.php';
+
 	// Create the Admin pages
 	require_once dirname( __FILE__ ) . '/lib/admin.php';
 }


### PR DESCRIPTION
This PR is a very basic proof of concept branch. The designs are based off of p6riRB-3nD-p2. See p6riRB-3qJ-p2 for some additional background.

There are some important TODOs I would like to see implemented if we go this route. This was also a quick try branch and borrows some code from https://github.com/automattic/calypsoify - so we would want to clean up CSS if we want this route.

I would also want to update the menu handling code. Right now it just hides everything except plugin menus. Instead, I would rather create our own menu system backend that we could hook in, and only show on WooCommerce pages. There are some TODOs in the branch around this.

Other Notes: It overrides things on all wp-admin pages at the moment. I also haven’t touched mobile. It looks best on a newer page like the Revenue report page. There is still styling work todo.

<img width="1680" alt="screen shot 2018-08-10 at 12 26 09 pm" src="https://user-images.githubusercontent.com/689165/43981064-61b2209a-9cbe-11e8-8b46-79ca06c6566b.png">
