### PR TITLE
Increase contrast of the tooltip title color

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -96,7 +96,7 @@
 			width: 100%;
 			text-transform: uppercase;
 			font-size: 11px;
-			color: $core-grey-dark-100;
+			color: $core-grey-dark-300;
 			opacity: 0.6;
 			margin-top: 0;
 		}


### PR DESCRIPTION
Small PR that fixes this comment from @ryelle: https://github.com/woocommerce/wc-admin/issues/373#issuecomment-419566199

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/3616980/45815404-d0646b80-bcd8-11e8-9bf8-95218d652bed.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45815876-47e6ca80-bcda-11e8-86a9-6aabc3040d18.png)

**Steps to test**
- Go to a page with a chart.
- Verify the tooltip title has the new color.