### PR TITLE
Add interval selection to the revenue report

### DIFF
--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -194,7 +194,7 @@ D3Chart.propTypes = {
 	/**
 	 * Interval specification (hourly, daily, weekly etc.)
 	 */
-	interval: PropTypes.oneOf( [ 'hour', 'day', 'week', 'month', 'quater', 'year' ] ),
+	interval: PropTypes.oneOf( [ 'hour', 'day', 'week', 'month', 'quarter', 'year' ] ),
 	/**
 	 * Margins for axis and chart padding.
 	 */

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -199,6 +199,15 @@
 	}
 }
 
+.woocommerce-chart__interval-select {
+	margin: 0;
+
+	.components-select-control__input {
+		border: 0;
+		box-shadow: none;
+	}
+}
+
 .woocommerce-chart__container {
 	position: relative;
 	width: 100%;

--- a/client/lib/date/test/index.js
+++ b/client/lib/date/test/index.js
@@ -681,12 +681,43 @@ describe( 'getDateDifferenceInDays', () => {
 } );
 
 describe( 'getPreviousDate', () => {
-	it( 'should return valid date for previous period', () => {
-		const previousDate = getPreviousDate( '2018-08-21', 92, 'previous_period' );
-		expect( previousDate.format( isoDateFormat ) ).toBe( '2018-05-21' );
+	it( 'should return valid date for previous period by days', () => {
+		const date = '2018-08-21';
+		const primaryStart = '2018-08-25';
+		const secondaryStart = '2018-08-15';
+		const previousDate = getPreviousDate(
+			date,
+			primaryStart,
+			secondaryStart,
+			'previous_period',
+			'day'
+		);
+		expect( previousDate.format( isoDateFormat ) ).toBe( '2018-08-11' );
+	} );
+	it( 'should return valid date for previous period by months', () => {
+		const date = '2018-08-21';
+		const primaryStart = '2018-08-01';
+		const secondaryStart = '2018-07-01';
+		const previousDate = getPreviousDate(
+			date,
+			primaryStart,
+			secondaryStart,
+			'previous_period',
+			'month'
+		);
+		expect( previousDate.format( isoDateFormat ) ).toBe( '2018-07-21' );
 	} );
 	it( 'should return valid date for previous year', () => {
-		const previousDate = getPreviousDate( '2018-08-21', 92, 'previous_year' );
+		const date = '2018-08-21';
+		const primaryStart = '2018-08-01';
+		const secondaryStart = '2018-07-01';
+		const previousDate = getPreviousDate(
+			date,
+			primaryStart,
+			secondaryStart,
+			'previous_year',
+			'day'
+		);
 		expect( previousDate.format( isoDateFormat ) ).toBe( '2017-08-21' );
 	} );
 } );


### PR DESCRIPTION
This branch adds the ability to view revenue data by different intervals (hours, days, weeks, etc). It adds a new dropdown to the chart allowing you to select from valid intervals.

I'm AFK starting Monday, so @timmyc or someone might need to follow-up here. I wanted to post what I have working so we can go from there.

---

There are a few issues I noted when working on this branch:

* When requesting ?interval=week, an extra single date is sometimes appended by the API. I.e. try "Quarter to Date" and it includes July 1st by itself, and then starts doing weeks:

```
{"interval":"week","date_start":"2018-07-01 00:00:00","date_start_gmt":"2018-07-01 00:00:00","date_end":"2018-07-01 23:59:59","date_end_gmt":"2018-07-01 23:59:59",....

{"interval":"week","date_start":"2018-07-02 00:00:00","date_start_gmt":"2018-07-02 00:00:00","date_end":"2018-07-08 23:59:59","date_end_gmt":"2018-07-08 23:59:59",....

{"interval":"week","date_start":"2018-07-09 00:00:00","date_start_gmt":"2018-07-09 00:00:00","date_end":"2018-07-15 23:59:59","date_end_gmt":"2018-07-15 23:59:59",....
```

cc @peterfabian 

* Zero-filling still an issue, so you may see missing dates. It's best to test with a data set right now where there is no gaps.

* It looks like our D3 still might need some work on spacing of data points cc @greenafrican . I think part of the reason for the weird display is some missing zero days, however it still seems like they shouldn't bunch up like this:

<img width="907" alt="screen shot 2018-09-07 at 11 44 56 am" src="https://user-images.githubusercontent.com/689165/45229905-38589200-b295-11e8-834f-808398949e57.png">

---

To Test:

* Make sure you are using the v3 feature branch, and have test orders. You can use https://github.com/woocommerce/wc-smooth-generator to create test orders. I recently added the ability to create orders for a specific date range, and for setting a random time.
* Test various date spans and check the allowed intervals in the dropdown.
* Test different intervals like hour, day, etc.

<img width="907" alt="screen shot 2018-09-07 at 11 35 12 am" src="https://user-images.githubusercontent.com/689165/45230362-93d74f80-b296-11e8-9144-00b5489cf117.png">
