### PR TITLE
Round average orders in order summary

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -57,7 +57,7 @@ class OrdersReport extends Component {
 			{
 				key: 'avg_items_per_order',
 				label: __( 'Average Items Per Order', 'wc-admin' ),
-				type: 'number',
+				type: 'average',
 			},
 			{
 				key: 'orders_count',
@@ -103,6 +103,10 @@ class OrdersReport extends Component {
 			}
 
 			switch ( type ) {
+				case 'average':
+					value = Math.round( value );
+					secondaryValue = secondaryValue && Math.round( secondaryValue );
+					break;
 				case 'currency':
 					value = formatCurrency( value );
 					secondaryValue = secondaryValue && formatCurrency( secondaryValue );


### PR DESCRIPTION
/\*_ @format _/

Average items per order should be a round number.  This PR makes sure that it is.

### Screenshots

![screen shot 2018-10-12 at 10 30 58 am](https://user-images.githubusercontent.com/6817400/46875976-207fab00-ce0b-11e8-909f-901a54ede2dc.png)
![screen shot 2018-10-12 at 10 31 49 am](https://user-images.githubusercontent.com/6817400/46875977-207fab00-ce0b-11e8-8340-3151912d9bba.png)

### Detailed test instructions:

 - Open: /wp-admin/admin.php?page=wc-admin#/analytics/orders
 - Observe numbers are rounded