### PR TITLE
IE11: Align header cells in Orders table

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -45,12 +45,12 @@ class OrdersReport extends Component {
 				<Card title="Orders">
 					<table style={ { width: '100%' } }>
 						<thead>
-							<tr style={ { textAlign: 'left' } }>
-								<th>Id</th>
-								<th>Date</th>
-								<th>Total</th>
-								<th>Status</th>
-								<th>Action</th>
+							<tr>
+								<th style={ { textAlign: 'left' } }>Id</th>
+								<th style={ { textAlign: 'left' } }>Date</th>
+								<th style={ { textAlign: 'left' } }>Total</th>
+								<th style={ { textAlign: 'left' } }>Status</th>
+								<th style={ { textAlign: 'left' } }>Action</th>
 							</tr>
 						</thead>
 						<tbody>


### PR DESCRIPTION
Part of #243.

It looks like `th` cells were not inheriting `text-align` from the parent `tr` in IE11. I applied the styles directly to the cells so the problem should be fixed now.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45218463-fe44bb80-b2a7-11e8-88ff-cf3b9b33534d.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45218529-2c2a0000-b2a8-11e8-8e0a-c617808dbcf4.png)

**Steps to test**
- Make sure you have some products + orders. [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator) can help creating them.
- Open the _Orders_ page under _Analytics_.
- Verify the headers of the _Orders_ table are aligned to the left.