### PR TITLE
Chart: Add styling needed to not be wrapped by card.

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -338,18 +338,16 @@ export class RevenueReport extends Component {
 		} );
 
 		return (
-			<Card title="">
-				<Chart
-					data={ chartData }
-					title={ selectedChart.label }
-					interval={ currentInterval }
-					allowedIntervals={ allowedIntervals }
-					tooltipFormat={ formats.tooltipFormat }
-					xFormat={ formats.xFormat }
-					x2Format={ formats.x2Format }
-					dateParser={ '%Y-%m-%dT%H:%M:%S' }
-				/>
-			</Card>
+			<Chart
+				data={ chartData }
+				title={ selectedChart.label }
+				interval={ currentInterval }
+				allowedIntervals={ allowedIntervals }
+				tooltipFormat={ formats.tooltipFormat }
+				xFormat={ formats.xFormat }
+				x2Format={ formats.x2Format }
+				dateParser={ '%Y-%m-%dT%H:%M:%S' }
+			/>
 		);
 	}
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -1,8 +1,10 @@
 /** @format */
 .woocommerce-chart {
+	margin-top: -$gap;
 	margin-bottom: $gap-large;
 	background: white;
 	border: 1px solid $core-grey-light-700;
+	border-top: 0;
 
 	@include breakpoint( '<782px' ) {
 		margin-left: -16px;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -1,15 +1,20 @@
 /** @format */
 .woocommerce-chart {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	align-items: flex-start;
-	margin: -$gap;
-	border-top: 1px solid $core-grey-light-700;
+	margin-bottom: $gap-large;
+	background: white;
+	border: 1px solid $core-grey-light-700;
+
+	@include breakpoint( '<782px' ) {
+		margin-left: -16px;
+		margin-right: -16px;
+		margin-bottom: $gap-small;
+		border-left: none;
+		border-right: none;
+		width: auto;
+	}
 
 	.woocommerce-chart__header {
 		min-height: 50px;
-		border-top: 1px solid $core-grey-light-700;
 		border-bottom: 1px solid $core-grey-light-700;
 		display: flex;
 		flex-wrap: nowrap;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -188,13 +188,9 @@
 
 	&.is-placeholder {
 		@include placeholder();
-		display: inline-block;
 		height: 200px;
 		width: 100%;
-		margin: 0;
 		padding: 0;
-		margin-bottom: $gap;
-		border: 1px solid $core-grey-light-700;
 	}
 }
 


### PR DESCRIPTION
For #361 - This removes the need to wrap the chart in a `<Card />` component and cleans up the styling of the Chart css a bit to match how `<Card />` operates.

__Before__
![image](https://user-images.githubusercontent.com/22080/45520713-76f7bc00-b76f-11e8-808c-db711b0a4b08.png)

__After__
![image](https://user-images.githubusercontent.com/22080/45520663-4152d300-b76f-11e8-8bb4-bf601c22cb58.png)

__Design__
![image](https://user-images.githubusercontent.com/22080/45520726-8ecf4000-b76f-11e8-9235-883f331db62f.png)

__To Test__
- Open up the revenue report
- Verify things look a bit cleaned up in the header area at a wide and narrow viewport