### PR TITLE
Reposition chevron icon for first column in tables

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -104,14 +104,11 @@ th.woocommerce-table__item {
 }
 
 .woocommerce-table__header {
-	font-weight: bold;
-	white-space: nowrap;
-}
-
-.woocommerce-table__header {
 	padding: $gap-smaller $gap-large;
 	background-color: #f8f9fa;
 	border-bottom: 1px solid $core-grey-light-700;
+	font-weight: bold;
+	white-space: nowrap;
 
 	& + .woocommerce-table__header {
 		border-left: 1px solid $core-grey-light-700;
@@ -119,6 +116,15 @@ th.woocommerce-table__item {
 		.rtl & {
 			border-left: 0;
 			border-right: 1px solid $core-grey-light-700;
+		}
+	}
+
+	&.is-left-aligned.is-sortable {
+		padding-left: $gap;
+		svg {
+			display: inline-flex;
+			order: 1;
+			margin-left: 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes #446 

This PR repositions the chevron sorting icon for the first column in tables to the right side of the column text.

### Screenshots

<img width="203" alt="screen shot 2018-10-16 at 5 26 40 pm" src="https://user-images.githubusercontent.com/10561050/47048524-a92e7c00-d168-11e8-9c2a-72dd1b33a137.png">

### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
2.  The chevron icon for the "Date" field should be to the right of the "Date" text.