### PR TITLE
IE11: Add fallback gutter for browsers that don't support CSS Custom properties

### DIFF
--- a/client/layout/activity-panel/activity-card/style.scss
+++ b/client/layout/activity-panel/activity-card/style.scss
@@ -2,6 +2,7 @@
 
 .woocommerce-activity-card {
 	position: relative;
+	padding: $fallback-gutter;
 	padding: $gutter;
 	background: $white;
 	border-bottom: 1px solid $core-grey-light-400;
@@ -21,7 +22,9 @@
 
 .woocommerce-activity-card__unread {
 	position: absolute;
+	top: calc(#{ $fallback-gutter } - 6px);
 	top: calc(#{ $gutter } - 6px);
+	right: calc(#{ $fallback-gutter } - 6px);
 	right: calc(#{ $gutter } - 6px);
 	width: 6px;
 	height: 6px;
@@ -139,6 +142,7 @@
 	}
 
 	.woocommerce-activity-card__icon {
+		margin-right: $fallback-gutter;
 		margin-right: $gutter;
 
 		.is-placeholder {

--- a/client/layout/activity-panel/activity-outbound-link/style.scss
+++ b/client/layout/activity-panel/activity-outbound-link/style.scss
@@ -7,6 +7,7 @@
 	height: 50px;
 	background: $core-grey-light-200;
 	border-bottom: 1px solid $core-grey-light-400;
+	padding: $gap $fallback-gutter;
 	padding: $gap $gutter;
 	font-size: 13px;
 	font-weight: 500;

--- a/client/layout/header/style.scss
+++ b/client/layout/header/style.scss
@@ -31,6 +31,7 @@
 	.woocommerce-layout__header-breadcrumbs {
 		font-size: 13px;
 		font-weight: normal;
+		padding: 0 0 0 $fallback-gutter-large;
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
 		height: 50px;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -5,6 +5,7 @@
 }
 
 .woocommerce-layout__primary {
+	margin: 80px 0 0 $fallback-gutter-large;
 	margin: 80px 0 0 $gutter-large;
 
 	@include breakpoint( '>1100px' ) {
@@ -13,6 +14,7 @@
 }
 
 .woocommerce-layout .woocommerce-layout__main {
+	padding-right: $fallback-gutter-large;
 	padding-right: $gutter-large;
 	max-width: 100%;
 }

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -1,5 +1,7 @@
 /** @format */
 
+$fallback-gutter: 24px;
+$fallback-gutter-large: 40px;
 $gutter: var(--main-gap);
 $gutter-large: var(--large-gap);
 


### PR DESCRIPTION
Part of #243.

IE11 doesn't support custom properties (CSS variables), which are used for spacing in several places.

We are using CSS variables so we can use SCSS variables that vary depending on media queries but without having to create a media query for each element that uses those variables.

**_variables.scss**
```SCSS
$gutter: var(--main-gap);
$gutter-large: var(--large-gap);
```

**_global.scss**
```SCSS
// By using CSS variables, we can switch the spacing rhythm using a single media query.
:root {
	--large-gap: 40px;
	--main-gap: 24px;
}
@media (max-width: 1100px) {
	:root {
		--large-gap: 24px;
	}
}
@media (max-width: 782px) {
	:root {
		--large-gap: 16px;
		--main-gap: 16px;
	}
}
```

That makes it hard to reproduce the same behavior in Internet Explorer. We would need to create a media query for each element using those variables (or create a mixin that handles that), which wouldn't be very maintainable in the future and makes us lose all the advantages of using CSS variables.

Given that Internet Explorer is only of PC and doesn't have phone/tablet versions, I think a good compromise would be always using the wide screen values.

```SCSS
$fallback-gutter: 24px;
$fallback-gutter-large: 40px;
```

This PR implements that. Internet Explorer 11 will use the fallback values (which are hard-coded values in px) and browsers that support CSS variables, will continue using variables.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45227880-dc583280-b2c1-11e8-9f41-321808640a0d.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45227904-ed08a880-b2c1-11e8-8cad-05a0f5650940.png)

**Steps to test**
- Go to the _Dashboard_ page (or any other).
- Verify that cards are correctly spaced (check before/after screenshots).