### PR TITLE
Orders table

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -39,7 +39,6 @@ class OrdersReport extends Component {
 					filters={ filters }
 					advancedConfig={ advancedFilterConfig }
 				/>
-				<p>Below is a temporary example</p>
 				<OrdersReportTable isRequesting={ isRequesting } orders={ orders } query={ query } />
 			</Fragment>
 		);

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -2,18 +2,21 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
+import { format as formatDate } from '@wordpress/date';
 import { withSelect, withDispatch } from '@wordpress/data';
-import moment from 'moment';
-import { partial } from 'lodash';
+import { map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { Card, ReportFilters } from '@woocommerce/components';
+import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { filters, advancedFilterConfig } from './config';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
+import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
+import { getAdminLink, onQueryChange } from 'lib/nav-utils';
 
 class OrdersReport extends Component {
 	constructor( props ) {
@@ -30,8 +33,228 @@ class OrdersReport extends Component {
 		requestUpdateOrder( updatedOrder );
 	}
 
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Date', 'wc-admin' ),
+				key: 'dateCreated',
+				required: true,
+				defaultSort: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Order #', 'wc-admin' ),
+				key: 'id',
+				required: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Status', 'wc-admin' ),
+				key: 'status',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Customer', 'wc-admin' ),
+				key: 'customerId',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Product(s)', 'wc-admin' ),
+				key: 'products',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Items Sold', 'wc-admin' ),
+				key: 'numberOfProducts',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Coupon(s)', 'wc-admin' ),
+				key: 'coupons',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'N. Revenue', 'wc-admin' ),
+				key: 'total',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+		];
+	}
+
+	formatRowData( row, statusNames ) {
+		const { date_created, id, status, customer_id, line_items, coupon_lines, total } = row;
+
+		return {
+			dateCreated: date_created,
+			orderLink: getAdminLink( 'post.php?post=' + id + '&action=edit' ),
+			id,
+			statusName: statusNames[ status ],
+			status,
+			customerId: customer_id,
+			productsDisplay: line_items.map( ( item, i ) => (
+				<Fragment>
+					{ i === 0 ? null : ', ' }
+					<a
+						className={ line_items.length > 1 ? 'inline' : null }
+						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
+					>
+						{ item.name }
+					</a>
+				</Fragment>
+			) ),
+			products: line_items
+				.map( item => item.name )
+				.join()
+				.toLowerCase(),
+			numberOfProducts: line_items.length,
+			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
+				<Fragment>
+					{ i === 0 ? null : ', ' }
+					<a
+						className={ coupon_lines.length > 1 ? 'inline' : null }
+						href={ getAdminLink( 'post.php?post=' + coupon.meta_data.value.id + '&action=edit' ) }
+					>
+						{ coupon.code }
+					</a>
+				</Fragment>
+			) ),
+			coupons: coupon_lines
+				.map( item => item.code )
+				.join()
+				.toLowerCase(),
+			total: getCurrencyFormatDecimal( total ),
+		};
+	}
+
+	formatTableData( data ) {
+		const statusNames = {
+			failed: __( 'Failed', 'wc-admin' ),
+			processing: __( 'Processing', 'wc-admin' ),
+			'on-hold': __( 'On hold', 'wc-admin' ),
+			completed: __( 'Completed', 'wc-admin' ),
+		};
+
+		return map( data, row => this.formatRowData( row, statusNames ) );
+	}
+
+	getRowsContent( tableData ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const formats = getDateFormatsForInterval( currentInterval );
+
+		return map( tableData, row => {
+			const {
+				dateCreated,
+				orderLink,
+				id,
+				statusName,
+				status,
+				customerId,
+				productsDisplay,
+				products,
+				numberOfProducts,
+				couponsDisplay,
+				coupons,
+				total,
+			} = row;
+
+			return [
+				{
+					display: formatDate( formats.tableFormat, dateCreated ),
+					value: dateCreated,
+				},
+				{
+					display: <a href={ orderLink }>{ id }</a>,
+					value: id,
+				},
+				{
+					display: statusName,
+					value: status,
+				},
+				{
+					display: customerId,
+					value: customerId,
+				},
+				{
+					display: productsDisplay,
+					value: products,
+				},
+				{
+					display: numberOfProducts,
+					value: numberOfProducts,
+				},
+				{
+					display: couponsDisplay,
+					value: coupons,
+				},
+				{
+					display: formatCurrency( total ),
+					value: getCurrencyFormatDecimal( total ),
+				},
+			];
+		} );
+	}
+
+	renderPlaceholderTable() {
+		const headers = this.getHeadersContent();
+
+		return (
+			<Card
+				title={ __( 'Revenue', 'wc-admin' ) }
+				className="woocommerce-analytics__table-placeholder"
+			>
+				<TablePlaceholder caption={ __( 'Orders last week', 'wc-admin' ) } headers={ headers } />
+			</Card>
+		);
+	}
+
+	renderTable() {
+		const { orders, query } = this.props;
+
+		const page = parseInt( query.page ) || 1;
+		const rowsPerPage = parseInt( query.per_page ) || 25;
+		const rows = this.getRowsContent(
+			orderBy(
+				this.formatTableData( orders ),
+				query.orderby || 'dateCreated',
+				query.order || 'asc'
+			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
+		);
+
+		const headers = this.getHeadersContent();
+
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date_start',
+			order: query.order || 'asc',
+		};
+
+		return (
+			<TableCard
+				title={ __( 'Orders last week', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ Object.keys( orders ).length }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				onClickDownload={ () => null /*this.onDownload( headers, rows, tableQuery )*/ }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ null }
+			/>
+		);
+	}
+
 	render() {
-		const { orders, orderIds, query, path } = this.props;
+		const { isRequesting, query, path } = this.props;
+
 		return (
 			<Fragment>
 				<ReportFilters
@@ -41,38 +264,7 @@ class OrdersReport extends Component {
 					advancedConfig={ advancedFilterConfig }
 				/>
 				<p>Below is a temporary example</p>
-				<Card title="Orders">
-					<table style={ { width: '100%' } }>
-						<thead>
-							<tr style={ { textAlign: 'left' } }>
-								<th>Id</th>
-								<th>Date</th>
-								<th>Total</th>
-								<th>Status</th>
-								<th>Action</th>
-							</tr>
-						</thead>
-						<tbody>
-							{ orderIds &&
-								orderIds.map( id => {
-									const order = orders[ id ];
-									return (
-										<tr key={ id }>
-											<td>{ id }</td>
-											<td>{ moment( order.date_created ).format( 'LL' ) }</td>
-											<td>{ order.total }</td>
-											<td>{ order.status }</td>
-											<td>
-												<Button isPrimary onClick={ partial( this.toggleStatus, order ) }>
-													Toggle Status
-												</Button>
-											</td>
-										</tr>
-									);
-								} ) }
-						</tbody>
-					</table>
-				</Card>
+				{ isRequesting ? this.renderPlaceholderTable() : this.renderTable() }
 			</Fragment>
 		);
 	}
@@ -80,11 +272,10 @@ class OrdersReport extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getOrders, getOrderIds } = select( 'wc-admin' );
-		return {
-			orders: getOrders(),
-			orderIds: getOrderIds(),
-		};
+		const { getOrders } = select( 'wc-admin' );
+		const orders = getOrders();
+		const isRequesting = select( 'core/data' ).isResolving( 'wc-admin', 'getOrders' );
+		return { isRequesting, orders };
 	} ),
 	withDispatch( dispatch => {
 		return {

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -2,21 +2,16 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { format as formatDate } from '@wordpress/date';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { ReportFilters } from '@woocommerce/components';
 import { filters, advancedFilterConfig } from './config';
-import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
-import { getAdminLink, onQueryChange } from 'lib/nav-utils';
+import OrdersReportTable from './table';
 
 class OrdersReport extends Component {
 	constructor( props ) {
@@ -33,227 +28,8 @@ class OrdersReport extends Component {
 		requestUpdateOrder( updatedOrder );
 	}
 
-	getHeadersContent() {
-		return [
-			{
-				label: __( 'Date', 'wc-admin' ),
-				key: 'dateCreated',
-				required: true,
-				defaultSort: true,
-				isSortable: true,
-			},
-			{
-				label: __( 'Order #', 'wc-admin' ),
-				key: 'id',
-				required: true,
-				isSortable: true,
-			},
-			{
-				label: __( 'Status', 'wc-admin' ),
-				key: 'status',
-				required: false,
-				isSortable: true,
-			},
-			{
-				label: __( 'Customer', 'wc-admin' ),
-				key: 'customerId',
-				required: false,
-				isSortable: true,
-			},
-			{
-				label: __( 'Product(s)', 'wc-admin' ),
-				key: 'products',
-				required: false,
-				isSortable: true,
-			},
-			{
-				label: __( 'Items Sold', 'wc-admin' ),
-				key: 'numberOfProducts',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Coupon(s)', 'wc-admin' ),
-				key: 'coupons',
-				required: false,
-				isSortable: true,
-			},
-			{
-				label: __( 'N. Revenue', 'wc-admin' ),
-				key: 'total',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-		];
-	}
-
-	formatRowData( row, statusNames ) {
-		const { date_created, id, status, customer_id, line_items, coupon_lines, total } = row;
-
-		return {
-			dateCreated: date_created,
-			orderLink: getAdminLink( 'post.php?post=' + id + '&action=edit' ),
-			id,
-			statusName: statusNames[ status ],
-			status,
-			customerId: customer_id,
-			productsDisplay: line_items.map( ( item, i ) => (
-				<Fragment>
-					{ i === 0 ? null : ', ' }
-					<a
-						className={ line_items.length > 1 ? 'inline' : null }
-						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
-					>
-						{ item.name }
-					</a>
-				</Fragment>
-			) ),
-			products: line_items
-				.map( item => item.name )
-				.join()
-				.toLowerCase(),
-			numberOfProducts: line_items.length,
-			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
-				<Fragment>
-					{ i === 0 ? null : ', ' }
-					<a
-						className={ coupon_lines.length > 1 ? 'inline' : null }
-						href={ getAdminLink( 'post.php?post=' + coupon.meta_data.value.id + '&action=edit' ) }
-					>
-						{ coupon.code }
-					</a>
-				</Fragment>
-			) ),
-			coupons: coupon_lines
-				.map( item => item.code )
-				.join()
-				.toLowerCase(),
-			total: getCurrencyFormatDecimal( total ),
-		};
-	}
-
-	formatTableData( data ) {
-		const statusNames = {
-			failed: __( 'Failed', 'wc-admin' ),
-			processing: __( 'Processing', 'wc-admin' ),
-			'on-hold': __( 'On hold', 'wc-admin' ),
-			completed: __( 'Completed', 'wc-admin' ),
-		};
-
-		return map( data, row => this.formatRowData( row, statusNames ) );
-	}
-
-	getRowsContent( tableData ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
-
-		return map( tableData, row => {
-			const {
-				dateCreated,
-				orderLink,
-				id,
-				statusName,
-				status,
-				customerId,
-				productsDisplay,
-				products,
-				numberOfProducts,
-				couponsDisplay,
-				coupons,
-				total,
-			} = row;
-
-			return [
-				{
-					display: formatDate( formats.tableFormat, dateCreated ),
-					value: dateCreated,
-				},
-				{
-					display: <a href={ orderLink }>{ id }</a>,
-					value: id,
-				},
-				{
-					display: statusName,
-					value: status,
-				},
-				{
-					display: customerId,
-					value: customerId,
-				},
-				{
-					display: productsDisplay,
-					value: products,
-				},
-				{
-					display: numberOfProducts,
-					value: numberOfProducts,
-				},
-				{
-					display: couponsDisplay,
-					value: coupons,
-				},
-				{
-					display: formatCurrency( total ),
-					value: getCurrencyFormatDecimal( total ),
-				},
-			];
-		} );
-	}
-
-	renderPlaceholderTable() {
-		const headers = this.getHeadersContent();
-
-		return (
-			<Card
-				title={ __( 'Revenue', 'wc-admin' ) }
-				className="woocommerce-analytics__table-placeholder"
-			>
-				<TablePlaceholder caption={ __( 'Orders last week', 'wc-admin' ) } headers={ headers } />
-			</Card>
-		);
-	}
-
-	renderTable() {
-		const { orders, query } = this.props;
-
-		const page = parseInt( query.page ) || 1;
-		const rowsPerPage = parseInt( query.per_page ) || 25;
-		const rows = this.getRowsContent(
-			orderBy(
-				this.formatTableData( orders ),
-				query.orderby || 'dateCreated',
-				query.order || 'asc'
-			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
-		);
-
-		const headers = this.getHeadersContent();
-
-		const tableQuery = {
-			...query,
-			orderby: query.orderby || 'date_start',
-			order: query.order || 'asc',
-		};
-
-		return (
-			<TableCard
-				title={ __( 'Orders last week', 'wc-admin' ) }
-				rows={ rows }
-				totalRows={ Object.keys( orders ).length }
-				rowsPerPage={ rowsPerPage }
-				headers={ headers }
-				onClickDownload={ () => null /*this.onDownload( headers, rows, tableQuery )*/ }
-				onQueryChange={ onQueryChange }
-				query={ tableQuery }
-				summary={ null }
-			/>
-		);
-	}
-
 	render() {
-		const { isRequesting, query, path } = this.props;
+		const { isRequesting, query, orders, path } = this.props;
 
 		return (
 			<Fragment>
@@ -264,7 +40,7 @@ class OrdersReport extends Component {
 					advancedConfig={ advancedFilterConfig }
 				/>
 				<p>Below is a temporary example</p>
-				{ isRequesting ? this.renderPlaceholderTable() : this.renderTable() }
+				<OrdersReportTable isRequesting={ isRequesting } orders={ orders } query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -29,7 +29,7 @@ class OrdersReport extends Component {
 	}
 
 	render() {
-		const { isRequesting, query, orders, path } = this.props;
+		const { isRequesting, orders, path, query } = this.props;
 
 		return (
 			<Fragment>

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -4,7 +4,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,16 +16,6 @@ import OrdersReportTable from './table';
 class OrdersReport extends Component {
 	constructor( props ) {
 		super( props );
-
-		this.toggleStatus = this.toggleStatus.bind( this );
-	}
-
-	toggleStatus( order ) {
-		const { requestUpdateOrder } = this.props;
-		const updatedOrder = { ...order };
-		const status = updatedOrder.status === 'completed' ? 'processing' : 'completed';
-		updatedOrder.status = status;
-		requestUpdateOrder( updatedOrder );
 	}
 
 	render() {
@@ -51,12 +41,5 @@ export default compose(
 		const orders = getOrders();
 		const isRequesting = select( 'core/data' ).isResolving( 'wc-admin', 'getOrders' );
 		return { isRequesting, orders };
-	} ),
-	withDispatch( dispatch => {
-		return {
-			requestUpdateOrder: function( updatedOrder ) {
-				dispatch( 'wc-admin' ).requestUpdateOrder( updatedOrder );
-			},
-		};
 	} )
 )( OrdersReport );

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -65,7 +65,7 @@ export default class OrdersReportTable extends Component {
 				label: __( 'Product(s)', 'wc-admin' ),
 				key: 'products',
 				required: false,
-				isSortable: true,
+				isSortable: false,
 			},
 			{
 				label: __( 'Items Sold', 'wc-admin' ),
@@ -78,7 +78,7 @@ export default class OrdersReportTable extends Component {
 				label: __( 'Coupon(s)', 'wc-admin' ),
 				key: 'coupons',
 				required: false,
-				isSortable: true,
+				isSortable: false,
 			},
 			{
 				label: __( 'N. Revenue', 'wc-admin' ),
@@ -110,40 +110,9 @@ export default class OrdersReportTable extends Component {
 				id,
 				status,
 				customer_id,
-				productsDisplay: line_items.map( ( item, i ) => (
-					<Fragment>
-						{ i === 0 ? null : ', ' }
-						<a
-							className={ line_items.length > 1 ? 'is-inline' : null }
-							href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
-						>
-							{ item.name }
-						</a>
-					</Fragment>
-				) ),
-				products: line_items
-					.map( item => item.name )
-					.join()
-					.toLowerCase(),
+				line_items,
 				items_sold: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
-				couponsDisplay: coupon_lines.map( ( coupon, i ) => (
-					<Fragment>
-						{ i === 0 ? null : ', ' }
-						<a
-							className={ coupon_lines.length > 1 ? 'is-inline' : null }
-							href={ getAdminLink(
-								// @TODO it should link to the coupons report
-								'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
-							) }
-						>
-							{ coupon.code }
-						</a>
-					</Fragment>
-				) ),
-				coupons: coupon_lines
-					.map( item => item.code )
-					.join()
-					.toLowerCase(),
+				coupon_lines,
 				net_revenue: getCurrencyFormatDecimal(
 					total - total_tax - shipping_total - discount_total
 				),
@@ -168,11 +137,9 @@ export default class OrdersReportTable extends Component {
 				id,
 				status,
 				customer_id,
-				productsDisplay,
-				products,
+				line_items,
 				items_sold,
-				couponsDisplay,
-				coupons,
+				coupon_lines,
 				net_revenue,
 			} = row;
 
@@ -196,16 +163,39 @@ export default class OrdersReportTable extends Component {
 					value: customer_id,
 				},
 				{
-					display: productsDisplay,
-					value: products,
+					display: line_items.map( ( item, i ) => (
+						<Fragment>
+							{ i === 0 ? null : ', ' }
+							<a
+								className={ line_items.length > 1 ? 'is-inline' : null }
+								href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
+							>
+								{ item.name }
+							</a>
+						</Fragment>
+					) ),
+					value: false,
 				},
 				{
 					display: items_sold,
 					value: items_sold,
 				},
 				{
-					display: couponsDisplay,
-					value: coupons,
+					display: coupon_lines.map( ( coupon, i ) => (
+						<Fragment>
+							{ i === 0 ? null : ', ' }
+							<a
+								className={ coupon_lines.length > 1 ? 'is-inline' : null }
+								href={ getAdminLink(
+									// @TODO it should link to the coupons report
+									'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
+								) }
+							>
+								{ coupon.code }
+							</a>
+						</Fragment>
+					) ),
+					value: false,
 				},
 				{
 					display: formatCurrency( net_revenue ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -167,6 +167,8 @@ export default class OrdersReportTable extends Component {
 					value: status,
 				},
 				{
+					// @TODO This should display customer type (new/returning) once it's
+					// implemented in the API
 					display: customerId,
 					value: customerId,
 				},

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -10,7 +10,7 @@ import { map, orderBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Card, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Card, OrderStatus, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
@@ -83,7 +83,7 @@ export default class OrdersReportTable extends Component {
 			{
 				label: __( 'N. Revenue', 'wc-admin' ),
 				key: 'net_revenue',
-				required: false,
+				required: true,
 				isSortable: true,
 				isNumeric: true,
 			},
@@ -126,12 +126,6 @@ export default class OrdersReportTable extends Component {
 		const { query } = this.props;
 		const currentInterval = getIntervalForQuery( query );
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
-		const statusNames = {
-			failed: __( 'Failed', 'wc-admin' ),
-			processing: __( 'Processing', 'wc-admin' ),
-			'on-hold': __( 'On hold', 'wc-admin' ),
-			completed: __( 'Completed', 'wc-admin' ),
-		};
 
 		return map( tableData, row => {
 			const {
@@ -156,7 +150,7 @@ export default class OrdersReportTable extends Component {
 					value: id,
 				},
 				{
-					display: statusNames[ status ],
+					display: <OrderStatus order={ { status } } />,
 					value: status,
 				},
 				{
@@ -205,7 +199,7 @@ export default class OrdersReportTable extends Component {
 	renderList( items ) {
 		// @TODO Use ViewMore component if there are many items.
 		return items.map( ( item, i ) => (
-			<Fragment>
+			<Fragment key={ i }>
 				{ i > 0 ? ', ' : null }
 				<a className={ items.length > 1 ? 'is-inline' : null } href={ item.href }>
 					{ item.label }
@@ -219,7 +213,7 @@ export default class OrdersReportTable extends Component {
 
 		return (
 			<Card
-				title={ __( 'Revenue', 'wc-admin' ) }
+				title={ __( 'Orders', 'wc-admin' ) }
 				className="woocommerce-analytics__table-placeholder"
 			>
 				<TablePlaceholder caption={ __( 'Orders last week', 'wc-admin' ) } headers={ headers } />
@@ -266,8 +260,6 @@ export default class OrdersReportTable extends Component {
 	render() {
 		const { isRequesting } = this.props;
 
-		return (
-			<Fragment>{ isRequesting ? this.renderPlaceholderTable() : this.renderTable() }</Fragment>
-		);
+		return isRequesting ? this.renderPlaceholderTable() : this.renderTable();
 	}
 }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
-import { map, orderBy } from 'lodash';
+import { get, map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -107,7 +107,7 @@ export default class OrdersReportTable extends Component {
 					{ i === 0 ? null : ', ' }
 					<a
 						className={ coupon_lines.length > 1 ? 'inline' : null }
-						href={ getAdminLink( 'post.php?post=' + coupon.meta_data.value.id + '&action=edit' ) }
+						href={ getAdminLink( 'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit' ) }
 					>
 						{ coupon.code }
 					</a>

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -103,7 +103,7 @@ export default class OrdersReportTable extends Component {
 				<Fragment>
 					{ i === 0 ? null : ', ' }
 					<a
-						className={ line_items.length > 1 ? 'inline' : null }
+						className={ line_items.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
 					>
 						{ item.name }
@@ -119,7 +119,7 @@ export default class OrdersReportTable extends Component {
 				<Fragment>
 					{ i === 0 ? null : ', ' }
 					<a
-						className={ coupon_lines.length > 1 ? 'inline' : null }
+						className={ coupon_lines.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink(
 							'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit'
 						) }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -11,6 +11,7 @@ import { map, orderBy } from 'lodash';
  * Internal dependencies
  */
 import { Card, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
@@ -18,6 +19,17 @@ import { getAdminLink, onQueryChange } from 'lib/nav-utils';
 export default class OrdersReportTable extends Component {
 	constructor( props ) {
 		super( props );
+	}
+
+	onDownload( headers, rows, query ) {
+		// @TODO The current implementation only downloads the contents displayed in the table.
+		// Another solution is required when the data set is larger (see #311).
+		return () => {
+			downloadCSVFile(
+				generateCSVFileName( 'orders', query ),
+				generateCSVDataFromTable( headers, rows )
+			);
+		};
 	}
 
 	getHeadersContent() {
@@ -249,7 +261,7 @@ export default class OrdersReportTable extends Component {
 				totalRows={ Object.keys( orders ).length }
 				rowsPerPage={ rowsPerPage }
 				headers={ headers }
-				onClickDownload={ () => null /*this.onDownload( headers, rows, tableQuery )*/ }
+				onClickDownload={ this.onDownload( headers, rows, tableQuery ) }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }
 				summary={ null }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -1,0 +1,249 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { format as formatDate } from '@wordpress/date';
+import { map, orderBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Card, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
+import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
+import { getAdminLink, onQueryChange } from 'lib/nav-utils';
+
+export default class OrdersReportTable extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Date', 'wc-admin' ),
+				key: 'dateCreated',
+				required: true,
+				defaultSort: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Order #', 'wc-admin' ),
+				key: 'id',
+				required: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Status', 'wc-admin' ),
+				key: 'status',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Customer', 'wc-admin' ),
+				key: 'customerId',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Product(s)', 'wc-admin' ),
+				key: 'products',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'Items Sold', 'wc-admin' ),
+				key: 'numberOfProducts',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Coupon(s)', 'wc-admin' ),
+				key: 'coupons',
+				required: false,
+				isSortable: true,
+			},
+			{
+				label: __( 'N. Revenue', 'wc-admin' ),
+				key: 'total',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+		];
+	}
+
+	formatRowData( row, statusNames ) {
+		const { date_created, id, status, customer_id, line_items, coupon_lines, total } = row;
+
+		return {
+			dateCreated: date_created,
+			orderLink: getAdminLink( 'post.php?post=' + id + '&action=edit' ),
+			id,
+			statusName: statusNames[ status ],
+			status,
+			customerId: customer_id,
+			productsDisplay: line_items.map( ( item, i ) => (
+				<Fragment>
+					{ i === 0 ? null : ', ' }
+					<a
+						className={ line_items.length > 1 ? 'inline' : null }
+						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
+					>
+						{ item.name }
+					</a>
+				</Fragment>
+			) ),
+			products: line_items
+				.map( item => item.name )
+				.join()
+				.toLowerCase(),
+			numberOfProducts: line_items.length,
+			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
+				<Fragment>
+					{ i === 0 ? null : ', ' }
+					<a
+						className={ coupon_lines.length > 1 ? 'inline' : null }
+						href={ getAdminLink( 'post.php?post=' + coupon.meta_data.value.id + '&action=edit' ) }
+					>
+						{ coupon.code }
+					</a>
+				</Fragment>
+			) ),
+			coupons: coupon_lines
+				.map( item => item.code )
+				.join()
+				.toLowerCase(),
+			total: getCurrencyFormatDecimal( total ),
+		};
+	}
+
+	formatTableData( data ) {
+		const statusNames = {
+			failed: __( 'Failed', 'wc-admin' ),
+			processing: __( 'Processing', 'wc-admin' ),
+			'on-hold': __( 'On hold', 'wc-admin' ),
+			completed: __( 'Completed', 'wc-admin' ),
+		};
+
+		return map( data, row => this.formatRowData( row, statusNames ) );
+	}
+
+	getRowsContent( tableData ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const formats = getDateFormatsForInterval( currentInterval );
+
+		return map( tableData, row => {
+			const {
+				dateCreated,
+				orderLink,
+				id,
+				statusName,
+				status,
+				customerId,
+				productsDisplay,
+				products,
+				numberOfProducts,
+				couponsDisplay,
+				coupons,
+				total,
+			} = row;
+
+			return [
+				{
+					display: formatDate( formats.tableFormat, dateCreated ),
+					value: dateCreated,
+				},
+				{
+					display: <a href={ orderLink }>{ id }</a>,
+					value: id,
+				},
+				{
+					display: statusName,
+					value: status,
+				},
+				{
+					display: customerId,
+					value: customerId,
+				},
+				{
+					display: productsDisplay,
+					value: products,
+				},
+				{
+					display: numberOfProducts,
+					value: numberOfProducts,
+				},
+				{
+					display: couponsDisplay,
+					value: coupons,
+				},
+				{
+					display: formatCurrency( total ),
+					value: getCurrencyFormatDecimal( total ),
+				},
+			];
+		} );
+	}
+
+	renderPlaceholderTable() {
+		const headers = this.getHeadersContent();
+
+		return (
+			<Card
+				title={ __( 'Revenue', 'wc-admin' ) }
+				className="woocommerce-analytics__table-placeholder"
+			>
+				<TablePlaceholder caption={ __( 'Orders last week', 'wc-admin' ) } headers={ headers } />
+			</Card>
+		);
+	}
+
+	renderTable() {
+		const { orders, query } = this.props;
+
+		const page = parseInt( query.page ) || 1;
+		const rowsPerPage = parseInt( query.per_page ) || 25;
+		const rows = this.getRowsContent(
+			orderBy(
+				this.formatTableData( orders ),
+				query.orderby || 'dateCreated',
+				query.order || 'asc'
+			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
+		);
+
+		const headers = this.getHeadersContent();
+
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date_start',
+			order: query.order || 'asc',
+		};
+
+		return (
+			<TableCard
+				title={ __( 'Orders last week', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ Object.keys( orders ).length }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				onClickDownload={ () => null /*this.onDownload( headers, rows, tableQuery )*/ }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ null }
+			/>
+		);
+	}
+
+	render() {
+		const { isRequesting } = this.props;
+
+		return (
+			<Fragment>{ isRequesting ? this.renderPlaceholderTable() : this.renderTable() }</Fragment>
+		);
+	}
+}

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
-import { get, map, orderBy } from 'lodash';
+import { map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -121,7 +121,8 @@ export default class OrdersReportTable extends Component {
 					<a
 						className={ coupon_lines.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink(
-							'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit'
+							// @TODO it should link to the coupons report
+							'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
 						) }
 					>
 						{ coupon.code }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -90,66 +90,71 @@ export default class OrdersReportTable extends Component {
 		];
 	}
 
-	formatRowData( row, statusNames ) {
-		const {
-			date_created,
-			id,
-			status,
-			customer_id,
-			line_items,
-			coupon_lines,
-			total,
-			total_tax,
-			shipping_total,
-			discount_total,
-		} = row;
+	formatTableData( data ) {
+		return map( data, row => {
+			const {
+				date_created,
+				id,
+				status,
+				customer_id,
+				line_items,
+				coupon_lines,
+				total,
+				total_tax,
+				shipping_total,
+				discount_total,
+			} = row;
 
-		return {
-			date_created,
-			orderLink: getAdminLink( 'post.php?post=' + id + '&action=edit' ),
-			id,
-			statusName: statusNames[ status ],
-			status,
-			customer_id,
-			productsDisplay: line_items.map( ( item, i ) => (
-				<Fragment>
-					{ i === 0 ? null : ', ' }
-					<a
-						className={ line_items.length > 1 ? 'is-inline' : null }
-						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
-					>
-						{ item.name }
-					</a>
-				</Fragment>
-			) ),
-			products: line_items
-				.map( item => item.name )
-				.join()
-				.toLowerCase(),
-			items_sold: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
-			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
-				<Fragment>
-					{ i === 0 ? null : ', ' }
-					<a
-						className={ coupon_lines.length > 1 ? 'is-inline' : null }
-						href={ getAdminLink(
-							// @TODO it should link to the coupons report
-							'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
-						) }
-					>
-						{ coupon.code }
-					</a>
-				</Fragment>
-			) ),
-			coupons: coupon_lines
-				.map( item => item.code )
-				.join()
-				.toLowerCase(),
-			net_revenue: getCurrencyFormatDecimal( total - total_tax - shipping_total - discount_total ),
-		};
+			return {
+				date_created,
+				id,
+				status,
+				customer_id,
+				productsDisplay: line_items.map( ( item, i ) => (
+					<Fragment>
+						{ i === 0 ? null : ', ' }
+						<a
+							className={ line_items.length > 1 ? 'is-inline' : null }
+							href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
+						>
+							{ item.name }
+						</a>
+					</Fragment>
+				) ),
+				products: line_items
+					.map( item => item.name )
+					.join()
+					.toLowerCase(),
+				items_sold: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
+				couponsDisplay: coupon_lines.map( ( coupon, i ) => (
+					<Fragment>
+						{ i === 0 ? null : ', ' }
+						<a
+							className={ coupon_lines.length > 1 ? 'is-inline' : null }
+							href={ getAdminLink(
+								// @TODO it should link to the coupons report
+								'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
+							) }
+						>
+							{ coupon.code }
+						</a>
+					</Fragment>
+				) ),
+				coupons: coupon_lines
+					.map( item => item.code )
+					.join()
+					.toLowerCase(),
+				net_revenue: getCurrencyFormatDecimal(
+					total - total_tax - shipping_total - discount_total
+				),
+			};
+		} );
 	}
 
-	formatTableData( data ) {
+	getRowsContent( tableData ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const formats = getDateFormatsForInterval( currentInterval );
 		const statusNames = {
 			failed: __( 'Failed', 'wc-admin' ),
 			processing: __( 'Processing', 'wc-admin' ),
@@ -157,20 +162,10 @@ export default class OrdersReportTable extends Component {
 			completed: __( 'Completed', 'wc-admin' ),
 		};
 
-		return map( data, row => this.formatRowData( row, statusNames ) );
-	}
-
-	getRowsContent( tableData ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
-
 		return map( tableData, row => {
 			const {
 				date_created,
-				orderLink,
 				id,
-				statusName,
 				status,
 				customer_id,
 				productsDisplay,
@@ -187,11 +182,11 @@ export default class OrdersReportTable extends Component {
 					value: date_created,
 				},
 				{
-					display: <a href={ orderLink }>{ id }</a>,
+					display: <a href={ getAdminLink( 'post.php?post=' + id + '&action=edit' ) }>{ id }</a>,
 					value: id,
 				},
 				{
-					display: statusName,
+					display: statusNames[ status ],
 					value: status,
 				},
 				{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -36,7 +36,7 @@ export default class OrdersReportTable extends Component {
 		return [
 			{
 				label: __( 'Date', 'wc-admin' ),
-				key: 'dateCreated',
+				key: 'date_created',
 				required: true,
 				defaultSort: true,
 				isIdentifier: true,
@@ -57,7 +57,7 @@ export default class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Customer', 'wc-admin' ),
-				key: 'customerId',
+				key: 'customer_id',
 				required: false,
 				isSortable: true,
 			},
@@ -69,7 +69,7 @@ export default class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Items Sold', 'wc-admin' ),
-				key: 'numberOfProducts',
+				key: 'items_sold',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
@@ -82,7 +82,7 @@ export default class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'N. Revenue', 'wc-admin' ),
-				key: 'netRevenue',
+				key: 'net_revenue',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
@@ -105,12 +105,12 @@ export default class OrdersReportTable extends Component {
 		} = row;
 
 		return {
-			dateCreated: date_created,
+			date_created,
 			orderLink: getAdminLink( 'post.php?post=' + id + '&action=edit' ),
 			id,
 			statusName: statusNames[ status ],
 			status,
-			customerId: customer_id,
+			customer_id,
 			productsDisplay: line_items.map( ( item, i ) => (
 				<Fragment>
 					{ i === 0 ? null : ', ' }
@@ -126,7 +126,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => item.name )
 				.join()
 				.toLowerCase(),
-			numberOfProducts: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
+			items_sold: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
 			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
 				<Fragment>
 					{ i === 0 ? null : ', ' }
@@ -145,7 +145,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => item.code )
 				.join()
 				.toLowerCase(),
-			netRevenue: getCurrencyFormatDecimal( total - total_tax - shipping_total - discount_total ),
+			net_revenue: getCurrencyFormatDecimal( total - total_tax - shipping_total - discount_total ),
 		};
 	}
 
@@ -167,24 +167,24 @@ export default class OrdersReportTable extends Component {
 
 		return map( tableData, row => {
 			const {
-				dateCreated,
+				date_created,
 				orderLink,
 				id,
 				statusName,
 				status,
-				customerId,
+				customer_id,
 				productsDisplay,
 				products,
-				numberOfProducts,
+				items_sold,
 				couponsDisplay,
 				coupons,
-				netRevenue,
+				net_revenue,
 			} = row;
 
 			return [
 				{
-					display: formatDate( formats.tableFormat, dateCreated ),
-					value: dateCreated,
+					display: formatDate( formats.tableFormat, date_created ),
+					value: date_created,
 				},
 				{
 					display: <a href={ orderLink }>{ id }</a>,
@@ -197,24 +197,24 @@ export default class OrdersReportTable extends Component {
 				{
 					// @TODO This should display customer type (new/returning) once it's
 					// implemented in the API
-					display: customerId,
-					value: customerId,
+					display: customer_id,
+					value: customer_id,
 				},
 				{
 					display: productsDisplay,
 					value: products,
 				},
 				{
-					display: numberOfProducts,
-					value: numberOfProducts,
+					display: items_sold,
+					value: items_sold,
 				},
 				{
 					display: couponsDisplay,
 					value: coupons,
 				},
 				{
-					display: formatCurrency( netRevenue ),
-					value: netRevenue,
+					display: formatCurrency( net_revenue ),
+					value: net_revenue,
 				},
 			];
 		} );
@@ -241,7 +241,7 @@ export default class OrdersReportTable extends Component {
 		const rows = this.getRowsContent(
 			orderBy(
 				this.formatTableData( orders ),
-				query.orderby || 'dateCreated',
+				query.orderby || 'date_created',
 				query.order || 'asc'
 			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
 		);
@@ -250,7 +250,7 @@ export default class OrdersReportTable extends Component {
 
 		const tableQuery = {
 			...query,
-			orderby: query.orderby || 'date_start',
+			orderby: query.orderby || 'date_created',
 			order: query.order || 'asc',
 		};
 

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -99,6 +99,7 @@ export default class OrdersReportTable extends Component {
 				customer_id,
 				line_items,
 				coupon_lines,
+				currency,
 				total,
 				total_tax,
 				shipping_total,
@@ -113,6 +114,7 @@ export default class OrdersReportTable extends Component {
 				line_items,
 				items_sold: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
 				coupon_lines,
+				currency,
 				net_revenue: getCurrencyFormatDecimal(
 					total - total_tax - shipping_total - discount_total
 				),
@@ -140,6 +142,7 @@ export default class OrdersReportTable extends Component {
 				line_items,
 				items_sold,
 				coupon_lines,
+				currency,
 				net_revenue,
 			} = row;
 
@@ -186,7 +189,7 @@ export default class OrdersReportTable extends Component {
 					value: false,
 				},
 				{
-					display: formatCurrency( net_revenue ),
+					display: formatCurrency( net_revenue, currency ),
 					value: net_revenue,
 				},
 			];

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -114,7 +114,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => item.name )
 				.join()
 				.toLowerCase(),
-			numberOfProducts: line_items.length,
+			numberOfProducts: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
 			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
 				<Fragment>
 					{ i === 0 ? null : ', ' }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -27,12 +27,14 @@ export default class OrdersReportTable extends Component {
 				key: 'dateCreated',
 				required: true,
 				defaultSort: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
 				key: 'id',
 				required: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -172,7 +172,10 @@ export default class OrdersReportTable extends Component {
 							label: item.name,
 						} ) )
 					),
-					value: false,
+					value: line_items
+						.map( item => item.name )
+						.join()
+						.toLowerCase(),
 				},
 				{
 					display: items_sold,
@@ -186,7 +189,10 @@ export default class OrdersReportTable extends Component {
 							label: coupon.code,
 						} ) )
 					),
-					value: false,
+					value: coupon_lines
+						.map( item => item.code )
+						.join()
+						.toLowerCase(),
 				},
 				{
 					display: formatCurrency( net_revenue, currency ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -123,7 +123,7 @@ export default class OrdersReportTable extends Component {
 	getRowsContent( tableData ) {
 		const { query } = this.props;
 		const currentInterval = getIntervalForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
+		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 		const statusNames = {
 			failed: __( 'Failed', 'wc-admin' ),
 			processing: __( 'Processing', 'wc-admin' ),
@@ -145,7 +145,7 @@ export default class OrdersReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( formats.tableFormat, date_created ),
+					display: formatDate( tableFormat, date_created ),
 					value: date_created,
 				},
 				{
@@ -158,22 +158,17 @@ export default class OrdersReportTable extends Component {
 				},
 				{
 					// @TODO This should display customer type (new/returning) once it's
-					// implemented in the API
+					// implemented in the API.
 					display: customer_id,
 					value: customer_id,
 				},
 				{
-					display: line_items.map( ( item, i ) => (
-						<Fragment>
-							{ i === 0 ? null : ', ' }
-							<a
-								className={ line_items.length > 1 ? 'is-inline' : null }
-								href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
-							>
-								{ item.name }
-							</a>
-						</Fragment>
-					) ),
+					display: this.renderList(
+						line_items.map( item => ( {
+							href: getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ),
+							label: item.name,
+						} ) )
+					),
 					value: false,
 				},
 				{
@@ -181,20 +176,13 @@ export default class OrdersReportTable extends Component {
 					value: items_sold,
 				},
 				{
-					display: coupon_lines.map( ( coupon, i ) => (
-						<Fragment>
-							{ i === 0 ? null : ', ' }
-							<a
-								className={ coupon_lines.length > 1 ? 'is-inline' : null }
-								href={ getAdminLink(
-									// @TODO it should link to the coupons report
-									'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
-								) }
-							>
-								{ coupon.code }
-							</a>
-						</Fragment>
-					) ),
+					display: this.renderList(
+						coupon_lines.map( coupon => ( {
+							// @TODO It should link to the coupons report.
+							href: getAdminLink( 'edit.php?s=' + coupon.code + '&post_type=shop_coupon' ),
+							label: coupon.code,
+						} ) )
+					),
 					value: false,
 				},
 				{
@@ -203,6 +191,18 @@ export default class OrdersReportTable extends Component {
 				},
 			];
 		} );
+	}
+
+	renderList( items ) {
+		// @TODO Use ViewMore component if there are many items.
+		return items.map( ( item, i ) => (
+			<Fragment>
+				{ i > 0 ? ', ' : null }
+				<a className={ items.length > 1 ? 'is-inline' : null } href={ item.href }>
+					{ item.label }
+				</a>
+			</Fragment>
+		) );
 	}
 
 	renderPlaceholderTable() {

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -39,14 +39,14 @@ export default class OrdersReportTable extends Component {
 				key: 'date_created',
 				required: true,
 				defaultSort: true,
-				isIdentifier: true,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
 				key: 'id',
 				required: true,
-				isIdentifier: true,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -68,7 +68,7 @@ export default class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'N. Revenue', 'wc-admin' ),
-				key: 'total',
+				key: 'netRevenue',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
@@ -77,7 +77,18 @@ export default class OrdersReportTable extends Component {
 	}
 
 	formatRowData( row, statusNames ) {
-		const { date_created, id, status, customer_id, line_items, coupon_lines, total } = row;
+		const {
+			date_created,
+			id,
+			status,
+			customer_id,
+			line_items,
+			coupon_lines,
+			total,
+			total_tax,
+			shipping_total,
+			discount_total,
+		} = row;
 
 		return {
 			dateCreated: date_created,
@@ -107,7 +118,9 @@ export default class OrdersReportTable extends Component {
 					{ i === 0 ? null : ', ' }
 					<a
 						className={ coupon_lines.length > 1 ? 'inline' : null }
-						href={ getAdminLink( 'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit' ) }
+						href={ getAdminLink(
+							'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit'
+						) }
 					>
 						{ coupon.code }
 					</a>
@@ -117,7 +130,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => item.code )
 				.join()
 				.toLowerCase(),
-			total: getCurrencyFormatDecimal( total ),
+			netRevenue: getCurrencyFormatDecimal( total - total_tax - shipping_total - discount_total ),
 		};
 	}
 
@@ -150,7 +163,7 @@ export default class OrdersReportTable extends Component {
 				numberOfProducts,
 				couponsDisplay,
 				coupons,
-				total,
+				netRevenue,
 			} = row;
 
 			return [
@@ -185,8 +198,8 @@ export default class OrdersReportTable extends Component {
 					value: coupons,
 				},
 				{
-					display: formatCurrency( total ),
-					value: getCurrencyFormatDecimal( total ),
+					display: formatCurrency( netRevenue ),
+					value: netRevenue,
 				},
 			];
 		} );

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -24,6 +24,7 @@ export default class extends Component {
 				label: __( 'Product Title', 'wc-admin' ),
 				key: 'name',
 				required: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -24,7 +24,7 @@ export default class extends Component {
 				label: __( 'Product Title', 'wc-admin' ),
 				key: 'name',
 				required: true,
-				isIdentifier: true,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -63,6 +63,7 @@ export class RevenueReport extends Component {
 				key: 'date_start',
 				required: true,
 				defaultSort: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{
@@ -70,6 +71,7 @@ export class RevenueReport extends Component {
 				key: 'orders_count',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Gross Revenue', 'wc-admin' ),

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -63,7 +63,7 @@ export class RevenueReport extends Component {
 				key: 'date_start',
 				required: true,
 				defaultSort: true,
-				isIdentifier: true,
+				isLeftAligned: true,
 				isSortable: true,
 			},
 			{

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -48,11 +48,13 @@
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;
 
-	a {
+	a:not(.inline) {
 		display: block;
 		margin: ($gap*-1) ($gap-large*-1);
 		padding: $gap $gap-large;
+	}
 
+	a {
 		&:hover,
 		&:focus {
 			color: $woocommerce-700;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -73,7 +73,7 @@
 		width: 80%;
 	}
 
-	&:not(.is-identifier) {
+	&:not(.is-left-aligned) {
 		text-align: right;
 
 		.rtl & {

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -48,13 +48,13 @@
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;
 
-	a:not(.inline) {
-		display: block;
-		margin: ($gap*-1) ($gap-large*-1);
-		padding: $gap $gap-large;
-	}
-
 	a {
+		&:not(.is-inline) {
+			display: block;
+			margin: ($gap*-1) ($gap-large*-1);
+			padding: $gap $gap-large;
+		}
+
 		&:hover,
 		&:focus {
 			color: $woocommerce-700;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -73,21 +73,24 @@
 		width: 80%;
 	}
 
-	&.is-numeric {
+	&:not(.is-identifier) {
 		text-align: right;
 
 		button {
 			justify-content: flex-end;
 		}
+	}
 
-		.is-placeholder {
-			max-width: 40px;
-		}
+	&.is-numeric .is-placeholder {
+		max-width: 40px;
 	}
 }
 
-.woocommerce-table__header,
 th.woocommerce-table__item {
+	font-weight: normal;
+}
+
+.woocommerce-table__header {
 	font-weight: bold;
 	white-space: nowrap;
 }

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -76,6 +76,10 @@
 	&:not(.is-identifier) {
 		text-align: right;
 
+		.rtl & {
+			text-align: left;
+		}
+
 		button {
 			justify-content: flex-end;
 		}
@@ -102,6 +106,11 @@ th.woocommerce-table__item {
 
 	& + .woocommerce-table__header {
 		border-left: 1px solid $core-grey-light-700;
+
+		.rtl & {
+			border-left: 0;
+			border-right: 1px solid $core-grey-light-700;
+		}
 	}
 
 	.components-button.is-button {
@@ -113,6 +122,10 @@ th.woocommerce-table__item {
 		border: none;
 		background: transparent;
 		box-shadow: none !important;
+
+		.rtl & {
+			padding: $gap-smaller 0 $gap-smaller $gap-large;
+		}
 
 		// @todo Add interactive styles
 		&:hover {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -120,11 +120,11 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { isIdentifier, isSortable, isNumeric, key, label } = header;
+								const { isLeftAligned, isSortable, isNumeric, key, label } = header;
 								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
-										'is-identifier': isIdentifier,
+										'is-left-aligned': isLeftAligned,
 										'is-sortable': isSortable,
 										'is-sorted': sortedBy === key,
 										'is-numeric': isNumeric,
@@ -174,11 +174,11 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
-									const { isIdentifier, isNumeric } = headers[ j ];
+									const { isLeftAligned, isNumeric } = headers[ j ];
 									const isHeader = rowHeader === j;
 									const Cell = isHeader ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {
-										'is-identifier': isIdentifier,
+										'is-left-aligned': isLeftAligned,
 										'is-numeric': isNumeric,
 									} );
 									return (
@@ -220,9 +220,9 @@ Table.propTypes = {
 			 */
 			defaultSort: PropTypes.bool,
 			/**
-			 * Boolean, true if this column is an identifier for the row.
+			 * Boolean, true if this column should be aligned to the left.
 			 */
-			isIdentifier: PropTypes.bool,
+			isLeftAligned: PropTypes.bool,
 			/**
 			 * Boolean, true if this column is a number value.
 			 */

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -120,10 +120,11 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { isSortable, isNumeric, key, label } = header;
+								const { isIdentifier, isSortable, isNumeric, key, label } = header;
 								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
+										'is-identifier': isIdentifier,
 										'is-sortable': isSortable,
 										'is-sorted': sortedBy === key,
 										'is-numeric': isNumeric,
@@ -173,10 +174,11 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
-									const { isNumeric } = headers[ j ];
+									const { isIdentifier, isNumeric } = headers[ j ];
 									const isHeader = rowHeader === j;
 									const Cell = isHeader ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {
+										'is-identifier': isIdentifier,
 										'is-numeric': isNumeric,
 									} );
 									return (
@@ -217,6 +219,10 @@ Table.propTypes = {
 			 * Boolean, true if this column is the default for sorting. Only one column should have this set.
 			 */
 			defaultSort: PropTypes.bool,
+			/**
+			 * Boolean, true if this column is an identifier for the row.
+			 */
+			isIdentifier: PropTypes.bool,
 			/**
 			 * Boolean, true if this column is a number value.
 			 */

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -25,7 +25,7 @@ export class TopSellingProducts extends Component {
 				label: __( 'Product', 'wc-admin' ),
 				key: 'product',
 				required: true,
-				isIdentifier: true,
+				isLeftAligned: true,
 				isSortable: false,
 			},
 			{

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -25,6 +25,7 @@ export class TopSellingProducts extends Component {
 				label: __( 'Product', 'wc-admin' ),
 				key: 'product',
 				required: true,
+				isIdentifier: true,
 				isSortable: false,
 			},
 			{

--- a/client/lib/csv/__mocks__/mock-csv-data.js
+++ b/client/lib/csv/__mocks__/mock-csv-data.js
@@ -1,4 +1,4 @@
 /** @format */
 
-export default `Date,Orders,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
-2018-04-29T00:00:00,30,200,19,19,100,19,200`;
+export default `Date,Orders,Description,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
+2018-04-29T00:00:00,30,lorem ipsum,200,19,19,100,19,200`;

--- a/client/lib/csv/__mocks__/mock-headers.js
+++ b/client/lib/csv/__mocks__/mock-headers.js
@@ -10,6 +10,10 @@ export default [
 		key: 'orders_count',
 	},
 	{
+		label: 'Description',
+		key: 'description',
+	},
+	{
 		label: 'Gross Revenue',
 		key: 'gross_revenue',
 	},

--- a/client/lib/csv/__mocks__/mock-rows.js
+++ b/client/lib/csv/__mocks__/mock-rows.js
@@ -11,6 +11,10 @@ export default [
 			value: '30',
 		},
 		{
+			display: 'Lorem, ipsum',
+			value: 'lorem, ipsum',
+		},
+		{
 			display: '€200.00',
 			value: 200,
 		},

--- a/client/lib/csv/index.js
+++ b/client/lib/csv/index.js
@@ -11,7 +11,11 @@ function getCSVHeaders( headers ) {
 
 function getCSVRows( rows ) {
 	return Array.isArray( rows )
-		? rows.map( row => row.map( rowItem => rowItem.value ).join( ',' ) ).join( '\n' )
+		? rows
+				.map( row =>
+					row.map( rowItem => rowItem.value.toString().replace( /,/g, '' ) ).join( ',' )
+				)
+				.join( '\n' )
 		: [];
 }
 

--- a/client/store/orders/reducer.js
+++ b/client/store/orders/reducer.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { union } from 'lodash';
 
 const DEFAULT_STATE = {
 	orders: {},
@@ -13,7 +9,6 @@ export default function ordersReducer( state = DEFAULT_STATE, action ) {
 	switch ( action.type ) {
 		case 'SET_ORDERS':
 			const { orders } = action;
-			const ids = orders.map( order => order.id );
 			const ordersMap = orders.reduce( ( map, order ) => {
 				map[ order.id ] = order;
 				return map;
@@ -21,7 +16,6 @@ export default function ordersReducer( state = DEFAULT_STATE, action ) {
 			return {
 				...state,
 				orders: Object.assign( {}, state.orders, ordersMap ),
-				ids: union( state.ids, ids ),
 			};
 		case 'UPDATE_ORDER':
 			const updatedOrders = { ...state.orders };

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -4,7 +4,4 @@ export default {
 	getOrders( state ) {
 		return state.orders.orders;
 	},
-	getOrderIds( state ) {
-		return state.orders.ids;
-	},
 };


### PR DESCRIPTION
Part of #418.

**Changes**
* Add a _Orders last week_ table to the _Orders_ page in _Analytics_.
* CSV download now removes commas from values.
* All table values are now aligned to the right except the ones marked as identifiers. Until now, we were only aligning to the right numeric values, but that didn't seem to follow the designs.
* Set `th`'s `font-weight` to `normal` as it is in the designs.
* Other minor fixes with RTL and tables.

**Screenshot**
![image](https://user-images.githubusercontent.com/3616980/46668302-49fec380-cbcc-11e8-8d75-0351261df2a8.png)

**Steps to test**
* Go to _Analytics_ > _Orders_.
* Verify the table with the latest orders is there and works as expected.
* Try sorting rows, downloading its contents, clicking on the links, etc.

**Work for follow-up PRs**
This PR was already getting big so I will continue working on this in follow-up PRs for this features:
* Pagination (#519).
* `ViewMore` Component for long lists (#503).

**Future changes (can't be implemented yet)**
* We are currently displaying the customer ID instead of the customer type (new/returning). There is a `@TODO` comment in the code so we can implement it once it's in the API.
* The coupon will have to link to the coupon report (added a `@TODO` comment to the code as well).
* Totals in the footer of the table.