### PR TITLE
Minor padding tweaks to ellipsis menu items

### DIFF
--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -23,7 +23,7 @@
 
 	.woocommerce-ellipsis-menu__title,
 	.woocommerce-ellipsis-menu__item {
-		padding: 12px;
+		padding: 10px 12px 4px;
 	}
 
 	.woocommerce-ellipsis-menu__item {


### PR DESCRIPTION
The reduces the padding around ellipsis menu items, the overall height for each row is now 40px: 

**before:**
<img width="689" alt="screen shot 2018-09-18 at 10 57 03 am" src="https://user-images.githubusercontent.com/4500952/45706678-b9374980-bb31-11e8-9a3a-55199188ce01.png">

**After:**
<img width="509" alt="screen shot 2018-09-18 at 10 49 39 am" src="https://user-images.githubusercontent.com/4500952/45706721-d3712780-bb31-11e8-89ab-6757be9a0cb1.png">
