### PR TITLE
Component – Table: Add compare checkboxes

### DIFF
--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -11,8 +11,11 @@ import apiFetch from '@wordpress/api-fetch';
 import { getIdsFromQuery, stringifyQuery } from 'lib/nav-utils';
 import { NAMESPACE } from 'store/constants';
 
-export function getProductLabelsById( queryString ) {
+export function getProductLabelsById( queryString = '' ) {
 	const idList = getIdsFromQuery( queryString );
+	if ( idList.length < 1 ) {
+		return Promise.resolve( [] );
+	}
 	const payload = stringifyQuery( {
 		include: idList.join( ',' ),
 		per_page: idList.length,
@@ -20,8 +23,11 @@ export function getProductLabelsById( queryString ) {
 	return apiFetch( { path: `${ NAMESPACE }products${ payload }` } );
 }
 
-export function getCategoryLabelsById( queryString ) {
+export function getCategoryLabelsById( queryString = '' ) {
 	const idList = getIdsFromQuery( queryString );
+	if ( idList.length < 1 ) {
+		return Promise.resolve( [] );
+	}
 	const payload = stringifyQuery( {
 		include: idList.join( ',' ),
 		per_page: idList.length,

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -139,6 +139,8 @@ export default class extends Component {
 				totalRows={ 500 }
 				rowsPerPage={ rowsPerPage }
 				headers={ headers }
+				compareBy={ 'product' }
+				ids={ products.map( p => p.product_id ) }
 				onClickDownload={ noop }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -22,15 +22,15 @@
 	align-items: center;
 
 	.has-action & {
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: auto 1fr;
 	}
 
 	.has-menu & {
-		grid-template-columns: 1fr 24px;
+		grid-template-columns: auto 24px;
 	}
 
 	.has-menu.has-action & {
-		grid-template-columns: 1fr 1fr 48px;
+		grid-template-columns: auto 1fr 48px;
 	}
 }
 
@@ -52,7 +52,7 @@
 }
 
 .woocommerce-card__title {
-	margin: 0;
+	margin: 0 $gap 0 0;
 	// EllipsisMenu is 24px, so to match we add 6px padding around the
 	// heading text, which we know is 18px from line-height.
 	padding: 3px 0;

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -45,9 +45,6 @@ class CompareFilter extends Component {
 		const prevIds = getIdsFromQuery( prevQuery[ param ] );
 		const currentIds = getIdsFromQuery( query[ param ] );
 		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { selected: currentIds } );
-			/* eslint-enable react/no-did-update-set-state */
 			getLabels( query[ param ] ).then( this.updateLabels );
 		}
 	}

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -4,14 +4,15 @@
  */
 import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import { getIdsFromQuery, updateQueryString } from 'lib/nav-utils';
 import Search from 'components/search';
-import { updateQueryString } from 'lib/nav-utils';
 
 /**
  * Displays a card + search used to filter results as a comparison between objects.
@@ -31,12 +32,23 @@ class CompareFilter extends Component {
 		}
 	}
 
-	componentDidUpdate( { param } ) {
-		if ( param !== this.props.param ) {
+	componentDidUpdate( { param: prevParam, query: prevQuery } ) {
+		const { getLabels, param, path, query } = this.props;
+		if ( prevParam !== param ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( { selected: [] } );
-			updateQueryString( { [ param ]: '' }, this.props.path, this.props.query );
 			/* eslint-enable react/no-did-update-set-state */
+			updateQueryString( { [ param ]: '' }, path, query );
+			return;
+		}
+
+		const prevIds = getIdsFromQuery( prevQuery[ param ] );
+		const currentIds = getIdsFromQuery( query[ param ] );
+		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { selected: currentIds } );
+			/* eslint-enable react/no-did-update-set-state */
+			getLabels( query[ param ] ).then( this.updateLabels );
 		}
 	}
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button, IconButton, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { fill, find, findIndex, first, noop, partial, uniq } from 'lodash';
+import { fill, find, findIndex, first, isEqual, noop, partial, uniq } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -41,6 +41,17 @@ class TableCard extends Component {
 		this.onCompare = this.onCompare.bind( this );
 		this.selectRow = this.selectRow.bind( this );
 		this.selectAllRows = this.selectAllRows.bind( this );
+	}
+
+	componentDidUpdate( { query: prevQuery } ) {
+		const { compareBy, query } = this.props;
+		const prevIds = getIdsFromQuery( prevQuery[ compareBy ] );
+		const currentIds = getIdsFromQuery( query[ compareBy ] );
+		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { selectedRows: currentIds } );
+			/* eslint-enable react/no-did-update-set-state */
+		}
 	}
 
 	toggleCols( selected ) {

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -185,15 +185,23 @@ class TableCard extends Component {
 				title={ title }
 				action={ [
 					compareBy && (
-						<Button onClick={ this.onCompare } isDefault>
+						<Button key="compare" onClick={ this.onCompare } isDefault>
 							{ __( 'Compare', 'wc-admin' ) }
 						</Button>
 					),
 					compareBy && (
-						<div style={ { padding: '4px 12px', color: '#6c7781' } }>Placeholder for search</div>
+						<div key="search" style={ { padding: '4px 12px', color: '#6c7781' } }>
+							Placeholder for search
+						</div>
 					),
 					onClickDownload && (
-						<IconButton onClick={ onClickDownload } icon="arrow-down" size={ 18 } isDefault>
+						<IconButton
+							key="download"
+							onClick={ onClickDownload }
+							icon="arrow-down"
+							size={ 18 }
+							isDefault
+						>
 							{ __( 'Download', 'wc-admin' ) }
 						</IconButton>
 					),
@@ -259,7 +267,7 @@ TableCard.propTypes = {
 		} )
 	),
 	/**
-	 * A list of IDs, matching to the row list so that id[ 0 ] contains the object ID for the object displayed in row[ 0 ].
+	 * A list of IDs, matching to the row list so that ids[ 0 ] contains the object ID for the object displayed in row[ 0 ].
 	 */
 	ids: PropTypes.arrayOf( PropTypes.number ),
 	/**

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -4,6 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button, IconButton, ToggleControl } from '@wordpress/components';
+import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { fill, find, findIndex, first, isEqual, noop, partial, uniq } from 'lodash';
 import PropTypes from 'prop-types';
@@ -173,15 +174,23 @@ class TableCard extends Component {
 			headers = [ this.getAllCheckbox(), ...headers ];
 		}
 
+		const className = classnames( {
+			'woocommerce-table': true,
+			'has-compare': !! compareBy,
+		} );
+
 		return (
 			<Card
-				className="woocommerce-table"
+				className={ className }
 				title={ title }
 				action={ [
 					compareBy && (
 						<Button onClick={ this.onCompare } isDefault>
 							{ __( 'Compare', 'wc-admin' ) }
 						</Button>
+					),
+					compareBy && (
+						<div style={ { padding: '4px 12px', color: '#6c7781' } }>Placeholder for search</div>
 					),
 					onClickDownload && (
 						<IconButton onClick={ onClickDownload } icon="arrow-down" size={ 18 } isDefault>

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -3,8 +3,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button, IconButton, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { IconButton, ToggleControl } from '@wordpress/components';
 import { fill, find, findIndex, first, noop, partial, uniq } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -36,6 +36,7 @@ class TableCard extends Component {
 			selectedRows: [],
 		};
 		this.toggleCols = this.toggleCols.bind( this );
+		this.onCompare = this.onCompare.bind( this );
 		this.selectRow = this.selectRow.bind( this );
 		this.selectAllRows = this.selectAllRows.bind( this );
 	}
@@ -58,6 +59,14 @@ class TableCard extends Component {
 				),
 			} ) );
 		};
+	}
+
+	onCompare() {
+		const { compareBy, onQueryChange } = this.props;
+		const { selectedRows } = this.state;
+		if ( compareBy ) {
+			onQueryChange( 'compare' )( compareBy, selectedRows.join( ',' ) );
+		}
 	}
 
 	filterCols( rows = [] ) {
@@ -155,13 +164,18 @@ class TableCard extends Component {
 			<Card
 				className="woocommerce-table"
 				title={ title }
-				action={
+				action={ [
+					compareBy && (
+						<Button onClick={ this.onCompare } isDefault>
+							{ __( 'Compare', 'wc-admin' ) }
+						</Button>
+					),
 					onClickDownload && (
 						<IconButton onClick={ onClickDownload } icon="arrow-down" size={ 18 } isDefault>
 							{ __( 'Download', 'wc-admin' ) }
 						</IconButton>
-					)
-				}
+					),
+				] }
 				menu={
 					<EllipsisMenu label={ __( 'Choose which values to display', 'wc-admin' ) }>
 						<MenuTitle>{ __( 'Columns:', 'wc-admin' ) }</MenuTitle>

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import Card from 'components/card';
 import EllipsisMenu from 'components/ellipsis-menu';
+import { getIdsFromQuery } from 'lib/nav-utils';
 import MenuItem from 'components/ellipsis-menu/menu-item';
 import MenuTitle from 'components/ellipsis-menu/menu-title';
 import Pagination from 'components/pagination';
@@ -31,9 +32,10 @@ import TableSummary from './summary';
 class TableCard extends Component {
 	constructor( props ) {
 		super( props );
+		const { compareBy, query } = props;
 		this.state = {
 			showCols: fill( Array( props.headers.length ), true ),
-			selectedRows: [],
+			selectedRows: getIdsFromQuery( query[ compareBy ] ),
 		};
 		this.toggleCols = this.toggleCols.bind( this );
 		this.onCompare = this.onCompare.bind( this );

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -10,6 +10,15 @@
 	.woocommerce-card__menu {
 		justify-self: flex-end;
 	}
+
+	&.has-compare {
+		.woocommerce-card__action {
+			text-align: left;
+			display: grid;
+			width: 100%;
+			grid-template-columns: auto 1fr auto;
+		}
+	}
 }
 
 .woocommerce-table__caption {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -79,7 +79,10 @@ class Table extends Component {
 				role="group"
 			>
 				<table>
-					<caption id={ `caption-${ instanceId }` } className="woocommerce-table__caption screen-reader-text">
+					<caption
+						id={ `caption-${ instanceId }` }
+						className="woocommerce-table__caption screen-reader-text"
+					>
 						{ caption }
 						{ tabIndex === '0' && <small>{ __( '(scroll to see more)', 'wc-admin' ) }</small> }
 					</caption>
@@ -198,7 +201,7 @@ Table.propTypes = {
 			/**
 			 * The display label for this column.
 			 */
-			label: PropTypes.string,
+			label: PropTypes.node,
 			/**
 			 * Boolean, true if this column should always display in the table (not shown in toggle-able list).
 			 */

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -6,9 +6,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import { IconButton } from '@wordpress/components';
-import { find, get, noop, uniqueId } from 'lodash';
+import { find, get, noop } from 'lodash';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
 const ASC = 'asc';
 const DESC = 'desc';
@@ -26,8 +27,6 @@ class Table extends Component {
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
-		this.headersID = uniqueId( 'header-' );
-		this.captionID = uniqueId( 'caption-' );
 	}
 
 	componentDidMount() {
@@ -55,7 +54,16 @@ class Table extends Component {
 	}
 
 	render() {
-		const { ariaHidden, caption, classNames, headers, query, rowHeader, rows } = this.props;
+		const {
+			ariaHidden,
+			caption,
+			classNames,
+			headers,
+			instanceId,
+			query,
+			rowHeader,
+			rows,
+		} = this.props;
 		const { tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
@@ -67,11 +75,11 @@ class Table extends Component {
 				ref={ this.container }
 				tabIndex={ tabIndex }
 				aria-hidden={ ariaHidden }
-				aria-labelledby={ this.captionID }
+				aria-labelledby={ `caption-${ instanceId }` }
 				role="group"
 			>
 				<table>
-					<caption id={ this.captionID } className="woocommerce-table__caption screen-reader-text">
+					<caption id={ `caption-${ instanceId }` } className="woocommerce-table__caption screen-reader-text">
 						{ caption }
 						{ tabIndex === '0' && <small>{ __( '(scroll to see more)', 'wc-admin' ) }</small> }
 					</caption>
@@ -79,6 +87,7 @@ class Table extends Component {
 						<tr>
 							{ headers.map( ( header, i ) => {
 								const { isSortable, isNumeric, key, label } = header;
+								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
 										'is-sortable': isSortable,
@@ -110,13 +119,13 @@ class Table extends Component {
 															<Gridicon size={ 18 } icon="chevron-down" />
 														)
 													}
-													aria-describedby={ `${ this.headersID }-${ i }` }
+													aria-describedby={ labelId }
 													onClick={ this.sortBy( key ) }
 													isDefault
 												>
 													{ label }
 												</IconButton>
-												<span className="screen-reader-text" id={ `${ this.headersID }-${ i }` }>
+												<span className="screen-reader-text" id={ labelId }>
 													{ iconLabel }
 												</span>
 											</Fragment>
@@ -236,4 +245,4 @@ Table.defaultProps = {
 	rowHeader: 0,
 };
 
-export default Table;
+export default withInstanceId( Table );

--- a/client/components/tag/index.js
+++ b/client/components/tag/index.js
@@ -22,6 +22,11 @@ import './style.scss';
  */
 const Tag = ( { id, instanceId, label, remove, removeLabel, screenReaderLabel, className } ) => {
 	screenReaderLabel = screenReaderLabel || label;
+	if ( ! label ) {
+		// A null label probably means something went wrong
+		// @todo Maybe this should be a loading indicator?
+		return null;
+	}
 	const classes = classnames( 'woocommerce-tag', className, {
 		'has-remove': !! remove,
 	} );


### PR DESCRIPTION
See #94, builds on #387 – This PR adds the ability to enable checkboxes on table rows to filter a report by items. Checking rows, then hitting the Compare button, will update the URL query to update the page. As this is mock data, there isn't a chart, so the page data doesn't update yet.

This works with the Compare filter #364, so changes in one component will update the other.

![screen shot 2018-09-11 at 12 41 33 pm](https://user-images.githubusercontent.com/541093/45374423-0b232100-b5c0-11e8-989b-515ae8a867d0.png)

You can trigger these checkboxes by passing in the `compareBy` prop - this will be the query param used to update the URL. You'll also need to pass in a list of IDs corresponding to each item in a row. When the "Compare" button is clicked, the component updates the URL query to be:

`filter=compare-{ compareBy }&{ compareBy }={ list of selected IDs }`

This should match the parameters in the product filter constants ([example, `product`](https://github.com/woocommerce/wc-admin/blob/master/client/analytics/report/products/constants.js#L31), [example, `product_cat`](https://github.com/woocommerce/wc-admin/blob/master/client/analytics/report/products/constants.js#L54)) – for the product table, we want to compare by product, not product categories, so we use `product`.

**To test**

- Open `client/analytics/report/products/__mocks__/data.js` & update the IDs & names to products in your site
- Open the product report, Analytics > Products
- See the checkboxes, select a few
- Click the Compare button in the table header – the Compare filter should appear, and fill in with your selected products as tags (this won't work if you don't update the mock data above)
- Reload the page, the selected products should still fill in the Compare filter, and be selected in the table
- Update the Compare filter by searching for a product in the table, click the filter card's Compare button
- The corresponding row in the product table should appear checked
- Clear all by Xing the tags or unchecking the rows, make sure the two stay synced
- Check that the Revenue report is not updated by this change

Note: Switching from "Show: Product Comparison" to "Show: All Products" does not remove the products query right now, so that _does not_ currently clear the selected rows.
