### PR TITLE
DatePicker: update selected tab to reflect update to TabPanel component

### DIFF
--- a/client/components/filters/date/content.js
+++ b/client/components/filters/date/content.js
@@ -83,7 +83,7 @@ class DatePickerContent extends Component {
 						initialTabName={ 'custom' === period ? 'custom' : 'period' }
 						onSelect={ this.onTabSelect }
 					>
-						{ selectedTab => (
+						{ ( { name: selectedTab } ) => (
 							<Fragment>
 								{ selectedTab === 'period' && (
 									<PresetPeriods onSelect={ onUpdate } period={ period } />

--- a/client/components/filters/date/content.js
+++ b/client/components/filters/date/content.js
@@ -83,12 +83,12 @@ class DatePickerContent extends Component {
 						initialTabName={ 'custom' === period ? 'custom' : 'period' }
 						onSelect={ this.onTabSelect }
 					>
-						{ ( { name: selectedTab } ) => (
+						{ selected => (
 							<Fragment>
-								{ selectedTab === 'period' && (
+								{ selected.name === 'period' && (
 									<PresetPeriods onSelect={ onUpdate } period={ period } />
 								) }
-								{ selectedTab === 'custom' && (
+								{ selected.name === 'custom' && (
 									<DateRange
 										after={ after }
 										before={ before }
@@ -104,8 +104,8 @@ class DatePickerContent extends Component {
 								) }
 								<div
 									className={ classnames( 'woocommerce-filters-date__content-controls', {
-										'is-sticky-bottom': selectedTab === 'custom' && isMobileViewport(),
-										'is-custom': selectedTab === 'custom',
+										'is-sticky-bottom': selected.name === 'custom' && isMobileViewport(),
+										'is-custom': selected.name === 'custom',
 									} ) }
 								>
 									<H className="woocommerce-filters-date__text">
@@ -113,7 +113,7 @@ class DatePickerContent extends Component {
 									</H>
 									<ComparePeriods onSelect={ onUpdate } compare={ compare } />
 									<div className="woocommerce-filters-date__button-group">
-										{ selectedTab === 'custom' && (
+										{ selected.name === 'custom' && (
 											<Button
 												className="woocommerce-filters-date__button"
 												isDefault
@@ -123,10 +123,10 @@ class DatePickerContent extends Component {
 												{ __( 'Reset', 'wc-admin' ) }
 											</Button>
 										) }
-										{ isValidSelection( selectedTab ) ? (
+										{ isValidSelection( selected.name ) ? (
 											<Button
 												className="woocommerce-filters-date__button"
-												onClick={ onSelect( selectedTab, onClose ) }
+												onClick={ onSelect( selected.name, onClose ) }
 												isPrimary
 											>
 												{ __( 'Update', 'wc-admin' ) }


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/5476, the core Gutenberg `TabPanel` component changed how the selected tab property is passed back, to an object rather than the name of the selected panel. This PR just tweaks the render function that renders the panel to destructure the name into the `selectedTab` variable.

**To test**

- Open any page with a datepicker
- You can see the date picker & toggle between the Preset & Custom panels