### PR TITLE
Revenue Report: Use href on SummaryNumber components.

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import Card from 'components/card';
 import Chart from 'components/chart';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { getAdminLink, updateQueryString } from 'lib/nav-utils';
+import { getAdminLink, getNewPath, updateQueryString } from 'lib/nav-utils';
 import { getReportData } from 'lib/swagger';
 import Header from 'layout/header';
 import { ReportFilters } from 'components/filters';
@@ -250,9 +250,7 @@ class RevenueReport extends Component {
 					break;
 			}
 
-			const onClick = () => {
-				this.onQueryChange( 'chart' )( key );
-			};
+			const href = getNewPath( { chart: key } );
 
 			return (
 				<SummaryNumber
@@ -261,7 +259,7 @@ class RevenueReport extends Component {
 					label={ label }
 					selected={ isSelected }
 					delta={ 0 }
-					onToggle={ onClick }
+					href={ href }
 				/>
 			);
 		} );


### PR DESCRIPTION
This is a quick follow-up to #304 - where @ryelle kindly let me know I should have used a simple `href` prop on the Summary Number items! I have a way of taking the harder path whenever possible 🤦‍♂️ 

__To Test__
- Open up the Revenue Report
- Click on the Summary Numbers to verify the chart changes as expected
- Open up the date picker and set some dates to have additional query params
- Click on a Summary Number again and verify all query args are preserved and the chart is still updated