### PR TITLE
Add w.js when wc_tracker is enabled.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -57,6 +57,19 @@ function wc_admin_register_script() {
 
 	wp_enqueue_script( 'wp-api' );
 
+	// Add Tracks script to the DOM if tracking is opted in
+	$tracking_enabled = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
+	if( $tracking_enabled ) {
+		$tracking_script  = "var wc_tracking_script = document.createElement( 'script' );\n";
+		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; //TODO Version/cache buster
+		$tracking_script .= "wc_tracking_script.type = 'text/javascript';\n";
+		$tracking_script .= "wc_tracking_script.async = true;\n";
+		$tracking_script .= "wc_tracking_script.defer = true;\n";
+		$tracking_script .= "window._tkq = window._tkq || [];\n";
+		$tracking_script .= "document.head.appendChild( wc_tracking_script );\n";
+		wp_add_inline_script( 'wc-components', $tracking_script, 'before' );
+	}
+
 	/**
 	 * TODO: On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and 
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
@@ -75,6 +88,7 @@ function wc_admin_register_script() {
 		),
 		'orderStatuses'    => wc_get_order_statuses(),
 		'siteTitle'        => get_bloginfo( 'name' ),
+		'trackingEnabled'  => $tracking_enabled,
 	);
 
 	wp_add_inline_script(


### PR DESCRIPTION
For #8 

In preparation for releasing `wc-admin` to the .org repository, we should begin to add in tracking to aspects of the project so we can get a better idea of how users are interacting with the new designs. To enable us to do so, this PR adds a script tag for `w.js` to be loaded onto wc-admin pages when the option to `woocommerce_allow_tracking` is set to `yes`. `w.js` will give us the necessary pipeline to record tracks events.

My first inclination was to use `wp_enqueue_script` but it appears there is no way to easily defer/async load the stats asset this route, so instead I took some inspiration from [`loadScript`](https://github.com/Automattic/wp-calypso/blob/13c2f3b579487c245cdc800918343039c6984b51/client/lib/load-script/dom-operations.js) in Calypso to arrive at this solution. Since I can't think of an immediate need to load other external scripts like this, I figured doing a quick one-off implementation would be good for now, but would absolutely be open to ways to improve this _interesting_ code 😄 .

__Questions__
- Not entirely certain if tracks will record properly for sites that are not WooPack ( /cc @greenafrican and @psealock for any ideas here )
- In other projects when loading `w.js` a cache buster string is added to force a download of a new version. I have omitted that here, but we will likely need to add that in 😢 

After this is merged in, I anticipate doing another PR to create a simple `lib/analytics` wrapper that can key off of `wcSettings.trackingEnabled` that will allow components to record tracks. At this layer we can also add in logic to try and filter out our test envs from being tracked too.

__To Test__
- Enable tracking on your site by updating via `update_option( 'woocommerce_allow_tracking', 'yes' );`
- Open up a wc-admin page, and in the js console, verify that `_tkq` is present
- Disable the wc tracker `update_option( 'woocommerce_allow_tracking', 'no' );`
- Refresh the wc-admin page and verify `_tkq` is not present on the window
