### PR TITLE
Advanced Filters: Add api fetch for Search results

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -4,6 +4,11 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getProductLabelsById } from 'analytics/report/products/config';
+
 export const filters = [
 	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
 	{
@@ -55,6 +60,7 @@ export const advancedFilterConfig = {
 		input: {
 			component: 'Search',
 			type: 'products',
+			getLabels: getProductLabelsById,
 		},
 	},
 	code: {

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -13,7 +13,7 @@ import { partial } from 'lodash';
  * Internal dependencies
  */
 import { Card, ReportFilters } from '@woocommerce/components';
-import { filters, advancedFilterConfig } from './constants';
+import { filters, advancedFilterConfig } from './config';
 import './style.scss';
 
 class OrdersReport extends Component {

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -9,6 +9,31 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { stringifyQuery } from 'lib/nav-utils';
+import { NAMESPACE } from 'store/constants';
+
+export const getProductLabelsById = queryString => {
+	const idList = queryString
+		.split( ',' )
+		.map( id => parseInt( id, 10 ) )
+		.filter( Boolean );
+	const payload = stringifyQuery( {
+		include: idList.join( ',' ),
+		per_page: idList.length,
+	} );
+	return apiFetch( { path: NAMESPACE + 'products' + payload } );
+};
+
+export const getCategoryLabelsById = queryString => {
+	const idList = queryString
+		.split( ',' )
+		.map( id => parseInt( id, 10 ) )
+		.filter( Boolean );
+	const payload = stringifyQuery( {
+		include: idList.join( ',' ),
+		per_page: idList.length,
+	} );
+	return apiFetch( { path: NAMESPACE + 'products/categories' + payload } );
+};
 
 export const filters = [
 	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
@@ -29,17 +54,7 @@ export const filters = [
 		settings: {
 			type: 'products',
 			param: 'product',
-			getLabels: function( queryString ) {
-				const idList = queryString
-					.split( ',' )
-					.map( id => parseInt( id, 10 ) )
-					.filter( Boolean );
-				const payload = stringifyQuery( {
-					include: idList.join( ',' ),
-					per_page: idList.length,
-				} );
-				return apiFetch( { path: '/wc/v3/products' + payload } );
-			},
+			getLabels: getProductLabelsById,
 			labels: {
 				title: __( 'Compare Products', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
@@ -52,17 +67,7 @@ export const filters = [
 		settings: {
 			type: 'product_cats',
 			param: 'product_cat',
-			getLabels: function( queryString ) {
-				const idList = queryString
-					.split( ',' )
-					.map( id => parseInt( id, 10 ) )
-					.filter( Boolean );
-				const payload = stringifyQuery( {
-					include: idList.join( ',' ),
-					per_page: idList.length,
-				} );
-				return apiFetch( { path: '/wc/v3/products/categories' + payload } );
-			},
+			getLabels: getCategoryLabelsById,
 			labels: {
 				title: __( 'Compare Product Categories', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -7,7 +7,7 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { filters } from './constants';
+import { filters } from './config';
 import { ReportFilters } from '@woocommerce/components';
 import './style.scss';
 

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -31,11 +31,9 @@ const matches = [
 class AdvancedFilters extends Component {
 	constructor( props ) {
 		super( props );
-		const activeFiltersFromQuery = getActiveFiltersFromQuery( props.query, props.config );
 		this.state = {
 			match: matches[ 0 ],
-			activeFilters: activeFiltersFromQuery,
-			previousFilters: activeFiltersFromQuery,
+			activeFilters: getActiveFiltersFromQuery( props.query, props.config ),
 		};
 
 		this.filterListRef = createRef();
@@ -107,7 +105,7 @@ class AdvancedFilters extends Component {
 			newFilter.value = filterConfig.input.options[ 0 ].value;
 		}
 		if ( filterConfig.input && 'Search' === filterConfig.input.component ) {
-			newFilter.value = [];
+			newFilter.value = '';
 		}
 		this.setState( state => {
 			return {
@@ -129,9 +127,8 @@ class AdvancedFilters extends Component {
 	}
 
 	getUpdateHref( activeFilters ) {
-		const { previousFilters } = this.state;
-		const { path, query } = this.props;
-		const updatedQuery = getQueryFromActiveFilters( activeFilters, previousFilters );
+		const { path, query, config } = this.props;
+		const updatedQuery = getQueryFromActiveFilters( activeFilters, query, config );
 		return getNewPath( updatedQuery, path, query );
 	}
 

--- a/client/components/filters/advanced/search-filter.js
+++ b/client/components/filters/advanced/search-filter.js
@@ -14,27 +14,38 @@ import PropTypes from 'prop-types';
 import Search from 'components/search';
 
 class SearchFilter extends Component {
-	constructor() {
-		super();
+	constructor( { filter, config } ) {
+		super( ...arguments );
 		this.onSearchChange = this.onSearchChange.bind( this );
+		this.state = {
+			selected: [],
+		};
+
+		this.updateLabels = this.updateLabels.bind( this );
+
+		if ( filter.value.length ) {
+			config.input.getLabels( filter.value ).then( this.updateLabels );
+		}
+	}
+
+	updateLabels( data ) {
+		const selected = data.map( p => ( { id: p.id, label: p.name } ) );
+		this.setState( { selected } );
 	}
 
 	onSearchChange( values ) {
+		this.setState( {
+			selected: values,
+		} );
 		const { filter, onFilterChange } = this.props;
-		const nextValues = values.map( value => value.id );
-		onFilterChange( filter.key, 'value', nextValues );
+		const idList = values.map( value => value.id ).join( ',' );
+		onFilterChange( filter.key, 'value', idList );
 	}
 
 	render() {
 		const { filter, config, onFilterChange } = this.props;
-		const { key, rule, value } = filter;
-		const selected = value.map( id => {
-			// For now
-			return {
-				id: parseInt( id, 10 ),
-				label: id.toString(),
-			};
-		} );
+		const { selected } = this.state;
+		const { key, rule } = filter;
 		return (
 			<Fragment>
 				<div className="woocommerce-filters-advanced__fieldset-legend">{ config.label }</div>
@@ -75,7 +86,7 @@ SearchFilter.propTypes = {
 	filter: PropTypes.shape( {
 		key: PropTypes.string,
 		rule: PropTypes.string,
-		value: PropTypes.array,
+		value: PropTypes.string,
 	} ).isRequired,
 	/**
 	 * Function to be called on update.

--- a/client/components/filters/advanced/utils.js
+++ b/client/components/filters/advanced/utils.js
@@ -19,22 +19,12 @@ export const getUrlKey = ( key, rule ) => {
 };
 
 /**
- * Convert url values to array of objects for <Search /> component
- *
- * @param {string} str - url query parameter value
- * @return {array} - array of Search values
- */
-export const getSearchFilterValue = str => {
-	return str.length ? str.trim().split( ',' ) : [];
-};
-
-/**
  * Describe activeFilter object.
  *
  * @typedef {Object} activeFilter
  * @property {string} key - filter key.
  * @property {string} [rule] - a modifying rule for a filter, eg 'includes' or 'is_not'.
- * @property {string|array} value - filter value(s).
+ * @property {string} value - filter value(s).
  */
 
 /**
@@ -54,9 +44,7 @@ export const getActiveFiltersFromQuery = ( query, config ) => {
 				} );
 
 				if ( match ) {
-					const rawValue = query[ getUrlKey( configKey, match.value ) ];
-					const value =
-						'Search' === filter.input.component ? getSearchFilterValue( rawValue ) : rawValue;
+					const value = query[ getUrlKey( configKey, match.value ) ];
 					return {
 						key: configKey,
 						rule: match.value,
@@ -77,39 +65,26 @@ export const getActiveFiltersFromQuery = ( query, config ) => {
 };
 
 /**
- * Create a string value for url. Return a string directly or concatenate ids if supplied
- * an array of objects.
- *
- * @param {string|array} value - value of an activeFilter
- * @return {string|null} - url query param value
- */
-export const getUrlValue = value => {
-	if ( Array.isArray( value ) ) {
-		return value.length ? value.join( ',' ) : null;
-	}
-	return 'string' === typeof value ? value : null;
-};
-
-/**
  * Given activeFilters, create a new query object to update the url. Use previousFilters to
  * Remove unused params.
  *
- * @param {activeFilters[]} nextFilters - activeFilters shown in the UI
- * @param {activeFilters[]} previousFilters - filters represented by the current url
+ * @param {activeFilters[]} activeFilters - activeFilters shown in the UI
+ * @param {object} query - the current url query object
+ * @param {object} config - config object
  * @return {object} - query object representing the new parameters
  */
-export const getQueryFromActiveFilters = ( nextFilters, previousFilters = [] ) => {
-	const previousData = previousFilters.reduce( ( query, filter ) => {
-		query[ getUrlKey( filter.key, filter.rule ) ] = undefined;
-		return query;
+export const getQueryFromActiveFilters = ( activeFilters, query, config ) => {
+	const previousFilters = getActiveFiltersFromQuery( query, config );
+	const previousData = previousFilters.reduce( ( data, filter ) => {
+		data[ getUrlKey( filter.key, filter.rule ) ] = undefined;
+		return data;
 	}, {} );
-	const data = nextFilters.reduce( ( query, filter ) => {
-		const urlValue = getUrlValue( filter.value );
-		if ( urlValue ) {
-			query[ getUrlKey( filter.key, filter.rule ) ] = urlValue;
+	const nextData = activeFilters.reduce( ( data, filter ) => {
+		if ( filter.value ) {
+			data[ getUrlKey( filter.key, filter.rule ) ] = filter.value;
 		}
-		return query;
+		return data;
 	}, {} );
 
-	return { ...previousData, ...data };
+	return { ...previousData, ...nextData };
 };

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -46,7 +46,6 @@ class ReportFilters extends Component {
 			return (
 				<div className="woocommerce-filters__advanced-filters">
 					<AdvancedFilters
-						key={ JSON.stringify( query ) }
 						config={ advancedConfig }
 						filterTitle={ __( 'Orders', 'wc-admin' ) }
 						path={ path }


### PR DESCRIPTION
Add request for products in the products filter so labels can be correctly displayed

<img width="411" alt="screen shot 2018-09-13 at 1 14 22 pm" src="https://user-images.githubusercontent.com/1922453/45461418-1066a400-b757-11e8-9144-e4ff3ef48376.png">

Following the pattern set in https://github.com/woocommerce/wc-admin/pull/368

### Other related changes

* Simplify logic to always handle values as stings, ie `"1,2,3"`. And handle splitting at component level
* Remove `key={ JSON.stringify( query ) }` to preserve child component state
* Simplify comparison of next to previous urls to disable "Filter" button
* Rename report `constants.js` to `config.js` because those files are no longer simply constants.

## Test
1. `/wp-admin/admin.php?page=wc-admin#/analytics/orders?filter=advanced`
2. Add products filter 
3. Add/remove and filter to see url change and labels displayed
4. Refresh the page and see labels appear

Note: If you're running Gutenberg 3.8, the "Add filter" popover is in the wrong place. That fix is here, https://github.com/woocommerce/wc-admin/pull/396