### PR TITLE
Dashboard: Use isNumeric in Top Selling Products.

### DIFF
--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -33,18 +33,21 @@ class TopSellingProducts extends Component {
 				key: 'items_sold',
 				required: false,
 				isSortable: false,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Orders', 'wc-admin' ),
 				key: 'orders_count',
 				required: false,
 				isSortable: false,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Gross Revenue', 'wc-admin' ),
 				key: 'gross_revenue',
 				required: true,
 				isSortable: false,
+				isNumeric: true,
 			},
 		];
 	}


### PR DESCRIPTION
Super quick PR to add in the new `isNumeric` prop to the headers in the Top Selling Products block on the dashboard:

__Before__
![dashboard woo test woocommerce 2018-08-16 16-37-12](https://user-images.githubusercontent.com/22080/44240568-a8cb3200-a173-11e8-8f4b-76b1b31f15b8.png)

__After__
![dashboard woo test woocommerce 2018-08-16 16-43-57](https://user-images.githubusercontent.com/22080/44240572-ad8fe600-a173-11e8-90aa-11b8e50040e3.png)
