### PR TITLE
Fixes number formatting on charts

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -67,7 +67,6 @@ class ReportChart extends Component {
 				},
 			};
 		} );
-
 		return (
 			<Chart
 				data={ chartData }
@@ -80,6 +79,7 @@ class ReportChart extends Component {
 				xFormat={ formats.xFormat }
 				x2Format={ formats.x2Format }
 				dateParser={ '%Y-%m-%dT%H:%M:%S' }
+				valueType={ selectedChart.type }
 			/>
 		);
 	}

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -84,6 +84,7 @@ class D3Chart extends Component {
 			height: params.height - margin.top - margin.bottom,
 			width: params.width - margin.left - margin.right,
 			tooltip: d3Select( this.tooltipRef.current ),
+			valueType: params.valueType,
 		} );
 		drawAxis( g, adjParams );
 		type === 'line' && drawLines( g, data, adjParams );
@@ -109,6 +110,7 @@ class D3Chart extends Component {
 			xFormat,
 			x2Format,
 			yFormat,
+			valueType,
 		} = this.props;
 		const { width } = this.state;
 		const calculatedWidth = width || node.offsetWidth;
@@ -154,6 +156,7 @@ class D3Chart extends Component {
 			yScale,
 			yTickOffset: getYTickOffset( adjHeight, scale, yMax ),
 			yFormat,
+			valueType,
 		};
 	}
 

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -196,9 +196,10 @@ class Chart extends Component {
 			tooltipTitle,
 			xFormat,
 			x2Format,
-			yFormat,
 			interval,
+			valueType,
 		} = this.props;
+		let { yFormat } = this.props;
 		const legendDirection = layout === 'standard' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
 		const chartDirection = layout === 'comparison' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
 		const legend = (
@@ -209,6 +210,7 @@ class Chart extends Component {
 				handleLegendHover={ this.handleLegendHover }
 				handleLegendToggle={ this.handleLegendToggle }
 				legendDirection={ legendDirection }
+				valueType={ valueType }
 			/>
 		);
 		const margin = {
@@ -217,6 +219,18 @@ class Chart extends Component {
 			right: 30,
 			top: 0,
 		};
+
+		switch ( valueType ) {
+			case 'average':
+				yFormat = '.0f';
+				break;
+			case 'currency':
+				yFormat = '$.3s';
+				break;
+			case 'number':
+				yFormat = '.0f';
+				break;
+		}
 		return (
 			<div className="woocommerce-chart" ref={ this.chartRef }>
 				<div className="woocommerce-chart__header">
@@ -277,6 +291,7 @@ class Chart extends Component {
 							xFormat={ xFormat }
 							x2Format={ x2Format }
 							yFormat={ yFormat }
+							valueType={ valueType }
 						/>
 					</div>
 					{ width < WIDE_BREAKPOINT && <div className="woocommerce-chart__footer">{ legend }</div> }
@@ -350,6 +365,10 @@ Chart.propTypes = {
 	 * Allowed intervals to show in a dropdown.
 	 */
 	allowedIntervals: PropTypes.array,
+	/**
+	 * What type of data is to be displayed? Number, Average, String?
+	 */
+	valueType: PropTypes.string,
 };
 
 Chart.defaultProps = {

--- a/client/components/chart/legend.js
+++ b/client/components/chart/legend.js
@@ -13,6 +13,21 @@ import './style.scss';
 import { formatCurrency } from 'lib/currency';
 import { getColor } from './utils';
 
+function getFormatedTotal( total, valueType ) {
+	let rowTotal = total;
+	switch ( valueType ) {
+		case 'average':
+			rowTotal = Math.round( total );
+			break;
+		case 'currency':
+			rowTotal = formatCurrency( total );
+			break;
+		case 'number':
+			break;
+	}
+	return rowTotal;
+}
+
 /**
  * A legend specifically designed for the WooCommerce admin charts.
  */
@@ -24,6 +39,7 @@ class Legend extends Component {
 			handleLegendHover,
 			handleLegendToggle,
 			legendDirection,
+			valueType,
 		} = this.props;
 		const colorParams = {
 			orderedKeys: data,
@@ -68,7 +84,7 @@ class Legend extends Component {
 									{ row.key }
 								</span>
 								<span className="woocommerce-legend__item-total" id={ row.key }>
-									{ formatCurrency( row.total ) }
+									{ getFormatedTotal( row.total, valueType ) }
 								</span>
 							</div>
 						</button>
@@ -104,6 +120,10 @@ Legend.propTypes = {
 	 * Display legend items as a `row` or `column` inside a flex-box.
 	 */
 	legendDirection: PropTypes.oneOf( [ 'row', 'column' ] ),
+	/**
+	 * What type of data is to be displayed? Number, Average, String?
+	 */
+	valueType: PropTypes.string,
 };
 
 Legend.defaultProps = {

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -398,6 +398,21 @@ export const drawAxis = ( node, params ) => {
 const getTooltipRowLabel = ( d, row, params ) =>
 	d[ row.key ].labelDate ? formatDate( params.pointLabelFormat, d[ row.key ].labelDate ) : row.key;
 
+const getFormatedTotal = ( total, valueType ) => {
+	let rowTotal = total;
+	switch ( valueType ) {
+		case 'average':
+			rowTotal = Math.round( total );
+			break;
+		case 'currency':
+			rowTotal = formatCurrency( total );
+			break;
+		case 'number':
+			break;
+	}
+	return rowTotal;
+};
+
 const showTooltip = ( params, d, position ) => {
 	const keys = params.orderedKeys.filter( row => row.visible ).map(
 		row => `
@@ -406,7 +421,7 @@ const showTooltip = ( params, d, position ) => {
 						<span class="key-color" style="background-color:${ getColor( row.key, params ) }"></span>
 						<span class="key-key">${ getTooltipRowLabel( d, row, params ) }</span>
 					</div>
-					<span class="key-value">${ formatCurrency( d[ row.key ].value ) }</span>
+					<span class="key-value">${ getFormatedTotal( d[ row.key ].value, params.valueType ) }</span>
 				</li>
 			`
 	);


### PR DESCRIPTION
/\*_ @format _/

Fixes #516 

Adds formatting functions where neccesary to show correct number formats on graph.

### Screenshots

![screen shot 2018-10-15 at 2 30 40 pm](https://user-images.githubusercontent.com/6817400/46970398-f20e0400-d086-11e8-81e1-67d54d3b1bb3.png)
![screen shot 2018-10-15 at 2 30 46 pm](https://user-images.githubusercontent.com/6817400/46970399-f2a69a80-d086-11e8-8f33-8254d1b4bc0d.png)


### Detailed test instructions:

 - Go: /wp-admin/admin.php?page=wc-admin#/analytics/orders?period=month&compare=previous_period&chart=orders_count
 - Observe correct formatting on charts

Note:  This function would probably be best in a utils somewhere.  Where is the best place to put it?
