### PR TITLE
Break out summary numbers from chart/table data on the revenue report

### DIFF
--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
-import { map, find, isEqual } from 'lodash';
+import { map, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { withSelect } from '@wordpress/data';
 
@@ -28,7 +28,7 @@ import {
 import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getAdminLink, getNewPath, onQueryChange } from 'lib/nav-utils';
-import { getReportChartData } from 'store/reports/utils';
+import { getReportChartData, getSummaryNumbers } from 'store/reports/utils';
 import {
 	getAllowedIntervalsForQuery,
 	getCurrentDates,
@@ -42,38 +42,7 @@ import { MAX_PER_PAGE } from 'store/constants';
 export class RevenueReport extends Component {
 	constructor() {
 		super();
-		this.state = {
-			primaryTotals: null,
-			secondaryTotals: null,
-		};
 		this.onDownload = this.onDownload.bind( this );
-	}
-
-	// Track primary and secondary 'totals' indepdent of query.
-	// We don't want each little query update (interval, sorting, etc)
-	componentDidUpdate( prevProps ) {
-		/* eslint-disable react/no-did-update-set-state */
-
-		if ( ! isEqual( prevProps.dates, this.props.dates ) ) {
-			this.setState( {
-				primaryTotals: null,
-				secondaryTotals: null,
-			} );
-		}
-
-		const { secondaryData, primaryData } = this.props;
-		if ( ! isEqual( prevProps.secondaryData, secondaryData ) ) {
-			if ( secondaryData && secondaryData.data && secondaryData.data.totals ) {
-				this.setState( { secondaryTotals: secondaryData.data.totals } );
-			}
-		}
-
-		if ( ! isEqual( prevProps.primaryData, primaryData ) ) {
-			if ( primaryData && primaryData.data && primaryData.data.totals ) {
-				this.setState( { primaryTotals: primaryData.data.totals } );
-			}
-		}
-		/* eslint-enable react/no-did-update-set-state */
 	}
 
 	onDownload( headers, rows, query ) {
@@ -264,12 +233,12 @@ export class RevenueReport extends Component {
 	renderChartSummaryNumbers() {
 		const selectedChart = this.getSelectedChart();
 		const charts = this.getCharts();
-		if ( ! this.state.primaryTotals || ! this.state.secondaryTotals ) {
+		if ( this.props.summaryNumbers.isRequesting ) {
 			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
 		}
 
-		const totals = this.state.primaryTotals || {};
-		const secondaryTotals = this.state.secondaryTotals || {};
+		const totals = this.props.summaryNumbers.totals.primary || {};
+		const secondaryTotals = this.props.summaryNumbers.totals.secondary || {};
 		const { compare } = getDateParamsFromQuery( this.props.query );
 
 		const summaryNumbers = map( this.getCharts(), chart => {
@@ -420,9 +389,21 @@ export class RevenueReport extends Component {
 	}
 
 	render() {
-		const { path, query, primaryData, secondaryData, isTableDataError } = this.props;
+		const {
+			path,
+			query,
+			primaryData,
+			secondaryData,
+			summaryNumbers,
+			isTableDataError,
+		} = this.props;
 
-		if ( primaryData.isError || secondaryData.isError || isTableDataError ) {
+		if (
+			primaryData.isError ||
+			secondaryData.isError ||
+			isTableDataError ||
+			summaryNumbers.isError
+		) {
 			let title, actionLabel, actionURL, actionCallback;
 			if ( primaryData.isError || secondaryData.isError ) {
 				title = __( 'There was an error getting your stats. Please try again.', 'wc-admin' );
@@ -480,6 +461,15 @@ export default compose(
 			per_page: MAX_PER_PAGE,
 		};
 
+		const summaryNumbers = getSummaryNumbers(
+			'revenue',
+			{
+				primary: datesFromQuery.primary,
+				secondary: datesFromQuery.secondary,
+			},
+			select
+		);
+
 		const primaryData = getReportChartData(
 			'revenue',
 			{
@@ -514,22 +504,8 @@ export default compose(
 		const isTableDataError = isReportStatsError( 'revenue', tableQuery );
 		const isTableDataRequesting = isReportStatsRequesting( 'revenue', tableQuery );
 
-		const primaryDates = {
-			after: datesFromQuery.primary.after,
-			before: datesFromQuery.primary.before,
-		};
-		const secondaryDates = {
-			after: datesFromQuery.secondary.after,
-			before: datesFromQuery.secondary.before,
-		};
-
-		const dates = {
-			primaryDates,
-			secondaryDates,
-		};
-
 		return {
-			dates,
+			summaryNumbers,
 			primaryData,
 			secondaryData,
 			tableQuery,

--- a/client/analytics/report/revenue/test/index.js
+++ b/client/analytics/report/revenue/test/index.js
@@ -33,11 +33,19 @@ describe( 'RevenueReport', () => {
 			totalPages: 1,
 		};
 
+		const summaryNumbers = {
+			totals: {
+				primary: {},
+				secondary: {},
+			},
+		};
+
 		const revenueReport = shallow(
 			<RevenueReport
 				params={ { report: 'revenue' } }
 				path="/analytics/revenue"
 				query={ {} }
+				summaryNumbers={ summaryNumbers }
 				primaryData={ primaryData }
 				tableData={ primaryData }
 				secondaryData={ primaryData }

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -33,6 +33,62 @@ export function isReportDataEmpty( report ) {
 }
 
 /**
+ * Returns summary number totals needed to render a report page.
+ *
+ * @param  {String} endpoint Report  API Endpoint
+ * @param  {Object} dates  Primary and secondary dates.
+ * @param {object} select Instance of @wordpress/select
+ * @return {Object}  Object containing summary number responses.
+ */
+export function getSummaryNumbers( endpoint, dates, select ) {
+	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+	const response = {
+		isRequesting: false,
+		isError: false,
+		totals: {
+			primary: null,
+			secondary: null,
+		},
+	};
+
+	const baseQuery = {
+		interval: 'day',
+		per_page: 1, // We only need the `totals` part of the response.
+	};
+
+	const primaryQuery = {
+		...baseQuery,
+		after: dates.primary.after + 'T00:00:00+00:00',
+		before: dates.primary.before + 'T23:59:59+00:00',
+	};
+	const primary = getReportStats( endpoint, primaryQuery );
+	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
+		return { ...response, isRequesting: true };
+	} else if ( isReportStatsError( endpoint, primaryQuery ) ) {
+		return { ...response, isError: true };
+	}
+
+	const primaryTotals = ( primary && primary.data && primary.data.totals ) || null;
+
+	const secondaryQuery = {
+		...baseQuery,
+		per_page: 1,
+		after: dates.secondary.after + 'T00:00:00+00:00',
+		before: dates.secondary.before + 'T23:59:59+00:00',
+	};
+	const secondary = getReportStats( endpoint, secondaryQuery );
+	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
+		return { ...response, isRequesting: true };
+	} else if ( isReportStatsError( endpoint, secondaryQuery ) ) {
+		return { ...response, isError: true };
+	}
+
+	const secondaryTotals = ( secondary && secondary.data && secondary.data.totals ) || null;
+
+	return { ...response, totals: { primary: primaryTotals, secondary: secondaryTotals } };
+}
+
+/**
  * Returns all of the data needed to render a chart with summary numbers on a report page.
  *
  * @param  {String} endpoint Report  API Endpoint


### PR DESCRIPTION
This PR updates the approach to querying and rendering summary numbers.

Previously, we used the data appended at the top of the chart data calls. This would tie the loading indicators for the summary numbers to the chart, and meant the totals would update as the interval (day vs week switched). Another attempt was to store the charts totals in state and only update them if dates changed too (and not other things like interval) but this was a bit messy and not really working correctly.

Instead, I've decided to pull the summary numbers as part of a smaller separate requests. That way they can remain the same when other queries on the page change (chart interval, pagination pages/sorting), and they can update properly when the selected dates actually change. It adds additional requests to the initial loading, but I think this is OK and cleaner then before. If anyone else has some ideas let me know.

To Test:
* Run `npm test` and make sure all tests pass
* Make some test revenue report requests, make sure all loading indicators go away. Make sure data loads in.
