### PR TITLE
Fix pagination alignment/451

### DIFF
--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -31,6 +31,9 @@
 
 	.components-button:not(:disabled):not([aria-disabled='true']) {
 		color: $black;
+		height: 30px;
+		width: 32px;
+		justify-content: center;
 	}
 
 	.components-icon-button:not(:disabled):not([aria-disabled='true']):hover {
@@ -55,21 +58,22 @@
 	margin-left: $spacing;
 
 	@include breakpoint( '<782px' ) {
-		margin-top: 14px;
+		margin-top: $gap;
 		margin-left: 0;
 	}
-}
-
-.woocommerce-pagination__page-picker-input {
-	margin-left: $spacing / 2;
-	width: 60px;
+	.woocommerce-pagination__page-picker-input {
+		margin-left: $spacing / 2;
+		width: 60px;
+		height: 34px;
+		box-shadow: none;
+	}
 }
 
 .woocommerce-pagination__per-page-picker {
 	margin-left: $spacing;
 
 	@include breakpoint( '<782px' ) {
-		margin-top: 14px;
+		margin-top: $gap;
 		margin-left: 0;
 	}
 	.components-base-control {
@@ -84,6 +88,8 @@
 
 	.components-select-control__input {
 		width: 60px;
+		height: 34px;
+		box-shadow: none;
 	}
 
 	.components-base-control__label {

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -7,6 +7,10 @@
 	justify-content: center;
 	align-items: center;
 
+	@include breakpoint( '<782px' ) {
+		flex-direction: column;
+	}
+
 	input {
 		border-radius: 4px;
 	}
@@ -48,7 +52,12 @@
 }
 
 .woocommerce-pagination__page-picker {
-	margin-left: $spacing / 2;
+	margin-left: $spacing;
+
+	@include breakpoint( '<782px' ) {
+		margin-top: 14px;
+		margin-left: 0;
+	}
 }
 
 .woocommerce-pagination__page-picker-input {
@@ -57,8 +66,12 @@
 }
 
 .woocommerce-pagination__per-page-picker {
-	margin-left: $spacing / 2;
+	margin-left: $spacing;
 
+	@include breakpoint( '<782px' ) {
+		margin-top: 14px;
+		margin-left: 0;
+	}
 	.components-base-control {
 		margin-bottom: 0;
 	}
@@ -66,6 +79,7 @@
 		display: flex;
 		flex-direction: row;
 		align-items: baseline;
+		margin-bottom: 0;
 	}
 
 	.components-select-control__input {


### PR DESCRIPTION
Fixes #451 

Fixes the alignment for pagination and wraps pagination fields on mobile.  Also matches the height for input items and buttons.

### Screenshots

<img width="547" alt="screen shot 2018-10-16 at 10 13 56 am" src="https://user-images.githubusercontent.com/10561050/47022782-3e5f4f80-d12c-11e8-88cc-a138e65d2046.png">
<img width="217" alt="screen shot 2018-10-16 at 10 14 04 am" src="https://user-images.githubusercontent.com/10561050/47022783-3e5f4f80-d12c-11e8-8f7a-2d1efb399e27.png">


### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2.  Confirm that text and inputs are vertically aligned.
3.  On smaller screen sizes (<792px) confirm that pagination items wrap correctly.
