### PR TITLE
IE11: avoid reviews date overlapping product name

### DIFF
--- a/client/layout/activity-panel/activity-card/style.scss
+++ b/client/layout/activity-panel/activity-card/style.scss
@@ -77,15 +77,17 @@
 	@include breakpoint( '>782px' ) {
 		grid-area: header;
 		display: grid;
-		grid-template-areas:
+		grid-template:
 			'title date'
-			'subtitle date';
+			'subtitle date' /
+			1fr auto;
 
 		.woocommerce-activity-card__title {
 			grid-area: title;
 		}
 
 		.woocommerce-activity-card__date {
+			display: block;
 			grid-area: date;
 			justify-self: end;
 			margin-bottom: 0;


### PR DESCRIPTION
Part of #243.

There were two issues here:
- IE11 doesn't apply grid styling to inline elements (the date is a `span`).
- In IE11 `auto` sizing might occupy less than 100% of the width so `1fr auto` was required to make sure the grid takes all the available space.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45497496-42d4c900-b778-11e8-83de-e54a705fbee5.png)


After:
![image](https://user-images.githubusercontent.com/3616980/45497577-76afee80-b778-11e8-8f0d-a8f62abf9754.png)


**Steps to test**
- Open the _Reviews_ panel.
- Verify that the date doesn't overlap the product name.