### PR TITLE
Advanced Filters: Add url support

### DIFF
--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -28,7 +28,7 @@ export const advancedFilterConfig = {
 		addLabel: __( 'Order Status', 'wc-admin' ),
 		rules: [
 			{ value: 'is', label: __( 'Is', 'wc-admin' ) },
-			{ value: 'is-not', label: __( 'Is Not', 'wc-admin' ) },
+			{ value: 'is_not', label: __( 'Is Not', 'wc-admin' ) },
 		],
 		input: {
 			component: 'SelectControl',
@@ -43,28 +43,28 @@ export const advancedFilterConfig = {
 			],
 		},
 	},
-	product: {
+	product_id: {
 		label: __( 'Product', 'wc-admin' ),
 		addLabel: __( 'Products', 'wc-admin' ),
 		rules: [
 			{ value: 'includes', label: __( 'Includes', 'wc-admin' ) },
 			{ value: 'excludes', label: __( 'Excludes', 'wc-admin' ) },
 			{ value: 'is', label: __( 'Is', 'wc-admin' ) },
-			{ value: 'is-not', label: __( 'Is Not', 'wc-admin' ) },
+			{ value: 'is_not', label: __( 'Is Not', 'wc-admin' ) },
 		],
 		input: {
 			component: 'Search',
 			type: 'products',
 		},
 	},
-	coupon: {
+	code: {
 		label: __( 'Coupon Code', 'wc-admin' ),
 		addLabel: __( 'Coupon Codes', 'wc-admin' ),
 		rules: [
 			{ value: 'includes', label: __( 'Includes', 'wc-admin' ) },
 			{ value: 'excludes', label: __( 'Excludes', 'wc-admin' ) },
 			{ value: 'is', label: __( 'Is', 'wc-admin' ) },
-			{ value: 'is-not', label: __( 'Is Not', 'wc-admin' ) },
+			{ value: 'is_not', label: __( 'Is Not', 'wc-admin' ) },
 		],
 		input: {
 			component: 'Search',
@@ -74,9 +74,12 @@ export const advancedFilterConfig = {
 	customer: {
 		label: __( 'Customer is', 'wc-admin' ),
 		addLabel: __( 'Customer Type', 'wc-admin' ),
-		rules: [
-			{ value: 'new', label: __( 'New', 'wc-admin' ) },
-			{ value: 'returning', label: __( 'Returning', 'wc-admin' ) },
-		],
+		input: {
+			component: 'SelectControl',
+			options: [
+				{ value: 'new', label: __( 'New', 'wc-admin' ) },
+				{ value: 'returning', label: __( 'Returning', 'wc-admin' ) },
+			],
+		},
 	},
 };

--- a/client/components/filters/advanced/search-filter.js
+++ b/client/components/filters/advanced/search-filter.js
@@ -1,0 +1,86 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+import { partial } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Search from 'components/search';
+
+class SearchFilter extends Component {
+	constructor() {
+		super();
+		this.onSearchChange = this.onSearchChange.bind( this );
+	}
+
+	onSearchChange( values ) {
+		const { filter, onFilterChange } = this.props;
+		const nextValues = values.map( value => value.id );
+		onFilterChange( filter.key, 'value', nextValues );
+	}
+
+	render() {
+		const { filter, config, onFilterChange } = this.props;
+		const { key, rule, value } = filter;
+		const selected = value.map( id => {
+			// For now
+			return {
+				id: parseInt( id, 10 ),
+				label: id.toString(),
+			};
+		} );
+		return (
+			<Fragment>
+				<div className="woocommerce-filters-advanced__fieldset-legend">{ config.label }</div>
+				{ rule && (
+					<SelectControl
+						className="woocommerce-filters-advanced__list-specifier"
+						options={ config.rules }
+						value={ rule }
+						onChange={ partial( onFilterChange, key, 'rule' ) }
+						aria-label={ sprintf( __( 'Select a %s filter match', 'wc-admin' ), config.addLabel ) }
+					/>
+				) }
+				<div className="woocommerce-filters-advanced__list-selector">
+					<Search
+						onChange={ this.onSearchChange }
+						type={ config.input.type }
+						selected={ selected }
+					/>
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+SearchFilter.propTypes = {
+	/**
+	 * The configuration object for the single filter to be rendered.
+	 */
+	config: PropTypes.shape( {
+		label: PropTypes.string,
+		addLabel: PropTypes.string,
+		rules: PropTypes.arrayOf( PropTypes.object ),
+		input: PropTypes.object,
+	} ).isRequired,
+	/**
+	 * The activeFilter handed down by AdvancedFilters.
+	 */
+	filter: PropTypes.shape( {
+		key: PropTypes.string,
+		rule: PropTypes.string,
+		value: PropTypes.array,
+	} ).isRequired,
+	/**
+	 * Function to be called on update.
+	 */
+	onFilterChange: PropTypes.func.isRequired,
+};
+
+export default SearchFilter;

--- a/client/components/filters/advanced/select-filter.js
+++ b/client/components/filters/advanced/select-filter.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+import { partial } from 'lodash';
+import PropTypes from 'prop-types';
+
+const SelectFilter = ( { filter, config, onFilterChange } ) => {
+	const { key, rule, value } = filter;
+	return (
+		<Fragment>
+			<div className="woocommerce-filters-advanced__fieldset-legend">{ config.label }</div>
+			{ rule && (
+				<SelectControl
+					className="woocommerce-filters-advanced__list-specifier"
+					options={ config.rules }
+					value={ rule }
+					onChange={ partial( onFilterChange, key, 'rule' ) }
+					aria-label={ sprintf( __( 'Select a %s filter match', 'wc-admin' ), config.addLabel ) }
+				/>
+			) }
+			<div className="woocommerce-filters-advanced__list-selector">
+				<SelectControl
+					className="woocommerce-filters-advanced__list-select"
+					options={ config.input.options }
+					value={ value }
+					onChange={ partial( onFilterChange, filter.key, 'value' ) }
+					aria-label={ sprintf( __( 'Select %s', 'wc-admin' ), config.label ) }
+				/>
+			</div>
+		</Fragment>
+	);
+};
+
+SelectFilter.propTypes = {
+	/**
+	 * The configuration object for the single filter to be rendered.
+	 */
+	config: PropTypes.shape( {
+		label: PropTypes.string,
+		addLabel: PropTypes.string,
+		rules: PropTypes.arrayOf( PropTypes.object ),
+		input: PropTypes.object,
+	} ).isRequired,
+	/**
+	 * The activeFilter handed down by AdvancedFilters.
+	 */
+	filter: PropTypes.shape( {
+		key: PropTypes.string,
+		rule: PropTypes.string,
+		value: PropTypes.string,
+	} ).isRequired,
+	/**
+	 * Function to be called on update.
+	 */
+	onFilterChange: PropTypes.func.isRequired,
+};
+
+export default SelectFilter;

--- a/client/components/filters/advanced/style.scss
+++ b/client/components/filters/advanced/style.scss
@@ -29,12 +29,16 @@
 }
 
 .woocommerce-filters-advanced__list-item {
-	padding: $gap-smaller $gap;
+	padding: 0 $gap 0 0;
 	margin: 0;
 	display: grid;
 	grid-template-columns: auto 40px;
 	background-color: $core-grey-light-100;
 	border-bottom: 1px solid $core-grey-light-700;
+
+	fieldset {
+		padding: $gap-smaller $gap;
+	}
 
 	&:hover {
 		background-color: $core-grey-light-200;
@@ -116,7 +120,7 @@
 .woocommerce-filters-advanced__controls {
 	padding: $gap-smaller $gap;
 
-	& > button {
+	.components-button {
 		margin-right: $gap;
 	}
 }
@@ -144,8 +148,6 @@
 }
 
 .woocommerce-filters-advanced__list-selector {
-	padding: 0 0 0 $gap-smaller;
-
 	@include breakpoint( '<782px' ) {
 		padding: $gap-smallest 0;
 	}
@@ -154,5 +156,13 @@
 .woocommerce-filters-advanced__list-specifier {
 	@include breakpoint( '<782px' ) {
 		padding: $gap-smallest 0;
+	}
+
+	& + .woocommerce-filters-advanced__list-selector {
+		padding: 0 0 0 $gap-smaller;
+
+		@include breakpoint( '<782px' ) {
+			padding: $gap-smallest 0;
+		}
 	}
 }

--- a/client/components/filters/advanced/test/utils.js
+++ b/client/components/filters/advanced/test/utils.js
@@ -1,0 +1,179 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	getUrlKey,
+	getSearchFilterValue,
+	getActiveFiltersFromQuery,
+	getUrlValue,
+	getQueryFromActiveFilters,
+} from '../utils';
+
+describe( 'getUrlKey', () => {
+	it( 'should return a correctly formatted string', () => {
+		const key = getUrlKey( 'key', 'rule' );
+		expect( key ).toBe( 'key_rule' );
+	} );
+
+	it( 'should return a correctly formatted string with no rule', () => {
+		const key = getUrlKey( 'key' );
+		expect( key ).toBe( 'key' );
+	} );
+} );
+
+describe( 'getSearchFilterValue', () => {
+	it( 'should convert url query param into value readable by Search component', () => {
+		const str = '1,2,3';
+		const values = getSearchFilterValue( str );
+		expect( Array.isArray( values ) ).toBeTruthy();
+		expect( values[ 0 ] ).toBe( '1' );
+		expect( values[ 1 ] ).toBe( '2' );
+		expect( values[ 2 ] ).toBe( '3' );
+	} );
+
+	it( 'should convert an empty string into an empty array', () => {
+		const str = '';
+		const values = getSearchFilterValue( str );
+		expect( Array.isArray( values ) ).toBeTruthy();
+		expect( values.length ).toBe( 0 );
+	} );
+} );
+
+describe( 'getActiveFiltersFromQuery', () => {
+	const config = {
+		with_select: {
+			rules: [ { value: 'is' } ],
+			input: {
+				component: 'SelectControl',
+				options: [ { value: 'pending' } ],
+			},
+		},
+		with_search: {
+			rules: [ { value: 'includes' } ],
+			input: {
+				component: 'Search',
+			},
+		},
+		with_no_rules: {
+			input: {
+				component: 'SelectControl',
+				options: [ { value: 'pending' } ],
+			},
+		},
+	};
+
+	it( 'should return activeFilters from a query', () => {
+		const query = {
+			with_select_is: 'pending',
+			with_search_includes: '',
+			with_no_rules: 'pending',
+		};
+
+		const activeFilters = getActiveFiltersFromQuery( query, config );
+		expect( Array.isArray( activeFilters ) ).toBeTruthy();
+		expect( activeFilters.length ).toBe( 3 );
+
+		// with_select
+		const with_select = activeFilters[ 0 ];
+		expect( with_select.key ).toBe( 'with_select' );
+		expect( with_select.rule ).toBe( 'is' );
+		expect( with_select.value ).toBe( 'pending' );
+
+		// with_search
+		const with_search = activeFilters[ 1 ];
+		expect( with_search.key ).toBe( 'with_search' );
+		expect( with_search.rule ).toBe( 'includes' );
+		expect( with_search.value ).toEqual( [] );
+
+		// with_search
+		const with_no_rules = activeFilters[ 2 ];
+		expect( with_no_rules.key ).toBe( 'with_no_rules' );
+		expect( with_no_rules.rule ).toBeUndefined();
+		expect( with_no_rules.value ).toEqual( 'pending' );
+	} );
+
+	it( 'should ignore irrelevant query parameters', () => {
+		const query = {
+			with_select: 'pending', // no rule associated
+			status: 45,
+		};
+
+		const activeFilters = getActiveFiltersFromQuery( query, config );
+		expect( activeFilters.length ).toBe( 0 );
+	} );
+
+	it( 'should return an empty array with no relevant parameters', () => {
+		const query = {};
+
+		const activeFilters = getActiveFiltersFromQuery( query, config );
+		expect( Array.isArray( activeFilters ) ).toBe( true );
+		expect( activeFilters.length ).toBe( 0 );
+	} );
+} );
+
+describe( 'getUrlValue', () => {
+	it( 'should pass through a string', () => {
+		const value = getUrlValue( 'my string' );
+		expect( value ).toBe( 'my string' );
+	} );
+
+	it( 'should return null for a non-string value', () => {
+		const value = getUrlValue( {} );
+		expect( value ).toBeNull();
+	} );
+
+	it( 'should return null for an empty array', () => {
+		const value = getUrlValue( [] );
+		expect( value ).toBeNull();
+	} );
+
+	it( 'should return comma separated values when given an array', () => {
+		const value = getUrlValue( [ 1, 2, 3 ] );
+		expect( value ).toBe( '1,2,3' );
+	} );
+} );
+
+describe( 'getQueryFromActiveFilters', () => {
+	it( 'should return a query object from activeFilters', () => {
+		const activeFilters = [
+			{ key: 'status', rule: 'is', value: 'open' },
+			{
+				key: 'things',
+				rule: 'includes',
+				value: [ 1, 2, 3 ],
+			},
+			{ key: 'customer', value: 'new' },
+		];
+
+		const query = getQueryFromActiveFilters( activeFilters );
+		expect( query.status_is ).toBe( 'open' );
+		expect( query.things_includes ).toBe( '1,2,3' );
+		expect( query.customer ).toBe( 'new' );
+	} );
+
+	it( 'should remove parameters from the previous filters', () => {
+		const nextFilters = [];
+		const previousFilters = [
+			{ key: 'status', rule: 'is', value: 'open' },
+			{
+				key: 'things',
+				rule: 'includes',
+				value: [ 1, 2, 3 ],
+			},
+			{ key: 'customer', value: 'new' },
+		];
+
+		const query = getQueryFromActiveFilters( nextFilters, previousFilters );
+		expect( query.status_is ).toBeUndefined();
+		expect( query.things_includes ).toBeUndefined();
+		expect( query.customer ).toBeUndefined();
+	} );
+} );

--- a/client/components/filters/advanced/utils.js
+++ b/client/components/filters/advanced/utils.js
@@ -1,0 +1,115 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { find, compact } from 'lodash';
+
+/**
+ * Get the url query key from the filter key and rule.
+ *
+ * @param {string} key - filter key.
+ * @param {string} rule - filter rule.
+ * @return {string} - url query key.
+ */
+export const getUrlKey = ( key, rule ) => {
+	if ( rule && rule.length ) {
+		return `${ key }_${ rule }`;
+	}
+	return key;
+};
+
+/**
+ * Convert url values to array of objects for <Search /> component
+ *
+ * @param {string} str - url query parameter value
+ * @return {array} - array of Search values
+ */
+export const getSearchFilterValue = str => {
+	return str.length ? str.trim().split( ',' ) : [];
+};
+
+/**
+ * Describe activeFilter object.
+ *
+ * @typedef {Object} activeFilter
+ * @property {string} key - filter key.
+ * @property {string} [rule] - a modifying rule for a filter, eg 'includes' or 'is_not'.
+ * @property {string|array} value - filter value(s).
+ */
+
+/**
+ * Given a query object, return an array of activeFilters, if any.
+ *
+ * @param {object} query - query oject
+ * @param {object} config - config object
+ * @return {activeFilters[]} - array of activeFilters
+ */
+export const getActiveFiltersFromQuery = ( query, config ) => {
+	return compact(
+		Object.keys( config ).map( configKey => {
+			const filter = config[ configKey ];
+			if ( filter.rules ) {
+				const match = find( filter.rules, rule => {
+					return query.hasOwnProperty( getUrlKey( configKey, rule.value ) );
+				} );
+
+				if ( match ) {
+					const rawValue = query[ getUrlKey( configKey, match.value ) ];
+					const value =
+						'Search' === filter.input.component ? getSearchFilterValue( rawValue ) : rawValue;
+					return {
+						key: configKey,
+						rule: match.value,
+						value,
+					};
+				}
+				return null;
+			}
+			if ( query[ configKey ] ) {
+				return {
+					key: configKey,
+					value: query[ configKey ],
+				};
+			}
+			return null;
+		} )
+	);
+};
+
+/**
+ * Create a string value for url. Return a string directly or concatenate ids if supplied
+ * an array of objects.
+ *
+ * @param {string|array} value - value of an activeFilter
+ * @return {string|null} - url query param value
+ */
+export const getUrlValue = value => {
+	if ( Array.isArray( value ) ) {
+		return value.length ? value.join( ',' ) : null;
+	}
+	return 'string' === typeof value ? value : null;
+};
+
+/**
+ * Given activeFilters, create a new query object to update the url. Use previousFilters to
+ * Remove unused params.
+ *
+ * @param {activeFilters[]} nextFilters - activeFilters shown in the UI
+ * @param {activeFilters[]} previousFilters - filters represented by the current url
+ * @return {object} - query object representing the new parameters
+ */
+export const getQueryFromActiveFilters = ( nextFilters, previousFilters = [] ) => {
+	const previousData = previousFilters.reduce( ( query, filter ) => {
+		query[ getUrlKey( filter.key, filter.rule ) ] = undefined;
+		return query;
+	}, {} );
+	const data = nextFilters.reduce( ( query, filter ) => {
+		const urlValue = getUrlValue( filter.value );
+		if ( urlValue ) {
+			query[ getUrlKey( filter.key, filter.rule ) ] = urlValue;
+		}
+		return query;
+	}, {} );
+
+	return { ...previousData, ...data };
+};

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -46,6 +46,7 @@ class ReportFilters extends Component {
 			return (
 				<div className="woocommerce-filters__advanced-filters">
 					<AdvancedFilters
+						key={ JSON.stringify( query ) }
 						config={ advancedConfig }
 						filterTitle={ __( 'Orders', 'wc-admin' ) }
 						path={ path }

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -123,7 +123,7 @@ Search.propTypes = {
 	 */
 	type: PropTypes.oneOf( [ 'products', 'product_cats', 'orders', 'customers' ] ).isRequired,
 	/**
-	 * An array of objects describing selected values
+	 * An array of objects describing selected values.
 	 */
 	selected: PropTypes.arrayOf(
 		PropTypes.shape( {

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -39,6 +39,16 @@ export const getAdminLink = path => {
 };
 
 /**
+ * Converts a query object to a query string.
+ *
+ * @param {Object} query parameters to be converted.
+ * @return {String} Query string.
+ */
+export const stringifyQuery = query => {
+	return query ? '?' + stringify( query ) : '';
+};
+
+/**
  * Return a URL with set query parameters.
  *
  * @param {Object} query object of params to be updated.
@@ -47,8 +57,8 @@ export const getAdminLink = path => {
  * @return {String}  Updated URL merging query params into existing params.
  */
 export const getNewPath = ( query, path = getPath(), currentQuery = getQuery() ) => {
-	const queryString = stringify( { ...currentQuery, ...query } );
-	return `${ path }?${ queryString }`;
+	const queryString = stringifyQuery( { ...currentQuery, ...query } );
+	return `${ path }${ queryString }`;
 };
 
 /**
@@ -61,14 +71,4 @@ export const getNewPath = ( query, path = getPath(), currentQuery = getQuery() )
 export const updateQueryString = ( query, path = getPath(), currentQuery = getQuery() ) => {
 	const newPath = getNewPath( query, path, currentQuery );
 	history.push( newPath );
-};
-
-/**
- * Converts a query object to a query string.
- *
- * @param {Object} query parameters to be converted.
- * @return {String} Query string.
- */
-export const stringifyQuery = query => {
-	return query ? '?' + stringify( query ) : '';
 };

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -37,6 +37,10 @@
 		color: $woocommerce-500;
 	}
 
+	a.components-button.is-button {
+		color: $white;
+	}
+
 	a:hover,
 	a:active,
 	a:focus,


### PR DESCRIPTION
Allow Advanced Filters to initialise from url query parameters and manipulate parameters as a function of changes in the UI.

Given an added filter,

![screen shot 2018-09-04 at 2 43 46 pm](https://user-images.githubusercontent.com/1922453/45007231-f808d200-b050-11e8-883e-892252ee16a0.png)

A URL representation will be `&status_is=pending`

![screen shot 2018-09-04 at 2 44 48 pm](https://user-images.githubusercontent.com/1922453/45007325-63eb3a80-b051-11e8-85ad-d32b1af01ec4.png)

Filters with multiple values, such as products, will have ids for products joined by ",". Encoded, it will look like this in the url

```
&product_includes=50%2C48
```

 ### Tasks to be completed in follow up PRs

* Handling tags in Search component. I'll need to query the products endpoint in a follow up PR. Until then, i'm just using the id as the label.
![screen shot 2018-09-04 at 3 12 22 pm](https://user-images.githubusercontent.com/1922453/45008124-f9d49480-b054-11e8-9703-17dfe1196651.png)
* Add url support for `&match=any`
* Look into allowing the `,` to not be encoded/decoded so it remains in the url. Is it worth it? (I think yes)

### Test

1. `/wp-admin/admin.php?page=wc-admin#/analytics/orders?filter=advanced`
2. Add/remove/modify/clear filters and see the url update accordingly
