### PR TITLE
Fix the summaryNumber display when in toggle-button state

### DIFF
--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -203,10 +203,15 @@ $inner-border: $core-grey-light-500;
 		padding: 0;
 		list-style: none;
 		border-bottom: 1px solid $outer-border;
+		border-right: 1px solid $outer-border;
 
 		.components-button {
 			text-align: left;
 			display: block;
+		}
+
+		@include breakpoint( '<782px' ) {
+			border-right: none;
 		}
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -202,9 +202,11 @@ $inner-border: $core-grey-light-500;
 	&.is-dropdown-button {
 		padding: 0;
 		list-style: none;
+		border-bottom: 1px solid $outer-border;
 
 		.components-button {
 			text-align: left;
+			display: block;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #310 – SummaryNumber should display correctly now:

![screen shot 2018-08-21 at 5 26 42 pm](https://user-images.githubusercontent.com/541093/44430005-66389980-a567-11e8-8f54-dec58e357f04.png)

**To test**

- Look at SummaryNumbers on a screen < 1100px wide