### PR TITLE
Add empty state message to Top Selling Products card

### DIFF
--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -81,21 +81,37 @@ export class TopSellingProducts extends Component {
 		} );
 	}
 
-	render() {
+	getCardContents( title ) {
 		const { data, isRequesting, isError } = this.props;
 
-		// @TODO We will need to update it with a error/empty data indicator
 		const rows = isRequesting || isError ? [] : this.getRowsContent( data );
 		const headers = this.getHeadersContent();
+
+		if ( isRequesting ) {
+			return <TablePlaceholder caption={ title } headers={ headers } />;
+		}
+
+		if ( isError ) {
+			// @TODO An error notice should be displayed when there is an error
+		}
+
+		if ( rows.length === 0 ) {
+			return (
+				<div className="woocommerce-top-selling-products__empty-message">
+					{ __( 'When new orders arrive, popular products will be listed here.', 'wc-admin' ) }
+				</div>
+			);
+		}
+
+		return <Table caption={ title } rows={ rows } headers={ headers } />;
+	}
+
+	render() {
 		const title = __( 'Top Selling Products', 'wc-admin' );
 
 		return (
 			<Card title={ title } className="woocommerce-top-selling-products">
-				{ isRequesting ? (
-					<TablePlaceholder caption={ title } headers={ headers } />
-				) : (
-					<Table caption={ title } rows={ rows } headers={ headers } />
-				) }
+				{ this.getCardContents( title ) }
 			</Card>
 		);
 	}

--- a/client/dashboard/top-selling-products/style.scss
+++ b/client/dashboard/top-selling-products/style.scss
@@ -4,6 +4,13 @@
 		padding: 0;
 	}
 
+	.woocommerce-top-selling-products__empty-message {
+		background: $core-grey-light-100;
+		color: $core-grey-dark-500;
+		padding: $gap-largest 0;
+		text-align: center;
+	}
+
 	.woocommerce-table__table {
 		margin-bottom: 0;
 

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -30,6 +30,14 @@ describe( 'TopSellingProducts', () => {
 		expect( topSellingProducts.find( 'TablePlaceholder' ).length ).toBe( 1 );
 	} );
 
+	test( 'should render empty message when there are no rows', () => {
+		const topSellingProducts = shallow( <TopSellingProducts data={ {} } /> );
+
+		expect(
+			topSellingProducts.find( '.woocommerce-top-selling-products__empty-message' ).length
+		).toBe( 1 );
+	} );
+
 	test( 'should render correct data in the table', () => {
 		const topSellingProducts = shallow( <TopSellingProducts data={ mockData } /> );
 		const table = topSellingProducts.find( 'Table' );


### PR DESCRIPTION
Part of #108.

[Design](https://github.com/woocommerce/wc-admin/issues/108) by @jameskoster.

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/45169332-b1a4a600-b1fd-11e8-885e-ff483bdca845.png)

**Steps to test**
- Run `npm test` to verify tests are passing.
- Force `rows` to be empty in the Top Selling Products table. Go to `client/dashboard/top-selling-products/index.js` and replace this line:
  `const rows = isRequesting || isError ? [] : this.getRowsContent( data );`
  with
  `const rows = [];`
- Go to the _Dashboard_ page.
- Check that the _Top Selling Products_ card is displaying a message instead of the table.

We will still have to handle the case when there was an error.