### PR TITLE
Reports: DRY queries for report requests

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -4,9 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
-import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 
 /**
@@ -20,8 +18,6 @@ import {
 	getIntervalForQuery,
 	getPreviousDate,
 } from 'lib/date';
-import { getReportChartData } from 'store/reports/utils';
-import { MAX_PER_PAGE } from 'store/constants';
 import ReportError from 'analytics/components/report-error';
 
 class ReportChart extends Component {
@@ -94,41 +90,6 @@ ReportChart.propTypes = {
 	primaryData: PropTypes.object.isRequired,
 	secondaryData: PropTypes.object.isRequired,
 	selectedChart: PropTypes.object.isRequired,
-	query: PropTypes.object.isRequired,
 };
 
-export default compose(
-	withSelect( ( select, props ) => {
-		const { query, endpoint } = props;
-		const interval = getIntervalForQuery( query );
-		const datesFromQuery = getCurrentDates( query );
-		const baseArgs = {
-			order: 'asc',
-			interval: interval,
-			per_page: MAX_PER_PAGE,
-		};
-		const primaryData = getReportChartData(
-			endpoint,
-			{
-				...baseArgs,
-				after: datesFromQuery.primary.after,
-				before: datesFromQuery.primary.before,
-			},
-			select
-		);
-
-		const secondaryData = getReportChartData(
-			endpoint,
-			{
-				...baseArgs,
-				after: datesFromQuery.secondary.after,
-				before: datesFromQuery.secondary.before,
-			},
-			select
-		);
-		return {
-			primaryData,
-			secondaryData,
-		};
-	} )
-)( ReportChart );
+export default ReportChart;

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import { formatCurrency } from 'lib/currency';
 import { getNewPath } from 'lib/nav-utils';
 import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce/components';
-import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
+import { getDateParamsFromQuery } from 'lib/date';
 import { getSummaryNumbers } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
 class ReportSummary extends Component {
@@ -88,20 +88,14 @@ ReportSummary.propTypes = {
 	endpoint: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 	selectedChart: PropTypes.object.isRequired,
+	primaryQuery: PropTypes.object.isRequired,
+	secondaryQuery: PropTypes.object.isRequired,
 };
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query, endpoint } = props;
-		const datesFromQuery = getCurrentDates( query );
-		const summaryNumbers = getSummaryNumbers(
-			endpoint,
-			{
-				primary: datesFromQuery.primary,
-				secondary: datesFromQuery.secondary,
-			},
-			select
-		);
+		const { endpoint, primaryQuery, secondaryQuery } = props;
+		const summaryNumbers = getSummaryNumbers( endpoint, primaryQuery, secondaryQuery, select );
 
 		return {
 			summaryNumbers,

--- a/client/analytics/report/orders/chart.js
+++ b/client/analytics/report/orders/chart.js
@@ -51,7 +51,7 @@ class OrdersReportChart extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, primaryQuery, secondaryQuery, primaryData, secondaryData } = this.props;
 		return (
 			<Fragment>
 				<ReportSummary
@@ -59,12 +59,15 @@ class OrdersReportChart extends Component {
 					endpoint="orders"
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
+					primaryQuery={ primaryQuery }
+					secondaryQuery={ secondaryQuery }
 				/>
 				<ReportChart
 					charts={ this.getCharts() }
-					endpoint="orders"
-					query={ query }
 					selectedChart={ this.getSelectedChart() }
+					query={ query }
+					primaryData={ primaryData }
+					secondaryData={ secondaryData }
 				/>
 			</Fragment>
 		);
@@ -73,6 +76,10 @@ class OrdersReportChart extends Component {
 
 OrdersReportChart.propTypes = {
 	query: PropTypes.object.isRequired,
+	primaryQuery: PropTypes.object.isRequired,
+	secondaryQuery: PropTypes.object.isRequired,
+	primaryData: PropTypes.object.isRequired,
+	secondaryData: PropTypes.object.isRequired,
 };
 
 export default OrdersReportChart;

--- a/client/analytics/report/revenue/chart.js
+++ b/client/analytics/report/revenue/chart.js
@@ -61,7 +61,7 @@ class OrdersReportChart extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, primaryData, secondaryData, primaryQuery, secondaryQuery } = this.props;
 		return (
 			<Fragment>
 				<ReportSummary
@@ -69,12 +69,15 @@ class OrdersReportChart extends Component {
 					endpoint="revenue"
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
+					primaryQuery={ primaryQuery }
+					secondaryQuery={ secondaryQuery }
 				/>
 				<ReportChart
 					charts={ this.getCharts() }
-					endpoint="revenue"
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
+					primaryData={ primaryData }
+					secondaryData={ secondaryData }
 				/>
 			</Fragment>
 		);
@@ -83,6 +86,10 @@ class OrdersReportChart extends Component {
 
 OrdersReportChart.propTypes = {
 	query: PropTypes.object.isRequired,
+	primaryQuery: PropTypes.object.isRequired,
+	secondaryQuery: PropTypes.object.isRequired,
+	primaryData: PropTypes.object.isRequired,
+	secondaryData: PropTypes.object.isRequired,
 };
 
 export default OrdersReportChart;

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -17,7 +17,12 @@ import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/c
 import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
-import { appendTimestamp, getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
+import {
+	appendTimestamp,
+	getCurrentDates,
+	getDateFormatsForInterval,
+	getIntervalForQuery,
+} from 'lib/date';
 import OrdersReportChart from './chart';
 import { getReportChartData } from 'store/reports/utils';
 import { MAX_PER_PAGE } from 'store/constants';
@@ -245,14 +250,14 @@ export default compose(
 
 		const primaryQuery = {
 			...baseArgs,
-			after: datesFromQuery.primary.after + 'T00:00:00+00:00',
-			before: datesFromQuery.primary.before + 'T23:59:59+00:00',
+			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		};
 
 		const secondaryQuery = {
 			...baseArgs,
-			after: datesFromQuery.secondary.after + 'T00:00:00+00:00',
-			before: datesFromQuery.secondary.before + 'T23:59:59+00:00',
+			after: appendTimestamp( datesFromQuery.secondary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.secondary.before, 'end' ),
 		};
 
 		const primaryData = getReportChartData( 'revenue', primaryQuery, select );

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -239,15 +239,14 @@ describe( 'getSummaryNumbers()', () => {
 		},
 	};
 
-	const dates = {
-		primary: {
-			after: '2018-10-10',
-			before: '2018-10-10',
-		},
-		secondary: {
-			after: '2018-10-09',
-			before: '2018-10-09',
-		},
+	const primaryQuery = {
+		after: '2018-10-10T00:00:00+00:00',
+		before: '2018-10-10T23:59:59+00:00',
+	};
+
+	const secondaryQuery = {
+		after: '2018-10-09T00:00:00+00:00',
+		before: '2018-10-09T23:59:59+00:00',
 	};
 
 	beforeAll( () => {
@@ -280,7 +279,7 @@ describe( 'getSummaryNumbers()', () => {
 		setIsReportStatsRequesting( () => {
 			return true;
 		} );
-		const result = getSummaryNumbers( 'revenue', dates, select );
+		const result = getSummaryNumbers( 'revenue', primaryQuery, secondaryQuery, select );
 		expect( result ).toEqual( { ...response, isRequesting: true } );
 	} );
 
@@ -291,7 +290,7 @@ describe( 'getSummaryNumbers()', () => {
 		setIsReportStatsError( () => {
 			return true;
 		} );
-		const result = getSummaryNumbers( 'revenue', dates, select );
+		const result = getSummaryNumbers( 'revenue', primaryQuery, secondaryQuery, select );
 		expect( result ).toEqual( { ...response, isError: true } );
 	} );
 
@@ -336,7 +335,7 @@ describe( 'getSummaryNumbers()', () => {
 			};
 		} );
 
-		const result = getSummaryNumbers( 'revenue', dates, select );
+		const result = getSummaryNumbers( 'revenue', primaryQuery, secondaryQuery, select );
 		expect( result ).toEqual( { ...response, totals } );
 	} );
 } );

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -9,7 +9,6 @@ import { forEach, isNull } from 'lodash';
  * Internal dependencies
  */
 import { MAX_PER_PAGE } from 'store/constants';
-import { appendTimestamp } from 'lib/date';
 
 /**
  * Returns true if a report object is empty.
@@ -37,11 +36,12 @@ export function isReportDataEmpty( report ) {
  * Returns summary number totals needed to render a report page.
  *
  * @param  {String} endpoint Report  API Endpoint
- * @param  {Object} dates  Primary and secondary dates.
+ * @param  {Object} primaryQuery Query object for primary timeseries data
+ * @param  {Object} secondaryQuery Query object for secondary timeseries data
  * @param {object} select Instance of @wordpress/select
  * @return {Object}  Object containing summary number responses.
  */
-export function getSummaryNumbers( endpoint, dates, select ) {
+export function getSummaryNumbers( endpoint, primaryQuery, secondaryQuery, select ) {
 	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
 	const response = {
 		isRequesting: false,
@@ -52,16 +52,6 @@ export function getSummaryNumbers( endpoint, dates, select ) {
 		},
 	};
 
-	const baseQuery = {
-		interval: 'day',
-		per_page: 1, // We only need the `totals` part of the response.
-	};
-
-	const primaryQuery = {
-		...baseQuery,
-		after: appendTimestamp( dates.primary.after, 'start' ),
-		before: appendTimestamp( dates.primary.before, 'end' ),
-	};
 	const primary = getReportStats( endpoint, primaryQuery );
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
@@ -71,12 +61,6 @@ export function getSummaryNumbers( endpoint, dates, select ) {
 
 	const primaryTotals = ( primary && primary.data && primary.data.totals ) || null;
 
-	const secondaryQuery = {
-		...baseQuery,
-		per_page: 1,
-		after: appendTimestamp( dates.secondary.after, 'start' ),
-		before: appendTimestamp( dates.secondary.before, 'end' ),
-	};
 	const secondary = getReportStats( endpoint, secondaryQuery );
 	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
 		return { ...response, isRequesting: true };
@@ -109,9 +93,6 @@ export function getReportChartData( endpoint, query, select ) {
 			intervals: [],
 		},
 	};
-
-	query.after = appendTimestamp( query.after, 'start' );
-	query.before = appendTimestamp( query.before, 'end' );
 
 	const stats = getReportStats( endpoint, query );
 


### PR DESCRIPTION
### Problem

Creation and modification of queries used to make requests for Chart, SummaryNumbers, and Table were in 3 different places. This results in two extra requests. Eventually, filter arguments will need to be added, so changes here are the first step in that process by consolidating creation of queries in one place.

### Solution

Make `tableQuery`, `primaryQuery`, `secondaryQuery` in the index.js of each report and pass down the queries and resulting data.

### Next Steps

* Modify `getSummaryNumbers` so it accepts the data returned from `getReportChartData` to avoid duplicate requests made by successive selector calls.
* Pass down data/errors instead of queries.
* Handle errors at the component level
* Make time stamp additions, ie `+ 'T23:59:59+00:00'`, directly in `getCurrentDates`.

### Test

View Orders and Revenue Reports and ensure no regressions.

@belcherj This is related to your refactoring. I'm open to suggestions if you had other thoughts on this.
