### PR TITLE
Transpose and update format of chart tooltip dates

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -316,11 +316,11 @@ export class RevenueReport extends Component {
 			return {
 				date: formatDate( 'Y-m-d\\TH:i:s', interval.date_start ),
 				[ primaryKey ]: {
-					label: formatDate( 'F j, Y', interval.date_start ),
+					label: formatDate( formats.pointLabelFormat, interval.date_start ),
 					value: interval.subtotals[ selectedChart.key ] || 0,
 				},
 				[ secondaryKey ]: {
-					label: formatDate( 'F j, Y', secondaryDate ),
+					label: formatDate( formats.pointLabelFormat, secondaryDate ),
 					value: ( secondaryInterval && secondaryInterval.subtotals[ selectedChart.key ] ) || 0,
 				},
 			};

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -316,11 +316,11 @@ export class RevenueReport extends Component {
 			return {
 				date: formatDate( 'Y-m-d\\TH:i:s', interval.date_start ),
 				[ primaryKey ]: {
-					label: formatDate( formats.pointLabelFormat, interval.date_start ),
+					labelDate: interval.date_start,
 					value: interval.subtotals[ selectedChart.key ] || 0,
 				},
 				[ secondaryKey ]: {
-					label: formatDate( formats.pointLabelFormat, secondaryDate ),
+					labelDate: secondaryDate,
 					value: ( secondaryInterval && secondaryInterval.subtotals[ selectedChart.key ] ) || 0,
 				},
 			};
@@ -332,6 +332,7 @@ export class RevenueReport extends Component {
 				title={ selectedChart.label }
 				interval={ currentInterval }
 				allowedIntervals={ allowedIntervals }
+				pointLabelFormat={ formats.pointLabelFormat }
 				tooltipTitle={ selectedChart.label }
 				xFormat={ formats.xFormat }
 				x2Format={ formats.x2Format }

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -316,11 +316,11 @@ export class RevenueReport extends Component {
 			return {
 				date: formatDate( 'Y-m-d\\TH:i:s', interval.date_start ),
 				[ primaryKey ]: {
-					label: formatDate( 'd F, Y', secondaryDate ),
+					label: formatDate( 'd F, Y', interval.date_start ),
 					value: interval.subtotals[ selectedChart.key ] || 0,
 				},
 				[ secondaryKey ]: {
-					label: formatDate( 'd F, Y', interval.date_start ),
+					label: formatDate( 'd F, Y', secondaryDate ),
 					value: ( secondaryInterval && secondaryInterval.subtotals[ selectedChart.key ] ) || 0,
 				},
 			};

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -316,11 +316,11 @@ export class RevenueReport extends Component {
 			return {
 				date: formatDate( 'Y-m-d\\TH:i:s', interval.date_start ),
 				[ primaryKey ]: {
-					label: formatDate( 'd F, Y', interval.date_start ),
+					label: formatDate( 'F j, Y', interval.date_start ),
 					value: interval.subtotals[ selectedChart.key ] || 0,
 				},
 				[ secondaryKey ]: {
-					label: formatDate( 'd F, Y', secondaryDate ),
+					label: formatDate( 'F j, Y', secondaryDate ),
 					value: ( secondaryInterval && secondaryInterval.subtotals[ selectedChart.key ] ) || 0,
 				},
 			};

--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -22,8 +22,8 @@ This component accepts timeseries `data` prop in the following format (with date
 [
 	{
 		date: '%Y-%m-%d', // string in `dateParser` format (see below)
-		category1: { label: 'label', value: value }, // string (optional), number
-		category2: { label: 'label', value: value }, // string (optional), number
+		category1: { labelDate: date, value: value }, // string (optional), number
+		category2: { labelDate: date, value: value }, // string (optional), number
 		...
 	},
 	...
@@ -34,7 +34,7 @@ For example:
 [
 	{
 		date: '2018-06-25',
-		category1: { label: 'Tooltip label', value: 1234.56 },
+		category1: { labelDate: '2018-09-09 00:00:00', value: 1234.56 },
 		category2: { value: 9876 },
 		...
 	},
@@ -50,6 +50,7 @@ Name | Type | Default | Description
 `data`* | `array` | none | An array of data as specified above
 `dateParser` | `string` | `%Y-%m-%dT%H:%M:%S` | Format to parse datetimes in the data
 `type`* | `string` | `line` | Chart type of either `line` or `bar`
+`pointLabelFormat` | `string` | `` | Date format of the point labels (might be used in tooltips and ARIA properties)
 `title` | `string` | none | Chart title
 `tooltipFormat` | `string` | `%B %d, %Y` | Title and format of the tooltip title date if `tooltipTitle` is missing
 `tooltipTitle` | `string` | `` | Title and format of the tooltip title

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -101,6 +101,7 @@ class D3Chart extends Component {
 			layout,
 			margin,
 			orderedKeys,
+			pointLabelFormat,
 			tooltipFormat,
 			tooltipTitle,
 			type,
@@ -132,6 +133,7 @@ class D3Chart extends Component {
 			lineData,
 			margin,
 			orderedKeys: newOrderedKeys,
+			pointLabelFormat,
 			parseDate,
 			scale,
 			tooltipFormat: d3TimeFormat( tooltipFormat ),
@@ -206,6 +208,10 @@ D3Chart.propTypes = {
 	 * to the left or 'compact' has the legend below
 	 */
 	layout: PropTypes.oneOf( [ 'standard', 'comparison', 'compact' ] ),
+	/**
+	 * Date format of the point labels (might be used in tooltips and ARIA properties).
+	 */
+	pointLabelFormat: PropTypes.string,
 	/**
 	 * Margins for axis and chart padding.
 	 */

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -188,6 +188,7 @@ class Chart extends Component {
 		const {
 			dateParser,
 			layout,
+			pointLabelFormat,
 			title,
 			tooltipFormat,
 			tooltipTitle,
@@ -263,6 +264,7 @@ class Chart extends Component {
 						height={ 300 }
 						margin={ margin }
 						orderedKeys={ orderedKeys }
+						pointLabelFormat={ pointLabelFormat }
 						tooltipFormat={ tooltipFormat }
 						tooltipTitle={ tooltipTitle }
 						type={ type }
@@ -288,6 +290,10 @@ Chart.propTypes = {
 	 * Format to parse dates into d3 time format
 	 */
 	dateParser: PropTypes.string.isRequired,
+	/**
+	 * Date format of the point labels (might be used in tooltips and ARIA properties).
+	 */
+	pointLabelFormat: PropTypes.string,
 	/**
 	 * A datetime formatting string to format the date displayed as the title of the toolip
 	 * if `tooltipTitle` is missing, passed to d3TimeFormat.

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -15,6 +15,7 @@ import {
 } from 'd3-scale';
 import { event as d3Event, mouse as d3Mouse, select as d3Select } from 'd3-selection';
 import { line as d3Line } from 'd3-shape';
+import { format as formatDate } from '@wordpress/date';
 /**
  * Internal dependencies
  */
@@ -390,6 +391,9 @@ export const drawAxis = ( node, params ) => {
 		.remove();
 };
 
+const getTooltipRowLabel = ( d, row, params ) =>
+	d[ row.key ].labelDate ? formatDate( params.pointLabelFormat, d[ row.key ].labelDate ) : row.key;
+
 const showTooltip = ( node, params, d, position ) => {
 	const chartCoords = node.node().getBoundingClientRect();
 	let [ xPosition, yPosition ] = position ? position : d3Mouse( node.node() );
@@ -400,7 +404,7 @@ const showTooltip = ( node, params, d, position ) => {
 				<li class="key-row">
 					<div class="key-container">
 						<span class="key-color" style="background-color:${ getColor( row.key, params ) }"></span>
-						<span class="key-key">${ d[ row.key ].label ? d[ row.key ].label : row.key }</span>
+						<span class="key-key">${ getTooltipRowLabel( d, row, params ) }</span>
 					</div>
 					<span class="key-value">${ formatCurrency( d[ row.key ].value ) }</span>
 				</li>

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -401,6 +401,7 @@ export function getIntervalForQuery( query ) {
  * @return {String} Current interval.
  */
 export function getDateFormatsForInterval( interval ) {
+	let pointLabelFormat = 'F j, Y';
 	let tooltipFormat = '%B %d %Y';
 	let xFormat = '%Y-%m-%d';
 	let x2Format = '%b %y';
@@ -408,6 +409,7 @@ export function getDateFormatsForInterval( interval ) {
 
 	switch ( interval ) {
 		case 'hour':
+			pointLabelFormat = 'h A';
 			tooltipFormat = '%I %p';
 			xFormat = '%I %p';
 			tableFormat = 'h A';
@@ -421,12 +423,14 @@ export function getDateFormatsForInterval( interval ) {
 			break;
 		case 'quarter':
 		case 'month':
+			pointLabelFormat = 'F Y';
 			tooltipFormat = '%B %Y';
 			xFormat = '%b %y';
 			x2Format = '';
 			tableFormat = 'M Y';
 			break;
 		case 'year':
+			pointLabelFormat = 'Y';
 			tooltipFormat = '%Y';
 			xFormat = '%Y';
 			tableFormat = 'Y';
@@ -434,6 +438,7 @@ export function getDateFormatsForInterval( interval ) {
 	}
 
 	return {
+		pointLabelFormat,
 		tooltipFormat,
 		xFormat,
 		x2Format,


### PR DESCRIPTION
Fixes #465.

**Screenshots**
![image](https://user-images.githubusercontent.com/3616980/45871828-aff6e880-bd8e-11e8-9caa-3f13f61aaeb0.png)

**Steps to test**
- Go to any page with a chart.
- Hover the points and verify the tooltip displays the dates in the format 'September 4, 2018' and they are in the correct order (they were transposed until now).