### PR TITLE
Top Products: Display Product Name.

### DIFF
--- a/client/dashboard/top-selling-products/__mocks__/mock-data.js
+++ b/client/dashboard/top-selling-products/__mocks__/mock-data.js
@@ -9,7 +9,8 @@ And as such will require data layer logic for products to fully build the table
     "product_id": 20,
     "items_sold": 100,
     "gross_revenue": 999.99,
-    "orders_count": 54,
+		"orders_count": 54,
+		"name": 'Product name',
     "_links": {
       "product": [
         {
@@ -27,6 +28,7 @@ export default [
 		items_sold: 1000,
 		gross_revenue: 999.99,
 		orders_count: 54,
+		name: 'awesome shirt',
 		_links: {
 			product: [
 				{
@@ -40,6 +42,7 @@ export default [
 		items_sold: 90,
 		gross_revenue: 875,
 		orders_count: 41,
+		name: 'awesome pants',
 		_links: {
 			product: [
 				{
@@ -53,6 +56,7 @@ export default [
 		items_sold: 55,
 		gross_revenue: 75.75,
 		orders_count: 28,
+		name: 'awesome hat',
 		_links: {
 			product: [
 				{
@@ -66,6 +70,7 @@ export default [
 		items_sold: 10,
 		gross_revenue: 24.5,
 		orders_count: 14,
+		name: 'awesome sticker',
 		_links: {
 			product: [
 				{
@@ -79,6 +84,7 @@ export default [
 		items_sold: 1,
 		gross_revenue: 0.99,
 		orders_count: 1,
+		name: 'awesome button',
 		_links: {
 			product: [
 				{

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -53,17 +53,15 @@ export class TopSellingProducts extends Component {
 
 	getRowsContent( data ) {
 		return map( data, row => {
-			const { product_id, items_sold, gross_revenue, orders_count } = row;
+			const { product_id, items_sold, gross_revenue, orders_count, name } = row;
 
-			// @TODO We also will need to have product data to properly display the product name here
-			const productName = `Product ${ product_id }`;
 			const productLink = (
-				<a href={ getAdminLink( `/post.php?post=${ product_id }&action=edit` ) }>{ productName }</a>
+				<a href={ getAdminLink( `/post.php?post=${ product_id }&action=edit` ) }>{ name }</a>
 			);
 			return [
 				{
 					display: productLink,
-					value: productName,
+					value: name,
 				},
 				{
 					display: numberFormat( items_sold ),
@@ -123,7 +121,7 @@ export default compose(
 		const endpoint = NAMESPACE + 'reports/products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
-		const query = { orderby: 'items_sold', per_page: 5 };
+		const query = { orderby: 'items_sold', per_page: 5, extended_product_info: 1 };
 
 		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -43,7 +43,7 @@ describe( 'TopSellingProducts', () => {
 		const table = topSellingProducts.find( 'Table' );
 		const firstRow = table.props().rows[ 0 ];
 
-		expect( firstRow[ 0 ].value ).toBe( `Product ${ mockData[ 0 ].product_id }` );
+		expect( firstRow[ 0 ].value ).toBe( mockData[ 0 ].name );
 		expect( firstRow[ 1 ].display ).toBe( numberFormat( mockData[ 0 ].items_sold ) );
 		expect( firstRow[ 1 ].value ).toBe( mockData[ 0 ].items_sold );
 		expect( firstRow[ 2 ].display ).toBe( numberFormat( mockData[ 0 ].orders_count ) );
@@ -73,7 +73,7 @@ describe( 'TopSellingProducts', () => {
 		const topSellingProducts = topSellingProductsWrapper.root.findByType( TopSellingProducts );
 
 		const endpoint = '/wc/v3/reports/products';
-		const query = { orderby: 'items_sold', per_page: 5 };
+		const query = { orderby: 'items_sold', per_page: 5, extended_product_info: 1 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
 		expect( getReportStatsMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );


### PR DESCRIPTION
Super quick final PR to get the Top Selling Products finished up.

Closes #108

This utilizes the `extended_product_info` query arg on the product stats endpoint to have the product name returned in the API response, and then uses it in the display:

__Before__
<img width="600" alt="top-selling-before" src="https://user-images.githubusercontent.com/22080/45515375-d4364200-b75c-11e8-8ebf-928e8c61ce6c.png">

__After__
<img width="662" alt="top-selling-after" src="https://user-images.githubusercontent.com/22080/45515385-d9938c80-b75c-11e8-946e-039b75c7bf71.png">

__To Test__
- Make sure you local env has some recent order data, if not use smooth generator or place a manual order
- Open up the Dashboard page, and verify the product names are shown in the Top Selling Products block
