### PR TITLE
Activity Panel: Inbox: Add REST API (GETters only)

### DIFF
--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -137,9 +137,13 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $data, $request ) {
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
+		$context                   = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data                      = $this->add_additional_fields_to_object( $data, $request );
+		$data['date_created_gmt']  = wc_rest_prepare_date_response( $data['date_created'] );
+		$data['date_created']      = wc_rest_prepare_date_response( $data['date_created'], false );
+		$data['date_reminder_gmt'] = wc_rest_prepare_date_response( $data['date_reminder'] );
+		$data['date_reminder']     = wc_rest_prepare_date_response( $data['date_reminder'], false );
+		$data                      = $this->filter_response_by_context( $data, $context );
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * REST API Reports categories controller
+ * REST API Admin Notes controller
  *
- * Handles requests to the /reports/categories endpoint.
+ * Handles requests to the admin notes endpoint.
  *
  * @package WooCommerce Admin/API
  */
@@ -10,10 +10,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST API Reports categories controller class.
+ * REST API Admin Notes controller class.
  *
  * @package WooCommerce/API
- * @extends WC_REST_Reports_Controller
+ * @extends WC_REST_CRUD_Controller
  */
 class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 
@@ -32,7 +32,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	protected $rest_base = 'admin/notes';
 
 	/**
-	 * Register the routes for Shipping Zones.
+	 * Register the routes for admin notes.
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -102,7 +102,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	}
 
 	/**
-	 * Check whether a given request has permission to read notes.
+	 * Check whether a given request has permission to read a single note.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -90,7 +90,22 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$notes = WC_Admin_Notes::get_notes();
+		$per_page = isset( $request['per_page'] ) ? intval( $request['per_page'] ) : 10;
+		if ( $per_page <= 0 ) {
+			$per_page = 1;
+		}
+
+		$page = isset( $request['page'] ) ? intval( $request['page'] ) : 1;
+		if ( $page <= 0 ) {
+			$page = 1;
+		}
+
+		$args = array(
+			'per_page' => $per_page,
+			'page'     => $page,
+		);
+
+		$notes = WC_Admin_Notes::get_notes( 'edit', $args );
 
 		$data = array();
 		foreach ( (array) $notes as $note_obj ) {
@@ -98,7 +113,11 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 			$note   = $this->prepare_response_for_collection( $note );
 			$data[] = $note;
 		}
-		return rest_ensure_response( $data );
+
+		$response = rest_ensure_response( $data );
+		$response->header( 'X-WP-Total', WC_Admin_Notes::get_notes_count() );
+
+		return $response;
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -185,4 +185,120 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		 */
 		return apply_filters( 'woocommerce_rest_prepare_admin_note', $response, $data, $request );
 	}
+
+	/**
+	 * Retrieves the item's schema for display / public consumption purposes.
+	 *
+	 * @return array Public item schema data.
+	 */
+	public function get_public_item_schema() {
+		$schema = parent::get_public_item_schema();
+
+		$schema['properties']['id'] = array(
+			'description' => __( 'ID of the note record.', 'wc-admin' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['name'] = array(
+			'description' => __( 'Name of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['type'] = array(
+			'description' => __( 'Type of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['locale'] = array(
+			'description' => __( 'Locale used for the note title and content.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['title'] = array(
+			'description' => __( 'Title of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['content'] = array(
+			'description' => __( 'Content of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['icon'] = array(
+			'description' => __( 'Icon (gridicon) for the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['content_data'] = array(
+			'description' => __( 'Content data for the note. JSON string. Available for re-localization.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['status'] = array(
+			'description' => __( 'Status of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['source'] = array(
+			'description' => __( 'Source of the note.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['date_created'] = array(
+			'description' => __( 'Date the note was created.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['date_created_gmt'] = array(
+			'description' => __( 'Date the note was created (GMT).', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['date_reminder'] = array(
+			'description' => __( 'Date after which the user should be reminded of the note, if any.', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['date_reminder_gmt'] = array(
+			'description' => __( 'Date after which the user should be reminded of the note, if any (GMT).', 'wc-admin' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$schema['properties']['actions'] = array(
+			'description' => __( 'An array of actions, if any, for the note.', 'wc-admin' ),
+			'type'        => 'array',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		return $schema;
+	}
 }

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * REST API Reports categories controller
+ *
+ * Handles requests to the /reports/categories endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Reports categories controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Reports_Controller
+ */
+class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'admin/notes';
+
+	/**
+	 * Register the routes for Shipping Zones.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d-]+)', array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique ID for the resource.', 'wc-admin' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Get a single note.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$note = WC_Admin_Notes::get_note( $request->get_param( 'id' ) );
+		if ( is_wp_error( $note ) ) {
+			return $note;
+		}
+
+		$data = $note->get_data();
+		$data = $this->prepare_item_for_response( $data, $request );
+		$data = $this->prepare_response_for_collection( $data );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get all notes.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$notes = WC_Admin_Notes::get_notes();
+
+		$data = array();
+		foreach ( (array) $notes as $note_obj ) {
+			$note   = $this->prepare_item_for_response( $note_obj, $request );
+			$note   = $this->prepare_response_for_collection( $note );
+			$data[] = $note;
+		}
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Check whether a given request has permission to read notes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'wc-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to read notes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'wc-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Prepare a note object for serialization.
+	 *
+	 * @param array           $data Note data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $data, $request ) {
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+		$response->add_links( array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $data['id'] ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		) );
+		/**
+		 * Filter a note returned from the API.
+		 *
+		 * Allows modification of the note data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $data The original note.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_admin_note', $response, $data, $request );
+	}
+}

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -162,7 +162,12 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$data['date_created']      = wc_rest_prepare_date_response( $data['date_created'], false );
 		$data['date_reminder_gmt'] = wc_rest_prepare_date_response( $data['date_reminder'] );
 		$data['date_reminder']     = wc_rest_prepare_date_response( $data['date_reminder'], false );
-		$data                      = $this->filter_response_by_context( $data, $context );
+		$data['title']             = stripslashes( $data['title'] );
+		$data['content']           = stripslashes( $data['content'] );
+		foreach ( (array) $data['actions'] as $key => $value ) {
+			$data['actions'][ $key ]->label = stripslashes( $data['actions'][ $key ]->label );
+		}
+		$data = $this->filter_response_by_context( $data, $context );
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -92,7 +92,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	public function get_items( $request ) {
 		$per_page = isset( $request['per_page'] ) ? intval( $request['per_page'] ) : 10;
 		if ( $per_page <= 0 ) {
-			$per_page = 1;
+			$per_page = 10;
 		}
 
 		$page = isset( $request['page'] ) ? intval( $request['page'] ) : 1;
@@ -214,7 +214,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		$schema['properties']['type'] = array(
-			'description' => __( 'Type of the note.', 'wc-admin' ),
+			'description' => __( 'The type of the note (e.g. error, warning, etc.).', 'wc-admin' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -256,7 +256,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		$schema['properties']['status'] = array(
-			'description' => __( 'Status of the note.', 'wc-admin' ),
+			'description' => __( 'The status of the note (e.g. unactioned, actioned).', 'wc-admin' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -69,6 +69,7 @@ class WC_Admin_Api_Init {
 	 * Init REST API.
 	 */
 	public function rest_api_init() {
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-admin-notes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-system-status-tools-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-categories-controller.php';
@@ -86,6 +87,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
 
 		$controllers = array(
+			'WC_Admin_REST_Admin_Notes_Controller',
 			'WC_Admin_REST_Reports_Controller',
 			'WC_Admin_REST_System_Status_Tools_Controller',
 			'WC_Admin_REST_Reports_Products_Controller',

--- a/includes/class-wc-admin-note.php
+++ b/includes/class-wc-admin-note.php
@@ -288,7 +288,7 @@ class WC_Admin_Note extends WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note type prop cannot be empty.', 'wc-admin' ) );
 		}
 
-		if ( ! in_array( $type, self::get_allowed_types() ) ) {
+		if ( ! in_array( $type, self::get_allowed_types(), true ) ) {
 			$this->error(
 				'admin_note_invalid_data',
 				sprintf(
@@ -388,7 +388,7 @@ class WC_Admin_Note extends WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note status prop cannot be empty.', 'wc-admin' ) );
 		}
 
-		if ( ! in_array( $status, self::get_allowed_statuses() ) ) {
+		if ( ! in_array( $status, self::get_allowed_statuses(), true ) ) {
 			$this->error(
 				'admin_note_invalid_data',
 				sprintf(

--- a/includes/class-wc-admin-note.php
+++ b/includes/class-wc-admin-note.php
@@ -68,7 +68,7 @@ class WC_Admin_Note extends WC_Data {
 
 		if ( $data instanceof WC_Admin_Note ) {
 			$this->set_id( absint( $data->get_id() ) );
-		} elseif ( is_numeric( $data ) && 'admin-note' === get_post_type( $data ) ) {
+		} elseif ( is_numeric( $data ) ) {
 			$this->set_id( $data );
 		} elseif ( is_object( $data ) && ! empty( $data->note_id ) ) {
 			$this->set_id( $data->note_id );

--- a/includes/class-wc-admin-notes.php
+++ b/includes/class-wc-admin-notes.php
@@ -19,7 +19,7 @@ class WC_Admin_Notes {
 	 * @param array  $args Arguments to pass to the query( e.g. per_page and page).
 	 * @return array Array of arrays.
 	 */
-	public static function get_notes( $context = 'admin', $args = array() ) {
+	public static function get_notes( $context = 'edit', $args = array() ) {
 		$data_store = WC_Data_Store::load( 'admin-note' );
 		$raw_notes  = $data_store->get_notes( $args );
 		$notes      = array();

--- a/includes/class-wc-admin-notes.php
+++ b/includes/class-wc-admin-notes.php
@@ -16,11 +16,12 @@ class WC_Admin_Notes {
 	 * Get notes from the database.
 	 *
 	 * @param string $context Getting notes for what context. Valid values: view, edit.
+	 * @param array  $args Arguments to pass to the query( e.g. per_page and page).
 	 * @return array Array of arrays.
 	 */
-	public static function get_notes( $context = 'admin' ) {
+	public static function get_notes( $context = 'admin', $args = array() ) {
 		$data_store = WC_Data_Store::load( 'admin-note' );
-		$raw_notes  = $data_store->get_notes();
+		$raw_notes  = $data_store->get_notes( $args );
 		$notes      = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
 			$note                               = new WC_Admin_Note( $raw_note );
@@ -57,5 +58,15 @@ class WC_Admin_Notes {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Get the total number of notes
+	 *
+	 * @return int
+	 */
+	public static function get_notes_count() {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		return $data_store->get_notes_count();
 	}
 }

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -33,9 +33,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 			'source'  => $note->get_source(),
 		);
 
-		$encoding_options = defined( 'JSON_FORCE_OBJECT' ) ? JSON_FORCE_OBJECT : 0; // phpcs:ignore PHPCompatibility.PHP.NewConstants
-
-		$note_to_be_inserted['content_data']  = wp_json_encode( $note->get_content_data(), $encoding_options );
+		$note_to_be_inserted['content_data']  = wp_json_encode( $note->get_content_data() );
 		$note_to_be_inserted['date_created']  = gmdate( 'Y-m-d H:i:s', $date_created );
 		$note_to_be_inserted['date_reminder'] = null;
 
@@ -104,7 +102,6 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function update( &$note ) {
 		global $wpdb;
-		$encoding_options = defined( 'JSON_FORCE_OBJECT' ) ? JSON_FORCE_OBJECT : 0; // phpcs:ignore PHPCompatibility.PHP.NewConstants
 
 		if ( $note->get_id() ) {
 			$wpdb->update(
@@ -115,7 +112,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 					'title'         => $note->get_title(),
 					'content'       => $note->get_content(),
 					'icon'          => $note->get_icon(),
-					'content_data'  => wp_json_encode( $note->get_content_data(), $encoding_options ),
+					'content_data'  => wp_json_encode( $note->get_content_data() ),
 					'status'        => $note->get_status(),
 					'source'        => $note->get_source(),
 					'date_created'  => $note->get_date_created(),
@@ -214,7 +211,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		$per_page = isset( $args['per_page'] ) ? intval( $args['per_page'] ) : 10;
 		if ( $per_page <= 0 ) {
-			$per_page = 1;
+			$per_page = 10;
 		}
 
 		$page = isset( $args['page'] ) ? intval( $args['page'] ) : 1;


### PR DESCRIPTION
See #176

Adds GET /wp-json/wc/v3/admin/notes and GET /wp-json/wc/v3/admin/notes/{ID} support

To test:

Create a few notes if you haven't already using the https://github.com/Automattic/wc-admin-notes-test-bench/
In wp-admin > WooCommerce > Settings > Advanced > REST API, create a new key and secret with read/write permission.
Use a tool like Postman to send an OAuth 1.0 request to  GET /wp-json/wc/v3/admin/notes
(Put the key in the consumer key field and the secret in the consumer secret field)
Make sure you get your notes back
Make sure the response headers include the correct total number of notes in `X-WP-Total`
Repeat the test, this time adding params like `per_page` and/or 'page' to paginate through the results

Now, send an OAuth 1.0 request to  GET /wp-json/wc/v3/admin/notes/{ID} where {ID} is a specific note ID.  Make sure you get that note back too.
