### PR TITLE
Add table shadow element to tables

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -58,12 +58,7 @@
 	top: 0;
 	width: 41px;
 	height: 100%;
-	background: linear-gradient(
-		90deg,
-		rgba(255, 255, 255, 0),
-		rgba(249, 249, 249, 0.5238),
-		rgba(225, 225, 225, 1)
-	);
+	background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
 }
 
 .woocommerce-table__header,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -38,6 +38,7 @@
 .woocommerce-table__table {
 	overflow-x: auto;
 	margin-bottom: $gap;
+	position: relative;
 
 	table {
 		border-collapse: collapse;
@@ -48,6 +49,21 @@
 	tr:focus-within {
 		background-color: $core-grey-light-200;
 	}
+}
+
+.woocommerce-table__shadow {
+	content: '';
+	position: absolute;
+	right: 0;
+	top: 0;
+	width: 41px;
+	height: 100%;
+	background: linear-gradient(
+		90deg,
+		rgba(255, 255, 255, 0),
+		rgba(249, 249, 249, 0.5238),
+		rgba(225, 225, 225, 1)
+	);
 }
 
 .woocommerce-table__header,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -46,6 +46,21 @@
 .woocommerce-table__table {
 	overflow-x: auto;
 
+	&:after {
+		content: '';
+		position: absolute;
+		right: 0;
+		top: 0;
+		width: 41px;
+		height: 100%;
+		background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
+		visibility: hidden;
+	}
+
+	&.is-scrollable:after {
+		visibility: visible;
+	}
+
 	table {
 		border-collapse: collapse;
 		width: 100%;
@@ -55,15 +70,6 @@
 	tr:focus-within {
 		background-color: $core-grey-light-200;
 	}
-}
-
-.woocommerce-table__shadow {
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 41px;
-	height: 100%;
-	background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
 }
 
 .woocommerce-table__header,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -3,7 +3,7 @@
 .woocommerce-table {
 	.woocommerce-card__body {
 		padding: 0;
-		padding-bottom: $gap;
+		position: relative;
 	}
 
 	.woocommerce-card__action,
@@ -28,6 +28,14 @@
 			height: auto;
 		}
 	}
+
+	.woocommerce-pagination {
+		padding-top: $gap;
+		padding-bottom: $gap;
+		z-index: 1;
+		background: white;
+		position: relative;
+	}
 }
 
 .woocommerce-table__caption {
@@ -37,8 +45,6 @@
 
 .woocommerce-table__table {
 	overflow-x: auto;
-	margin-bottom: $gap;
-	position: relative;
 
 	table {
 		border-collapse: collapse;

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -52,13 +52,12 @@
 }
 
 .woocommerce-table__shadow {
-	content: '';
 	position: absolute;
 	right: 0;
 	top: 0;
 	width: 41px;
 	height: 100%;
-	background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
+	background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
 }
 
 .woocommerce-table__header,

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -56,12 +56,10 @@ class Table extends Component {
 		this.state = {
 			tabIndex: null,
 			shadowStyles: {
-				transform: 'translateX(0)',
 				visibility: 'hidden',
 			},
 		};
 		this.container = createRef();
-		this.tableShadow = createRef();
 		this.sortBy = this.sortBy.bind( this );
 	}
 
@@ -100,7 +98,6 @@ class Table extends Component {
 		const scrolledToEnd = table.scrollWidth - table.scrollLeft <= table.offsetWidth;
 		this.setState( {
 			shadowStyles: {
-				transform: 'translateX(' + this.container.current.scrollLeft + 'px)',
 				visibility: scrolledToEnd ? 'hidden' : 'visible',
 			},
 		} );

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -55,9 +55,7 @@ class Table extends Component {
 		super( props );
 		this.state = {
 			tabIndex: null,
-			shadowStyles: {
-				visibility: 'hidden',
-			},
+			isScrollable: false,
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
@@ -97,9 +95,7 @@ class Table extends Component {
 		const table = this.container.current;
 		const scrolledToEnd = table.scrollWidth - table.scrollLeft <= table.offsetWidth;
 		this.setState( {
-			shadowStyles: {
-				visibility: scrolledToEnd ? 'hidden' : 'visible',
-			},
+			isScrollable: scrolledToEnd ? false : true,
 		} );
 	};
 
@@ -115,7 +111,9 @@ class Table extends Component {
 			rows,
 		} = this.props;
 		const { tabIndex } = this.state;
-		const classes = classnames( 'woocommerce-table__table', classNames );
+		const classes = classnames( 'woocommerce-table__table', classNames, {
+			'is-scrollable': this.state.isScrollable,
+		} );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
 		const sortDir = query.order || DESC;
 
@@ -211,7 +209,6 @@ class Table extends Component {
 						) ) }
 					</tbody>
 				</table>
-				<div className="woocommerce-table__shadow" style={ this.state.shadowStyles } />
 			</div>
 		);
 	}

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -55,8 +55,13 @@ class Table extends Component {
 		super( props );
 		this.state = {
 			tabIndex: null,
+			shadowStyles: {
+				transform: 'translateX(0)',
+				visibility: 'hidden',
+			},
 		};
 		this.container = createRef();
+		this.tableShadow = createRef();
 		this.sortBy = this.sortBy.bind( this );
 	}
 
@@ -68,6 +73,12 @@ class Table extends Component {
 			tabIndex: scrollable ? '0' : null,
 		} );
 		/* eslint-enable react/no-did-mount-set-state */
+		this.updateTableShadow();
+		window.addEventListener( 'resize', this.updateTableShadow );
+	}
+
+	componentDidUnmount() {
+		window.removeEventListener( 'resize', this.updateTableShadow );
 	}
 
 	sortBy( key ) {
@@ -83,6 +94,17 @@ class Table extends Component {
 			this.props.onSort( key, dir );
 		};
 	}
+
+	updateTableShadow = () => {
+		const table = this.container.current;
+		const scrolledToEnd = table.scrollWidth - table.scrollLeft <= table.offsetWidth;
+		this.setState( {
+			shadowStyles: {
+				transform: 'translateX(' + this.container.current.scrollLeft + 'px)',
+				visibility: scrolledToEnd ? 'hidden' : 'visible',
+			},
+		} );
+	};
 
 	render() {
 		const {
@@ -108,6 +130,7 @@ class Table extends Component {
 				aria-hidden={ ariaHidden }
 				aria-labelledby={ `caption-${ instanceId }` }
 				role="group"
+				onScroll={ this.updateTableShadow }
 			>
 				<table>
 					<caption
@@ -191,6 +214,11 @@ class Table extends Component {
 						) ) }
 					</tbody>
 				</table>
+				<div
+					ref={ this.tableShadow }
+					className="woocommerce-table__shadow"
+					style={ this.state.shadowStyles }
+				/>
 			</div>
 		);
 	}

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -214,11 +214,7 @@ class Table extends Component {
 						) ) }
 					</tbody>
 				</table>
-				<div
-					ref={ this.tableShadow }
-					className="woocommerce-table__shadow"
-					style={ this.state.shadowStyles }
-				/>
+				<div className="woocommerce-table__shadow" style={ this.state.shadowStyles } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #450 

This adds a shadow to all tables with a horizontal overflow until the table has been scrolled to the end.

### Screenshots

<img width="300" alt="screen shot 2018-10-16 at 4 02 22 pm" src="https://user-images.githubusercontent.com/10561050/47043952-f7d61900-d15c-11e8-93c8-e52036aeb21c.png">

### Detailed test instructions:

1.  Open `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`.
2.  Narrow viewport width to make table scrollable.
3.  Scroll to end to make sure shadow is not visible when fully scrolled to the right.
4.  Resize screen to desktop view to confirm that shadow styles are recalculated (hidden) on resize.
