### PR TITLE
IE11: fix dates overlapping in Custom filter

### DIFF
--- a/client/components/calendar/style.scss
+++ b/client/components/calendar/style.scss
@@ -79,6 +79,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	grid-column-start: 2;
 }
 
 .woocommerce-calendar__input {
@@ -93,6 +94,14 @@
 		path {
 			fill: $core-grey-dark-300;
 		}
+	}
+
+	&:first-child {
+		grid-column-start: 1;
+	}
+
+	&:last-child {
+		grid-column-start: 3;
 	}
 
 	&.is-empty {


### PR DESCRIPTION
Part of #243.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/3616980/45539484-326d2e80-b80a-11e8-86b4-c54f1e8153f8.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45539109-1026e100-b809-11e8-955c-6ebab2d92f97.png)

**Steps to test**
- Go to the _Revenue_ page under _Analytics_.
- Open the _Date range_ dropdown and click on _Custom_.
- Verify that two date inputs are visible.