### PR TITLE
Table Component: Apply scope only to the row headers

### DIFF
--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -127,12 +127,13 @@ class Table extends Component {
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
 									const { isNumeric } = headers[ j ];
-									const Cell = rowHeader === j ? 'th' : 'td';
+									const isHeader = rowHeader === j;
+									const Cell = isHeader ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {
 										'is-numeric': isNumeric,
 									} );
 									return (
-										<Cell scope="row" key={ j } className={ cellClasses }>
+										<Cell scope={ isHeader ? 'row' : null } key={ j } className={ cellClasses }>
 											{ getDisplay( cell ) }
 										</Cell>
 									);


### PR DESCRIPTION
The `scope` attribute should only apply to row headers, `th`s – as it's meant to indicate which item in the row is the label for all other cells. 

**To test**

- Load a page with a table, `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
- Inspect element to check that scope is only applied to one cell per row, the `th`.