### PR TITLE
Send params with Orders table API calls

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -321,6 +321,7 @@ export default compose(
 			per_page: query.per_page || 25,
 			after: datesFromQuery.primary.after + 'T00:00:00+00:00',
 			before: datesFromQuery.primary.before + 'T23:59:59+00:00',
+			status: [ 'processing', 'on-hold', 'completed' ],
 		};
 		const orders = getOrders( tableQuery );
 		const isTableDataError = isGetOrdersError( tableQuery );

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -199,7 +199,8 @@ class OrdersReport extends Component {
 
 	render() {
 		const {
-			isRequesting,
+			isTableDataError,
+			isTableDataRequesting,
 			orders,
 			path,
 			query,
@@ -208,9 +209,14 @@ class OrdersReport extends Component {
 			summaryNumbers,
 		} = this.props;
 
-		if ( primaryData.isError || secondaryData.isError || summaryNumbers.isError ) {
+		if (
+			primaryData.isError ||
+			secondaryData.isError ||
+			isTableDataError ||
+			summaryNumbers.isError
+		) {
 			let title, actionLabel, actionURL, actionCallback;
-			if ( primaryData.isError || secondaryData.isError ) {
+			if ( primaryData.isError || secondaryData.isError || isTableDataError ) {
 				title = __( 'There was an error getting your stats. Please try again.', 'wc-admin' );
 				actionLabel = __( 'Reload', 'wc-admin' );
 				actionCallback = () => {
@@ -247,7 +253,7 @@ class OrdersReport extends Component {
 				{ this.renderChartSummaryNumbers() }
 				{ this.renderChart() }
 				<OrdersReportTable
-					isRequesting={ isRequesting }
+					isRequesting={ isTableDataRequesting }
 					orders={ orders }
 					query={ query }
 					totalRows={ get(
@@ -307,7 +313,7 @@ export default compose(
 			select
 		);
 
-		const { getOrders, isGetOrdersRequesting } = select( 'wc-admin' );
+		const { getOrders, isGetOrdersError, isGetOrdersRequesting } = select( 'wc-admin' );
 		const tableQuery = {
 			orderby: query.orderby || 'date',
 			order: query.order || 'asc',
@@ -317,10 +323,12 @@ export default compose(
 			before: datesFromQuery.primary.before + 'T23:59:59+00:00',
 		};
 		const orders = getOrders( tableQuery );
-		const isRequesting = isGetOrdersRequesting( tableQuery );
+		const isTableDataError = isGetOrdersError( tableQuery );
+		const isTableDataRequesting = isGetOrdersRequesting( tableQuery );
 
 		return {
-			isRequesting,
+			isTableDataError,
+			isTableDataRequesting,
 			orders,
 			primaryData,
 			secondaryData,

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -36,7 +36,7 @@ export default class OrdersReportTable extends Component {
 		return [
 			{
 				label: __( 'Date', 'wc-admin' ),
-				key: 'date_created',
+				key: 'date',
 				required: true,
 				defaultSort: true,
 				isLeftAligned: true,
@@ -53,13 +53,13 @@ export default class OrdersReportTable extends Component {
 				label: __( 'Status', 'wc-admin' ),
 				key: 'status',
 				required: false,
-				isSortable: true,
+				isSortable: false,
 			},
 			{
 				label: __( 'Customer', 'wc-admin' ),
 				key: 'customer_id',
 				required: false,
-				isSortable: true,
+				isSortable: false,
 			},
 			{
 				label: __( 'Product(s)', 'wc-admin' ),
@@ -71,7 +71,7 @@ export default class OrdersReportTable extends Component {
 				label: __( 'Items Sold', 'wc-admin' ),
 				key: 'items_sold',
 				required: false,
-				isSortable: true,
+				isSortable: false,
 				isNumeric: true,
 			},
 			{
@@ -84,7 +84,7 @@ export default class OrdersReportTable extends Component {
 				label: __( 'N. Revenue', 'wc-admin' ),
 				key: 'net_revenue',
 				required: true,
-				isSortable: true,
+				isSortable: false,
 				isNumeric: true,
 			},
 		];
@@ -107,7 +107,7 @@ export default class OrdersReportTable extends Component {
 			} = row;
 
 			return {
-				date_created,
+				date: date_created,
 				id,
 				status,
 				customer_id,
@@ -129,7 +129,7 @@ export default class OrdersReportTable extends Component {
 
 		return map( tableData, row => {
 			const {
-				date_created,
+				date,
 				id,
 				status,
 				customer_id,
@@ -142,8 +142,8 @@ export default class OrdersReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( tableFormat, date_created ),
-					value: date_created,
+					display: formatDate( tableFormat, date ),
+					value: date,
 				},
 				{
 					display: <a href={ getAdminLink( 'post.php?post=' + id + '&action=edit' ) }>{ id }</a>,
@@ -216,20 +216,20 @@ export default class OrdersReportTable extends Component {
 				title={ __( 'Orders', 'wc-admin' ) }
 				className="woocommerce-analytics__table-placeholder"
 			>
-				<TablePlaceholder caption={ __( 'Orders last week', 'wc-admin' ) } headers={ headers } />
+				<TablePlaceholder caption={ __( 'Orders', 'wc-admin' ) } headers={ headers } />
 			</Card>
 		);
 	}
 
 	renderTable() {
-		const { orders, query } = this.props;
+		const { orders, query, totalRows } = this.props;
 
 		const page = parseInt( query.page ) || 1;
 		const rowsPerPage = parseInt( query.per_page ) || 25;
 		const rows = this.getRowsContent(
 			orderBy(
 				this.formatTableData( orders ),
-				query.orderby || 'date_created',
+				query.orderby || 'date',
 				query.order || 'asc'
 			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
 		);
@@ -238,15 +238,15 @@ export default class OrdersReportTable extends Component {
 
 		const tableQuery = {
 			...query,
-			orderby: query.orderby || 'date_created',
+			orderby: query.orderby || 'date',
 			order: query.order || 'asc',
 		};
 
 		return (
 			<TableCard
-				title={ __( 'Orders last week', 'wc-admin' ) }
+				title={ __( 'Orders', 'wc-admin' ) }
 				rows={ rows }
-				totalRows={ Object.keys( orders ).length }
+				totalRows={ totalRows }
 				rowsPerPage={ rowsPerPage }
 				headers={ headers }
 				onClickDownload={ this.onDownload( headers, rows, tableQuery ) }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -224,14 +224,9 @@ export default class OrdersReportTable extends Component {
 	renderTable() {
 		const { orders, query, totalRows } = this.props;
 
-		const page = parseInt( query.page ) || 1;
 		const rowsPerPage = parseInt( query.per_page ) || 25;
 		const rows = this.getRowsContent(
-			orderBy(
-				this.formatTableData( orders ),
-				query.orderby || 'date',
-				query.order || 'asc'
-			).slice( ( page - 1 ) * rowsPerPage, page * rowsPerPage )
+			orderBy( this.formatTableData( orders ), query.orderby || 'date', query.order || 'asc' )
 		);
 
 		const headers = this.getHeadersContent();

--- a/client/store/orders/actions.js
+++ b/client/store/orders/actions.js
@@ -1,9 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { dispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
 
 export default {
 	setOrders( orders, query ) {
@@ -17,33 +12,6 @@ export default {
 		return {
 			type: 'SET_ORDERS_ERROR',
 			query: query || {},
-		};
-	},
-	updateOrder( order ) {
-		return {
-			type: 'UPDATE_ORDER',
-			order,
-		};
-	},
-	requestUpdateOrder( order ) {
-		return async () => {
-			// Lets be optimistic
-			dispatch( 'wc-admin' ).updateOrder( order );
-			try {
-				const updatedOrder = await apiFetch( {
-					path: '/wc/v3/orders/' + order.id,
-					method: 'PUT',
-					data: order,
-				} );
-
-				dispatch( 'wc-admin' ).updateOrder( updatedOrder );
-			} catch ( error ) {
-				if ( error && error.responseJSON ) {
-					alert( error.responseJSON.message );
-				} else {
-					alert( error );
-				}
-			}
 		};
 	},
 };

--- a/client/store/orders/actions.js
+++ b/client/store/orders/actions.js
@@ -6,10 +6,17 @@ import { dispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 export default {
-	setOrders( orders ) {
+	setOrders( orders, query ) {
 		return {
 			type: 'SET_ORDERS',
 			orders,
+			query: query || {},
+		};
+	},
+	setOrdersError( query ) {
+		return {
+			type: 'SET_ORDERS_ERROR',
+			query: query || {},
 		};
 	},
 	updateOrder( order ) {

--- a/client/store/orders/reducer.js
+++ b/client/store/orders/reducer.js
@@ -1,22 +1,32 @@
 /** @format */
 
-const DEFAULT_STATE = {
-	orders: {},
-	ids: [],
-};
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/utils';
+
+const DEFAULT_STATE = {};
 
 export default function ordersReducer( state = DEFAULT_STATE, action ) {
+	const queryKey = getJsonString( action.query );
+
 	switch ( action.type ) {
 		case 'SET_ORDERS':
-			const { orders } = action;
-			const ordersMap = orders.reduce( ( map, order ) => {
-				map[ order.id ] = order;
-				return map;
-			}, {} );
-			return {
-				...state,
-				orders: Object.assign( {}, state.orders, ordersMap ),
-			};
+			return merge( {}, state, {
+				[ queryKey ]: action.orders,
+			} );
+
+		case 'SET_ORDERS_ERROR':
+			return merge( {}, state, {
+				[ queryKey ]: ERROR,
+			} );
+
 		case 'UPDATE_ORDER':
 			const updatedOrders = { ...state.orders };
 			updatedOrders[ action.order.id ] = action.order;

--- a/client/store/orders/reducer.js
+++ b/client/store/orders/reducer.js
@@ -26,14 +26,6 @@ export default function ordersReducer( state = DEFAULT_STATE, action ) {
 			return merge( {}, state, {
 				[ queryKey ]: ERROR,
 			} );
-
-		case 'UPDATE_ORDER':
-			const updatedOrders = { ...state.orders };
-			updatedOrders[ action.order.id ] = action.order;
-			return {
-				...state,
-				orders: updatedOrders,
-			};
 	}
 
 	return state;

--- a/client/store/orders/resolvers.js
+++ b/client/store/orders/resolvers.js
@@ -14,13 +14,9 @@ export default {
 	async getOrders( state, query ) {
 		try {
 			const orders = await apiFetch( { path: '/wc/v3/orders' + stringifyQuery( query ) } );
-			dispatch( 'wc-admin' ).setOrders( orders );
+			dispatch( 'wc-admin' ).setOrders( orders, query );
 		} catch ( error ) {
-			if ( error && error.responseJSON ) {
-				alert( error.responseJSON.message );
-			} else {
-				alert( error );
-			}
+			dispatch( 'wc-admin' ).setOrdersError( query );
 		}
 	},
 };

--- a/client/store/orders/resolvers.js
+++ b/client/store/orders/resolvers.js
@@ -9,11 +9,12 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { stringifyQuery } from 'lib/nav-utils';
+import { NAMESPACE } from 'store/constants';
 
 export default {
 	async getOrders( state, query ) {
 		try {
-			const orders = await apiFetch( { path: '/wc/v3/orders' + stringifyQuery( query ) } );
+			const orders = await apiFetch( { path: NAMESPACE + 'orders' + stringifyQuery( query ) } );
 			dispatch( 'wc-admin' ).setOrders( orders, query );
 		} catch ( error ) {
 			dispatch( 'wc-admin' ).setOrdersError( query );

--- a/client/store/orders/resolvers.js
+++ b/client/store/orders/resolvers.js
@@ -5,10 +5,15 @@
 import { dispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
+import { stringifyQuery } from 'lib/nav-utils';
+
 export default {
-	async getOrders() {
+	async getOrders( state, query ) {
 		try {
-			const orders = await apiFetch( { path: '/wc/v3/orders' } );
+			const orders = await apiFetch( { path: '/wc/v3/orders' + stringifyQuery( query ) } );
 			dispatch( 'wc-admin' ).setOrders( orders );
 		} catch ( error ) {
 			if ( error && error.responseJSON ) {

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -40,7 +40,7 @@ export default {
 	 * Returns true if a get orders request has returned an error.
 	 *
 	 * @param  {Object} state     Current state
-	 * @param  {Object} query     Report query paremters
+	 * @param  {Object} query     Query paremeters
 	 * @return {Boolean}          True if the `getOrders` request has failed, false otherwise
 	 */
 	isGetOrdersError( state, query ) {

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -3,12 +3,28 @@
 /**
  * External dependencies
  */
+import { get } from 'lodash';
 import { select } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { getJsonString } from 'store/utils';
+import { ERROR } from 'store/constants';
+
+/**
+ * Returns orders for a specific query.
+ *
+ * @param  {Object} state     Current state
+ * @param  {Object} query     Report query paremters
+ * @return {Object}           Report details
+ */
+function getOrders( state, query = {} ) {
+	return get( state, [ 'orders', getJsonString( query ) ], [] );
+}
+
 export default {
-	getOrders( state ) {
-		return state.orders.orders;
-	},
+	getOrders,
 
 	/**
 	 * Returns true if a query is pending.
@@ -18,5 +34,16 @@ export default {
 	 */
 	isGetOrdersRequesting( state, ...args ) {
 		return select( 'core/data' ).isResolving( 'wc-admin', 'getOrders', args );
+	},
+
+	/**
+	 * Returns true if a get orders request has returned an error.
+	 *
+	 * @param  {Object} state     Current state
+	 * @param  {Object} query     Report query paremters
+	 * @return {Boolean}          True if the `getOrders` request has failed, false otherwise
+	 */
+	isGetOrdersError( state, query ) {
+		return ERROR === getOrders( state, query );
 	},
 };

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -17,7 +17,7 @@ import { ERROR } from 'store/constants';
  *
  * @param  {Object} state     Current state
  * @param  {Object} query     Report query paremters
- * @return {Object}           Report details
+ * @return {Array}            Report details
  */
 function getOrders( state, query = {} ) {
 	return get( state, [ 'orders', getJsonString( query ) ], [] );

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -40,7 +40,7 @@ export default {
 	 * Returns true if a get orders request has returned an error.
 	 *
 	 * @param  {Object} state     Current state
-	 * @param  {Object} query     Query paremeters
+	 * @param  {Object} query     Query parameters
 	 * @return {Boolean}          True if the `getOrders` request has failed, false otherwise
 	 */
 	isGetOrdersError( state, query ) {

--- a/client/store/orders/selectors.js
+++ b/client/store/orders/selectors.js
@@ -1,7 +1,22 @@
 /** @format */
 
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
 export default {
 	getOrders( state ) {
 		return state.orders.orders;
+	},
+
+	/**
+	 * Returns true if a query is pending.
+	 *
+	 * @param  {Object} state   Current state
+	 * @return {Boolean}        True if the `getOrders` request is pending, false otherwise
+	 */
+	isGetOrdersRequesting( state, ...args ) {
+		return select( 'core/data' ).isResolving( 'wc-admin', 'getOrders', args );
 	},
 };

--- a/client/store/orders/test/reducer.js
+++ b/client/store/orders/test/reducer.js
@@ -1,0 +1,80 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import ordersReducer from '../reducer';
+import { getJsonString } from 'store/utils';
+
+describe( 'ordersReducer()', () => {
+	it( 'returns an empty data object by default', () => {
+		const state = ordersReducer( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received orders data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'date',
+		};
+		const orders = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+
+		const state = ordersReducer( originalState, {
+			type: 'SET_ORDERS',
+			query,
+			orders,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( orders );
+	} );
+
+	it( 'tracks multiple queries in orders data', () => {
+		const otherQuery = {
+			orderby: 'id',
+		};
+		const otherQueryKey = getJsonString( otherQuery );
+		const otherOrders = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+		const otherQueryState = {
+			[ otherQueryKey ]: otherOrders,
+		};
+		const originalState = deepFreeze( otherQueryState );
+		const query = {
+			orderby: 'date',
+		};
+		const orders = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+
+		const state = ordersReducer( originalState, {
+			type: 'SET_ORDERS',
+			query,
+			orders,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( orders );
+		expect( state[ otherQueryKey ] ).toEqual( otherOrders );
+	} );
+
+	it( 'returns with received error data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'date',
+		};
+
+		const state = ordersReducer( originalState, {
+			type: 'SET_ORDERS_ERROR',
+			query,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( ERROR );
+	} );
+} );

--- a/client/store/orders/test/resolvers.js
+++ b/client/store/orders/test/resolvers.js
@@ -1,0 +1,42 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import resolvers from '../resolvers';
+
+const { getOrders } = resolvers;
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'getOrders', () => {
+	const ORDERS_1 = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+
+	const ORDERS_2 = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+
+	beforeAll( () => {
+		apiFetch.mockImplementation( options => {
+			if ( options.path === '/wc/v3/orders' ) {
+				return Promise.resolve( ORDERS_1 );
+			}
+			if ( options.path === '/wc/v3/orders&orderby=id' ) {
+				return Promise.resolve( ORDERS_2 );
+			}
+		} );
+	} );
+
+	it( 'returns requested report data', async () => {
+		getOrders().then( data => expect( data ).toEqual( ORDERS_1 ) );
+	} );
+
+	it( 'returns requested report data for a specific query', async () => {
+		getOrders( { orderby: 'id' } ).then( data => expect( data ).toEqual( ORDERS_2 ) );
+	} );
+} );

--- a/client/store/orders/test/selectors.js
+++ b/client/store/orders/test/selectors.js
@@ -1,0 +1,92 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import selectors from '../selectors';
+import { select } from '@wordpress/data';
+import { getJsonString } from 'store/utils';
+
+const { getOrders, isGetOrdersRequesting, isGetOrdersError } = selectors;
+jest.mock( '@wordpress/data', () => ( {
+	...require.requireActual( '@wordpress/data' ),
+	select: jest.fn().mockReturnValue( {} ),
+} ) );
+
+const query = { orderby: 'date' };
+const queryKey = getJsonString( query );
+
+describe( 'getOrders()', () => {
+	it( 'returns an empty array when no orders are available', () => {
+		const state = deepFreeze( {} );
+		expect( getOrders( state, query ) ).toEqual( [] );
+	} );
+
+	it( 'returns stored orders for current query', () => {
+		const orders = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const state = deepFreeze( {
+			orders: {
+				[ queryKey ]: orders,
+			},
+		} );
+		expect( getOrders( state, query ) ).toEqual( orders );
+	} );
+} );
+
+describe( 'isGetOrdersRequesting()', () => {
+	beforeAll( () => {
+		select( 'core/data' ).isResolving = jest.fn().mockReturnValue( false );
+	} );
+
+	afterAll( () => {
+		select( 'core/data' ).isResolving.mockRestore();
+	} );
+
+	function setIsResolving( isResolving ) {
+		select( 'core/data' ).isResolving.mockImplementation(
+			( reducerKey, selectorName ) =>
+				isResolving && reducerKey === 'wc-admin' && selectorName === 'getOrders'
+		);
+	}
+
+	it( 'returns false if never requested', () => {
+		const result = isGetOrdersRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if request finished', () => {
+		setIsResolving( false );
+		const result = isGetOrdersRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		setIsResolving( true );
+		const result = isGetOrdersRequesting( query );
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isGetOrdersError()', () => {
+	it( 'returns false by default', () => {
+		const state = deepFreeze( {} );
+		expect( isGetOrdersError( state, query ) ).toEqual( false );
+	} );
+
+	it( 'returns true if ERROR constant is found', () => {
+		const state = deepFreeze( {
+			orders: {
+				[ queryKey ]: ERROR,
+			},
+		} );
+		expect( isGetOrdersError( state, query ) ).toEqual( true );
+	} );
+} );

--- a/client/store/reports/stats/selectors.js
+++ b/client/store/reports/stats/selectors.js
@@ -43,7 +43,7 @@ export default {
 	 *
 	 * @param  {Object} state     Current state
 	 * @param  {String} endpoint  Stats endpoint
-	 * @param  {Object} query     Report query paremeters
+	 * @param  {Object} query     Report query parameters
 	 * @return {Boolean}          True if the `getReportStats` request has failed, false otherwise
 	 */
 	isReportStatsError( state, endpoint, query ) {

--- a/client/store/reports/stats/selectors.js
+++ b/client/store/reports/stats/selectors.js
@@ -43,7 +43,7 @@ export default {
 	 *
 	 * @param  {Object} state     Current state
 	 * @param  {String} endpoint  Stats endpoint
-	 * @param  {Object} query     Report query paremters
+	 * @param  {Object} query     Report query paremeters
 	 * @return {Boolean}          True if the `getReportStats` request has failed, false otherwise
 	 */
 	isReportStatsError( state, endpoint, query ) {


### PR DESCRIPTION
Part of #418.

Follow-up of #493.

Makes the _Orders_ table API calls have the relevant parameters so sorting and pagination work.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/46884644-dd96f500-ce55-11e8-8e19-825f7776201f.png)

### Detailed test instructions

 - Go to _Analytics_ > _Orders_.
 - Verify the table works as expected. Try: sorting, changing number of rows per page, moving around the pages, etc.
- Verify when changing the date range, the table contents update accordingly.

### Notes

- Currently the API only allows sorting by date and id (https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-orders).
- For now, we display an empty list if there are no orders, but maybe a message or a different UI would be preferred? cc @LevinMedia 
![image](https://user-images.githubusercontent.com/3616980/46919606-ed434480-cfe1-11e8-9d00-9c28f166206a.png)
