### PR TITLE
Adds report error component

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -22,10 +22,15 @@ import {
 } from 'lib/date';
 import { getReportChartData } from 'store/reports/utils';
 import { MAX_PER_PAGE } from 'store/constants';
+import ReportError from 'analytics/components/report-error';
 
 class ReportChart extends Component {
 	render() {
 		const { primaryData, secondaryData, selectedChart, query } = this.props;
+
+		if ( primaryData.isError || secondaryData.isError ) {
+			return <ReportError isError={ true } />;
+		}
 
 		if ( primaryData.isRequesting || secondaryData.isRequesting ) {
 			return (

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -29,7 +29,7 @@ class ReportChart extends Component {
 		const { primaryData, secondaryData, selectedChart, query } = this.props;
 
 		if ( primaryData.isError || secondaryData.isError ) {
-			return <ReportError isError={ true } />;
+			return <ReportError isError />;
 		}
 
 		if ( primaryData.isRequesting || secondaryData.isRequesting ) {

--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -41,8 +41,8 @@ class ReportError extends Component {
 }
 
 ReportError.propTypes = {
-	isError: PropTypes.boolean,
-	isEmpty: PropTypes.boolean,
+	isError: PropTypes.bool,
+	isEmpty: PropTypes.bool,
 };
 
 export default ReportError;

--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -4,7 +4,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
 /**
@@ -46,4 +45,4 @@ ReportError.propTypes = {
 	isEmpty: PropTypes.boolean,
 };
 
-export default compose( ReportError );
+export default ReportError;

--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -1,0 +1,49 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { EmptyContent } from '@woocommerce/components';
+import { getAdminLink } from 'lib/nav-utils';
+
+class ReportError extends Component {
+	render() {
+		const { isError, isEmpty } = this.props;
+		let title, actionLabel, actionURL, actionCallback;
+
+		if ( isError ) {
+			title = __( 'There was an error getting your stats. Please try again.', 'wc-admin' );
+			actionLabel = __( 'Reload', 'wc-admin' );
+			actionCallback = () => {
+				// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
+				window.location.reload();
+			};
+		} else if ( isEmpty ) {
+			title = __( 'No results could be found for this date range.', 'wc-admin' );
+			actionLabel = __( 'View Orders', 'wc-admin' );
+			actionURL = getAdminLink( 'edit.php?post_type=shop_order' );
+		}
+		return (
+			<EmptyContent
+				title={ title }
+				actionLabel={ actionLabel }
+				actionURL={ actionURL }
+				actionCallback={ actionCallback }
+			/>
+		);
+	}
+}
+
+ReportError.propTypes = {
+	isError: PropTypes.boolean,
+	isEmpty: PropTypes.boolean,
+};
+
+export default compose( ReportError );

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -23,7 +23,7 @@ class ReportSummary extends Component {
 		const { selectedChart, charts } = this.props;
 
 		if ( this.props.summaryNumbers.isError ) {
-			return <ReportError isError={ true } />;
+			return <ReportError isError />;
 		}
 
 		if ( this.props.summaryNumbers.isRequesting ) {

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -17,9 +17,15 @@ import { getNewPath } from 'lib/nav-utils';
 import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce/components';
 import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
 import { getSummaryNumbers } from 'store/reports/utils';
+import ReportError from 'analytics/components/report-error';
 class ReportSummary extends Component {
 	render() {
 		const { selectedChart, charts } = this.props;
+
+		if ( this.props.summaryNumbers.isError ) {
+			return <ReportError isError={ true } />;
+		}
+
 		if ( this.props.summaryNumbers.isRequesting ) {
 			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
 		}


### PR DESCRIPTION
Adds a component to display if there is a data error.  We need to error the empty content component to be less huge and add some padding.

![screen shot 2018-10-16 at 12 51 38 pm](https://user-images.githubusercontent.com/6817400/47033305-71acd900-d142-11e8-931a-4f243bf83e71.png)

### Detailed test instructions:

 - Go: /wp-admin/admin.php?page=wc-admin#/analytics/orders?period=last_month&compare=previous_period&chart=avg_items_per_order
- Make page error.  You can add a `!` here: https://github.com/woocommerce/wc-admin/pull/543/files#diff-669849a93d17525c122e870f4e747142R25 or here: https://github.com/woocommerce/wc-admin/pull/543/files#diff-e634ee55f27a62796c86de6d587b69b1R31
