### PR TITLE
Hide day from X axis when the time period is too long

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -40,7 +40,7 @@ class ReportChart extends Component {
 
 		const currentInterval = getIntervalForQuery( query );
 		const allowedIntervals = getAllowedIntervalsForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
+		const formats = getDateFormatsForInterval( currentInterval, primaryData.data.intervals.length );
 		const { primary, secondary } = getCurrentDates( query );
 		const primaryKey = `${ primary.label } (${ primary.range })`;
 		const secondaryKey = `${ secondary.label } (${ secondary.range })`;

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -99,6 +99,7 @@ class D3Chart extends Component {
 			dateParser,
 			height,
 			layout,
+			interval,
 			margin,
 			mode,
 			orderedKeys,
@@ -125,7 +126,7 @@ class D3Chart extends Component {
 		const uniqueDates = getUniqueDates( lineData, parseDate );
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth );
-		const xTicks = getXTicks( uniqueDates, adjWidth, layout );
+		const xTicks = getXTicks( uniqueDates, adjWidth, layout, interval );
 		return {
 			colorScheme,
 			dateSpaces: getDateSpaces( uniqueDates, adjWidth, xLineScale ),

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -241,14 +241,13 @@ const calculateMaxXTicks = ( width, layout ) => {
 };
 
 /**
- * Filter out irrelevant dates from uniqueDates if there are too many
- * @param {array} uniqueDates - all the unique dates from the input data for the chart
- * @returns {integer} Unique dates filtered
+ * Filter out irrelevant dates so only the first date of each month is kept.
+ * @param {array} dates - string dates.
+ * @returns {array} Filtered dates.
  */
-const filterXAxisDates = uniqueDates => {
-	return uniqueDates.filter(
-		( date, i ) =>
-			i === 0 || new Date( date ).getMonth() !== new Date( uniqueDates[ i - 1 ] ).getMonth()
+const getFirstDatePerMonth = dates => {
+	return dates.filter(
+		( date, i ) => i === 0 || new Date( date ).getMonth() !== new Date( dates[ i - 1 ] ).getMonth()
 	);
 };
 
@@ -256,7 +255,7 @@ const filterXAxisDates = uniqueDates => {
  * Get x-axis ticks given the unique dates and the increment factor.
  * @param {array} uniqueDates - all the unique dates from the input data for the chart
  * @param {integer} incrementFactor - increment factor for the visible ticks.
- * @returns {integer} Ticks for the x-axis.
+ * @returns {array} Ticks for the x-axis.
  */
 const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 	const ticks = [];
@@ -308,7 +307,7 @@ export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 	const maxTicks = calculateMaxXTicks( width, layout );
 
 	if ( uniqueDates.length > dayTicksThreshold && interval === 'day' ) {
-		uniqueDates = filterXAxisDates( uniqueDates );
+		uniqueDates = getFirstDatePerMonth( uniqueDates );
 	}
 	if ( uniqueDates.length <= maxTicks ) {
 		return uniqueDates;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -20,6 +20,7 @@ import { format as formatDate } from '@wordpress/date';
  * Internal dependencies
  */
 import { formatCurrency } from 'lib/currency';
+import { dayTicksThreshold } from 'lib/date';
 
 /**
  * Describes `smallestFactor`
@@ -302,7 +303,7 @@ export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 
 	if ( uniqueDates.length <= maxTicks ) {
 		return uniqueDates;
-	} else if ( uniqueDates.length > 180 && interval === 'day' ) {
+	} else if ( uniqueDates.length > dayTicksThreshold && interval === 'day' ) {
 		uniqueDates = filterXAxisDates( uniqueDates );
 	}
 

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -307,10 +307,11 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 	const maxTicks = calculateMaxXTicks( width, layout );
 
+	if ( uniqueDates.length > dayTicksThreshold && interval === 'day' ) {
+		uniqueDates = filterXAxisDates( uniqueDates );
+	}
 	if ( uniqueDates.length <= maxTicks ) {
 		return uniqueDates;
-	} else if ( uniqueDates.length > dayTicksThreshold && interval === 'day' ) {
-		uniqueDates = filterXAxisDates( uniqueDates );
 	}
 
 	const incrementFactor = calculateXTicksIncrementFactor( uniqueDates, maxTicks );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -276,6 +276,12 @@ const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 	return ticks;
 };
 
+/**
+ * Calculates the increment factor between ticks so there aren't more than maxTicks.
+ * @param {array} uniqueDates - all the unique dates from the input data for the chart
+ * @param {integer} maxTicks - maximum number of ticks that can be displayed in the x-axis
+ * @returns {integer} x-axis ticks increment factor
+ */
 const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 	let factors = [];
 	let i = 1;
@@ -291,7 +297,7 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 };
 
 /**
- * Describes getXTicks
+ * Returns ticks for the x-axis.
  * @param {array} uniqueDates - all the unique dates from the input data for the chart
  * @param {integer} width - calculated page width
  * @param {string} layout - standard, comparison or compact chart types

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -240,6 +240,18 @@ const calculateMaxXTicks = ( width, layout ) => {
 };
 
 /**
+ * Filter out irrelevant dates from uniqueDates if there are too many
+ * @param {array} uniqueDates - all the unique dates from the input data for the chart
+ * @returns {integer} Unique dates filtered
+ */
+const filterXAxisDates = uniqueDates => {
+	return uniqueDates.filter(
+		( date, i ) =>
+			i === 0 || new Date( date ).getMonth() !== new Date( uniqueDates[ i - 1 ] ).getMonth()
+	);
+};
+
+/**
  * Get x-axis ticks given the unique dates and the increment factor.
  * @param {array} uniqueDates - all the unique dates from the input data for the chart
  * @param {integer} incrementFactor - increment factor for the visible ticks.
@@ -247,6 +259,7 @@ const calculateMaxXTicks = ( width, layout ) => {
  */
 const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 	const ticks = [];
+
 	for ( let idx = 0; idx < uniqueDates.length; idx = idx + incrementFactor ) {
 		ticks.push( uniqueDates[ idx ] );
 	}
@@ -281,13 +294,16 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
  * @param {array} uniqueDates - all the unique dates from the input data for the chart
  * @param {integer} width - calculated page width
  * @param {string} layout - standard, comparison or compact chart types
+ * @param {string} interval - string of the interval used in the graph (hour, day, week...)
  * @returns {integer} number of x-axis ticks based on width and chart layout
  */
-export const getXTicks = ( uniqueDates, width, layout ) => {
+export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 	const maxTicks = calculateMaxXTicks( width, layout );
 
 	if ( uniqueDates.length <= maxTicks ) {
 		return uniqueDates;
+	} else if ( uniqueDates.length > 180 && interval === 'day' ) {
+		uniqueDates = filterXAxisDates( uniqueDates );
 	}
 
 	const incrementFactor = calculateXTicksIncrementFactor( uniqueDates, maxTicks );
@@ -356,9 +372,7 @@ export const drawAxis = ( node, params ) => {
 					const monthDate = d instanceof Date ? d : new Date( d );
 					let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
 					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
-					return monthDate.getDate() === 1 ||
-						i === 0 ||
-						params.x2Format( monthDate ) !== params.x2Format( prevMonth )
+					return i === 0 || params.x2Format( monthDate ) !== params.x2Format( prevMonth )
 						? params.x2Format( monthDate )
 						: '';
 				} )

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -337,7 +337,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(0,${ params.height })` )
+		.attr( 'transform', `translate(0, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -348,7 +348,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis axis-month' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(3, ${ params.height + 20 })` )
+		.attr( 'transform', `translate(0, ${ params.height + 20 })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -306,7 +306,7 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 	const maxTicks = calculateMaxXTicks( width, layout );
 
-	if ( uniqueDates.length > dayTicksThreshold && interval === 'day' ) {
+	if ( uniqueDates.length >= dayTicksThreshold && interval === 'day' ) {
 		uniqueDates = getFirstDatePerMonth( uniqueDates );
 	}
 	if ( uniqueDates.length <= maxTicks ) {

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -394,9 +394,10 @@ export function getIntervalForQuery( query ) {
  * See https://github.com/d3/d3-time-format for chart formats.
  *
  * @param  {String} interval Interval to get date formats for.
+ * @param  {Int}    [ticks] Number of ticks the axis will have.
  * @return {String} Current interval.
  */
-export function getDateFormatsForInterval( interval ) {
+export function getDateFormatsForInterval( interval, ticks = 0 ) {
 	let pointLabelFormat = 'F j, Y';
 	let tooltipFormat = '%B %d %Y';
 	let xFormat = '%Y-%m-%d';
@@ -411,7 +412,12 @@ export function getDateFormatsForInterval( interval ) {
 			tableFormat = 'h A';
 			break;
 		case 'day':
-			xFormat = '%d';
+			if ( ticks < 180 ) {
+				xFormat = '%d';
+			} else {
+				xFormat = '%b';
+				x2Format = '%Y';
+			}
 			break;
 		case 'week':
 			xFormat = '%d';

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -389,6 +389,8 @@ export function getIntervalForQuery( query ) {
 	return current;
 }
 
+export const dayTicksThreshold = 180;
+
 /**
  * Returns date formats for the current interval.
  * See https://github.com/d3/d3-time-format for chart formats.
@@ -412,7 +414,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 			tableFormat = 'h A';
 			break;
 		case 'day':
-			if ( ticks < 180 ) {
+			if ( ticks < dayTicksThreshold ) {
 				xFormat = '%d';
 			} else {
 				xFormat = '%b';


### PR DESCRIPTION
Fixes 4th checkbox from #382.

Hides the day number from the X axis and align ticks to the beginning of the month.

This PR also refactors the function `getXTicks`, which was becoming too big, and splits it in smaller functions.

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/3616980/46956869-a2cfcf80-d096-11e8-9e65-247122c5aa99.png)

After:

![image](https://user-images.githubusercontent.com/3616980/46965999-ac643200-d0ac-11e8-981f-efb71a7356bf.png)

### Detailed test instructions:

- Go to _Analytics_ > _Orders_ (or any other page with a time chart).
- In the date picker, select a long range (over 6 months) and display chart data _By day_.
- Verify the chart X axis labels have the new format.
