### PR TITLE
Proposal: use native Array.isArray() instead of lodash function

### DIFF
--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { IconButton, ToggleControl } from '@wordpress/components';
-import { fill, find, findIndex, first, isArray, noop } from 'lodash';
+import { fill, find, findIndex, first, noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -50,7 +50,7 @@ class TableCard extends Component {
 	filterCols( rows = [] ) {
 		const { showCols } = this.state;
 		// Header is a 1d array
-		if ( ! isArray( first( rows ) ) ) {
+		if ( ! Array.isArray( first( rows ) ) ) {
 			return rows.filter( ( col, i ) => showCols[ i ] );
 		}
 		// Rows is a 2d array

--- a/client/layout/activity-panel/activity-card/index.js
+++ b/client/layout/activity-panel/activity-card/index.js
@@ -5,7 +5,6 @@
 import classnames from 'classnames';
 import { cloneElement, Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
-import { isArray } from 'lodash';
 import { moment } from '@wordpress/date';
 import PropTypes from 'prop-types';
 
@@ -19,7 +18,7 @@ class ActivityCard extends Component {
 	render() {
 		const { actions, className, children, date, icon, subtitle, title, unread } = this.props;
 		const cardClassName = classnames( 'woocommerce-activity-card', className );
-		const actionsList = isArray( actions ) ? actions : [ actions ];
+		const actionsList = Array.isArray( actions ) ? actions : [ actions ];
 
 		return (
 			<section className={ cardClassName }>

--- a/client/layout/header/index.js
+++ b/client/layout/header/index.js
@@ -7,7 +7,6 @@ import { Component } from '@wordpress/element';
 import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Fill } from 'react-slot-fill';
-import { isArray } from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
@@ -56,11 +55,11 @@ class Header extends Component {
 	render() {
 		const { sections, isEmbedded } = this.props;
 		const { isScrolled } = this.state;
-		const _sections = isArray( sections ) ? sections : [ sections ];
+		const _sections = Array.isArray( sections ) ? sections : [ sections ];
 
 		const documentTitle = _sections
 			.map( section => {
-				return isArray( section ) ? section[ 1 ] : section;
+				return Array.isArray( section ) ? section[ 1 ] : section;
 			} )
 			.reverse()
 			.join( ' &lsaquo; ' );
@@ -84,7 +83,7 @@ class Header extends Component {
 						<Link href="/">WooCommerce</Link>
 					</span>
 					{ _sections.map( ( section, i ) => {
-						const sectionPiece = isArray( section ) ? (
+						const sectionPiece = Array.isArray( section ) ? (
 							<Link href={ section[ 0 ] } type={ isEmbedded ? 'wp-admin' : 'wc-admin' }>
 								{ section[ 1 ] }
 							</Link>


### PR DESCRIPTION
Lodash `isArray` package [is deprecated](https://www.npmjs.com/package/lodash.isarray) and it works exactly the same than `Array.isArray`, which is native in JavaScript. Indeed, the lodash implementation is just a [map to that function](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L11285).

So I would like to propose using the native solution over the lodash function.
