### PR TITLE
Make tabular data independent of chart interval

### DIFF
--- a/client/analytics/report/revenue/test/index.js
+++ b/client/analytics/report/revenue/test/index.js
@@ -29,13 +29,17 @@ describe( 'RevenueReport', () => {
 
 		const primaryData = {
 			data: mockData,
+			totalResults: 7,
+			totalPages: 1,
 		};
 
 		const revenueReport = shallow(
 			<RevenueReport
 				params={ { report: 'revenue' } }
-				path="/analytics/revenue" query={ {} }
+				path="/analytics/revenue"
+				query={ {} }
 				primaryData={ primaryData }
+				tableData={ primaryData }
 				secondaryData={ primaryData }
 			/>
 		);
@@ -44,7 +48,7 @@ describe( 'RevenueReport', () => {
 		tableCard.props().onClickDownload();
 
 		expect( downloadCSVFile ).toHaveBeenCalledWith(
-			'revenue-' + moment().format( 'YYYY-MM-DD' ) + '-orderby-date_start-order-asc.csv',
+			'revenue-' + moment().format( 'YYYY-MM-DD' ) + '.csv',
 			mockCSV
 		);
 	} );

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -16,7 +16,7 @@ import Table from './table';
  */
 class TablePlaceholder extends Component {
 	render() {
-		const { caption, headers, numberOfRows } = this.props;
+		const { caption, headers, numberOfRows, query } = this.props;
 		const rows = range( numberOfRows ).map( () =>
 			headers.map( () => ( { display: <span className="is-placeholder" /> } ) )
 		);
@@ -29,12 +29,17 @@ class TablePlaceholder extends Component {
 				headers={ headers }
 				rowHeader={ false }
 				rows={ rows }
+				query={ query }
 			/>
 		);
 	}
 }
 
 TablePlaceholder.propTypes = {
+	/**
+	 *  An object of the query parameters passed to the page, ex `{ page: 2, per_page: 5 }`.
+	 */
+	query: PropTypes.object,
 	/**
 	 * A label for the content in this table.
 	 */

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -427,13 +427,11 @@ export function getDateFormatsForInterval( interval ) {
 			tooltipFormat = '%B %Y';
 			xFormat = '%b %y';
 			x2Format = '';
-			tableFormat = 'M Y';
 			break;
 		case 'year':
 			pointLabelFormat = 'Y';
 			tooltipFormat = '%Y';
 			xFormat = '%Y';
-			tableFormat = 'Y';
 			break;
 	}
 

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -322,6 +322,8 @@ export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
 
 /**
  * Returns the allowed selectable intervals for a specific query.
+ * TODO Add support for hours. `` if ( differenceInDays <= 1 ) { allowed = [ 'hour' ]; }
+ * Today/yesterday/default: allowed = [ 'hour' ];
  *
  * @param  {Object} query Current query
  * @return {Array} Array containing allowed intervals.
@@ -341,17 +343,11 @@ export function getAllowedIntervalsForQuery( query ) {
 			allowed = [ 'day', 'week' ];
 		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
 			allowed = [ 'day' ];
-		} else if ( differenceInDays <= 1 ) {
-			allowed = [ 'hour' ];
 		} else {
 			allowed = [ 'day' ];
 		}
 	} else {
 		switch ( query.period ) {
-			case 'today':
-			case 'yesterday':
-				allowed = [ 'hour' ];
-				break;
 			case 'week':
 			case 'last_week':
 				allowed = [ 'day' ];

--- a/client/store/reports/stats/actions.js
+++ b/client/store/reports/stats/actions.js
@@ -1,11 +1,13 @@
 /** @format */
 
 export default {
-	setReportStats( endpoint, report, query ) {
+	setReportStats( endpoint, report, query, totalResults, totalPages ) {
 		return {
 			type: 'SET_REPORT_STATS',
 			endpoint,
 			report,
+			totalResults,
+			totalPages,
 			query: query || {},
 		};
 	},

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { isReportDataEmpty, getAllReportData } from '../utils';
+import { isReportDataEmpty, getReportChartData } from '../utils';
 
 describe( 'isReportDataEmpty()', () => {
 	it( 'returns false if report is valid', () => {
@@ -34,8 +34,7 @@ describe( 'isReportDataEmpty()', () => {
 	} );
 } );
 
-// TODO Use more general selectors from https://github.com/woocommerce/wc-admin/pull/307
-describe( 'getAllReportData()', () => {
+describe( 'getReportChartData()', () => {
 	const select = jest.fn().mockReturnValue( {} );
 	const response = {
 		isEmpty: false,
@@ -77,7 +76,7 @@ describe( 'getAllReportData()', () => {
 		setIsReportStatsRequesting( () => {
 			return true;
 		} );
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, isRequesting: true } );
 	} );
 
@@ -88,7 +87,7 @@ describe( 'getAllReportData()', () => {
 		setIsReportStatsError( () => {
 			return true;
 		} );
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, isError: true } );
 	} );
 
@@ -123,7 +122,7 @@ describe( 'getAllReportData()', () => {
 			};
 		} );
 
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, data: { ...data } } );
 	} );
 
@@ -169,7 +168,7 @@ describe( 'getAllReportData()', () => {
 			};
 		} );
 
-		const actualResponse = getAllReportData( 'revenue', {}, select );
+		const actualResponse = getReportChartData( 'revenue', {}, select );
 		const expectedResponse = {
 			...response,
 			data: {
@@ -192,7 +191,7 @@ describe( 'getAllReportData()', () => {
 			return false;
 		} );
 
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, isRequesting: true } );
 	} );
 
@@ -206,7 +205,7 @@ describe( 'getAllReportData()', () => {
 			}
 			return false;
 		} );
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, isError: true } );
 	} );
 
@@ -224,7 +223,7 @@ describe( 'getAllReportData()', () => {
 			};
 		} );
 
-		const result = getAllReportData( 'revenue', {}, select );
+		const result = getReportChartData( 'revenue', {}, select );
 		expect( result ).toEqual( { ...response, isEmpty: true } );
 	} );
 } );

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -34,14 +34,13 @@ export function isReportDataEmpty( report ) {
 
 /**
  * Returns all of the data needed to render a chart with summary numbers on a report page.
- * TODO Use more general selectors from https://github.com/woocommerce/wc-admin/pull/307
  *
  * @param  {String} endpoint Report  API Endpoint
  * @param  {Object} query  API arguments
  * @param {object} select Instance of @wordpress/select
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
-export function getAllReportData( endpoint, query, select ) {
+export function getReportChartData( endpoint, query, select ) {
 	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
 
 	const response = {


### PR DESCRIPTION
This PR makes the table data return data per day, instead of by the selected chart interval. Fixes #385. Fixes #384.

This does not support 'hours' yet. Once #482 is fixed, support for hours in the table will be added.

<img width="672" alt="screen shot 2018-09-26 at 10 06 33 am" src="https://user-images.githubusercontent.com/689165/46085441-0dff4380-c174-11e8-9b76-6ff6dcf178c9.png">

To Test:

* Run `npm test`
* Make a request with lots of days (week to date, month to date, year to date)
* Select an interval other than day
* Verify the table displays days
* Test sorting/pagination