### PR TITLE
Deactivate plugin if dependencies not met

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -63,6 +63,16 @@ function activate_wc_admin_plugin() {
 register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'activate_wc_admin_plugin' );
 
 /**
+ * Deactivate wc-admin plugin if dependencies not satisfied.
+ */
+function deactivate_wc_admin_plugin() {
+	if ( ! dependencies_satisfied() ) {
+		deactivate_plugins( plugin_basename( WC_ADMIN_PLUGIN_FILE ) );
+	}
+}
+add_action( 'admin_init', 'deactivate_wc_admin_plugin' );
+
+/**
  * Set up the plugin, only if we can detect both Gutenberg and WooCommerce
  */
 function wc_admin_plugins_loaded() {

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -68,6 +68,7 @@ register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'activate_wc_admin_plugin' );
 function deactivate_wc_admin_plugin() {
 	if ( ! dependencies_satisfied() ) {
 		deactivate_plugins( plugin_basename( WC_ADMIN_PLUGIN_FILE ) );
+		unset( $_GET['activate'] );
 	}
 }
 add_action( 'admin_init', 'deactivate_wc_admin_plugin' );


### PR DESCRIPTION
Tables are installed on the hook `woocommerce_install_get_tables` which doesn't get refired if WooCommerce is not activated on initial wc-admin plugin activation.

This PR prevents the plugin from being activated if dependencies are not also activated.

Fixes #528 

### Bug replication

1.  On a fresh install (or remove all wc-admin related tables) install and activate wc-admin.
2.  Install and activate WooCommerce.
3.  Visit Revenue page and you should see the following error since tables were never created.

<img width="1516" alt="revenue_error" src="https://user-images.githubusercontent.com/10561050/46971269-86796600-d089-11e8-8a93-7a72df399449.png">

### Detailed test instructions:

1.  Install and attempt to activate wc-admin without WooCommerce or Gutenberg installed.
2.  Plugin notice should still read `The WooCommerce Admin feature plugin requires both Gutenberg and WooCommerce to be installed and active.`
3.  Plugin should be deactivated.