### PR TITLE
Make buttons to switch between bar and line chart accessible

### DIFF
--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { get, isEqual, partial } from 'lodash';
 import { Component, createRef } from '@wordpress/element';
-import { IconButton, SelectControl } from '@wordpress/components';
+import { IconButton, NavigableMenu, SelectControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { interpolateViridis as d3InterpolateViridis } from 'd3-scale-chromatic';
 import { formatDefaultLocale as d3FormatDefaultLocale } from 'd3-format';
@@ -219,7 +219,11 @@ class Chart extends Component {
 					<span className="woocommerce-chart__title">{ title }</span>
 					{ width > WIDE_BREAKPOINT && legendDirection === 'row' && legend }
 					{ this.renderIntervalSelector() }
-					<div className="woocommerce-chart__types" role="radiogroup">
+					<NavigableMenu
+						className="woocommerce-chart__types"
+						orientation="horizontal"
+						role="menubar"
+					>
 						<IconButton
 							className={ classNames( 'woocommerce-chart__type-button', {
 								'woocommerce-chart__type-button-selected': type === 'line',
@@ -227,7 +231,8 @@ class Chart extends Component {
 							icon={ <Gridicon icon="line-graph" /> }
 							title={ __( 'Line chart', 'wc-admin' ) }
 							aria-checked={ type === 'line' }
-							role="radio"
+							role="menuitemradio"
+							tabIndex={ type === 'line' ? 0 : -1 }
 							onClick={ partial( this.handleTypeToggle, 'line' ) }
 						/>
 						<IconButton
@@ -237,10 +242,11 @@ class Chart extends Component {
 							icon={ <Gridicon icon="stats-alt" /> }
 							title={ __( 'Bar chart', 'wc-admin' ) }
 							aria-checked={ type === 'bar' }
-							role="radio"
+							role="menuitemradio"
+							tabIndex={ type === 'bar' ? 0 : -1 }
 							onClick={ partial( this.handleTypeToggle, 'bar' ) }
 						/>
-					</div>
+					</NavigableMenu>
 				</div>
 				<div
 					className={ classNames(

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -219,12 +219,15 @@ class Chart extends Component {
 					<span className="woocommerce-chart__title">{ title }</span>
 					{ width > WIDE_BREAKPOINT && legendDirection === 'row' && legend }
 					{ this.renderIntervalSelector() }
-					<div className="woocommerce-chart__types">
+					<div className="woocommerce-chart__types" role="radiogroup">
 						<IconButton
 							className={ classNames( 'woocommerce-chart__type-button', {
 								'woocommerce-chart__type-button-selected': type === 'line',
 							} ) }
 							icon={ <Gridicon icon="line-graph" /> }
+							title={ __( 'Line chart', 'wc-admin' ) }
+							aria-checked={ type === 'line' }
+							role="radio"
 							onClick={ partial( this.handleTypeToggle, 'line' ) }
 						/>
 						<IconButton
@@ -232,6 +235,9 @@ class Chart extends Component {
 								'woocommerce-chart__type-button-selected': type === 'bar',
 							} ) }
 							icon={ <Gridicon icon="stats-alt" /> }
+							title={ __( 'Bar chart', 'wc-admin' ) }
+							aria-checked={ type === 'bar' }
+							role="radio"
 							onClick={ partial( this.handleTypeToggle, 'bar' ) }
 						/>
 					</div>


### PR DESCRIPTION
Related to #421.

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/45636179-54371180-baa7-11e8-96c9-fe3bc76e6eda.png)

**Steps to test**
* Activate the Screen Reader in your system. That depends on the operating system you're using, in Gnome Linux distros it is under _Settings_ > _Universal access_.
* Go to any page with a chart.
* Navigate the page with the `Tab` key.
* Verify that the screen reader reads out the name of the buttons and which one is selected.