### PR TITLE
Animation mixin + add `prefers-reduced-motion` support to existing animations

### DIFF
--- a/client/components/animation-slider/style.scss
+++ b/client/components/animation-slider/style.scss
@@ -68,4 +68,11 @@ The CSSTransition element creates a containing div without a class
 		animation: slide-out-right;
 		animation-duration: $duration;
 	}
+
+	@media screen and (prefers-reduced-motion: reduce) {
+		.slide-enter-active,
+		.slide-exit-active {
+			animation: none !important;
+		}
+	}
 }

--- a/client/components/dropdown-button/style.scss
+++ b/client/components/dropdown-button/style.scss
@@ -20,7 +20,7 @@
 		border-style: solid;
 		border-width: 6px 6px 0 6px;
 		border-color: $core-grey-dark-500 transparent transparent transparent;
-		transition: transform ease 0.2s;
+		@include animate-transform;
 	}
 
 	&.is-open {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -325,7 +325,7 @@ $inner-border: $core-grey-light-500;
 		position: absolute;
 		top: 44px;
 		right: $gap;
-		transition: transform ease 0.2s;
+		@include animate-transform;
 	}
 
 	.is-dropdown-expanded & {

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -28,6 +28,11 @@
 	}
 }
 
+// Adds animation to transforms
+@mixin animate-transform( $duration: 0.2s ) {
+	transition: transform ease 0.2s;
+}
+
 // Gutenberg Button variables. These are temporary until Gutenberg's variables are exposed.
 @mixin button-style__focus-active() {
 	background-color: $white;

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -31,6 +31,10 @@
 // Adds animation to transforms
 @mixin animate-transform( $duration: 0.2s ) {
 	transition: transform ease 0.2s;
+
+	@media screen and (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
 }
 
 // Gutenberg Button variables. These are temporary until Gutenberg's variables are exposed.

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -30,7 +30,7 @@
 
 // Adds animation to transforms
 @mixin animate-transform( $duration: 0.2s ) {
-	transition: transform ease 0.2s;
+	transition: transform ease $duration;
 
 	@media screen and (prefers-reduced-motion: reduce) {
 		transition: none;


### PR DESCRIPTION
This PR adds a mixin to control the animation used to rotate the chevron on `DropdownButton` & `SummaryNumber`. Technically, this mixin only controls a `transition` on the `transform` prop, because `DropdownButton` & `SummaryNumber` use slightly different classes & transforms, but the mixin lets us control the speed & [timing function](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function) of these rotations in one single place.

I've also added [`prefers-reduced-motion` support](https://css-tricks.com/introduction-reduced-motion-media-query/) to this mixin and the AnimationSlider component.

**To test**

- Go to Analytics > Revenue
- Check that the dropdown button arrow rotates when opened by clicking the date range filter
- Shrink your screen to &lt; 1100px, reload
- Check that the SummaryNumber toggle flips when clicked

Turn on reduced motion in System Preferences > Accessibility > Display > ☑️  Reduce motion

![screen shot 2018-08-22 at 4 47 21 pm](https://user-images.githubusercontent.com/541093/44489992-0e636680-a62b-11e8-9809-013b5bba0d79.png)

Using Safari (only browser with support), check the above: make sure the arrows flip but no animated rotation. (Firefox recently added support, but I don't know which version)

Go to Analytics > Products, and open the "show" filter. Click "Single Product", the panel should switch without the slide animation.

cc'ing @woocommerce/woo-core-design so they know this mixin exists & that we're supporting reduced motion for animations.