### PR TITLE
Tracks: Record page views on route changes.

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -43,7 +43,7 @@ class Layout extends Component {
 		}
 
 		// Remove leading slash, and camel case remaining pathname
-		let path = pathname.substring( 1 ).replace( /\//, '_' );
+		let path = pathname.substring( 1 ).replace( /\//g, '_' );
 
 		// When pathname is `/` we are on the dashboard
 		if ( path.length === 0 ) {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -6,6 +6,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { Router, Route, Switch } from 'react-router-dom';
 import { Slot } from 'react-slot-fill';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,8 +16,43 @@ import Header from 'layout/header';
 import { Controller, getPages } from './controller';
 import history from 'lib/history';
 import Notices from './notices';
+import { recordPageView } from 'lib/tracks';
 
 class Layout extends Component {
+	componentDidMount() {
+		this.recordPageViewTrack();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const previousPath = get( prevProps, 'location.pathname' );
+		const currentPath = get( this.props, 'location.pathname' );
+
+		if ( ! previousPath || ! currentPath ) {
+			return;
+		}
+
+		if ( previousPath !== currentPath ) {
+			this.recordPageViewTrack();
+		}
+	}
+
+	recordPageViewTrack() {
+		const pathname = get( this.props, 'location.pathname' );
+		if ( ! pathname ) {
+			return;
+		}
+
+		// Remove leading slash, and camel case remaining pathname
+		let path = pathname.substring( 1 ).replace( /\//, '_' );
+
+		// When pathname is `/` we are on the dashboard
+		if ( path.length === 0 ) {
+			path = 'dashboard';
+		}
+
+		recordPageView( path );
+	}
+
 	render() {
 		const { isEmbeded, ...restProps } = this.props;
 		return (


### PR DESCRIPTION
For #8 

This implements usage of `recordPageView` to tracks when routes are first mounted/changed within `wc-admin`. I initially had this logic as a HOC, but realized that page view tracking might only be needed at the router level... an HOC for general tracks recording might be of use, but that can be rolled if/when the need arises.

![dashboard woo test woocommerce 2018-09-18 16-28-51](https://user-images.githubusercontent.com/22080/45722166-fb777f80-bb5f-11e8-94eb-ec9e363d770a.png)

__To Test__
- Enable tracking on your site by updating via `update_option( 'woocommerce_allow_tracking', 'yes' );`
- With your JS console open to the network tab, open up the dashboard
- search "All" for t.gif, verify it looks like it does above
- navigate to the revenue report
- verify that t.gif was requested again, but this time with a `path=analytics_revenue`
- change the date range using the date picker, verify that no t.gif request is made.

__Extra Credit__
- Disable the wc tracker `update_option( 'woocommerce_allow_tracking', 'no' );`
- Refresh the revenue report page and verify no request to `t.gif` was made