### PR TITLE
Components – Search: Pass through aria label props

### DIFF
--- a/client/components/search/example.md
+++ b/client/components/search/example.md
@@ -1,14 +1,14 @@
 ```jsx
 import { Search } from '@woocommerce/components';
 
-class MySearch extends Component {
-	updateLocalValue( results ) {
-		// Do something with results.
-	}
-	render() {
-		return (
-			<Search type="products" onChange={ this.updateLocalValue } />
-		);
-	}
-}
+const MySearch = withState( {
+	selected: [],
+} )( ( { selected, setState } ) => (
+	<Search
+		type="products"
+		placeholder="Search for a product"
+		selected={ selected }
+		onChange={ items => setState( { selected: items } ) }
+	/>
+) );
 ```

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -73,8 +73,12 @@ class Search extends Component {
 
 	render() {
 		const autocompleter = this.getAutocompleter();
-		const { ariaLabelledby, placeholder, selected } = this.props;
+		const { placeholder, selected } = this.props;
 		const { value = '' } = this.state;
+		const aria = {
+			'aria-labelledby': this.props[ 'aria-labelledby' ],
+			'aria-label': this.props[ 'aria-label' ],
+		};
 		return (
 			<div className="woocommerce-search">
 				<Gridicon className="woocommerce-search__icon" icon="search" />
@@ -86,9 +90,9 @@ class Search extends Component {
 							placeholder={ placeholder }
 							className="woocommerce-search__input"
 							onChange={ this.updateSearch( onChange ) }
-							aria-labelledby={ ariaLabelledby }
 							aria-owns={ listBoxId }
 							aria-activedescendant={ activeId }
+							{ ...aria }
 						/>
 					) }
 				</Autocomplete>


### PR DESCRIPTION
As noted https://github.com/woocommerce/wc-admin/pull/457#discussion_r220603117, `Search` only supports `ariaLabelledBy` as a custom prop, not `aria-label`. Passing that prop is ignored currently. This PR updates the Search component to accept `aria-label` and `aria-labelledby`. These are passed through to the search input itself.

I've also updated the Search example in devdocs to be a working example.

**To test**

- View `/wp-admin/admin.php?page=wc-admin#/devdocs/search`
- Inspect the input
- No `aria-label*` attributes are there
- Edit `components/search/example.md`, add an `aria-label`
- Reload, inspect the input - there should be your aria-label
- Edit `components/search/example.md`, add an `aria-labelledby`
- Reload, inspect the input - there should be your aria-labelledby
