### PR TITLE
IE11: Fix Date filters grid not displaying correctly

### DIFF
--- a/client/components/filters/date/style.scss
+++ b/client/components/filters/date/style.scss
@@ -35,6 +35,10 @@
 }
 
 .woocommerce-filters-date__tab {
+	@include set-grid-item-position( 2, 2 );
+}
+
+.woocommerce-filters-date__tab {
 	outline: none;
 	border: 1px solid $woocommerce;
 	padding: $gap-smaller;

--- a/client/components/segmented-selection/index.js
+++ b/client/components/segmented-selection/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { partial, uniqueId } from 'lodash';
@@ -28,7 +28,7 @@ class SegmentedSelection extends Component {
 						}
 						const id = uniqueId( `${ value }_` );
 						return (
-							<Fragment key={ value }>
+							<div className="woocommerce-segmented-selection__item" key={ value }>
 								{ /* eslint-disable jsx-a11y/label-has-for */ }
 								<input
 									className="woocommerce-segmented-selection__input"
@@ -42,7 +42,7 @@ class SegmentedSelection extends Component {
 									<span className="woocommerce-segmented-selection__label">{ label }</span>
 								</label>
 								{ /* eslint-enable jsx-a11y/label-has-for */ }
-							</Fragment>
+							</div>
 						);
 					} ) }
 				</div>

--- a/client/components/segmented-selection/style.scss
+++ b/client/components/segmented-selection/style.scss
@@ -11,8 +11,25 @@
 	display: grid;
 	border-top: 1px solid $core-grey-light-700;
 	border-bottom: 1px solid $core-grey-light-700;
-	grid-gap: 1px;
 	background-color: $core-grey-light-700;
+}
+
+.woocommerce-segmented-selection__item {
+	display: block;
+	@include set-grid-item-position( 2, 10 );
+
+	&:nth-child(2n) {
+		border-left: 1px solid $core-grey-light-700;
+		border-top: 1px solid $core-grey-light-700;
+	}
+
+	&:nth-child(2n + 1) {
+		border-top: 1px solid $core-grey-light-700;
+	}
+
+	&:nth-child(-n + 2) {
+		border-top: 0;
+	}
 }
 
 .woocommerce-segmented-selection__label {


### PR DESCRIPTION
Part of #243.

Fixes filters display bugs in IE11 related to CSS Grid.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45086542-a705e600-b103-11e8-88b6-3d51585d765e.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45086138-d10ad880-b102-11e8-82b0-4196bdb8c4e7.png)

**Steps to test**
- Open the _Revenue_ page under _Analytics_ and open the _Date Range_ drop-down.
- Verify the grid is displayed correctly with IE11.