### PR TITLE
Adds Orders Summary and Orders Graph

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -2,24 +2,78 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import moment from 'moment';
-import { partial } from 'lodash';
+import { map, partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { Card, ReportFilters } from '@woocommerce/components';
+import {
+	Card,
+	ReportFilters,
+	SummaryList,
+	SummaryListPlaceholder,
+	SummaryNumber,
+} from '@woocommerce/components';
 import { filters, advancedFilterConfig } from './config';
+import { formatCurrency } from 'lib/currency';
+import { getNewPath } from 'lib/nav-utils';
+import { getReportChartData } from 'store/reports/utils';
+import { getCurrentDates, getDateParamsFromQuery, getIntervalForQuery } from 'lib/date';
+import { MAX_PER_PAGE } from 'store/constants';
 
 class OrdersReport extends Component {
 	constructor( props ) {
 		super( props );
 
+		this.state = {
+			primaryTotals: null,
+			secondaryTotals: null,
+		};
+
 		this.toggleStatus = this.toggleStatus.bind( this );
+	}
+
+	getCharts() {
+		return [
+			{
+				key: 'net_revenue',
+				label: __( 'Net Revenue', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'avg_order_value',
+				label: __( 'Avergae Order Value', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'avg_items_per_order',
+				label: __( 'Average Items Per Order', 'wc-admin' ),
+				type: 'number',
+			},
+			{
+				key: 'Orders Count',
+				label: __( 'Orders Count', 'wc-admin' ),
+				type: 'number',
+			},
+		];
+	}
+
+	getSelectedChart() {
+		const { query } = this.props;
+		const charts = this.getCharts();
+
+		const chart = find( charts, { key: query.chart } );
+		if ( chart ) {
+			return chart;
+		}
+
+		return charts[ 0 ];
 	}
 
 	toggleStatus( order ) {
@@ -28,6 +82,65 @@ class OrdersReport extends Component {
 		const status = updatedOrder.status === 'completed' ? 'processing' : 'completed';
 		updatedOrder.status = status;
 		requestUpdateOrder( updatedOrder );
+	}
+
+	renderChartSummaryNumbers() {
+		const selectedChart = this.getSelectedChart();
+		const charts = this.getCharts();
+		if ( ! this.state.primaryTotals || ! this.state.secondaryTotals ) {
+			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
+		}
+
+		const totals = this.state.primaryTotals || {};
+		const secondaryTotals = this.state.secondaryTotals || {};
+		const { compare } = getDateParamsFromQuery( this.props.query );
+
+		const summaryNumbers = map( this.getCharts(), chart => {
+			const { key, label, type } = chart;
+			const isSelected = selectedChart.key === key;
+
+			let value = parseFloat( totals[ key ] );
+			let secondaryValue =
+				( secondaryTotals[ key ] && parseFloat( secondaryTotals[ key ] ) ) || undefined;
+
+			let delta = 0;
+			if ( secondaryValue && secondaryValue !== 0 ) {
+				delta = Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
+			}
+
+			switch ( type ) {
+				// TODO: implement other format handlers
+				case 'currency':
+					value = formatCurrency( value );
+					secondaryValue = secondaryValue && formatCurrency( secondaryValue );
+					break;
+				case 'number':
+					value = value;
+					secondaryValue = secondaryValue;
+					break;
+			}
+
+			const href = getNewPath( { chart: key } );
+
+			return (
+				<SummaryNumber
+					key={ key }
+					value={ value }
+					label={ label }
+					selected={ isSelected }
+					prevValue={ secondaryValue }
+					prevLabel={
+						'previous_period' === compare
+							? __( 'Previous Period:', 'wc-admin' )
+							: __( 'Previous Year:', 'wc-admin' )
+					}
+					delta={ delta }
+					href={ href }
+				/>
+			);
+		} );
+
+		return <SummaryList>{ summaryNumbers }</SummaryList>;
 	}
 
 	render() {
@@ -40,6 +153,7 @@ class OrdersReport extends Component {
 					filters={ filters }
 					advancedConfig={ advancedFilterConfig }
 				/>
+				{ this.renderChartSummaryNumbers() }
 				<p>Below is a temporary example</p>
 				<Card title="Orders">
 					<table style={ { width: '100%' } }>
@@ -79,11 +193,41 @@ class OrdersReport extends Component {
 }
 
 export default compose(
-	withSelect( select => {
+	withSelect( ( select, props ) => {
 		const { getOrders, getOrderIds } = select( 'wc-admin' );
+		const { query } = props;
+		const interval = getIntervalForQuery( query );
+		const datesFromQuery = getCurrentDates( query );
+		const baseArgs = {
+			order: 'asc',
+			interval: interval,
+			per_page: MAX_PER_PAGE,
+		};
+
+		const primaryData = getReportChartData(
+			'orders',
+			{
+				...baseArgs,
+				after: datesFromQuery.primary.after,
+				before: datesFromQuery.primary.before,
+			},
+			select
+		);
+
+		const secondaryData = getReportChartData(
+			'orders',
+			{
+				...baseArgs,
+				after: datesFromQuery.secondary.after,
+				before: datesFromQuery.secondary.before,
+			},
+			select
+		);
 		return {
 			orders: getOrders(),
 			orderIds: getOrderIds(),
+			primaryData,
+			secondaryData,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { map } from 'lodash';
+import { map, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,6 +35,33 @@ class OrdersReport extends Component {
 		};
 	}
 
+	// Track primary and secondary 'totals' indepdent of query.
+	// We don't want each little query update (interval, sorting, etc)
+	componentDidUpdate( prevProps ) {
+		/* eslint-disable react/no-did-update-set-state */
+
+		if ( ! isEqual( prevProps.dates, this.props.dates ) ) {
+			this.setState( {
+				primaryTotals: null,
+				secondaryTotals: null,
+			} );
+		}
+
+		const { secondaryData, primaryData } = this.props;
+		if ( ! isEqual( prevProps.secondaryData, secondaryData ) ) {
+			if ( secondaryData && secondaryData.data && secondaryData.data.totals ) {
+				this.setState( { secondaryTotals: secondaryData.data.totals } );
+			}
+		}
+
+		if ( ! isEqual( prevProps.primaryData, primaryData ) ) {
+			if ( primaryData && primaryData.data && primaryData.data.totals ) {
+				this.setState( { primaryTotals: primaryData.data.totals } );
+			}
+		}
+		/* eslint-enable react/no-did-update-set-state */
+	}
+
 	getCharts() {
 		return [
 			{
@@ -53,7 +80,7 @@ class OrdersReport extends Component {
 				type: 'number',
 			},
 			{
-				key: 'Orders Count',
+				key: 'orders_count',
 				label: __( 'Orders Count', 'wc-admin' ),
 				type: 'number',
 			},

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -437,6 +437,7 @@ export class RevenueReport extends Component {
 
 				{ this.renderChartSummaryNumbers() }
 				{ this.renderChart() }
+				{ this.renderTable() }
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -449,7 +449,6 @@ export class RevenueReport extends Component {
 
 				{ this.renderChartSummaryNumbers() }
 				{ this.renderChart() }
-				{ this.renderTable() }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
Closes #410 and Closes #417 

This adds the Orders Summary #410 and Orders Chart #417 

As stated in #410 the API provides data different that what is in the mock.  This PR adds what is available via the API.

![screen shot 2018-10-11 at 3 27 53 pm](https://user-images.githubusercontent.com/6817400/46828924-5882e180-cd6a-11e8-9634-3b5aeca79404.png)

