### PR TITLE
Updates to standard line chart layer order, and y-axis ticks

### DIFF
--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -280,7 +280,7 @@ D3Chart.defaultProps = {
 	width: 600,
 	xFormat: '%Y-%m-%d',
 	x2Format: '',
-	yFormat: '.3s',
+	yFormat: '.1s',
 };
 
 export default D3Chart;

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -358,7 +358,7 @@ Chart.defaultProps = {
 	tooltipFormat: '%B %d, %Y',
 	xFormat: '%d',
 	x2Format: '%b %Y',
-	yFormat: '$.3s',
+	yFormat: '$.1s',
 	layout: 'standard',
 	mode: 'item-comparison',
 	type: 'line',

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -489,7 +489,7 @@ export const drawLines = ( node, data, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'lines' )
 		.selectAll( '.line-g' )
-		.data( params.lineData.filter( d => d.visible ) )
+		.data( params.lineData.filter( d => d.visible ).reverse() )
 		.enter()
 		.append( 'g' )
 		.attr( 'class', 'line-g' )


### PR DESCRIPTION
This small PR re-orders the z-index for the standard line charts, ensuring the selected period (blue line) renders on top of the comparison period (green line)

Additionally, it removes the decimal points from the y-axis ticks: 

**Before:**

<img width="268" alt="screen shot 2018-10-12 at 8 21 18 am" src="https://user-images.githubusercontent.com/4500952/46881079-55860080-cdff-11e8-92b8-71d02135d727.png">

**After:**

<img width="391" alt="screen shot 2018-10-12 at 8 21 51 am" src="https://user-images.githubusercontent.com/4500952/46881191-954ce800-cdff-11e8-8615-7ec72962f538.png">

huge shoutout to @Aljullu for getting me pointed in the right direction on this one. 