### PR TITLE
Filters: Add path & query back to filter props

### DIFF
--- a/client/components/filters/README.md
+++ b/client/components/filters/README.md
@@ -7,14 +7,20 @@ Add a collection of report filters to a page. This uses `DatePicker` & `FilterPi
 
 ```jsx
 // For just DatePicker…
-<ReportFilters />
+<ReportFilters path={ path } query={ query } />
 
 // To add FilterPicker too, pass through filter config:
 <ReportFilters
 	filters={ filters }
-	filterPaths={ filterPaths } />
+	filterPaths={ filterPaths }
+	path={ path }
+	query={ query } />
 ```
 
 - `advancedConfig`: Config option passed through to `AdvancedFilters`
 - `filters`: Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 - `filterPaths`: Config option passed through to `FilterPicker`
+- `path` (required): The `path` parameter supplied by React-Router
+- `query`: The query string represented in object form
+
+`path` & `query` are passed through to the individual filter components.

--- a/client/components/filters/advanced/README.md
+++ b/client/components/filters/advanced/README.md
@@ -50,6 +50,9 @@ render: function() {
 ## AdvancedFilters Props
 
 * `config` (required): The configuration object required to render filters
+* `filterTitle` (required): Name of this filter, used in translations
+* `path` (required): The `path` parameter supplied by React-Router
+* `query`: The query string represented in object form
 
 ## config object jsDoc
 

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -233,6 +233,12 @@ class AdvancedFilters extends Component {
 AdvancedFilters.propTypes = {
 	config: PropTypes.object.isRequired,
 	filterTitle: PropTypes.string.isRequired,
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object,
+};
+
+AdvancedFilters.defaultProps = {
+	query: {},
 };
 
 export default AdvancedFilters;

--- a/client/components/filters/date/README.md
+++ b/client/components/filters/date/README.md
@@ -6,16 +6,18 @@ Select a range of dates or single dates
 ## Usage
 
 ```jsx
-<DatePicker key={ JSON.stringify( query ) } />
+<DatePicker key={ JSON.stringify( query ) } path={ path } query={ query } />
 ```
 
 ### Props
 
 Required props are marked with `*`.
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`key`| `*` | none |  Force a recalculation or reset of internal state when this key changes. Useful for a url change, for instance
+Name    | Type     | Default | Description
+------- | -------- | ------- | ---
+`key`*  | string   | none    |  Force a recalculation or reset of internal state when this key changes. Useful for a url change, for instance
+`path`* | `string` | none    | The `path` parameter supplied by React-Router
+`query` | `object` | `{}`    | The query string represented in object form
 
 ## URL as the source of truth
 

--- a/client/components/filters/date/index.js
+++ b/client/components/filters/date/index.js
@@ -2,9 +2,10 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { Dropdown } from '@wordpress/components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import { Dropdown } from '@wordpress/components';
 import DatePickerContent from './content';
 import DropdownButton from 'components/dropdown-button';
 import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
-import { getQuery, updateQueryString } from 'lib/nav-utils';
+import { updateQueryString } from 'lib/nav-utils';
 import './style.scss';
 
 const shortDateFormat = __( 'MM/DD/YYYY', 'wc-admin' );
@@ -29,7 +30,7 @@ class DatePicker extends Component {
 	}
 
 	getResetState() {
-		const { period, compare, before, after } = getDateParamsFromQuery( getQuery() );
+		const { period, compare, before, after } = getDateParamsFromQuery( this.props.query );
 		return {
 			period,
 			compare,
@@ -48,6 +49,7 @@ class DatePicker extends Component {
 	}
 
 	onSelect( selectedTab, onClose ) {
+		const { path, query } = this.props;
 		return event => {
 			const { period, compare, after, before } = this.state;
 			const data = {
@@ -58,13 +60,13 @@ class DatePicker extends Component {
 				data.after = after ? after.format( isoDateFormat ) : '';
 				data.before = before ? before.format( isoDateFormat ) : '';
 			}
-			updateQueryString( data );
+			updateQueryString( data, path, query );
 			onClose( event );
 		};
 	}
 
 	getButtonLabel() {
-		const { primary, secondary } = getCurrentDates( getQuery() );
+		const { primary, secondary } = getCurrentDates( this.props.query );
 		return [
 			`${ primary.label } (${ primary.range })`,
 			`${ __( 'vs.', 'wc-admin' ) } ${ secondary.label } (${ secondary.range })`,
@@ -141,5 +143,14 @@ class DatePicker extends Component {
 		);
 	}
 }
+
+DatePicker.propTypes = {
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object,
+};
+
+DatePicker.defaultProps = {
+	query: {},
+};
 
 export default DatePicker;

--- a/client/components/filters/filter/README.md
+++ b/client/components/filters/filter/README.md
@@ -40,6 +40,8 @@ const renderFilterPicker = () => {
 		<FilterPicker
 			filters={ filters }
 			filterPaths={ filterPaths }
+			path={ path }
+			query={ query }
 		/>
 	);
 }
@@ -49,3 +51,5 @@ const renderFilterPicker = () => {
 
 * `filters` (required): An array of filters and subFilters to construct the menu
 * `filterPaths` (required): A map of representing the structure of the tree. Required for faster lookups than searches
+* `path` (required): The `path` parameter supplied by React-Router
+* `query`: The query string represented in object form

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
  */
 import AnimationSlider from 'components/animation-slider';
 import DropdownButton from 'components/dropdown-button';
-import { getQuery, updateQueryString } from 'lib/nav-utils';
+import { updateQueryString } from 'lib/nav-utils';
 import './style.scss';
 
 export const DEFAULT_FILTER = 'all';
@@ -25,7 +25,7 @@ class FilterPicker extends Component {
 
 		const { filterPaths } = props;
 		this.state = {
-			nav: filterPaths[ this.getFilterValue() ],
+			nav: filterPaths[ this.getFilterValue( props ) ],
 			animate: null,
 		};
 
@@ -35,14 +35,13 @@ class FilterPicker extends Component {
 		this.goBack = this.goBack.bind( this );
 	}
 
-	getFilterValue() {
-		const query = getQuery();
+	getFilterValue( { query } ) {
 		return query.filter || DEFAULT_FILTER;
 	}
 
 	getSelectedFilter() {
 		const { filters, filterPaths } = this.props;
-		const value = this.getFilterValue();
+		const value = this.getFilterValue( this.props );
 		const filterPath = filterPaths[ value ];
 		const visibleFilters = this.getVisibleFilters( filters, [ ...filterPath ] );
 		return find( visibleFilters, filter => filter.value === value );
@@ -105,9 +104,10 @@ class FilterPicker extends Component {
 			);
 		}
 
+		const { path, query } = this.props;
 		const onClick = event => {
 			onClose( event );
-			updateQueryString( { filter: filter.value } );
+			updateQueryString( { filter: filter.value }, path, query );
 		};
 
 		return (
@@ -164,6 +164,12 @@ class FilterPicker extends Component {
 FilterPicker.propTypes = {
 	filters: PropTypes.array.isRequired,
 	filterPaths: PropTypes.object.isRequired,
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object,
+};
+
+FilterPicker.defaultProps = {
+	query: {},
 };
 
 export default FilterPicker;

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -15,12 +15,10 @@ import AdvancedFilters from './advanced';
 import Card from 'components/card';
 import DatePicker from './date';
 import FilterPicker from './filter';
-import { getQuery } from 'lib/nav-utils';
 import { H, Section } from 'layout/section';
 import './style.scss';
 
-const ReportFilters = ( { advancedConfig, filters, filterPaths } ) => {
-	const query = getQuery();
+const ReportFilters = ( { advancedConfig, filters, filterPaths, query, path } ) => {
 	let advancedCard = false;
 	switch ( query.filter ) {
 		case 'compare':
@@ -43,7 +41,12 @@ const ReportFilters = ( { advancedConfig, filters, filterPaths } ) => {
 			break;
 		case 'advanced':
 			advancedCard = (
-				<AdvancedFilters config={ advancedConfig } filterTitle={ __( 'Orders', 'wc-admin' ) } />
+				<AdvancedFilters
+					config={ advancedConfig }
+					filterTitle={ __( 'Orders', 'wc-admin' ) }
+					path={ path }
+					query={ query }
+				/>
 			);
 			break;
 	}
@@ -53,8 +56,15 @@ const ReportFilters = ( { advancedConfig, filters, filterPaths } ) => {
 			<H className="screen-reader-text">{ __( 'Filters', 'wc-admin' ) }</H>
 			<Section component="div" className="woocommerce-filters">
 				<div className="woocommerce-filters__basic-filters">
-					<DatePicker key={ JSON.stringify( query ) } />
-					{ !! filters.length && <FilterPicker filters={ filters } filterPaths={ filterPaths } /> }
+					<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
+					{ !! filters.length && (
+						<FilterPicker
+							filters={ filters }
+							filterPaths={ filterPaths }
+							query={ query }
+							path={ path }
+						/>
+					) }
 				</div>
 				{ false !== advancedCard && (
 					<div className="woocommerce-filters__advanced-filters">{ advancedCard }</div>
@@ -68,12 +78,15 @@ ReportFilters.propTypes = {
 	advancedConfig: PropTypes.object,
 	filters: PropTypes.array,
 	filterPaths: PropTypes.object,
+	path: PropTypes.string.isRequired,
+	query: PropTypes.object,
 };
 
 ReportFilters.defaultProps = {
 	advancedConfig: {},
 	filters: [],
 	filterPaths: {},
+	query: {},
 };
 
 export { ReportFilters };

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -55,9 +55,11 @@ export const getNewPath = ( query, path = getPath(), currentQuery = getQuery() )
  * Updates the query parameters of the current page.
  *
  * @param {Object} query object of params to be updated.
+ * @param {String} path Relative path (defaults to current path).
+ * @param {Object} currentQuery object of current query params (defaults to current querystring).
  */
-export const updateQueryString = query => {
-	const newPath = getNewPath( query );
+export const updateQueryString = ( query, path = getPath(), currentQuery = getQuery() ) => {
+	const newPath = getNewPath( query, path, currentQuery );
 	history.push( newPath );
 };
 


### PR DESCRIPTION
This fixes the issues raised in #297 & #305 – the query & path can get "stuck" in other page settings.

Testing that path updates correctly:

- Go to the Analytics > Products page first, and update a filter.
- It should update the URL.
- Go to the Analytics > Orders page and update a filter.
- You should still be on the orders report, and the filter should be set in the URL.

Testing that query updates correctly:

- Go to Analytics > Orders, and click "show top orders by items sold".
- It should update the URL.
- Go to Analytics > Products, the filter on this page should be reset to "All Products"