### PR TITLE
IE11: fix CSS grid in Summary

### DIFF
--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -98,7 +98,7 @@ $inner-border: $core-grey-light-500;
 	}
 
 	.woocommerce-summary__item-delta {
-		flex: 0;
+		flex: 0 1 auto;
 		display: flex;
 		flex-wrap: none;
 	}

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -103,6 +103,7 @@ $inner-border: $core-grey-light-500;
 		flex-wrap: none;
 	}
 
+	&,
 	&.has-one-item,
 	&.has-1-items {
 		grid-template-columns: 1fr;
@@ -212,6 +213,43 @@ $inner-border: $core-grey-light-500;
 
 		@include breakpoint( '<782px' ) {
 			border-right: none;
+		}
+	}
+}
+
+// IE11 doesn't auto-position grid children, so their position must be set manually
+@mixin set-grid-positions( $breakpoints ) {
+	@for $i from 1 through length( $breakpoints ) {
+		$number_of_items: $i;
+		$breakpoint: nth($breakpoints, $i);
+		@for $j from 1 through $number_of_items {
+			.has-#{$number_of_items}-items > .woocommerce-summary__item-container:nth-child(#{$j}) {
+				grid-column-start: #{($j - 1) % $breakpoint + 1};
+				grid-column-end: #{($j - 1) % $breakpoint + 2};
+				grid-row-start: #{floor(($j - 1) / $breakpoint) + 1};
+				grid-row-end: #{floor(($j - 1) / $breakpoint) + 2};
+			}
+		}
+	}
+}
+
+// These arrays can be read like this:
+// When there are 9 items, the breakpoint appears after the 5th item in large screens
+// and after the 3rd one when the screen is <1365px. On screens smaller than 1100px,
+// all items are displayed one below the other.
+@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ) );
+
+@include breakpoint( '<1365px' ) {
+	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ) );
+}
+
+@include breakpoint( '<1100px' ) {
+	@for $i from 1 through 10 {
+		.woocommerce-summary > .woocommerce-summary__item-container:nth-child(#{$i}) {
+			grid-column-start: 1;
+			grid-column-end: 2;
+			grid-row-start: #{$i};
+			grid-row-end: #{$i+1};
 		}
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -218,29 +218,14 @@ $inner-border: $core-grey-light-500;
 }
 
 // IE11 doesn't auto-position grid children, so their position must be set manually
-@mixin set-grid-positions( $breakpoints ) {
-	@for $i from 1 through length( $breakpoints ) {
-		$number_of_items: $i;
-		$breakpoint: nth($breakpoints, $i);
-		@for $j from 1 through $number_of_items {
-			.has-#{$number_of_items}-items > .woocommerce-summary__item-container:nth-child(#{$j}) {
-				grid-column-start: #{($j - 1) % $breakpoint + 1};
-				grid-column-end: #{($j - 1) % $breakpoint + 2};
-				grid-row-start: #{floor(($j - 1) / $breakpoint) + 1};
-				grid-row-end: #{floor(($j - 1) / $breakpoint) + 2};
-			}
-		}
-	}
-}
-
 // These arrays can be read like this:
 // When there are 9 items, the breakpoint appears after the 5th item in large screens
 // and after the 3rd one when the screen is <1365px. On screens smaller than 1100px,
 // all items are displayed one below the other.
-@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ) );
+@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ), 'woocommerce-summary__item-container' );
 
 @include breakpoint( '<1365px' ) {
-	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ) );
+	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ), 'woocommerce-summary__item-container' );
 }
 
 @include breakpoint( '<1100px' ) {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -218,14 +218,56 @@ $inner-border: $core-grey-light-500;
 }
 
 // IE11 doesn't auto-position grid children, so their position must be set manually
-// These arrays can be read like this:
-// When there are 9 items, the breakpoint appears after the 5th item in large screens
-// and after the 3rd one when the screen is <1365px. On screens smaller than 1100px,
-// all items are displayed one below the other.
-@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ), 'woocommerce-summary__item-container' );
+.has-1-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 1, 1 );
+}
 
-@include breakpoint( '<1365px' ) {
-	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ), 'woocommerce-summary__item-container' );
+.has-2-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 2, 2 );
+}
+
+.has-3-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 3, 3 );
+}
+
+.has-4-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 4, 4 );
+}
+
+.has-5-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 5, 5 );
+}
+
+.has-6-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 6, 6 );
+
+	@include breakpoint( '<1365px' ) {
+		@include set-grid-item-position( 3, 6 );
+	}
+}
+
+.has-7-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 4, 7 );
+}
+
+.has-8-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 4, 8 );
+}
+
+.has-9-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 5, 9 );
+
+	@include breakpoint( '<1365px' ) {
+		@include set-grid-item-position( 3, 9 );
+	}
+}
+
+.has-10-items .woocommerce-summary__item-container {
+	@include set-grid-item-position( 5, 10 );
+
+	@include breakpoint( '<1365px' ) {
+		@include set-grid-item-position( 4, 10 );
+	}
 }
 
 @include breakpoint( '<1100px' ) {

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -48,26 +48,14 @@
 	outline-offset: -2px;
 }
 
-// Sets grid positions for children of grid elements.
-@mixin set-item-grid-position( $breakpoint, $items_class, $number_of_items ) {
-	@for $i from 1 through $number_of_items {
-		.#{$items_class}:nth-child(#{$i}) {
-			grid-column-start: #{($i - 1) % $breakpoint + 1};
-			grid-column-end: #{($i - 1) % $breakpoint + 2};
-			grid-row-start: #{floor(($i - 1) / $breakpoint) + 1};
-			grid-row-end: #{floor(($i - 1) / $breakpoint) + 2};
-		}
-	}
-}
-
-// Sets grid positions for children of grid elements which can have an unknown
-// number of children, which is added to the parent element as a class `.has-X-items`.
-@mixin set-grid-positions( $breakpoints, $items_class ) {
-	@for $i from 1 through length( $breakpoints ) {
-		$number_of_items: $i;
-		$breakpoint: nth($breakpoints, $i);
-		.has-#{$number_of_items}-items {
-			@include set-item-grid-position( $breakpoint, $items_class, $number_of_items );
+// Sets positions for children of grid elements
+@mixin set-grid-item-position( $wrap-after, $number-of-items ) {
+	@for $i from 1 through $number-of-items {
+		&:nth-child(#{$i}) {
+			grid-column-start: #{($i - 1) % $wrap-after + 1};
+			grid-column-end: #{($i - 1) % $wrap-after + 2};
+			grid-row-start: #{floor(($i - 1) / $wrap-after) + 1};
+			grid-row-end: #{floor(($i - 1) / $wrap-after) + 2};
 		}
 	}
 }

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -47,3 +47,27 @@
 	outline: 2px solid transparent;
 	outline-offset: -2px;
 }
+
+// Sets grid positions for children of grid elements.
+@mixin set-item-grid-position( $breakpoint, $items_class, $number_of_items ) {
+	@for $i from 1 through $number_of_items {
+		.#{$items_class}:nth-child(#{$i}) {
+			grid-column-start: #{($i - 1) % $breakpoint + 1};
+			grid-column-end: #{($i - 1) % $breakpoint + 2};
+			grid-row-start: #{floor(($i - 1) / $breakpoint) + 1};
+			grid-row-end: #{floor(($i - 1) / $breakpoint) + 2};
+		}
+	}
+}
+
+// Sets grid positions for children of grid elements which can have an unknown
+// number of children, which is added to the parent element as a class `.has-X-items`.
+@mixin set-grid-positions( $breakpoints, $items_class ) {
+	@for $i from 1 through length( $breakpoints ) {
+		$number_of_items: $i;
+		$breakpoint: nth($breakpoints, $i);
+		.has-#{$number_of_items}-items {
+			@include set-item-grid-position( $breakpoint, $items_class, $number_of_items );
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1924,29 +1924,41 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.0.1.tgz",
-      "integrity": "sha512-ytUcgSKu1mZh8pCJq54BkaK7ijigK+nhqVmu8PYOR00letCkrU71qTfKnzhQgn7by/QJvlJGUAofMt+jyXJTxA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.3.tgz",
+      "integrity": "sha512-No9xrkPCGIHc9I52e+u1MuvkwfTOIXQt3tu+jGSONAJf4awvQmqOTWmk7JhA9Q3BTvBYIRdpS9PLFtrmpZcImg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.1",
-        "caniuse-lite": "^1.0.30000865",
+        "browserslist": "^4.0.2",
+        "caniuse-lite": "^1.0.30000878",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.1",
+        "postcss": "^7.0.2",
         "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
+          "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000878",
+            "electron-to-chromium": "^1.3.61",
+            "node-releases": "^1.0.0-alpha.11"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000883",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
+          "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.62",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
+          "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+          "dev": true
         }
       }
     },
@@ -12693,9 +12705,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -13815,9 +13827,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.1.tgz",
-      "integrity": "sha512-c6M68yZX0bWnZ0GcX8duWcfweGeGQvYgw6w4xksRePDmrpCrLMqneN07xwce17ACWBAr0S+DoI0T31axZ21TKg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@wordpress/postcss-themes": "^1.0.1",
     "@wordpress/scripts": "^2.0.2",
     "ast-types": "^0.11.5",
-    "autoprefixer": "9.0.1",
+    "autoprefixer": "^9.1.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
     "babel-loader": "^8.0.0-beta.4",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -19,7 +19,7 @@ module.exports = {
 				},
 			},
 		} ),
-		require( 'autoprefixer' ),
+		require( 'autoprefixer' )( { grid: true } ),
 		require( 'postcss-color-function' ),
 	],
 };


### PR DESCRIPTION
Part of #243.

**Changes and open question**
- Updated `autoprefixer` because last versions include several fixes regarding CSS grid.
- Enabled `grid` setting from `autoprefixer`, it will try to translate CSS standard grid code to the older spec supported by Internet Explorer.
- The biggest problem when working with CSS grid in Internet Explorer is that it doesn't auto-position elements one after the other, instead, their position must be explicitly set. Doing some math, I could get it working with a simple SCSS mixin. However, when compiled, it's >1000 lines of CSS, **I wonder if it might make sense to create an independent CSS stylesheet for IE11** so we don't pollute the one other browsers will download.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45039520-175d2a80-b064-11e8-8ba5-6062bb50966e.png)
![image](https://user-images.githubusercontent.com/3616980/45039035-f7793700-b062-11e8-8460-7ab99dd2d137.png)


After:
![image](https://user-images.githubusercontent.com/3616980/45038980-cef13d00-b062-11e8-80a4-0fdc4948026a.png)
![image](https://user-images.githubusercontent.com/3616980/45039003-dca6c280-b062-11e8-99c2-fa5a5ce54140.png)



**Steps to test**
- Open the _Dashboard_ and verify that all items under _Store Performance_ are aligned in rows on IE11.
- Do the same in the _Revenue_ page under _Analytics_ (see screenshots above).
