### PR TITLE
Component - chart: adjust chart height and dots

### DIFF
--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -202,6 +202,9 @@ class Chart extends Component {
 		let { yFormat } = this.props;
 		const legendDirection = layout === 'standard' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
 		const chartDirection = layout === 'comparison' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
+		let chartHeight = width > 1329 ? 300 : 220;
+		chartHeight = width <= 1329 && width > 783 ? 220 : chartHeight;
+		chartHeight = width <= 783 ? 180 : chartHeight;
 		const legend = (
 			<Legend
 				className={ 'woocommerce-chart__legend' }
@@ -278,7 +281,7 @@ class Chart extends Component {
 							colorScheme={ d3InterpolateViridis }
 							data={ visibleData }
 							dateParser={ dateParser }
-							height={ 300 }
+							height={ chartHeight }
 							margin={ margin }
 							mode={ mode }
 							orderedKeys={ orderedKeys }

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -588,7 +588,9 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'role', 'region' )
 		.attr( 'aria-label', d => d.key );
 
-	const lineStroke = params.width <= 1329 || params.uniqueDates.length > 50 ? 2 : 3;
+	let lineStroke = params.width <= 1329 || params.uniqueDates.length > 50 ? 2 : 3;
+	lineStroke = params.width <= 783 ? 1.25 : lineStroke;
+	const dotRadius = params.width <= 1329 ? 4 : 6;
 
 	series
 		.append( 'path' )
@@ -609,10 +611,10 @@ export const drawLines = ( node, data, params ) => {
 			.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
 			.enter()
 			.append( 'circle' )
-			.attr( 'r', 6 )
+			.attr( 'r', dotRadius )
 			.attr( 'fill', d => getColor( d.key, params ) )
 			.attr( 'stroke', '#fff' )
-			.attr( 'stroke-width', 3 )
+			.attr( 'stroke-width', lineStroke + 1 )
 			.style( 'opacity', d => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
@@ -658,10 +660,10 @@ export const drawLines = ( node, data, params ) => {
 		.data( d => d.values )
 		.enter()
 		.append( 'circle' )
-		.attr( 'r', 8 )
+		.attr( 'r', dotRadius + 2 )
 		.attr( 'fill', d => getColor( d.key, params ) )
 		.attr( 'stroke', '#fff' )
-		.attr( 'stroke-width', 4 )
+		.attr( 'stroke-width', lineStroke + 2 )
 		.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
 		.attr( 'cy', d => params.yScale( d.value ) );
 

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -588,7 +588,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'role', 'region' )
 		.attr( 'aria-label', d => d.key );
 
-	const lineStroke = params.width <= 1024 || params.uniqueDates.length > 50 ? 2 : 3;
+	const lineStroke = params.width <= 1329 || params.uniqueDates.length > 50 ? 2 : 3;
 
 	series
 		.append( 'path' )
@@ -603,16 +603,16 @@ export const drawLines = ( node, data, params ) => {
 		} )
 		.attr( 'd', d => params.line( d.values ) );
 
-	params.width / params.uniqueDates.length > 50 &&
+	params.width / params.uniqueDates.length > 36 &&
 		series
 			.selectAll( 'circle' )
 			.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
 			.enter()
 			.append( 'circle' )
-			.attr( 'r', lineStroke * 2 )
+			.attr( 'r', 6 )
 			.attr( 'fill', d => getColor( d.key, params ) )
 			.attr( 'stroke', '#fff' )
-			.attr( 'stroke-width', lineStroke )
+			.attr( 'stroke-width', 3 )
 			.style( 'opacity', d => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -588,10 +588,12 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'role', 'region' )
 		.attr( 'aria-label', d => d.key );
 
+	const lineStroke = params.width <= 1024 || params.uniqueDates.length > 50 ? 2 : 3;
+
 	series
 		.append( 'path' )
 		.attr( 'fill', 'none' )
-		.attr( 'stroke-width', 3 )
+		.attr( 'stroke-width', lineStroke )
 		.attr( 'stroke-linejoin', 'round' )
 		.attr( 'stroke-linecap', 'round' )
 		.attr( 'stroke', d => getColor( d.key, params ) )
@@ -601,16 +603,16 @@ export const drawLines = ( node, data, params ) => {
 		} )
 		.attr( 'd', d => params.line( d.values ) );
 
-	params.uniqueDates.length < 50 &&
+	params.width / params.uniqueDates.length > 50 &&
 		series
 			.selectAll( 'circle' )
 			.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
 			.enter()
 			.append( 'circle' )
-			.attr( 'r', 6 )
+			.attr( 'r', lineStroke * 2 )
 			.attr( 'fill', d => getColor( d.key, params ) )
 			.attr( 'stroke', '#fff' )
-			.attr( 'stroke-width', 3 )
+			.attr( 'stroke-width', lineStroke )
 			.style( 'opacity', d => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;


### PR DESCRIPTION
Fixes #505 

This PR aims to:
- calculate the expected height of the chart, given the width
- updates the stroke of the line chat based on the width or number of x ticks
- recalculate whether or not to show line chart dots, depending on the width and number of x ticks 

### Screenshots
Viewport > 1329
X-ticks < 50
![screenshot 2018-10-16 14 57 30](https://user-images.githubusercontent.com/1160732/47018296-c3f6f580-d154-11e8-87c4-e70558096140.png)

Viewport > 1329
X-ticks > 50
![screenshot 2018-10-16 14 58 07](https://user-images.githubusercontent.com/1160732/47018315-cf4a2100-d154-11e8-89fc-78398eb38346.png)

Viewport < 1329
X-ticks < 50
![screenshot 2018-10-16 15 04 11](https://user-images.githubusercontent.com/1160732/47018378-e8eb6880-d154-11e8-8b2b-fef851322eb4.png)


### Detailed test instructions:

- Change screen size, reload the page and ensure heights, dots and strokes are as expected
