### PR TITLE
Fix activity panel tabs misaligned in Chrome and Safari

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -38,6 +38,7 @@
 	width: 100%;
 	display: flex;
 	height: 60px;
+	justify-content: flex-end;
 
 	@include breakpoint( '>1100px' ) {
 		height: 80px;
@@ -64,6 +65,7 @@
 	}
 
 	.woocommerce-layout__activity-panel-tab {
+		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		border: none;
@@ -71,6 +73,8 @@
 		cursor: pointer;
 		background-color: $white;
 		color: $core-grey-dark-500;
+		max-width: min-content;
+		min-width: 80px;
 		width: 100%;
 		height: 60px;
 		border-bottom: 3px solid $white;


### PR DESCRIPTION
This PR fixes two issues:
- One reported by @justinshreve (https://github.com/woocommerce/wc-admin/pull/355#issue-213344922) that made the activity panel tabs to be misaligned in Chrome. The issue was introduced by https://github.com/woocommerce/wc-admin/commit/f82523a1ca95301c18a9acb8dc2c2198a266f723 when fixing it for IE11.
- Another issue in Safari, which was not rendering the activity panel tabs correctly either.

All inconsistencies between browsers should be fixed now (tested with Firefox, Chrome, Safari and IE11).

**Screenshots**
Before (Chrome):
![image](https://user-images.githubusercontent.com/3616980/46024909-06925880-c0e8-11e8-85c1-da02baf22649.png)

After (Chrome):
![image](https://user-images.githubusercontent.com/3616980/46024464-24ab8900-c0e7-11e8-8dd2-2ac739c0e5aa.png)

Before (Safari):
![image](https://user-images.githubusercontent.com/3616980/46024869-f4181f00-c0e7-11e8-8c80-c1b74ec85859.png)

After (Safari):
![image](https://user-images.githubusercontent.com/3616980/46024833-dea2f500-c0e7-11e8-8c3a-403f0db9f047.png)



**Steps to test**
- Open any page that renders the activity panel tabs.
- Verify the activity panels are rendered correctly in Chrome and Safari.