### PR TITLE
Remove apiRequest in favor of apiFetch

### DIFF
--- a/client/store/orders/actions.js
+++ b/client/store/orders/actions.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { dispatch } from '@wordpress/data';
-import apiRequest from '@wordpress/api-request';
+import apiFetch from '@wordpress/api-fetch';
 
 export default {
 	setOrders( orders ) {
@@ -23,7 +23,7 @@ export default {
 			// Lets be optimistic
 			dispatch( 'wc-admin' ).updateOrder( order );
 			try {
-				const updatedOrder = await apiRequest( {
+				const updatedOrder = await apiFetch( {
 					path: '/wc/v3/orders/' + order.id,
 					method: 'PUT',
 					data: order,

--- a/client/store/orders/resolvers.js
+++ b/client/store/orders/resolvers.js
@@ -3,12 +3,12 @@
  * External dependencies
  */
 import { dispatch } from '@wordpress/data';
-import apiRequest from '@wordpress/api-request';
+import apiFetch from '@wordpress/api-fetch';
 
 export default {
 	async getOrders() {
 		try {
-			const orders = await apiRequest( { path: '/wc/v3/orders' } );
+			const orders = await apiFetch( { path: '/wc/v3/orders' } );
 			dispatch( 'wc-admin' ).setOrders( orders );
 		} catch ( error ) {
 			if ( error && error.responseJSON ) {

--- a/client/store/reports/revenue/stats/resolvers.js
+++ b/client/store/reports/revenue/stats/resolvers.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-const { apiFetch } = wp;
+import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,23 +1005,38 @@
       }
     },
     "@wordpress/api-fetch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-1.0.1.tgz",
-      "integrity": "sha512-kPExW7bJATzjR1zJTYAjsJdRwoapuxEUDTUiz9l++u8b4hODgM6JJpQHDAOULdRlCHkir7L4Sm3KJwwg4WsQ6g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-1.1.1.tgz",
+      "integrity": "sha512-+9l80mmTlWV8OsFporLTVhW9NR20KgfGRy7LR/lSch2noQfmDxUZRXPAn3QhqCrGUI05w9aaALkrFIB6cLyvwA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.52",
-        "@wordpress/i18n": "^1.2.1",
-        "jquery": "^3.3.1"
-      }
-    },
-    "@wordpress/api-request": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-request/-/api-request-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-MTGUY0nl0DV5BAcfmEBY7cQz39/q1+opG3RvEOo51Wyc8Ifh03DiPSsQqeS0FxuIOSB47ZehLtN29aZyR78b7A==",
-      "dev": true,
-      "requires": {
-        "jquery": "^3.3.1"
+        "@babel/runtime-corejs2": "7.0.0-beta.56",
+        "@wordpress/hooks": "^1.3.3",
+        "@wordpress/i18n": "^1.2.3"
+      },
+      "dependencies": {
+        "@wordpress/hooks": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-1.3.3.tgz",
+          "integrity": "sha512-k7JRx5I9ZcC0oYN1H3TtmZ4HJEn9CGb73ta4EXfqHb/BH4GKg/HxLxWBl2UZiA0SBpK9PGbg4lalHE43PoeeWw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime-corejs2": "7.0.0-beta.56"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-1.2.3.tgz",
+          "integrity": "sha512-ABa8cr3cfzS6YocxeBjrc1iHxt28S0EglX0heGKHUtyAQZEg5K+AtWCEJiqhthWpqnXkDEp9ZIqzXkRGhhHuYw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime-corejs2": "7.0.0-beta.56",
+            "gettext-parser": "^1.3.1",
+            "jed": "^1.1.1",
+            "lodash": "^4.17.10",
+            "memize": "^1.0.5"
+          }
+        }
       }
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
@@ -10283,12 +10298,6 @@
       "requires": {
         "merge-stream": "^1.0.1"
       }
-    },
-    "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
-      "dev": true
     },
     "js-base64": {
       "version": "2.4.8",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
     "test:watch": "npm run test -- --watch"
   },
   "devDependencies": {
-    "autoprefixer": "9.0.1",
     "@babel/core": "^7.0.0-beta.54",
     "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.54",
-    "@wordpress/api-request": "^1.0.0-alpha.3",
+    "@wordpress/api-fetch": "^1.1.1",
     "@wordpress/babel-plugin-import-jsx-pragma": "^1.0.1",
     "@wordpress/babel-plugin-makepot": "^2.0.1",
     "@wordpress/babel-preset-default": "^2.0.2",
@@ -45,6 +44,7 @@
     "@wordpress/keycodes": "^1.0.1",
     "@wordpress/postcss-themes": "^1.0.1",
     "@wordpress/scripts": "^2.0.2",
+    "autoprefixer": "9.0.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
     "babel-loader": "^8.0.0-beta.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 
 const externals = {
 	'@woocommerce/components': { this: [ 'wc', 'components' ] },
+	'@wordpress/api-fetch': { this: [ 'wp', 'apiFetch' ] },
 	'@wordpress/blocks': { this: [ 'wp', 'blocks' ] },
 	'@wordpress/components': { this: [ 'wp', 'components' ] },
 	'@wordpress/compose': { this: [ 'wp', 'compose' ] },
@@ -20,7 +21,6 @@ const externals = {
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },
-	'@wordpress/api-request': { this: [ 'wp', 'apiRequest' ] },
 	jquery: 'jQuery',
 	tinymce: 'tinymce',
 	moment: 'moment',


### PR DESCRIPTION
I mentioned this in my comment on https://github.com/woocommerce/wc-admin/pull/307#discussion_r211651239 – `apiRequest` was deprecated, so let's get rid of it. We can use `apiFetch` instead. All this PR does is a replacement, apiFetch for apiRequest. It also swaps the externals in webpack.config.js so we are correctly calling this from the `wp` global.

To test

- Run tests
- Check pages that make API requests, there should be no change