### PR TITLE
Fix y-axis tick labels

### DIFF
--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -280,7 +280,7 @@ D3Chart.defaultProps = {
 	width: 600,
 	xFormat: '%Y-%m-%d',
 	x2Format: '',
-	yFormat: '.1s',
+	yFormat: '.3s',
 };
 
 export default D3Chart;

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -358,7 +358,7 @@ Chart.defaultProps = {
 	tooltipFormat: '%B %d, %Y',
 	xFormat: '%d',
 	x2Format: '%b %Y',
-	yFormat: '$.1s',
+	yFormat: '$.3s',
 	layout: 'standard',
 	mode: 'item-comparison',
 	type: 'line',


### PR DESCRIPTION
This PR reverts a portion of #518 which caused the y-axis ticks to be mis-labeled. 

**Currently:**

<img width="832" alt="screen shot 2018-10-12 at 1 15 25 pm" src="https://user-images.githubusercontent.com/4500952/46893143-d277a100-ce24-11e8-83d3-c21568655483.png">

note, the intervals don't equate to 1/3rds

Fixed via this PR:

<img width="627" alt="screen shot 2018-10-12 at 1 43 55 pm" src="https://user-images.githubusercontent.com/4500952/46893159-e6bb9e00-ce24-11e8-990c-36ddaffc0401.png">

To create more regular y-axis intervals, we should consider switching to two y-axis ticks instead of three. cc @greenafrican 
