### PR TITLE
TableCard Fix: Add a default value to `labels` to prevent warning

### DIFF
--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -166,7 +166,7 @@ class TableCard extends Component {
 	render() {
 		const {
 			compareBy,
-			labels,
+			labels = {},
 			onClickDownload,
 			onQueryChange,
 			query,


### PR DESCRIPTION
Fixes an error where labels is undefined if nothing is passed through:

`Uncaught TypeError: Cannot read property 'downloadButton' of undefined`

**To test**

- Visit the Revenue report on master
- Grey screen, error in console
- Check out this branch, try again
- The report should load correctly