### PR TITLE
Add products report Chart and Summary

### DIFF
--- a/client/analytics/report/products/chart.js
+++ b/client/analytics/report/products/chart.js
@@ -17,6 +17,11 @@ class ProductsReportChart extends Component {
 	getCharts() {
 		return [
 			{
+				key: 'items_sold',
+				label: __( 'Items Sold', 'wc-admin' ),
+				type: 'number',
+			},
+			{
 				key: 'gross_revenue',
 				label: __( 'Gross Revenue', 'wc-admin' ),
 				type: 'currency',
@@ -24,11 +29,6 @@ class ProductsReportChart extends Component {
 			{
 				key: 'orders_count',
 				label: __( 'Orders Count', 'wc-admin' ),
-				type: 'number',
-			},
-			{
-				key: 'items_sold',
-				label: __( 'Items Sold', 'wc-admin' ),
 				type: 'number',
 			},
 		];

--- a/client/analytics/report/products/chart.js
+++ b/client/analytics/report/products/chart.js
@@ -1,0 +1,73 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ReportChart from 'analytics/components/report-chart';
+import ReportSummary from 'analytics/components/report-summary';
+
+class ProductsReportChart extends Component {
+	getCharts() {
+		return [
+			{
+				key: 'gross_revenue',
+				label: __( 'Gross Revenue', 'wc-admin' ),
+				type: 'currency',
+			},
+			{
+				key: 'orders_count',
+				label: __( 'Orders Count', 'wc-admin' ),
+				type: 'number',
+			},
+			{
+				key: 'items_sold',
+				label: __( 'Items Sold', 'wc-admin' ),
+				type: 'number',
+			},
+		];
+	}
+
+	getSelectedChart() {
+		const { query } = this.props;
+		const charts = this.getCharts();
+		const chart = find( charts, { key: query.chart } );
+		if ( chart ) {
+			return chart;
+		}
+
+		return charts[ 0 ];
+	}
+
+	render() {
+		const { query } = this.props;
+		return (
+			<Fragment>
+				<ReportSummary
+					charts={ this.getCharts() }
+					endpoint="products"
+					query={ query }
+					selectedChart={ this.getSelectedChart() }
+				/>
+				<ReportChart
+					charts={ this.getCharts() }
+					endpoint="products"
+					query={ query }
+					selectedChart={ this.getSelectedChart() }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+ProductsReportChart.propTypes = {
+	query: PropTypes.object.isRequired,
+};
+
+export default ProductsReportChart;

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -14,10 +14,11 @@ import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { numberFormat } from 'lib/number';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
 import { ReportFilters, TableCard } from '@woocommerce/components';
+import ProductsReportChart from './chart';
 
 import products from './__mocks__/data';
 
-export default class extends Component {
+class ProductsReport extends Component {
 	getHeadersContent() {
 		return [
 			{
@@ -160,9 +161,11 @@ export default class extends Component {
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
-
+				<ProductsReportChart query={ query } />
 				{ this.renderTable() }
 			</Fragment>
 		);
 	}
 }
+
+export default ProductsReport;


### PR DESCRIPTION
Fixes #534 

Add chart and summary numbers for the products report.

For some reason the API is breaking when using the default query.  

### Screenshots

![screen shot 2018-10-16 at 5 03 34 pm](https://user-images.githubusercontent.com/6817400/47047466-a716ee00-d165-11e8-9f95-13c57c05dff0.png)


### Detailed test instructions:

 - Go: /wp-admin/admin.php?page=wc-admin#/analytics/products?period=month&compare=previous_period
 - Observe Summary and Chart