### PR TITLE
Fixes focus state on DatePicker to match Gutenberg

### DIFF
--- a/client/components/filters/date/style.scss
+++ b/client/components/filters/date/style.scss
@@ -62,7 +62,7 @@
 	}
 
 	&:focus {
-		outline: 2px solid lightseagreen;
+		box-shadow: inset 0 -1px 0 #00435d, 0 0 0 2px #bfe7f3;
 	}
 }
 


### PR DESCRIPTION
Fixes #407  

### Good Description:

This PR makes the focus state on the DatePicker tabs look more like Gutenberg

 ### Changes proposed in this PR:
 
* Removes outline on focus
* Replaces with box-shadow

 ### Clear Detailed Test instructions:
 
 * Open a date picker and click on the Presets/Custom tabs
* Observe the focus state on those tabs
 
### Screenshots
Before:
![screen shot 2018-10-10 at 10 52 50 am](https://user-images.githubusercontent.com/6817400/46745239-acae9880-cc7a-11e8-8cb2-20e205391fca.png)

After:
![screen shot 2018-10-10 at 10 52 10 am](https://user-images.githubusercontent.com/6817400/46745186-96084180-cc7a-11e8-8ab7-0fb785d38f89.png)
