### PR TITLE
Advanced Filters: Update label config to provide more specific labeling to each filter

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -29,8 +29,12 @@ export const filters = [
 
 export const advancedFilterConfig = {
 	status: {
-		label: __( 'Order Status', 'wc-admin' ),
-		addLabel: __( 'Order Status', 'wc-admin' ),
+		labels: {
+			add: __( 'Order Status', 'wc-admin' ),
+			remove: __( 'Remove order status filter', 'wc-admin' ),
+			rule: __( 'Select an order status filter match', 'wc-admin' ),
+			title: __( 'Order Status', 'wc-admin' ),
+		},
 		rules: [
 			{ value: 'is', label: __( 'Is', 'wc-admin' ) },
 			{ value: 'is_not', label: __( 'Is Not', 'wc-admin' ) },
@@ -49,8 +53,13 @@ export const advancedFilterConfig = {
 		},
 	},
 	product_id: {
-		label: __( 'Product', 'wc-admin' ),
-		addLabel: __( 'Products', 'wc-admin' ),
+		labels: {
+			add: __( 'Products', 'wc-admin' ),
+			placeholder: __( 'Search products', 'wc-admin' ),
+			remove: __( 'Remove products filter', 'wc-admin' ),
+			rule: __( 'Select a product filter match', 'wc-admin' ),
+			title: __( 'Product', 'wc-admin' ),
+		},
 		rules: [
 			{ value: 'includes', label: __( 'Includes', 'wc-admin' ) },
 			{ value: 'excludes', label: __( 'Excludes', 'wc-admin' ) },
@@ -64,8 +73,13 @@ export const advancedFilterConfig = {
 		},
 	},
 	code: {
-		label: __( 'Coupon Code', 'wc-admin' ),
-		addLabel: __( 'Coupon Codes', 'wc-admin' ),
+		labels: {
+			add: __( 'Coupon Codes', 'wc-admin' ),
+			placeholder: __( 'Search coupons', 'wc-admin' ),
+			remove: __( 'Remove coupon filter', 'wc-admin' ),
+			rule: __( 'Select a coupon filter match', 'wc-admin' ),
+			title: __( 'Coupon Code', 'wc-admin' ),
+		},
 		rules: [
 			{ value: 'includes', label: __( 'Includes', 'wc-admin' ) },
 			{ value: 'excludes', label: __( 'Excludes', 'wc-admin' ) },
@@ -78,8 +92,12 @@ export const advancedFilterConfig = {
 		},
 	},
 	customer: {
-		label: __( 'Customer is', 'wc-admin' ),
-		addLabel: __( 'Customer Type', 'wc-admin' ),
+		labels: {
+			add: __( 'Customer Type', 'wc-admin' ),
+			remove: __( 'Remove customer filter', 'wc-admin' ),
+			rule: __( 'Select a customer filter match', 'wc-admin' ),
+			title: __( 'Customer is', 'wc-admin' ),
+		},
 		input: {
 			component: 'SelectControl',
 			options: [

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -143,25 +143,25 @@ class AdvancedFilters extends Component {
 				<ul className="woocommerce-filters-advanced__list" ref={ this.filterListRef }>
 					{ activeFilters.map( filter => {
 						const { key } = filter;
-						const filterConfig = config[ key ];
+						const { input, labels } = config[ key ];
 						return (
 							<li className="woocommerce-filters-advanced__list-item" key={ key }>
 								{ /*eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex*/ }
 								<fieldset tabIndex="0">
 									{ /*eslint-enable-next-line jsx-a11y/no-noninteractive-tabindex*/ }
-									<legend className="screen-reader-text">{ filterConfig.label }</legend>
+									<legend className="screen-reader-text">{ labels.title }</legend>
 									<div className="woocommerce-filters-advanced__fieldset">
-										{ 'SelectControl' === filterConfig.input.component && (
+										{ 'SelectControl' === input.component && (
 											<SelectFilter
 												filter={ filter }
-												config={ filterConfig }
+												config={ config[ key ] }
 												onFilterChange={ this.onFilterChange }
 											/>
 										) }
-										{ 'Search' === filterConfig.input.component && (
+										{ 'Search' === input.component && (
 											<SearchFilter
 												filter={ filter }
-												config={ filterConfig }
+												config={ config[ key ] }
 												onFilterChange={ this.onFilterChange }
 											/>
 										) }
@@ -169,7 +169,7 @@ class AdvancedFilters extends Component {
 								</fieldset>
 								<IconButton
 									className="woocommerce-filters-advanced__remove"
-									label={ sprintf( __( 'Remove %s filter', 'wc-admin' ), filterConfig.label ) }
+									label={ labels.remove }
 									onClick={ partial( this.removeFilter, key ) }
 									icon={ <Gridicon icon="cross-small" /> }
 								/>
@@ -197,7 +197,7 @@ class AdvancedFilters extends Component {
 									{ availableFilterKeys.map( key => (
 										<li key={ key }>
 											<Button onClick={ partial( this.addFilter, key, onClose ) }>
-												{ config[ key ].addLabel }
+												{ config[ key ].labels.add }
 											</Button>
 										</li>
 									) ) }
@@ -237,8 +237,12 @@ AdvancedFilters.propTypes = {
 	 */
 	config: PropTypes.objectOf(
 		PropTypes.shape( {
-			label: PropTypes.string,
-			addLabel: PropTypes.string,
+			labels: PropTypes.shape( {
+				add: PropTypes.string,
+				placeholder: PropTypes.string,
+				remove: PropTypes.string,
+				title: PropTypes.string,
+			} ),
 			rules: PropTypes.arrayOf( PropTypes.object ),
 			input: PropTypes.object,
 		} )

--- a/client/components/filters/advanced/search-filter.js
+++ b/client/components/filters/advanced/search-filter.js
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { partial } from 'lodash';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -43,26 +43,34 @@ class SearchFilter extends Component {
 	}
 
 	render() {
-		const { filter, config, onFilterChange } = this.props;
+		const { config, filter, instanceId, onFilterChange } = this.props;
 		const { selected } = this.state;
 		const { key, rule } = filter;
+		const { input, labels, rules } = config;
 		return (
 			<Fragment>
-				<div className="woocommerce-filters-advanced__fieldset-legend">{ config.label }</div>
+				<div
+					id={ `${ key }-${ instanceId }` }
+					className="woocommerce-filters-advanced__fieldset-legend"
+				>
+					{ labels.title }
+				</div>
 				{ rule && (
 					<SelectControl
 						className="woocommerce-filters-advanced__list-specifier"
-						options={ config.rules }
+						options={ rules }
 						value={ rule }
 						onChange={ partial( onFilterChange, key, 'rule' ) }
-						aria-label={ sprintf( __( 'Select a %s filter match', 'wc-admin' ), config.addLabel ) }
+						aria-label={ labels.rule }
 					/>
 				) }
 				<div className="woocommerce-filters-advanced__list-selector">
 					<Search
 						onChange={ this.onSearchChange }
-						type={ config.input.type }
+						type={ input.type }
+						placeholder={ labels.placeholder }
 						selected={ selected }
+						ariaLabelledby={ `${ key }-${ instanceId }` }
 					/>
 				</div>
 			</Fragment>
@@ -75,8 +83,11 @@ SearchFilter.propTypes = {
 	 * The configuration object for the single filter to be rendered.
 	 */
 	config: PropTypes.shape( {
-		label: PropTypes.string,
-		addLabel: PropTypes.string,
+		labels: PropTypes.shape( {
+			placeholder: PropTypes.string,
+			rule: PropTypes.string,
+			title: PropTypes.string,
+		} ),
 		rules: PropTypes.arrayOf( PropTypes.object ),
 		input: PropTypes.object,
 	} ).isRequired,
@@ -94,4 +105,4 @@ SearchFilter.propTypes = {
 	onFilterChange: PropTypes.func.isRequired,
 };
 
-export default SearchFilter;
+export default withInstanceId( SearchFilter );

--- a/client/components/filters/advanced/select-filter.js
+++ b/client/components/filters/advanced/select-filter.js
@@ -2,33 +2,39 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { partial } from 'lodash';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
-const SelectFilter = ( { filter, config, onFilterChange } ) => {
+const SelectFilter = ( { config, filter, instanceId, onFilterChange } ) => {
 	const { key, rule, value } = filter;
+	const { input, labels, rules } = config;
 	return (
 		<Fragment>
-			<div className="woocommerce-filters-advanced__fieldset-legend">{ config.label }</div>
+			<div
+				id={ `${ key }-${ instanceId }` }
+				className="woocommerce-filters-advanced__fieldset-legend"
+			>
+				{ labels.title }
+			</div>
 			{ rule && (
 				<SelectControl
 					className="woocommerce-filters-advanced__list-specifier"
-					options={ config.rules }
+					options={ rules }
 					value={ rule }
 					onChange={ partial( onFilterChange, key, 'rule' ) }
-					aria-label={ sprintf( __( 'Select a %s filter match', 'wc-admin' ), config.addLabel ) }
+					aria-label={ labels.rule }
 				/>
 			) }
 			<div className="woocommerce-filters-advanced__list-selector">
 				<SelectControl
 					className="woocommerce-filters-advanced__list-select"
-					options={ config.input.options }
+					options={ input.options }
 					value={ value }
 					onChange={ partial( onFilterChange, filter.key, 'value' ) }
-					aria-label={ sprintf( __( 'Select %s', 'wc-admin' ), config.label ) }
+					aria-labelledby={ `${ key }-${ instanceId }` }
 				/>
 			</div>
 		</Fragment>
@@ -40,8 +46,10 @@ SelectFilter.propTypes = {
 	 * The configuration object for the single filter to be rendered.
 	 */
 	config: PropTypes.shape( {
-		label: PropTypes.string,
-		addLabel: PropTypes.string,
+		labels: PropTypes.shape( {
+			rule: PropTypes.string,
+			title: PropTypes.string,
+		} ),
 		rules: PropTypes.arrayOf( PropTypes.object ),
 		input: PropTypes.object,
 	} ).isRequired,
@@ -59,4 +67,4 @@ SelectFilter.propTypes = {
 	onFilterChange: PropTypes.func.isRequired,
 };
 
-export default SelectFilter;
+export default withInstanceId( SelectFilter );


### PR DESCRIPTION
This PR builds on #431 to provide the placeholder label to SearchFilter. While doing this, I decided to refactor the way labels are handled in `advancedFilterConfig` to provide more labels to each filter (and avoid piecing together translations). Now we have an object `labels`, instead of top-level `label`/`addLabel`.

- `add`: used in the "Add filter" dropdown (was `addLabel`)
- `placeholder`: used as the placeholder for Search (doesn't apply to Select)
- `remove`: used on the X next to each filter row
- `rule`: used as a label for the "rules" dropdown (includes, is, etc)
- `title`: used as the row label, also added to the filter dropdown by an aria-labelledby attribute (was `label`)

**To test**

- View the orders report
- Click Show > Advanced Filters
- Ensure all filters display correctly