### PR TITLE
DaptePicker: fix erorr message popover

### DIFF
--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -128,7 +128,7 @@
 
 .woocommerce-filters-date__content {
 	.woocommerce-calendar__input-error {
-		//display: none;
+		display: none;
 
 		.components-popover__content {
 			background-color: $core-grey-dark-400;

--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -126,24 +126,32 @@
 	}
 }
 
-.woocommerce-calendar__input-error {
-	display: none;
+.woocommerce-filters-date__content {
+	.woocommerce-calendar__input-error {
+		display: none;
 
-	.components-popover__content {
-		background-color: $core-grey-dark-400;
-		color: $white;
-		padding: 0.5em;
-		border: none;
+		.components-popover__content {
+			background-color: $core-grey-dark-400;
+			color: $white;
+			padding: 0.5em;
+			border: none;
+		}
+
+		&.components-popover {
+			.components-popover__content {
+				min-width: 100px;
+				text-align: center;
+			}
+
+			&:not(.no-arrow):not(.is-mobile).is-bottom:before {
+				border-bottom-color: $core-grey-dark-400;
+				z-index: 1;
+				top: -6px;
+			}
+		}
 	}
 
-	&.components-popover {
-		.components-popover__content {
-			min-width: 100px;
-			text-align: center;
-		}
-
-		&:not(.no-arrow):after {
-			border-color: $core-grey-dark-400;
-		}
+	&.is-mobile .woocommerce-calendar__input-error .components-popover__content {
+		height: initial;
 	}
 }

--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -128,7 +128,7 @@
 
 .woocommerce-filters-date__content {
 	.woocommerce-calendar__input-error {
-		display: none;
+		//display: none;
 
 		.components-popover__content {
 			background-color: $core-grey-dark-400;
@@ -140,6 +140,7 @@
 		&.components-popover {
 			.components-popover__content {
 				min-width: 100px;
+				width: 100px;
 				text-align: center;
 			}
 

--- a/client/components/filters/date/style.scss
+++ b/client/components/filters/date/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		.components-tab-panel__tab-content {
-			height: calc(100% - $gap-larger);
+			height: calc(100% - 36px);
 		}
 	}
 }


### PR DESCRIPTION
Fix a CSS regression in Datepicker error warnings.

## Before

![screen shot 2018-08-29 at 2 52 41 pm](https://user-images.githubusercontent.com/1922453/44762454-3c045e80-ab9b-11e8-8ead-8ecb0b197264.png)

## After

![screen shot 2018-08-29 at 2 51 50 pm](https://user-images.githubusercontent.com/1922453/44762458-43c40300-ab9b-11e8-85c2-f2887011b43a.png)

## Test

1. Change screen width to mobile (popover positioning off otherwise, to be dealt with separately)
2. Open the Custom Datepicker
2. Create an invalid date
3. See the error message render correctly