### PR TITLE
Change default date format for chart tooltips

### DIFF
--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -51,6 +51,6 @@ Name | Type | Default | Description
 `dateParser` | `string` | `%Y-%m-%dT%H:%M:%S` | Format to parse datetimes in the data
 `type`* | `string` | `line` | Chart type of either `line` or `bar`
 `title` | `string` | none | Chart title
-`tooltipFormat` | `string` | `%Y-%m-%d` | Title and format of the tooltip title
+`tooltipFormat` | `string` | `%B %d, %Y` | Title and format of the tooltip title
 `xFormat` | `string` | `%Y-%m-%d` | d3TimeFormat of the x-axis values
 `yFormat` | `string` | `.3s` | d3Format of the y-axis values

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -254,7 +254,7 @@ D3Chart.defaultProps = {
 		top: 20,
 	},
 	layout: 'standard',
-	tooltipFormat: '%Y-%m-%d',
+	tooltipFormat: '%B %d, %Y',
 	type: 'line',
 	width: 600,
 	xFormat: '%Y-%m-%d',

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -332,7 +332,7 @@ Chart.propTypes = {
 Chart.defaultProps = {
 	data: [],
 	dateParser: '%Y-%m-%dT%H:%M:%S',
-	tooltipFormat: '%Y-%m-%d',
+	tooltipFormat: '%B %d, %Y',
 	xFormat: '%d',
 	x2Format: '%b %Y',
 	yFormat: '$.3s',


### PR DESCRIPTION
Fixes the section _Comparison Graph_ of #373.

This PR changes the date format for the comparison graph in the _Dashboard_ page and makes that date format the default.

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/3616980/45815404-d0646b80-bcd8-11e8-9bf8-95218d652bed.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45815353-aad76200-bcd8-11e8-87f0-13e8f290f87c.png)


**Steps to test**
- Go to the _Dashboard_ page.
- Verify the tooltip title date has a human readable format.