### PR TITLE
DatePicker: Fix Error message positioning on non-mobile widths

### DIFF
--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -128,7 +128,7 @@
 
 .woocommerce-filters-date__content {
 	.woocommerce-calendar__input-error {
-		display: none;
+		//display: none;
 
 		.components-popover__content {
 			background-color: $core-grey-dark-400;

--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -128,7 +128,7 @@
 
 .woocommerce-filters-date__content {
 	.woocommerce-calendar__input-error {
-		//display: none;
+		display: none;
 
 		.components-popover__content {
 			background-color: $core-grey-dark-400;

--- a/client/components/filters/date/style.scss
+++ b/client/components/filters/date/style.scss
@@ -105,3 +105,8 @@
 		margin: 0 $gap-small;
 	}
 }
+
+.woocommerce-filters-date__content.is-center:not(.is-mobile) > .components-popover__content {
+	transform: none;
+	margin-left: -160px;
+}


### PR DESCRIPTION
Continues from https://github.com/woocommerce/wc-admin/pull/324

Popovers inside of popovers were being positioned incorrectly. This is due to CSS transform being applied to center popovers. This causes a new positioning context for descendants (see below) and gives `Element.getBoundingClientRect()` positioning relative to the container, not the viewport.

Luckily, we have a fixed width we are dealing with, so we can replace the CSS transform with a negative margin.

>For elements whose layout is governed by the CSS box model, any value other than none for the transform also causes the element to become a containing block, and the object acts as a containing block for fixed positioned descendants.

~ https://www.w3.org/TR/css-transforms-1/

## Before

![screen shot 2018-08-29 at 3 59 57 pm](https://user-images.githubusercontent.com/1922453/44764912-1af53b00-aba6-11e8-8c3d-34c28980bd75.png)

## After

![screen shot 2018-08-29 at 4 00 15 pm](https://user-images.githubusercontent.com/1922453/44764920-247ea300-aba6-11e8-9837-410677574d19.png)

## Test

1. Enter dates into the Datepicker
2. Change one to an invalid date
3. Ensure the error message popover is correctly positioned 
4. Test on mobile and normal widths