### PR TITLE
Make Top Selling Products table to have the same height in all states

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -34,7 +34,7 @@
 
 .woocommerce-table__header,
 .woocommerce-table__item {
-	font-size: 0.8125rem;
+	@include font-size( 13 );
 	padding: $gap $gap-large;
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -34,6 +34,7 @@
 
 .woocommerce-table__header,
 .woocommerce-table__item {
+	font-size: 0.8125rem;
 	padding: $gap $gap-large;
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -123,7 +123,7 @@ export default compose(
 		const endpoint = NAMESPACE + 'reports/products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
-		const query = { orderby: 'items_sold' };
+		const query = { orderby: 'items_sold', per_page: 5 };
 
 		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );

--- a/client/dashboard/top-selling-products/style.scss
+++ b/client/dashboard/top-selling-products/style.scss
@@ -4,10 +4,17 @@
 		padding: 0;
 	}
 
+	$row-text-height: 1.1375rem;
+	$row-height: #{$gap * 2} + #{$row-text-height} + 1px;
+	$header-row-height: #{$gap-smaller * 2} + #{$row-text-height} + 1px;
 	.woocommerce-top-selling-products__empty-message {
+		align-items: center;
 		background: $core-grey-light-100;
 		color: $core-grey-dark-500;
-		padding: $gap-largest 0;
+		display: flex;
+		height: calc((#{$row-height}) * 5 + #{$header-row-height});
+		justify-content: center;
+		padding: $gap;
 		text-align: center;
 	}
 

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -73,7 +73,7 @@ describe( 'TopSellingProducts', () => {
 		const topSellingProducts = topSellingProductsWrapper.root.findByType( TopSellingProducts );
 
 		const endpoint = '/wc/v3/reports/products';
-		const query = { orderby: 'items_sold' };
+		const query = { orderby: 'items_sold', per_page: 5 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
 		expect( getReportStatsMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );


### PR DESCRIPTION
Part of #108.

Follow-up of #365.

Make Top Selling Products table to have the same height in all states. This way there are no height jumps neither the scroll changes before/after loading the products list.

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/45425217-fd8d9a00-b698-11e8-8bc8-16a4aee642ec.png)

![image](https://user-images.githubusercontent.com/3616980/45425241-0f6f3d00-b699-11e8-9cf9-c974d5660737.png)

![image](https://user-images.githubusercontent.com/3616980/45425286-2b72de80-b699-11e8-81f2-4a0224d5bffc.png)

**Steps to test**
1. Run `npm test` to verify tests are passing.
2. Force `rows` to be empty in the Top Selling Products table. Go to `client/dashboard/top-selling-products/index.js` and replace this line:
  `const rows = isRequesting || isError ? [] : this.getRowsContent( data );`
  with
  `const rows = [];`
3. Go to the _Dashboard_ page.
4. Check that `.woocommerce-card__body` has height 291.2px.
5. Undo the changes in step 2.
6. Make sure you have some products + orders. [wc-smooth-generator](https://github.com/woocommerce/wc-smooth-generator) can help creating them.
7. Go to the _Dashboard_ page again.
8. Check that there are no reflows between the loading table and the loaded table. And that `.woocommerce-card__body` has height 291.2px.
