### PR TITLE
Removes unwanted orders report filters

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -14,19 +14,6 @@ const { orderStatuses } = wcSettings;
 
 export const filters = [
 	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
-	{
-		label: __( 'Single Order', 'wc-admin' ),
-		value: 'single',
-		subFilters: [
-			{
-				component: 'Search',
-				value: 'single_order',
-				path: [ 'single' ],
-			},
-		],
-	},
-	{ label: __( 'Top Orders by Items Sold', 'wc-admin' ), value: 'top_items' },
-	{ label: __( 'Top Orders by Gross Sales', 'wc-admin' ), value: 'top_sales' },
 	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
 ];
 


### PR DESCRIPTION
Fixes #527

Removes orders filters as specified in #527

### Screenshots

![screen shot 2018-10-17 at 2 49 41 pm](https://user-images.githubusercontent.com/6817400/47109311-ec95f280-d21b-11e8-9826-d229fa1693a3.png)
![screen shot 2018-10-17 at 2 49 50 pm](https://user-images.githubusercontent.com/6817400/47109313-ec95f280-d21b-11e8-9b88-b5e855e68a8c.png)


### Detailed test instructions:

 - Open: /wp-admin/admin.php?page=wc-admin#/analytics/orders
 - Observe filters
