### PR TITLE
updating datepicker styles

### DIFF
--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -14,6 +14,7 @@
 
 .woocommerce-calendar__react-dates {
 	width: 100%;
+	overflow-x: hidden;
 
 	.DayPicker {
 		margin: 0 auto;

--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -53,6 +53,12 @@
 	.DayPicker_weekHeader_li {
 		color: $core-grey-dark-400;
 	}
+
+	.DayPickerNavigation_button {
+		&:focus {
+			outline: 2px solid #bfe7f3;
+		}
+	}
 }
 
 .woocommerce-calendar__inputs {

--- a/client/components/filters/style.scss
+++ b/client/components/filters/style.scss
@@ -35,7 +35,7 @@
 .woocommerce-filters-date__content,
 .woocommerce-filters-filter__content {
 	.components-popover__content {
-		width: 320px;
+		width: 322px;
 		border: 1px solid $core-grey-light-700;
 		background-color: $white;
 	}
@@ -44,6 +44,7 @@
 		.components-popover__content {
 			width: 100%;
 			height: 100%;
+			border: none;
 		}
 	}
 }

--- a/client/components/filters/style.scss
+++ b/client/components/filters/style.scss
@@ -35,7 +35,7 @@
 .woocommerce-filters-date__content,
 .woocommerce-filters-filter__content {
 	.components-popover__content {
-		width: 322px;
+		width: 320px;
 		border: 1px solid $core-grey-light-700;
 		background-color: $white;
 	}


### PR DESCRIPTION
Minor style adjustments to elements of the date picker: 

- the width adjustment on line 38 removed the two pixel scroll previously noted in #318 however it may not be necessary with the adjustments @psealock made in #327 

- removes the pop over border on mobile: the pop over is full screen and doesn't require the border.

- updates the focus color on calendar dates and month switchers

