### PR TITLE
Component – Search: Add “product category” autocompleter

### DIFF
--- a/client/components/search/autocompleters/index.js
+++ b/client/components/search/autocompleters/index.js
@@ -3,3 +3,4 @@
  * Export all autocompleters
  */
 export { default as product } from './product';
+export { default as productCategory } from './product-cat';

--- a/client/components/search/autocompleters/product-cat.js
+++ b/client/components/search/autocompleters/product-cat.js
@@ -8,17 +8,16 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
-import ProductImage from 'components/product-image';
 import { stringifyQuery } from 'lib/nav-utils';
 
 /**
- * A products completer.
+ * A product categories completer.
  * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
  *
  * @type {Completer}
  */
 export default {
-	name: 'products',
+	name: 'product_cats',
 	className: 'woocommerce-search__product-result',
 	options( search ) {
 		let payload = '';
@@ -26,28 +25,21 @@ export default {
 			const query = {
 				search: encodeURIComponent( search ),
 				per_page: 10,
-				orderby: 'popularity',
+				orderby: 'count',
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: '/wc/v3/products' + payload } );
+		return apiFetch( { path: '/wc/v3/products/categories' + payload } );
 	},
 	isDebounced: true,
-	getOptionKeywords( product ) {
-		return [ product.name ];
+	getOptionKeywords( cat ) {
+		return [ cat.name ];
 	},
-	getOptionLabel( product, query ) {
-		const match = computeSuggestionMatch( product.name, query ) || {};
+	getOptionLabel( cat, query ) {
+		const match = computeSuggestionMatch( cat.name, query ) || {};
+		// @todo bring back ProductImage, but allow for product category image
 		return [
-			<ProductImage
-				key="thumbnail"
-				className="woocommerce-search__result-thumbnail"
-				product={ product }
-				width={ 18 }
-				height={ 18 }
-				alt=""
-			/>,
-			<span key="name" className="woocommerce-search__result-name" aria-label={ product.name }>
+			<span key="name" className="woocommerce-search__result-name" aria-label={ cat.name }>
 				{ match.suggestionBeforeMatch }
 				<strong className="components-form-token-field__suggestion-match">
 					{ match.suggestionMatch }
@@ -58,10 +50,10 @@ export default {
 	},
 	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
 	// of replace/insertion, so we can just return the value.
-	getOptionCompletion( product ) {
+	getOptionCompletion( cat ) {
 		const value = {
-			id: product.id,
-			label: product.name,
+			id: cat.id,
+			label: cat.name,
 		};
 		return value;
 	},

--- a/client/components/search/autocompleters/utils.js
+++ b/client/components/search/autocompleters/utils.js
@@ -1,0 +1,21 @@
+/** @format */
+/**
+ * Parse a string suggestion, split apart by where the first matching query is.
+ * Used to display matched partial in bold.
+ *
+ * @param {string} suggestion The item's label as returned from the API.
+ * @param {string} query The search term to match in the string.
+ * @return {object} A list in three parts: before, match, and after.
+ */
+export function computeSuggestionMatch( suggestion, query ) {
+	if ( ! query ) {
+		return null;
+	}
+	const indexOfMatch = suggestion.toLocaleLowerCase().indexOf( query.toLocaleLowerCase() );
+
+	return {
+		suggestionBeforeMatch: suggestion.substring( 0, indexOfMatch ),
+		suggestionMatch: suggestion.substring( indexOfMatch, indexOfMatch + query.length ),
+		suggestionAfterMatch: suggestion.substring( indexOfMatch + query.length ),
+	};
+}

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { product } from './autocompleters';
+import { product, productCategory } from './autocompleters';
 import Tag from 'components/tag';
 import './style.scss';
 
@@ -61,6 +61,8 @@ class Search extends Component {
 		switch ( this.props.type ) {
 			case 'products':
 				return product;
+			case 'product_cats':
+				return productCategory;
 			default:
 				return {};
 		}
@@ -119,7 +121,7 @@ Search.propTypes = {
 	/**
 	 * The object type to be used in searching.
 	 */
-	type: PropTypes.oneOf( [ 'products', 'orders', 'customers' ] ).isRequired,
+	type: PropTypes.oneOf( [ 'products', 'product_cats', 'orders', 'customers' ] ).isRequired,
 	/**
 	 * An array of objects describing selected values
 	 */


### PR DESCRIPTION
Fixes #343 – This PR adds a "product category" autocompleter based off the products autocompleter. I also moved the `computeSuggestionMatch` function to a utils file, since we'll use that in multiple autocompleters to highlight the search term.

Currently this does not show the product category thumbnail, since `ProductImage` only works with product objects.

![screen shot 2018-09-06 at 4 32 27 pm](https://user-images.githubusercontent.com/541093/45183582-7ea8e500-b1f2-11e8-91ea-559182477ca2.png)

Test in conjunction with a following PR, as it is this isn't used in the UI anywhere. See #368 