### PR TITLE
Store: Add generic reports stats support.

### DIFF
--- a/client/store/reports/index.js
+++ b/client/store/reports/index.js
@@ -10,18 +10,23 @@ import { combineReducers } from 'redux';
  */
 
 import revenue from './revenue';
+import stats from './stats';
 
 export default {
 	reducer: combineReducers( {
 		revenue: revenue.reducer,
+		stats: stats.reducer,
 	} ),
 	actions: {
 		...revenue.actions,
+		...stats.actions,
 	},
 	selectors: {
 		...revenue.selectors,
+		...stats.selectors,
 	},
 	resolvers: {
 		...revenue.resolvers,
+		...stats.resolvers,
 	},
 };

--- a/client/store/reports/stats/actions.js
+++ b/client/store/reports/stats/actions.js
@@ -1,0 +1,19 @@
+/** @format */
+
+export default {
+	setReportStats( endpoint, report, query ) {
+		return {
+			type: 'SET_REPORT_STATS',
+			endpoint,
+			report,
+			query: query || {},
+		};
+	},
+	setReportStatsError( endpoint, query ) {
+		return {
+			type: 'SET_REPORT_STATS_ERROR',
+			endpoint,
+			query: query || {},
+		};
+	},
+};

--- a/client/store/reports/stats/index.js
+++ b/client/store/reports/stats/index.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import actions from './actions';
+import selectors from './selectors';
+import resolvers from './resolvers';
+
+export default {
+	actions,
+	selectors,
+	resolvers,
+};

--- a/client/store/reports/stats/index.js
+++ b/client/store/reports/stats/index.js
@@ -5,10 +5,12 @@
  */
 import actions from './actions';
 import selectors from './selectors';
+import reducer from './reducer';
 import resolvers from './resolvers';
 
 export default {
 	actions,
 	selectors,
+	reducer,
 	resolvers,
 };

--- a/client/store/reports/stats/reducer.js
+++ b/client/store/reports/stats/reducer.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getQueryKey } from 'store/util';
+
+const DEFAULT_STATE = {};
+
+export default function reportStatsReducer( state = DEFAULT_STATE, action ) {
+	if ( 'SET_REPORT_STATS' === action.type ) {
+		const queryKey = getQueryKey( action.query );
+		return merge( {}, state, {
+			[ action.endpoint ]: {
+				[ queryKey ]: action.report,
+			},
+		} );
+	}
+
+	if ( 'SET_REPORT_STATS_ERROR' === action.type ) {
+		const queryKey = getQueryKey( action.query );
+		return merge( {}, state, {
+			[ action.endpoint ]: {
+				[ queryKey ]: ERROR,
+			},
+		} );
+	}
+
+	return state;
+}

--- a/client/store/reports/stats/reducer.js
+++ b/client/store/reports/stats/reducer.js
@@ -9,13 +9,13 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import { ERROR } from 'store/constants';
-import { getQueryKey } from 'store/util';
+import { getJsonString } from 'store/util';
 
 const DEFAULT_STATE = {};
 
 export default function reportStatsReducer( state = DEFAULT_STATE, action ) {
 	if ( 'SET_REPORT_STATS' === action.type ) {
-		const queryKey = getQueryKey( action.query );
+		const queryKey = getJsonString( action.query );
 		return merge( {}, state, {
 			[ action.endpoint ]: {
 				[ queryKey ]: action.report,
@@ -24,7 +24,7 @@ export default function reportStatsReducer( state = DEFAULT_STATE, action ) {
 	}
 
 	if ( 'SET_REPORT_STATS_ERROR' === action.type ) {
-		const queryKey = getQueryKey( action.query );
+		const queryKey = getJsonString( action.query );
 		return merge( {}, state, {
 			[ action.endpoint ]: {
 				[ queryKey ]: ERROR,

--- a/client/store/reports/stats/resolvers.js
+++ b/client/store/reports/stats/resolvers.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+const { apiFetch } = wp;
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { stringifyQuery } from 'lib/nav-utils';
+import { NAMESPACE } from 'store/constants';
+
+export default {
+	async getReportStats( state, endpoint, query ) {
+		try {
+			const report = await apiFetch( {
+				path: NAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query ),
+			} );
+			dispatch( 'wc-admin' ).setReportStats( endpoint, report, query );
+		} catch ( error ) {
+			dispatch( 'wc-admin' ).setReportStatsError( endpoint, query );
+		}
+	},
+};

--- a/client/store/reports/stats/resolvers.js
+++ b/client/store/reports/stats/resolvers.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-const { apiFetch } = wp;
+import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 
 /**
@@ -14,9 +14,16 @@ import { NAMESPACE } from 'store/constants';
 
 export default {
 	async getReportStats( state, endpoint, query ) {
+		const statEndpoints = [ 'orders', 'revenue', 'products' ];
+		let apiPath = endpoint;
+
+		if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
+			apiPath = NAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
+		}
+
 		try {
 			const report = await apiFetch( {
-				path: NAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query ),
+				path: apiPath,
 			} );
 			dispatch( 'wc-admin' ).setReportStats( endpoint, report, query );
 		} catch ( error ) {

--- a/client/store/reports/stats/selectors.js
+++ b/client/store/reports/stats/selectors.js
@@ -10,6 +10,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/util';
 
 /**
  * Returns report stats details for a specific endpoint query.
@@ -19,10 +20,9 @@ import { ERROR } from 'store/constants';
  * @param  {Object} query     Report query paremters
  * @return {Object}           Report details
  */
-function getReportStats( state, endpoint, query ) {
+function getReportStats( state, endpoint, query = {} ) {
 	const queries = get( state, [ 'reports', 'stats', endpoint ], {} );
-	const _query = query || {};
-	return queries[ JSON.stringify( _query, Object.keys( _query ).sort() ) ] || null;
+	return queries[ getJsonString( query ) ] || null;
 }
 
 export default {

--- a/client/store/reports/stats/selectors.js
+++ b/client/store/reports/stats/selectors.js
@@ -1,0 +1,52 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+
+/**
+ * Returns report stats details for a specific endpoint query.
+ *
+ * @param  {Object} state     Current state
+ * @param  {String} endpoint  Stats endpoint
+ * @param  {Object} query     Report query paremters
+ * @return {Object}           Report details
+ */
+function getReportStats( state, endpoint, query ) {
+	const queries = get( state, [ 'reports', 'stats', endpoint ], {} );
+	const _query = query || {};
+	return queries[ JSON.stringify( _query, Object.keys( _query ).sort() ) ] || null;
+}
+
+export default {
+	getReportStats,
+
+	/**
+	 * Returns true if a stat query is pending.
+	 *
+	 * @param  {Object} state  Current state
+	 * @return {Boolean}        True if the `getReportRevenueStats` request is pending, false otherwise
+	 */
+	isReportStatsRequesting( state, ...args ) {
+		return select( 'core/data' ).isResolving( 'wc-admin', 'getReportStats', args );
+	},
+
+	/**
+	 * Returns true if a report stat request has returned an error.
+	 *
+	 * @param  {Object} state     Current state
+	 * @param  {String} endpoint  Stats endpoint
+	 * @param  {Object} query     Report query paremters
+	 * @return {Boolean}          True if the `getReportStats` request has failed, false otherwise
+	 */
+	isReportStatsError( state, endpoint, query ) {
+		return ERROR === getReportStats( state, endpoint, query );
+	},
+};

--- a/client/store/reports/stats/test/reducer.js
+++ b/client/store/reports/stats/test/reducer.js
@@ -12,7 +12,7 @@ import deepFreeze from 'deep-freeze';
  */
 import { ERROR } from 'store/constants';
 import reportStatsReducer from '../reducer';
-import { getQueryKey } from 'store/util';
+import { getJsonString } from 'store/util';
 
 describe( 'reportStatsReducer()', () => {
 	it( 'returns an empty data object by default', () => {
@@ -43,17 +43,17 @@ describe( 'reportStatsReducer()', () => {
 			report,
 		} );
 
-		const queryKey = getQueryKey( query );
+		const queryKey = getJsonString( query );
 		expect( state[ endpoint ][ queryKey ] ).toEqual( report );
 	} );
 
-	it( 'tracks multiple queries per enpdoint in report data', () => {
+	it( 'tracks multiple queries per endpoint in report data', () => {
 		const otherQuery = {
 			after: '2018-01-04T00:00:00+00:00',
 			before: '2018-07-14T00:00:00+00:00',
 			interval: 'week',
 		};
-		const otherQueryKey = getQueryKey( otherQuery );
+		const otherQueryKey = getJsonString( otherQuery );
 		const otherQueryState = {
 			revenue: {
 				[ otherQueryKey ]: { totals: 1000 },
@@ -81,9 +81,48 @@ describe( 'reportStatsReducer()', () => {
 			report,
 		} );
 
-		const queryKey = getQueryKey( query );
+		const queryKey = getJsonString( query );
 		expect( state[ endpoint ][ queryKey ] ).toEqual( report );
 		expect( state[ endpoint ][ otherQueryKey ].totals ).toEqual( 1000 );
+	} );
+
+	it( 'tracks multiple endpoints in report data', () => {
+		const productsQuery = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'week',
+		};
+		const productsQueryKey = getJsonString( productsQuery );
+		const productsQueryState = {
+			products: {
+				[ productsQueryKey ]: { totals: 1999 },
+			},
+		};
+		const originalState = deepFreeze( productsQueryState );
+		const query = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'day',
+		};
+		const report = {
+			totals: {
+				orders_count: 10,
+				num_items_sold: 9,
+			},
+			interval: [ 0, 1, 2 ],
+		};
+		const endpoint = 'revenue';
+
+		const state = reportStatsReducer( originalState, {
+			type: 'SET_REPORT_STATS',
+			endpoint,
+			query,
+			report,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( report );
+		expect( state.products[ productsQueryKey ].totals ).toEqual( 1999 );
 	} );
 
 	it( 'returns with received error data', () => {
@@ -101,7 +140,7 @@ describe( 'reportStatsReducer()', () => {
 			query,
 		} );
 
-		const queryKey = getQueryKey( query );
+		const queryKey = getJsonString( query );
 		expect( state[ endpoint ][ queryKey ] ).toEqual( ERROR );
 	} );
 } );

--- a/client/store/reports/stats/test/reducer.js
+++ b/client/store/reports/stats/test/reducer.js
@@ -1,0 +1,107 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import reportStatsReducer from '../reducer';
+import { getQueryKey } from 'store/util';
+
+describe( 'reportStatsReducer()', () => {
+	it( 'returns an empty data object by default', () => {
+		const state = reportStatsReducer( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received report data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'day',
+		};
+		const report = {
+			totals: {
+				orders_count: 10,
+				num_items_sold: 9,
+			},
+			interval: [ 0, 1, 2 ],
+		};
+		const endpoint = 'revenue';
+
+		const state = reportStatsReducer( originalState, {
+			type: 'SET_REPORT_STATS',
+			endpoint,
+			query,
+			report,
+		} );
+
+		const queryKey = getQueryKey( query );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( report );
+	} );
+
+	it( 'tracks multiple queries per enpdoint in report data', () => {
+		const otherQuery = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'week',
+		};
+		const otherQueryKey = getQueryKey( otherQuery );
+		const otherQueryState = {
+			revenue: {
+				[ otherQueryKey ]: { totals: 1000 },
+			},
+		};
+		const originalState = deepFreeze( otherQueryState );
+		const query = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'day',
+		};
+		const report = {
+			totals: {
+				orders_count: 10,
+				num_items_sold: 9,
+			},
+			interval: [ 0, 1, 2 ],
+		};
+		const endpoint = 'revenue';
+
+		const state = reportStatsReducer( originalState, {
+			type: 'SET_REPORT_STATS',
+			endpoint,
+			query,
+			report,
+		} );
+
+		const queryKey = getQueryKey( query );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( report );
+		expect( state[ endpoint ][ otherQueryKey ].totals ).toEqual( 1000 );
+	} );
+
+	it( 'returns with received error data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			after: '2018-01-04T00:00:00+00:00',
+			before: '2018-07-14T00:00:00+00:00',
+			interval: 'day',
+		};
+		const endpoint = 'revenue';
+
+		const state = reportStatsReducer( originalState, {
+			type: 'SET_REPORT_STATS_ERROR',
+			endpoint,
+			query,
+		} );
+
+		const queryKey = getQueryKey( query );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( ERROR );
+	} );
+} );

--- a/client/store/reports/stats/test/resolvers.js
+++ b/client/store/reports/stats/test/resolvers.js
@@ -1,0 +1,62 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import resolvers from '../resolvers';
+
+const { getReportStats } = resolvers;
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'getReportStats', () => {
+	const REPORT_1 = {
+		totals: {
+			orders_count: 10,
+			num_items_sold: 9,
+		},
+		interval: [ 0, 1, 2 ],
+	};
+
+	const REPORT_2 = {
+		totals: {
+			orders_count: 5,
+			items_sold: 5,
+			gross_revenue: 999.99,
+		},
+		intervals: [
+			{
+				interval: 'week',
+				subtotals: {},
+			},
+		],
+	};
+
+	beforeAll( () => {
+		apiFetch.mockImplementation( options => {
+			if ( options.path === '/wc/v3/reports/revenue/stats' ) {
+				return Promise.resolve( REPORT_1 );
+			}
+			if ( options.path === '/wc/v3/reports/products/stats?interval=week' ) {
+				return Promise.resolve( REPORT_2 );
+			}
+		} );
+	} );
+
+	it( 'returns requested report data', async () => {
+		getReportStats( 'revenue' ).then( data => expect( data ).toEqual( REPORT_1 ) );
+	} );
+
+	it( 'returns requested report data for a specific query', async () => {
+		getReportStats( 'products', { interval: 'week' } ).then( data =>
+			expect( data ).toEqual( REPORT_2 )
+		);
+	} );
+} );

--- a/client/store/reports/stats/test/selectors.js
+++ b/client/store/reports/stats/test/selectors.js
@@ -1,0 +1,102 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import selectors from '../selectors';
+import { select } from '@wordpress/data';
+
+const { getReportStats, isReportStatsRequesting, isReportStatsError } = selectors;
+jest.mock( '@wordpress/data', () => ( {
+	...require.requireActual( '@wordpress/data' ),
+	select: jest.fn().mockReturnValue( {} ),
+} ) );
+
+const endpointName = 'revenue';
+
+describe( 'getReportStats()', () => {
+	it( 'returns null when no report data is available', () => {
+		const state = deepFreeze( {} );
+		expect( getReportStats( state, endpointName ) ).toEqual( null );
+	} );
+	it( 'returns stored report information by endpoint and query combination', () => {
+		const report = {
+			totals: {
+				orders_count: 10,
+				num_items_sold: 9,
+			},
+			interval: [ 0, 1, 2 ],
+		};
+		const state = deepFreeze( {
+			reports: {
+				stats: {
+					revenue: {
+						'{}': { ...report },
+					},
+				},
+			},
+		} );
+		expect( getReportStats( state, endpointName ) ).toEqual( report );
+	} );
+} );
+
+describe( 'isReportStatsRequesting()', () => {
+	beforeAll( () => {
+		select( 'core/data' ).isResolving = jest.fn().mockReturnValue( false );
+	} );
+
+	afterAll( () => {
+		select( 'core/data' ).isResolving.mockRestore();
+	} );
+
+	function setIsResolving( isResolving ) {
+		select( 'core/data' ).isResolving.mockImplementation(
+			( reducerKey, selectorName ) =>
+				isResolving && reducerKey === 'wc-admin' && selectorName === 'getReportStats'
+		);
+	}
+
+	it( 'returns false if never requested', () => {
+		const result = isReportStatsRequesting( endpointName );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if request finished', () => {
+		setIsResolving( false );
+		const result = isReportStatsRequesting( endpointName );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		setIsResolving( true );
+		const result = isReportStatsRequesting( endpointName );
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isReportStatsError()', () => {
+	it( 'returns false by default', () => {
+		const state = deepFreeze( {} );
+		expect( isReportStatsError( state, endpointName ) ).toEqual( false );
+	} );
+	it( 'returns true if ERROR constant is found', () => {
+		const state = deepFreeze( {
+			reports: {
+				stats: {
+					revenue: {
+						'{}': ERROR,
+					},
+				},
+			},
+		} );
+		expect( isReportStatsError( state, endpointName ) ).toEqual( true );
+	} );
+} );

--- a/client/store/util.js
+++ b/client/store/util.js
@@ -1,7 +1,8 @@
+/** @format */
+
 /**
  * Returns a string representation of a sorted query object.
  *
- * @format
  * @param {Object} query Current state
  * @return {String}       Query Key
  */

--- a/client/store/util.js
+++ b/client/store/util.js
@@ -6,6 +6,6 @@
  * @return {String}       Query Key
  */
 
-export function getQueryKey( query = {} ) {
+export function getJsonString( query = {} ) {
 	return JSON.stringify( query, Object.keys( query ).sort() );
 }

--- a/client/store/util.js
+++ b/client/store/util.js
@@ -1,0 +1,11 @@
+/**
+ * Returns a string representation of a sorted query object.
+ *
+ * @format
+ * @param {Object} query Current state
+ * @return {String}       Query Key
+ */
+
+export function getQueryKey( query = {} ) {
+	return JSON.stringify( query, Object.keys( query ).sort() );
+}


### PR DESCRIPTION
Background: p90Yrv-LX-p2

This PR is very much nearly a copy/paste of @justinshreve's fine work he already shipped to add data layer support for the revenue/stats enpdoint - but it just adds in the ability to use the same logic against any of the `wc/v3/%endpoint%/stats` endpoints.

If this approach looks good, it can replace the existing logic that is being used in the Revenue report, and it will also allow building out of the "Top Products" block on the dashboard page, and also be used in various upcoming report issues.

__To Test__
- No functionality changes introduced in this PR. Just ensure the test suite is passing `npm test client/store/reports/stats`