### PR TITLE
Make it possible to navigate charts with the keyboard

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -400,7 +400,6 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'fill', d => getColor( d.key, params ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', 3 )
-		.attr( 'tabindex', '0' )
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;
 			return d.visible ? opacity : 0;
@@ -410,11 +409,7 @@ export const drawLines = ( node, data, params ) => {
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverLineChart( d, i, nodes, node, data, params )
 		)
-		.on( 'focus', ( d, i, nodes ) => {
-			const position = calculatePositionInChart( d3Event.target, node.node() );
-			handleMouseOverLineChart( d, i, nodes, node, data, params, position );
-		} )
-		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 
 	const focus = node
 		.append( 'g' )
@@ -442,10 +437,15 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'width', d => d.width )
 		.attr( 'height', params.height )
 		.attr( 'opacity', 0 )
+		.attr( 'tabindex', '0' )
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverLineChart( d, i, nodes, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+		.on( 'focus', ( d, i, nodes ) => {
+			const position = calculatePositionInChart( d3Event.target, node.node() );
+			handleMouseOverLineChart( d, i, nodes, node, data, params, position );
+		} )
+		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 };
 
 export const drawBars = ( node, data, params ) => {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -345,7 +345,7 @@ const handleMouseOutBarChart = ( d, i, nodes, params ) => {
 	d3Select( nodes[ i ].parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0' );
-	params.tooltip.style( 'display', 'flex' );
+	params.tooltip.style( 'display', 'none' );
 };
 
 const handleMouseOverLineChart = ( d, i, nodes, node, data, params ) => {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -13,7 +13,7 @@ import {
 	scaleLinear as d3ScaleLinear,
 	scaleTime as d3ScaleTime,
 } from 'd3-scale';
-import { mouse as d3Mouse, select as d3Select } from 'd3-selection';
+import { event as d3Event, mouse as d3Mouse, select as d3Select } from 'd3-selection';
 import { line as d3Line } from 'd3-shape';
 /**
  * Internal dependencies
@@ -304,9 +304,9 @@ export const drawAxis = ( node, params ) => {
 		.remove();
 };
 
-const showTooltip = ( node, params, d ) => {
+const showTooltip = ( node, params, d, position ) => {
 	const chartCoords = node.node().getBoundingClientRect();
-	let [ xPosition, yPosition ] = d3Mouse( node.node() );
+	let [ xPosition, yPosition ] = position ? position : d3Mouse( node.node() );
 	xPosition = xPosition > chartCoords.width - 340 ? xPosition - 340 : xPosition + 100;
 	yPosition = yPosition > chartCoords.height - 150 ? yPosition - 200 : yPosition + 20;
 	const keys = params.orderedKeys.filter( row => row.visible ).map(
@@ -334,11 +334,11 @@ const showTooltip = ( node, params, d ) => {
 		` );
 };
 
-const handleMouseOverBarChart = ( d, i, nodes, node, data, params ) => {
+const handleMouseOverBarChart = ( d, i, nodes, node, data, params, position ) => {
 	d3Select( nodes[ i ].parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0.1' );
-	showTooltip( node, params, d );
+	showTooltip( node, params, d, position );
 };
 
 const handleMouseOutBarChart = ( d, i, nodes, params ) => {
@@ -348,11 +348,11 @@ const handleMouseOutBarChart = ( d, i, nodes, params ) => {
 	params.tooltip.style( 'display', 'none' );
 };
 
-const handleMouseOverLineChart = ( d, i, nodes, node, data, params ) => {
+const handleMouseOverLineChart = ( d, i, nodes, node, data, params, position ) => {
 	d3Select( nodes[ i ].parentNode )
 		.select( '.focus-grid' )
 		.attr( 'opacity', '1' );
-	showTooltip( node, params, data.find( e => e.date === d.date ) );
+	showTooltip( node, params, data.find( e => e.date === d.date ), position );
 };
 
 const handleMouseOutLineChart = ( d, i, nodes, params ) => {
@@ -394,6 +394,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'fill', d => getColor( d.key, params ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', 3 )
+		.attr( 'tabindex', '0' )
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;
 			return d.visible ? opacity : 0;
@@ -403,7 +404,13 @@ export const drawLines = ( node, data, params ) => {
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverLineChart( d, i, nodes, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+		.on( 'focus', ( d, i, nodes ) => {
+			const circleBox = d3Event.target.getBoundingClientRect();
+			const graphBox = node.node().getBoundingClientRect();
+			const position = [ circleBox.x - graphBox.x, circleBox.y - graphBox.y ];
+			handleMouseOverLineChart( d, i, nodes, node, data, params, position );
+		} )
+		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 
 	const focus = node
 		.append( 'g' )
@@ -492,8 +499,15 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'width', params.xGroupScale.range()[ 1 ] )
 		.attr( 'height', params.height )
 		.attr( 'opacity', '0' )
+		.attr( 'tabindex', '0' )
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverBarChart( d, i, nodes, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'focus', ( d, i, nodes ) => {
+			const rectangleBox = d3Event.target.getBoundingClientRect();
+			const graphBox = node.node().getBoundingClientRect();
+			const position = [ rectangleBox.x - graphBox.x, rectangleBox.y - graphBox.y ];
+			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
+		} )
+		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
 };

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -362,6 +362,12 @@ const handleMouseOutLineChart = ( d, i, nodes, params ) => {
 	params.tooltip.style( 'display', 'none' );
 };
 
+const calculatePositionInChart = ( element, chart ) => {
+	const elementCoords = element.getBoundingClientRect();
+	const chartCoords = chart.getBoundingClientRect();
+	return [ elementCoords.x - chartCoords.x, elementCoords.y - chartCoords.y ];
+};
+
 export const drawLines = ( node, data, params ) => {
 	const series = node
 		.append( 'g' )
@@ -405,9 +411,7 @@ export const drawLines = ( node, data, params ) => {
 			handleMouseOverLineChart( d, i, nodes, node, data, params )
 		)
 		.on( 'focus', ( d, i, nodes ) => {
-			const circleBox = d3Event.target.getBoundingClientRect();
-			const graphBox = node.node().getBoundingClientRect();
-			const position = [ circleBox.x - graphBox.x, circleBox.y - graphBox.y ];
+			const position = calculatePositionInChart( d3Event.target, node.node() );
 			handleMouseOverLineChart( d, i, nodes, node, data, params, position );
 		} )
 		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
@@ -504,9 +508,7 @@ export const drawBars = ( node, data, params ) => {
 			handleMouseOverBarChart( d, i, nodes, node, data, params )
 		)
 		.on( 'focus', ( d, i, nodes ) => {
-			const rectangleBox = d3Event.target.getBoundingClientRect();
-			const graphBox = node.node().getBoundingClientRect();
-			const position = [ rectangleBox.x - graphBox.x, rectangleBox.y - graphBox.y ];
+			const position = calculatePositionInChart( d3Event.target, node.node() );
 			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
 		} )
 		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );


### PR DESCRIPTION
Part of #208.

Makes chart columns of data focusable and shows the tooltip when they are focused.

This PR also fixes a bug that was making the tooltip not to disappear in bar charts (33129dc5cdc3b445b15ff1a5b637ee125a9d4ccd).

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/45492583-f59f2a00-b76c-11e8-9a24-37c2c3208c3c.png)
![image](https://user-images.githubusercontent.com/3616980/45491355-d2bf4680-b769-11e8-8e5a-3fbe104c5c90.png)

**Steps to test**
* Go to any page with a chart.
* Navigate the page with the `Tab` key.
* Verify that you can focus chart elements and, when focused, the tooltip is displayed.
* Check both, the line chart and the bar chart.