### PR TITLE
Fix TopSellingProducts table not correctly loading data 

### DIFF
--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { map } from 'lodash';
+import { get, map } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -109,10 +109,10 @@ export default compose(
 		// { after: '2018-04-22', before: '2018-05-06' }
 		const query = { orderby: 'items_sold' };
 
-		const data = getReportStats( endpoint, query );
+		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );
 		const isError = isReportStatsError( endpoint, query );
 
-		return { data, isRequesting, isError };
+		return { data: get( stats, 'data', [] ), isRequesting, isError };
 	} )
 )( TopSellingProducts );

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -45,7 +45,7 @@ describe( 'TopSellingProducts', () => {
 	} );
 
 	test( 'should load report stats from API', () => {
-		const getReportStatsMock = jest.fn().mockReturnValue( mockData );
+		const getReportStatsMock = jest.fn().mockReturnValue( { data: mockData } );
 		const isReportStatsRequestingMock = jest.fn().mockReturnValue( false );
 		const isReportStatsErrorMock = jest.fn().mockReturnValue( false );
 		const registry = createRegistry();

--- a/client/store/reports/stats/reducer.js
+++ b/client/store/reports/stats/reducer.js
@@ -19,9 +19,7 @@ export default function reportStatsReducer( state = DEFAULT_STATE, action ) {
 		return merge( {}, state, {
 			[ action.endpoint ]: {
 				[ queryKey ]: {
-					data: {
-						...action.report,
-					},
+					data: action.report,
 					totalResults: action.totalResults,
 					totalPages: action.totalPages,
 				},


### PR DESCRIPTION
Update `TopSellingProducts` table API connection to correctly work with the new selectors response format introduced in #316.

This PR doesn't introduce any visible change, it just fixes a JS error that was appearing in the _Dashboard_ in `master`.

![image](https://user-images.githubusercontent.com/3616980/44794932-da97bc00-aba9-11e8-9133-9bd52c9e9c11.png)

**Steps to test**

- Run `npm test` to verify tests are passing.
- Make sure you have some products + orders. [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator) can help creating them.
- Pull the latest WooCommerce v3 API from `feature/rest-api-v3-reports`.
- Go to the _Dashboard_ page.
- Verify that there is no JS error and the table is correctly populated.

@justinshreve I would like if you can specially review the change in `client/store/reports/stats/reducer.js`. I think it shouldn't break anything and doing a quick test everything seems to work well, but I might have missed something.