### PR TITLE
Segmented-selection: remove focus outline in favor of inset box-shadow

### DIFF
--- a/client/components/filters/date/index.js
+++ b/client/components/filters/date/index.js
@@ -59,6 +59,9 @@ class DatePicker extends Component {
 			if ( 'custom' === selectedTab ) {
 				data.after = after ? after.format( isoDateFormat ) : '';
 				data.before = before ? before.format( isoDateFormat ) : '';
+			} else {
+				data.after = undefined;
+				data.before = undefined;
 			}
 			updateQueryString( data, path, query );
 			onClose( event );

--- a/client/components/segmented-selection/style.scss
+++ b/client/components/segmented-selection/style.scss
@@ -56,17 +56,6 @@
 	}
 
 	&:focus + label .woocommerce-segmented-selection__label {
-		/**
-		Must use outline instead of border here to avoid having the
-		elements below shift by 2 pixel on focus. This trickery is needed
-		so that left and right edges can be seen as those borders are actually
-		part of the parent CSS grid.
-		 */
-		outline: 1px solid $black;
-		width: calc(100% - 1px);
-	}
-
-	&:nth-child(4n + 1):focus + label .woocommerce-segmented-selection__label {
-		transform: translateX(1px);
+		box-shadow: inset 0 0 0 1px $black;
 	}
 }


### PR DESCRIPTION
Segmented selections in the left hand column of the presets in the DatePicker jumped 1px to the right when selected. Previously, this was to accomodate differences between border and focus' outline.

## Fix
Use inset `box-shadow` for focus styles.

## Regression also fixed
When looking at a custom date range and then switching to a preset, query parameters `before` and `after` were persisting. They are now explicitly set to `undefined` so `qs.stringify` will remove them.

## Test
Select DatePicker presets and see if everything looks ok. Also check to make sure query parameters behave as expected on selection.