### PR TITLE
Add Search queries to state

### DIFF
--- a/client/analytics/report/orders/constants.js
+++ b/client/analytics/report/orders/constants.js
@@ -55,6 +55,16 @@ export const advancedFilterConfig = {
 		input: {
 			component: 'Search',
 			type: 'products',
+			getValues: ( filterValues, select ) => {
+				const { getProductById } = select( 'wc-admin' );
+				return filterValues.map( id => {
+					const product = getProductById( id );
+					return {
+						id: parseInt( id, 10 ),
+						label: ( product && product.name ) || id.toString(),
+					};
+				} );
+			},
 		},
 	},
 	code: {
@@ -69,6 +79,17 @@ export const advancedFilterConfig = {
 		input: {
 			component: 'Search',
 			type: 'products', // For now. "coupons" autocompleter required
+			getValues: ( filterValues, select ) => {
+				// Again, for now
+				const { getProductById } = select( 'wc-admin' );
+				return filterValues.map( id => {
+					const product = getProductById( id );
+					return {
+						id: parseInt( id, 10 ),
+						label: ( product && product.name ) || id.toString(),
+					};
+				} );
+			},
 		},
 	},
 	customer: {

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -13,8 +13,8 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Search from 'components/search';
 import Link from 'components/link';
+import Selector from './selector';
 import { getActiveFiltersFromQuery, getQueryFromActiveFilters } from './utils';
 import { getNewPath } from 'lib/nav-utils';
 import './style.scss';
@@ -41,7 +41,6 @@ class AdvancedFilters extends Component {
 
 		this.onMatchChange = this.onMatchChange.bind( this );
 		this.onFilterChange = this.onFilterChange.bind( this );
-		this.getSelector = this.getSelector.bind( this );
 		this.getAvailableFilterKeys = this.getAvailableFilterKeys.bind( this );
 		this.addFilter = this.addFilter.bind( this );
 		this.removeFilter = this.removeFilter.bind( this );
@@ -89,35 +88,6 @@ class AdvancedFilters extends Component {
 				<span>{ __( 'Filters', 'wc-admin' ) }</span>
 			</Fragment>
 		);
-	}
-
-	getSelector( filter ) {
-		const filterConfig = this.props.config[ filter.key ];
-		const { input } = filterConfig;
-		if ( ! input ) {
-			return null;
-		}
-		if ( 'SelectControl' === input.component ) {
-			return (
-				<SelectControl
-					className="woocommerce-filters-advanced__list-select"
-					options={ input.options }
-					value={ filter.value }
-					onChange={ partial( this.onFilterChange, filter.key, 'value' ) }
-					aria-label={ sprintf( __( 'Select %s', 'wc-admin' ), filterConfig.label ) }
-				/>
-			);
-		}
-		if ( 'Search' === input.component ) {
-			return (
-				<Search
-					onChange={ partial( this.onFilterChange, filter.key, 'value' ) }
-					type={ input.type }
-					selected={ filter.value }
-				/>
-			);
-		}
-		return null;
 	}
 
 	getAvailableFilterKeys() {
@@ -197,7 +167,11 @@ class AdvancedFilters extends Component {
 											/>
 										) }
 										<div className="woocommerce-filters-advanced__list-selector">
-											{ this.getSelector( filter ) }
+											<Selector
+												filter={ filter }
+												config={ config }
+												onFilterChange={ this.onFilterChange }
+											/>
 										</div>
 									</div>
 								</fieldset>

--- a/client/components/filters/advanced/selector.js
+++ b/client/components/filters/advanced/selector.js
@@ -1,0 +1,71 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
+import { partial } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Search from 'components/search';
+
+class Selector extends Component {
+	constructor() {
+		super();
+		this.onSearchChange = this.onSearchChange.bind( this );
+	}
+
+	onSearchChange( values ) {
+		const { filter, onFilterChange } = this.props;
+		const nextValues = values.map( value => value.id );
+		onFilterChange( nextValues, filter.key, 'value' );
+	}
+
+	render() {
+		const { filter, config, onFilterChange, searchValue } = this.props;
+		const filterConfig = config[ filter.key ];
+		const { input } = filterConfig;
+		if ( ! input ) {
+			return null;
+		}
+		if ( 'SelectControl' === input.component ) {
+			return (
+				<SelectControl
+					className="woocommerce-filters-advanced__list-select"
+					options={ input.options }
+					value={ filter.value }
+					onChange={ partial( onFilterChange, filter.key, 'value' ) }
+					aria-label={ sprintf( __( 'Select %s', 'wc-admin' ), filterConfig.label ) }
+				/>
+			);
+		}
+		if ( 'Search' === input.component ) {
+			return (
+				<Search onChange={ this.onSearchChange } type={ input.type } selected={ searchValue } />
+			);
+		}
+		return null;
+	}
+}
+
+export default withSelect( ( select, props ) => {
+	const { filter } = props;
+	// const filterConfig = config[ filter.key ];
+	// const { input } = filterConfig;
+	if ( Array.isArray( filter.value ) ) {
+		const { getProductById } = select( 'wc-admin' );
+		return {
+			searchValue: filter.value.map( id => {
+				const product = getProductById( id );
+				return {
+					id: parseInt( id, 10 ),
+					label: ( product && product.name ) || id.toString(),
+				};
+			} ),
+		};
+	}
+} )( Selector );

--- a/client/components/filters/advanced/selector.js
+++ b/client/components/filters/advanced/selector.js
@@ -22,7 +22,7 @@ class Selector extends Component {
 	onSearchChange( values ) {
 		const { filter, onFilterChange } = this.props;
 		const nextValues = values.map( value => value.id );
-		onFilterChange( nextValues, filter.key, 'value' );
+		onFilterChange( filter.key, 'value', nextValues );
 	}
 
 	render() {

--- a/client/components/filters/advanced/selector.js
+++ b/client/components/filters/advanced/selector.js
@@ -26,7 +26,7 @@ class Selector extends Component {
 	}
 
 	render() {
-		const { filter, config, onFilterChange, searchValue } = this.props;
+		const { filter, config, onFilterChange, searchValues } = this.props;
 		const filterConfig = config[ filter.key ];
 		const { input } = filterConfig;
 		if ( ! input ) {
@@ -45,7 +45,7 @@ class Selector extends Component {
 		}
 		if ( 'Search' === input.component ) {
 			return (
-				<Search onChange={ this.onSearchChange } type={ input.type } selected={ searchValue } />
+				<Search onChange={ this.onSearchChange } type={ input.type } selected={ searchValues } />
 			);
 		}
 		return null;
@@ -53,19 +53,10 @@ class Selector extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { filter } = props;
-	// const filterConfig = config[ filter.key ];
-	// const { input } = filterConfig;
-	if ( Array.isArray( filter.value ) ) {
-		const { getProductById } = select( 'wc-admin' );
-		return {
-			searchValue: filter.value.map( id => {
-				const product = getProductById( id );
-				return {
-					id: parseInt( id, 10 ),
-					label: ( product && product.name ) || id.toString(),
-				};
-			} ),
-		};
-	}
+	const { filter, config } = props;
+	const filterConfig = config[ filter.key ];
+	const { input } = filterConfig;
+	return {
+		searchValues: 'Search' === input.component ? input.getValues( filter.value, select ) : [],
+	};
 } )( Selector );

--- a/client/components/filters/advanced/test/utils.js
+++ b/client/components/filters/advanced/test/utils.js
@@ -34,9 +34,9 @@ describe( 'getSearchFilterValue', () => {
 		const str = '1,2,3';
 		const values = getSearchFilterValue( str );
 		expect( Array.isArray( values ) ).toBeTruthy();
-		expect( 'number' === typeof values[ 0 ].id ).toBeTruthy();
-		expect( values[ 0 ].id ).toBe( 1 );
-		expect( values[ 0 ].label ).toBe( '1' );
+		expect( values[ 0 ] ).toBe( '1' );
+		expect( values[ 1 ] ).toBe( '2' );
+		expect( values[ 2 ] ).toBe( '3' );
 	} );
 
 	it( 'should convert an empty string into an empty array', () => {
@@ -135,12 +135,8 @@ describe( 'getUrlValue', () => {
 		expect( value ).toBeNull();
 	} );
 
-	it( 'should return an array of concatenated ids given an array of objects', () => {
-		const value = getUrlValue( [
-			{ id: 1, label: 'one' },
-			{ id: 2, label: 'one' },
-			{ id: 3, label: 'one' },
-		] );
+	it( 'should return comma separated values when given an array', () => {
+		const value = getUrlValue( [ 1, 2, 3 ] );
 		expect( value ).toBe( '1,2,3' );
 	} );
 } );
@@ -152,7 +148,7 @@ describe( 'getQueryFromActiveFilters', () => {
 			{
 				key: 'things',
 				rule: 'includes',
-				value: [ { id: 1 }, { id: 2 }, { id: 3 } ],
+				value: [ 1, 2, 3 ],
 			},
 			{ key: 'customer', value: 'new' },
 		];
@@ -170,7 +166,7 @@ describe( 'getQueryFromActiveFilters', () => {
 			{
 				key: 'things',
 				rule: 'includes',
-				value: [ { id: 1 }, { id: 2 }, { id: 3 } ],
+				value: [ 1, 2, 3 ],
 			},
 			{ key: 'customer', value: 'new' },
 		];

--- a/client/components/filters/advanced/utils.js
+++ b/client/components/filters/advanced/utils.js
@@ -25,10 +25,7 @@ export const getUrlKey = ( key, rule ) => {
  * @return {{id: Number, label: String}[]} - array of Search tags
  */
 export const getSearchFilterValue = str => {
-	if ( str.length ) {
-		return str.split( ',' ).map( value => ( { id: parseInt( value, 10 ), label: value } ) );
-	}
-	return [];
+	return str.length ? str.split( ',' ) : [];
 };
 
 /**
@@ -88,7 +85,7 @@ export const getActiveFiltersFromQuery = ( query, config ) => {
  */
 export const getUrlValue = value => {
 	if ( Array.isArray( value ) ) {
-		return value.length ? value.map( v => v.id ).join( ',' ) : null;
+		return value.length ? value.join( ',' ) : null;
 	}
 	return 'string' === typeof value ? value : null;
 };

--- a/client/components/filters/advanced/utils.js
+++ b/client/components/filters/advanced/utils.js
@@ -22,7 +22,7 @@ export const getUrlKey = ( key, rule ) => {
  * Convert url values to array of objects for <Search /> component
  *
  * @param {string} str - url query parameter value
- * @return {{id: Number, label: String}[]} - array of Search tags
+ * @return {array} - array of Search values
  */
 export const getSearchFilterValue = str => {
 	return str.length ? str.split( ',' ) : [];

--- a/client/components/search/autocomplete.js
+++ b/client/components/search/autocomplete.js
@@ -6,7 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button, withFocusOutside, withSpokenMessages } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { escapeRegExp, map, debounce } from 'lodash';
+import { escapeRegExp, map, debounce, noop } from 'lodash';
 import { ENTER, ESCAPE, UP, DOWN, LEFT, TAB, RIGHT } from '@wordpress/keycodes';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { dispatch } from '@wordpress/data';
@@ -127,7 +127,7 @@ export class Autocomplete extends Component {
 	 * @param {string}    query     The query, if any.
 	 */
 	loadOptions( completer, query ) {
-		const { options } = completer;
+		const { options, saveAction } = completer;
 
 		/*
 		 * We support both synchronous and asynchronous retrieval of completer options
@@ -143,7 +143,8 @@ export class Autocomplete extends Component {
 		const promise = ( this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( optionsData => {
-			dispatch( 'wc-admin' ).setProducts( optionsData, query );
+			const saveFn = dispatch( 'wc-admin' )[ saveAction ] || noop;
+			saveFn( optionsData, query );
 
 			if ( promise !== this.activePromise ) {
 				// Another promise has become active since this one was asked to resolve, so do nothing,

--- a/client/components/search/autocomplete.js
+++ b/client/components/search/autocomplete.js
@@ -9,6 +9,7 @@ import { Component } from '@wordpress/element';
 import { escapeRegExp, map, debounce } from 'lodash';
 import { ENTER, ESCAPE, UP, DOWN, LEFT, TAB, RIGHT } from '@wordpress/keycodes';
 import { withInstanceId, compose } from '@wordpress/compose';
+import { dispatch } from '@wordpress/data';
 
 function filterOptions( search, options = [], maxResults = 10 ) {
 	const filtered = [];
@@ -142,6 +143,8 @@ export class Autocomplete extends Component {
 		const promise = ( this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( optionsData => {
+			dispatch( 'wc-admin' ).setProducts( optionsData, query );
+
 			if ( promise !== this.activePromise ) {
 				// Another promise has become active since this one was asked to resolve, so do nothing,
 				// or else we might end triggering a race condition updating the state.

--- a/client/components/search/autocompleters/product.js
+++ b/client/components/search/autocompleters/product.js
@@ -77,4 +77,5 @@ export default {
 		};
 		return value;
 	},
+	saveAction: 'setProducts',
 };

--- a/client/store/products/actions.js
+++ b/client/store/products/actions.js
@@ -2,6 +2,7 @@
 
 export default {
 	setProducts( products, query ) {
+		console.log( products );
 		return {
 			type: 'SET_PRODUCTS',
 			products,

--- a/client/store/products/actions.js
+++ b/client/store/products/actions.js
@@ -2,7 +2,6 @@
 
 export default {
 	setProducts( products, query ) {
-		console.log( products );
 		return {
 			type: 'SET_PRODUCTS',
 			products,

--- a/client/store/products/reducer.js
+++ b/client/store/products/reducer.js
@@ -26,11 +26,11 @@ export default function productsReducer( state = DEFAULT_STATE, action ) {
 		const queries = {
 			...prevQueries,
 			[ queryKey ]: [ ...action.products ],
-			products: { ...state.products, ...productsMap },
 		};
 		return {
 			...state,
 			queries,
+			products: { ...state.products, ...productsMap },
 		};
 	}
 	if ( 'SET_PRODUCTS_ERROR' === action.type ) {

--- a/client/store/products/reducer.js
+++ b/client/store/products/reducer.js
@@ -12,15 +12,21 @@ import { getJsonString } from 'store/utils';
 
 export const DEFAULT_STATE = {
 	queries: {},
+	products: {},
 };
 
 export default function productsReducer( state = DEFAULT_STATE, action ) {
 	if ( 'SET_PRODUCTS' === action.type ) {
 		const prevQueries = get( state, 'queries', {} );
 		const queryKey = getJsonString( action.query );
+		const productsMap = action.products.reduce( ( map, product ) => {
+			map[ product.id ] = product;
+			return map;
+		}, {} );
 		const queries = {
 			...prevQueries,
 			[ queryKey ]: [ ...action.products ],
+			products: { ...state.products, ...productsMap },
 		};
 		return {
 			...state,

--- a/client/store/products/resolvers.js
+++ b/client/store/products/resolvers.js
@@ -10,17 +10,20 @@ import { dispatch } from '@wordpress/data';
  */
 import { stringifyQuery } from 'lib/nav-utils';
 
+async function getProducts( state, query ) {
+	try {
+		const params = stringifyQuery( query );
+		const products = await apiFetch( { path: '/wc/v3/products' + params } );
+		dispatch( 'wc-admin' ).setProducts( products, query );
+	} catch ( error ) {
+		dispatch( 'wc-admin' ).setProductsError( query );
+	}
+}
+
 export default {
-	async getProducts( state, query ) {
-		try {
-			const params = stringifyQuery( query );
-			const products = await apiFetch( { path: '/wc/v3/products' + params } );
-			dispatch( 'wc-admin' ).setProducts( products, query );
-		} catch ( error ) {
-			dispatch( 'wc-admin' ).setProductsError( query );
-		}
-	},
+	getProducts,
+
 	async getProductById( state, id ) {
-		this.getProducts( state, { id } );
+		getProducts( state, { id } );
 	},
 };

--- a/client/store/products/resolvers.js
+++ b/client/store/products/resolvers.js
@@ -4,16 +4,23 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
-import { stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import { stringifyQuery } from 'lib/nav-utils';
 
 export default {
 	async getProducts( state, query ) {
 		try {
-			const params = query ? '?' + stringify( query ) : '';
+			const params = stringifyQuery( query );
 			const products = await apiFetch( { path: '/wc/v3/products' + params } );
 			dispatch( 'wc-admin' ).setProducts( products, query );
 		} catch ( error ) {
 			dispatch( 'wc-admin' ).setProductsError( query );
 		}
+	},
+	async getProductById( state, id ) {
+		this.getProducts( state, { id } );
 	},
 };

--- a/client/store/products/selectors.js
+++ b/client/store/products/selectors.js
@@ -49,6 +49,6 @@ export default {
 	},
 
 	getProductById( state, id ) {
-		return get( state, 'products.products', id );
+		return get( state, 'products.products', {} )[ id ];
 	},
 };

--- a/client/store/products/selectors.js
+++ b/client/store/products/selectors.js
@@ -47,4 +47,8 @@ export default {
 	isProductsError( state, query ) {
 		return ERROR === getProducts( state, query );
 	},
+
+	getProductById( state, id ) {
+		return get( state, 'products.products', id );
+	},
 };


### PR DESCRIPTION
By adding Search component query results to the data layer, product names corresponding to ids in the url query parameters can be initialised on page load. 

## In Progress...
continuing from https://github.com/woocommerce/wc-admin/pull/349