### PR TITLE
Try: Page controller and wc-admin menu system

### DIFF
--- a/client/components/link/index.js
+++ b/client/components/link/index.js
@@ -28,7 +28,7 @@ class Link extends Component {
 		} else if ( 'external' === type ) {
 			path = href;
 		} else {
-			path = getAdminLink( 'admin.php?page=wc-admin#' + href );
+			path = getAdminLink( 'admin.php?page=woocommerce#' + href );
 		}
 
 		return (

--- a/client/index.js
+++ b/client/index.js
@@ -13,6 +13,7 @@ import { Provider as SlotFillProvider } from 'react-slot-fill';
 import './stylesheets/_index.scss';
 import { PageLayout } from './layout';
 import 'store';
+import Menu from './menu';
 
 render(
 	<APIProvider
@@ -24,4 +25,16 @@ render(
 		</SlotFillProvider>
 	</APIProvider>,
 	document.getElementById( 'root' )
+);
+
+render(
+	<APIProvider
+		{ ...wpApiSettings }
+		{ ...pick( wp.api, [ 'postTypeRestBaseMapping', 'taxonomyRestBaseMapping' ] ) }
+	>
+		<SlotFillProvider>
+			<Menu />
+		</SlotFillProvider>
+	</APIProvider>,
+	document.getElementById( 'adminmenuwrap' )
 );

--- a/client/menu/index.js
+++ b/client/menu/index.js
@@ -1,0 +1,141 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { find, filter, isNull, forEach } from 'lodash';
+import history from 'lib/history';
+
+/**
+ * Internal dependencies
+ */
+import { getPath } from 'lib/nav-utils';
+
+// TODO Add support for icons
+export default class Menu extends Component {
+	constructor() {
+		super();
+		this.state = {
+			currentPath: '',
+		};
+	}
+
+	// TODO Refactor the router code a bit, so we can more easily get an update to date path here.
+	componentDidMount() {
+		/* eslint-disable */
+		this.setState( {
+			currentPath: getPath(),
+		} );
+		history.listen( () => {
+			this.setState( {
+				currentPath: getPath(),
+			} );
+		} );
+		/* eslint-enable */
+	}
+
+	renderTopLevelMenus() {
+		const menus = filter( wcSettings.menuData.menus, menu => {
+			return isNull( menu.parent );
+		} );
+
+		return (
+			menus.map( menu => {
+				return (
+					<li className="wp-not-current-submenu menu-top" key={ menu.id }>
+						<a href={ menu.path } className="wp-not-current-submenu menu-top">
+							<div className="wp-menu-arrow">
+								<div />
+							</div>
+							<div className="wp-menu-image dashicons-before dashicons-admin-generic">
+								<br />
+							</div>
+							<div className="wp-menu-name">{ menu.title }</div>
+						</a>
+					</li>
+				);
+			} ) || null
+		);
+	}
+
+	renderMenuForSection( section ) {
+		let parentItem = {};
+		const currentItem = find( wcSettings.menuData.menus, menu => {
+			return menu.id === section;
+		} );
+
+		if ( isNull( currentItem.parent ) ) {
+			parentItem = { ...currentItem };
+		} else {
+			let has_sub_items = false;
+
+			forEach( wcSettings.menuData.menus, menuItem => {
+				if ( currentItem.parent === menuItem.id ) {
+					parentItem = { ...menuItem };
+				}
+				if ( section === menuItem.parent ) {
+					has_sub_items = true;
+				}
+			} );
+
+			forEach( wcSettings.menuData.menus, menuItem => {
+				if ( has_sub_items && section === menuItem.id ) {
+					parentItem = {
+						...menuItem,
+						title: parentItem.title + ' / ' + menuItem.title,
+					};
+				}
+			} );
+		}
+
+		const items = filter( wcSettings.menuData.menus, menu => {
+			return menu.parent === parentItem.id;
+		} );
+
+		return (
+			<li
+				className="wp-first-item wp-has-submenu wp-has-current-submenu wp-menu-open menu-top"
+				id="admin_page_products"
+			>
+				<a
+					href={ parentItem.path }
+					className="wp-first-item wp-has-submenu wp-has-current-submenu wp-menu-open menu-top"
+				>
+					<div className="wp-menu-arrow">
+						<div />
+					</div>
+					<div className="wp-menu-image dashicons-before dashicons-admin-generic">
+						<br />
+					</div>
+					<div className="wp-menu-name">{ parentItem.title }</div>
+				</a>
+				<ul className="wp-submenu wp-submenu-wrap">
+					<li className="wp-submenu-head" aria-hidden="true">
+						{ parentItem.title }
+					</li>
+					{ items.map( item => {
+						return (
+							<li key={ item.id }>
+								<a href={ item.path }>{ item.title }</a>
+							</li>
+						);
+					} ) || null }
+				</ul>
+			</li>
+		);
+	}
+
+	render() {
+		const currentPath = 'admin.php?page=woocommerce#' + this.state.currentPath;
+		const currentSection = wcSettings.menuData.pathsToIds[ currentPath ] || '';
+
+		return (
+			<ul id="adminmenu">
+				{ currentSection
+					? this.renderMenuForSection( currentSection )
+					: this.renderTopLevelMenus() }
+			</ul>
+		);
+	}
+}

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -1,6 +1,23 @@
 /** @format */
 // css resets some wp-admin specific rules so that the app fits better in the extension container
+
 .woocommerce-page {
+	#collapse-menu {
+		display: none;
+	}
+
+	#adminmenu .wp-submenu {
+		position: relative;
+		z-index: 3;
+		top: auto;
+		left: auto;
+		right: auto;
+		bottom: auto;
+		border: 0 none;
+		margin-top: 0;
+		box-shadow: none;
+	}
+
 	.wrap {
 		margin: 0;
 	}

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -1,153 +1,134 @@
 <?php
 /**
- * Returns true if we are on a JS powered admin page.
- */
-function wc_admin_is_admin_page() {
-	global $hook_suffix;
-	if ( in_array( $hook_suffix, array( 'woocommerce_page_wc-admin' ) ) ) {
-		return true;
-	}
-	return false;
-}
-
-/**
- * Returns true if we are on a "classic" (non JS app) powered admin page.
- * `wc_get_screen_ids` will also return IDs for extensions that have properly registered themselves.
- */
-function wc_admin_is_embed_enabled_wc_page() {
-	$screen_id = wc_admin_get_current_screen_id();
-	if ( ! $screen_id ) {
-		return false;
-	}
-
-	$screens = wc_admin_get_embed_enabled_screen_ids();
-
-	if ( in_array( $screen_id, $screens ) ) {
-		return true;
-	}
-	return false;
-}
-
-/**
- * Add a single page to a given parent top-level-item.
- *
- * @param array $options {
- *     Array describing the menu item.
- *
- *     @type string $title Menu title
- *     @type string $parent Parent path or menu ID
- *     @type string $path Path for this page, full path in app context; ex /analytics/report
- * }
- */
-function wc_admin_register_page( $options ) {
-	$defaults = array(
-		'parent' => '/analytics',
-	);
-	$options  = wp_parse_args( $options, $defaults );
-	add_submenu_page(
-		'/' === $options['parent'][0] ? "wc-admin#{$options['parent']}" : $options['parent'],
-		$options['title'],
-		$options['title'],
-		'manage_options',
-		"wc-admin#{$options['path']}",
-		'wc_admin_page'
-	);
-}
-
-/**
  * Register menu pages for the Dashboard and Analytics sections.
  */
 function wc_admin_register_pages() {
 	global $menu, $submenu;
 
-	add_submenu_page(
-		'woocommerce',
-		__( 'WooCommerce Dashboard', 'wc-admin' ),
-		__( 'Dashboard', 'wc-admin' ),
-		'manage_options',
-		'wc-admin',
-		'wc_admin_page'
-	);
-
-	add_menu_page(
-		__( 'WooCommerce Analytics', 'wc-admin' ),
-		__( 'Analytics', 'wc-admin' ),
-		'manage_options',
-		'wc-admin#/analytics',
-		'wc_admin_page',
-		'dashicons-chart-bar',
-		56 // After WooCommerce & Product menu items.
-	);
+	wc_admin_add_menu_link( array(
+		'id' => 'analytics',
+		'title' => __( 'Analytics', 'wc-admin' ),
+		'path'  => '/analytics',
+		'js_page' => true,
+	) );
 
 	wc_admin_register_page( array(
+		'id'     => 'analytics-report-test',
 		'title'  => __( 'Report Title', 'wc-admin' ),
-		'parent' => '/analytics',
+		'parent' => 'analytics',
 		'path'   => '/analytics/test',
 	) );
 
 	wc_admin_register_page( array(
+		'id'     => 'analytics-report-revenue',
 		'title'  => __( 'Revenue', 'wc-admin' ),
-		'parent' => '/analytics',
+		'parent' => 'analytics',
 		'path'   => '/analytics/revenue',
 	) );
 
 	wc_admin_register_page( array(
+		'id'     => 'analytics-report-products',
 		'title'  => __( 'Products', 'wc-admin' ),
-		'parent' => '/analytics',
+		'parent' => 'analytics',
 		'path'   => '/analytics/products',
 	) );
 
 	wc_admin_register_page( array(
+		'id'     => 'analytics-report-orders',
 		'title'  => __( 'Orders', 'wc-admin' ),
-		'parent' => '/analytics',
+		'parent' => 'analytics',
 		'path'   => '/analytics/orders',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'     => 'coupons',
+		'path'   => 'edit.php?post_type=shop_coupon',
+		'title'  => __( 'Coupons', 'wc-admin' ),
+		'screen_id' => 'edit-shop_coupon',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'          => 'coupons-add',
+		'parent'      => 'coupons',
+		'path'        => 'post-new.php?post_type=shop_coupon',
+		'title'       => __( 'Add New', 'wc-admin' ),
+		'screen_id'   => 'add-shop_coupon',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'        => 'products',
+		'parent'    => null,
+		'path'      => 'edit.php?post_type=product',
+		'title'     => __( 'Products', 'wc-admin' ),
+		'screen_id' => 'edit-product',
+	) );
+
+	wc_admin_add_menu_link( array(
+		'id'     => 'products-all',
+		'title'  => __( 'All Products', 'wc-admin' ),
+		'parent' => 'products',
+		'path'   => 'edit.php?post_type=product',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'     => 'products-add',
+		'title'  => __( 'Add New', 'wc-admin' ),
+		'parent' => 'products',
+		'path'   => 'post-new.php?post_type=product',
+		'screen_id' => 'add-product',
+	) );
+
+	wc_admin_add_menu_link( array(
+		'id'     => 'coupons-test',
+		'title'  => __( 'Test Link', 'wc-admin' ),
+		'parent' => 'coupons-add',
+		'path'   => '#test',
+	) );
+
+	wc_admin_add_menu_link( array(
+		'id'     => 'coupons-test',
+		'title'  => __( 'Test Link', 'wc-admin' ),
+		'parent' => 'coupons-add',
+		'path'   => '#test',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'           => 'edit-coupon',
+		'title'        => __( 'Edit Coupon', 'wc-admin' ),
+		'parent'       => 'coupons',
+		'screen_id'    => 'shop_coupon',
+		'show_in_menu' => false,
+	) );
+
+	wc_admin_connect_page( array(
+		'id'        => 'settings',
+		'title'     => __( 'Settings', 'wc-admin' ),
+		'screen_id' => 'woocommerce_page_wc-settings-general',
+		'path'      => 'admin.php?page=wc-settings',
+	) );
+
+	wc_admin_add_menu_link( array(
+		'id'     => 'settings-general',
+		'title'  => __( 'General', 'wc-admin' ),
+		'parent' => 'settings',
+		'path'   => 'admin.php?page=wc-settings&tab=general',
+	) );
+
+	wc_admin_connect_page( array(
+		'id'        => 'settings-products',
+		'title'     => __( 'Products', 'wc-admin' ),
+		'parent'    => 'settings',
+		'screen_id' => 'woocommerce_page_wc-settings-products',
+		'path'      => 'admin.php?page=wc-settings&tab=products',
 	) );
 }
 add_action( 'admin_menu', 'wc_admin_register_pages' );
 
 /**
- * This method is temporary while this is a feature plugin. As a part of core,
- * we can integrate this better with wc-admin-menus.
- *
- * It makes dashboard the top level link for 'WooCommerce' and renames the first Analytics menu item.
- */
-function wc_admin_link_structure() {
-	global $submenu;
-	// User does not have capabilites to see the submenu.
-	if ( ! current_user_can( 'manage_woocommerce' ) ) {
-		return;
-	}
-
-	$wc_admin_key = null;
-	foreach ( $submenu['woocommerce'] as $submenu_key => $submenu_item ) {
-		if ( 'wc-admin' === $submenu_item[2] ) {
-			$wc_admin_key = $submenu_key;
-			break;
-		}
-	}
-
-	if ( ! $wc_admin_key ) {
-		return;
-	}
-
-	$menu = $submenu['woocommerce'][ $wc_admin_key ];
-
-	// Move menu item to top of array.
-	unset( $submenu['woocommerce'][ $wc_admin_key ] );
-	array_unshift( $submenu['woocommerce'], $menu );
-
-	// Rename "Analytics" to Overview (otherwise this reads Analytics > Analytics).
-	$submenu['wc-admin#/analytics'][0][0] = __( 'Overview', 'wc-admin' );
-}
-
-// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
-add_action( 'admin_head', 'wc_admin_link_structure', 20 );
-
-/**
  * Load the assets on the admin pages
  */
 function wc_admin_enqueue_script() {
-	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+	if ( ! is_wc_admin_page() ) {
 		return;
 	}
 
@@ -159,13 +140,13 @@ add_action( 'admin_enqueue_scripts', 'wc_admin_enqueue_script' );
 function wc_admin_admin_body_class( $admin_body_class = '' ) {
 	global $hook_suffix;
 
-	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+	if ( ! is_wc_admin_page() ) {
 		return $admin_body_class;
 	}
 
 	$classes = explode( ' ', trim( $admin_body_class ) );
 	$classes[] = 'woocommerce-page';
-	if ( wc_admin_is_embed_enabled_wc_page() ) {
+	if ( is_wc_admin_embed_page() ) {
 		$classes[] = 'woocommerce-embed-page';
 	}
 	$admin_body_class = implode( ' ', array_unique( $classes ) );
@@ -175,7 +156,7 @@ add_filter( 'admin_body_class', 'wc_admin_admin_body_class' );
 
 
 function wc_admin_admin_before_notices() {
-	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+	if ( ! is_wc_admin_page() ) {
 		return;
 	}
 	echo '<div class="woocommerce-layout__notice-list-hide" id="wp__notice-list">';
@@ -184,7 +165,7 @@ function wc_admin_admin_before_notices() {
 add_action( 'admin_notices', 'wc_admin_admin_before_notices', 0 );
 
 function wc_admin_admin_after_notices() {
-	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+	if ( ! is_wc_admin_page() ) {
 		return;
 	}
 	echo '</div>';
@@ -193,12 +174,12 @@ add_action( 'admin_notices', 'wc_admin_admin_after_notices', PHP_INT_MAX );
 
 // TODO Can we do some URL rewriting so we can figure out which page they are on server side?
 function wc_admin_admin_title( $admin_title ) {
-	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+	if ( ! is_wc_admin_page() ) {
 		return $admin_title;
 	}
 
-	if ( wc_admin_is_embed_enabled_wc_page() ) {
-		$sections = wc_admin_get_embed_breadcrumbs();
+	if ( is_wc_admin_embed_page() ) {
+		$sections = wc_admin_get_breadcrumbs();
 		$sections = is_array( $sections ) ? $sections : array( $sections );
 		$pieces   = array();
 
@@ -228,17 +209,17 @@ function wc_admin_page(){
 }
 
 /**
- * Set up a div for the header embed to render into.
+ * Set up a div for the embedded header to render into.
  * The initial contents here are meant as a place loader for when the PHP page initialy loads.
 
  * TODO Icon Placeholders for the ActivityPanel, when we implement the new designs.
  */
-function woocommerce_embed_page_header() {
-	if ( ! wc_admin_is_embed_enabled_wc_page() ) {
+function wc_admin_embed_page_header() {
+	if ( ! is_wc_admin_embed_page() ) {
 		return;
 	}
 
-	$sections    = wc_admin_get_embed_breadcrumbs();
+	$sections    = wc_admin_get_breadcrumbs();
 	$sections    = is_array( $sections ) ? $sections : array( $sections );
 	$breadcrumbs = '';
 	foreach ( $sections as $section ) {
@@ -250,7 +231,7 @@ function woocommerce_embed_page_header() {
 		<div class="woocommerce-layout">
 			<div class="woocommerce-layout__header is-embed-loading">
 				<h1 class="woocommerce-layout__header-breadcrumbs">
-					<span><a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-admin#/' ) ); ?>">WooCommerce</a></span>
+					<span><a href="<?php echo esc_url( admin_url( 'admin.php?page=woocommerce#/' ) ); ?>">WooCommerce</a></span>
 					<?php echo $breadcrumbs; ?>
 				</h1>
 			</div>
@@ -262,4 +243,4 @@ function woocommerce_embed_page_header() {
 	<?php
 }
 
-add_action( 'in_admin_header', 'woocommerce_embed_page_header' );
+add_action( 'in_admin_header', 'wc_admin_embed_page_header' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -9,10 +9,7 @@
  * Registers the JS & CSS for the admin and admin embed
  */
 function wc_admin_register_script() {
-	// Are we displaying the full React app or just embedding the header on a classic screen?
-	$screen_id = wc_admin_get_current_screen_id();
-
-	if ( in_array( $screen_id, wc_admin_get_embed_enabled_screen_ids() ) ) {
+	if ( is_wc_admin_embed_page() ) {
 		$js_entry  = 'dist/embedded.js';
 		$css_entry = 'dist/css/embedded.css';
 	} else {
@@ -61,7 +58,7 @@ function wc_admin_register_script() {
 	$settings = array(
 		'adminUrl'         => admin_url(),
 		'wcAssetUrl'       => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'embedBreadcrumbs' => wc_admin_get_embed_breadcrumbs(),
+		'embedBreadcrumbs' => wc_admin_get_breadcrumbs(),
 		'siteLocale'       => esc_attr( get_bloginfo( 'language' ) ),
 		'currency'         => wc_admin_currency_settings(),
 		'date'             => array(
@@ -69,6 +66,7 @@ function wc_admin_register_script() {
 		),
 		'orderStatuses'    => wc_get_order_statuses(),
 		'siteTitle'        => get_bloginfo( 'name' ),
+		'menuData'         => wc_admin_menu_json(),
 	);
 
 	wp_add_inline_script(

--- a/lib/common.php
+++ b/lib/common.php
@@ -27,7 +27,9 @@ function wc_admin_url( $path ) {
  * so certain pages like 'add new' pages can have different breadcrumbs or handling.
  * It also catches some more unique dynamic pages like taxonomy/attribute management.
  *
- * Format: {$current_screen->action}-{$current_screen->action}, or just {$current_screen->action} if no action is found
+ * Format: {$current_screen->action}-{$current_screen->action}-tab,
+ * {$current_screen->action}-{$current_screen->action} if no tab is present,
+ * or just {$current_screen->action} if no action or tab is present.
  *
  * @return string Current screen ID.
  */
@@ -42,204 +44,24 @@ function wc_admin_get_current_screen_id() {
 		$current_screen_id = 'product_page_product_attributes';
 	}
 
-	return $current_screen_id;
-}
-
-/**
- * Returns breadcrumbs for the current page.
- *
- * TODO When merging to core, we should explore a better API for defining breadcrumbs, instead of just defining an array.
- */
-function wc_admin_get_embed_breadcrumbs() {
-	$current_screen_id = wc_admin_get_current_screen_id();
-
-	// If a page has a tab, we can append that to the screen ID and show another pagination level
-	$pages_with_tabs = array(
+	// Default tabs
+	$pages_with_tabs = apply_filters( 'wc_admin_pages_with-tabs', array(
 		'wc-reports'  => 'orders',
 		'wc-settings' => 'general',
 		'wc-status'   => 'status',
-	);
-	$tab = '';
+	) );
 	if ( ! empty( $_GET['page' ] ) ) {
 		if ( in_array( $_GET['page'], array_keys( $pages_with_tabs ) ) ) {
-			$tab = ! empty( $_GET['tab'] ) ? $_GET['tab'] . '-' : $pages_with_tabs[ $_GET['page'] ] . '-';
+			if ( ! empty( $_GET['tab'] ) ) {
+				$tab = $_GET['tab'];
+			} else {
+				$tab = $pages_with_tabs[ $_GET['page'] ];
+			}
+			$current_screen_id = $current_screen_id . '-' . $tab;
 		}
 	}
 
-	$breadcrumbs = apply_filters( 'wc_admin_get_breadcrumbs', array(
-		'edit-shop_order' => __( 'Orders', 'wc-admin' ),
-		'add-shop_order'  => array(
-			array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' )
-		),
-		'shop_order'     => array(
-			array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
-			__( 'Edit Order', 'wc-admin' )
-		),
-		'edit-shop_coupon' => __( 'Coupons', 'wc-admin' ),
-		'add-shop_coupon'  => array(
-			array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' )
-		),
-		'shop_coupon' => array(
-			array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
-			__( 'Edit Coupon', 'wc-admin' )
-		),
-		'woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) )
-		),
-		'orders-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Orders', 'wc-admin' )
-		),
-		'customers-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Customers', 'wc-admin' )
-		),
-		'stock-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Stock', 'wc-admin' )
-		),
-		'taxes-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Taxes', 'wc-admin' )
-		),
-		'woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) )
-		),
-		'general-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'General', 'wc-admin' ),
-		),
-		'products-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Products', 'wc-admin' ),
-		),
-		'tax-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Tax', 'wc-admin' ),
-		),
-		'shipping-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Shipping', 'wc-admin' ),
-		),
-		'checkout-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Payments', 'wc-admin' ),
-		),
-		'email-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Emails', 'wc-admin' ),
-		),
-		'advanced-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Advanced', 'wc-admin' ),
-		),
-		'woocommerce_page_wc-status'  => array(
-			__( 'Status', 'wc-admin' ),
-		),
-		'status-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'System Status', 'wc-admin' ),
-		),
-		'tools-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'Tools', 'wc-admin' ),
-		),
-		'logs-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'Logs', 'wc-admin' ),
-		),
-		'connect-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'WooCommerce Services Status', 'wc-admin' ),
-		),
-		'woocommerce_page_wc-addons' => __( 'Extensions', 'wc-admin' ),
-		'edit-product' => __( 'Products', 'wc-admin' ),
-		'product_page_product_importer'  => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Import', 'wc-admin' ),
-		),
-		'product_page_product_exporter' =>  array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Export', 'wc-admin' ),
-		),
-		'add-product' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' ),
-		),
-		'product' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Edit Product', 'wc-admin' ),
-		),
-		'edit-product_cat' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Categories', 'wc-admin' ),
-		),
-		'edit-product_tag' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Tags', 'wc-admin' ),
-		),
-		'product_page_product_attributes' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Attributes', 'wc-admin' ),
-		),
-	) );
-
-
-	if ( ! empty ( $breadcrumbs[ $tab . $current_screen_id ] ) ) {
-		return $breadcrumbs[ $tab . $current_screen_id ];
-	} else if ( ! empty( $breadcrumbs[ $current_screen_id ] ) ) {
-		return $breadcrumbs[ $current_screen_id ];
-	} else {
-		return '';
-	}
-}
-
-/**
-  * `wc_admin_get_embed_enabled_screen_ids`,  `wc_admin_get_embed_enabled_plugin_screen_ids`,
-  * `wc_admin_get_embed_enabled_screen_ids` should be considered temporary functions for the feature plugin.
-  *  This is separate from WC's screen_id functions so that extensions explictly have to opt-in to the feature plugin.
-  *  TODO When merging to core, we should explore a better API for opting into the new header for extensions.
- */
-function wc_admin_get_embed_enabled_core_screen_ids() {
-	$screens = array(
-		'edit-shop_order',
-		'shop_order',
-		'add-shop_order',
-		'edit-shop_coupon',
-		'shop_coupon',
-		'add-shop_coupon',
-		'woocommerce_page_wc-reports',
-		'woocommerce_page_wc-settings',
-		'woocommerce_page_wc-status',
-		'woocommerce_page_wc-addons',
-		'edit-product',
-		'product_page_product_importer',
-		'product_page_product_exporter',
-		'add-product',
-		'product',
-		'edit-product_cat',
-		'edit-product_tag',
-		'product_page_product_attributes',
-	);
-	return apply_filters( 'wc_admin_get_embed_enabled_core_screens_ids', $screens );
-}
-
-/**
- * If any extensions want to show the new header, they can register their screen ids.
- * Separate so extensions can register support for the feature plugin separately.
- */
-function wc_admin_get_embed_enabled_plugin_screen_ids() {
-	$screens = array();
-	return apply_filters( 'wc_admin_get_embed_enabled_plugin_screens_ids', $screens );
-}
-
-/**
- * Returns core and plugin screen IDs for a list of screens the new header should be enabled on.
- */
-function wc_admin_get_embed_enabled_screen_ids() {
-	return array_merge( wc_admin_get_embed_enabled_core_screen_ids(), wc_admin_get_embed_enabled_plugin_screen_ids() );
+	return $current_screen_id;
 }
 
 /**

--- a/lib/page-controller.php
+++ b/lib/page-controller.php
@@ -1,0 +1,524 @@
+<?php
+// TODO Add support for priorities.
+
+/**
+ * Adds a JS powered page to wc-admin.
+ *
+ * @param array $options {
+ *	 Array describing the page.
+ *
+ *   @type string      id           Id to reference the page.
+ *	 @type string      title        Page title. Used in menus and breadcrumbs.
+ *   @type string|null parent       Parent ID. Null for new top level page.
+ *   @type string      path         Path for this page, full path in app context; ex /analytics/report
+ *   @type string      screen_id    WooCommerce screen ID (wc_admin_get_current_screen_id`). Used for correctly identifying which pages are wc-admin pages.
+ *   @type string      capability   Capability needed to access the page.
+ *   @type bool        show_in_menu True if this page should be shown in the sidebar. False otherwise.
+ *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
+ * }
+ */
+function wc_admin_register_page( $options ) {
+	$defaults = array(
+		'parent'       => null,
+		'capability'   => 'manage_options',
+		'show_in_menu' => true,
+		'screen_id'    => 'toplevel_page_woocommerce',
+		'path'         => '',
+	);
+
+	$options            = wp_parse_args( $options, $defaults );
+	$options['js_page'] = true;
+	$options['path']    = 'admin.php?page=woocommerce#' . $options['path'];
+	
+	if ( ! empty( $options['parent'] ) ) {
+		add_submenu_page(
+			$options['parent'],
+			$options['title'],
+			$options['title'],
+			$options['capability'],
+			$options['path'],
+			'wc_admin_page'
+		);
+	} else {
+		add_menu_page(
+			$options['title'],
+			$options['title'],
+			$options['capability'],
+			$options['path'],
+			'wc_admin_page',
+			''
+		);
+	}
+
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	if ( true === $options['show_in_menu'] ) {
+		$WC_Admin_Page_Controller->register_menu( $options );
+	}
+	$WC_Admin_Page_Controller->register_page( $options );
+}
+
+/**
+ * Connects a wp-admin page to a wc-admin page.
+ * The page will no longer be shown in wp-admin and will get WooCommerce design elements (breadcrumbs, nav, purples, etc).
+ *
+ * @param array $options {
+ *	 Array describing the page.
+ *
+ *   @type string      id           Id to reference the page.
+ *	 @type string      title        Page title. Used in menus and breadcrumbs.
+ *   @type string|null parent       Parent ID. Null for new top level page.
+ *   @type string      path         Path for this page, full path in app context; ex /analytics/report
+ *   @type string      screen_id    WooCommerce screen ID (wc_admin_get_current_screen_id`). Used for correctly identifying which pages are wc-admin pages.
+ *   @type string      capability   Capability needed to access the page.
+ *   @type bool        show_in_menu True if this page should be shown in the sidebar. False otherwise.
+ *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
+ * }
+ */
+function wc_admin_connect_page( $options ) {
+	$defaults = array(
+		'parent'       => null,
+		'capability'   => 'manage_options',
+		'show_in_menu' => true,
+	);
+	$options            = wp_parse_args( $options, $defaults );
+	$options['js_page'] = false;
+
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	if ( true === $options['show_in_menu'] ) {
+		$WC_Admin_Page_Controller->register_menu( $options );
+	}
+	$WC_Admin_Page_Controller->register_page( $options );
+}
+
+/**
+ * Adds an arbitary menu link to wc-admin.
+ *
+ * @param array $options {
+ *	 Array describing the menu item.
+ *
+ *   @type string      id           Id to reference the page.
+ *	 @type string      title        Page title. Used in menus and breadcrumbs.
+ *   @type string|null parent       Parent ID. Null for new top level page.
+ *   @type string      path         Path for this page, full path in app context; ex /analytics/report
+ *   @type string      screen_id    WooCommerce screen ID (wc_admin_get_current_screen_id`). Used for correctly identifying which pages are wc-admin pages.
+ *   @type string      capability   Capability needed to access the page.
+ *   @type bool        show_in_menu True if this page should be shown in the sidebar. False otherwise.
+ *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
+ *   @type bool        js_page      True if this links to a JS powered wc-admin page. False otherwise.
+ * }
+ */
+function wc_admin_add_menu_link( $options ) {
+	$defaults = array(
+		'parent'     => null,
+		'capability' => 'manage_options',
+		'js_page'    => false,
+	);
+	$options = wp_parse_args( $options, $defaults );
+	
+	$options['show_in_menu'] = true;
+	$options['path']         = $options['js_page'] ? 'admin.php?page=woocommerce#' . $options['path'] : $options['path'];
+	
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	$WC_Admin_Page_Controller->register_menu( $options );
+}
+
+/**
+ * Returns breadcrumbs for the current page.
+ *
+ * @return array Array of breadcrumb steps. Example: array( 'Settings', 'Genera' );
+ */
+function wc_admin_get_breadcrumbs() {
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	return $WC_Admin_Page_Controller->get_breadcrumbs_for_screen();
+}
+
+/**
+ * Returns if we are on a JS powered admin page.
+ *
+ * @return bool True if this is a JS powered admin page. False otherwise.
+ */
+function is_wc_admin_page() {
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	$pages                    = $WC_Admin_Page_Controller->get_registered_pages();
+	$screen_id                = wc_admin_get_current_screen_id();
+	$is_registered_page       = false;
+
+	foreach ( $pages as $page ) {
+		if ( $screen_id === $page['screen_id' ] ) {
+			$is_registered_page = true;
+			break;
+		}
+	}
+
+	return $is_registered_page;
+}
+
+/**
+ * Returns if we are on a "classic" (non JS app) powered admin page where we need to embed parts of the wc-admin experience.
+ *
+ * @return bool True if this is a classic admin page. False otherwise.
+ */
+function is_wc_admin_embed_page() {
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	$pages                    = $WC_Admin_Page_Controller->get_registered_pages();
+	$screen_id                = wc_admin_get_current_screen_id();
+	$is_embed_page            = false;
+
+	foreach ( $pages as $page ) {
+		if ( $screen_id === $page['screen_id' ] && ! $page['js_page'] ) {
+			$is_embed_page = true;
+			break;
+		}
+	}
+
+	return $is_embed_page;
+}
+
+/**
+ * Returns wc-admin menu information for use as a JSON object in the JS app.
+ *
+ * @return array All menu items, and some info about the current page.
+ */
+function wc_admin_menu_json() {
+	$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();
+	$menus                    = $WC_Admin_Page_Controller->get_registered_menus();
+	$ids                      = $WC_Admin_Page_Controller->get_ids_for_current_page();
+
+	return array_merge( $ids, array(
+		'menus'      => $menus,
+		'pathsToIds' => $WC_Admin_Page_Controller->get_path_to_id_mapping(),
+	) );
+}
+
+/**
+ * WC_Admin_Page_Controller
+ * 
+ * Manages all of the admin pages that make up the 'wc-admin' application.
+ * This includes registering support for wc-admin, menu handling, and breadcrumb generation.
+ * Generally, the class is not used directly. The following helper functions can be used instead:
+ *
+ * wc_admin_register_page, wc_admin_connect_page, wc_admin_add_menu_link, wc_admin_get_breadcrumbs,
+ * is_wc_admin_page, is_wc_admin_embed_page.
+ * 
+ */
+class WC_Admin_Page_Controller {
+	static $instance = false;
+
+	/**
+	 * wc-admin menu items
+	 * Only pages with show_in_menu, or extra links added via `wc_admin_add_menu_link` show up here.
+	 */
+	private $menus = array();
+
+	/**
+	 * wc-admin registered pages
+	 * Contains information (breadcrumbs, menu info) about JS powered pages and classic WooCommerce pages.
+	 */
+	private $pages = array();
+
+	/**
+	 * We want a single instance of this class so we can accurately track registered menus and pages.
+	 */
+	public static function getInstance() {
+		if ( !self::$instance )
+			self::$instance = new self;
+		
+		return self::$instance;
+	}
+
+	/**
+	 * Hooks into WordPress to overtake the menu system on WooCommerce pages.
+	 */
+	private function __construct() {
+		add_action( 'wp_loaded', array( $this, 'setup_menu_hooks' ) );
+	}
+
+	public function setup_menu_hooks() {
+		$late_priority = PHP_INT_MAX;
+		add_action( 'admin_head', array( $this, 'remove_woocommerce_menus' ), $late_priority );
+		add_action( 'admin_head', array( $this, 'menu_handler' ), $late_priority );
+		add_action( 'admin_menu', array( $this, 'add_main_woocommerce_link' ), $late_priority );
+	}
+
+	/**
+	 * Registers a menu item.
+	 * @param array $options. Array describing the menu. See wc_admin_register_page.
+	 */
+	public function register_menu( $options ) {
+		global $menu, $submenu;
+		$this->menus[] = $options;
+		$this->id_mapping_to_path[ $options['id' ] ] = $options['path'];
+	}
+
+	/**
+	 * Registers a page.
+	 *
+	 * @param array $options. Array describing the page. See wc_admin_register_page.
+	 */
+	public function register_page( $options ) {
+		$this->pages[] = $options;
+	}
+
+	/**
+	 * Returns an array of registered wc-admin pages.
+	 *
+	 * @return array Array of registered pages.
+	 */
+	public function get_registered_pages() {
+		return $this->pages;
+	}
+
+	/**
+	 * Returns an array of registered wc-admin menus.
+	 *
+	 * @return array Array of registered menus.
+	 */
+	public function get_registered_menus() {
+		return $this->menus;
+	}
+
+	/**
+	 * Returns an array of path to ID maps.
+	 *
+	 * @return array Array paths to ids.
+	 */
+	public function get_path_to_id_mapping() {
+		return array_flip( $this->id_mapping_to_path );
+	}
+
+	/**
+	 * Gets ids associated with the current page.
+	 *
+	 * @return array Array of page info. Contains `current_id` for the current page, and 'parent' for the parent object.
+	 */
+	public function get_ids_for_current_page() {
+		$screen_id  = wc_admin_get_current_screen_id();
+		
+		if ( 'toplevel_page_woocommerce' === $screen_id ) {
+			return( array(
+				'current_id' => '',
+				'parent'     => '',
+			) );
+		}
+
+		$current_id = null;
+		$parent     = null;
+		foreach ( $this->pages as $page ) {
+			if ( $screen_id === $page['screen_id' ] ) {
+				$current_id = $page['id'];
+				$parent     = $page['parent'];
+				break;
+			}
+		}
+
+		return array(
+			'current_id' => $current_id,
+			'parent'     => $parent,
+		);
+	}
+
+	/**
+	 * Returns breadcrumbs for the current screen.
+	 *
+	 * @return array Array of breadcrumb steps.
+	 */
+	function get_breadcrumbs_for_screen() {
+		$screen_id   = wc_admin_get_current_screen_id();
+		$breadcrumbs = array();
+		$steps       = array();
+
+		if ( 'toplevel_page_woocommerce' === $screen_id ) {
+			return ''; // Handled via the app
+		}
+
+		$parent_item = array();
+		$page_ids    = $this->get_ids_for_current_page();
+		$current_id  = $page_ids['current_id'];
+		$parent      = $page_ids['parent'];
+
+		if ( $parent !== null ) {
+			$has_sub_items = false;
+			foreach ( $this->pages as $page_item ) {
+				if ( $parent === $page_item['id' ] ) {
+					$parent_item = $page_item;
+				}
+			}
+			foreach( $this->pages as $page_item ) {
+				if ( $current_id === $page_item['id'] ) {
+					$steps[] = array( $parent_item['path'], $parent_item['title'] );
+					$steps[] = array( $page_item['path'], $page_item['title'] );
+					break;
+				}
+			}
+		} else {
+			foreach ( $this->pages as $page_item ) {
+				if ( $current_id === $page_item['id'] ) {
+					$steps[] = array( $page_item['path'], $page_item['title'] );
+					break;
+				}
+			}
+		}
+
+		// The final breadcrumb step should never be linked.
+		$last_key = count( $steps ) - 1;
+		$steps[ $last_key ] = $steps[ $last_key ][ 1 ];
+
+		return $steps;
+	}
+
+	/**
+	 * Gets the displayable menus for the current screen.
+	 *
+	 * @return array Array of menu items.
+	 */
+	function get_menus_for_screen() {
+		$screen_id = wc_admin_get_current_screen_id();
+		$menus     = array();
+	
+		// JS App. Show all navigation
+		if ( 'toplevel_page_woocommerce' === $screen_id ) {
+			foreach ( $this->menus as $menu_item ) {
+				if ( empty( $menu_item['parent'] ) ) {
+					$menus[] = $menu_item;
+				}
+			}
+			return $menus;
+		}
+
+		$parent_item = array();
+		$page_ids    = $this->get_ids_for_current_page();
+		$current_id  = $page_ids['current_id'];
+		$parent      = $page_ids['parent'];
+		if ( $parent !== null ) {
+			$has_sub_items = false;
+			foreach ( $this->menus as $menu_item ) {
+				if ( $parent === $menu_item['id' ] ) {
+					$parent_item = $menu_item;
+				}
+				if ( $current_id === $menu_item['parent'] ) {
+					$has_sub_items = true;
+				}
+			}
+
+			foreach( $this->menus as $menu_item ) {
+				// This is a third level navigation item 
+				if ( $has_sub_items && $current_id === $menu_item['id'] ) {
+					$parent_item['id'] = $menu_item['id'];
+					$parent_item['path'] = $menu_item['path'];
+					$parent_item['parent'] = '';
+					$parent_item['title'] = $parent_item['title'] . ' / ' . $menu_item['title'];
+					break;
+				}
+
+				if ( $parent === $menu_item['parent'] ) {
+					$menus[] = $menu_item;
+				}
+			}
+
+		} else {
+			foreach ( $this->menus as $menu_item ) {
+				if ( $current_id === $menu_item['id'] ) {
+					$parent_item = $menu_item;
+					break;
+				}
+			}
+		}
+
+		array_unshift( $menus, $parent_item );
+
+		foreach ( $this->menus as $menu_item ) {
+			if ( $current_id === $menu_item['parent'] ) {
+				$menus[] = $menu_item;
+			}
+		}
+
+		return $menus;
+	}
+
+	/**
+	 * Takes the registered menus for wc-admin, and converts them to WP's menu system.
+	 */
+	function menu_handler() {
+		global $menu, $submenu;
+
+		if ( ! is_wc_admin_page() ) {
+			return false;
+		}
+
+		// Resets All Registered WP Menus
+		$menu    = array();
+		$submenu = array();
+		
+		$menus_for_screen = $this->get_menus_for_screen();
+		foreach ( $menus_for_screen as $menu_item ) {
+			$icon_class = empty( $menu_item['icon'] ) ? 'menu-icon-generic' : '';
+			$icon       = empty( $menu_item['icon'] ) ? 'dashicons-admin-generic' : $menu_item['icon'];
+			$hookname   = get_plugin_page_hookname( plugin_basename( $menu_item['id'] ), '' );
+
+			if ( empty( $menu_item['parent' ] ) ) {
+				$menu[] = array(
+					$menu_item['title'],
+					$menu_item['capability'],
+					$this->id_mapping_to_path[ $menu_item['id'] ], // ?
+					'',
+					'menu-top ' . $icon_class . $hookname,
+					$hookname,
+					$icon,
+				);
+			} else {
+				$submenu[ $this->id_mapping_to_path[ $menu_item['parent'] ] ][] = array(
+					$menu_item['title'],
+					$menu_item['capability'],
+					$menu_item['path'],
+					$menu_item['title'],
+				);
+			}
+		}
+	}
+
+	/**
+	 * Main handler for the single page app.
+	 * This is also our main entry point/link to WooCommerce from wp-admin.
+	 */
+	public function add_main_woocommerce_link() {
+		global $menu, $submenu;
+		add_menu_page(
+			__( 'WooCommerce', 'wc-admin' ),
+			__( 'WooCommerce', 'wc-admin' ),
+			'manage_options',
+			'woocommerce',
+			'wc_admin_page',
+			'',
+			56
+		);
+	}
+
+	/**
+	 * Removes all registered WooCommerce menus from wp-admin.
+	 */
+	public function remove_woocommerce_menus() {
+		global $menu, $submenu;	
+
+		if ( is_wc_admin_page() ) {
+			return false;
+		}
+
+		foreach ( $menu as $menu_item ) {
+			if ( in_array( $menu_item[ 2 ], $this->id_mapping_to_path ) ) {
+				remove_menu_page( $menu_item[ 2 ] );
+			}
+		}
+
+		remove_menu_page( 'woocommerce' );
+
+		foreach ( $submenu as $submenu_key => $submenu_items ) {
+			foreach ( $submenu_items as $submenu_item ) {
+				if ( in_array( $submenu_item[ 2 ], $this->id_mapping_to_path ) || 'woocommerce' === $submenu_key ) {
+					remove_submenu_page( $submenu_key, $submenu_item[ 2 ] );
+				}
+			}
+		}
+	}
+}
+
+$WC_Admin_Page_Controller = WC_Admin_Page_Controller::getInstance();

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -46,6 +46,9 @@ function wc_admin_plugins_loaded() {
 	// Register script files
 	require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 
+	// wc-admin page controller
+	require_once dirname( __FILE__ ) . '/lib/page-controller.php';
+
 	// Create the Admin pages
 	require_once dirname( __FILE__ ) . '/lib/admin.php';
 }


### PR DESCRIPTION
**Note: This branch is an experiment and is not meant to be merged as-is.**

As a part of HACK Week, I looked into replacing the WordPress admin navigation with our own menu system on wc-admin pages. See p90Yrv-Mk-p2 for more information.

In #290 (`Try: Proof of concept WooCommerce wp-admin skin`) I just removed all core menus. This PR instead allows us to register pages, connect existing WooCommerce/wp-admin pages to wc-admin, and add menu items. All of these items are then used to generate the menus. We use WP's handling on classic pages to generate the HTML, and otherwise use a `Menu` component when you are navigating the JS app.

While not ready for merge, I think this is a great starting point once we flesh out the rest of the navigation requirements (for example, it is undetermined how active states will work - see p6riRB-3sK-p2) and it also proves that the necessary hooks are provided to do this.

I also wouldn't mind splitting out some of `lib/page-controller.php` earlier and merging it. It improves things like breadcrumb generation and provides better helpers for converting wp-admin pages to wc-admin pages.

These helper functions are also supposed to help with backwards compatibility. Extensions on older versions of WooCommerce continue using `add_menu_page`, etc. Extensions that detect a newer WC version then just need to wrap those pages -- while keeping around the existing WP functions.

See https://cloudup.com/cqsgUKg3cXQ for a demo or give it a spin.