### PR TITLE
Update the order of orders report summary numbers

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -18,6 +18,8 @@ import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce
 import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
 import { getSummaryNumbers } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
+import { numberFormat } from 'lib/number';
+
 class ReportSummary extends Component {
 	render() {
 		const { selectedChart, charts } = this.props;
@@ -56,6 +58,8 @@ class ReportSummary extends Component {
 					secondaryValue = secondaryValue && formatCurrency( secondaryValue );
 					break;
 				case 'number':
+					value = numberFormat( value );
+					secondaryValue = secondaryValue && numberFormat( secondaryValue );
 					break;
 			}
 

--- a/client/analytics/report/orders/chart.js
+++ b/client/analytics/report/orders/chart.js
@@ -17,6 +17,11 @@ class OrdersReportChart extends Component {
 	getCharts() {
 		return [
 			{
+				key: 'orders_count',
+				label: __( 'Orders Count', 'wc-admin' ),
+				type: 'number',
+			},
+			{
 				key: 'net_revenue',
 				label: __( 'Net Revenue', 'wc-admin' ),
 				type: 'currency',
@@ -30,11 +35,6 @@ class OrdersReportChart extends Component {
 				key: 'avg_items_per_order',
 				label: __( 'Average Items Per Order', 'wc-admin' ),
 				type: 'average',
-			},
-			{
-				key: 'orders_count',
-				label: __( 'Orders Count', 'wc-admin' ),
-				type: 'number',
 			},
 		];
 	}


### PR DESCRIPTION
This PR re-orders the summary numbers on the order report, placing the order count first (Most relevant data point for this report)

<img width="1225" alt="screen shot 2018-10-16 at 1 35 54 pm" src="https://user-images.githubusercontent.com/4500952/47045804-93a95a00-d148-11e8-932f-0fa39e44ebc2.png">

I'd also like to ensure there's a comma separator on the "Number" summary number type (note the screen shot above, no comma) - I tried to find where I'd make that change / addition, but alas... I'm just a designer 👨‍🎨 If someone could point me in the right direction, I'll add it with another commit. 