### PR TITLE
Fix: chart legend was not visible at 1340px width

### DIFF
--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -197,8 +197,8 @@ class Chart extends Component {
 			yFormat,
 			interval,
 		} = this.props;
-		const legendDirection = layout === 'standard' && width > WIDE_BREAKPOINT ? 'row' : 'column';
-		const chartDirection = layout === 'comparison' && width > WIDE_BREAKPOINT ? 'row' : 'column';
+		const legendDirection = layout === 'standard' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
+		const chartDirection = layout === 'comparison' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
 		const legend = (
 			<Legend
 				className={ 'woocommerce-chart__legend' }
@@ -219,7 +219,7 @@ class Chart extends Component {
 			<div className="woocommerce-chart" ref={ this.chartRef }>
 				<div className="woocommerce-chart__header">
 					<span className="woocommerce-chart__title">{ title }</span>
-					{ width > WIDE_BREAKPOINT && legendDirection === 'row' && legend }
+					{ width >= WIDE_BREAKPOINT && legendDirection === 'row' && legend }
 					{ this.renderIntervalSelector() }
 					<NavigableMenu
 						className="woocommerce-chart__types"
@@ -256,7 +256,7 @@ class Chart extends Component {
 						`woocommerce-chart__body-${ chartDirection }`
 					) }
 				>
-					{ width > WIDE_BREAKPOINT && legendDirection === 'column' && legend }
+					{ width >= WIDE_BREAKPOINT && legendDirection === 'column' && legend }
 					<D3Chart
 						colorScheme={ d3InterpolateViridis }
 						data={ visibleData }


### PR DESCRIPTION
While working in #416, I noticed that when resizing the window to 1340px wide, the chart legend was not displayed. This small PR should fix that.

**Screenshots**
_(notice the top bar of the screenshots are the browser devtools, I included them to display the screen width)_
Before:
![image](https://user-images.githubusercontent.com/3616980/45960561-ca45f600-c01c-11e8-83ac-5fea04183902.png)

After:
![image](https://user-images.githubusercontent.com/3616980/45960835-64a63980-c01d-11e8-8561-8562ca0dd351.png)



**Steps to test**
- Go to the _Revenue_ page under _Analytics_.
- Resize the window to 1340px wide (your browser devtools will help introducing the exact number).
- Verify that the chart legend is displayed.