### PR TITLE
Extensions: Add filter to allow third-party registration of reports

### DIFF
--- a/client/analytics/report/README.md
+++ b/client/analytics/report/README.md
@@ -1,0 +1,36 @@
+Reports
+=======
+
+The core reports offered by WooCommerce live in this folder. The Header is added automatically by the parent Report component, each individual component should contain just the report contents.
+
+## Extending Reports
+
+New reports can be added by third-parties without altering `wc-admin`, by hooking into the reports filter, `woocommerce-reports-list`. For example:
+
+```js
+addFilter( 'woocommerce-reports-list', 'wc-example/my-report', pages => {
+	return [
+		...pages,
+		{
+			report: 'example',
+			title: 'My Example Extension',
+			component: Report,
+		},
+	];
+} );
+```
+
+Each report is defined by an object containing `report`, `title`, `component`.
+
+- `report` (string): The path used to show the report, ex: `/analytics/example`
+- `title` (string): The title shown in the breadcrumbs & document title.
+- `component` (react component): The component containing the report content- everything on the page under the breadcrumbs header.
+
+The component will get the following props:
+
+- `query` (object): The query string for the current view, can be used to paginate reports, or sort/filter report data.
+- `path` (string): The exact path for this view.
+- `pathMatch` (string): The route matched for this view, should always be `/analytics/:report`.
+- `params` (object): This will contain the `report` from the path, which should match `report` in the page object.
+
+**Note:** Adding your page to `woocommerce-reports-list` does not add the item to the admin menu, you'll need to do that in PHP with `wc_admin_register_page`.

--- a/client/analytics/report/example.js
+++ b/client/analytics/report/example.js
@@ -8,19 +8,12 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Header from 'layout/header';
 import { SummaryList, SummaryNumber } from '@woocommerce/components';
 
 export default class extends Component {
 	render() {
 		return (
 			<Fragment>
-				<Header
-					sections={ [
-						[ '/analytics', __( 'Analytics', 'wc-admin' ) ],
-						__( 'Report Title', 'wc-admin' ),
-					] }
-				/>
 				<h2>One Data Point</h2>
 				<SummaryList>
 					<SummaryNumber

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -18,7 +18,7 @@ import ProductsReport from './products';
 import RevenueReport from './revenue';
 import useFilters from 'components/higher-order/use-filters';
 
-const REPORTS_FILTER = 'woocommerce-report';
+const REPORTS_FILTER = 'woocommerce-reports-list';
 
 const getReports = () => {
 	const reports = applyFilters( REPORTS_FILTER, [
@@ -48,7 +48,28 @@ const getReports = () => {
 };
 
 class Report extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			hasError: false,
+		};
+	}
+
+	componentDidCatch( error ) {
+		this.setState( {
+			hasError: true,
+		} );
+		/* eslint-disable no-console */
+		console.warn( error );
+		/* eslint-enable no-console */
+	}
+
 	render() {
+		if ( this.state.hasError ) {
+			return null;
+		}
+
 		const { params } = this.props;
 		const report = find( getReports(), { report: params.report } );
 		if ( ! report ) {

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -2,30 +2,65 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ExampleReport from './example';
-import RevenueReport from './revenue';
+import Header from 'layout/header';
+import OrdersReport from './orders';
 import ProductsReport from './products';
-import OrdersReport from './orders/';
+import RevenueReport from './revenue';
+import useFilters from 'components/higher-order/use-filters';
+
+const REPORTS_FILTER = 'woocommerce-report';
+
+const getReports = () => {
+	const reports = applyFilters( REPORTS_FILTER, [
+		{
+			report: 'revenue',
+			title: __( 'Revenue', 'wc-admin' ),
+			component: RevenueReport,
+		},
+		{
+			report: 'products',
+			title: __( 'Products', 'wc-admin' ),
+			component: ProductsReport,
+		},
+		{
+			report: 'orders',
+			title: __( 'Orders', 'wc-admin' ),
+			component: OrdersReport,
+		},
+		{
+			report: 'test',
+			title: __( 'Example', 'wc-admin' ),
+			component: ExampleReport,
+		},
+	] );
+
+	return reports;
+};
 
 class Report extends Component {
 	render() {
 		const { params } = this.props;
-		switch ( params.report ) {
-			case 'revenue':
-				return <RevenueReport { ...this.props } />;
-			case 'products':
-				return <ProductsReport { ...this.props } />;
-			case 'orders':
-				return <OrdersReport { ...this.props } />;
-			default:
-				return <ExampleReport />;
+		const report = find( getReports(), { report: params.report } );
+		if ( ! report ) {
+			return null;
 		}
+		const Container = report.component;
+		return (
+			<Fragment>
+				<Header sections={ [ [ '/analytics', __( 'Analytics', 'wc-admin' ) ], report.title ] } />
+				<Container { ...this.props } />
+			</Fragment>
+		);
 	}
 }
 
@@ -33,4 +68,4 @@ Report.propTypes = {
 	params: PropTypes.object.isRequired,
 };
 
-export default Report;
+export default useFilters( REPORTS_FILTER )( Report );

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
@@ -15,7 +14,6 @@ import { partial } from 'lodash';
  */
 import { Card, ReportFilters } from '@woocommerce/components';
 import { filters, filterPaths, advancedFilterConfig } from './constants';
-import Header from 'layout/header/index';
 import './style.scss';
 
 class OrdersReport extends Component {
@@ -37,12 +35,6 @@ class OrdersReport extends Component {
 		const { orders, orderIds, query, path } = this.props;
 		return (
 			<Fragment>
-				<Header
-					sections={ [
-						[ '/analytics', __( 'Analytics', 'wc-admin' ) ],
-						__( 'Orders', 'wc-admin' ),
-					] }
-				/>
 				<ReportFilters
 					query={ query }
 					path={ path }
@@ -50,7 +42,6 @@ class OrdersReport extends Component {
 					filterPaths={ filterPaths }
 					advancedConfig={ advancedFilterConfig }
 				/>
-
 				<p>Below is a temporary example</p>
 				<Card title="Orders">
 					<table style={ { width: '100%' } }>

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -2,14 +2,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { filterPaths, filters } from './constants';
-import Header from 'layout/header';
 import { ReportFilters } from '@woocommerce/components';
 import './style.scss';
 
@@ -19,12 +17,6 @@ export default class extends Component {
 
 		return (
 			<Fragment>
-				<Header
-					sections={ [
-						[ '/analytics', __( 'Analytics', 'wc-admin' ) ],
-						__( 'Products', 'wc-admin' ),
-					] }
-				/>
 				<ReportFilters
 					query={ query }
 					path={ path }

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -22,7 +22,6 @@ import {
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getAdminLink, updateQueryString } from 'lib/nav-utils';
 import { getReportData } from 'lib/swagger';
-import Header from 'layout/header';
 
 // Mock data until we fetch from an API
 import rawData from './mock-data';
@@ -292,12 +291,6 @@ class RevenueReport extends Component {
 
 		return (
 			<Fragment>
-				<Header
-					sections={ [
-						[ '/analytics', __( 'Analytics', 'wc-admin' ) ],
-						__( 'Revenue', 'wc-admin' ),
-					] }
-				/>
 				<ReportFilters query={ query } path={ path } />
 
 				{ this.getChartSummaryNumbers() }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -29,12 +29,37 @@ function wc_admin_is_embed_enabled_wc_page() {
 }
 
 /**
- * Register menu pages for the Dashboard and Analytics sections
+ * Add a single page to a given parent top-level-item.
+ *
+ * @param array $options {
+ *     Array describing the menu item.
+ *
+ *     @type string $title Menu title
+ *     @type string $parent Parent path or menu ID
+ *     @type string $path Path for this page, full path in app context; ex /analytics/report
+ * }
  */
-function wc_admin_register_pages(){
+function wc_admin_register_page( $options ) {
+	$defaults = array(
+		'parent' => '/analytics',
+	);
+	$options  = wp_parse_args( $options, $defaults );
+	add_submenu_page(
+		'/' === $options['parent'][0] ? "wc-admin#{$options['parent']}" : $options['parent'],
+		$options['title'],
+		$options['title'],
+		'manage_options',
+		"wc-admin#{$options['path']}",
+		'wc_admin_page'
+	);
+}
+
+/**
+ * Register menu pages for the Dashboard and Analytics sections.
+ */
+function wc_admin_register_pages() {
 	global $menu, $submenu;
 
-	// woocommerce_page_wc-admin
 	add_submenu_page(
 		'woocommerce',
 		__( 'WooCommerce Dashboard', 'wc-admin' ),
@@ -44,8 +69,6 @@ function wc_admin_register_pages(){
 		'wc_admin_page'
 	);
 
-
-	// toplevel_page_wooanalytics
 	add_menu_page(
 		__( 'WooCommerce Analytics', 'wc-admin' ),
 		__( 'Analytics', 'wc-admin' ),
@@ -53,45 +76,32 @@ function wc_admin_register_pages(){
 		'wc-admin#/analytics',
 		'wc_admin_page',
 		'dashicons-chart-bar',
-		56 // After WooCommerce & Product menu items
+		56 // After WooCommerce & Product menu items.
 	);
 
-	// TODO: Remove. Test report link
-	add_submenu_page(
-		'wc-admin#/analytics',
-		__( 'Report Title', 'wc-admin' ),
-		__( 'Report Title', 'wc-admin' ),
-		'manage_options',
-		'wc-admin#/analytics/test',
-		'wc_admin_page'
-	);
+	wc_admin_register_page( array(
+		'title'  => __( 'Report Title', 'wc-admin' ),
+		'parent' => '/analytics',
+		'path'   => '/analytics/test',
+	) );
 
-	add_submenu_page(
-		'wc-admin#/analytics',
-		__( 'Revenue', 'wc-admin' ),
-		__( 'Revenue', 'wc-admin' ),
-		'manage_options',
-		'wc-admin#/analytics/revenue',
-		'wc_admin_page'
-	);
+	wc_admin_register_page( array(
+		'title'  => __( 'Revenue', 'wc-admin' ),
+		'parent' => '/analytics',
+		'path'   => '/analytics/revenue',
+	) );
 
-	add_submenu_page(
-		'wc-admin#/analytics',
-		__( 'Products', 'wc-admin' ),
-		__( 'Products', 'wc-admin' ),
-		'manage_options',
-		'wc-admin#/analytics/products',
-		'wc_admin_page'
-	);
+	wc_admin_register_page( array(
+		'title'  => __( 'Products', 'wc-admin' ),
+		'parent' => '/analytics',
+		'path'   => '/analytics/products',
+	) );
 
-	add_submenu_page(
-		'wc-admin#/analytics',
-		__( 'Orders', 'wc-admin' ),
-		__( 'Orders', 'wc-admin' ),
-		'manage_options',
-		'wc-admin#/analytics/orders',
-		'wc_admin_page'
-	);
+	wc_admin_register_page( array(
+		'title'  => __( 'Orders', 'wc-admin' ),
+		'parent' => '/analytics',
+		'path'   => '/analytics/orders',
+	) );
 }
 add_action( 'admin_menu', 'wc_admin_register_pages' );
 
@@ -103,7 +113,7 @@ add_action( 'admin_menu', 'wc_admin_register_pages' );
  */
 function wc_admin_link_structure() {
 	global $submenu;
-	// User does not have capabilites to see the submenu
+	// User does not have capabilites to see the submenu.
 	if ( ! current_user_can( 'manage_woocommerce' ) ) {
 		return;
 	}
@@ -120,21 +130,23 @@ function wc_admin_link_structure() {
 		return;
 	}
 
-	$menu    = $submenu['woocommerce'][ $wc_admin_key ];
-	$menu[2] = 'admin.php?page=wc-admin#/';
-	unset( $submenu['woocommerce'][ $wc_admin_key ] );
+	$menu = $submenu['woocommerce'][ $wc_admin_key ];
 
+	// Move menu item to top of array.
+	unset( $submenu['woocommerce'][ $wc_admin_key ] );
 	array_unshift( $submenu['woocommerce'], $menu );
+
+	// Rename "Analytics" to Overview (otherwise this reads Analytics > Analytics).
 	$submenu['wc-admin#/analytics'][0][0] = __( 'Overview', 'wc-admin' );
 }
 
-// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165
+// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 add_action( 'admin_head', 'wc_admin_link_structure', 20 );
 
 /**
  * Load the assets on the admin pages
  */
-function wc_admin_enqueue_script(){
+function wc_admin_enqueue_script() {
 	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
 		return;
 	}


### PR DESCRIPTION
This PR builds on #297 to give third-parties the ability to register pages in Reports. This is a chain of PRs working towards extensibility in WC Admin, #254 .

First I've refactored the menu registration function to create [a helper that extension devs can use, `wc_admin_register_page`](https://github.com/woocommerce/wc-admin/blob/try/extensions-filter/lib/admin.php#L31-L55). This abstracts away some of the strangeness that comes from having the hash routing, so a 3rd party dev can ignore the `wc-admin#` parts, and can simply register a new menu item like this:

```php
wc_admin_register_page( array(
	'title'  => 'Menu Label'
	'parent' => '/analytics',
	'path'   => '/analytics/new-report',
) );
```

Right now this is only useful for Analytics subpages. My idea is that as wc-admin takes over, we can create different functions for different "parents", like core does with `add_theme_page`/`add_comments_page` etc.

Adding to the menu doesn't handle the react side of things, for that we need to add the report to a new reports list, using a filter. You can read more in [the README for this](https://github.com/woocommerce/wc-admin/blob/try/extensions-filter/client/analytics/report/README.md), which should also serve as docs for 3rd party devs.

The update to each report is due to now adding the Header in the parent `Report`, rather than inside each report itself - this ensures 3rd party reports will always have the Header.

**To test**

- Try my [example extension](https://github.com/woocommerce/wc-admin/files/2288485/wc-example-ext.zip): this adds a menu item to Analytics, a new "report" at `/wp-admin/admin.php?page=wc-admin#/analytics/my-ext`

Future work might add more error-checking against 3rd-party misuse- currently anyone can unregister existing reports, or override them (or maybe that's OK?). We'll want to add some documentation on the components available, and maybe on how to set up webpack.  