### PR TITLE
Add/filters search

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -14,11 +14,6 @@ const { orderStatuses } = wcSettings;
 
 export const filters = [
 	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
-	{ label: __( 'New Customers', 'wc-admin' ), value: 'new_customers' },
-	{
-		label: __( 'Returning Customers', 'wc-admin' ),
-		value: 'returning_customers',
-	},
 	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
 ];
 

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -14,6 +14,11 @@ const { orderStatuses } = wcSettings;
 
 export const filters = [
 	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
+	{ label: __( 'New Customers', 'wc-admin' ), value: 'new_customers' },
+	{
+		label: __( 'Returning Customers', 'wc-admin' ),
+		value: 'returning_customers',
+	},
 	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
 ];
 

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -14,12 +14,24 @@ export const filters = [
 	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
 	{
 		label: __( 'Single Product', 'wc-admin' ),
-		value: 'single',
+		value: 'single_product',
 		subFilters: [
 			{
 				component: 'Search',
-				value: 'single_search',
-				path: [ 'single' ],
+				value: 'product',
+				path: [ 'single_product' ],
+				settings: {
+					type: 'products',
+					param: 'product',
+					getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
+						id: product.id,
+						label: product.name,
+					} ) ),
+					labels: {
+						placeholder: __( 'Type to search for a product', 'wc-admin' ),
+						button: __( 'Single Product', 'wc-admin' ),
+					},
+				},
 			},
 		],
 	},
@@ -59,6 +71,12 @@ export const filters = [
 			},
 		},
 	},
-	{ label: __( 'Top Products by Items Sold', 'wc-admin' ), value: 'top_items' },
-	{ label: __( 'Top Products by Gross Sales', 'wc-admin' ), value: 'top_sales' },
+	{
+		label: __( 'Top Products by Items Sold', 'wc-admin' ),
+		value: 'top_items',
+	},
+	{
+		label: __( 'Top Products by Gross Sales', 'wc-admin' ),
+		value: 'top_sales',
+	},
 ];

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -41,7 +41,7 @@ class CompareFilter extends Component {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( { selected: [] } );
 			/* eslint-enable react/no-did-update-set-state */
-			updateQueryString( { [ param ]: '' }, path, query );
+			updateQueryString( { [ param ]: undefined }, path, query );
 			return;
 		}
 

--- a/client/components/filters/style.scss
+++ b/client/components/filters/style.scss
@@ -72,3 +72,16 @@
 		margin-right: $gap;
 	}
 }
+
+.woocommerce-filters-filter__search {
+	.woocommerce-search__autocomplete-results {
+		position: static;
+	}
+	.woocommerce-search__inline-container {
+		overflow: hidden;
+
+		&:not(.is-active) {
+			border: none;
+		}
+	}
+}


### PR DESCRIPTION
**Design:** p6riRB-3lk-p2

Add Search to top level filters

## Screenshots

![screen shot 2018-10-17 at 2 33 21 pm](https://user-images.githubusercontent.com/1922453/47056626-c66f5300-d219-11e8-8df3-7d511d00be2a.png)

![screen shot 2018-10-17 at 2 33 47 pm](https://user-images.githubusercontent.com/1922453/47056628-c8d1ad00-d219-11e8-9baf-163ac93b9728.png)

## Test

1. `/wp-admin/admin.php?page=wc-admin#/analytics/products`.
2. Under "Show", choose "Single Product".
3. Search for a product and select one.
4. See the url update
5. Delete, change, choose other filters and make sure behaviour is expected, including with keyboard.
