### PR TITLE
Refactors code to vanilla js and removes jQuery

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,34 +1,29 @@
+/** @format */
+
 {
-    "root": true,
-    "parser": "babel-eslint",
-    "extends": [
-        "wpcalypso/react",
-        "plugin:jsx-a11y/recommended"
-    ],
-    "plugins": [
-        "jsx-a11y",
-        "jest"
-    ],
-    "env": {
-        "browser": true,
-        "jest/globals": true,
-        "node": true
-    },
-    "globals": {
-        "jQuery": true,
-        "wp": true,
-        "wpApiSettings": true,
-        "wcSettings": true
-    },
-    "rules": {
-        "camelcase": 0,
-        "indent": 0,
-        "max-len": [ 2, { "code": 140 } ],
-        "no-console": 1,
-        "react/no-danger": 0,
-        "react/react-in-jsx-scope": 0,
-        "wpcalypso/import-no-redux-combine-reducers": 0,
-        "wpcalypso/jsx-classname-namespace": 0,
-        "wpcalypso/redux-no-bound-selectors": 1
-    }
+	"root": true,
+	"parser": "babel-eslint",
+	"extends": [ "wpcalypso/react", "plugin:jsx-a11y/recommended" ],
+	"plugins": [ "jsx-a11y", "jest" ],
+	"env": {
+		"browser": true,
+		"jest/globals": true,
+		"node": true,
+	},
+	"globals": {
+		"wp": true,
+		"wpApiSettings": true,
+		"wcSettings": true,
+	},
+	"rules": {
+		"camelcase": 0,
+		"indent": 0,
+		"max-len": [ 2, { "code": 140 } ],
+		"no-console": 1,
+		"react/no-danger": 0,
+		"react/react-in-jsx-scope": 0,
+		"wpcalypso/import-no-redux-combine-reducers": 0,
+		"wpcalypso/jsx-classname-namespace": 0,
+		"wpcalypso/redux-no-bound-selectors": 1,
+	},
 }

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -72,9 +72,11 @@ window.wpNavMenuClassChange = function( menuClass, pathname ) {
 	submenu.classList.add( 'wp-not-current-submenu' );
 	submenu.classList.add( 'menu-top' );
 
-	document
-		.querySelector( `li > a[href$="admin.php?page=wc-admin${ path }"]` )
-		.parentElement.classList.add( 'current' );
+	Array.from(
+		document.querySelectorAll( `li > a[href$="admin.php?page=wc-admin${ path }"]` )
+	).forEach( function( item ) {
+		item.parentElement.classList.add( 'current' );
+	} );
 
 	const currentMenu = document.querySelector( '#' + menuClass );
 	currentMenu.classList.remove( 'wp-not-current-submenu' );

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -61,20 +61,26 @@ class Controller extends Component {
 // When the route changes, we need to update wp-admin's menu with the correct section & current link
 window.wpNavMenuClassChange = function( menuClass, pathname ) {
 	const path = '/' === pathname ? '' : '#' + pathname;
-	jQuery( '.current' ).each( function( i, obj ) {
-		jQuery( obj ).removeClass( 'current' );
+	Array.from( document.getElementsByClassName( 'current' ) ).forEach( function( item ) {
+		item.classList.remove( 'current' );
 	} );
-	jQuery( '.wp-has-current-submenu' )
-		.removeClass( 'wp-has-current-submenu' )
-		.removeClass( 'wp-menu-open' )
-		.removeClass( 'selected' )
-		.addClass( 'wp-not-current-submenu menu-top' );
-	jQuery( 'li > a[href$="admin.php?page=wc-admin' + path + '"]' )
-		.parent()
-		.addClass( 'current' );
-	jQuery( '#' + menuClass )
-		.removeClass( 'wp-not-current-submenu' )
-		.addClass( 'wp-has-current-submenu wp-menu-open current' );
+
+	const submenu = document.querySelector( '.wp-has-current-submenu' );
+	submenu.classList.remove( 'wp-has-current-submenu' );
+	submenu.classList.remove( 'wp-menu-open' );
+	submenu.classList.remove( 'selected' );
+	submenu.classList.add( 'wp-not-current-submenu' );
+	submenu.classList.add( 'menu-top' );
+
+	document
+		.querySelector( `li > a[href$="admin.php?page=wc-admin${ path }"]` )
+		.parentElement.classList.add( 'current' );
+
+	const currentMenu = document.querySelector( '#' + menuClass );
+	currentMenu.classList.remove( 'wp-not-current-submenu' );
+	currentMenu.classList.add( 'wp-has-current-submenu' );
+	currentMenu.classList.add( 'wp-menu-open' );
+	currentMenu.classList.add( 'current' );
 };
 
 export { Controller, getPages };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,6 @@ const externals = {
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },
-	jquery: 'jQuery',
 	tinymce: 'tinymce',
 	moment: 'moment',
 	react: 'React',


### PR DESCRIPTION
This PR:

- Removes jQuery as an accepted global for eslint.
- Removes jQuery as an external webpack dependency.
- Refactors jQuery code to use vanilla JS

Testing instructions:

- Run PR locally
- Toggle the different menu states to see if errors occur
- Toggle the different menu states to see if menus open and close properly