### PR TITLE
IE11: Add required polyfills so react-dates works in Internet Explorer 11

### DIFF
--- a/client/components/calendar/index.js
+++ b/client/components/calendar/index.js
@@ -4,6 +4,8 @@
  */
 import { Component } from '@wordpress/element';
 import moment from 'moment';
+import 'core-js/fn/object/assign';
+import 'core-js/fn/array/from';
 import {
 	DayPickerRangeController,
 	isInclusivelyAfterDay,


### PR DESCRIPTION
Part of #243.

When displaying a calendar in Internet Explorer 11, a JavaScript error was raised and the app stopped working. That's because `react-dates` uses some JS features which are not yet available for IE11.

`react-dates` [developers](https://github.com/airbnb/react-dates/issues/1076#issuecomment-373760082) [recommend](https://github.com/airbnb/react-dates/issues/779#issuecomment-337721786) [using](https://github.com/airbnb/react-dates/issues/476#issuecomment-297751389) `airbnb-browser-shims` to prevent this issue, but doing some testing I found loading the required polyfills individually instead of the entire Airbnb Browser Shims package produces smaller builds.

![image](https://user-images.githubusercontent.com/3616980/45100984-c6fcd000-b12a-11e8-8540-8fc93f239b6b.png)

**Steps to test**
- Go to _Analytics_ > _Revenue_ and open the _Date Range:_ dropdown. There, click on _Custom_ so the calendar appears. Until now, a JavaScript error was appearing in Internet Explorer 11, but it should work fine, now.

(The layout of that dropdown is still broken until #353 and #354 are merged)