### PR TITLE
Fix Gutenberg 3.7 compatibility: Remove APIProvider

### DIFF
--- a/client/embedded.js
+++ b/client/embedded.js
@@ -2,8 +2,6 @@
 /**
  * External dependencies
  */
-import { APIProvider } from '@wordpress/components';
-import { pick } from 'lodash';
 import { render } from '@wordpress/element';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 
@@ -14,13 +12,8 @@ import './stylesheets/_embedded.scss';
 import { EmbedLayout } from './layout';
 
 render(
-	<APIProvider
-		{ ...wpApiSettings }
-		{ ...pick( wp.api, [ 'postTypeRestBaseMapping', 'taxonomyRestBaseMapping' ] ) }
-	>
-		<SlotFillProvider>
-			<EmbedLayout />
-		</SlotFillProvider>
-	</APIProvider>,
+	<SlotFillProvider>
+		<EmbedLayout />
+	</SlotFillProvider>,
 	document.getElementById( 'woocommerce-embedded-root' )
 );

--- a/client/index.js
+++ b/client/index.js
@@ -2,8 +2,6 @@
 /**
  * External dependencies
  */
-import { APIProvider } from '@wordpress/components';
-import { pick } from 'lodash';
 import { render } from '@wordpress/element';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 
@@ -15,13 +13,8 @@ import { PageLayout } from './layout';
 import 'store';
 
 render(
-	<APIProvider
-		{ ...wpApiSettings }
-		{ ...pick( wp.api, [ 'postTypeRestBaseMapping', 'taxonomyRestBaseMapping' ] ) }
-	>
-		<SlotFillProvider>
-			<PageLayout />
-		</SlotFillProvider>
-	</APIProvider>,
+	<SlotFillProvider>
+		<PageLayout />
+	</SlotFillProvider>,
 	document.getElementById( 'root' )
 );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -55,13 +55,11 @@ function wc_admin_register_script() {
 	$content     = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "wc-admin" );';
 	wp_add_inline_script( 'wc-components', $content, 'before' );
 
-	wp_enqueue_script( 'wp-api' );
-
-	// Add Tracks script to the DOM if tracking is opted in
+	// Add Tracks script to the DOM if tracking is opted in.
 	$tracking_enabled = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
-	if( $tracking_enabled ) {
+	if ( $tracking_enabled ) {
 		$tracking_script  = "var wc_tracking_script = document.createElement( 'script' );\n";
-		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; //TODO Version/cache buster
+		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; // TODO Version/cache buster.
 		$tracking_script .= "wc_tracking_script.type = 'text/javascript';\n";
 		$tracking_script .= "wc_tracking_script.async = true;\n";
 		$tracking_script .= "wc_tracking_script.defer = true;\n";
@@ -71,7 +69,7 @@ function wc_admin_register_script() {
 	}
 
 	/**
-	 * TODO: On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and 
+	 * TODO: On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
 	 */
 


### PR DESCRIPTION
[`withApiData` has been removed in Gutenberg v3.7.0](https://github.com/WordPress/gutenberg/blob/master/docs/reference/deprecated.md#370), which includes the `APIProvider` HoC. We don't appear to be using anything provided by `withApiData`, so I think this can be safely removed from the app.

I think `wp_enqueue_script( 'wp-api' );` can also be removed as a script dependency too.

**To test**

- Update Gutenberg to 3.7 or master
- Build the app
- Make sure the page renders
- Check that the tests are passing