### PR TITLE
Dropdown: fix positioning

### DIFF
--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -183,6 +183,7 @@ class AdvancedFilters extends Component {
 				{ availableFilterKeys.length > 0 && (
 					<div className="woocommerce-filters-advanced__add-filter">
 						<Dropdown
+							className="woocommerce-filters-advanced__add-filter-dropdown"
 							position="bottom center"
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<IconButton

--- a/client/components/filters/advanced/style.scss
+++ b/client/components/filters/advanced/style.scss
@@ -99,6 +99,10 @@
 	}
 }
 
+.woocommerce-filters-advanced__add-filter-dropdown {
+	display: inline-block;
+}
+
 .woocommerce-filters-advanced__add-button {
 	color: inherit;
 	padding: $gap-smaller;


### PR DESCRIPTION
Gutenberg's `<Dropdown />` slightly changed the way it measures center by looking at the element itself rather than an internal `div` that was previously rendered.

https://github.com/WordPress/gutenberg/commit/20650111b6e307eef4dc2850d044f2be682c0871#diff-ff8751703831372f5614bbd1a0d8bf3fL76

This PR sets a width to `<Dropdown />` so the popover is rendered correctly.

## Test
1. `/wp-admin/admin.php?page=wc-admin#/analytics/orders?filter=advanced`
2. "Add a filter" and see dropdown rendering correctly centered.