### PR TITLE
Component - Chart: check if second x axis tick required

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -242,7 +242,13 @@ export const drawAxis = ( node, params ) => {
 				.tickValues( params.uniqueDates.map( d => ( params.type === 'line' ? new Date( d ) : d ) ) )
 				.tickFormat( ( d, i ) => {
 					const monthDate = d instanceof Date ? d : new Date( d );
-					return monthDate.getDate() === 1 || i === 0 ? params.x2Format( monthDate ) : '';
+					let prevMonth = i !== 0 ? params.uniqueDates[ i - 1 ] : params.uniqueDates[ i ];
+					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
+					return monthDate.getDate() === 1 ||
+						i === 0 ||
+						params.x2Format( monthDate ) !== params.x2Format( prevMonth )
+						? params.x2Format( monthDate )
+						: '';
 				} )
 		)
 		.call( g => g.select( '.domain' ).remove() );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -329,7 +329,7 @@ export const drawAxis = ( node, params ) => {
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => {
 					const monthDate = d instanceof Date ? d : new Date( d );
-					let prevMonth = i !== 0 ? params.uniqueDates[ i - 1 ] : params.uniqueDates[ i ];
+					let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
 					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
 					return monthDate.getDate() === 1 ||
 						i === 0 ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -8190,11 +8190,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-    },
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "d3-selection": "^1.3.0",
     "d3-shape": "^1.2.0",
     "d3-time-format": "^2.1.1",
-    "he": "^1.1.1",
     "lodash": "^4.17.10",
     "react-dates": "^16.7.0",
     "react-slot-fill": "^2.0.1",


### PR DESCRIPTION
Chart Master Thread: #164 

This PR ensures that there is a second x-axis tick whenever the value for the second x-axis tick changes, month, year etc. This should also work on the PR that reduces the x-axis ticks.

![screenshot 2018-09-14 13 37 27](https://user-images.githubusercontent.com/1160732/45548319-2e4e0a80-b824-11e8-865e-97f167cfbe26.png)

To test (once #398 is merged):
- change the date picker to a longer range like year to date or quater to date
- ensure that the chart includes the month and year for the first tick of that month
- resize the chart and see that it updates as you'd expect

