### PR TITLE
Fix Column Toggle Error

### DIFF
--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -137,6 +137,9 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
+									if ( ! headers[ j ] ) {
+										return false;
+									}
 									const { isNumeric } = headers[ j ];
 									const Cell = rowHeader === j ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import { IconButton } from '@wordpress/components';
-import { find, get, isEqual, noop, uniqueId } from 'lodash';
+import { find, get, noop, uniqueId } from 'lodash';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
@@ -20,22 +20,11 @@ class Table extends Component {
 		super( props );
 		this.state = {
 			tabIndex: null,
-			rows: props.rows || [],
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
 		this.headersID = uniqueId( 'header-' );
 		this.captionID = uniqueId( 'caption-' );
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( ! isEqual( this.props.rows, prevProps.rows ) ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				rows: this.props.rows,
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
 	}
 
 	componentDidMount() {
@@ -63,8 +52,8 @@ class Table extends Component {
 	}
 
 	render() {
-		const { caption, classNames, headers, query, rowHeader } = this.props;
-		const { rows, tabIndex } = this.state;
+		const { caption, classNames, headers, query, rowHeader, rows } = this.props;
+		const { tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
 		const sortDir = query.order || DESC;
@@ -137,9 +126,6 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
-									if ( ! headers[ j ] ) {
-										return false;
-									}
 									const { isNumeric } = headers[ j ];
 									const Cell = rowHeader === j ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {


### PR DESCRIPTION
This tiny PR fixes a bug with the Table column show/hide controls. To reproduce, go to the revenue report, click the EllipsisMenu, and hide a column, you will see an error in the console and the page will break.

`Uncaught TypeError: Cannot read property 'isNumeric' of undefined`
