### PR TITLE
Create TablePlaceholder component to be used when table contents are loading

### DIFF
--- a/client/components/index.js
+++ b/client/components/index.js
@@ -27,6 +27,6 @@ export { default as Search } from './search';
 export { default as SegmentedSelection } from './segmented-selection';
 export { default as SplitButton } from './split-button';
 export { SummaryList, SummaryNumber } from './summary';
-export { TableCard, Table, TableSummary } from './table';
+export { TableCard, Table, TableSummary, TablePlaceholder } from './table';
 export { default as Tag } from './tag';
 export { default as useFilters } from './higher-order/use-filters';

--- a/client/components/table/README.md
+++ b/client/components/table/README.md
@@ -9,6 +9,8 @@ This is an accessible, sortable, and scrollable table for displaying tabular dat
 
 `TableSummary` can also be used alone, and will display the list of data passed in on a single line.
 
+`TablePlaceholder` behaves like `Table` but displays placeholder boxes instead of data. Can be used while loading.
+
 ## How to use:
 
 ```jsx
@@ -62,6 +64,12 @@ render: function() {
 ### `TableSummary` props
 
 * `data`: An array of objects with `label` & `value` properties, which display on a single line.
+
+### `TablePlaceholder` props
+
+* `caption` (required): A label for the content in this table
+* `headers`: An array of column headers (see `Table` props).
+* `numberOfRows`: An integer with the number of rows to display. Defaults to 5.
 
 ## Rows Format
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -158,3 +158,4 @@ TableCard.defaultProps = {
 };
 
 export { TableCard, Table, TableSummary };
+export { default as TablePlaceholder } from './placeholder';

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -1,0 +1,52 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { range } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Table from './table';
+
+class TablePlaceholder extends Component {
+	render() {
+		const { caption, headers, numberOfRows } = this.props;
+		const rows = range( numberOfRows ).map( () =>
+			headers.map( () => ( { display: <span className="is-placeholder" /> } ) )
+		);
+
+		return (
+			<Table
+				ariaHidden={ true }
+				caption={ caption }
+				classNames="is-loading"
+				headers={ headers }
+				rowHeader={ false }
+				rows={ rows }
+			/>
+		);
+	}
+}
+
+TablePlaceholder.propTypes = {
+	caption: PropTypes.string.isRequired,
+	headers: PropTypes.arrayOf(
+		PropTypes.shape( {
+			defaultSort: PropTypes.bool,
+			isSortable: PropTypes.bool,
+			key: PropTypes.string,
+			label: PropTypes.string,
+			required: PropTypes.bool,
+		} )
+	),
+	numberOfRows: PropTypes.number,
+};
+
+TablePlaceholder.defaultProps = {
+	numberOfRows: 5,
+};
+
+export default TablePlaceholder;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -53,11 +53,23 @@
 		}
 	}
 
+	.is-placeholder {
+		@include placeholder();
+		display: inline-block;
+		height: 16px;
+		max-width: 120px;
+		width: 80%;
+	}
+
 	&.is-numeric {
 		text-align: right;
 
 		button {
 			justify-content: flex-end;
+		}
+
+		.is-placeholder {
+			max-width: 40px;
 		}
 	}
 }

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -52,7 +52,7 @@ class Table extends Component {
 	}
 
 	render() {
-		const { caption, classNames, headers, query, rowHeader, rows } = this.props;
+		const { ariaHidden, caption, classNames, headers, query, rowHeader, rows } = this.props;
 		const { tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
@@ -63,6 +63,7 @@ class Table extends Component {
 				className={ classes }
 				ref={ this.container }
 				tabIndex={ tabIndex }
+				aria-hidden={ ariaHidden }
 				aria-labelledby={ this.captionID }
 				role="group"
 			>
@@ -148,6 +149,7 @@ class Table extends Component {
 }
 
 Table.propTypes = {
+	ariaHidden: PropTypes.bool,
 	caption: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	headers: PropTypes.arrayOf(
@@ -173,6 +175,7 @@ Table.propTypes = {
 };
 
 Table.defaultProps = {
+	ariaHidden: false,
 	headers: [],
 	onSort: noop,
 	query: {},

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Card, Table } from '@woocommerce/components';
+import { Card, Table, TablePlaceholder } from '@woocommerce/components';
 import { getAdminLink } from 'lib/nav-utils';
 import { numberFormat } from 'lib/number';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
@@ -84,14 +84,18 @@ export class TopSellingProducts extends Component {
 	render() {
 		const { data, isRequesting, isError } = this.props;
 
-		// @TODO We will need to update it with a loading/empty data indicator
+		// @TODO We will need to update it with a error/empty data indicator
 		const rows = isRequesting || isError ? [] : this.getRowsContent( data );
 		const headers = this.getHeadersContent();
 		const title = __( 'Top Selling Products', 'wc-admin' );
 
 		return (
 			<Card title={ title } className="woocommerce-top-selling-products">
-				<Table caption={ title } rows={ rows } headers={ headers } />
+				{ isRequesting ? (
+					<TablePlaceholder caption={ title } headers={ headers } />
+				) : (
+					<Table caption={ title } rows={ rows } headers={ headers } />
+				) }
 			</Card>
 		);
 	}

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -20,9 +20,16 @@ import mockData from '../__mocks__/mock-data';
 jest.mock( '@woocommerce/components', () => ( {
 	...require.requireActual( '@woocommerce/components' ),
 	Table: () => null,
+	TablePlaceholder: () => null,
 } ) );
 
 describe( 'TopSellingProducts', () => {
+	test( 'should render placeholder table while requesting', () => {
+		const topSellingProducts = shallow( <TopSellingProducts data={ {} } isRequesting={ true } /> );
+
+		expect( topSellingProducts.find( 'TablePlaceholder' ).length ).toBe( 1 );
+	} );
+
 	test( 'should render correct data in the table', () => {
 		const topSellingProducts = shallow( <TopSellingProducts data={ mockData } /> );
 		const table = topSellingProducts.find( 'Table' );


### PR DESCRIPTION
Fixes: #328.

![image](https://user-images.githubusercontent.com/3616980/44903645-5fe7b180-ad0d-11e8-889e-e34198951295.png)

**Steps to test**
- Run `npm test` to verify tests are passing.
- Force `isRequesting` to be true in the Top Selling Products table. Go to `client/dashboard/top-selling-products/index.js` and replace [this line](https://github.com/woocommerce/wc-admin/pull/338/files#diff-f083c8ddf4f7c61e09bba4a0108c1569L109):
  `const isRequesting = isReportStatsRequesting( endpoint, query );`
  with
  `const isRequesting = true;`
- Go to the _Dashboard_ page.
- Check that the _Top Selling Products_ is displaying placeholders instead of real data.