### PR TITLE
Adds WooCommerce version requirement and message

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -30,7 +30,7 @@ if ( ! defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {
 function wc_admin_plugins_notice() {
 	$message = sprintf(
 		/* translators: 1: URL of Gutenberg plugin, 2: URL of WooCommerce plugin */
-		__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">Gutenberg</a> and <a href="%2$s">WooCommerce</a> to be installed and active.', 'wc-admin' ),
+		__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">Gutenberg</a> and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
 		'https://wordpress.org/plugins/gutenberg/',
 		'https://wordpress.org/plugins/woocommerce/'
 	);
@@ -44,7 +44,7 @@ function wc_admin_plugins_notice() {
  */
 function dependencies_satisfied() {
 	return ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' ) )
-			&& class_exists( 'WooCommerce' );
+			&& class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
 }
 
 /**


### PR DESCRIPTION
/\*_ @format _/

Fixes #509

Adds a check to ensure that WooCommerce > 3.5 is installed.  If it is not > 3.5 it throws the dependencies notice.

### Screenshots

![screen shot 2018-10-15 at 10 42 27 am](https://user-images.githubusercontent.com/6817400/46958452-d7786280-d067-11e8-8c7c-4b13bd9f3998.png)


### Detailed test instructions:

 - Install WooCommerce version < 3.5
 - Deactivate admin plugin
 - Reactivate Plugin
 - Observe notice