### PR TITLE
Update chart interval select alignment

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -202,7 +202,12 @@
 	justify-content: center;
 	margin: 0 0 0 auto;
 	min-height: 50px;
-	padding: 0 $gap;
+	padding: 8px $gap 0 $gap;
+
+	@include breakpoint( '<782px' ) {
+		padding: 0 $gap;
+		margin-top: -8px;
+	}
 
 	.rtl & {
 		margin: 0 auto 0 0;


### PR DESCRIPTION
Slight tweaks to the alignment of the chart interval select: vertical alignment on larger viewports, reduces margin to tighten things up on small viewports.

**Before:**

<img width="1350" alt="screen shot 2018-09-26 at 3 18 02 pm" src="https://user-images.githubusercontent.com/4500952/46112513-b971bd80-c19f-11e8-989c-e77971cf2c64.png">

<img width="504" alt="screen shot 2018-09-26 at 3 18 26 pm" src="https://user-images.githubusercontent.com/4500952/46112527-c1c9f880-c19f-11e8-8ff3-18dc17062532.png">

**After:**

<img width="1329" alt="screen shot 2018-09-26 at 3 13 00 pm" src="https://user-images.githubusercontent.com/4500952/46112544-ce4e5100-c19f-11e8-96f9-5b2f7bddd4df.png">

<img width="501" alt="screen shot 2018-09-26 at 3 12 40 pm" src="https://user-images.githubusercontent.com/4500952/46112553-defec700-c19f-11e8-9422-72e5f956eb41.png">

