### PR TITLE
Add basic visual component docs

### DIFF
--- a/client/components/image-asset/example.js
+++ b/client/components/image-asset/example.js
@@ -1,0 +1,30 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DocsExample from 'devdocs/docs-example';
+import ImageAsset from './';
+
+export default class ImageAssetExample extends Component {
+	static defaultProps = {
+		displayName: 'ImageAsset',
+		exampleCode: (
+			<div>
+				<ImageAsset src="/empty-content.svg" alt="" width={ 200 } height={ 200 } />
+			</div>
+		),
+	};
+
+	renderExample() {
+		return this.props.exampleCode;
+	}
+
+	render = () => {
+		return <DocsExample { ...this.props }>{ this.renderExample() }</DocsExample>;
+	};
+}

--- a/client/components/split-button/example.js
+++ b/client/components/split-button/example.js
@@ -1,0 +1,82 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import DocsExample from 'devdocs/docs-example';
+import SplitButton from './';
+
+export default class SplitButtonExample extends Component {
+	static defaultProps = {
+		displayName: 'SplitButton',
+		exampleCode: (
+			<div>
+				<SplitButton
+					isPrimary
+					mainLabel="Primary Button"
+					menuLabel="Select an action"
+					onClick={ () => alert( 'Primary Main Action clicked' ) }
+					controls={ [
+						{
+							label: 'Up',
+							onClick: () => alert( 'Primary Up clicked' ),
+						},
+						{
+							label: 'Right',
+							onClick: () => alert( 'Primary Right clicked' ),
+						},
+						{
+							label: 'Down',
+							icon: <Gridicon icon="arrow-down" />,
+							onClick: () => alert( 'Primary Down clicked' ),
+						},
+						{
+							label: 'Left',
+							icon: <Gridicon icon="arrow-left" />,
+							onClick: () => alert( 'Primary Left clicked' ),
+						},
+					] }
+				/>
+				<SplitButton
+					mainIcon={ <Gridicon icon="pencil" /> }
+					menuLabel="Select an action"
+					onClick={ () => alert( 'Icon Only Action clicked' ) }
+					controls={ [
+						{
+							label: 'Up',
+							icon: <Gridicon icon="arrow-up" />,
+							onClick: () => alert( 'Icon Only Up clicked' ),
+						},
+						{
+							label: 'Right',
+							onClick: () => alert( 'Icon Only Right clicked' ),
+						},
+						{
+							label: 'Down',
+							icon: <Gridicon icon="arrow-down" />,
+							onClick: () => alert( 'Icon Only Down clicked' ),
+						},
+						{
+							label: 'Left',
+							icon: <Gridicon icon="arrow-left" />,
+							onClick: () => alert( 'Icon Only Left clicked' ),
+						},
+					] }
+				/>
+			</div>
+		),
+	};
+
+	renderExample() {
+		return this.props.exampleCode;
+	}
+
+	render = () => {
+		return <DocsExample { ...this.props }>{ this.renderExample() }</DocsExample>;
+	};
+}

--- a/client/devdocs/docs-example/index.js
+++ b/client/devdocs/docs-example/index.js
@@ -1,0 +1,89 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import history from 'lib/history';
+
+/**
+ * Internal dependencies
+ */
+import { getPath } from 'lib/nav-utils';
+import { Link } from '@woocommerce/components';
+
+// TODO Render README from this.props.readmeFilePath
+export default class DocsExample extends Component {
+	constructor() {
+		super();
+		this.state = {
+			currentPath: '/devdocs',
+		};
+	}
+
+	componentDidMount() {
+		/* eslint-disable */
+		this.setState( {
+			currentPath: getPath(),
+		} );
+		this.unlisten = history.listen( () => {
+			this.setState( {
+				currentPath: getPath(),
+			} );
+		} );
+		/* eslint-enable */
+	}
+
+	componentWillUnmount() {
+		this.unlisten();
+	}
+
+	// TODO Fix showing code example. Some components don't come through correctly (`<Gridicons />` becomes `<T />` for example
+	// and functions are output differently.
+	// TODO Add code highlighting.
+	// To use, add `jsx-to-string` to package.json
+	// <pre style={ { whiteSpace: 'pre-wrap' } }>{ this.renderCodeExample() }</pre>
+	/*renderCodeExample() {
+		if ( ! this.props.exampleCode ) {
+			return null;
+		}
+
+		if ( typeof this.props.exampleCode === 'string' ) {
+			return this.props.exampleCode;
+		}
+
+		return jsxToString( this.props.exampleCode, { useFunctionCode: true } );
+	}*/
+
+	render() {
+		// Describes how the component documentation should look on the main listing page.
+		if ( '/devdocs' === this.state.currentPath || '/devdocs/' === this.state.currentPath ) {
+			return (
+				<Fragment>
+					<h2>
+						<Link href={ `/devdocs/${ this.props.displayName }` }>{ this.props.displayName }</Link>
+					</h2>
+					{ this.props.children }
+				</Fragment>
+			);
+		}
+
+		// Describes how the component documentation should look on it's individual component page.
+		let component = this.state.currentPath.replace( '/devdocs/', '' );
+		if ( component.substr( -1 ) === '/' ) {
+			component = component.substr( 0, component.length - 1 );
+		}
+
+		if ( this.props.displayName !== component ) {
+			return null;
+		}
+
+		return (
+			<Fragment>
+				<h2>
+					<Link href={ `/devdocs/${ this.props.displayName }` }>{ this.props.displayName }</Link>
+				</h2>
+				{ this.props.children }
+			</Fragment>
+		);
+	}
+}

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ImageAsset from 'components/image-asset/example';
+import SplitButton from 'components/split-button/example';
+
+export default class DevDocs extends Component {
+	render() {
+		return (
+			<Fragment>
+				<ImageAsset readmeFilePath="image-asset" />
+				<SplitButton readmeFilePath="split-button" />
+			</Fragment>
+		);
+	}
+}

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -12,12 +12,23 @@ import { find } from 'lodash';
 import Analytics from 'analytics';
 import AnalyticsReport from 'analytics/report';
 import Dashboard from 'dashboard';
+import DevDocs from 'devdocs';
 
 const getPages = () => {
 	const pages = [
 		{
 			container: Dashboard,
 			path: '/',
+			wpMenu: 'toplevel_page_woocommerce',
+		},
+		{
+			container: DevDocs,
+			path: '/devdocs',
+			wpMenu: 'toplevel_page_woocommerce',
+		},
+		{
+			container: DevDocs,
+			path: '/devdocs/:component',
 			wpMenu: 'toplevel_page_woocommerce',
 		},
 		{

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -69,6 +69,14 @@ function wc_admin_register_pages() {
 		'wc_admin_page'
 	);
 
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		wc_admin_register_page( array(
+			'title'  => 'DevDocs',
+			'parent' => 'woocommerce', // Exposed on the main menu for now.
+			'path'   => '/devdocs',
+		) );
+	}
+
 	add_menu_page(
 		__( 'WooCommerce Analytics', 'wc-admin' ),
 		__( 'Analytics', 'wc-admin' ),


### PR DESCRIPTION
Note: I really do mean basic here.

After our chat today, and removing some example code, I tried to put together a basic component example viewer that we can use to share examples with 3PDs. It is only exposed as a menu item if you have WP debug mode and script debug turned on.

The intention is to use this prior to us figuring things out with Calypso devdocs (as noted, our components rely on various things that might not be available in that environment yet). The long term goal is to use Calypso devdocs. 

The `example.js` files we would add to power this are based on the ones from Calypso (passing code to `exampleCode`, etc) -- so this gives us the added bonus of preparing our examples early.

I had some trouble getting code examples to also show up and didn't want to spend too much time on it at the moment (see commented out code) but I figured this  could serve as a starting point and a place for example usage.

<img width="576" alt="screen shot 2018-09-05 at 2 02 04 pm" src="https://user-images.githubusercontent.com/689165/45113383-3917e980-b118-11e8-96c5-bb2f34c127fa.png">
