### PR TITLE
Search Component: Move `selected` to props

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -14,12 +14,14 @@ import Header from 'layout/header';
 export default class extends Component {
 	constructor( props ) {
 		super( props );
+		this.state = {
+			selected: [],
+		};
 		this.onChange = this.onChange.bind( this );
 	}
 
-	onChange() {
-		// Here we can do whatever we want with `results`
-		// console.log( results );
+	onChange( selected ) {
+		this.setState( { selected } );
 	}
 
 	render() {
@@ -27,7 +29,7 @@ export default class extends Component {
 			<Fragment>
 				<Header sections={ [ __( 'Analytics', 'wc-admin' ) ] } />
 				<Card title="Overview Section">
-					<Search onChange={ this.onChange } type="products" />
+					<Search onChange={ this.onChange } type="products" selected={ this.state.selected } />
 				</Card>
 			</Fragment>
 		);

--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -53,7 +53,8 @@ export const advancedFilterConfig = {
 			{ value: 'is-not', label: __( 'Is Not', 'wc-admin' ) },
 		],
 		input: {
-			component: 'FormTokenField',
+			component: 'Search',
+			type: 'products',
 		},
 	},
 	coupon: {
@@ -66,7 +67,8 @@ export const advancedFilterConfig = {
 			{ value: 'is-not', label: __( 'Is Not', 'wc-admin' ) },
 		],
 		input: {
-			component: 'FormTokenField',
+			component: 'Search',
+			type: 'products', // For now. "coupons" autocompleter required
 		},
 	},
 	customer: {

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -4,7 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment, createRef } from '@wordpress/element';
-import { SelectControl, Button, FormTokenField, Dropdown, IconButton } from '@wordpress/components';
+import { SelectControl, Button, Dropdown, IconButton } from '@wordpress/components';
 import { partial, findIndex, find, difference } from 'lodash';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Search from 'components/search';
 import './style.scss';
 
 const matches = [
@@ -106,12 +107,12 @@ class AdvancedFilters extends Component {
 				/>
 			);
 		}
-		if ( 'FormTokenField' === input.component ) {
+		if ( 'Search' === input.component ) {
 			return (
-				<FormTokenField
-					value={ filter.value }
+				<Search
 					onChange={ partial( this.onFilterChange, filter.key, 'value' ) }
-					placeholder={ sprintf( __( 'Add %s', 'wc-admin' ), filterConfig.label ) }
+					type={ input.type }
+					selected={ filter.value }
 				/>
 			);
 		}

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -22,3 +22,4 @@ class MySearchBox extends Component {
 
 - `onChange`: Function called when selected results change, passed result list.
 - `type` (required): Which object type to search, can be one of `customers`, `orders`, or `products`.
+- `selected`: An array of objects describing selected values.

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -23,39 +23,30 @@ class Search extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			selected: [],
 			value: '',
 		};
 
 		this.selectResult = this.selectResult.bind( this );
 		this.removeResult = this.removeResult.bind( this );
-		this.triggerChange = this.triggerChange.bind( this );
 		this.updateSearch = this.updateSearch.bind( this );
 	}
 
 	selectResult( value ) {
+		const { selected, onChange } = this.props;
 		// Check if this is already selected
-		const isSelected = findIndex( this.state.selected, { id: value.id } );
+		const isSelected = findIndex( selected, { id: value.id } );
 		if ( -1 === isSelected ) {
-			this.setState(
-				( { selected } ) => ( { selected: [ ...selected, value ], value: '' } ),
-				this.triggerChange
-			);
+			this.setState( { value: '' } );
+			onChange( [ ...selected, value ] );
 		}
 	}
 
 	removeResult( id ) {
 		return () => {
-			this.setState( ( { selected } ) => {
-				const i = findIndex( selected, { id } );
-				return { selected: [ ...selected.slice( 0, i ), ...selected.slice( i + 1 ) ] };
-			}, this.triggerChange );
+			const { selected, onChange } = this.props;
+			const i = findIndex( selected, { id } );
+			onChange( [ ...selected.slice( 0, i ), ...selected.slice( i + 1 ) ] );
 		};
-	}
-
-	triggerChange() {
-		const { onChange } = this.props;
-		onChange( this.state.selected );
 	}
 
 	updateSearch( onChange ) {
@@ -77,7 +68,8 @@ class Search extends Component {
 
 	render() {
 		const autocompleter = this.getAutocompleter();
-		const { selected = [], value = '' } = this.state;
+		const { selected } = this.props;
+		const { value = '' } = this.state;
 		return (
 			<div className="woocommerce-search">
 				<Autocomplete completer={ autocompleter } onSelect={ this.selectResult }>
@@ -128,10 +120,20 @@ Search.propTypes = {
 	 * The object type to be used in searching.
 	 */
 	type: PropTypes.oneOf( [ 'products', 'orders', 'customers' ] ).isRequired,
+	/**
+	 * An array of objects describing selected values
+	 */
+	selected: PropTypes.arrayOf(
+		PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+			label: PropTypes.string.isRequired,
+		} )
+	),
 };
 
 Search.defaultProps = {
 	onChange: noop,
+	selected: [],
 };
 
 export default Search;


### PR DESCRIPTION
The Search component will eventually be pre-populated with values derived from url parameters. By moving `selected` from internal state to a prop, we can facilitate that.

This PR also adds the Search component to Advanced Filters.

## Test
1. `/wp-admin/admin.php?page=wc-admin#/analytics`
2. Ensure the Search example hasn't regressed