### PR TITLE
Component - Chart: factorial spacing of x-axis ticks

### DIFF
--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -122,7 +122,7 @@ class D3Chart extends Component {
 		const uniqueDates = getUniqueDates( lineData, parseDate );
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth );
-		const xTicks = getXTicks( adjWidth, layout );
+		const xTicks = getXTicks( uniqueDates, adjWidth, layout );
 		return {
 			colorScheme,
 			dateSpaces: getDateSpaces( uniqueDates, adjWidth, xLineScale ),

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -200,7 +200,8 @@ D3Chart.propTypes = {
 	 */
 	interval: PropTypes.oneOf( [ 'hour', 'day', 'week', 'month', 'quarter', 'year' ] ),
 	/**
-	 * `standard` (default) legend layout in the header or `comparison` moves legend layout to the left
+	 * `standard` (default) legend layout in the header or `comparison` moves legend layout
+	 * to the left or 'compact' has the legend below
 	 */
 	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
 	/**

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -23,6 +23,7 @@ import {
 	getOrderedKeys,
 	getLine,
 	getLineData,
+	getXTicks,
 	getUniqueKeys,
 	getUniqueDates,
 	getXScale,
@@ -97,6 +98,7 @@ class D3Chart extends Component {
 			data,
 			dateParser,
 			height,
+			layout,
 			margin,
 			orderedKeys,
 			tooltipFormat,
@@ -120,6 +122,7 @@ class D3Chart extends Component {
 		const uniqueDates = getUniqueDates( lineData, parseDate );
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth );
+		const xTicks = getXTicks( adjWidth, layout );
 		return {
 			colorScheme,
 			dateSpaces: getDateSpaces( uniqueDates, adjWidth, xLineScale ),
@@ -139,6 +142,7 @@ class D3Chart extends Component {
 			x2Format: d3TimeFormat( x2Format ),
 			xGroupScale: getXGroupScale( orderedKeys, xScale ),
 			xLineScale,
+			xTicks,
 			xScale,
 			yMax,
 			yScale,
@@ -196,6 +200,10 @@ D3Chart.propTypes = {
 	 */
 	interval: PropTypes.oneOf( [ 'hour', 'day', 'week', 'month', 'quarter', 'year' ] ),
 	/**
+	 * `standard` (default) legend layout in the header or `comparison` moves legend layout to the left
+	 */
+	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
+	/**
 	 * Margins for axis and chart padding.
 	 */
 	margin: PropTypes.shape( {
@@ -244,6 +252,7 @@ D3Chart.defaultProps = {
 		right: 0,
 		top: 20,
 	},
+	layout: 'standard',
 	tooltipFormat: '%Y-%m-%d',
 	type: 'line',
 	width: 600,

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -291,7 +291,8 @@ Chart.propTypes = {
 	 */
 	yFormat: PropTypes.string,
 	/**
-	 * `standard` (default) legend layout in the header or `comparison` moves legend layout to the left
+	 * `standard` (default) legend layout in the header or `comparison` moves legend layout
+	 * to the left or 'compact' has the legend below
 	 */
 	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
 	/**

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -293,7 +293,7 @@ Chart.propTypes = {
 	/**
 	 * `standard` (default) legend layout in the header or `comparison` moves legend layout to the left
 	 */
-	layout: PropTypes.oneOf( [ 'standard', 'comparison' ] ),
+	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
 	/**
 	 * A title describing this chart.
 	 */

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -342,7 +342,7 @@ export const drawAxis = ( node, params ) => {
 		.attr( 'transform', `translate(0, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
-				.tickValues( params.uniqueDates.map( d => ( params.type === 'line' ? new Date( d ) : d ) ) )
+				.tickValues( ticks )
 				.tickSize( 5 )
 				.tickFormat( '' )
 		);

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -188,6 +188,36 @@ export const getLine = ( xLineScale, yScale ) =>
 		.y( d => yScale( d.value ) );
 
 /**
+ * Describes getXTicks
+ * @param {integer} width - calculated page width
+ * @param {string} layout - standard, comparison or compact chart types
+ * @returns {integer} number of x-axis ticks based on width and chart layout
+ */
+export const getXTicks = ( width, layout ) => {
+	if ( width < 783 ) {
+		return 7;
+	} else if ( width >= 783 && width < 1129 ) {
+		return 12;
+	} else if ( width >= 1130 && width < 1365 ) {
+		if ( layout === 'standard' ) {
+			return 16;
+		} else if ( layout === 'comparison' ) {
+			return 12;
+		} else if ( layout === 'compact' ) {
+			return 7;
+		}
+	} else if ( width >= 1365 ) {
+		if ( layout === 'standard' ) {
+			return 31;
+		} else if ( layout === 'comparison' ) {
+			return 16;
+		} else if ( layout === 'compact' ) {
+			return 12;
+		}
+	}
+};
+
+/**
  * Describes getDateSpaces
  * @param {array} uniqueDates - from `getUniqueDates`
  * @param {number} width - calculated width of the charting space
@@ -223,13 +253,18 @@ export const drawAxis = ( node, params ) => {
 		yGrids.push( i / 3 * params.yMax );
 	}
 
+	let ticks = params.uniqueDates.map( d => ( params.type === 'line' ? new Date( d ) : d ) );
+	while ( ticks.length >= params.xTicks ) {
+		ticks = ticks.filter( ( x, i ) => i % 2 || i === 0 || i === ticks.length - 1 );
+	}
+
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis' )
 		.attr( 'transform', `translate(0,${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
-				.tickValues( params.uniqueDates.map( d => ( params.type === 'line' ? new Date( d ) : d ) ) )
+				.tickValues( ticks )
 				.tickFormat( d => params.xFormat( d instanceof Date ? d : new Date( d ) ) )
 		);
 
@@ -239,7 +274,7 @@ export const drawAxis = ( node, params ) => {
 		.attr( 'transform', `translate(3, ${ params.height + 20 })` )
 		.call(
 			d3AxisBottom( xScale )
-				.tickValues( params.uniqueDates.map( d => ( params.type === 'line' ? new Date( d ) : d ) ) )
+				.tickValues( ticks )
 				.tickFormat( ( d, i ) => {
 					const monthDate = d instanceof Date ? d : new Date( d );
 					return monthDate.getDate() === 1 || i === 0 ? params.x2Format( monthDate ) : '';

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -378,25 +378,26 @@ export const drawLines = ( node, data, params ) => {
 		} )
 		.attr( 'd', d => params.line( d.values ) );
 
-	series
-		.selectAll( 'circle' )
-		.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
-		.enter()
-		.append( 'circle' )
-		.attr( 'r', 6 )
-		.attr( 'fill', d => getColor( d.key, params ) )
-		.attr( 'stroke', '#fff' )
-		.attr( 'stroke-width', 3 )
-		.style( 'opacity', d => {
-			const opacity = d.focus ? 1 : 0.1;
-			return d.visible ? opacity : 0;
-		} )
-		.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
-		.attr( 'cy', d => params.yScale( d.value ) )
-		.on( 'mouseover', ( d, i, nodes ) =>
-			handleMouseOverLineChart( d, i, nodes, node, data, params )
-		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+	params.uniqueDates.length < 50 &&
+		series
+			.selectAll( 'circle' )
+			.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
+			.enter()
+			.append( 'circle' )
+			.attr( 'r', 6 )
+			.attr( 'fill', d => getColor( d.key, params ) )
+			.attr( 'stroke', '#fff' )
+			.attr( 'stroke-width', 3 )
+			.style( 'opacity', d => {
+				const opacity = d.focus ? 1 : 0.1;
+				return d.visible ? opacity : 0;
+			} )
+			.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
+			.attr( 'cy', d => params.yScale( d.value ) )
+			.on( 'mouseover', ( d, i, nodes ) =>
+				handleMouseOverLineChart( d, i, nodes, node, data, params )
+			)
+			.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 
 	const focus = node
 		.append( 'g' )

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -26,12 +26,11 @@ import { formatCurrency } from 'lib/currency';
  * @returns {integer} smallest factor of num
  */
 export const getFactors = inputNum => {
-	const num = Math.round( inputNum );
 	const num_factors = [];
-	for ( let i = 1; i <= Math.floor( Math.sqrt( num ) ); i += 1 ) {
-		if ( num % i === 0 ) {
+	for ( let i = 1; i <= Math.floor( Math.sqrt( inputNum ) ); i += 1 ) {
+		if ( inputNum % i === 0 ) {
 			num_factors.push( i );
-			num / i !== i && num_factors.push( num / i );
+			inputNum / i !== i && num_factors.push( inputNum / i );
 		}
 	}
 	num_factors.sort( ( x, y ) => x - y ); // numeric sort
@@ -236,6 +235,9 @@ export const getXTicks = ( uniqueDates, width, layout ) => {
 		} else if ( layout === 'compact' ) {
 			ticks = 12;
 		}
+	}
+	if ( uniqueDates.length <= ticks ) {
+		return uniqueDates;
 	}
 	let factors = [];
 	let i = 0;


### PR DESCRIPTION
Chart Master Thread: #164 

This PR attempts to reduce the number of x-axis ticks to under the maximum as specified in the chart designs - [p6riRB-3jq](https://wp.me/p6riRB-3jq)

For more information on how `getXTicks()` works, see this post, which runs through the logic - [p90Yrv-Nw](https://wp.me/p90Yrv-Nw)

This PR resolves one of the items from #382 

Testing Instructions:
- adjust the number of days in the date picker
- resize the screen
- ensure there are fewer ticks than the max ticks defined [p6riRB-3jq](https://wp.me/p6riRB-3jq) and that the first and last ticks are visible