### PR TITLE
Make tooltip position be relative to the hovered elements instead of the mouse

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -208,6 +208,7 @@
 
 	.tooltip {
 		position: absolute;
+		pointer-events: none;
 	}
 }
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -79,7 +79,7 @@
 	.tooltip {
 		border: 1px solid $core-grey-light-700;
 		position: absolute;
-		display: none;
+		display: flex;
 		min-width: 324px;
 		height: auto;
 		background-color: $white;
@@ -89,6 +89,8 @@
 		flex-direction: column;
 		flex-wrap: nowrap;
 		justify-content: flex-start;
+		pointer-events: none;
+		visibility: hidden;
 
 		h4 {
 			text-align: left;
@@ -208,7 +210,6 @@
 
 	.tooltip {
 		position: absolute;
-		pointer-events: none;
 	}
 }
 

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -418,6 +418,7 @@ const showTooltip = ( params, d, position ) => {
 	params.tooltip
 		.style( 'left', position.x + 'px' )
 		.style( 'top', position.y + 'px' )
+		.style( 'visibility', 'visible' )
 		.style( 'display', 'flex' ).html( `
 			<div>
 				<h4>${ tooltipTitle }</h4>
@@ -439,7 +440,7 @@ const handleMouseOutBarChart = ( parentNode, params ) => {
 	d3Select( parentNode )
 		.select( '.barfocus' )
 		.attr( 'opacity', '0' );
-	params.tooltip.style( 'display', 'none' );
+	params.tooltip.style( 'visibility', 'hidden' );
 };
 
 const handleMouseOverLineChart = ( date, parentNode, node, data, params, position ) => {
@@ -453,17 +454,18 @@ const handleMouseOutLineChart = ( parentNode, params ) => {
 	d3Select( parentNode )
 		.select( '.focus-grid' )
 		.attr( 'opacity', '0' );
-	params.tooltip.style( 'display', 'none' );
+	params.tooltip.style( 'visibility', 'hidden' );
 };
 
 const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 	const elementCoords = element.getBoundingClientRect();
 	const chartCoords = chart.getBoundingClientRect();
-	const tooltipMargin = 24;
+	const tooltipBox = d3Select( '.tooltip' ).node().getBoundingClientRect();
 	const tooltipSize = {
-		height: 204,
-		width: 324,
+		height: tooltipBox.height || 204,
+		width: tooltipBox.width || 324,
 	};
+	const tooltipMargin = 24;
 	let xPosition =
 		elementCoords.x + elementCoords.width * elementWidthRatio - chartCoords.x + tooltipMargin;
 	let yPosition = elementCoords.y - chartCoords.y + tooltipMargin;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -468,15 +468,15 @@ const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 		elementCoords.x + elementCoords.width * elementWidthRatio - chartCoords.x + tooltipMargin;
 	let yPosition = elementCoords.y - chartCoords.y + tooltipMargin;
 	if ( xPosition + tooltipSize.width + tooltipMargin > chartCoords.width ) {
-		xPosition =
+		xPosition = Math.max( 0,
 			elementCoords.x +
 			elementCoords.width * ( 1 - elementWidthRatio ) -
 			tooltipSize.width -
 			tooltipMargin -
-			chartCoords.x;
+			chartCoords.x );
 	}
 	if ( yPosition + tooltipSize.height + tooltipMargin > chartCoords.height ) {
-		yPosition = elementCoords.y - tooltipSize.height - tooltipMargin - chartCoords.x;
+		yPosition = Math.max( 0, elementCoords.y - tooltipSize.height - tooltipMargin - chartCoords.y );
 	}
 
 	return { x: xPosition, y: yPosition };

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -459,7 +459,7 @@ const handleMouseOutLineChart = ( parentNode, params ) => {
 const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 	const elementCoords = element.getBoundingClientRect();
 	const chartCoords = chart.getBoundingClientRect();
-	const tooltipMargin = 30;
+	const tooltipMargin = 24;
 	const tooltipSize = {
 		height: 204,
 		width: 324,

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -418,8 +418,7 @@ const showTooltip = ( params, d, position ) => {
 	params.tooltip
 		.style( 'left', position.x + 'px' )
 		.style( 'top', position.y + 'px' )
-		.style( 'visibility', 'visible' )
-		.style( 'display', 'flex' ).html( `
+		.style( 'visibility', 'visible' ).html( `
 			<div>
 				<h4>${ tooltipTitle }</h4>
 				<ul>
@@ -460,22 +459,23 @@ const handleMouseOutLineChart = ( parentNode, params ) => {
 const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 	const elementCoords = element.getBoundingClientRect();
 	const chartCoords = chart.getBoundingClientRect();
-	const tooltipBox = d3Select( '.tooltip' ).node().getBoundingClientRect();
-	const tooltipSize = {
-		height: tooltipBox.height || 204,
-		width: tooltipBox.width || 324,
-	};
+	const tooltipSize = d3Select( '.tooltip' )
+		.node()
+		.getBoundingClientRect();
 	const tooltipMargin = 24;
+
 	let xPosition =
-		elementCoords.x + elementCoords.width * elementWidthRatio - chartCoords.x + tooltipMargin;
-	let yPosition = elementCoords.y - chartCoords.y + tooltipMargin;
+		elementCoords.x + elementCoords.width * elementWidthRatio + tooltipMargin - chartCoords.x;
+	let yPosition = elementCoords.y + tooltipMargin - chartCoords.y;
 	if ( xPosition + tooltipSize.width + tooltipMargin > chartCoords.width ) {
-		xPosition = Math.max( 0,
+		xPosition = Math.max(
+			0,
 			elementCoords.x +
-			elementCoords.width * ( 1 - elementWidthRatio ) -
-			tooltipSize.width -
-			tooltipMargin -
-			chartCoords.x );
+				elementCoords.width * ( 1 - elementWidthRatio ) -
+				tooltipSize.width -
+				tooltipMargin -
+				chartCoords.x
+		);
 	}
 	if ( yPosition + tooltipSize.height + tooltipMargin > chartCoords.height ) {
 		yPosition = Math.max( 0, elementCoords.y - tooltipSize.height - tooltipMargin - chartCoords.y );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -628,7 +628,8 @@ export const drawBars = ( node, data, params ) => {
 			return d.visible ? opacity : 0;
 		} )
 		.on( 'focus', ( d, i, nodes ) => {
-			const position = calculateTooltipPosition( d3Event.target, node.node() );
+			const targetNode = d.value > 0 ? d3Event.target : d3Event.target.parentNode;
+			const position = calculateTooltipPosition( targetNode, node.node() );
 			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'blur', ( d, i, nodes ) => handleMouseOutBarChart( nodes[ i ].parentNode, params ) );


### PR DESCRIPTION
Fixes the section _Overflow and wrapping_ of #373.

With this PR, the tooltip is positioned based on its size and the hovered/focused element instead of the mouse position.

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/3616980/46020959-d777e900-c0df-11e8-8aed-4be956ee8ed5.png)


After:
![image](https://user-images.githubusercontent.com/3616980/46020943-cd55ea80-c0df-11e8-806b-83b78c98f1f8.png)


**Steps to test**
- Go to any page with a chart.
- Try hovering/focusing the elements of the chart and verify the tooltip never overflows the chart.
- Test both, line and bar charts.