### PR TITLE
Reports: Update summary number label based on selected compare interval

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -30,11 +30,12 @@ import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getAdminLink, getNewPath, onQueryChange } from 'lib/nav-utils';
 import { getReportChartData } from 'store/reports/utils';
 import {
-	getCurrentDates,
-	getPreviousDate,
-	getIntervalForQuery,
 	getAllowedIntervalsForQuery,
+	getCurrentDates,
 	getDateFormatsForInterval,
+	getDateParamsFromQuery,
+	getIntervalForQuery,
+	getPreviousDate,
 } from 'lib/date';
 import { MAX_PER_PAGE } from 'store/constants';
 
@@ -267,6 +268,7 @@ export class RevenueReport extends Component {
 
 		const totals = this.state.primaryTotals || {};
 		const secondaryTotals = this.state.secondaryTotals || {};
+		const { compare } = getDateParamsFromQuery( this.props.query );
 
 		const summaryNumbers = map( this.getCharts(), chart => {
 			const { key, label, type } = chart;
@@ -298,6 +300,11 @@ export class RevenueReport extends Component {
 					label={ label }
 					selected={ isSelected }
 					prevValue={ secondaryValue }
+					prevLabel={
+						'previous_period' === compare
+							? __( 'Previous Period:', 'wc-admin' )
+							: __( 'Previous Year:', 'wc-admin' )
+					}
 					delta={ delta }
 					href={ href }
 				/>


### PR DESCRIPTION
Fixes #395 – The SummaryNumber "previous…" label now updates to match the selected comparison period.

<img width="378" alt="screen shot 2018-10-10 at 2 35 41 pm" src="https://user-images.githubusercontent.com/541093/46758037-c9a69400-cc99-11e8-901f-43def09391de.png">
<img width="379" alt="screen shot 2018-10-10 at 2 35 12 pm" src="https://user-images.githubusercontent.com/541093/46758038-c9a69400-cc99-11e8-9876-1d2b2a405c53.png">

A future improvement could be to generate a nicer string for previous period; "Previous Month" etc, but for now we can leave "Previous Period".

**To test**

- Open the Revenue report
- Check that the summary numbers say "Previous Period: [value]"
- Open the date filter & switch "Compare to" to "Previous Year"
- The summary numbers should update to say "Previous Year: [value]"

_Note_ I was having some trouble with the summary numbers loading when the requested data set is empty, but I haven't tracked that down yet.