### PR TITLE
Chart Component: remove chart legend ordering for layout=standard and color scales

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -305,7 +305,7 @@ export class RevenueReport extends Component {
 
 		return (
 			<Card title="">
-				<Chart data={ chartData } title={ selectedChart.label } />
+				<Chart data={ chartData } title={ selectedChart.label } dateParser={ '%Y-%m-%d' } />
 			</Card>
 		);
 	}

--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -8,6 +8,7 @@ A simple D3 line and bar chart component for timeseries data in React.
 ```jsx
 <Chart
 	data={ timeseries }
+	dateParser={ '%Y-%m-%d' }
 	tooltipFormat={ 'Date is %Y-%m-%d' }
 	type={ 'bar' }
 	xFormat={ '%d' }
@@ -20,7 +21,7 @@ This component accepts timeseries `data` prop in the following format (with date
 ```
 [
 	{
-		date: '%Y-%m-%dT%H:%M:%S', // string
+		date: '%Y-%m-%d', // string in `dateParser` format (see below)
 		category1: value, // number
 		category2: value, // number
 		...
@@ -32,7 +33,7 @@ For example:
 ```
 [
 	{
-		date: '2018-06-25T00:00:00',
+		date: '2018-06-25',
 		category1: 1234.56,
 		category2: 9876,
 		...
@@ -47,6 +48,7 @@ Required props are marked with `*`.
 Name | Type | Default | Description
 --- | --- | --- | ---
 `data`* | `array` | none | An array of data as specified above(below)
+`dateParser` | `string` | `%Y-%m-%dT%H:%M:%S` | Format to parse datetimes in the data
 `type`* | `string` | `line` | Chart type of either `line` or `bar`
 `title` | `string` | none | Chart title
 `tooltipFormat` | `string` | `%Y-%m-%d` | Title and format of the tooltip title

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 import { Component, createRef } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { timeFormat as d3TimeFormat } from 'd3-time-format';
+import { timeFormat as d3TimeFormat, utcParse as d3UTCParse } from 'd3-time-format';
 import { select as d3Select } from 'd3-selection';
 
 /**
@@ -91,6 +91,7 @@ class D3Chart extends Component {
 		const {
 			colorScheme,
 			data,
+			dateParser,
 			height,
 			margin,
 			orderedKeys,
@@ -111,7 +112,8 @@ class D3Chart extends Component {
 		const lineData = getLineData( data, newOrderedKeys );
 		const yMax = getYMax( lineData );
 		const yScale = getYScale( adjHeight, yMax );
-		const uniqueDates = getUniqueDates( lineData );
+		const parseDate = d3UTCParse( dateParser );
+		const uniqueDates = getUniqueDates( lineData, parseDate );
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth );
 		return {
@@ -122,6 +124,7 @@ class D3Chart extends Component {
 			lineData,
 			margin,
 			orderedKeys: newOrderedKeys,
+			parseDate,
 			scale,
 			tooltipFormat: d3TimeFormat( tooltipFormat ),
 			type,
@@ -176,6 +179,10 @@ D3Chart.propTypes = {
 	 */
 	data: PropTypes.array.isRequired,
 	/**
+	 * Format to parse dates into d3 time format
+	 */
+	dateParser: PropTypes.string.isRequired,
+	/**
 	 * Relative viewpoirt height of the `svg`.
 	 */
 	height: PropTypes.number,
@@ -224,6 +231,7 @@ D3Chart.propTypes = {
 
 D3Chart.defaultProps = {
 	data: [],
+	dateParser: '%Y-%m-%dT%H:%M:%S',
 	height: 200,
 	margin: {
 		bottom: 30,

--- a/client/components/chart/example.js
+++ b/client/components/chart/example.js
@@ -93,7 +93,7 @@ class WidgetCharts extends Component {
 					</ul>
 				</Card>
 				<Card title={ __( 'Store Charts', 'wc-admin' ) }>
-					<Chart data={ this.state.someOrders } title="Example Chart" />
+					<Chart data={ this.state.someOrders } title="Example Chart" layout="comparison" />
 				</Card>
 			</Fragment>
 		);

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -129,8 +129,10 @@ class Chart extends Component {
 
 	render() {
 		const { orderedKeys, visibleData, width } = this.state;
-		const legendDirection = orderedKeys.length <= 2 && width > WIDE_BREAKPOINT ? 'row' : 'column';
-		const chartDirection = orderedKeys.length > 2 && width > WIDE_BREAKPOINT ? 'row' : 'column';
+		const legendDirection =
+			this.props.layout === 'standard' && width > WIDE_BREAKPOINT ? 'row' : 'column';
+		const chartDirection =
+			this.props.layout === 'comparison' && width > WIDE_BREAKPOINT ? 'row' : 'column';
 		const legend = (
 			<Legend
 				className={ 'woocommerce-chart__legend' }
@@ -186,10 +188,6 @@ Chart.propTypes = {
 	 */
 	data: PropTypes.array.isRequired,
 	/**
-	 * A title describing this chart.
-	 */
-	title: PropTypes.string,
-	/**
 	 * A datetime formatting string to format the title of the toolip, passed to d3TimeFormat.
 	 */
 	tooltipFormat: PropTypes.string,
@@ -209,6 +207,14 @@ Chart.propTypes = {
 	 * A number formatting string, passed to d3Format.
 	 */
 	yFormat: PropTypes.string,
+	/**
+	 * `standard` (default) legend layout in the header or `comparison` moves legend layout to the left
+	 */
+	layout: PropTypes.oneOf( [ 'standard', 'comparison' ] ),
+	/**
+	 * A title describing this chart.
+	 */
+	title: PropTypes.string,
 };
 
 Chart.defaultProps = {
@@ -217,6 +223,7 @@ Chart.defaultProps = {
 	xFormat: '%d',
 	x2Format: '%b %Y',
 	yFormat: '$.3s',
+	layout: 'standard',
 };
 
 export default Chart;

--- a/client/components/chart/test/utils.js
+++ b/client/components/chart/test/utils.js
@@ -4,6 +4,7 @@
  * @format
  */
 // import { noop } from 'lodash';
+import { utcParse as d3UTCParse } from 'd3-time-format';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import {
 	getYMax,
 	getYScale,
 	getYTickOffset,
-	parseDate,
 } from '../utils';
 
 const orderedKeys = [
@@ -64,10 +64,11 @@ const orderedDates = [
 	'2018-06-03T00:00:00',
 	'2018-06-04T00:00:00',
 ];
+const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
 const testUniqueKeys = getUniqueKeys( dummyOrders );
 const testOrderedKeys = getOrderedKeys( dummyOrders, testUniqueKeys );
 const testLineData = getLineData( dummyOrders, testOrderedKeys );
-const testUniqueDates = getUniqueDates( testLineData );
+const testUniqueDates = getUniqueDates( testLineData, parseDate );
 const testXScale = getXScale( testUniqueDates, 100 );
 const testXLineScale = getXLineScale( testUniqueDates, 100 );
 const testYMax = getYMax( testLineData );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -15,13 +15,10 @@ import {
 } from 'd3-scale';
 import { mouse as d3Mouse, select as d3Select } from 'd3-selection';
 import { line as d3Line } from 'd3-shape';
-import { utcParse as d3UTCParse } from 'd3-time-format';
 /**
  * Internal dependencies
  */
 import { formatCurrency } from 'lib/currency';
-
-export const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
 
 function decodeSymbol( str ) {
 	return str.replace( /&#(\d+);/g, ( match, dec ) => String.fromCharCode( dec ) );
@@ -87,9 +84,10 @@ export const getLineData = ( data, orderedKeys ) =>
 /**
  * Describes `getUniqueDates`
  * @param {array} lineData - from `GetLineData`
+ * @param {function} parseDate - D3 time format parser
  * @returns {array} an array of unique date values sorted from earliest to latest
  */
-export const getUniqueDates = lineData => {
+export const getUniqueDates = ( lineData, parseDate ) => {
 	return [
 		...new Set(
 			lineData.reduce( ( accum, { values } ) => {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -99,10 +99,21 @@ export const getUniqueDates = ( lineData, parseDate ) => {
 };
 
 export const getColor = ( key, params ) => {
-	const keyValue =
-		params.orderedKeys.length > 1
-			? findIndex( params.orderedKeys, d => d.key === key ) / ( params.orderedKeys.length - 1 )
-			: 0;
+	const smallColorScales = [
+		[],
+		[ 0.5 ],
+		[ 0.333, 0.667 ],
+		[ 0.2, 0.5, 0.8 ],
+		[ 0.12, 0.375, 0.625, 0.88 ],
+	];
+	let keyValue = 0;
+	const len = params.orderedKeys.length;
+	const idx = findIndex( params.orderedKeys, d => d.key === key );
+	if ( len < 5 ) {
+		keyValue = smallColorScales[ len ][ idx ];
+	} else {
+		keyValue = idx / ( params.orderedKeys.length - 1 );
+	}
 	return params.colorScheme( keyValue );
 };
 


### PR DESCRIPTION
Chart Master Thread: #164 

PR relates to Issue #379 and #375 

- This PR ensures that the categories are only sorted by total if the chart `layout='comparison'`. 
- It also makes a change to the chart component to allow for a `dateParser` prop to be included to ensure the date are properly formatted by d3. The README doc is also updated to include the new prop.
- The PR also adds custom colour scales for the sequential d3 chromatic colours as per #375 

Fixes: #379 

Note: this branch requires https://github.com/woocommerce/wc-admin/pull/380 
