### PR TITLE
Align status indicator to the right in Orders table

### DIFF
--- a/client/analytics/report/orders/style.scss
+++ b/client/analytics/report/orders/style.scss
@@ -1,0 +1,10 @@
+/** @format */
+
+.woocommerce-orders-table__status {
+	flex-direction: row-reverse;
+
+	.woocommerce-order-status__indicator {
+		margin-right: 0;
+		margin-left: $gap-smallest * 2;
+	}
+}

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -22,6 +22,7 @@ import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from '
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
+import './style.scss';
 
 export default class OrdersReportTable extends Component {
 	constructor( props ) {
@@ -171,7 +172,9 @@ export default class OrdersReportTable extends Component {
 					value: id,
 				},
 				{
-					display: <OrderStatus order={ { status } } />,
+					display: (
+						<OrderStatus className="woocommerce-orders-table__status" order={ { status } } />
+					),
 					value: status,
 				},
 				{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -54,7 +54,6 @@ export default class OrdersReportTable extends Component {
 				label: __( 'Order #', 'wc-admin' ),
 				key: 'id',
 				required: true,
-				isLeftAligned: true,
 				isSortable: true,
 			},
 			{


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/pull/493#discussion_r225390436 and https://github.com/woocommerce/wc-admin/pull/539#issuecomment-430305208.

In the _Orders_ table:

- Aligns the status indicator to the right.

- Aligns the _Order #_ column to the right too.

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/3616980/47006629-a31fa780-d136-11e8-85cd-3f8065f1d071.png)

After:

![image](https://user-images.githubusercontent.com/3616980/47072524-821e8b80-d1f6-11e8-832f-15a526948f3c.png)

### Detailed test instructions:

- Go to _Analytics_ > _Orders_.
- Verify the _Order #_ and _Status_ columns are right-aligned and the status indicator is on the right side.
