### PR TITLE
Docs Project: Add markdown files, docsify to render site

### DIFF
--- a/bin/generate-docs/index.js
+++ b/bin/generate-docs/index.js
@@ -69,5 +69,5 @@ function generateMarkdown( docObject ) {
 	let markdownString = getTitle( docObject.displayName ) + '\n';
 	markdownString += getDescription( docObject.description ) + '\n';
 	markdownString += getProps( docObject.props );
-	return markdownString;
+	return markdownString + '\n';
 }

--- a/bin/generate-docs/lib/formatting.js
+++ b/bin/generate-docs/lib/formatting.js
@@ -43,11 +43,11 @@ function getProp( propName, prop ) {
 	prop.required && lines.push( '- **Required**' );
 	lines.push( '- Type: ' + getPropType( prop.type, propName ) );
 	lines.push( '- Default: ' + getPropDefaultValue( prop.defaultValue ) );
-	lines.push( '\n' );
-	lines.push( prop.description );
-	lines.push( '\n' );
+	lines.push( '' );
+	prop.description && lines.push( prop.description );
+	lines.push( '' );
 
-	return lines.filter( Boolean ).join( '\n' );
+	return lines.join( '\n' );
 }
 
 /**
@@ -107,15 +107,15 @@ function getPropType( type ) {
 	switch ( type.name ) {
 		case 'arrayOf':
 			// replacing "Object" is a hack for shape proptypes.
-			value = 'Array \n' + getPropType( type.value ).replace( 'Object \n', '' );
+			value = 'Array\n' + getPropType( type.value ).replace( 'Object\n', '' );
 			break;
 		case 'objectOf':
 			// replacing "Object" is a hack for shape proptypes.
-			value = 'Object \n' + getPropType( type.value ).replace( 'Object \n', '' );
+			value = 'Object\n' + getPropType( type.value ).replace( 'Object\n', '' );
 			break;
 		case 'shape':
 			value = map( type.value, ( v, key ) => `\n  - ${ key }: ` + getPropType( v ) ).join( '' );
-			value = 'Object \n' + value.replace( /^\n/, '' );
+			value = 'Object\n' + value.replace( /^\n/, '' );
 			break;
 		case 'enum':
 			value = 'One of: ' + type.value.map( v => v.value ).join( ', ' );

--- a/bin/generate-docs/lib/formatting.js
+++ b/bin/generate-docs/lib/formatting.js
@@ -124,7 +124,7 @@ function getPropType( type ) {
 			value = 'One of type: ' + type.value.map( v => v.name ).join( ', ' );
 			break;
 		default:
-			value = labels[ type.name ] || type.name;
+			value = ( labels[ type.name ] || type.name ) + ( type.description ? ` - ${ type.description }` : '' );
 	}
 
 	return value;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# WooCommerce Admin
+
+This is a feature plugin for a modern, javascript-driven WooCommerce Admin experience.
+
+---
+
+:warning: This project is in active development, and is not ready for general use. You can follow the features in development by looking at the [project's issues](https://github.com/woocommerce/wc-admin/issues). **We do not recommend running this on production sites.**
+
+---
+
+## Prerequisites
+
+[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin. You also need v3 of the WooCommerce REST API, which you can get by installing the feature branch of WooCommerce. [Clone the feature branch from github](https://github.com/woocommerce/woocommerce/tree/feature/rest-api-v3), or [download a zip of WooCommerce](https://github.com/woocommerce/woocommerce/archive/feature/rest-api-v3.zip).
+
+For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
+
+## Development
+
+After cloning the repo, install dependencies with `npm install`. Now you can build the files using one of these commands:
+
+ - `npm run build` : Build a production version
+ - `npm start` : Build a development version, watch files for changes
+
+There are also some helper scripts:
+
+ - `npm run lint` : Run eslint over the javascript files
+ - `npm run i18n` : Create a PHP file with the strings from the javascript files, [used to get around lack of JS support in WordPress.org](https://github.com/WordPress/packages/tree/master/packages/i18n#build).

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,27 @@
+* Home
+
+  * [Overview](/)
+
+* Components
+
+  * [AnimationSlider](components/animation-slider.md)
+  * [Calendar](components/calendar.md)
+  * [Card](components/card.md)
+  * [Chart](components/chart.md)
+  * [Count](components/count.md)
+  * [DropdownButton](components/dropdown-button.md)
+  * [EllipsisMenu](components/ellipsis-menu.md)
+  * [Filters](components/filters.md)
+  * [Flag](components/flag.md)
+  * [Gravatar](components/gravatar.md)
+  * [Link](components/link.md)
+  * [OrderStatus](components/order-status.md)
+  * [Pagination](components/pagination.md)
+  * [ProductImage](components/product-image.md)
+  * [Rating](components/rating.md)
+  * [Search](components/search.md)
+  * [SegmentedSelection](components/segmented-selection.md)
+  * [SplitButton](components/split-button.md)
+  * [Summary](components/summary.md)
+  * [Table](components/table.md)
+  * [Tag](components/tag.md)

--- a/docs/components/animation-slider.md
+++ b/docs/components/animation-slider.md
@@ -13,9 +13,7 @@ Props
 - Type: Function
 - Default: null
 
-
 A function returning rendered content with argument status, reflecting `CSSTransition` status.
-
 
 ### `animationKey`
 
@@ -23,24 +21,19 @@ A function returning rendered content with argument status, reflecting `CSSTrans
 - Type: *
 - Default: null
 
-
 A unique identifier for each slideable page.
-
 
 ### `animate`
 
 - Type: One of: null, 'left', 'right'
 - Default: null
 
-
 null, 'left', 'right', to designate which direction to slide on a change.
-
 
 ### `focusOnChange`
 
 - Type: Boolean
 - Default: null
-
 
 When set to true, the first focusable element will be focused after an animation has finished.
 

--- a/docs/components/animation-slider.md
+++ b/docs/components/animation-slider.md
@@ -1,0 +1,46 @@
+`AnimationSlider` (component)
+=============================
+
+This component creates slideable content controlled by an animate prop to direct the contents to slide left or right.
+All other props are passed to `CSSTransition`. More info at http://reactcommunity.org/react-transition-group/css-transition
+
+Props
+-----
+
+### `children`
+
+- **Required**
+- Type: Function
+- Default: null
+
+
+A function returning rendered content with argument status, reflecting `CSSTransition` status.
+
+
+### `animationKey`
+
+- **Required**
+- Type: *
+- Default: null
+
+
+A unique identifier for each slideable page.
+
+
+### `animate`
+
+- Type: One of: null, 'left', 'right'
+- Default: null
+
+
+null, 'left', 'right', to designate which direction to slide on a change.
+
+
+### `focusOnChange`
+
+- Type: Boolean
+- Default: null
+
+
+When set to true, the first focusable element will be focused after an animation has finished.
+

--- a/docs/components/calendar.md
+++ b/docs/components/calendar.md
@@ -1,0 +1,100 @@
+`DateRange` (component)
+=======================
+
+This is wrapper for a [react-dates](https://github.com/airbnb/react-dates) powered calendar.
+
+Props
+-----
+
+### `after`
+
+- Type: Object
+- Default: null
+
+
+A moment date object representing the selected start. `null` for no selection.
+
+
+### `afterError`
+
+- Type: String
+- Default: null
+
+
+A string error message, shown to the user.
+
+
+### `afterText`
+
+- Type: String
+- Default: null
+
+
+The start date in human-readable format. Displayed in the text input.
+
+
+### `before`
+
+- Type: Object
+- Default: null
+
+
+A moment date object representing the selected end. `null` for no selection.
+
+
+### `beforeError`
+
+- Type: String
+- Default: null
+
+
+A string error message, shown to the user.
+
+
+### `beforeText`
+
+- Type: String
+- Default: null
+
+
+The end date in human-readable format. Displayed in the text input.
+
+
+### `focusedInput`
+
+- Type: String
+- Default: null
+
+
+String identifying which is the currently focused input (start or end).
+
+
+### `invalidDays`
+
+- Type: One of type: enum, func
+- Default: null
+
+
+Optionally invalidate certain days. `past`, `future`, `none`, or function are accepted.
+A function will be passed to react-dates' `isOutsideRange` prop
+
+
+### `onUpdate`
+
+- **Required**
+- Type: Function
+- Default: null
+
+
+A function called upon selection of a date.
+
+
+### `shortDateFormat`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The date format in moment.js-style tokens.
+

--- a/docs/components/calendar.md
+++ b/docs/components/calendar.md
@@ -11,73 +11,57 @@ Props
 - Type: Object
 - Default: null
 
-
 A moment date object representing the selected start. `null` for no selection.
-
 
 ### `afterError`
 
 - Type: String
 - Default: null
 
-
 A string error message, shown to the user.
-
 
 ### `afterText`
 
 - Type: String
 - Default: null
 
-
 The start date in human-readable format. Displayed in the text input.
-
 
 ### `before`
 
 - Type: Object
 - Default: null
 
-
 A moment date object representing the selected end. `null` for no selection.
-
 
 ### `beforeError`
 
 - Type: String
 - Default: null
 
-
 A string error message, shown to the user.
-
 
 ### `beforeText`
 
 - Type: String
 - Default: null
 
-
 The end date in human-readable format. Displayed in the text input.
-
 
 ### `focusedInput`
 
 - Type: String
 - Default: null
 
-
 String identifying which is the currently focused input (start or end).
-
 
 ### `invalidDays`
 
 - Type: One of type: enum, func
 - Default: null
 
-
 Optionally invalidate certain days. `past`, `future`, `none`, or function are accepted.
 A function will be passed to react-dates' `isOutsideRange` prop
-
 
 ### `onUpdate`
 
@@ -85,16 +69,13 @@ A function will be passed to react-dates' `isOutsideRange` prop
 - Type: Function
 - Default: null
 
-
 A function called upon selection of a date.
-
 
 ### `shortDateFormat`
 
 - **Required**
 - Type: String
 - Default: null
-
 
 The date format in moment.js-style tokens.
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -1,0 +1,44 @@
+`Card` (component)
+==================
+
+A basic card component with a header. The header can contain a title, an action, and an `EllipsisMenu` menu.
+
+Props
+-----
+
+### `action`
+
+- Type: ReactNode
+- Default: null
+
+
+One "primary" action for this card, appears in the card header.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+
+### `menu`
+
+- Type: (custom validator)
+- Default: null
+
+
+An `EllipsisMenu`, with filters used to control the content visible in this card
+
+
+### `title`
+
+- **Required**
+- Type: One of type: string, node
+- Default: null
+
+
+The title to use for this card.
+

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -11,34 +11,27 @@ Props
 - Type: ReactNode
 - Default: null
 
-
 One "primary" action for this card, appears in the card header.
-
 
 ### `className`
 
 - Type: String
 - Default: null
 
-
 Additional CSS classes.
-
 
 ### `menu`
 
 - Type: (custom validator)
 - Default: null
 
-
 An `EllipsisMenu`, with filters used to control the content visible in this card
-
 
 ### `title`
 
 - **Required**
 - Type: One of type: string, node
 - Default: null
-
 
 The title to use for this card.
 

--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -1,0 +1,202 @@
+`Chart` (component)
+===================
+
+A chart container using d3, to display timeseries data with an interactive legend.
+
+Props
+-----
+
+### `data`
+
+- Type: Array
+- Default: `[]`
+
+
+An array of data.
+
+
+### `title`
+
+- Type: String
+- Default: null
+
+
+A title describing this chart.
+
+`D3Chart` (component)
+=====================
+
+A simple D3 line and bar chart component for timeseries data in React.
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+
+### `colorScheme`
+
+- Type: Function
+- Default: null
+
+
+A chromatic color function to be passed down to d3.
+
+
+### `data`
+
+- Type: Array
+- Default: `[]`
+
+
+An array of data.
+
+
+### `height`
+
+- Type: Number
+- Default: `200`
+
+
+Relative viewpoirt height of the `svg`.
+
+
+### `legend`
+
+- Type: Array
+- Default: null
+
+
+@todo Remove – not used?
+
+
+### `margin`
+
+- Type: Object 
+  - bottom: Number
+  - left: Number
+  - right: Number
+  - top: Number
+- Default: `{
+    bottom: 30,
+    left: 40,
+    right: 0,
+    top: 20,
+}`
+
+
+Margins for axis and chart padding.
+
+
+### `orderedKeys`
+
+- Type: Array
+- Default: null
+
+
+The list of labels for this chart.
+
+
+### `type`
+
+- Type: One of: 'bar', 'line'
+- Default: `'line'`
+
+
+Chart type of either `line` or `bar`.
+
+
+### `width`
+
+- Type: Number
+- Default: `600`
+
+
+Relative viewport width of the `svg`.
+
+
+### `xFormat`
+
+- Type: String
+- Default: `'%Y-%m-%d'`
+
+
+A datetime formatting string, passed to d3TimeFormat.
+
+
+### `yFormat`
+
+- Type: String
+- Default: `',.0f'`
+
+
+A number formatting string, passed to d3Format.
+
+`Legend` (component)
+====================
+
+A legend specifically designed for the WooCommerce admin charts.
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+
+### `colorScheme`
+
+- Type: Function
+- Default: null
+
+
+A chromatic color function to be passed down to d3.
+
+
+### `data`
+
+- **Required**
+- Type: Array
+- Default: null
+
+
+An array of `orderedKeys`.
+
+
+### `handleLegendToggle`
+
+- Type: Function
+- Default: null
+
+
+Handles `onClick` event.
+
+
+### `handleLegendHover`
+
+- Type: Function
+- Default: null
+
+
+Handles `onMouseEnter`/`onMouseLeave` events.
+
+
+### `legendDirection`
+
+- Type: One of: 'row', 'column'
+- Default: `'row'`
+
+
+Display legend items as a `row` or `column` inside a flex-box.
+

--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -11,15 +11,12 @@ Props
 - Type: Array
 - Default: `[]`
 
-
 An array of data.
-
 
 ### `title`
 
 - Type: String
 - Default: null
-
 
 A title describing this chart.
 
@@ -36,49 +33,39 @@ Props
 - Type: String
 - Default: null
 
-
 Additional CSS classes.
-
 
 ### `colorScheme`
 
 - Type: Function
 - Default: null
 
-
 A chromatic color function to be passed down to d3.
-
 
 ### `data`
 
 - Type: Array
 - Default: `[]`
 
-
 An array of data.
-
 
 ### `height`
 
 - Type: Number
 - Default: `200`
 
-
 Relative viewpoirt height of the `svg`.
-
 
 ### `legend`
 
 - Type: Array
 - Default: null
 
-
 @todo Remove – not used?
-
 
 ### `margin`
 
-- Type: Object 
+- Type: Object
   - bottom: Number
   - left: Number
   - right: Number
@@ -90,51 +77,40 @@ Relative viewpoirt height of the `svg`.
     top: 20,
 }`
 
-
 Margins for axis and chart padding.
-
 
 ### `orderedKeys`
 
 - Type: Array
 - Default: null
 
-
 The list of labels for this chart.
-
 
 ### `type`
 
 - Type: One of: 'bar', 'line'
 - Default: `'line'`
 
-
 Chart type of either `line` or `bar`.
-
 
 ### `width`
 
 - Type: Number
 - Default: `600`
 
-
 Relative viewport width of the `svg`.
-
 
 ### `xFormat`
 
 - Type: String
 - Default: `'%Y-%m-%d'`
 
-
 A datetime formatting string, passed to d3TimeFormat.
-
 
 ### `yFormat`
 
 - Type: String
 - Default: `',.0f'`
-
 
 A number formatting string, passed to d3Format.
 
@@ -151,18 +127,14 @@ Props
 - Type: String
 - Default: null
 
-
 Additional CSS classes.
-
 
 ### `colorScheme`
 
 - Type: Function
 - Default: null
 
-
 A chromatic color function to be passed down to d3.
-
 
 ### `data`
 
@@ -170,33 +142,26 @@ A chromatic color function to be passed down to d3.
 - Type: Array
 - Default: null
 
-
 An array of `orderedKeys`.
-
 
 ### `handleLegendToggle`
 
 - Type: Function
 - Default: null
 
-
 Handles `onClick` event.
-
 
 ### `handleLegendHover`
 
 - Type: Function
 - Default: null
 
-
 Handles `onMouseEnter`/`onMouseLeave` events.
-
 
 ### `legendDirection`
 
 - Type: One of: 'row', 'column'
 - Default: `'row'`
-
 
 Display legend items as a `row` or `column` inside a flex-box.
 

--- a/docs/components/count.md
+++ b/docs/components/count.md
@@ -14,15 +14,12 @@ Props
 - Type: Number
 - Default: null
 
-
 Value of the number to be displayed.
-
 
 ### `label`
 
 - Type: String
 - Default: `''`
-
 
 A translated label with the number in context, used for screen readers.
 

--- a/docs/components/count.md
+++ b/docs/components/count.md
@@ -1,0 +1,28 @@
+`Count` (component)
+===================
+
+Display a number with a styled border.
+
+
+
+Props
+-----
+
+### `count`
+
+- **Required**
+- Type: Number
+- Default: null
+
+
+Value of the number to be displayed.
+
+
+### `label`
+
+- Type: String
+- Default: `''`
+
+
+A translated label with the number in context, used for screen readers.
+

--- a/docs/components/dropdown-button.md
+++ b/docs/components/dropdown-button.md
@@ -15,15 +15,12 @@ Props
 - Type: Array
 - Default: null
 
-
 An array of elements to be rendered as the content of the button.
-
 
 ### `isOpen`
 
 - Type: Boolean
 - Default: null
-
 
 Boolean describing if the dropdown in open or not.
 

--- a/docs/components/dropdown-button.md
+++ b/docs/components/dropdown-button.md
@@ -1,0 +1,29 @@
+`DropdownButton` (component)
+============================
+
+A button useful for a launcher of a dropdown component. The button is 100% width of its container and displays
+single or multiple lines rendered as `<span/>` elments.
+
+@param { object } props Props passed to component.
+
+
+Props
+-----
+
+### `labels`
+
+- Type: Array
+- Default: null
+
+
+An array of elements to be rendered as the content of the button.
+
+
+### `isOpen`
+
+- Type: Boolean
+- Default: null
+
+
+Boolean describing if the dropdown in open or not.
+

--- a/docs/components/ellipsis-menu.md
+++ b/docs/components/ellipsis-menu.md
@@ -1,0 +1,84 @@
+`EllipsisMenu` (component)
+==========================
+
+This is a dropdown menu hidden behind a vertical ellipsis icon. When clicked, the inner MenuItems are displayed.
+
+Props
+-----
+
+### `label`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The label shown when hovering/focusing on the icon button.
+
+
+### `children`
+
+- Type: ReactNode
+- Default: null
+
+
+A list of `MenuTitle`/`MenuItem` components
+
+`MenuItem` (component)
+======================
+
+`MenuItem` is used to give the item an accessible wrapper, with the `menuitem` role and added keyboard functionality (`onInvoke`).
+`MenuItem`s can also be deemed "clickable", though this is disabled by default because generally the inner component handles
+the click event.
+
+Props
+-----
+
+### `children`
+
+- Type: ReactNode
+- Default: null
+
+
+A renderable component (or string) which will be displayed as the content of this item. Generally a `ToggleControl`.
+
+
+### `isClickable`
+
+- Type: Boolean
+- Default: `false`
+
+
+Boolean to control whether the MenuItem should handle the click event. Defaults to false, assuming your child component
+handles the click event.
+
+
+### `onInvoke`
+
+- **Required**
+- Type: Function
+- Default: null
+
+
+A function called when this item is activated via keyboard ENTER or SPACE; or when the item is clicked
+(only if `isClickable` is set).
+
+`MenuTitle` (component)
+=======================
+
+`MenuTitle` is another valid Menu child, but this does not have any accessibility attributes associated
+(so this should not be used in place of the `EllipsisMenu` prop `label`).
+
+
+
+Props
+-----
+
+### `children`
+
+- Type: ReactNode
+- Default: null
+
+
+A renderable component (or string) which will be displayed as the content of this item.
+

--- a/docs/components/ellipsis-menu.md
+++ b/docs/components/ellipsis-menu.md
@@ -12,15 +12,12 @@ Props
 - Type: String
 - Default: null
 
-
 The label shown when hovering/focusing on the icon button.
-
 
 ### `children`
 
 - Type: ReactNode
 - Default: null
-
 
 A list of `MenuTitle`/`MenuItem` components
 
@@ -39,26 +36,21 @@ Props
 - Type: ReactNode
 - Default: null
 
-
 A renderable component (or string) which will be displayed as the content of this item. Generally a `ToggleControl`.
-
 
 ### `isClickable`
 
 - Type: Boolean
 - Default: `false`
 
-
 Boolean to control whether the MenuItem should handle the click event. Defaults to false, assuming your child component
 handles the click event.
-
 
 ### `onInvoke`
 
 - **Required**
 - Type: Function
 - Default: null
-
 
 A function called when this item is activated via keyboard ENTER or SPACE; or when the item is clicked
 (only if `isClickable` is set).
@@ -78,7 +70,6 @@ Props
 
 - Type: ReactNode
 - Default: null
-
 
 A renderable component (or string) which will be displayed as the content of this item.
 

--- a/docs/components/filters.md
+++ b/docs/components/filters.md
@@ -1,0 +1,166 @@
+`ReportFilters` (component)
+===========================
+
+Add a collection of report filters to a page. This uses `DatePicker` & `FilterPicker` for the "basic" filters, and `AdvancedFilters`
+or a comparison card if "advanced" or "compare" are picked from `FilterPicker`.
+
+
+
+Props
+-----
+
+### `advancedConfig`
+
+- Type: Object
+- Default: `{}`
+
+
+Config option passed through to `AdvancedFilters`
+
+
+### `filters`
+
+- Type: Array
+- Default: `[]`
+
+
+Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
+
+
+### `path`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The `path` parameter supplied by React-Router
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+The query string represented in object form
+
+`AdvancedFilters` (component)
+=============================
+
+Displays a configurable set of filters which can modify query parameters.
+
+Props
+-----
+
+### `config`
+
+- **Required**
+- Type: Object 
+  - label: String
+  - addLabel: String
+  - rules: Array 
+Object
+  - input: Object
+- Default: null
+
+
+The configuration object required to render filters.
+
+
+### `filterTitle`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+Name of this filter, used in translations.
+
+
+### `path`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The `path` parameter supplied by React-Router.
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+The query string represented in object form.
+
+`DatePicker` (component)
+========================
+
+Select a range of dates or single dates.
+
+Props
+-----
+
+### `path`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The `path` parameter supplied by React-Router.
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+The query string represented in object form.
+
+`FilterPicker` (component)
+==========================
+
+Modify a url query parameter via a dropdown selection of configurable options.
+This component manipulates the `filter` query parameter.
+
+Props
+-----
+
+### `filters`
+
+- **Required**
+- Type: Array 
+  - component: String
+  - label: String
+  - path: String
+  - subFilters: Array
+  - value: String
+- Default: null
+
+
+An array of filters and subFilters to construct the menu.
+
+
+### `path`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The `path` parameter supplied by React-Router.
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+The query string represented in object form.
+

--- a/docs/components/filters.md
+++ b/docs/components/filters.md
@@ -56,10 +56,10 @@ Props
 ### `config`
 
 - **Required**
-- Type: Object 
+- Type: Object
   - label: String
   - addLabel: String
-  - rules: Array 
+  - rules: Array
 Object
   - input: Object
 - Default: null
@@ -134,12 +134,13 @@ Props
 ### `filters`
 
 - **Required**
-- Type: Array 
-  - component: String
-  - label: String
-  - path: String
-  - subFilters: Array
-  - value: String
+- Type: Array
+  - component: String - A custom component used instead of a button, might have special handling for filtering. TBD, not yet implemented.
+  - label: String - The label for this filter. Optional only for custom component filters.
+  - path: String - An array representing the "path" to this filter, if nested.
+  - subFilters: Array - An array of more filter objects that act as "children" to this item.
+This set of filters is shown if the parent filter is clicked.
+  - value: String - The value for this filter, used to set the `filter` query param when clicked, if there are no `subFilters`.
 - Default: null
 
 
@@ -163,4 +164,3 @@ The `path` parameter supplied by React-Router.
 
 
 The query string represented in object form.
-

--- a/docs/components/filters.md
+++ b/docs/components/filters.md
@@ -14,18 +14,14 @@ Props
 - Type: Object
 - Default: `{}`
 
-
 Config option passed through to `AdvancedFilters`
-
 
 ### `filters`
 
 - Type: Array
 - Default: `[]`
 
-
 Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
-
 
 ### `path`
 
@@ -33,15 +29,12 @@ Config option passed through to `FilterPicker` - if not used, `FilterPicker` is 
 - Type: String
 - Default: null
 
-
 The `path` parameter supplied by React-Router
-
 
 ### `query`
 
 - Type: Object
 - Default: `{}`
-
 
 The query string represented in object form
 
@@ -64,9 +57,7 @@ Object
   - input: Object
 - Default: null
 
-
 The configuration object required to render filters.
-
 
 ### `filterTitle`
 
@@ -74,9 +65,7 @@ The configuration object required to render filters.
 - Type: String
 - Default: null
 
-
 Name of this filter, used in translations.
-
 
 ### `path`
 
@@ -84,15 +73,12 @@ Name of this filter, used in translations.
 - Type: String
 - Default: null
 
-
 The `path` parameter supplied by React-Router.
-
 
 ### `query`
 
 - Type: Object
 - Default: `{}`
-
 
 The query string represented in object form.
 
@@ -110,15 +96,12 @@ Props
 - Type: String
 - Default: null
 
-
 The `path` parameter supplied by React-Router.
-
 
 ### `query`
 
 - Type: Object
 - Default: `{}`
-
 
 The query string represented in object form.
 
@@ -143,9 +126,7 @@ This set of filters is shown if the parent filter is clicked.
   - value: String - The value for this filter, used to set the `filter` query param when clicked, if there are no `subFilters`.
 - Default: null
 
-
 An array of filters and subFilters to construct the menu.
-
 
 ### `path`
 
@@ -153,14 +134,12 @@ An array of filters and subFilters to construct the menu.
 - Type: String
 - Default: null
 
-
 The `path` parameter supplied by React-Router.
-
 
 ### `query`
 
 - Type: Object
 - Default: `{}`
 
-
 The query string represented in object form.
+

--- a/docs/components/flag.md
+++ b/docs/components/flag.md
@@ -1,0 +1,63 @@
+`Flag` (component)
+==================
+
+Use the `Flag` component to display a country's flag.
+
+
+
+Props
+-----
+
+### `code`
+
+- Type: String
+- Default: null
+
+
+Two letter, three letter or three digit country code.
+
+
+### `order`
+
+- Type: Object
+- Default: null
+
+
+An order can be passed instead of `code` and the code will automatically be pulled from the billing or shipping data.
+
+
+### `round`
+
+- Type: Boolean
+- Default: `true`
+
+
+True to display a rounded flag.
+
+
+### `height`
+
+- Type: Number
+- Default: `24`
+
+
+Flag image height.
+
+
+### `width`
+
+- Type: Number
+- Default: `24`
+
+
+Flag image width.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+

--- a/docs/components/flag.md
+++ b/docs/components/flag.md
@@ -13,51 +13,40 @@ Props
 - Type: String
 - Default: null
 
-
 Two letter, three letter or three digit country code.
-
 
 ### `order`
 
 - Type: Object
 - Default: null
 
-
 An order can be passed instead of `code` and the code will automatically be pulled from the billing or shipping data.
-
 
 ### `round`
 
 - Type: Boolean
 - Default: `true`
 
-
 True to display a rounded flag.
-
 
 ### `height`
 
 - Type: Number
 - Default: `24`
 
-
 Flag image height.
-
 
 ### `width`
 
 - Type: Number
 - Default: `24`
 
-
 Flag image width.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional CSS classes.
 

--- a/docs/components/gravatar.md
+++ b/docs/components/gravatar.md
@@ -1,0 +1,54 @@
+`Gravatar` (component)
+======================
+
+Display a users Gravatar.
+
+
+
+Props
+-----
+
+### `user`
+
+- Type: One of type: object, string
+- Default: null
+
+
+The address to hash for displaying a Gravatar. Can be an email address or WP-API user object.
+
+
+### `alt`
+
+- Type: String
+- Default: null
+
+
+Text to display as the image alt attribute.
+
+
+### `title`
+
+- Type: String
+- Default: null
+
+
+Text to use for the image's title
+
+
+### `size`
+
+- Type: Number
+- Default: `60`
+
+
+Default 60. The size of Gravatar to request.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+

--- a/docs/components/gravatar.md
+++ b/docs/components/gravatar.md
@@ -13,42 +13,33 @@ Props
 - Type: One of type: object, string
 - Default: null
 
-
 The address to hash for displaying a Gravatar. Can be an email address or WP-API user object.
-
 
 ### `alt`
 
 - Type: String
 - Default: null
 
-
 Text to display as the image alt attribute.
-
 
 ### `title`
 
 - Type: String
 - Default: null
 
-
 Text to use for the image's title
-
 
 ### `size`
 
 - Type: Number
 - Default: `60`
 
-
 Default 60. The size of Gravatar to request.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional CSS classes.
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -1,0 +1,27 @@
+`Link` (component)
+==================
+
+Use `Link` to create a link to another resource. It accepts a type to automatically
+create wp-admin links, wc-admin links, and external links.
+
+Props
+-----
+
+### `href`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The resource to link to.
+
+
+### `type`
+
+- Type: One of: 'wp-admin', 'wc-admin', 'external'
+- Default: `'wc-admin'`
+
+
+Type of link. For wp-admin and wc-admin, the correct prefix is appended.
+

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -13,15 +13,12 @@ Props
 - Type: String
 - Default: null
 
-
 The resource to link to.
-
 
 ### `type`
 
 - Type: One of: 'wp-admin', 'wc-admin', 'external'
 - Default: `'wc-admin'`
-
 
 Type of link. For wp-admin and wc-admin, the correct prefix is appended.
 

--- a/docs/components/order-status.md
+++ b/docs/components/order-status.md
@@ -14,15 +14,12 @@ Props
 - Type: Object
 - Default: null
 
-
 The order to display a status for.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional CSS classes.
 

--- a/docs/components/order-status.md
+++ b/docs/components/order-status.md
@@ -1,0 +1,28 @@
+`OrderStatus` (component)
+=========================
+
+Use `OrderStatus` to display a badge with human-friendly text describing the current order status.
+
+
+
+Props
+-----
+
+### `order`
+
+- **Required**
+- Type: Object
+- Default: null
+
+
+The order to display a status for.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -1,0 +1,65 @@
+`Pagination` (component)
+========================
+
+Use `Pagination` to allow navigation between pages that represent a collection of items.
+The component allows for selecting a new page and items per page options.
+
+Props
+-----
+
+### `page`
+
+- **Required**
+- Type: Number
+- Default: null
+
+
+The current page of the collection.
+
+
+### `onPageChange`
+
+- Type: Function
+- Default: `noop`
+
+
+A function to execute when the page is changed.
+
+
+### `perPage`
+
+- **Required**
+- Type: Number
+- Default: null
+
+
+The amount of results that are being displayed per page.
+
+
+### `onPerPageChange`
+
+- Type: Function
+- Default: `noop`
+
+
+A function to execute when the per page option is changed.
+
+
+### `total`
+
+- **Required**
+- Type: Number
+- Default: null
+
+
+The total number of results.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional classNames.
+

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -13,18 +13,14 @@ Props
 - Type: Number
 - Default: null
 
-
 The current page of the collection.
-
 
 ### `onPageChange`
 
 - Type: Function
 - Default: `noop`
 
-
 A function to execute when the page is changed.
-
 
 ### `perPage`
 
@@ -32,18 +28,14 @@ A function to execute when the page is changed.
 - Type: Number
 - Default: null
 
-
 The amount of results that are being displayed per page.
-
 
 ### `onPerPageChange`
 
 - Type: Function
 - Default: `noop`
 
-
 A function to execute when the per page option is changed.
-
 
 ### `total`
 
@@ -51,15 +43,12 @@ A function to execute when the per page option is changed.
 - Type: Number
 - Default: null
 
-
 The total number of results.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional classNames.
 

--- a/docs/components/product-image.md
+++ b/docs/components/product-image.md
@@ -14,43 +14,34 @@ Props
 - Type: Number
 - Default: `60`
 
-
 The width of image to display.
-
 
 ### `height`
 
 - Type: Number
 - Default: `60`
 
-
 The height of image to display.
-
 
 ### `className`
 
 - Type: String
 - Default: `''`
 
-
 Additional CSS classes.
-
 
 ### `product`
 
 - Type: Object
 - Default: null
 
-
 Product object. The image to display will be pulled from `product.images`.
 See https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties
-
 
 ### `alt`
 
 - Type: String
 - Default: null
-
 
 Text to use as the image alt attribute.
 

--- a/docs/components/product-image.md
+++ b/docs/components/product-image.md
@@ -1,0 +1,56 @@
+`ProductImage` (component)
+==========================
+
+Use `ProductImage` to display a product's featured image. If no image can be found, a placeholder matching the front-end image
+placeholder will be displayed.
+
+
+
+Props
+-----
+
+### `width`
+
+- Type: Number
+- Default: `60`
+
+
+The width of image to display.
+
+
+### `height`
+
+- Type: Number
+- Default: `60`
+
+
+The height of image to display.
+
+
+### `className`
+
+- Type: String
+- Default: `''`
+
+
+Additional CSS classes.
+
+
+### `product`
+
+- Type: Object
+- Default: null
+
+
+Product object. The image to display will be pulled from `product.images`.
+See https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties
+
+
+### `alt`
+
+- Type: String
+- Default: null
+
+
+Text to use as the image alt attribute.
+

--- a/docs/components/rating.md
+++ b/docs/components/rating.md
@@ -1,0 +1,84 @@
+`Rating` (component)
+====================
+
+Use `Rating` to display a set of stars, filled, empty or half-filled, that represents a
+rating in a scale between 0 and the prop `totalStars` (default 5).
+
+Props
+-----
+
+### `rating`
+
+- Type: Number
+- Default: `0`
+
+
+Number of stars that should be filled. You can pass a partial number of stars like `2.5`.
+
+
+### `totalStars`
+
+- Type: Number
+- Default: `5`
+
+
+The total number of stars the rating is out of.
+
+
+### `size`
+
+- Type: Number
+- Default: `18`
+
+
+The size in pixels the stars should be rendered at.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+`ProductRating` (component)
+===========================
+
+Display a set of stars representing the product's average rating.
+
+
+
+Props
+-----
+
+### `product`
+
+- **Required**
+- Type: Object
+- Default: null
+
+
+A product object containing a `average_rating`.
+See https://woocommerce.github.io/woocommerce-rest-api-docs/#products.
+
+`ReviewRating` (component)
+==========================
+
+Display a set of stars representing the review's rating.
+
+
+
+Props
+-----
+
+### `review`
+
+- **Required**
+- Type: Object
+- Default: null
+
+
+A review object containing a `rating`.
+See https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-product-reviews.
+

--- a/docs/components/rating.md
+++ b/docs/components/rating.md
@@ -12,33 +12,26 @@ Props
 - Type: Number
 - Default: `0`
 
-
 Number of stars that should be filled. You can pass a partial number of stars like `2.5`.
-
 
 ### `totalStars`
 
 - Type: Number
 - Default: `5`
 
-
 The total number of stars the rating is out of.
-
 
 ### `size`
 
 - Type: Number
 - Default: `18`
 
-
 The size in pixels the stars should be rendered at.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional CSS classes.
 
@@ -58,7 +51,6 @@ Props
 - Type: Object
 - Default: null
 
-
 A product object containing a `average_rating`.
 See https://woocommerce.github.io/woocommerce-rest-api-docs/#products.
 
@@ -77,7 +69,6 @@ Props
 - **Required**
 - Type: Object
 - Default: null
-
 
 A review object containing a `rating`.
 See https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-product-reviews.

--- a/docs/components/search.md
+++ b/docs/components/search.md
@@ -12,16 +12,13 @@ Props
 - Type: Function
 - Default: `noop`
 
-
 Function called when selected results change, passed result list.
-
 
 ### `type`
 
 - **Required**
 - Type: One of: 'products', 'orders', 'customers'
 - Default: null
-
 
 The object type to be used in searching.
 

--- a/docs/components/search.md
+++ b/docs/components/search.md
@@ -1,0 +1,27 @@
+`Search` (component)
+====================
+
+A search box which autocompletes results while typing, allowing for the user to select an existing object
+(product, order, customer, etc). Currently only products are supported.
+
+Props
+-----
+
+### `onChange`
+
+- Type: Function
+- Default: `noop`
+
+
+Function called when selected results change, passed result list.
+
+
+### `type`
+
+- **Required**
+- Type: One of: 'products', 'orders', 'customers'
+- Default: null
+
+
+The object type to be used in searching.
+

--- a/docs/components/segmented-selection.md
+++ b/docs/components/segmented-selection.md
@@ -1,0 +1,67 @@
+`SegmentedSelection` (component)
+================================
+
+Create a panel of styled selectable options rendering stylized checkboxes and labels
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+
+### `options`
+
+- **Required**
+- Type: Array 
+  - value: String
+  - label: String
+- Default: null
+
+
+An Array of options to render. The array needs to be composed of objects with properties `label` and `value`.
+
+
+### `selected`
+
+- Type: String
+- Default: null
+
+
+Value of selected item.
+
+
+### `onSelect`
+
+- **Required**
+- Type: Function
+- Default: null
+
+
+Callback to be executed after selection
+
+
+### `name`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+This will be the key in the key and value arguments supplied to `onSelect`.
+
+
+### `legend`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+Create a legend visible to screen readers.
+

--- a/docs/components/segmented-selection.md
+++ b/docs/components/segmented-selection.md
@@ -11,30 +11,24 @@ Props
 - Type: String
 - Default: null
 
-
 Additional CSS classes.
-
 
 ### `options`
 
 - **Required**
-- Type: Array 
+- Type: Array
   - value: String
   - label: String
 - Default: null
 
-
 An Array of options to render. The array needs to be composed of objects with properties `label` and `value`.
-
 
 ### `selected`
 
 - Type: String
 - Default: null
 
-
 Value of selected item.
-
 
 ### `onSelect`
 
@@ -42,9 +36,7 @@ Value of selected item.
 - Type: Function
 - Default: null
 
-
 Callback to be executed after selection
-
 
 ### `name`
 
@@ -52,16 +44,13 @@ Callback to be executed after selection
 - Type: String
 - Default: null
 
-
 This will be the key in the key and value arguments supplied to `onSelect`.
-
 
 ### `legend`
 
 - **Required**
 - Type: String
 - Default: null
-
 
 Create a legend visible to screen readers.
 

--- a/docs/components/split-button.md
+++ b/docs/components/split-button.md
@@ -1,0 +1,76 @@
+`SplitButton` (component)
+=========================
+
+A component for displaying a button with a main action plus a secondary set of actions behind a menu toggle.
+
+
+
+Props
+-----
+
+### `isPrimary`
+
+- Type: Boolean
+- Default: `false`
+
+
+Whether the button is styled as a primary button.
+
+
+### `mainIcon`
+
+- Type: ReactNode
+- Default: null
+
+
+Icon for the main button.
+
+
+### `mainLabel`
+
+- Type: String
+- Default: null
+
+
+Label for the main button.
+
+
+### `onClick`
+
+- Type: Function
+- Default: `noop`
+
+
+Function to activate when the the main button is clicked.
+
+
+### `menuLabel`
+
+- Type: String
+- Default: null
+
+
+Label to display for the menu of actions, used as a heading on the mobile popover and for accessible text.
+
+
+### `controls`
+
+- **Required**
+- Type: Array 
+  - icon: One of type: string, element
+  - label: String
+  - onClick: Function
+- Default: null
+
+
+An array of additional actions. Accepts additional icon, label, and onClick props.
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+

--- a/docs/components/split-button.md
+++ b/docs/components/split-button.md
@@ -13,64 +13,51 @@ Props
 - Type: Boolean
 - Default: `false`
 
-
 Whether the button is styled as a primary button.
-
 
 ### `mainIcon`
 
 - Type: ReactNode
 - Default: null
 
-
 Icon for the main button.
-
 
 ### `mainLabel`
 
 - Type: String
 - Default: null
 
-
 Label for the main button.
-
 
 ### `onClick`
 
 - Type: Function
 - Default: `noop`
 
-
 Function to activate when the the main button is clicked.
-
 
 ### `menuLabel`
 
 - Type: String
 - Default: null
 
-
 Label to display for the menu of actions, used as a heading on the mobile popover and for accessible text.
-
 
 ### `controls`
 
 - **Required**
-- Type: Array 
+- Type: Array
   - icon: One of type: string, element
   - label: String - Label displayed for this button.
   - onClick: Function - Click handler for this button.
 - Default: null
 
-
 An array of additional actions. Accepts additional icon, label, and onClick props.
-
 
 ### `className`
 
 - Type: String
 - Default: null
-
 
 Additional CSS classes.
 

--- a/docs/components/split-button.md
+++ b/docs/components/split-button.md
@@ -58,8 +58,8 @@ Label to display for the menu of actions, used as a heading on the mobile popove
 - **Required**
 - Type: Array 
   - icon: One of type: string, element
-  - label: String
-  - onClick: Function
+  - label: String - Label displayed for this button.
+  - onClick: Function - Click handler for this button.
 - Default: null
 
 

--- a/docs/components/summary.md
+++ b/docs/components/summary.md
@@ -1,0 +1,134 @@
+`SummaryList` (component)
+=========================
+
+A container element for a list of SummaryNumbers. This component handles detecting & switching to
+the mobile format on smaller screens.
+
+
+
+Props
+-----
+
+### `children`
+
+- **Required**
+- Type: ReactNode
+- Default: null
+
+
+A list of `<SummaryNumber />`s
+
+
+### `label`
+
+- Type: String
+- Default: null
+
+
+An optional label of this group, read to screen reader users. Defaults to "Performance Indicators".
+
+`SummaryNumber` (component)
+===========================
+
+A component to show a value, label, and an optional change percentage. Can also act as a link to a specific report focus.
+
+
+
+Props
+-----
+
+### `delta`
+
+- Type: Number
+- Default: null
+
+
+A number to represent the percentage change since the last comparison period -
+positive numbers will show a green up arrow, negative numbers will show a
+red down arrow. If omitted, no change value will display.
+
+
+### `href`
+
+- Type: String
+- Default: `'/analytics'`
+
+
+An internal link to the report focused on this number.
+
+
+### `isOpen`
+
+- Type: Boolean
+- Default: `false`
+
+
+Boolean describing whether the menu list is open. Only applies in mobile view,
+and only applies to the toggle-able item (first in the list).
+
+
+### `label`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+A string description of this value, ex "Revenue", or "New Customers"
+
+
+### `onToggle`
+
+- Type: Function
+- Default: null
+
+
+A function used to switch the given SummaryNumber to a button, and called on click.
+
+
+### `prevLabel`
+
+- Type: String
+- Default: `__( 'Previous Period:', 'wc-admin' )`
+
+
+A string description of the previous value's timeframe, ex "Previous Year:".
+
+
+### `prevValue`
+
+- Type: One of type: number, string
+- Default: null
+
+
+A string or number value to display - a string is allowed so we can accept currency formatting.
+If omitted, this section won't display.
+
+
+### `reverseTrend`
+
+- Type: Boolean
+- Default: `false`
+
+
+A boolean used to indicate that a negative delta is "good", and should be styled like a positive (and vice-versa).
+
+
+### `selected`
+
+- Type: Boolean
+- Default: `false`
+
+
+A boolean used to show a highlight style on this number.
+
+
+### `value`
+
+- **Required**
+- Type: One of type: number, string
+- Default: null
+
+
+A string or number value to display - a string is allowed so we can accept currency formatting.
+

--- a/docs/components/summary.md
+++ b/docs/components/summary.md
@@ -15,15 +15,12 @@ Props
 - Type: ReactNode
 - Default: null
 
-
 A list of `<SummaryNumber />`s
-
 
 ### `label`
 
 - Type: String
 - Default: null
-
 
 An optional label of this group, read to screen reader users. Defaults to "Performance Indicators".
 
@@ -42,30 +39,24 @@ Props
 - Type: Number
 - Default: null
 
-
-A number to represent the percentage change since the last comparison period -
-positive numbers will show a green up arrow, negative numbers will show a
-red down arrow. If omitted, no change value will display.
-
+A number to represent the percentage change since the last comparison period - positive numbers will show
+a green up arrow, negative numbers will show a red down arrow, and zero will show a flat right arrow.
+If omitted, no change value will display.
 
 ### `href`
 
 - Type: String
 - Default: `'/analytics'`
 
-
 An internal link to the report focused on this number.
-
 
 ### `isOpen`
 
 - Type: Boolean
 - Default: `false`
 
-
 Boolean describing whether the menu list is open. Only applies in mobile view,
 and only applies to the toggle-able item (first in the list).
-
 
 ### `label`
 
@@ -73,62 +64,49 @@ and only applies to the toggle-able item (first in the list).
 - Type: String
 - Default: null
 
-
 A string description of this value, ex "Revenue", or "New Customers"
-
 
 ### `onToggle`
 
 - Type: Function
 - Default: null
 
-
 A function used to switch the given SummaryNumber to a button, and called on click.
-
 
 ### `prevLabel`
 
 - Type: String
 - Default: `__( 'Previous Period:', 'wc-admin' )`
 
-
 A string description of the previous value's timeframe, ex "Previous Year:".
-
 
 ### `prevValue`
 
 - Type: One of type: number, string
 - Default: null
 
-
 A string or number value to display - a string is allowed so we can accept currency formatting.
 If omitted, this section won't display.
-
 
 ### `reverseTrend`
 
 - Type: Boolean
 - Default: `false`
 
-
 A boolean used to indicate that a negative delta is "good", and should be styled like a positive (and vice-versa).
-
 
 ### `selected`
 
 - Type: Boolean
 - Default: `false`
 
-
 A boolean used to show a highlight style on this number.
-
 
 ### `value`
 
 - **Required**
 - Type: One of type: number, string
 - Default: null
-
 
 A string or number value to display - a string is allowed so we can accept currency formatting.
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -142,12 +142,12 @@ Additional CSS classes.
 ### `headers`
 
 - Type: Array 
-  - defaultSort: Boolean
-  - isNumeric: Boolean
-  - isSortable: Boolean
-  - key: String
-  - label: String
-  - required: Boolean
+  - defaultSort: Boolean - Boolean, true if this column is the default for sorting. Only one column should have this set.
+  - isNumeric: Boolean - Boolean, true if this column is a number value.
+  - isSortable: Boolean - Boolean, true if this column is sortable.
+  - key: String - The API parameter name for this column, passed to `orderby` when sorting via API.
+  - label: String - The display label for this column.
+  - required: Boolean - Boolean, true if this column should always display in the table (not shown in toggle-able list).
 - Default: `[]`
 
 
@@ -177,7 +177,7 @@ docs
 - **Required**
 - Type: Array 
 Array 
-  - display: ReactNode
+  - display: ReactNode - Display value, used for rendering- strings or elements are best here.
   - value: One of type: string, number, bool
 - Default: null
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -13,7 +13,90 @@ Props
 
 ### `headers`
 
-- Type: Array 
+- Type: Array
+  - defaultSort: Boolean
+  - isSortable: Boolean
+  - key: String
+  - label: String
+  - required: Boolean
+- Default: null
+
+An array of column headers (see `Table` props).
+
+### `onQueryChange`
+
+- Type: Function
+- Default: `noop`
+
+A function which returns a callback function to update the query string for a given `param`.
+
+### `onClickDownload`
+
+- Type: Function
+- Default: null
+
+A callback function which handles then "download" button press. Optional, if not used, the button won't appear.
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
+
+### `rowHeader`
+
+- Type: One of type: number, bool
+- Default: `0`
+
+An array of arrays of display/value object pairs (see `Table` props).
+
+### `rows`
+
+- Type: Array
+Array
+  - display: ReactNode
+  - value: One of type: string, number, bool
+- Default: `[]`
+
+Which column should be the row header, defaults to the first item (`0`) (see `Table` props).
+
+### `summary`
+
+- Type: Array
+  - label: ReactNode
+  - value: One of type: string, number
+- Default: null
+
+An array of objects with `label` & `value` properties, which display in a line under the table.
+Optional, can be left off to show no summary.
+
+### `title`
+
+- **Required**
+- Type: String
+- Default: null
+
+The title used in the card header, also used as the caption for the content in this table.
+
+`TablePlaceholder` (component)
+==============================
+
+
+
+Props
+-----
+
+### `caption`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+### `headers`
+
+- Type: Array
   - defaultSort: Boolean
   - isSortable: Boolean
   - key: String
@@ -22,77 +105,11 @@ Props
 - Default: null
 
 
-An array of column headers (see `Table` props).
+### `numberOfRows`
 
+- Type: Number
+- Default: `5`
 
-### `onQueryChange`
-
-- Type: Function
-- Default: `noop`
-
-
-A function which returns a callback function to update the query string for a given `param`.
-
-
-### `onClickDownload`
-
-- Type: Function
-- Default: null
-
-
-A callback function which handles then "download" button press. Optional, if not used, the button won't appear.
-
-
-### `query`
-
-- Type: Object
-- Default: `{}`
-
-
-An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
-
-
-### `rowHeader`
-
-- Type: One of type: number, bool
-- Default: `0`
-
-
-An array of arrays of display/value object pairs (see `Table` props).
-
-
-### `rows`
-
-- Type: Array 
-Array 
-  - display: ReactNode
-  - value: One of type: string, number, bool
-- Default: `[]`
-
-
-Which column should be the row header, defaults to the first item (`0`) (see `Table` props).
-
-
-### `summary`
-
-- Type: Array 
-  - label: ReactNode
-  - value: One of type: string, number
-- Default: null
-
-
-An array of objects with `label` & `value` properties, which display in a line under the table.
-Optional, can be left off to show no summary.
-
-
-### `title`
-
-- **Required**
-- Type: String
-- Default: null
-
-
-The title used in the card header, also used as the caption for the content in this table.
 
 `TableSummary` (component)
 ==========================
@@ -109,7 +126,6 @@ Props
 - Type: Array
 - Default: null
 
-
 An array of objects with `label` & `value` properties, which display on a single line.
 
 `Table` (component)
@@ -120,28 +136,32 @@ A table component, without the Card wrapper. This is a basic table display, sort
 Props
 -----
 
+### `ariaHidden`
+
+- Type: Boolean
+- Default: `false`
+
+Controls whether this component is hidden from screen readers. Used by the loading state, before there is data to read.
+Don't use this on real tables unless the table data is loaded elsewhere on the page.
+
 ### `caption`
 
 - **Required**
 - Type: String
 - Default: null
 
-
 A label for the content in this table
-
 
 ### `className`
 
 - Type: String
 - Default: null
 
-
 Additional CSS classes.
-
 
 ### `headers`
 
-- Type: Array 
+- Type: Array
   - defaultSort: Boolean - Boolean, true if this column is the default for sorting. Only one column should have this set.
   - isNumeric: Boolean - Boolean, true if this column is a number value.
   - isSortable: Boolean - Boolean, true if this column is sortable.
@@ -150,46 +170,37 @@ Additional CSS classes.
   - required: Boolean - Boolean, true if this column should always display in the table (not shown in toggle-able list).
 - Default: `[]`
 
-
 An array of column headers, as objects.
-
 
 ### `onSort`
 
 - Type: Function
 - Default: `noop`
 
-
 A function called when sortable table headers are clicked, gets the `header.key` as argument.
-
 
 ### `query`
 
 - Type: Object
 - Default: `{}`
 
-
-docs
-
+The query string represented in object form
 
 ### `rows`
 
 - **Required**
-- Type: Array 
-Array 
+- Type: Array
+Array
   - display: ReactNode - Display value, used for rendering- strings or elements are best here.
   - value: One of type: string, number, bool
 - Default: null
 
-
 An array of arrays of display/value object pairs.
-
 
 ### `rowHeader`
 
 - Type: One of type: number, bool
 - Default: `0`
-
 
 Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col
 is checkboxes, for example). Set to false to disable row headers.

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1,0 +1,196 @@
+`TableCard` (component)
+=======================
+
+This is an accessible, sortable, and scrollable table for displaying tabular data (like revenue and other analytics data).
+It accepts `headers` for column headers, and `rows` for the table content.
+`rowHeader` can be used to define the index of the row header (or false if no header).
+
+`TableCard` serves as Card wrapper & contains a card header, `<Table />`, `<TableSummary />`, and `<Pagination />`.
+This includes filtering and comparison functionality for report pages.
+
+Props
+-----
+
+### `headers`
+
+- Type: Array 
+  - defaultSort: Boolean
+  - isSortable: Boolean
+  - key: String
+  - label: String
+  - required: Boolean
+- Default: null
+
+
+An array of column headers (see `Table` props).
+
+
+### `onQueryChange`
+
+- Type: Function
+- Default: `noop`
+
+
+A function which returns a callback function to update the query string for a given `param`.
+
+
+### `onClickDownload`
+
+- Type: Function
+- Default: null
+
+
+A callback function which handles then "download" button press. Optional, if not used, the button won't appear.
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
+
+
+### `rowHeader`
+
+- Type: One of type: number, bool
+- Default: `0`
+
+
+An array of arrays of display/value object pairs (see `Table` props).
+
+
+### `rows`
+
+- Type: Array 
+Array 
+  - display: ReactNode
+  - value: One of type: string, number, bool
+- Default: `[]`
+
+
+Which column should be the row header, defaults to the first item (`0`) (see `Table` props).
+
+
+### `summary`
+
+- Type: Array 
+  - label: ReactNode
+  - value: One of type: string, number
+- Default: null
+
+
+An array of objects with `label` & `value` properties, which display in a line under the table.
+Optional, can be left off to show no summary.
+
+
+### `title`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The title used in the card header, also used as the caption for the content in this table.
+
+`TableSummary` (component)
+==========================
+
+A component to display summarized table data - the list of data passed in on a single line.
+
+
+
+Props
+-----
+
+### `data`
+
+- Type: Array
+- Default: null
+
+
+An array of objects with `label` & `value` properties, which display on a single line.
+
+`Table` (component)
+===================
+
+A table component, without the Card wrapper. This is a basic table display, sortable, but no default filtering.
+
+Props
+-----
+
+### `caption`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+A label for the content in this table
+
+
+### `className`
+
+- Type: String
+- Default: null
+
+
+Additional CSS classes.
+
+
+### `headers`
+
+- Type: Array 
+  - defaultSort: Boolean
+  - isNumeric: Boolean
+  - isSortable: Boolean
+  - key: String
+  - label: String
+  - required: Boolean
+- Default: `[]`
+
+
+An array of column headers, as objects.
+
+
+### `onSort`
+
+- Type: Function
+- Default: `noop`
+
+
+A function called when sortable table headers are clicked, gets the `header.key` as argument.
+
+
+### `query`
+
+- Type: Object
+- Default: `{}`
+
+
+docs
+
+
+### `rows`
+
+- **Required**
+- Type: Array 
+Array 
+  - display: ReactNode
+  - value: One of type: string, number, bool
+- Default: null
+
+
+An array of arrays of display/value object pairs.
+
+
+### `rowHeader`
+
+- Type: One of type: number, bool
+- Default: `0`
+
+
+Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col
+is checkboxes, for example). Set to false to disable row headers.
+

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -15,9 +15,7 @@ Props
 - Type: Number
 - Default: null
 
-
 The ID for this item, used in the remove function.
-
 
 ### `label`
 
@@ -25,33 +23,26 @@ The ID for this item, used in the remove function.
 - Type: String
 - Default: null
 
-
 The name for this item, displayed as the tag's text.
-
 
 ### `remove`
 
 - Type: Function
 - Default: null
 
-
 A function called when the remove X is clicked. If not used, no X icon will display.
-
 
 ### `removeLabel`
 
 - Type: String
 - Default: `__( 'Remove tag', 'wc-admin' )`
 
-
 The label for removing this item (shown when hovering on X, or read to screen reader users). Defaults to "Remove tag".
-
 
 ### `screenReaderLabel`
 
 - Type: String
 - Default: null
-
 
 A more descriptive label for screen reader users. Defaults to the `name` prop.
 

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -1,0 +1,57 @@
+`Tag` (component)
+=================
+
+This component can be used to show an item styled as a "tag", optionally with an `X` + "remove".
+Generally this is used in a collection of selected items, see the Search component.
+
+
+
+Props
+-----
+
+### `id`
+
+- **Required**
+- Type: Number
+- Default: null
+
+
+The ID for this item, used in the remove function.
+
+
+### `label`
+
+- **Required**
+- Type: String
+- Default: null
+
+
+The name for this item, displayed as the tag's text.
+
+
+### `remove`
+
+- Type: Function
+- Default: null
+
+
+A function called when the remove X is clicked. If not used, no X icon will display.
+
+
+### `removeLabel`
+
+- Type: String
+- Default: `__( 'Remove tag', 'wc-admin' )`
+
+
+The label for removing this item (shown when hovering on X, or read to screen reader users). Defaults to "Remove tag".
+
+
+### `screenReaderLabel`
+
+- Type: String
+- Default: null
+
+
+A more descriptive label for screen reader users. Defaults to the `name` prop.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,27 +2,42 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>wc-admin</title>
+	<title>WooCommerce Admin</title>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 	<meta name="description" content="Description">
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-	<link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+	<!-- Theme: Simple -->
+	<link rel="stylesheet" href="https://unpkg.com/docsify-themeable/dist/css/theme-simple.css">
+	<!-- Customization -->
+	<style>
+	:root {
+		--theme-color   : #95588a;
+	}
+	.markdown-section h1 code,
+	.markdown-section h2 code,
+	.markdown-section h3 code,
+	.markdown-section h4 code {
+		/* Code font is slightly larger-scale than heading font, so we'll size it accordingly. */
+		font-size: 0.9em;
+	}
+	</style>
 </head>
 <body>
 	<div id="app"></div>
 	<script>
 		window.$docsify = {
-			name: 'wc-admin',
+			name: 'WooCommerce Admin',
 			repo: 'https://github.com/woocommerce/wc-admin',
 			loadSidebar: true,
-			subMaxLevel: 2,
+			subMaxLevel: 3,
 			search: 'auto',
 			alias: {
 				'/.*/_sidebar.md': '/_sidebar.md',
 			},
 		};
 	</script>
-	<script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-	<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+	<script src="https://unpkg.com/docsify/lib/docsify.min.js"></script>
+	<script src="https://unpkg.com/docsify/lib/plugins/search.min.js"></script>
+	<script src="https://unpkg.com/docsify-themeable"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>wc-admin</title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta name="description" content="Description">
+	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+	<link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+</head>
+<body>
+	<div id="app"></div>
+	<script>
+		window.$docsify = {
+			name: 'wc-admin',
+			repo: 'https://github.com/woocommerce/wc-admin',
+			loadSidebar: true,
+			subMaxLevel: 2,
+			search: 'auto',
+			alias: {
+				'/.*/_sidebar.md': '/_sidebar.md',
+			},
+		};
+	</script>
+	<script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+	<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,6 +1624,15 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -2850,6 +2859,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
@@ -3207,6 +3235,29 @@
       "dev": true,
       "requires": {
         "hoek": "2.x.x"
+      }
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -3613,6 +3664,12 @@
         "rsvp": "^3.3.3"
       }
     },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3850,6 +3907,12 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -4166,6 +4229,49 @@
         "typedarray": "^0.0.6"
       }
     },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "connect-livereload": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.6.0.tgz",
+      "integrity": "sha1-+fAJh0rWg3GDr7FwtMTjhXodfOs=",
+      "dev": true
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -4253,6 +4359,19 @@
         }
       }
     },
+    "cp-file": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-4.2.0.tgz",
+      "integrity": "sha1-cVNhZjtx7eC23dvDyA4roC5yXsM=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^2.3.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -4261,6 +4380,15 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -4328,6 +4456,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "css-color-function": {
       "version": "1.3.3",
@@ -5076,6 +5210,12 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -5085,6 +5225,12 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "detect-conflict": {
       "version": "1.0.1",
@@ -5161,6 +5307,174 @@
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
+    },
+    "docsify": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/docsify/-/docsify-4.7.1.tgz",
+      "integrity": "sha512-RdM4oN9yYNboTlm9JtbTMIqjYjPF7WBF7W37NXCG1fZIBC83Ya8qdH9c1rpPkLYw8HekJzSO2P13f6z/GVKITA==",
+      "dev": true,
+      "requires": {
+        "marked": "^0.3.12",
+        "medium-zoom": "^0.4.0",
+        "opencollective": "^1.0.3",
+        "prismjs": "^1.9.0",
+        "tinydate": "^1.0.0",
+        "tweezer.js": "^1.4.0"
+      }
+    },
+    "docsify-cli": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/docsify-cli/-/docsify-cli-4.2.1.tgz",
+      "integrity": "sha512-0IPCQxLTtkXH4L1L4U+q1c9iUvdHyXST8CBwz0PYnwH4euD2zVI7iNHGXlP2FPAZZn/Lzg9+csVJO8RcxZp41w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "connect": "^3.6.0",
+        "connect-livereload": "^0.6.0",
+        "cp-file": "^4.1.1",
+        "docsify": ">=3",
+        "docsify-server-renderer": ">=4",
+        "fs-extra": "^2.1.2",
+        "livereload": "^0.6.2",
+        "lru-cache": "^4.1.1",
+        "open": "^0.0.5",
+        "serve-static": "^1.12.1",
+        "update-notifier": "^2.1.0",
+        "y18n": "^3.2.1",
+        "yargonaut": "^1.1.2",
+        "yargs": "^7.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    },
+    "docsify-server-renderer": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/docsify-server-renderer/-/docsify-server-renderer-4.7.1.tgz",
+      "integrity": "sha512-7gWwYlReLu6/z/eixod8ZiepMWdV5TjGsrkDcSTBWvgcjeebgvGIbjpPVH23cvj5f2n+wyZ+fqtQMjw7hK/YyA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "node-fetch": "^1.7.0",
+        "resolve-pathname": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "doctrine": {
       "version": "2.1.0",
@@ -5240,6 +5554,15 @@
         "domelementtype": "1"
       }
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5304,6 +5627,12 @@
       "integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA==",
       "dev": true
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "ejs": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
@@ -5353,6 +5682,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
@@ -5518,6 +5853,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5726,6 +6067,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter2": {
@@ -6250,6 +6597,12 @@
         }
       }
     },
+    "figlet": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.2.0.tgz",
+      "integrity": "sha1-bEZTc3j6tkkUa1phQ92gGbQwtBA=",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -6304,6 +6657,32 @@
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }
@@ -6453,6 +6832,12 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -6461,6 +6846,16 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -7347,6 +7742,15 @@
         "is-symbol": "^1.0.1"
       }
     },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -7906,6 +8310,26 @@
       "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -8019,6 +8443,12 @@
       "requires": {
         "resolve-from": "^3.0.0"
       }
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -8374,6 +8804,33 @@
       "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
       "dev": true
     },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        }
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -8398,6 +8855,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
       "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-object": {
@@ -8489,6 +8952,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -10601,6 +11070,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -10648,6 +11126,15 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-1.0.2.tgz",
       "integrity": "sha512-4u2TF1/mKmiawrkjzCxRKszdCvqRsPgTJwjmZZt0RE4OiZMzvFfb4kwqfFP/p0gvakH1lhQOfCMYXUOYI9dTgA==",
       "dev": true
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -10914,6 +11401,130 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        }
+      }
+    },
+    "livereload": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.6.3.tgz",
+      "integrity": "sha512-5SVeqHbKQWB69himud5GNRS8w1RgnMrYBnuIeZMiQ5ZctsIvhFfhKJclihxUS3NkOV7354rnA9rRz1IQBsgaNQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^1.7.0",
+        "opts": ">= 1.2.0",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "dev": true,
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
         }
       }
     },
@@ -11304,6 +11915,12 @@
       "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
       "dev": true
     },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
@@ -11331,6 +11948,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "medium-zoom": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npmjs.org/medium-zoom/-/medium-zoom-0.4.0.tgz",
+      "integrity": "sha512-0z7yMfd6I1BTCAa8QaR4cp5AqDkQD571GzhHIbbfefKEssGLSvs+4Xai/itOAncm4FBlF5gUoMQ22yW9/f8Sig==",
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -11585,6 +12208,12 @@
         "brorand": "^1.0.1"
       }
     },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
@@ -11827,6 +12456,12 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
       "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
     "nice-try": {
@@ -12515,6 +13150,15 @@
         "has": "^1.0.1"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12531,6 +13175,106 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
+    },
+    "opencollective": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "chalk": "1.1.3",
+        "inquirer": "3.0.6",
+        "minimist": "1.2.0",
+        "node-fetch": "1.6.3",
+        "opn": "4.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.1",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.6.3",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "opn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "optimist": {
@@ -12564,6 +13308,18 @@
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
       }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
+    "opts": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.6.tgz",
+      "integrity": "sha1-0YXAQlz9652h0YKQi2W1wCOP67M=",
+      "dev": true
     },
     "ora": {
       "version": "0.2.3",
@@ -12746,6 +13502,48 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        }
+      }
+    },
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -12762,6 +13560,12 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
       }
+    },
+    "parent-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
+      "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc=",
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.1",
@@ -12825,6 +13629,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -15243,6 +16053,29 @@
         "ansi-styles": "^3.2.0"
       }
     },
+    "prismjs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      },
+      "dependencies": {
+        "clipboard": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
+          "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
+          }
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -15471,11 +16304,37 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
     "raw-loader": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "react": {
       "version": "16.4.1",
@@ -16106,6 +16965,25 @@
         "unicode-match-property-value-ecmascript": "^1.0.2"
       }
     },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
     "regjsgen": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
@@ -16457,6 +17335,12 @@
         "aproba": "^1.1.1"
       }
     },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
+    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -16730,11 +17614,70 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      }
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
       "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
       "dev": true
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -16775,6 +17718,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -17156,6 +18105,12 @@
         }
       }
     },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
     "stdout-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
@@ -17458,6 +18413,15 @@
         }
       }
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
     "test-exclude": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
@@ -17530,6 +18494,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "dev": true
+    },
+    "tinydate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tinydate/-/tinydate-1.0.0.tgz",
+      "integrity": "sha1-IPMXVqE5We+MV+wTO6KbWt4ELKw=",
       "dev": true
     },
     "tinymce": {
@@ -17716,6 +18686,12 @@
       "dev": true,
       "optional": true
     },
+    "tweezer.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tweezer.js/-/tweezer.js-1.4.0.tgz",
+      "integrity": "sha1-IG/1aK00zw5WoEMH2Z/8Uhk9UEU=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -17833,6 +18809,12 @@
           }
         }
       }
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+      "dev": true
     },
     "underscore": {
       "version": "1.4.4",
@@ -17974,6 +18956,15 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
     "unist-util-is": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
@@ -18012,6 +19003,12 @@
       "requires": {
         "unist-util-is": "^2.1.2"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -18059,11 +19056,35 @@
       "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
       "dev": true
     },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
     "upath": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -18151,6 +19172,12 @@
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
       }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "uuid": {
       "version": "3.3.2",
@@ -18782,6 +19809,15 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "widest-line": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      }
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -18890,6 +19926,12 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
     },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -18913,6 +19955,44 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargonaut": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/yargonaut/-/yargonaut-1.1.4.tgz",
+      "integrity": "sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "figlet": "^1.1.1",
+        "parent-require": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
     },
     "yargs": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "pretest": "npm run -s install-if-no-packages",
     "test:help": "wp-scripts test-unit-js --help",
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "docs": "node ./bin/generate-docs"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.54",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "core-js": "^2.5.7",
     "css-loader": "^0.28.11",
     "deep-freeze": "^0.0.1",
+    "docsify-cli": "^4.2.1",
     "eslint": "^4.18.2",
     "eslint-config-wpcalypso": "^4.0.0",
     "eslint-loader": "^2.0.0",


### PR DESCRIPTION
This is the final PR, building on #334 & #336. This PR includes setup for a docsify site and the generated markdown files (which is why the diff is so large, and between this & copying the inline comments, why I created 3 PRs).

The goal of this set of PRs is to have a documentation source that third-party devs (and us) can look at for referencing the components exported on `wp.components`. We haven't been great at keeping READMEs up-to-date, but we're pretty good at propTypes. `react-docgen` can extract info from PropTypes & inline documentation, which is what we're doing in #336. Once we have that documentation info, we build it into markdown files that live in `/docs/components`.

Now we can use [`docsify`](https://docsify.js.org/) to render the files in `/docs` in a webpage. As long as we keep the inline docs up to date, which will be easier to check in PRs, the documentation will be correct. 🎉

We can even customize the docsify page with themes & plugins, so I've added the text search & customized the theme to be woo-flavored:

![docs](https://user-images.githubusercontent.com/541093/44885485-18badb80-ac8f-11e8-813e-3be0f3a543e6.png)

**To test**

- Run the docsify server locally: `npm install`, then `npx docsify serve ./docs`
- Make sure the documentation matches reality
- Change some documentation in an exported component, and run `npm run docs` to rebuild the markdown files
- The change should live-reload in docsify
- Export a new component in `client/components/index.js` (copy order-status for a simple one, change some names)
- Run `npm run docs` to rebuild the markdown files
- Check that the new component's docs are built in `/docs/components`, and that it shows up in the docsify site.

**Other notes**

- If this is merged to master, we can set up github pages to [automatically show this website](https://docsify.js.org/#/deploy?id=github-pages), so no need to host it anywhere special 👍 
- The docs generation script only builds `/docs/components`, we can manually write any other markdown files in the `/docs` dir & docsify will load it. We'll need to tweak how the sidebar is generated, though.
- `npm run docs` will now work to build the markdown files. This is not run on any commit hooks, but it could be? It might drastically slow down commits if we grow the components more…
- This doesn't handle live examples or code samples, I was thinking we might leave an `example.js` or `example.md` in each component dir, and read from that when building the markdown files, and inject the content there above the props listing.
