### PR TITLE
Tracks: Add basic util methods for tracks.

### DIFF
--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * Record an event to Tracks
+ *
+ * @param {String} eventName The name of the event to record, always prefixed with wca_
+ * @param {Object} eventProperties event properties to include in the event
+ */
+
+export function recordEvent( eventName, eventProperties ) {
+	if ( ! wcSettings.trackingEnabled ) {
+		return false;
+	}
+
+	// TODO - should we add validation/whitelist of tracks
+	// TODO - Don't send tracks in dev envs maybe based off WP_DEBUG?
+	const event = `wca_${ eventName }`;
+
+	// Should already be initialized via inline ./lib/clicent-assets.php
+	// but just being extra safe
+	window._tkq = window._tkq || [];
+	window._tkq.push( [ 'recordEvent', event, eventProperties ] );
+}
+
+/**
+ * Record a page view to Tracks
+ *
+ * @param {String} path the page/path to record a page view for
+ */
+
+export function recordPageView( path ) {
+	if ( ! path ) {
+		return;
+	}
+	recordEvent( 'page_view', { path } );
+}


### PR DESCRIPTION
This PR seeks to build upon #369 with the addition of some very basic util methods to either `recordEvent` or `recordPageView` via tracks. Based off similar logic found in the [Calypso analytics module](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/index.js#L367), and styled the event names from what is currently done in Jetpack [#](https://github.com/Automattic/jetpack/blob/f8078c2cd12ac508334da2fb08e37a92cf283c14/_inc/client/main.jsx#L158).

__Testing__
Nothing to really test at this time - no usage configured yet.