### PR TITLE
Update Card Component Styles on Mobile

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -4,6 +4,15 @@
 	margin-bottom: $gap-large;
 	background: white;
 	border: 1px solid $core-grey-light-700;
+
+	@include breakpoint( '<782px' ) {
+		margin-left: -16px;
+		margin-right: -16px;
+		margin-bottom: $gap-small;
+		border-left: none;
+		border-right: none;
+		width: auto;
+	}
 }
 
 .woocommerce-card__header {


### PR DESCRIPTION
This update makes the card component full width on viewports with less than 783px, bringing it in line with behavior detailed in the "component grid system"  linked at p6riRB-3dt-p2


Additionally  it removes the left and right borders, and decreases the margin between cards to 12px

**Before**
![screen recording 2018-08-30 at 04 07 pm](https://user-images.githubusercontent.com/4500952/44884311-aab2ec00-ac6f-11e8-8c4e-34babfa80494.gif)

**After**
![screen recording 2018-08-30 at 03 59 pm](https://user-images.githubusercontent.com/4500952/44884329-c3bb9d00-ac6f-11e8-98e0-153fefc09e1d.gif)

