### PR TITLE
Dashboard: Remove Chart Example

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -9,7 +9,6 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
-import ChartExample from 'components/chart/example';
 import Header from 'header';
 import StorePerformance from './store-performance';
 import TopSellingProducts from './top-selling-products';
@@ -20,7 +19,6 @@ export default class Dashboard extends Component {
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'wc-admin' ) ] } />
 				<StorePerformance />
-				<ChartExample />
 				<div className="woocommerce-dashboard__columns">
 					<div>
 						<TopSellingProducts />


### PR DESCRIPTION
This is a quick PR to cleanup the dashboard page a bit leading up to the Woo Sesh presentation. Just removing the chart example which is no longer needed.

### Screenshots

__Before__
![image](https://user-images.githubusercontent.com/22080/47037200-2b9c4900-d133-11e8-9bbd-93eca9c2af55.png)

__After__
![image](https://user-images.githubusercontent.com/22080/47037138-01e32200-d133-11e8-969a-d96c5457314c.png)

### Detailed test instructions:

- Visit the dasbhoard
- Note the missing chart. Pour some out for the 💹 and thank it for its time served on the dashboard. 
