### PR TITLE
Filters: Remove `filterpaths` props

### DIFF
--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -5,11 +5,10 @@
 import { __ } from '@wordpress/i18n';
 
 export const filters = [
-	{ label: __( 'All Orders', 'wc-admin' ), value: 'all', path: [] },
+	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
 	{
 		label: __( 'Single Order', 'wc-admin' ),
 		value: 'single',
-		path: [],
 		subFilters: [
 			{
 				label: __( 'Single Order', 'wc-admin' ),
@@ -19,9 +18,9 @@ export const filters = [
 			},
 		],
 	},
-	{ label: __( 'Top Orders by Items Sold', 'wc-admin' ), value: 'top_items', path: [] },
-	{ label: __( 'Top Orders by Gross Sales', 'wc-admin' ), value: 'top_sales', path: [] },
-	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced', path: [] },
+	{ label: __( 'Top Orders by Items Sold', 'wc-admin' ), value: 'top_items' },
+	{ label: __( 'Top Orders by Gross Sales', 'wc-admin' ), value: 'top_sales' },
+	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
 ];
 
 export const advancedFilterConfig = {

--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -11,7 +11,6 @@ export const filters = [
 		value: 'single',
 		subFilters: [
 			{
-				label: __( 'Single Order', 'wc-admin' ),
 				component: 'Search',
 				value: 'single_order',
 				path: [ 'single' ],

--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -5,31 +5,24 @@
 import { __ } from '@wordpress/i18n';
 
 export const filters = [
-	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
+	{ label: __( 'All Orders', 'wc-admin' ), value: 'all', path: [] },
 	{
 		label: __( 'Single Order', 'wc-admin' ),
 		value: 'single',
+		path: [],
 		subFilters: [
 			{
 				label: __( 'Single Order', 'wc-admin' ),
 				component: 'Search',
 				value: 'single_order',
+				path: [ 'single' ],
 			},
 		],
 	},
-	{ label: __( 'Top Orders by Items Sold', 'wc-admin' ), value: 'top_items' },
-	{ label: __( 'Top Orders by Gross Sales', 'wc-admin' ), value: 'top_sales' },
-	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
+	{ label: __( 'Top Orders by Items Sold', 'wc-admin' ), value: 'top_items', path: [] },
+	{ label: __( 'Top Orders by Gross Sales', 'wc-admin' ), value: 'top_sales', path: [] },
+	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced', path: [] },
 ];
-
-export const filterPaths = {
-	all: [],
-	single: [],
-	single_order: [ 'single' ],
-	top_items: [],
-	top_sales: [],
-	advanced: [],
-};
 
 export const advancedFilterConfig = {
 	status: {

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -13,7 +13,7 @@ import { partial } from 'lodash';
  * Internal dependencies
  */
 import { Card, ReportFilters } from '@woocommerce/components';
-import { filters, filterPaths, advancedFilterConfig } from './constants';
+import { filters, advancedFilterConfig } from './constants';
 import './style.scss';
 
 class OrdersReport extends Component {
@@ -39,7 +39,6 @@ class OrdersReport extends Component {
 					query={ query }
 					path={ path }
 					filters={ filters }
-					filterPaths={ filterPaths }
 					advancedConfig={ advancedFilterConfig }
 				/>
 				<p>Below is a temporary example</p>

--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -11,7 +11,6 @@ export const filters = [
 		value: 'single',
 		subFilters: [
 			{
-				label: __( 'Single Product', 'wc-admin' ),
 				component: 'Search',
 				value: 'single_search',
 				path: [ 'single' ],

--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -5,11 +5,10 @@
 import { __ } from '@wordpress/i18n';
 
 export const filters = [
-	{ label: __( 'All Products', 'wc-admin' ), value: 'all', path: [] },
+	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
 	{
 		label: __( 'Single Product', 'wc-admin' ),
 		value: 'single',
-		path: [],
 		subFilters: [
 			{
 				label: __( 'Single Product', 'wc-admin' ),
@@ -19,7 +18,7 @@ export const filters = [
 			},
 		],
 	},
-	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items', path: [] },
-	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales', path: [] },
-	{ label: __( 'Comparison', 'wc-admin' ), value: 'compare', path: [] },
+	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
+	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
+	{ label: __( 'Comparison', 'wc-admin' ), value: 'compare' },
 ];

--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -5,28 +5,21 @@
 import { __ } from '@wordpress/i18n';
 
 export const filters = [
-	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
+	{ label: __( 'All Products', 'wc-admin' ), value: 'all', path: [] },
 	{
 		label: __( 'Single Product', 'wc-admin' ),
 		value: 'single',
+		path: [],
 		subFilters: [
 			{
 				label: __( 'Single Product', 'wc-admin' ),
 				component: 'Search',
 				value: 'single_search',
+				path: [ 'single' ],
 			},
 		],
 	},
-	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
-	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
-	{ label: __( 'Comparison', 'wc-admin' ), value: 'compare' },
+	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items', path: [] },
+	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales', path: [] },
+	{ label: __( 'Comparison', 'wc-admin' ), value: 'compare', path: [] },
 ];
-
-export const filterPaths = {
-	all: [],
-	single: [],
-	single_search: [ 'single' ],
-	top_items: [],
-	top_sales: [],
-	compare: [],
-};

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -7,7 +7,7 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { filterPaths, filters } from './constants';
+import { filters } from './constants';
 import { ReportFilters } from '@woocommerce/components';
 import './style.scss';
 
@@ -17,12 +17,7 @@ export default class extends Component {
 
 		return (
 			<Fragment>
-				<ReportFilters
-					query={ query }
-					path={ path }
-					filters={ filters }
-					filterPaths={ filterPaths }
-				/>
+				<ReportFilters query={ query } path={ path } filters={ filters } />
 			</Fragment>
 		);
 	}

--- a/client/components/filters/README.md
+++ b/client/components/filters/README.md
@@ -12,14 +12,12 @@ Add a collection of report filters to a page. This uses `DatePicker` & `FilterPi
 // To add FilterPicker too, pass through filter config:
 <ReportFilters
 	filters={ filters }
-	filterPaths={ filterPaths }
 	path={ path }
 	query={ query } />
 ```
 
 - `advancedConfig`: Config option passed through to `AdvancedFilters`
 - `filters`: Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
-- `filterPaths`: Config option passed through to `FilterPicker`
 - `path` (required): The `path` parameter supplied by React-Router
 - `query`: The query string represented in object form
 

--- a/client/components/filters/filter/README.md
+++ b/client/components/filters/filter/README.md
@@ -47,3 +47,13 @@ const renderFilterPicker = () => {
 * `filters` (required): An array of filters and subFilters to construct the menu
 * `path` (required): The `path` parameter supplied by React-Router
 * `query`: The query string represented in object form
+
+### `filters` structure
+
+The `filters` prop is an array of filter objects. Each filter object should have the following format:
+
+* `label`: The label for this filter. Optional only for custom component filters.
+* `subFilters`: An array of more filter objects that act as "children" to this item. This set of filters is shown if the parent filter is clicked.
+* `value` (required): The value for this filter, used to set the `filter` query param when clicked, if there are no `subFilters`.
+* `path`: An array representing the "path" to this filter, if nested. See the Lunch > Pescatarian > Snapper example above.
+* `component`: A custom component used instead of a button, might have special handling for filtering. TBD, not yet implemented.

--- a/client/components/filters/filter/README.md
+++ b/client/components/filters/filter/README.md
@@ -1,55 +1,49 @@
 Filter Picker
-===
+=============
 
 Modify a url query parameter via a dropdown selection of configurable options. This component manipulates the `filter` query parameter.
 
 ## Usage
 
 ```jsx
-import FilterPicker from 'components/filter-picker';
+import { FilterPicker } from '@woocommerce/components';
 
 const renderFilterPicker = () => {
 	const filters = [
 		{ label: 'Breakfast', value: 'breakfast' },
-		{ label: 'Lunch', value: 'lunch', subFilters: [
-			{ label: 'Meat', value: 'meat' },
-			{ label: 'Vegan', value: 'vegan' },
-			{ label: 'Pescatarian', value: 'fish', subFilters: [
-				{ label: 'Snapper', value: 'snapper' },
-				{ label: 'Cod', value: 'cod' },
-			] },
-			// Specify a custom component to render (Work in Progress)
-			{ label: 'Other', value: 'other_fish', component: 'OtherFish' },
-		] },
+		{
+			label: 'Lunch',
+			value: 'lunch',
+			subFilters: [
+				{ label: 'Meat', value: 'meat', path: [ 'lunch' ] },
+				{ label: 'Vegan', value: 'vegan', path: [ 'lunch' ] },
+				{
+					label: 'Pescatarian',
+					value: 'fish',
+					path: [ 'lunch' ],
+					subFilters: [
+						{ label: 'Snapper', value: 'snapper', path: [ 'lunch', 'fish' ] },
+						{ label: 'Cod', value: 'cod', path: [ 'lunch', 'fish' ] },
+						// Specify a custom component to render (Work in Progress)
+						{
+							label: 'Other',
+							value: 'other_fish',
+							path: [ 'lunch', 'fish' ],
+							component: 'OtherFish',
+						},
+					],
+				},
+			],
+		},
 		{ label: 'Dinner', value: 'dinner' },
 	];
 
-	const filterPaths = {
-		breakfast: [],
-		lunch: [],
-		dinner: [],
-		meat: [ 'lunch' ],
-		vegan: [ 'lunch' ],
-		fish: [ 'lunch' ],
-		snapper: [ 'lunch', 'fish' ],
-		cod: [ 'lunch', 'fish' ],
-		other_fish: [ 'lunch', 'fish' ],
-	};
-
-	return (
-		<FilterPicker
-			filters={ filters }
-			filterPaths={ filterPaths }
-			path={ path }
-			query={ query }
-		/>
-	);
-}
+	return <FilterPicker filters={ filters } path={ path } query={ query } />;
+};
 ```
 
 ### Props
 
 * `filters` (required): An array of filters and subFilters to construct the menu
-* `filterPaths` (required): A map of representing the structure of the tree. Required for faster lookups than searches
 * `path` (required): The `path` parameter supplied by React-Router
 * `query`: The query string represented in object form

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -94,7 +94,9 @@ class FilterPicker extends Component {
 		if ( filter.component ) {
 			return (
 				<Fragment>
-					<span className="woocommerce-filters-filter__button">{ filter.label }</span>
+					{ filter.label && (
+						<span className="woocommerce-filters-filter__button">{ filter.label }</span>
+					) }
 					<input
 						type="text"
 						style={ { width: '100%', margin: '0' } }

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -23,7 +23,7 @@ class FilterPicker extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { path } = this.getFilter( props );
+		const { path = [] } = this.getFilter( props );
 		this.state = {
 			nav: path,
 			animate: null,
@@ -42,9 +42,9 @@ class FilterPicker extends Component {
 
 	getSelectedFilter() {
 		const { filters } = this.props;
-		const filter = this.getFilter( this.props );
-		const visibleFilters = this.getVisibleFilters( filters, [ ...filter.path ] );
-		return find( visibleFilters, { value: filter.value } );
+		const { path = [], value } = this.getFilter( this.props );
+		const visibleFilters = this.getVisibleFilters( filters, [ ...path ] );
+		return find( visibleFilters, { value } );
 	}
 
 	getLabels( selectedFilter ) {

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -3,10 +3,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
-import { Dropdown, Button, Dashicon } from '@wordpress/components';
-import { find, partial } from 'lodash';
+import { Button, Dashicon, Dropdown } from '@wordpress/components';
 import classnames from 'classnames';
+import { Component, Fragment } from '@wordpress/element';
+import { find, partial } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -23,9 +23,9 @@ class FilterPicker extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { filterPaths } = props;
+		const { path } = this.getFilter( props );
 		this.state = {
-			nav: filterPaths[ this.getFilterValue( props ) ],
+			nav: path,
 			animate: null,
 		};
 
@@ -35,16 +35,16 @@ class FilterPicker extends Component {
 		this.goBack = this.goBack.bind( this );
 	}
 
-	getFilterValue( { query } ) {
-		return query.filter || DEFAULT_FILTER;
+	getFilter( { filters, query } ) {
+		const value = query.filter || DEFAULT_FILTER;
+		return find( filters, { value } ) || {};
 	}
 
 	getSelectedFilter() {
-		const { filters, filterPaths } = this.props;
-		const value = this.getFilterValue( this.props );
-		const filterPath = filterPaths[ value ];
-		const visibleFilters = this.getVisibleFilters( filters, [ ...filterPath ] );
-		return find( visibleFilters, filter => filter.value === value );
+		const { filters } = this.props;
+		const filter = this.getFilter( this.props );
+		const visibleFilters = this.getVisibleFilters( filters, [ ...filter.path ] );
+		return find( visibleFilters, { value: filter.value } );
 	}
 
 	getLabels( selectedFilter ) {
@@ -52,25 +52,21 @@ class FilterPicker extends Component {
 		return selectedFilter ? [ selectedFilter.label ] : [];
 	}
 
-	selectSubFilters( value ) {
-		const nav = [ ...this.state.nav ];
-		nav.push( value );
-		this.setState( { nav, animate: 'left' } );
-	}
-
 	getVisibleFilters( filters, nav ) {
 		if ( nav.length === 0 ) {
 			return filters;
 		}
 		const value = nav.shift();
-		const nextFilters = find( filters, filter => value === filter.value );
+		const nextFilters = find( filters, { value } );
 		return this.getVisibleFilters( nextFilters && nextFilters.subFilters, nav );
 	}
 
+	selectSubFilters( value ) {
+		this.setState( prevState => ( { nav: [ ...prevState.nav, value ], animate: 'left' } ) );
+	}
+
 	goBack() {
-		const nav = [ ...this.state.nav ];
-		nav.pop();
-		this.setState( { nav, animate: 'right' } );
+		this.setState( prevState => ( { nav: prevState.nav.slice( 1 ), animate: 'right' } ) );
 	}
 
 	renderButton( filter, onClose ) {
@@ -163,7 +159,6 @@ class FilterPicker extends Component {
 
 FilterPicker.propTypes = {
 	filters: PropTypes.array.isRequired,
-	filterPaths: PropTypes.object.isRequired,
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object,
 };

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Dashicon, Dropdown } from '@wordpress/components';
+import { Button, Dropdown, IconButton } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { find, omit, partial } from 'lodash';
@@ -48,10 +48,10 @@ class FilterPicker extends Component {
 		return allFilters;
 	}
 
-	getFilter() {
+	getFilter( value = false ) {
 		const { filters, query } = this.props;
 		const allFilters = this.getAllFilters( filters );
-		const value = query.filter || DEFAULT_FILTER;
+		value = value || query.filter || DEFAULT_FILTER;
 		return find( allFilters, { value } ) || {};
 	}
 
@@ -94,13 +94,7 @@ class FilterPicker extends Component {
 		if ( filter.component ) {
 			return (
 				<Fragment>
-					<Button
-						className="woocommerce-filters-filter__button has-parent-nav"
-						onClick={ this.goBack }
-					>
-						<Dashicon icon="arrow-left-alt2" />
-						{ filter.label }
-					</Button>
+					<span className="woocommerce-filters-filter__button">{ filter.label }</span>
 					<input
 						type="text"
 						style={ { width: '100%', margin: '0' } }
@@ -127,6 +121,7 @@ class FilterPicker extends Component {
 		const { filters } = this.props;
 		const { nav, animate } = this.state;
 		const visibleFilters = this.getVisibleFilters( filters, nav );
+		const parentFilter = nav.length ? this.getFilter( nav[ nav.length - 1 ] ) : false;
 		const selectedFilter = this.getFilter();
 		return (
 			<div className="woocommerce-filters-filter">
@@ -147,6 +142,17 @@ class FilterPicker extends Component {
 						<AnimationSlider animationKey={ nav } animate={ animate } focusOnChange>
 							{ () => (
 								<ul className="woocommerce-filters-filter__content-list">
+									{ parentFilter && (
+										<li className="woocommerce-filters-filter__content-list-item">
+											<IconButton
+												className="woocommerce-filters-filter__button"
+												onClick={ this.goBack }
+												icon="arrow-left-alt2"
+											>
+												{ parentFilter.label }
+											</IconButton>
+										</li>
+									) }
 									{ visibleFilters.map( filter => (
 										<li
 											key={ filter.value }

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -18,7 +18,7 @@ import FilterPicker from './filter';
 import { H, Section } from 'layout/section';
 import './style.scss';
 
-const ReportFilters = ( { advancedConfig, filters, filterPaths, query, path } ) => {
+const ReportFilters = ( { advancedConfig, filters, query, path } ) => {
 	let advancedCard = false;
 	switch ( query.filter ) {
 		case 'compare':
@@ -58,12 +58,7 @@ const ReportFilters = ( { advancedConfig, filters, filterPaths, query, path } ) 
 				<div className="woocommerce-filters__basic-filters">
 					<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
 					{ !! filters.length && (
-						<FilterPicker
-							filters={ filters }
-							filterPaths={ filterPaths }
-							query={ query }
-							path={ path }
-						/>
+						<FilterPicker filters={ filters } query={ query } path={ path } />
 					) }
 				</div>
 				{ false !== advancedCard && (
@@ -77,7 +72,6 @@ const ReportFilters = ( { advancedConfig, filters, filterPaths, query, path } ) 
 ReportFilters.propTypes = {
 	advancedConfig: PropTypes.object,
 	filters: PropTypes.array,
-	filterPaths: PropTypes.object,
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object,
 };
@@ -85,7 +79,6 @@ ReportFilters.propTypes = {
 ReportFilters.defaultProps = {
 	advancedConfig: {},
 	filters: [],
-	filterPaths: {},
 	query: {},
 };
 


### PR DESCRIPTION
This PR adds the `path` to the filters config object, rather than as a separate prop– this makes the `Filters` props more concise, and allows us (and 3rd party devs) to define all filters in a single object.

While working on this, I also cleaned up the Filters functions, and moved the "go back" button to always be at the top of a list of subFilters:

![screen shot 2018-08-22 at 11 57 04 am](https://user-images.githubusercontent.com/541093/44475249-85383980-a602-11e8-98e3-7c6176fe266e.png)

I've also updated the READMEs, and added [docs for the structure of the filter list.](https://github.com/woocommerce/wc-admin/blob/remove/filters-filterpaths/client/components/filters/filter/README.md)

**To test**

- View filters on Products report
- Click through the options
  - "All Products", "Top…" and "Comparison" should set the filter param
  - "Single Product" should slide in a search option, the top button should bring back the main list
  - "Nested Example" should slide in a list of 3 demo options
- Click a demo option
  - It should set the filter param
  - Reload the page, open the filter again, it should display the Nested list + demo options, not the top-level filter list.
- Test on Orders report as well, there should be no change.


