### PR TITLE
Update/refactor revenue report using chart components

### DIFF
--- a/client/analytics/report/revenue/chart.js
+++ b/client/analytics/report/revenue/chart.js
@@ -1,0 +1,88 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ReportChart from 'analytics/components/report-chart';
+import ReportSummary from 'analytics/components/report-summary';
+
+class OrdersReportChart extends Component {
+	getCharts() {
+		return [
+			{
+				key: 'gross_revenue',
+				label: __( 'Gross Revenue', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'refunds',
+				label: __( 'Refunds', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'coupons',
+				label: __( 'Coupons', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'taxes',
+				label: __( 'Taxes', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'shipping',
+				label: __( 'Shipping', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'net_revenue',
+				label: __( 'Net Revenue', 'wc-admin' ),
+				type: 'currency',
+			},
+		];
+	}
+
+	getSelectedChart() {
+		const { query } = this.props;
+		const charts = this.getCharts();
+		const chart = find( charts, { key: query.chart } );
+		if ( chart ) {
+			return chart;
+		}
+
+		return charts[ 0 ];
+	}
+
+	render() {
+		const { query } = this.props;
+		return (
+			<Fragment>
+				<ReportSummary
+					charts={ this.getCharts() }
+					endpoint="revenue"
+					query={ query }
+					selectedChart={ this.getSelectedChart() }
+				/>
+				<ReportChart
+					charts={ this.getCharts() }
+					endpoint="revenue"
+					query={ query }
+					selectedChart={ this.getSelectedChart() }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+OrdersReportChart.propTypes = {
+	query: PropTypes.object.isRequired,
+};
+
+export default OrdersReportChart;

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -6,38 +6,19 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
-import { map, find } from 'lodash';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import {
-	Card,
-	Chart,
-	ChartPlaceholder,
-	EmptyContent,
-	ReportFilters,
-	SummaryList,
-	SummaryListPlaceholder,
-	SummaryNumber,
-	TableCard,
-	TablePlaceholder,
-} from '@woocommerce/components';
+import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { getAdminLink, getNewPath, onQueryChange } from 'lib/nav-utils';
-import { getReportChartData, getSummaryNumbers } from 'store/reports/utils';
-import {
-	getAllowedIntervalsForQuery,
-	getCurrentDates,
-	getDateFormatsForInterval,
-	getDateParamsFromQuery,
-	getIntervalForQuery,
-	getPreviousDate,
-} from 'lib/date';
-import { MAX_PER_PAGE } from 'store/constants';
+import { getAdminLink, onQueryChange } from 'lib/nav-utils';
+import { getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
+import OrdersReportChart from './chart';
 
 export class RevenueReport extends Component {
 	constructor() {
@@ -182,172 +163,6 @@ export class RevenueReport extends Component {
 		} );
 	}
 
-	getCharts() {
-		return [
-			{
-				key: 'gross_revenue',
-				label: __( 'Gross Revenue', 'wc-admin' ),
-				type: 'currency',
-			},
-			{
-				key: 'refunds',
-				label: __( 'Refunds', 'wc-admin' ),
-				type: 'currency',
-			},
-			{
-				key: 'coupons',
-				label: __( 'Coupons', 'wc-admin' ),
-				type: 'currency',
-			},
-			{
-				key: 'taxes',
-				label: __( 'Taxes', 'wc-admin' ),
-				type: 'currency',
-			},
-			{
-				key: 'shipping',
-				label: __( 'Shipping', 'wc-admin' ),
-				type: 'currency',
-			},
-			{
-				key: 'net_revenue',
-				label: __( 'Net Revenue', 'wc-admin' ),
-				type: 'currency',
-			},
-		];
-	}
-
-	getSelectedChart() {
-		const { query } = this.props;
-		const charts = this.getCharts();
-
-		const chart = find( charts, { key: query.chart } );
-		if ( chart ) {
-			return chart;
-		}
-
-		return charts[ 0 ];
-	}
-
-	// TODO since this pattern will exist on every report, this possibly should become a component
-	renderChartSummaryNumbers() {
-		const selectedChart = this.getSelectedChart();
-		const charts = this.getCharts();
-		if ( this.props.summaryNumbers.isRequesting ) {
-			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
-		}
-
-		const totals = this.props.summaryNumbers.totals.primary || {};
-		const secondaryTotals = this.props.summaryNumbers.totals.secondary || {};
-		const { compare } = getDateParamsFromQuery( this.props.query );
-
-		const summaryNumbers = map( this.getCharts(), chart => {
-			const { key, label, type } = chart;
-			const isSelected = selectedChart.key === key;
-
-			let value = parseFloat( totals[ key ] );
-			let secondaryValue =
-				( secondaryTotals[ key ] && parseFloat( secondaryTotals[ key ] ) ) || undefined;
-
-			let delta = 0;
-			if ( secondaryValue && secondaryValue !== 0 ) {
-				delta = Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
-			}
-
-			switch ( type ) {
-				// TODO: implement other format handlers
-				case 'currency':
-					value = formatCurrency( value );
-					secondaryValue = secondaryValue && formatCurrency( secondaryValue );
-					break;
-			}
-
-			const href = getNewPath( { chart: key } );
-
-			return (
-				<SummaryNumber
-					key={ key }
-					value={ value }
-					label={ label }
-					selected={ isSelected }
-					prevValue={ secondaryValue }
-					prevLabel={
-						'previous_period' === compare
-							? __( 'Previous Period:', 'wc-admin' )
-							: __( 'Previous Year:', 'wc-admin' )
-					}
-					delta={ delta }
-					href={ href }
-				/>
-			);
-		} );
-
-		return <SummaryList>{ summaryNumbers }</SummaryList>;
-	}
-
-	renderChart() {
-		const { primaryData, secondaryData, query } = this.props;
-
-		if ( primaryData.isRequesting || secondaryData.isRequesting ) {
-			return (
-				<Fragment>
-					<span className="screen-reader-text">
-						{ __( 'Your requested data is loading', 'wc-admin' ) }
-					</span>
-					<ChartPlaceholder />
-				</Fragment>
-			);
-		}
-
-		const currentInterval = getIntervalForQuery( query );
-		const allowedIntervals = getAllowedIntervalsForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
-
-		const { primary, secondary } = getCurrentDates( query );
-		const selectedChart = this.getSelectedChart();
-
-		const primaryKey = `${ primary.label } (${ primary.range })`;
-		const secondaryKey = `${ secondary.label } (${ secondary.range })`;
-
-		const chartData = primaryData.data.intervals.map( function( interval, index ) {
-			const secondaryDate = getPreviousDate(
-				formatDate( 'Y-m-d', interval.date_start ),
-				primary.after,
-				secondary.after,
-				query.compare,
-				currentInterval
-			);
-
-			const secondaryInterval = secondaryData.data.intervals[ index ];
-			return {
-				date: formatDate( 'Y-m-d\\TH:i:s', interval.date_start ),
-				[ primaryKey ]: {
-					labelDate: interval.date_start,
-					value: interval.subtotals[ selectedChart.key ] || 0,
-				},
-				[ secondaryKey ]: {
-					labelDate: secondaryDate,
-					value: ( secondaryInterval && secondaryInterval.subtotals[ selectedChart.key ] ) || 0,
-				},
-			};
-		} );
-
-		return (
-			<Chart
-				data={ chartData }
-				title={ selectedChart.label }
-				interval={ currentInterval }
-				allowedIntervals={ allowedIntervals }
-				mode="time-comparison"
-				pointLabelFormat={ formats.pointLabelFormat }
-				tooltipTitle={ selectedChart.label }
-				xFormat={ formats.xFormat }
-				x2Format={ formats.x2Format }
-				dateParser={ '%Y-%m-%dT%H:%M:%S' }
-			/>
-		);
-	}
-
 	renderTable() {
 		const { isTableDataRequesting, tableData, tableQuery } = this.props;
 		const headers = this.getHeadersContent();
@@ -389,54 +204,13 @@ export class RevenueReport extends Component {
 	}
 
 	render() {
-		const {
-			path,
-			query,
-			primaryData,
-			secondaryData,
-			summaryNumbers,
-			isTableDataError,
-		} = this.props;
-
-		if (
-			primaryData.isError ||
-			secondaryData.isError ||
-			isTableDataError ||
-			summaryNumbers.isError
-		) {
-			let title, actionLabel, actionURL, actionCallback;
-			if ( primaryData.isError || secondaryData.isError ) {
-				title = __( 'There was an error getting your stats. Please try again.', 'wc-admin' );
-				actionLabel = __( 'Reload', 'wc-admin' );
-				actionCallback = () => {
-					// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
-					window.location.reload();
-				};
-			} else {
-				title = __( 'No results could be found for this date range.', 'wc-admin' );
-				actionLabel = __( 'View Orders', 'wc-admin' );
-				actionURL = getAdminLink( 'edit.php?post_type=shop_order' );
-			}
-
-			return (
-				<Fragment>
-					<ReportFilters query={ query } path={ path } />
-					<EmptyContent
-						title={ title }
-						actionLabel={ actionLabel }
-						actionURL={ actionURL }
-						actionCallback={ actionCallback }
-					/>
-				</Fragment>
-			);
-		}
+		const { path, query } = this.props;
 
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } />
 
-				{ this.renderChartSummaryNumbers() }
-				{ this.renderChart() }
+				<OrdersReportChart query={ query } />
 				{ this.renderTable() }
 			</Fragment>
 		);
@@ -454,41 +228,6 @@ export default compose(
 		const { query } = props;
 		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
 		const datesFromQuery = getCurrentDates( query );
-		const interval = getIntervalForQuery( query );
-		const baseArgs = {
-			order: 'asc',
-			interval: interval,
-			per_page: MAX_PER_PAGE,
-		};
-
-		const summaryNumbers = getSummaryNumbers(
-			'revenue',
-			{
-				primary: datesFromQuery.primary,
-				secondary: datesFromQuery.secondary,
-			},
-			select
-		);
-
-		const primaryData = getReportChartData(
-			'revenue',
-			{
-				...baseArgs,
-				after: datesFromQuery.primary.after,
-				before: datesFromQuery.primary.before,
-			},
-			select
-		);
-
-		const secondaryData = getReportChartData(
-			'revenue',
-			{
-				...baseArgs,
-				after: datesFromQuery.secondary.after,
-				before: datesFromQuery.secondary.before,
-			},
-			select
-		);
 
 		// TODO Support hour here when viewing a single day
 		const tableQuery = {
@@ -505,9 +244,6 @@ export default compose(
 		const isTableDataRequesting = isReportStatsRequesting( 'revenue', tableQuery );
 
 		return {
-			summaryNumbers,
-			primaryData,
-			secondaryData,
 			tableQuery,
 			tableData,
 			isTableDataError,


### PR DESCRIPTION
/\*_ @format _/

Replaces hard coded Summary and Graph with the components that were created as part of the Orders report.

### Screenshots

![screen shot 2018-10-15 at 10 16 37 am](https://user-images.githubusercontent.com/6817400/46956562-9da55d00-d063-11e8-8f80-08f6c481652f.png)

### Detailed test instructions:

 - Go: /wp-admin/admin.php?page=wc-admin#/analytics/revenue?period=last_month&compare=previous_period
 - Does graph and summary look as it did before?

Gotchas:

Removed error state from main component.  Error states need to be added to the individual components (Summary, Graph, Table, etc.)

This PR requires that #517 be merged first.
