### PR TITLE
Connect revenue report table to the API

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -8,6 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import Header from 'layout/header';
 
 export default class extends Component {

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -4,6 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,17 +15,35 @@ import ProductsReport from './products';
 import OrdersReport from './orders/';
 
 class Report extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			previousQuery: props.query,
+		};
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Track the previous query, so we can continue displaying results in reports while updated results are pulled.
+		if ( ! isEqual( prevProps.query, this.props.query ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { previousQuery: prevProps.query } );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+	}
+
 	render() {
 		const { params } = this.props;
+		const { previousQuery } = this.state;
+
 		switch ( params.report ) {
 			case 'revenue':
-				return <RevenueReport { ...this.props } />;
+				return <RevenueReport { ...this.props } previousQuery={ previousQuery } />;
 			case 'products':
-				return <ProductsReport { ...this.props } />;
+				return <ProductsReport { ...this.props } previousQuery={ previousQuery } />;
 			case 'orders':
-				return <OrdersReport { ...this.props } />;
+				return <OrdersReport { ...this.props } previousQuery={ previousQuery } />;
 			default:
-				return <ExampleReport />;
+				return <ExampleReport previousQuery={ previousQuery } />;
 		}
 	}
 }

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -240,6 +240,7 @@ class RevenueReport extends Component {
 			);
 		}
 
+		// TODO Update Error Display
 		if ( isTableDataError ) {
 			return (
 				<div className="woocommerce-analytics__report-table-error">

--- a/client/analytics/report/revenue.js
+++ b/client/analytics/report/revenue.js
@@ -4,9 +4,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import classnames from 'classnames';
 import { format as formatDate } from '@wordpress/date';
 import { map, noop } from 'lodash';
 import PropTypes from 'prop-types';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,7 +20,8 @@ import { getReportData } from 'lib/swagger';
 import Header from 'layout/header';
 import { ReportFilters } from 'components/filters';
 import { SummaryList, SummaryNumber } from 'components/summary';
-import { TableCard } from 'components/table';
+import { TableCard, TableCardPlaceholder } from 'components/table';
+import { isReportDataEmpty, generateReportTableRequest } from 'store/reports/utils';
 
 // Mock data until we fetch from an API
 import rawData from './mock-data';
@@ -71,7 +75,7 @@ class RevenueReport extends Component {
 		return [
 			{
 				label: __( 'Date', 'wc-admin' ),
-				key: 'date_start',
+				key: 'date',
 				required: true,
 				defaultSort: true,
 				isSortable: true,
@@ -142,7 +146,11 @@ class RevenueReport extends Component {
 			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
 			// we need to know which kind of report this is, and parse the `label` to get this row's date
 			const orderLink = (
-				<a href={ getAdminLink( '/edit.php?post_type=shop_order&w=4&year=2018' ) }>
+				<a
+					href={ getAdminLink(
+						'/edit.php?post_type=shop_order&m=' + formatDate( 'Ymd', row.date_start )
+					) }
+				>
 					{ orders_count }
 				</a>
 			);
@@ -212,13 +220,67 @@ class RevenueReport extends Component {
 		];
 	}
 
-	render() {
-		const { path, query } = this.props;
-		const { totals = {}, intervals = [] } = this.state.stats;
-		const summary = this.getSummaryContent( totals ) || [];
-		const rows = this.getRowsContent( intervals ) || [];
+	renderTable() {
+		const {
+			tableData,
+			isTableDataRequesting,
+			isTableDataError,
+			query,
+			previousTableData,
+		} = this.props;
 		const headers = this.getHeadersContent();
 
+		if ( isTableDataRequesting && isReportDataEmpty( previousTableData ) ) {
+			return (
+				<TableCardPlaceholder
+					rows={ 10 }
+					headers={ headers }
+					title={ __( 'Revenue Last Week', 'wc-admin' ) }
+				/>
+			);
+		}
+
+		if ( isTableDataError ) {
+			return (
+				<div className="woocommerce-analytics__report-table-error">
+					{ __( 'There was an error retrieving your revenue summary. Please try again.' ) }
+				</div>
+			);
+		}
+
+		if ( isReportDataEmpty( tableData ) && ! isTableDataRequesting ) {
+			// TODO Return empty content component once it is built.
+			return null;
+		}
+
+		const data = isTableDataRequesting ? previousTableData : tableData;
+		const { totals = {}, intervals = [] } = ( data && data.data ) || {};
+		const { totalResults } = data;
+		const summary = this.getSummaryContent( totals ) || [];
+		const rows = this.getRowsContent( intervals ) || [];
+
+		const className = classnames( 'woocommerce-analytics__report-table-card', {
+			'is-requesting': isTableDataRequesting,
+		} );
+
+		return (
+			<TableCard
+				title={ __( 'Revenue Last Week', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ totalResults }
+				headers={ headers }
+				onClickDownload={ noop }
+				onQueryChange={ this.onQueryChange }
+				query={ query }
+				summary={ summary }
+				className={ className }
+			/>
+		);
+	}
+
+	render() {
+		const { path, query } = this.props;
+		const { totals = {} } = this.state.stats;
 		return (
 			<Fragment>
 				<Header
@@ -251,16 +313,7 @@ class RevenueReport extends Component {
 						label={ __( 'Taxes', 'wc-admin' ) }
 					/>
 				</SummaryList>
-
-				<TableCard
-					title={ __( 'Revenue Last Week', 'wc-admin' ) }
-					rows={ rows }
-					headers={ headers }
-					onClickDownload={ noop }
-					onQueryChange={ this.onQueryChange }
-					query={ query }
-					summary={ summary }
-				/>
+				{ this.renderTable() }
 			</Fragment>
 		);
 	}
@@ -272,4 +325,27 @@ RevenueReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default RevenueReport;
+export default compose(
+	withSelect( ( select, props ) => {
+		const {
+			getReportRevenueStats,
+			isReportRevenueStatsRequesting,
+			isReportRevenueStatsError,
+		} = select( 'wc-admin' );
+		const { query, previousQuery } = props;
+
+		const args = generateReportTableRequest( query );
+
+		const tableData = getReportRevenueStats( args );
+		const isTableDataError = isReportRevenueStatsError( args );
+		const isTableDataRequesting = isReportRevenueStatsRequesting( args );
+		const previousTableData = getReportRevenueStats( generateReportTableRequest( previousQuery ) );
+
+		return {
+			tableData,
+			isTableDataRequesting,
+			isTableDataError,
+			previousTableData,
+		};
+	} )
+)( RevenueReport );

--- a/client/analytics/style.scss
+++ b/client/analytics/style.scss
@@ -1,0 +1,14 @@
+/** @format */
+
+.woocommerce-analytics__report-table-card {
+	&.is-requesting {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background-color: $core-grey-light-100;
+	}
+}
+
+.woocommerce-analytics__report-table-error {
+	background: $white;
+	padding: $gap;
+	border: 1px solid $alert-red;
+}

--- a/client/components/pagination/index.js
+++ b/client/components/pagination/index.js
@@ -153,8 +153,6 @@ class Pagination extends Component {
 						{ value: '50', label: '50' },
 						{ value: '75', label: '75' },
 						{ value: '100', label: '100' },
-						{ value: '250', label: '250' },
-						{ value: '500', label: '500' },
 					] }
 				/>
 			</div>

--- a/client/components/table/README.md
+++ b/client/components/table/README.md
@@ -37,10 +37,11 @@ render: function() {
 * `onClickDownload`: A callback function which handles then "download" button press. Optional, if not used, the button won't appear.
 * `query`: An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
 * `rows` (required): An array of arrays of display/value object pairs (see `Table` props).
+* `totalRows` (required): The total number of results for the query. Used for the Pagination component.
 * `rowHeader`: Which column should be the row header, defaults to the first item (`0`) (see `Table` props).
 * `summary`: An array of objects with `label` & `value` properties, which display in a line under the table. Optional, can be left off to show no summary.
 * `title` (required): The title used in the card header, also used as the caption for the content in this table
-
+* `className`: Additional CSS classes.
 
 `rows`, `headers`, `rowHeader`, and `title` are passed through to `<Table />`. `summary` is passed through as `data` to `<TableSummary />`. `query.page`, `query.per_page`, and `onQueryChange` are passed through to `<Pagination />`.
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -4,6 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 import { IconButton, ToggleControl } from '@wordpress/components';
 import { fill, find, findIndex, first, isArray, noop } from 'lodash';
 import PropTypes from 'prop-types';
@@ -17,6 +18,7 @@ import { EllipsisMenu, MenuItem, MenuTitle } from 'components/ellipsis-menu';
 import Pagination from 'components/pagination';
 import Table from './table';
 import TableSummary from './summary';
+import TableCardPlaceholder from './placeholder';
 
 class TableCard extends Component {
 	constructor( props ) {
@@ -58,7 +60,16 @@ class TableCard extends Component {
 	}
 
 	render() {
-		const { onClickDownload, onQueryChange, query, rowHeader, summary, title } = this.props;
+		const {
+			onClickDownload,
+			onQueryChange,
+			query,
+			rowHeader,
+			summary,
+			title,
+			totalRows,
+			className,
+		} = this.props;
 		const { showCols } = this.state;
 		const allHeaders = this.props.headers;
 		const headers = this.filterCols( this.props.headers );
@@ -66,7 +77,7 @@ class TableCard extends Component {
 
 		return (
 			<Card
-				className="woocommerce-table"
+				className={ classnames( 'woocommerce-table', className ) }
 				title={ title }
 				action={
 					onClickDownload && (
@@ -110,7 +121,7 @@ class TableCard extends Component {
 				<Pagination
 					page={ parseInt( query.page ) || 1 }
 					perPage={ parseInt( query.per_page ) || 25 }
-					total={ 5000 }
+					total={ totalRows }
 					onPageChange={ onQueryChange( 'page' ) }
 					onPerPageChange={ onQueryChange( 'per_page' ) }
 				/>
@@ -141,6 +152,7 @@ TableCard.propTypes = {
 			} )
 		)
 	).isRequired,
+	totalRows: PropTypes.number.isRequired,
 	summary: PropTypes.arrayOf(
 		PropTypes.shape( {
 			label: PropTypes.node,
@@ -148,6 +160,7 @@ TableCard.propTypes = {
 		} )
 	),
 	title: PropTypes.string.isRequired,
+	className: PropTypes.string,
 };
 
 TableCard.defaultProps = {
@@ -157,4 +170,4 @@ TableCard.defaultProps = {
 	rows: [],
 };
 
-export { TableCard, Table, TableSummary };
+export { TableCard, Table, TableSummary, TableCardPlaceholder };

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -29,7 +29,6 @@ class TablePlaceholder extends Component {
 									const thProps = {
 										className: classnames( 'woocommerce-table__header' ),
 									};
-
 									return (
 										<th role="columnheader" scope="col" key={ i } { ...thProps }>
 											{ label }
@@ -40,11 +39,9 @@ class TablePlaceholder extends Component {
 							{ range( rows ).map( i => {
 								return (
 									<tr key={ i }>
-										{ headers.map( ( header, j ) => {
-											const Cell = 0 === j ? 'th' : 'td';
-											const cellClasses = classnames( 'woocommerce-table__item' );
-											return <Cell scope="row" key={ j } className={ cellClasses } />;
-										} ) }
+										{ headers.map( ( header, j ) => (
+											<td key={ j } className="woocommerce-table__item" />
+										) ) }
 									</tr>
 								);
 							} ) }

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -1,0 +1,76 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import classnames from 'classnames';
+import { range } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+class TablePlaceholder extends Component {
+	render() {
+		const { classNames, headers, title, rows } = this.props;
+		return (
+			<Card
+				className={ classnames( 'woocommerce-table is-placeholder', classNames ) }
+				title={ title }
+			>
+				<div className="woocommerce-table__table">
+					<table>
+						<tbody>
+							<tr>
+								{ headers.map( ( header, i ) => {
+									const { label } = header;
+									const thProps = {
+										className: classnames( 'woocommerce-table__header' ),
+									};
+
+									return (
+										<th role="columnheader" scope="col" key={ i } { ...thProps }>
+											{ label }
+										</th>
+									);
+								} ) }
+							</tr>
+							{ range( rows ).map( i => {
+								return (
+									<tr key={ i }>
+										{ headers.map( ( header, j ) => {
+											const Cell = 0 === j ? 'th' : 'td';
+											const cellClasses = classnames( 'woocommerce-table__item' );
+											return <Cell scope="row" key={ j } className={ cellClasses } />;
+										} ) }
+									</tr>
+								);
+							} ) }
+						</tbody>
+					</table>
+				</div>
+			</Card>
+		);
+	}
+}
+
+TablePlaceholder.propTypes = {
+	headers: PropTypes.arrayOf(
+		PropTypes.shape( {
+			defaultSort: PropTypes.bool,
+			isSortable: PropTypes.bool,
+			key: PropTypes.string,
+			label: PropTypes.string,
+			required: PropTypes.bool,
+		} )
+	),
+	rows: PropTypes.number.isRequired,
+};
+
+TablePlaceholder.defaultProps = {
+	headers: [],
+};
+
+export default TablePlaceholder;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -10,6 +10,11 @@
 	.woocommerce-card__menu {
 		justify-self: flex-end;
 	}
+
+	&.is-placeholder {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background-color: $core-grey-light-200;
+	}
 }
 
 .woocommerce-table__caption {

--- a/client/store/reports/revenue/stats/actions.js
+++ b/client/store/reports/revenue/stats/actions.js
@@ -1,10 +1,11 @@
 /** @format */
 
 export default {
-	setReportRevenueStats( report, query ) {
+	setReportRevenueStats( query, report, totalResults ) {
 		return {
 			type: 'SET_REPORT_REVENUE_STATS',
 			report,
+			totalResults,
 			query: query || {},
 		};
 	},

--- a/client/store/reports/revenue/stats/reducer.js
+++ b/client/store/reports/revenue/stats/reducer.js
@@ -9,6 +9,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { ERROR } from 'store/constants';
+import { serializeQuery } from 'store/utils';
 
 const DEFAULT_STATE = {
 	queries: {},
@@ -17,11 +18,14 @@ const DEFAULT_STATE = {
 export default function reportRevenueStatsReducer( state = DEFAULT_STATE, action ) {
 	if ( 'SET_REPORT_REVENUE_STATS' === action.type ) {
 		const prevQueries = get( state, 'queries', {} );
-		const query = JSON.stringify( action.query, Object.keys( action.query ).sort() );
+		const query = serializeQuery( action.query );
 		const queries = {
 			...prevQueries,
 			[ query ]: {
-				...action.report,
+				data: {
+					...action.report,
+				},
+				totalResults: action.totalResults,
 			},
 		};
 
@@ -33,7 +37,7 @@ export default function reportRevenueStatsReducer( state = DEFAULT_STATE, action
 
 	if ( 'SET_REPORT_REVENUE_STATS_ERROR' === action.type ) {
 		const prevQueries = get( state, 'queries', {} );
-		const query = JSON.stringify( action.query, Object.keys( action.query ).sort() );
+		const query = serializeQuery( action.query );
 		const queries = {
 			...prevQueries,
 			[ query ]: ERROR,

--- a/client/store/reports/revenue/stats/resolvers.js
+++ b/client/store/reports/revenue/stats/resolvers.js
@@ -15,10 +15,13 @@ import { NAMESPACE } from 'store/constants';
 export default {
 	async getReportRevenueStats( state, query ) {
 		try {
-			const report = await apiFetch( {
+			const response = await apiFetch( {
 				path: NAMESPACE + 'reports/revenue/stats' + stringifyQuery( query ),
+				parse: false,
 			} );
-			dispatch( 'wc-admin' ).setReportRevenueStats( report, query );
+			const report = await response.json();
+			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
+			dispatch( 'wc-admin' ).setReportRevenueStats( query, report, totalResults );
 		} catch ( error ) {
 			dispatch( 'wc-admin' ).setReportRevenueStatsError( query );
 		}

--- a/client/store/reports/revenue/stats/selectors.js
+++ b/client/store/reports/revenue/stats/selectors.js
@@ -10,6 +10,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { ERROR } from 'store/constants';
+import { serializeQuery } from 'store/utils';
 
 /**
  * Returns revenue report details for a specific report query.
@@ -20,8 +21,7 @@ import { ERROR } from 'store/constants';
  */
 function getReportRevenueStats( state, query ) {
 	const queries = get( state, 'reports.revenue.stats.queries', {} );
-	const _query = query || {};
-	return queries[ JSON.stringify( _query, Object.keys( _query ).sort() ) ] || null;
+	return queries[ serializeQuery( query || {} ) ] || null;
 }
 
 export default {

--- a/client/store/reports/revenue/stats/test/reducer.js
+++ b/client/store/reports/revenue/stats/test/reducer.js
@@ -38,9 +38,13 @@ describe( 'reportsRevenueStatsReducer()', () => {
 			type: 'SET_REPORT_REVENUE_STATS',
 			query,
 			report,
+			totalResults: 3,
 		} );
 
-		expect( state.queries[ JSON.stringify( query ) ] ).toEqual( report );
+		expect( state.queries[ JSON.stringify( query ) ] ).toEqual( {
+			data: { ...report },
+			totalResults: 3,
+		} );
 	} );
 
 	it( 'returns with received error data', () => {

--- a/client/store/reports/revenue/stats/test/selectors.js
+++ b/client/store/reports/revenue/stats/test/selectors.js
@@ -35,20 +35,20 @@ describe( 'getReportRevenueStats()', () => {
 				orders_count: 10,
 				num_items_sold: 9,
 			},
-			interval: [ 0, 1, 2 ],
+			intervals: [ 0, 1, 2 ],
 		};
 		const state = deepFreeze( {
 			reports: {
 				revenue: {
 					stats: {
 						queries: {
-							'{}': { ...report },
+							'{}': { data: { ...report } },
 						},
 					},
 				},
 			},
 		} );
-		expect( getReportRevenueStats( state ) ).toEqual( report );
+		expect( getReportRevenueStats( state ) ).toEqual( { data: { ...report } } );
 	} );
 } );
 

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -1,0 +1,35 @@
+/*
+* @format
+*/
+
+/**
+ * Internal dependencies
+ */
+import { isReportDataEmpty } from '../utils';
+
+describe( 'isReportRevenueStatsEmpty()', () => {
+	it( 'returns false if report is valid', () => {
+		const report = {
+			data: {
+				totals: {
+					orders_count: 10,
+					num_items_sold: 9,
+				},
+				intervals: [ 0, 1, 2 ],
+			},
+		};
+		expect( isReportDataEmpty( report ) ).toEqual( false );
+	} );
+	it( 'returns true if report object is undefined', () => {
+		expect( isReportDataEmpty( undefined ) ).toEqual( true );
+	} );
+	it( 'returns true if data response object is missing', () => {
+		expect( isReportDataEmpty( {} ) ).toEqual( true );
+	} );
+	it( 'returns true if totals response object is missing', () => {
+		expect( isReportDataEmpty( { data: {} } ) ).toEqual( true );
+	} );
+	it( 'returns true if intervals response object is empty', () => {
+		expect( isReportDataEmpty( { data: { intervals: [], totals: 2 } } ) ).toEqual( true );
+	} );
+} );

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNull } from 'lodash';
+
+/**
+ * Returns true if a revenue report object is empty.
+ *
+ * @param  {Object} report  Report to check
+ * @return {Boolean}        True if report is data is empty.
+ */
+export function isReportDataEmpty( report ) {
+	if ( ! report ) {
+		return true;
+	}
+
+	if ( ! report.data ) {
+		return true;
+	}
+
+	if ( ! report.data.totals || isNull( report.data.totals ) ) {
+		return true;
+	}
+
+	if ( ! report.data.intervals || 0 === report.data.intervals.length ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Returns a set of API request args for getting table data based on a query string.
+ *
+ * @param  {Object} query   Query object.
+ * @return {Object}         Object containing API request args for report endpoints.
+ */
+export function generateReportTableRequest( query ) {
+	return {
+		interval: 'day',
+		orderby: query.orderby || 'date',
+		order: query.order || 'desc',
+		page: query.page || 1,
+		per_page: query.per_page || 25,
+	};
+}

--- a/client/store/utils.js
+++ b/client/store/utils.js
@@ -1,0 +1,5 @@
+/** @format */
+
+export function serializeQuery( query ) {
+	return JSON.stringify( query, Object.keys( query ).sort() );
+}

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -20,13 +20,13 @@
 // Set up animation
 @keyframes loading-fade {
 	0% {
-		opacity: 0.7;
+		opacity: 0.5;
 	}
 	50% {
 		opacity: 1;
 	}
 	100% {
-		opacity: 0.7;
+		opacity: 0.5;
 	}
 }
 


### PR DESCRIPTION
This is a part of #225.

It connects the table part of the revenue report up to the API. You can page through the summary results and reorder columns. Other elements on the report are still hooked up to the swagger API. More to come later.

<img width="1047" alt="screen shot 2018-08-15 at 1 17 25 pm" src="https://user-images.githubusercontent.com/689165/44162573-ba86d980-a08e-11e8-80e5-262bc89a595d.png">

To Test:
* run `npm test` and make sure all tests pass
* Before testing on your site, you may want to generate a number of orders. You can use [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator) to do this. A PR of mine was just merged that allows you some control over date ranges for the generated orders. See the [README](https://github.com/woocommerce/wc-smooth-generator/blob/master/README.md#orders) for an example.
* Pull the latest WooCommerce v3 API from `feature/rest-api-v3-reports` (you might need to deactivate `wc-api-dev`).
* You need to deactivate and reactivate WooCommerce to get the correct summary MySQL tables. There is also a tool under system settings to rebuild the summary tables.
* Visit the revenue report.
* Test reordering columns, paging results, etc.



