### PR TITLE
IE11: fix Activity Panel tab icons missing and wrong alignment

### DIFF
--- a/client/layout/activity-panel/style.scss
+++ b/client/layout/activity-panel/style.scss
@@ -64,6 +64,8 @@
 	}
 
 	.woocommerce-layout__activity-panel-tab {
+		flex-direction: column;
+		justify-content: center;
 		border: none;
 		outline: none;
 		cursor: pointer;


### PR DESCRIPTION
Part of #243.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/44980517-632ea780-af70-11e8-8a7e-7a562e5f0f88.png)

After:
![image](https://user-images.githubusercontent.com/3616980/44980377-fa472f80-af6f-11e8-8ca3-957f599535e6.png)

**Steps to test**
Open any wc-admin page that displays the Activity Panel with Internet Explorer 11 and check that it looks like in other browsers.