### PR TITLE
Component – Filters: Add "comparison" card

### DIFF
--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -3,6 +3,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { stringifyQuery } from 'lib/nav-utils';
 
 export const filters = [
 	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
@@ -19,5 +25,27 @@ export const filters = [
 	},
 	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
 	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
-	{ label: __( 'Comparison', 'wc-admin' ), value: 'compare' },
+	{
+		label: __( 'Comparison', 'wc-admin' ),
+		value: 'compare',
+		settings: {
+			type: 'products',
+			param: 'products',
+			getLabels: function( queryString ) {
+				const idList = queryString
+					.split( ',' )
+					.map( id => parseInt( id, 10 ) )
+					.filter( Boolean );
+				const payload = stringifyQuery( {
+					include: idList.join( ',' ),
+					per_page: idList.length,
+				} );
+				return apiFetch( { path: '/wc/v3/products' + payload } );
+			},
+			labels: {
+				title: __( 'Compare Products', 'wc-admin' ),
+				update: __( 'Compare', 'wc-admin' ),
+			},
+		},
+	},
 ];

--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -26,11 +26,11 @@ export const filters = [
 	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
 	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
 	{
-		label: __( 'Comparison', 'wc-admin' ),
-		value: 'compare',
+		label: __( 'Compare Products', 'wc-admin' ),
+		value: 'compare-product',
 		settings: {
 			type: 'products',
-			param: 'products',
+			param: 'product',
 			getLabels: function( queryString ) {
 				const idList = queryString
 					.split( ',' )
@@ -44,6 +44,29 @@ export const filters = [
 			},
 			labels: {
 				title: __( 'Compare Products', 'wc-admin' ),
+				update: __( 'Compare', 'wc-admin' ),
+			},
+		},
+	},
+	{
+		label: __( 'Compare Product Categories', 'wc-admin' ),
+		value: 'compare-product_cat',
+		settings: {
+			type: 'product_cats',
+			param: 'product_cat',
+			getLabels: function( queryString ) {
+				const idList = queryString
+					.split( ',' )
+					.map( id => parseInt( id, 10 ) )
+					.filter( Boolean );
+				const payload = stringifyQuery( {
+					include: idList.join( ',' ),
+					per_page: idList.length,
+				} );
+				return apiFetch( { path: '/wc/v3/products/categories' + payload } );
+			},
+			labels: {
+				title: __( 'Compare Product Categories', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
 			},
 		},

--- a/client/analytics/report/products/constants.js
+++ b/client/analytics/report/products/constants.js
@@ -23,10 +23,8 @@ export const filters = [
 			},
 		],
 	},
-	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
-	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
 	{
-		label: __( 'Compare Products', 'wc-admin' ),
+		label: __( 'Product Comparison', 'wc-admin' ),
 		value: 'compare-product',
 		settings: {
 			type: 'products',
@@ -49,7 +47,7 @@ export const filters = [
 		},
 	},
 	{
-		label: __( 'Compare Product Categories', 'wc-admin' ),
+		label: __( 'Product Category Comparison', 'wc-admin' ),
 		value: 'compare-product_cat',
 		settings: {
 			type: 'product_cats',
@@ -71,4 +69,6 @@ export const filters = [
 			},
 		},
 	},
+	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
+	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
 ];

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -78,6 +78,10 @@ class CompareFilter extends Component {
 
 CompareFilter.propTypes = {
 	/**
+	 * Function used to fetch object labels via an API request, returns a Promise.
+	 */
+	getLabels: PropTypes.func.isRequired,
+	/**
 	 * Object of localized labels.
 	 */
 	labels: PropTypes.shape( {

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -37,10 +37,10 @@ class CompareFilter extends Component {
 	}
 
 	updateQuery() {
-		const { path, query } = this.props;
+		const { param, path, query } = this.props;
 		const { selected } = this.state;
 		const idList = selected.map( p => p.id );
-		updateQueryString( { products: idList.join( ',' ) }, path, query );
+		updateQueryString( { [ param ]: idList.join( ',' ) }, path, query );
 	}
 
 	render() {

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -31,6 +31,15 @@ class CompareFilter extends Component {
 		}
 	}
 
+	componentDidUpdate( { param } ) {
+		if ( param !== this.props.param ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { selected: [] } );
+			updateQueryString( { [ param ]: '' }, this.props.path, this.props.query );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+	}
+
 	updateLabels( data ) {
 		const selected = data.map( p => ( { id: p.id, label: p.name } ) );
 		this.setState( { selected } );

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -1,0 +1,60 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import PropTypes from 'prop-types';
+import { withState } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Search from 'components/search';
+import { updateQueryString } from 'lib/nav-utils';
+
+const CompareFilter = withState( {
+	selected: [],
+} )( ( { path, query, selected, setState } ) => {
+	const updateQuery = () => {
+		const idList = selected.map( p => p.id );
+		updateQueryString( { products: idList.join( ',' ) }, path, query );
+	};
+
+	return (
+		<Card title={ __( 'Compare Products', 'wc-admin' ) } className="woocommerce-filters__compare">
+			<div className="woocommerce-filters__compare-body">
+				<Search
+					type="products"
+					selected={ selected }
+					onChange={ value => {
+						setState( { selected: value } );
+					} }
+				/>
+			</div>
+			<div className="woocommerce-filters__compare-footer">
+				<Button onClick={ updateQuery } isDefault>
+					{ __( 'Compare', 'wc-admin' ) }
+				</Button>
+			</div>
+		</Card>
+	);
+} );
+
+CompareFilter.propTypes = {
+	/**
+	 * The `path` parameter supplied by React-Router
+	 */
+	path: PropTypes.string.isRequired,
+	/**
+	 * The query string represented in object form
+	 */
+	query: PropTypes.object,
+};
+
+CompareFilter.defaultProps = {
+	query: {},
+};
+
+export default CompareFilter;

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -14,7 +14,7 @@ import Search from 'components/search';
 import { updateQueryString } from 'lib/nav-utils';
 
 /**
- * @TODO Compare filter.
+ * Displays a card + search used to filter results as a comparison between objects.
  */
 class CompareFilter extends Component {
 	constructor( { getLabels, param, query } ) {

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { find } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
@@ -26,7 +27,9 @@ const ReportFilters = ( { advancedConfig, filters, query, path } ) => {
 	let advancedCard = false;
 	switch ( query.filter ) {
 		case 'compare':
-			advancedCard = <CompareFilter path={ path } query={ query } />;
+			const filter = find( filters, { value: 'compare' } );
+			const { settings = {} } = filter;
+			advancedCard = <CompareFilter path={ path } query={ query } { ...settings } />;
 			break;
 		case 'advanced':
 			advancedCard = (

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -3,16 +3,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import AdvancedFilters from './advanced';
-import Card from 'components/card';
+import CompareFilter from './compare';
 import DatePicker from './date';
 import FilterPicker from './filter';
 import { H, Section } from 'layout/section';
@@ -28,22 +26,7 @@ const ReportFilters = ( { advancedConfig, filters, query, path } ) => {
 	let advancedCard = false;
 	switch ( query.filter ) {
 		case 'compare':
-			advancedCard = (
-				<Card
-					title={ __( 'Compare Products', 'wc-admin' ) }
-					className="woocommerce-filters__compare"
-				>
-					<div className="woocommerce-filters__compare-body">
-						<input type="search" />
-						<div>Tokens</div>
-					</div>
-					<div className="woocommerce-filters__compare-footer">
-						<Button onClick={ noop } isDefault>
-							{ __( 'Compare', 'wc-admin' ) }
-						</Button>
-					</div>
-				</Card>
-			);
+			advancedCard = <CompareFilter path={ path } query={ query } />;
 			break;
 		case 'advanced':
 			advancedCard = (

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -3,8 +3,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
 import { find } from 'lodash';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
@@ -23,43 +23,57 @@ import './style.scss';
  *
  * @return { object } -
  */
-const ReportFilters = ( { advancedConfig, filters, query, path } ) => {
-	let advancedCard = false;
-	switch ( query.filter ) {
-		case 'compare':
-			const filter = find( filters, { value: 'compare' } );
+class ReportFilters extends Component {
+	renderCard() {
+		const { advancedConfig, filters, query, path } = this.props;
+		if ( ! query.filter ) {
+			return null;
+		}
+
+		if ( 0 === query.filter.indexOf( 'compare' ) ) {
+			const filter = find( filters, { value: query.filter } );
+			if ( ! filter ) {
+				return null;
+			}
 			const { settings = {} } = filter;
-			advancedCard = <CompareFilter path={ path } query={ query } { ...settings } />;
-			break;
-		case 'advanced':
-			advancedCard = (
-				<AdvancedFilters
-					config={ advancedConfig }
-					filterTitle={ __( 'Orders', 'wc-admin' ) }
-					path={ path }
-					query={ query }
-				/>
+			return (
+				<div className="woocommerce-filters__advanced-filters">
+					<CompareFilter path={ path } query={ query } { ...settings } />
+				</div>
 			);
-			break;
+		}
+		if ( 'advanced' === query.filter ) {
+			return (
+				<div className="woocommerce-filters__advanced-filters">
+					<AdvancedFilters
+						config={ advancedConfig }
+						filterTitle={ __( 'Orders', 'wc-admin' ) }
+						path={ path }
+						query={ query }
+					/>
+				</div>
+			);
+		}
 	}
 
-	return (
-		<Fragment>
-			<H className="screen-reader-text">{ __( 'Filters', 'wc-admin' ) }</H>
-			<Section component="div" className="woocommerce-filters">
-				<div className="woocommerce-filters__basic-filters">
-					<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
-					{ !! filters.length && (
-						<FilterPicker filters={ filters } query={ query } path={ path } />
-					) }
-				</div>
-				{ false !== advancedCard && (
-					<div className="woocommerce-filters__advanced-filters">{ advancedCard }</div>
-				) }
-			</Section>
-		</Fragment>
-	);
-};
+	render() {
+		const { filters, query, path } = this.props;
+		return (
+			<Fragment>
+				<H className="screen-reader-text">{ __( 'Filters', 'wc-admin' ) }</H>
+				<Section component="div" className="woocommerce-filters">
+					<div className="woocommerce-filters__basic-filters">
+						<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
+						{ !! filters.length && (
+							<FilterPicker filters={ filters } query={ query } path={ path } />
+						) }
+					</div>
+					{ this.renderCard() }
+				</Section>
+			</Fragment>
+		);
+	}
+}
 
 ReportFilters.propTypes = {
 	/**


### PR DESCRIPTION
See #364 – This PR adds a "compare" filter to the filter options, which uses the Search component to find & select products or product categories (anything with an autocompleter). It then updates the URL when "Compare" is clicked, so other components that listen to the URL can update.

![screen shot 2018-09-06 at 4 16 49 pm](https://user-images.githubusercontent.com/541093/45183777-04c52b80-b1f3-11e8-9a1d-9c6929cfb6fe.png)

This design is not pixel-perfect, but I'm flagging for design feedback because I've changed up how this works just a bit: Rather than have the "Compare [dropdown]" [(screenshot)](https://user-images.githubusercontent.com/541093/45167842-03323e00-b1c8-11e8-88b0-10a92c3b1759.png), which will be harder to make accessible & harder to translate, I've split out "Compare Product" & "Compare Product Categories" into two options in the Show dropdown. Does this work? Maybe works for v1, and once we're further along with some reports we can revisit?

![screen shot 2018-09-06 at 4 16 55 pm](https://user-images.githubusercontent.com/541093/45184063-db58cf80-b1f3-11e8-9b2a-f0e92c2b1795.png)

Remaining work is being tracked at #364. This PR builds on #367, which added the product category autocompleter.

**To test**

This isn't synced to any report, but you can test the URL updates on the product report.

- View the product report
- Click the Show dropdown, pick either "Compare Product" or "Compare Product Categories"
- Use the search box to find some items to compare
- Click "Compare", the URL should update with IDs
- Force reload the page, the tags should fill in with the product/category names after an API request
