### PR TITLE
Tag: use label in removeLabel

### DIFF
--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -95,7 +95,6 @@ class Search extends Component {
 							id={ item.id }
 							label={ item.label }
 							remove={ this.removeResult }
-							removeLabel={ __( 'Remove product', 'wc-admin' ) }
 							screenReaderLabel={ screenReaderLabel }
 						/>
 					);

--- a/client/components/tag/index.js
+++ b/client/components/tag/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import { Button, Dashicon, IconButton, Popover } from '@wordpress/components';
@@ -27,7 +27,6 @@ const Tag = ( {
 	label,
 	popoverContents,
 	remove,
-	removeLabel,
 	screenReaderLabel,
 	setState,
 	className,
@@ -76,7 +75,7 @@ const Tag = ( {
 					className="woocommerce-tag__remove"
 					icon={ <Dashicon icon="dismiss" size={ 20 } /> }
 					onClick={ remove( id ) }
-					label={ removeLabel }
+					label={ sprintf( __( 'Remove %s', 'wc-admin' ), label ) }
 					aria-describedby={ labelId }
 				/>
 			) }
@@ -102,17 +101,9 @@ Tag.propTypes = {
 	 */
 	remove: PropTypes.func,
 	/**
-	 * The label for removing this item (shown when hovering on X, or read to screen reader users). Defaults to "Remove tag".
-	 */
-	removeLabel: PropTypes.string,
-	/**
 	 * A more descriptive label for screen reader users. Defaults to the `name` prop.
 	 */
 	screenReaderLabel: PropTypes.string,
-};
-
-Tag.defaultProps = {
-	removeLabel: __( 'Remove tag', 'wc-admin' ),
 };
 
 export default withState( {


### PR DESCRIPTION
Labels for the remove button on a `<Tag>` component were product specific. This PR removes that in favour of simply using the label instead.

### Screenshots
Sighted users:
![screen shot 2018-10-12 at 11 53 37 am](https://user-images.githubusercontent.com/1922453/46838726-18c60380-ce17-11e8-9784-832e9e0246a5.png)

With the button highlighted, screen readers say the following (screenshot captured using a different example):
<img width="402" alt="screen shot 2018-10-12 at 12 07 14 pm" src="https://user-images.githubusercontent.com/1922453/46838826-75c1b980-ce17-11e8-85f8-6981b69dd6b7.png">

### Test

1. `/wp-admin/admin.php?page=wc-admin#/devdocs/search`
2. Use the search tag to look up a product
3. Ensure the remove button labels work correctly
