### PR TITLE
[WIP] Table cells alignment

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -39,7 +39,6 @@ class OrdersReport extends Component {
 					filters={ filters }
 					advancedConfig={ advancedFilterConfig }
 				/>
-				<p>Below is a temporary example</p>
 				<OrdersReportTable isRequesting={ isRequesting } orders={ orders } query={ query } />
 			</Fragment>
 		);

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -103,7 +103,7 @@ export default class OrdersReportTable extends Component {
 				<Fragment>
 					{ i === 0 ? null : ', ' }
 					<a
-						className={ line_items.length > 1 ? 'inline' : null }
+						className={ line_items.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink( 'post.php?post=' + item.product_id + '&action=edit' ) }
 					>
 						{ item.name }
@@ -119,7 +119,7 @@ export default class OrdersReportTable extends Component {
 				<Fragment>
 					{ i === 0 ? null : ', ' }
 					<a
-						className={ coupon_lines.length > 1 ? 'inline' : null }
+						className={ coupon_lines.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink(
 							'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit'
 						) }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
-import { get, map, orderBy } from 'lodash';
+import { map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -121,7 +121,8 @@ export default class OrdersReportTable extends Component {
 					<a
 						className={ coupon_lines.length > 1 ? 'is-inline' : null }
 						href={ getAdminLink(
-							'post.php?post=' + get( coupon, [ 'meta_data', 'value', 'id' ] ) + '&action=edit'
+							// @TODO it should link to the coupons report
+							'edit.php?s=' + coupon.code + '&post_type=shop_coupon'
 						) }
 					>
 						{ coupon.code }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -114,7 +114,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => item.name )
 				.join()
 				.toLowerCase(),
-			numberOfProducts: line_items.length,
+			numberOfProducts: line_items.reduce( ( acc, item ) => item.quantity + acc, 0 ),
 			couponsDisplay: coupon_lines.map( ( coupon, i ) => (
 				<Fragment>
 					{ i === 0 ? null : ', ' }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -27,12 +27,14 @@ export default class OrdersReportTable extends Component {
 				key: 'dateCreated',
 				required: true,
 				defaultSort: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
 				key: 'id',
 				required: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -11,6 +11,7 @@ import { map, orderBy } from 'lodash';
  * Internal dependencies
  */
 import { Card, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
@@ -18,6 +19,17 @@ import { getAdminLink, onQueryChange } from 'lib/nav-utils';
 export default class OrdersReportTable extends Component {
 	constructor( props ) {
 		super( props );
+	}
+
+	onDownload( headers, rows, query ) {
+		// @TODO The current implementation only downloads the contents displayed in the table.
+		// Another solution is required when the data set is larger (see #311).
+		return () => {
+			downloadCSVFile(
+				generateCSVFileName( 'orders', query ),
+				generateCSVDataFromTable( headers, rows )
+			);
+		};
 	}
 
 	getHeadersContent() {
@@ -248,7 +260,7 @@ export default class OrdersReportTable extends Component {
 				totalRows={ Object.keys( orders ).length }
 				rowsPerPage={ rowsPerPage }
 				headers={ headers }
-				onClickDownload={ () => null /*this.onDownload( headers, rows, tableQuery )*/ }
+				onClickDownload={ this.onDownload( headers, rows, tableQuery ) }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }
 				summary={ null }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -227,11 +227,10 @@ export default class OrdersReportTable extends Component {
 		const page = parseInt( query.page ) || 1;
 		const rowsPerPage = parseInt( query.per_page ) || 25;
 		const rows = this.getRowsContent(
-			orderBy(
-				this.formatTableData( orders ),
-				query.orderby || 'dateCreated',
-				query.order || 'asc'
-			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
+			orderBy( this.formatTableData( orders ), query.orderby, query.order || 'asc' ).slice(
+				( page - 1 ) * rowsPerPage,
+				page * rowsPerPage
+			)
 		);
 
 		const headers = this.getHeadersContent();

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -24,6 +24,7 @@ export default class extends Component {
 				label: __( 'Product Title', 'wc-admin' ),
 				key: 'name',
 				required: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -63,6 +63,7 @@ export class RevenueReport extends Component {
 				key: 'date_start',
 				required: true,
 				defaultSort: true,
+				isIdentifier: true,
 				isSortable: true,
 			},
 			{
@@ -70,6 +71,7 @@ export class RevenueReport extends Component {
 				key: 'orders_count',
 				required: false,
 				isSortable: true,
+				isNumeric: true,
 			},
 			{
 				label: __( 'Gross Revenue', 'wc-admin' ),

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -48,13 +48,13 @@
 	border-bottom: 1px solid $core-grey-light-500;
 	text-align: left;
 
-	a:not(.inline) {
-		display: block;
-		margin: ($gap*-1) ($gap-large*-1);
-		padding: $gap $gap-large;
-	}
-
 	a {
+		&:not(.is-inline) {
+			display: block;
+			margin: ($gap*-1) ($gap-large*-1);
+			padding: $gap $gap-large;
+		}
+
 		&:hover,
 		&:focus {
 			color: $woocommerce-700;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -73,21 +73,24 @@
 		width: 80%;
 	}
 
-	&.is-numeric {
+	&:not(.is-identifier) {
 		text-align: right;
 
 		button {
 			justify-content: flex-end;
 		}
+	}
 
-		.is-placeholder {
-			max-width: 40px;
-		}
+	&.is-numeric .is-placeholder {
+		max-width: 40px;
 	}
 }
 
-.woocommerce-table__header,
 th.woocommerce-table__item {
+	font-weight: normal;
+}
+
+.woocommerce-table__header {
 	font-weight: bold;
 	white-space: nowrap;
 }

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -120,10 +120,11 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { isSortable, isNumeric, key, label } = header;
+								const { isIdentifier, isSortable, isNumeric, key, label } = header;
 								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', {
+										'is-identifier': isIdentifier,
 										'is-sortable': isSortable,
 										'is-sorted': sortedBy === key,
 										'is-numeric': isNumeric,
@@ -173,10 +174,11 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
-									const { isNumeric } = headers[ j ];
+									const { isIdentifier, isNumeric } = headers[ j ];
 									const isHeader = rowHeader === j;
 									const Cell = isHeader ? 'th' : 'td';
 									const cellClasses = classnames( 'woocommerce-table__item', {
+										'is-identifier': isIdentifier,
 										'is-numeric': isNumeric,
 									} );
 									return (
@@ -217,6 +219,10 @@ Table.propTypes = {
 			 * Boolean, true if this column is the default for sorting. Only one column should have this set.
 			 */
 			defaultSort: PropTypes.bool,
+			/**
+			 * Boolean, true if this column is an identifier for the row.
+			 */
+			isIdentifier: PropTypes.bool,
 			/**
 			 * Boolean, true if this column is a number value.
 			 */

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -25,6 +25,7 @@ export class TopSellingProducts extends Component {
 				label: __( 'Product', 'wc-admin' ),
 				key: 'product',
 				required: true,
+				isIdentifier: true,
 				isSortable: false,
 			},
 			{

--- a/client/lib/csv/__mocks__/mock-csv-data.js
+++ b/client/lib/csv/__mocks__/mock-csv-data.js
@@ -1,4 +1,4 @@
 /** @format */
 
-export default `Date,Orders,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
-2018-04-29T00:00:00,30,200,19,19,100,19,200`;
+export default `Date,Orders,Description,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
+2018-04-29T00:00:00,30,lorem ipsum,200,19,19,100,19,200`;

--- a/client/lib/csv/__mocks__/mock-headers.js
+++ b/client/lib/csv/__mocks__/mock-headers.js
@@ -10,6 +10,10 @@ export default [
 		key: 'orders_count',
 	},
 	{
+		label: 'Description',
+		key: 'description',
+	},
+	{
 		label: 'Gross Revenue',
 		key: 'gross_revenue',
 	},

--- a/client/lib/csv/__mocks__/mock-rows.js
+++ b/client/lib/csv/__mocks__/mock-rows.js
@@ -11,6 +11,10 @@ export default [
 			value: '30',
 		},
 		{
+			display: 'Lorem, ipsum',
+			value: 'lorem, ipsum',
+		},
+		{
 			display: '€200.00',
 			value: 200,
 		},

--- a/client/lib/csv/index.js
+++ b/client/lib/csv/index.js
@@ -11,7 +11,11 @@ function getCSVHeaders( headers ) {
 
 function getCSVRows( rows ) {
 	return Array.isArray( rows )
-		? rows.map( row => row.map( rowItem => rowItem.value ).join( ',' ) ).join( '\n' )
+		? rows
+				.map( row =>
+					row.map( rowItem => rowItem.value.toString().replace( /,/g, '' ) ).join( ',' )
+				)
+				.join( '\n' )
 		: [];
 }
 


### PR DESCRIPTION
Follow-up of #493.

Until now, we were aligning only numeric cells to the right, but according to the designs, it looks like all cells should be right aligned but the ones that are used to identify the row contents.

This PR adds a property to table columns named `isIdentifier` which is used to align the cell contents to the correct side.

It also sets the `th.woocommerce-table__item` `font-size` to `normal` as it is in the designs.