### PR TITLE
Change toggle background color to woocommerce purple

### DIFF
--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -17,6 +17,10 @@
 		padding: 2px;
 	}
 
+	.components-form-toggle.is-checked .components-form-toggle__track {
+		background-color: $woocommerce;
+	}
+
 	.woocommerce-ellipsis-menu__content {
 		width: 100%;
 	}


### PR DESCRIPTION
Fixes #443 

Update the ellipsis toggle colors to the WooCommerce purple instead of default WP blue.

### Screenshots

<img width="324" alt="screen shot 2018-10-17 at 9 51 48 am" src="https://user-images.githubusercontent.com/10561050/47091311-a5dfd280-d1f2-11e8-9391-6cffc4a45427.png">

### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
2.  Click on ellipsis menu toggle on top of table.
3.  Confirm that color of active toggles is purple.
