### PR TITLE
[WIP] IE11: fix filters

### DIFF
--- a/client/components/filters/date/style.scss
+++ b/client/components/filters/date/style.scss
@@ -34,6 +34,8 @@
 	}
 }
 
+@include set-item-grid-position( 2, 'woocommerce-filters-date__tab', 2 );
+
 .woocommerce-filters-date__tab {
 	outline: none;
 	border: 1px solid $woocommerce;

--- a/client/components/segmented-selection/index.js
+++ b/client/components/segmented-selection/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { partial, uniqueId } from 'lodash';
@@ -28,7 +28,7 @@ class SegmentedSelection extends Component {
 						}
 						const id = uniqueId( `${ value }_` );
 						return (
-							<Fragment key={ value }>
+							<div className="woocommerce-segmented-selection__item" key={ value }>
 								{ /* eslint-disable jsx-a11y/label-has-for */ }
 								<input
 									className="woocommerce-segmented-selection__input"
@@ -42,7 +42,7 @@ class SegmentedSelection extends Component {
 									<span className="woocommerce-segmented-selection__label">{ label }</span>
 								</label>
 								{ /* eslint-enable jsx-a11y/label-has-for */ }
-							</Fragment>
+							</div>
 						);
 					} ) }
 				</div>

--- a/client/components/segmented-selection/style.scss
+++ b/client/components/segmented-selection/style.scss
@@ -11,8 +11,26 @@
 	display: grid;
 	border-top: 1px solid $core-grey-light-700;
 	border-bottom: 1px solid $core-grey-light-700;
-	grid-gap: 1px;
 	background-color: $core-grey-light-700;
+}
+
+@include set-item-grid-position( 2, 'woocommerce-segmented-selection__item', 10 );
+
+.woocommerce-segmented-selection__item {
+	display: block;
+
+	&:nth-child(2n) {
+		border-left: 1px solid $core-grey-light-700;
+		border-top: 1px solid $core-grey-light-700;
+	}
+
+	&:nth-child(2n + 1) {
+		border-top: 1px solid $core-grey-light-700;
+	}
+
+	&:nth-child(-n + 2) {
+		border-top: 0;
+	}
 }
 
 .woocommerce-segmented-selection__label {

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -98,7 +98,7 @@ $inner-border: $core-grey-light-500;
 	}
 
 	.woocommerce-summary__item-delta {
-		flex: 0;
+		flex: 0 1 auto;
 		display: flex;
 		flex-wrap: none;
 	}

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -103,6 +103,7 @@ $inner-border: $core-grey-light-500;
 		flex-wrap: none;
 	}
 
+	&,
 	&.has-one-item,
 	&.has-1-items {
 		grid-template-columns: 1fr;
@@ -212,6 +213,43 @@ $inner-border: $core-grey-light-500;
 
 		@include breakpoint( '<782px' ) {
 			border-right: none;
+		}
+	}
+}
+
+// IE11 doesn't auto-position grid children, so their position must be set manually
+@mixin set-grid-positions( $breakpoints ) {
+	@for $i from 1 through length( $breakpoints ) {
+		$number_of_items: $i;
+		$breakpoint: nth($breakpoints, $i);
+		@for $j from 1 through $number_of_items {
+			.has-#{$number_of_items}-items > .woocommerce-summary__item-container:nth-child(#{$j}) {
+				grid-column-start: #{($j - 1) % $breakpoint + 1};
+				grid-column-end: #{($j - 1) % $breakpoint + 2};
+				grid-row-start: #{floor(($j - 1) / $breakpoint) + 1};
+				grid-row-end: #{floor(($j - 1) / $breakpoint) + 2};
+			}
+		}
+	}
+}
+
+// These arrays can be read like this:
+// When there are 9 items, the breakpoint appears after the 5th item in large screens
+// and after the 3rd one when the screen is <1365px. On screens smaller than 1100px,
+// all items are displayed one below the other.
+@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ) );
+
+@include breakpoint( '<1365px' ) {
+	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ) );
+}
+
+@include breakpoint( '<1100px' ) {
+	@for $i from 1 through 10 {
+		.woocommerce-summary > .woocommerce-summary__item-container:nth-child(#{$i}) {
+			grid-column-start: 1;
+			grid-column-end: 2;
+			grid-row-start: #{$i};
+			grid-row-end: #{$i+1};
 		}
 	}
 }

--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -218,29 +218,14 @@ $inner-border: $core-grey-light-500;
 }
 
 // IE11 doesn't auto-position grid children, so their position must be set manually
-@mixin set-grid-positions( $breakpoints ) {
-	@for $i from 1 through length( $breakpoints ) {
-		$number_of_items: $i;
-		$breakpoint: nth($breakpoints, $i);
-		@for $j from 1 through $number_of_items {
-			.has-#{$number_of_items}-items > .woocommerce-summary__item-container:nth-child(#{$j}) {
-				grid-column-start: #{($j - 1) % $breakpoint + 1};
-				grid-column-end: #{($j - 1) % $breakpoint + 2};
-				grid-row-start: #{floor(($j - 1) / $breakpoint) + 1};
-				grid-row-end: #{floor(($j - 1) / $breakpoint) + 2};
-			}
-		}
-	}
-}
-
 // These arrays can be read like this:
 // When there are 9 items, the breakpoint appears after the 5th item in large screens
 // and after the 3rd one when the screen is <1365px. On screens smaller than 1100px,
 // all items are displayed one below the other.
-@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ) );
+@include set-grid-positions( ( 1, 2, 3, 4, 5, 6, 4, 4, 5, 5 ), 'woocommerce-summary__item-container' );
 
 @include breakpoint( '<1365px' ) {
-	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ) );
+	@include set-grid-positions( ( 1, 2, 3, 4, 5, 3, 4, 4, 3, 4 ), 'woocommerce-summary__item-container' );
 }
 
 @include breakpoint( '<1100px' ) {

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -47,3 +47,27 @@
 	outline: 2px solid transparent;
 	outline-offset: -2px;
 }
+
+// Sets grid positions for children of grid elements.
+@mixin set-item-grid-position( $breakpoint, $items_class, $number_of_items ) {
+	@for $i from 1 through $number_of_items {
+		.#{$items_class}:nth-child(#{$i}) {
+			grid-column-start: #{($i - 1) % $breakpoint + 1};
+			grid-column-end: #{($i - 1) % $breakpoint + 2};
+			grid-row-start: #{floor(($i - 1) / $breakpoint) + 1};
+			grid-row-end: #{floor(($i - 1) / $breakpoint) + 2};
+		}
+	}
+}
+
+// Sets grid positions for children of grid elements which can have an unknown
+// number of children, which is added to the parent element as a class `.has-X-items`.
+@mixin set-grid-positions( $breakpoints, $items_class ) {
+	@for $i from 1 through length( $breakpoints ) {
+		$number_of_items: $i;
+		$breakpoint: nth($breakpoints, $i);
+		.has-#{$number_of_items}-items {
+			@include set-item-grid-position( $breakpoint, $items_class, $number_of_items );
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1924,29 +1924,41 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.0.1.tgz",
-      "integrity": "sha512-ytUcgSKu1mZh8pCJq54BkaK7ijigK+nhqVmu8PYOR00letCkrU71qTfKnzhQgn7by/QJvlJGUAofMt+jyXJTxA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.3.tgz",
+      "integrity": "sha512-No9xrkPCGIHc9I52e+u1MuvkwfTOIXQt3tu+jGSONAJf4awvQmqOTWmk7JhA9Q3BTvBYIRdpS9PLFtrmpZcImg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.1",
-        "caniuse-lite": "^1.0.30000865",
+        "browserslist": "^4.0.2",
+        "caniuse-lite": "^1.0.30000878",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.1",
+        "postcss": "^7.0.2",
         "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-          "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
+          "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000865",
-            "electron-to-chromium": "^1.3.52",
-            "node-releases": "^1.0.0-alpha.10"
+            "caniuse-lite": "^1.0.30000878",
+            "electron-to-chromium": "^1.3.61",
+            "node-releases": "^1.0.0-alpha.11"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000883",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
+          "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.62",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
+          "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+          "dev": true
         }
       }
     },
@@ -12693,9 +12705,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -13815,9 +13827,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.1.tgz",
-      "integrity": "sha512-c6M68yZX0bWnZ0GcX8duWcfweGeGQvYgw6w4xksRePDmrpCrLMqneN07xwce17ACWBAr0S+DoI0T31axZ21TKg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@wordpress/postcss-themes": "^1.0.1",
     "@wordpress/scripts": "^2.0.2",
     "ast-types": "^0.11.5",
-    "autoprefixer": "9.0.1",
+    "autoprefixer": "^9.1.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
     "babel-loader": "^8.0.0-beta.4",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -19,7 +19,7 @@ module.exports = {
 				},
 			},
 		} ),
-		require( 'autoprefixer' ),
+		require( 'autoprefixer' )( { grid: true } ),
 		require( 'postcss-color-function' ),
 	],
 };


### PR DESCRIPTION
Part of #243. Follows #353.

Fixes filters display bugs in IE11 related to CSS Grid.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45086542-a705e600-b103-11e8-88b6-3d51585d765e.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45086138-d10ad880-b102-11e8-82b0-4196bdb8c4e7.png)

**Steps to test**
- Open the _Revenue_ page under _Analytics_ and open the _Date Range_ drop-down.
- Verify the grid is displayed correctly with IE11.
