### PR TITLE
Compare Filter: Wrap up compare card functionality

### DIFF
--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -56,7 +56,8 @@ export const filters = [
 			param: 'product',
 			getLabels: getProductLabelsById,
 			labels: {
-				placeholder: __( 'Search products', 'wc-admin' ),
+				helpText: __( 'Select at least two products to compare', 'wc-admin' ),
+				placeholder: __( 'Search for products to compare', 'wc-admin' ),
 				title: __( 'Compare Products', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
 			},
@@ -70,7 +71,8 @@ export const filters = [
 			param: 'product_cat',
 			getLabels: getCategoryLabelsById,
 			labels: {
-				placeholder: __( 'Search product categories', 'wc-admin' ),
+				helpText: __( 'Select at least two product categories to compare', 'wc-admin' ),
+				placeholder: __( 'Search for product categories to compare', 'wc-admin' ),
 				title: __( 'Compare Product Categories', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
 			},

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -56,6 +56,7 @@ export const filters = [
 			param: 'product',
 			getLabels: getProductLabelsById,
 			labels: {
+				placeholder: __( 'Search products', 'wc-admin' ),
 				title: __( 'Compare Products', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
 			},
@@ -69,6 +70,7 @@ export const filters = [
 			param: 'product_cat',
 			getLabels: getCategoryLabelsById,
 			labels: {
+				placeholder: __( 'Search product categories', 'wc-admin' ),
 				title: __( 'Compare Product Categories', 'wc-admin' ),
 				update: __( 'Compare', 'wc-admin' ),
 			},

--- a/client/components/filters/compare/button.js
+++ b/client/components/filters/compare/button.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Button, Tooltip } from '@wordpress/components';
+
+/**
+ * A button used when comparing items, if `count` is less than 2 a hoverable tooltip is added with `helpText`.
+ *
+ * @return { object } -
+ */
+const CompareButton = ( { count, children, helpText, onClick } ) =>
+	count < 2 ? (
+		<Tooltip text={ helpText }>
+			<span>
+				<Button isDefault disabled={ true }>
+					{ children }
+				</Button>
+			</span>
+		</Tooltip>
+	) : (
+		<Button isDefault onClick={ onClick }>
+			{ children }
+		</Button>
+	);
+
+CompareButton.propTypes = {
+	/**
+	 * The count of items selected.
+	 */
+	count: PropTypes.number.isRequired,
+	/**
+	 * The button content.
+	 */
+	children: PropTypes.node.isRequired,
+	/**
+	 * Text displayed when hovering over a disabled button.
+	 */
+	helpText: PropTypes.string.isRequired,
+	/**
+	 * The function called when the button is clicked.
+	 */
+	onClick: PropTypes.func.isRequired,
+};
+
+export default CompareButton;

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -76,7 +76,7 @@ class CompareFilter extends Component {
 					/>
 				</div>
 				<div className="woocommerce-filters__compare-footer">
-					<Button onClick={ this.updateQuery } isDefault>
+					<Button isDefault onClick={ this.updateQuery } disabled={ selected.length < 2 }>
 						{ labels.update }
 					</Button>
 				</div>

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { isEqual } from 'lodash';
@@ -11,7 +12,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Card from 'components/card';
-import { getIdsFromQuery, updateQueryString } from 'lib/nav-utils';
+import Link from 'components/link';
+import { getIdsFromQuery, getNewPath, updateQueryString } from 'lib/nav-utils';
 import Search from 'components/search';
 
 /**
@@ -24,6 +26,7 @@ class CompareFilter extends Component {
 			selected: [],
 		};
 
+		this.clearQuery = this.clearQuery.bind( this );
 		this.updateQuery = this.updateQuery.bind( this );
 		this.updateLabels = this.updateLabels.bind( this );
 
@@ -47,6 +50,11 @@ class CompareFilter extends Component {
 		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
 			getLabels( query[ param ] ).then( this.updateLabels );
 		}
+	}
+
+	clearQuery() {
+		const { param, path, query } = this.props;
+		return getNewPath( { [ param ]: '' }, path, query );
 	}
 
 	updateLabels( data ) {
@@ -80,6 +88,9 @@ class CompareFilter extends Component {
 					<Button isDefault onClick={ this.updateQuery } disabled={ selected.length < 2 }>
 						{ labels.update }
 					</Button>
+					<Link type="wc-admin" href={ this.clearQuery() }>
+						{ __( 'Clear all', 'wc-admin' ) }
+					</Link>
 				</div>
 			</Card>
 		);

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -70,6 +70,7 @@ class CompareFilter extends Component {
 					<Search
 						type={ type }
 						selected={ selected }
+						placeholder={ labels.placeholder }
 						onChange={ value => {
 							this.setState( { selected: value } );
 						} }
@@ -94,6 +95,10 @@ CompareFilter.propTypes = {
 	 * Object of localized labels.
 	 */
 	labels: PropTypes.shape( {
+		/**
+		 * Label for the search placeholder.
+		 */
+		placeholder: PropTypes.string,
 		/**
 		 * Label for the card title.
 		 */

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -87,7 +87,7 @@ class CompareFilter extends Component {
 				<div className="woocommerce-filters__compare-footer">
 					<CompareButton
 						count={ selected.length }
-						helpText={ __( 'Select at least 2 items to compare', 'wc-admin' ) }
+						helpText={ labels.helpText }
 						onClick={ this.updateQuery }
 					>
 						{ labels.update }

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
@@ -85,9 +85,19 @@ class CompareFilter extends Component {
 					/>
 				</div>
 				<div className="woocommerce-filters__compare-footer">
-					<Button isDefault onClick={ this.updateQuery } disabled={ selected.length < 2 }>
-						{ labels.update }
-					</Button>
+					{ selected.length < 2 ? (
+						<Tooltip text={ __( 'Select at least 2 items to compare', 'wc-admin' ) }>
+							<span>
+								<Button isDefault onClick={ this.updateQuery } disabled={ true }>
+									{ labels.update }
+								</Button>
+							</span>
+						</Tooltip>
+					) : (
+						<Button isDefault onClick={ this.updateQuery }>
+							{ labels.update }
+						</Button>
+					) }
 					<Link type="wc-admin" href={ this.clearQuery() }>
 						{ __( 'Clear all', 'wc-admin' ) }
 					</Link>

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Tooltip } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
@@ -12,6 +11,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompareButton from './button';
 import Link from 'components/link';
 import { getIdsFromQuery, getNewPath, updateQueryString } from 'lib/nav-utils';
 import Search from 'components/search';
@@ -85,19 +85,13 @@ class CompareFilter extends Component {
 					/>
 				</div>
 				<div className="woocommerce-filters__compare-footer">
-					{ selected.length < 2 ? (
-						<Tooltip text={ __( 'Select at least 2 items to compare', 'wc-admin' ) }>
-							<span>
-								<Button isDefault onClick={ this.updateQuery } disabled={ true }>
-									{ labels.update }
-								</Button>
-							</span>
-						</Tooltip>
-					) : (
-						<Button isDefault onClick={ this.updateQuery }>
-							{ labels.update }
-						</Button>
-					) }
+					<CompareButton
+						count={ selected.length }
+						helpText={ __( 'Select at least 2 items to compare', 'wc-admin' ) }
+						onClick={ this.updateQuery }
+					>
+						{ labels.update }
+					</CompareButton>
 					<Link type="wc-admin" href={ this.clearQuery() }>
 						{ __( 'Clear all', 'wc-admin' ) }
 					</Link>

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -54,7 +54,7 @@ class CompareFilter extends Component {
 
 	clearQuery() {
 		const { param, path, query } = this.props;
-		return getNewPath( { [ param ]: '' }, path, query );
+		return getNewPath( { [ param ]: undefined }, path, query );
 	}
 
 	updateLabels( data ) {

--- a/client/components/filters/style.scss
+++ b/client/components/filters/style.scss
@@ -61,4 +61,10 @@
 
 .woocommerce-filters__compare-footer {
 	padding: $gap;
+	display: flex;
+	align-items: center;
+
+	.components-button {
+		margin-right: $gap;
+	}
 }

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -5,6 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { findIndex, noop } from 'lodash';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
 /**
@@ -74,6 +75,7 @@ class Search extends Component {
 		const { value = '' } = this.state;
 		return (
 			<div className="woocommerce-search">
+				<Gridicon className="woocommerce-search__icon" icon="search" />
 				<Autocomplete completer={ autocompleter } onSelect={ this.selectResult }>
 					{ ( { listBoxId, activeId, onChange } ) => (
 						<input

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -70,7 +70,7 @@ class Search extends Component {
 
 	render() {
 		const autocompleter = this.getAutocompleter();
-		const { placeholder, selected } = this.props;
+		const { ariaLabelledby, placeholder, selected } = this.props;
 		const { value = '' } = this.state;
 		return (
 			<div className="woocommerce-search">
@@ -82,6 +82,7 @@ class Search extends Component {
 							placeholder={ placeholder }
 							className="woocommerce-search__input"
 							onChange={ this.updateSearch( onChange ) }
+							aria-labelledby={ ariaLabelledby }
 							aria-owns={ listBoxId }
 							aria-activedescendant={ activeId }
 						/>

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -70,7 +70,7 @@ class Search extends Component {
 
 	render() {
 		const autocompleter = this.getAutocompleter();
-		const { selected } = this.props;
+		const { placeholder, selected } = this.props;
 		const { value = '' } = this.state;
 		return (
 			<div className="woocommerce-search">
@@ -79,6 +79,7 @@ class Search extends Component {
 						<input
 							type="search"
 							value={ value }
+							placeholder={ placeholder }
 							className="woocommerce-search__input"
 							onChange={ this.updateSearch( onChange ) }
 							aria-owns={ listBoxId }
@@ -122,6 +123,10 @@ Search.propTypes = {
 	 * The object type to be used in searching.
 	 */
 	type: PropTypes.oneOf( [ 'products', 'product_cats', 'orders', 'customers' ] ).isRequired,
+	/**
+	 * A placeholder for the search input.
+	 */
+	placeholder: PropTypes.string,
 	/**
 	 * An array of objects describing selected values.
 	 */

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -3,9 +3,16 @@
 .woocommerce-search {
 	position: relative;
 
+	.woocommerce-search__icon {
+		position: absolute;
+		top: 10px;
+		left: 10px;
+		fill: $core-grey-light-900;
+	}
+
 	.woocommerce-search__input {
 		width: 100%;
-		padding: $gap-small;
+		padding: $gap-small $gap-small $gap-small 36px;
 		border: 1px solid $core-grey-light-700;
 	}
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -189,7 +189,7 @@ class TableCard extends Component {
 						<CompareButton
 							key="compare"
 							count={ selectedRows.length }
-							helpText={ __( 'Select at least 2 items to compare', 'wc-admin' ) }
+							helpText={ __( 'Select at least two items to compare', 'wc-admin' ) }
 							onClick={ this.onCompare }
 						>
 							{ __( 'Compare', 'wc-admin' ) }

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, IconButton, ToggleControl } from '@wordpress/components';
+import { Button, IconButton, ToggleControl, Tooltip } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { fill, find, findIndex, first, isEqual, noop, partial, uniq } from 'lodash';
@@ -179,21 +179,27 @@ class TableCard extends Component {
 			'has-compare': !! compareBy,
 		} );
 
+		const compareButton =
+			selectedRows.length < 2 ? (
+				<Tooltip text={ __( 'Select at least 2 items to compare', 'wc-admin' ) }>
+					<span>
+						<Button isDefault onClick={ this.onCompare } disabled={ true }>
+							{ __( 'Compare', 'wc-admin' ) }
+						</Button>
+					</span>
+				</Tooltip>
+			) : (
+				<Button isDefault onClick={ this.onCompare }>
+					{ __( 'Compare', 'wc-admin' ) }
+				</Button>
+			);
+
 		return (
 			<Card
 				className={ className }
 				title={ title }
 				action={ [
-					compareBy && (
-						<Button
-							key="compare"
-							isDefault
-							onClick={ this.onCompare }
-							disabled={ selectedRows.length < 2 }
-						>
-							{ __( 'Compare', 'wc-admin' ) }
-						</Button>
-					),
+					compareBy && compareButton,
 					compareBy && (
 						<div key="search" style={ { padding: '4px 12px', color: '#6c7781' } }>
 							Placeholder for search

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -3,10 +3,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, IconButton, ToggleControl, Tooltip } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { fill, find, findIndex, first, isEqual, noop, partial, uniq } from 'lodash';
+import { IconButton, ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 import Card from 'components/card';
+import CompareButton from 'components/filters/compare/button';
 import EllipsisMenu from 'components/ellipsis-menu';
 import { getIdsFromQuery } from 'lib/nav-utils';
 import MenuItem from 'components/ellipsis-menu/menu-item';
@@ -179,27 +180,21 @@ class TableCard extends Component {
 			'has-compare': !! compareBy,
 		} );
 
-		const compareButton =
-			selectedRows.length < 2 ? (
-				<Tooltip text={ __( 'Select at least 2 items to compare', 'wc-admin' ) }>
-					<span>
-						<Button isDefault onClick={ this.onCompare } disabled={ true }>
-							{ __( 'Compare', 'wc-admin' ) }
-						</Button>
-					</span>
-				</Tooltip>
-			) : (
-				<Button isDefault onClick={ this.onCompare }>
-					{ __( 'Compare', 'wc-admin' ) }
-				</Button>
-			);
-
 		return (
 			<Card
 				className={ className }
 				title={ title }
 				action={ [
-					compareBy && compareButton,
+					compareBy && (
+						<CompareButton
+							key="compare"
+							count={ selectedRows.length }
+							helpText={ __( 'Select at least 2 items to compare', 'wc-admin' ) }
+							onClick={ this.onCompare }
+						>
+							{ __( 'Compare', 'wc-admin' ) }
+						</CompareButton>
+					),
 					compareBy && (
 						<div key="search" style={ { padding: '4px 12px', color: '#6c7781' } }>
 							Placeholder for search

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -163,7 +163,7 @@ class TableCard extends Component {
 			title,
 			totalRows,
 		} = this.props;
-		const { showCols } = this.state;
+		const { selectedRows, showCols } = this.state;
 		const allHeaders = this.props.headers;
 		let headers = this.filterCols( this.props.headers );
 		let rows = this.filterCols( this.props.rows );
@@ -185,7 +185,12 @@ class TableCard extends Component {
 				title={ title }
 				action={ [
 					compareBy && (
-						<Button key="compare" onClick={ this.onCompare } isDefault>
+						<Button
+							key="compare"
+							isDefault
+							onClick={ this.onCompare }
+							disabled={ selectedRows.length < 2 }
+						>
 							{ __( 'Compare', 'wc-admin' ) }
 						</Button>
 					),


### PR DESCRIPTION
This PR fixes the last few tasks on #364:

- The compare button is disabled, with a popover on hover, if less than 2 items are selected - on both the compare filter card & the table header compare button.
- A placeholder has been added to the search component, and a placeholder label is passed through the filter config.
- A "Clear all" link has been added, to reset the compare filter.

<img width="375" alt="screen shot 2018-09-18 at 12 47 27 pm" src="https://user-images.githubusercontent.com/541093/45702930-040c8d80-bb41-11e8-9c07-ba16653678b9.png">

**To test**

- View the product report
- Click "Show", select "Product Comparison"
- See that Compare is disabled, hover & read the tooltip
- See that there is a placeholder in the search
- Compare multiple products either from the table rows or the search filter
- Clear selected products with the clear link