### PR TITLE
Improve charts accessibility

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -332,6 +332,7 @@ export class RevenueReport extends Component {
 				title={ selectedChart.label }
 				interval={ currentInterval }
 				allowedIntervals={ allowedIntervals }
+				mode="time-comparison"
 				pointLabelFormat={ formats.pointLabelFormat }
 				tooltipTitle={ selectedChart.label }
 				xFormat={ formats.xFormat }

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -100,6 +100,7 @@ class D3Chart extends Component {
 			height,
 			layout,
 			margin,
+			mode,
 			orderedKeys,
 			pointLabelFormat,
 			tooltipFormat,
@@ -132,6 +133,7 @@ class D3Chart extends Component {
 			line: getLine( xLineScale, yScale ),
 			lineData,
 			margin,
+			mode,
 			orderedKeys: newOrderedKeys,
 			pointLabelFormat,
 			parseDate,
@@ -222,6 +224,11 @@ D3Chart.propTypes = {
 		top: PropTypes.number,
 	} ),
 	/**
+	 * `items-comparison` (default) or `time-comparison`, this is used to generate correct
+	 * ARIA properties.
+	 */
+	mode: PropTypes.oneOf( [ 'item-comparison', 'time-comparison' ] ),
+	/**
 	 * The list of labels for this chart.
 	 */
 	orderedKeys: PropTypes.array,
@@ -267,6 +274,7 @@ D3Chart.defaultProps = {
 		top: 20,
 	},
 	layout: 'standard',
+	mode: 'item-comparison',
 	tooltipFormat: '%B %d, %Y',
 	type: 'line',
 	width: 600,

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -77,7 +77,6 @@ class D3Chart extends Component {
 		const { data, margin, type } = this.props;
 		const g = node
 			.attr( 'id', 'chart' )
-			.attr( 'role', 'table' )
 			.append( 'g' )
 			.attr( 'transform', `translate(${ margin.left },${ margin.top })` );
 

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -77,6 +77,7 @@ class D3Chart extends Component {
 		const { data, margin, type } = this.props;
 		const g = node
 			.attr( 'id', 'chart' )
+			.attr( 'role', 'table' )
 			.append( 'g' )
 			.attr( 'transform', `translate(${ margin.left },${ margin.top })` );
 

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -188,6 +188,7 @@ class Chart extends Component {
 		const {
 			dateParser,
 			layout,
+			mode,
 			pointLabelFormat,
 			title,
 			tooltipFormat,
@@ -263,6 +264,7 @@ class Chart extends Component {
 						dateParser={ dateParser }
 						height={ 300 }
 						margin={ margin }
+						mode={ mode }
 						orderedKeys={ orderedKeys }
 						pointLabelFormat={ pointLabelFormat }
 						tooltipFormat={ tooltipFormat }
@@ -321,6 +323,11 @@ Chart.propTypes = {
 	 */
 	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
 	/**
+	 * `item-comparison` (default) or `time-comparison`, this is used to generate correct
+	 * ARIA properties.
+	 */
+	mode: PropTypes.oneOf( [ 'item-comparison', 'time-comparison' ] ),
+	/**
 	 * A title describing this chart.
 	 */
 	title: PropTypes.string,
@@ -350,6 +357,7 @@ Chart.defaultProps = {
 	x2Format: '%b %Y',
 	yFormat: '$.3s',
 	layout: 'standard',
+	mode: 'item-comparison',
 	type: 'line',
 	interval: 'day',
 };

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -511,7 +511,7 @@ export const drawLines = ( node, data, params ) => {
 			.attr( 'aria-label', d => {
 				const label = d.label
 					? d.label
-					: formatDate( 'F j, Y', d.date instanceof Date ? d.date : new Date( d.date ) );
+					: params.tooltipFormat( d.date instanceof Date ? d.date : new Date( d.date ) );
 				return `${ label } ${ formatCurrency( d.value ) }`;
 			} )
 			.on( 'focus', ( d, i, nodes ) => {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -324,6 +324,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis axis-month' )
+		.attr( 'aria-hidden', 'true' )
 		.attr( 'transform', `translate(3, ${ params.height + 20 })` )
 		.call(
 			d3AxisBottom( xScale )
@@ -371,6 +372,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis y-axis' )
+		.attr( 'aria-hidden', 'true' )
 		.attr( 'transform', 'translate(-50, 0)' )
 		.attr( 'text-anchor', 'start' )
 		.call(
@@ -462,6 +464,12 @@ const calculatePositionInChart = ( element, chart ) => {
 	return [ elementCoords.x - chartCoords.x, elementCoords.y - chartCoords.y ];
 };
 
+const formatVoiceDate = ( params, d ) => {
+	const date = d instanceof Date ? d : new Date( d );
+	// @TODO probably we want a specific date format for dates read by TTS software
+	return params.xFormat( date ) + ' ' + params.x2Format( date );
+};
+
 export const drawLines = ( node, data, params ) => {
 	const series = node
 		.append( 'g' )
@@ -470,7 +478,9 @@ export const drawLines = ( node, data, params ) => {
 		.data( params.lineData.filter( d => d.visible ) )
 		.enter()
 		.append( 'g' )
-		.attr( 'class', 'line-g' );
+		.attr( 'class', 'line-g' )
+		.attr( 'role', 'region' )
+		.attr( 'aria-label', d => d.key );
 
 	series
 		.append( 'path' )
@@ -501,6 +511,7 @@ export const drawLines = ( node, data, params ) => {
 			} )
 			.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
 			.attr( 'cy', d => params.yScale( d.value ) )
+			.attr( 'aria-label', d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value ) )
 			.on( 'mouseover', ( d, i, nodes ) =>
 				handleMouseOverLineChart( d, i, nodes, node, data, params )
 			)
@@ -552,7 +563,9 @@ export const drawBars = ( node, data, params ) => {
 		.enter()
 		.append( 'g' )
 		.attr( 'transform', d => `translate(${ params.xScale( d.date ) },0)` )
-		.attr( 'class', 'bargroup' );
+		.attr( 'class', 'bargroup' )
+		.attr( 'role', 'region' )
+		.attr( 'aria-label', d => formatVoiceDate( params, d.date ) );
 
 	barGroup
 		.append( 'rect' )
@@ -581,6 +594,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'width', params.xGroupScale.bandwidth() )
 		.attr( 'height', d => params.height - params.yScale( d.value ) )
 		.attr( 'fill', d => getColor( d.key, params ) )
+		.attr( 'aria-label', d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value ) )
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;
 			return d.visible ? opacity : 0;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -314,6 +314,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis' )
+		.attr( 'aria-hidden', 'true' )
 		.attr( 'transform', `translate(0,${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -15,10 +15,7 @@ import {
 import { event as d3Event, mouse as d3Mouse, select as d3Select } from 'd3-selection';
 import { line as d3Line } from 'd3-shape';
 import { format as formatDate } from '@wordpress/date';
-<<<<<<< HEAD
-=======
 
->>>>>>> Set different ARIA properties depending on chart mode (time or item comparison)
 /**
  * Internal dependencies
  */
@@ -87,7 +84,7 @@ export const getLineData = ( data, orderedKeys ) =>
 		values: data.map( d => ( {
 			date: d.date,
 			focus: row.focus,
-			label: get( d, [ row.key, 'label' ], 0 ),
+			label: get( d, [ row.key, 'label' ], '' ),
 			value: get( d, [ row.key, 'value' ], 0 ),
 			visible: row.visible,
 		} ) ),

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -514,7 +514,7 @@ export const drawLines = ( node, data, params ) => {
 			.attr( 'tabindex', '0' )
 			.attr(
 				'aria-label',
-				d => `${ getTooltipDate( params, d.date ) } ${ d.key } ${ formatCurrency( d.value ) }`
+				d => `${ getTooltipDate( params, d.date ) } ${ formatCurrency( d.value ) }`
 			)
 			.on( 'focus', ( d, i, nodes ) => {
 				const position = calculatePositionInChart( d3Event.target, node.node() );
@@ -598,7 +598,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'tabindex', '0' )
 		.attr(
 			'aria-label',
-			d => `${ getTooltipDate( params, d.date ) } ${ d.key } ${ formatCurrency( d.value ) }`
+			d => `${ getTooltipDate( params, d.date ) } ${ formatCurrency( d.value ) }`
 		)
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -430,29 +430,29 @@ const showTooltip = ( node, params, d, position ) => {
 		` );
 };
 
-const handleMouseOverBarChart = ( d, i, nodes, node, data, params, position ) => {
-	d3Select( nodes[ i ].parentNode )
+const handleMouseOverBarChart = ( date, parentNode, node, data, params, position ) => {
+	d3Select( parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0.1' );
-	showTooltip( node, params, data.find( e => e.date === d.date ), position );
+	showTooltip( node, params, data.find( e => e.date === date ), position );
 };
 
-const handleMouseOutBarChart = ( d, i, nodes, params ) => {
-	d3Select( nodes[ i ].parentNode )
+const handleMouseOutBarChart = ( parentNode, params ) => {
+	d3Select( parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0' );
 	params.tooltip.style( 'display', 'none' );
 };
 
-const handleMouseOverLineChart = ( d, i, nodes, node, data, params, position ) => {
-	d3Select( nodes[ i ].parentNode )
+const handleMouseOverLineChart = ( date, parentNode, node, data, params, position ) => {
+	d3Select( parentNode )
 		.select( '.focus-grid' )
 		.attr( 'opacity', '1' );
-	showTooltip( node, params, data.find( e => e.date === d.date ), position );
+	showTooltip( node, params, data.find( e => e.date === date ), position );
 };
 
-const handleMouseOutLineChart = ( d, i, nodes, params ) => {
-	d3Select( nodes[ i ].parentNode )
+const handleMouseOutLineChart = ( parentNode, params ) => {
+	d3Select( parentNode )
 		.select( '.focus-grid' )
 		.attr( 'opacity', '0' );
 	params.tooltip.style( 'display', 'none' );
@@ -518,9 +518,9 @@ export const drawLines = ( node, data, params ) => {
 			)
 			.on( 'focus', ( d, i, nodes ) => {
 				const position = calculatePositionInChart( d3Event.target, node.node() );
-				handleMouseOverLineChart( d, i, nodes, node, data, params, position );
+				handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 			} )
-			.on( 'blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+			.on( 'blur', ( d, i, nodes ) => handleMouseOutLineChart( nodes[ i ].parentNode, params ) );
 
 	const focus = node
 		.append( 'g' )
@@ -549,9 +549,9 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'height', params.height )
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) =>
-			handleMouseOverLineChart( d, i, nodes, node, data, params )
+			handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( nodes[ i ].parentNode, params ) );
 };
 
 export const drawBars = ( node, data, params ) => {
@@ -606,9 +606,9 @@ export const drawBars = ( node, data, params ) => {
 		} )
 		.on( 'focus', ( d, i, nodes ) => {
 			const position = calculatePositionInChart( d3Event.target, node.node() );
-			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
+			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
-		.on( 'blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'blur', ( d, i, nodes ) => handleMouseOutBarChart( nodes[ i ].parentNode, params ) );
 
 	barGroup
 		.append( 'rect' )
@@ -619,7 +619,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'height', params.height )
 		.attr( 'opacity', '0' )
 		.on( 'mouseover', ( d, i, nodes ) =>
-			handleMouseOverBarChart( d, i, nodes, node, data, params )
+			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( nodes[ i ].parentNode, params ) );
 };

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -396,6 +396,11 @@ export const drawAxis = ( node, params ) => {
 const getTooltipRowLabel = ( d, row, params ) =>
 	d[ row.key ].labelDate ? formatDate( params.pointLabelFormat, d[ row.key ].labelDate ) : row.key;
 
+const getTooltipDate = ( params, d ) => {
+	const date = d instanceof Date ? d : new Date( d );
+	return params.tooltipFormat( date );
+};
+
 const showTooltip = ( node, params, d, position ) => {
 	const chartCoords = node.node().getBoundingClientRect();
 	let [ xPosition, yPosition ] = position ? position : d3Mouse( node.node() );
@@ -464,11 +469,6 @@ const calculatePositionInChart = ( element, chart ) => {
 	return [ elementCoords.x - chartCoords.x, elementCoords.y - chartCoords.y ];
 };
 
-const formatVoiceDate = ( params, d ) => {
-	const date = d instanceof Date ? d : new Date( d );
-	return params.tooltipFormat( date );
-};
-
 export const drawLines = ( node, data, params ) => {
 	const series = node
 		.append( 'g' )
@@ -513,7 +513,7 @@ export const drawLines = ( node, data, params ) => {
 			.attr( 'tabindex', '0' )
 			.attr(
 				'aria-label',
-				d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+				d => getTooltipDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
 			)
 			.on( 'focus', ( d, i, nodes ) => {
 				const position = calculatePositionInChart( d3Event.target, node.node() );
@@ -564,7 +564,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'transform', d => `translate(${ params.xScale( d.date ) },0)` )
 		.attr( 'class', 'bargroup' )
 		.attr( 'role', 'region' )
-		.attr( 'aria-label', d => formatVoiceDate( params, d.date ) );
+		.attr( 'aria-label', d => getTooltipDate( params, d.date ) );
 
 	barGroup
 		.append( 'rect' )
@@ -597,7 +597,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'tabindex', '0' )
 		.attr(
 			'aria-label',
-			d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+			d => getTooltipDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
 		)
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -466,8 +466,7 @@ const calculatePositionInChart = ( element, chart ) => {
 
 const formatVoiceDate = ( params, d ) => {
 	const date = d instanceof Date ? d : new Date( d );
-	// @TODO probably we want a specific date format for dates read by TTS software
-	return params.xFormat( date ) + ' ' + params.x2Format( date );
+	return params.tooltipFormat( date );
 };
 
 export const drawLines = ( node, data, params ) => {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -516,14 +516,11 @@ export const drawLines = ( node, data, params ) => {
 				'aria-label',
 				d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
 			)
-			.on( 'mouseover', ( d, i, nodes ) =>
-				handleMouseOverLineChart( d, i, nodes, node, data, params )
-			)
 			.on( 'focus', ( d, i, nodes ) => {
 				const position = calculatePositionInChart( d3Event.target, node.node() );
 				handleMouseOverLineChart( d, i, nodes, node, data, params, position );
 			} )
-			.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+			.on( 'blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 
 	const focus = node
 		.append( 'g' )
@@ -607,14 +604,11 @@ export const drawBars = ( node, data, params ) => {
 			const opacity = d.focus ? 1 : 0.1;
 			return d.visible ? opacity : 0;
 		} )
-		.on( 'mouseover', ( d, i, nodes ) =>
-			handleMouseOverBarChart( d, i, nodes, node, data, params )
-		)
 		.on( 'focus', ( d, i, nodes ) => {
 			const position = calculatePositionInChart( d3Event.target, node.node() );
 			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
 		} )
-		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
 
 	barGroup
 		.append( 'rect' )

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -434,7 +434,7 @@ const handleMouseOverBarChart = ( d, i, nodes, node, data, params, position ) =>
 	d3Select( nodes[ i ].parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0.1' );
-	showTooltip( node, params, d, position );
+	showTooltip( node, params, data.find( e => e.date === d.date ), position );
 };
 
 const handleMouseOutBarChart = ( d, i, nodes, params ) => {
@@ -511,11 +511,19 @@ export const drawLines = ( node, data, params ) => {
 			} )
 			.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
 			.attr( 'cy', d => params.yScale( d.value ) )
-			.attr( 'aria-label', d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value ) )
+			.attr( 'tabindex', '0' )
+			.attr(
+				'aria-label',
+				d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+			)
 			.on( 'mouseover', ( d, i, nodes ) =>
 				handleMouseOverLineChart( d, i, nodes, node, data, params )
 			)
-			.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+			.on( 'focus', ( d, i, nodes ) => {
+				const position = calculatePositionInChart( d3Event.target, node.node() );
+				handleMouseOverLineChart( d, i, nodes, node, data, params, position );
+			} )
+			.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 
 	const focus = node
 		.append( 'g' )
@@ -543,15 +551,10 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'width', d => d.width )
 		.attr( 'height', params.height )
 		.attr( 'opacity', 0 )
-		.attr( 'tabindex', '0' )
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverLineChart( d, i, nodes, node, data, params )
 		)
-		.on( 'focus', ( d, i, nodes ) => {
-			const position = calculatePositionInChart( d3Event.target, node.node() );
-			handleMouseOverLineChart( d, i, nodes, node, data, params, position );
-		} )
-		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
+		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( d, i, nodes, params ) );
 };
 
 export const drawBars = ( node, data, params ) => {
@@ -584,6 +587,7 @@ export const drawBars = ( node, data, params ) => {
 				focus: row.focus,
 				value: d[ row.key ].value,
 				visible: row.visible,
+				date: d.date,
 			} ) )
 		)
 		.enter()
@@ -594,7 +598,11 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'width', params.xGroupScale.bandwidth() )
 		.attr( 'height', d => params.height - params.yScale( d.value ) )
 		.attr( 'fill', d => getColor( d.key, params ) )
-		.attr( 'aria-label', d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value ) )
+		.attr( 'tabindex', '0' )
+		.attr(
+			'aria-label',
+			d => formatVoiceDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+		)
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;
 			return d.visible ? opacity : 0;
@@ -602,7 +610,11 @@ export const drawBars = ( node, data, params ) => {
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverBarChart( d, i, nodes, node, data, params )
 		)
-		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'focus', ( d, i, nodes ) => {
+			const position = calculatePositionInChart( d3Event.target, node.node() );
+			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
+		} )
+		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
 
 	barGroup
 		.append( 'rect' )
@@ -612,13 +624,8 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'width', params.xGroupScale.range()[ 1 ] )
 		.attr( 'height', params.height )
 		.attr( 'opacity', '0' )
-		.attr( 'tabindex', '0' )
 		.on( 'mouseover', ( d, i, nodes ) =>
 			handleMouseOverBarChart( d, i, nodes, node, data, params )
 		)
-		.on( 'focus', ( d, i, nodes ) => {
-			const position = calculatePositionInChart( d3Event.target, node.node() );
-			handleMouseOverBarChart( d, i, nodes, node, data, params, position );
-		} )
-		.on( 'mouseout blur', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
+		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( d, i, nodes, params ) );
 };

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -513,7 +513,7 @@ export const drawLines = ( node, data, params ) => {
 			.attr( 'tabindex', '0' )
 			.attr(
 				'aria-label',
-				d => getTooltipDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+				d => `${ getTooltipDate( params, d.date ) } ${ d.key } ${ formatCurrency( d.value ) }`
 			)
 			.on( 'focus', ( d, i, nodes ) => {
 				const position = calculatePositionInChart( d3Event.target, node.node() );
@@ -597,7 +597,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'tabindex', '0' )
 		.attr(
 			'aria-label',
-			d => getTooltipDate( params, d.date ) + ' ' + d.key + ' ' + formatCurrency( d.value )
+			d => `${ getTooltipDate( params, d.date ) } ${ d.key } ${ formatCurrency( d.value ) }`
 		)
 		.style( 'opacity', d => {
 			const opacity = d.focus ? 1 : 0.1;


### PR DESCRIPTION
This PR implements most (if not all) changes suggested in #208.

* #339 made it possible to focus columns (dates) in charts, this PR makes it possible to focus every single point (in line charts) and every single bar (in bar charts).

* Each point/bar has an `aria-label` property used by screen readers with the date, the label and the value.

* The Y and X axis are hidden. Given that the `aria-label` of each point already includes that information, we don't need them to be visible to screen readers.

* Functions `handleMouseOverBarChart`, `handleMouseOutLineChart`, etc. have been modified a bit, so we pass them fewer parameters. And I also removed some `mouseover`, `mouseout` events that were never triggered.

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/45628338-272d3380-ba94-11e8-9b71-31640bd3c302.png)

**Steps to test**
* Activate the Screen Reader in your system. That depends on the operating system you're using, in Gnome Linux distros it is under _Settings_ > _Universal access_.
* Go to any page with a chart.
* Navigate the page with the `Tab` key.
* Verify that you can focus chart elements and, when focused, the tooltip is displayed.
* Verify that the screen reader reads out the chart information.
* Check both, the line chart and the bar chart.

**Future work**
* The buttons to change between line chart and bar chart are not accessible (#422).
![image](https://user-images.githubusercontent.com/3616980/45628233-efbe8700-ba93-11e8-9430-19b74b81ac8e.png)
* For now I'm using the tooltip date for the screen reader, but with #373 I understand it will disappear. So a new param will need to be created (or renaming the `tooltipFormat` one).

Disclaimer: I'm not very experienced in accessibility, so feel free to do a harsh review and point me out any issue you encounter! :slightly_smiling_face: 