### PR TITLE
Create appendTimestamp() utils function

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -15,7 +15,7 @@ import { get } from 'lodash';
 import { EmptyContent, ReportFilters } from '@woocommerce/components';
 import { filters, advancedFilterConfig } from './config';
 import { getAdminLink } from 'lib/nav-utils';
-import { getCurrentDates, getIntervalForQuery } from 'lib/date';
+import { appendTimestamp, getCurrentDates, getIntervalForQuery } from 'lib/date';
 import { getReportChartData } from 'store/reports/utils';
 import { MAX_PER_PAGE } from 'store/constants';
 import OrdersReportChart from './chart';
@@ -122,8 +122,8 @@ export default compose(
 			order: query.order || 'asc',
 			page: query.page || 1,
 			per_page: query.per_page || 25,
-			after: datesFromQuery.primary.after + 'T00:00:00+00:00',
-			before: datesFromQuery.primary.before + 'T23:59:59+00:00',
+			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 			status: [ 'processing', 'on-hold', 'completed' ],
 		};
 		const orders = getOrders( tableQuery );

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -17,7 +17,7 @@ import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/c
 import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
-import { getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
+import { appendTimestamp, getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
 import OrdersReportChart from './chart';
 
 export class RevenueReport extends Component {
@@ -236,8 +236,8 @@ export default compose(
 			order: query.order || 'asc',
 			page: query.page || 1,
 			per_page: query.per_page || 25,
-			after: datesFromQuery.primary.after + 'T00:00:00+00:00',
-			before: datesFromQuery.primary.before + 'T23:59:59+00:00',
+			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		};
 		const tableData = getReportStats( 'revenue', tableQuery );
 		const isTableDataError = isReportStatsError( 'revenue', tableQuery );

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -55,8 +55,15 @@ export const periods = [
  * @param {string} timeOfDay - Either `start` or `end` of the day.
  * @return {string} - String date with timestamp attached.
  */
-export const appendTimestamp = ( date, timeOfDay ) =>
-	timeOfDay === 'start' ? date + 'T00:00:00+00:00' : date + 'T23:59:59+00:00';
+export const appendTimestamp = ( date, timeOfDay ) => {
+	if ( timeOfDay === 'start' ) {
+		return date + 'T00:00:00+00:00';
+	}
+	if ( timeOfDay === 'end' ) {
+		return date + 'T23:59:59+00:00';
+	}
+	throw new Error( 'appendTimestamp requires second parameter to be either `start` or `end`' );
+};
 
 /**
  * Convert a string to Moment object

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -49,6 +49,16 @@ export const periods = [
 ];
 
 /**
+ * Adds timestamp to a string date.
+ *
+ * @param {string} date - Date as a string.
+ * @param {string} timeOfDay - Either `start` or `end` of the day.
+ * @return {string} - String date with timestamp attached.
+ */
+export const appendTimestamp = ( date, timeOfDay ) =>
+	timeOfDay === 'start' ? date + 'T00:00:00+00:00' : date + 'T23:59:59+00:00';
+
+/**
  * Convert a string to Moment object
  *
  * @param {string} format - localized date string format

--- a/client/lib/date/test/index.js
+++ b/client/lib/date/test/index.js
@@ -32,6 +32,10 @@ describe( 'appendTimestamp', () => {
 	it( 'should append `end` timestamp', () => {
 		expect( appendTimestamp( '2018-01-01', 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
 	} );
+
+	it( 'should throw and error if `timeOfDay` is not valid', () => {
+		expect( () => appendTimestamp( '2018-01-01' ) ).toThrow( Error );
+	} );
 } );
 
 describe( 'toMoment', () => {

--- a/client/lib/date/test/index.js
+++ b/client/lib/date/test/index.js
@@ -10,6 +10,7 @@ import { setLocaleData } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
+	appendTimestamp,
 	toMoment,
 	getLastPeriod,
 	getCurrentPeriod,
@@ -22,6 +23,16 @@ import {
 	getDateDifferenceInDays,
 	getPreviousDate,
 } from 'lib/date';
+
+describe( 'appendTimestamp', () => {
+	it( 'should append `start` timestamp', () => {
+		expect( appendTimestamp( '2018-01-01', 'start' ) ).toEqual( '2018-01-01T00:00:00+00:00' );
+	} );
+
+	it( 'should append `end` timestamp', () => {
+		expect( appendTimestamp( '2018-01-01', 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
+	} );
+} );
 
 describe( 'toMoment', () => {
 	it( 'should pass through a valid Moment object as an argument', () => {

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -9,6 +9,7 @@ import { forEach, isNull } from 'lodash';
  * Internal dependencies
  */
 import { MAX_PER_PAGE } from 'store/constants';
+import { appendTimestamp } from 'lib/date';
 
 /**
  * Returns true if a report object is empty.
@@ -58,8 +59,8 @@ export function getSummaryNumbers( endpoint, dates, select ) {
 
 	const primaryQuery = {
 		...baseQuery,
-		after: dates.primary.after + 'T00:00:00+00:00',
-		before: dates.primary.before + 'T23:59:59+00:00',
+		after: appendTimestamp( dates.primary.after, 'start' ),
+		before: appendTimestamp( dates.primary.before, 'end' ),
 	};
 	const primary = getReportStats( endpoint, primaryQuery );
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
@@ -73,8 +74,8 @@ export function getSummaryNumbers( endpoint, dates, select ) {
 	const secondaryQuery = {
 		...baseQuery,
 		per_page: 1,
-		after: dates.secondary.after + 'T00:00:00+00:00',
-		before: dates.secondary.before + 'T23:59:59+00:00',
+		after: appendTimestamp( dates.secondary.after, 'start' ),
+		before: appendTimestamp( dates.secondary.before, 'end' ),
 	};
 	const secondary = getReportStats( endpoint, secondaryQuery );
 	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
@@ -109,8 +110,8 @@ export function getReportChartData( endpoint, query, select ) {
 		},
 	};
 
-	query.after += 'T00:00:00+00:00';
-	query.before += 'T23:59:59+00:00';
+	query.after = appendTimestamp( query.after, 'start' );
+	query.before = appendTimestamp( query.before, 'end' );
 
 	const stats = getReportStats( endpoint, query );
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/pull/519#discussion_r225335910.

Creates a function in `lib/date` that appends a timestamp to string dates. This way we don't have to hard-code the timestamps in many other files.

### Detailed test instructions:

 - Run `npm test` and verify the new tests pass.
 - Verify nothing is broken in `wc-admin`.
