### PR TITLE
Remove opacity property from chart tooltip title styles

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -97,7 +97,6 @@
 			text-transform: uppercase;
 			font-size: 11px;
 			color: $core-grey-dark-300;
-			opacity: 0.6;
 			margin-top: 0;
 		}
 


### PR DESCRIPTION
Fix this comment from @ryelle (https://github.com/woocommerce/wc-admin/pull/460#discussion_r219195204).

Contrast is 4.57, now.

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/3616980/45869159-057bc700-bd88-11e8-8018-b62efda398f5.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45868967-6c4cb080-bd87-11e8-817c-f41ee8e39ddc.png)

**Steps to test**
- Go to a page with a chart.
- Verify the tooltip title has the new color.