### PR TITLE
Change componentDidUnmount to componentWillUnmount

### DIFF
--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -73,7 +73,7 @@ class Table extends Component {
 		window.addEventListener( 'resize', this.updateTableShadow );
 	}
 
-	componentDidUnmount() {
+	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.updateTableShadow );
 	}
 


### PR DESCRIPTION
Fixes #562 

Switches `componentDidUnmount` for `componentWillUnmount` (I made an oopsy 😅 )

### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
2.  Confirm that no console warning is thrown