### PR TITLE
Activity Panel: Inbox: New Sales Record Note

### DIFF
--- a/includes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/class-wc-admin-notes-new-sales-record.php
@@ -29,7 +29,7 @@ class WC_Admin_Notes_New_Sales_Record {
 	 * @param string $date Date for sales to sum (i.e. YYYY-MM-DD).
 	 * @return floatval
 	 */
-	public function sum_sales_for_date( $date ) {
+	public static function sum_sales_for_date( $date ) {
 		$order_query = new WC_Order_Query( array( 'date_created' => $date ) );
 		$orders      = $order_query->get_orders();
 		$total       = 0;
@@ -44,9 +44,9 @@ class WC_Admin_Notes_New_Sales_Record {
 	/**
 	 * Possibly add a sales record note.
 	 */
-	public function possibly_add_sales_record_note() {
+	public static function possibly_add_sales_record_note() {
 		$yesterday = date( 'Y-m-d', current_time( 'timestamp', 0 ) - DAY_IN_SECONDS );
-		$total     = $this->sum_sales_for_date( $yesterday );
+		$total     = self::sum_sales_for_date( $yesterday );
 
 		// No sales yesterday? Bail.
 		if ( 0 >= $total ) {
@@ -107,6 +107,3 @@ class WC_Admin_Notes_New_Sales_Record {
 		}
 	}
 }
-
-// TODO Call schedule_recurring for once each day at 1 am or something.
-new WC_Admin_Notes_New_Sales_Record();

--- a/includes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/class-wc-admin-notes-new-sales-record.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * WooCommerce Admin (Dashboard) New Sales Record Note Provider.
+ *
+ * Adds a note to the merchant's inbox when the previous day's sales are a new record.
+ *
+ * @package WooCommerce Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_New_Sales_Record
+ */
+class WC_Admin_Notes_New_Sales_Record {
+	const RECORD_DATE_OPTION_KEY   = 'woocommerce_sales_record_date'; // YYYY-MM-DD.
+	const RECORD_AMOUNT_OPTION_KEY = 'woocommerce_sales_record_amount';
+
+	/**
+	 * Sales Record constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_footer', array( $this, 'sum_yesterdays_sales' ) );
+	}
+
+	/**
+	 * Returns the total of yesterday's sales.
+	 *
+	 * @param string $date Date for sales to sum (i.e. YYYY-MM-DD).
+	 * @return floatval
+	 */
+	public function sum_sales_for_date( $date ) {
+		$order_query = new WC_Order_Query( array( 'date_created' => $date ) );
+		$orders      = $order_query->get_orders();
+		$total       = 0;
+
+		foreach ( (array) $orders as $order ) {
+			$total += $order->get_total();
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Possibly add a sales record note.
+	 */
+	public function possibly_add_sales_record_note() {
+		$yesterday = date( 'Y-m-d', current_time( 'timestamp', 0 ) - DAY_IN_SECONDS );
+		$total     = $this->sum_sales_for_date( $yesterday );
+
+		// No sales yesterday? Bail.
+		if ( 0 <= $total ) {
+			return;
+		}
+
+		$record_date = get_option( RECORD_DATE_OPTION_KEY, '' );
+		$record_amt  = floatval( get_option( RECORD_AMOUNT_OPTION_KEY, 0 ) );
+
+		// No previous entry? Just enter what we have and return without generating a note.
+		if ( empty( $record_date ) ) {
+			update_option( RECORD_DATE_OPTION_KEY, $yesterday );
+			update_option( RECORD_AMOUNT_OPTION_KEY, $total );
+			return;
+		}
+
+		// Otherwise, if yesterdays total bested the record, update AND generate a note.
+		if ( $total > $record_amt ) {
+			update_option( RECORD_DATE_OPTION_KEY, $yesterday );
+			update_option( RECORD_AMOUNT_OPTION_KEY, $total );
+
+			$formatted_yesterday   = 'October 16th';
+			$formatted_total       = '$160.00';
+			$formatted_record_date = 'May 23rd';
+			$formatted_record_amt  = '$100.00';
+
+			$note_content = sprintf(
+				/* translators: */
+				__( 'Woohoo, %1$s was your record day for sales! Net revenue was %2$s beating the previous record of %3$s set on %4$s.', 'wc-admin' ),
+				$formatted_yesterday,
+				$formatted_total,
+				$formatted_record_amt,
+				$formatted_record_date
+			);
+
+			// TODO: Delete any pre-existing notes named wc-admin-new-sales-record.
+			$note = new WC_Admin_Note();
+			$note->set_title( __( 'New sales record!', 'wc-admin' ) );
+			$note->set_content( $note_content );
+			$note->set_content_data( '{}' );
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_icon( 'trophy' );
+			$note->set_name( 'wc-admin-new-sales-record' );
+			$note->set_source( 'wc-admin' );
+			$note->add_action( 'view-report', __( 'View report', 'wc-admin' ), '' );
+			$note->save();
+		}
+	}
+}
+
+// TODO Call schedule_recurring for once each day at 1 am or something.
+new WC_Admin_Notes_New_Sales_Record();

--- a/includes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/class-wc-admin-notes-new-sales-record.php
@@ -17,13 +17,6 @@ class WC_Admin_Notes_New_Sales_Record {
 	const RECORD_AMOUNT_OPTION_KEY = 'woocommerce_sales_record_amount';
 
 	/**
-	 * Sales Record constructor.
-	 */
-	public function __construct() {
-		add_action( 'admin_footer', array( $this, 'possibly_add_sales_record_note' ) );
-	}
-
-	/**
 	 * Returns the total of yesterday's sales.
 	 *
 	 * @param string $date Date for sales to sum (i.e. YYYY-MM-DD).

--- a/includes/class-wc-admin-notes.php
+++ b/includes/class-wc-admin-notes.php
@@ -69,4 +69,19 @@ class WC_Admin_Notes {
 		$data_store = WC_Data_Store::load( 'admin-note' );
 		return $data_store->get_notes_count();
 	}
+
+	/**
+	 * Deletes admin notes with a given name.
+	 *
+	 * @param string $name Name to search for.
+	 */
+	public static function delete_notes_with_name( $name ) {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( $name );
+		foreach ( (array) $note_ids as $note_id ) {
+			$note = new WC_Admin_Note( $note_id );
+			$note->set_id( $note_id );
+			$note->delete();
+		}
+	}
 }

--- a/includes/class-wc-admin-notes.php
+++ b/includes/class-wc-admin-notes.php
@@ -80,7 +80,6 @@ class WC_Admin_Notes {
 		$note_ids   = $data_store->get_notes_with_name( $name );
 		foreach ( (array) $note_ids as $note_id ) {
 			$note = new WC_Admin_Note( $note_id );
-			$note->set_id( $note_id );
 			$note->delete();
 		}
 	}

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -135,13 +135,13 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function delete( &$note, $args = array() ) {
 		$note_id = $note->get_id();
-		if ( $note->get_id() ) {
+		if ( $note_id ) {
 			global $wpdb;
 			$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_notes', array( 'note_id' => $note_id ) );
 			$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_note_actions', array( 'note_id' => $note_id ) );
 			$note->set_id( null );
 		}
-		do_action( 'woocommerce_trash_note', $id );
+		do_action( 'woocommerce_trash_note', $note_id );
 	}
 
 	/**
@@ -240,6 +240,22 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		";
 
 		return $wpdb->get_var( $query ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Find all the notes with a given name.
+	 *
+	 * @param string $name Name to search for.
+	 * @return array An array of matching note ids.
+	 */
+	public function get_notes_with_name( $name ) {
+		global $wpdb;
+		return $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT note_id FROM {$wpdb->prefix}woocommerce_admin_notes WHERE name = %s ORDER BY note_id ASC;",
+				$name
+			)
+		);
 	}
 
 }

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -205,13 +205,6 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_notes( $args = array() ) {
 		global $wpdb;
 
-		// Build the query.
-		$query = "
-			SELECT note_id, title, content
-			FROM {$wpdb->prefix}woocommerce_admin_notes
-			ORDER BY note_id DESC
-		";
-
 		$per_page = isset( $args['per_page'] ) ? intval( $args['per_page'] ) : 10;
 		if ( $per_page <= 0 ) {
 			$per_page = 10;
@@ -225,7 +218,13 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$offset     = $per_page * ( $page - 1 );
 		$pagination = sprintf( ' LIMIT %d, %d', $offset, $per_page );
 
-		return $wpdb->get_results( $query . $pagination ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT note_id, title, content FROM {$wpdb->prefix}woocommerce_admin_notes ORDER BY note_id DESC LIMIT %d, %d",
+				$offset,
+				$per_page
+			)
+		);
 	}
 
 	/**
@@ -235,14 +234,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function get_notes_count() {
 		global $wpdb;
-
-		// Build the query.
-		$query = "
-			SELECT COUNT(*)
-			FROM {$wpdb->prefix}woocommerce_admin_notes
-		";
-
-		return $wpdb->get_var( $query ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+		return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_admin_notes" );
 	}
 
 	/**
@@ -255,7 +248,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		global $wpdb;
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT note_id FROM {$wpdb->prefix}woocommerce_admin_notes WHERE name = %s ORDER BY note_id ASC;",
+				"SELECT note_id FROM {$wpdb->prefix}woocommerce_admin_notes WHERE name = %s ORDER BY note_id ASC",
 				$name
 			)
 		);

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -105,7 +105,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( $note->get_id() ) {
 			$wpdb->update(
-				$wpdb->prefix . 'woocommerce_admin_notes', array(
+				$wpdb->prefix . 'woocommerce_admin_notes',
+				array(
 					'name'          => $note->get_name(),
 					'type'          => $note->get_type(),
 					'locale'        => $note->get_locale(),
@@ -117,7 +118,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 					'source'        => $note->get_source(),
 					'date_created'  => $note->get_date_created(),
 					'date_reminder' => $note->get_date_reminder(),
-				), array( 'note_id' => $note->get_id() )
+				),
+				array( 'note_id' => $note->get_id() )
 			);
 		}
 
@@ -183,7 +185,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_note_actions', array( 'note_id' => $note->get_id() ) );
 		foreach ( $note->get_actions( 'edit' ) as $action ) {
 			$wpdb->insert(
-				$wpdb->prefix . 'woocommerce_admin_note_actions', array(
+				$wpdb->prefix . 'woocommerce_admin_note_actions',
+				array(
 					'note_id' => $note->get_id(),
 					'name'    => $action->name,
 					'label'   => $action->label,

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -50,10 +50,10 @@ function dependencies_satisfied() {
 /**
  * Daily events to run.
  */
-function wc_admin_daily() {
+function do_wc_admin_daily() {
 	WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
 }
-add_action( 'wc_admin_daily', 'wc_admin_daily' );
+add_action( 'wc_admin_daily', 'do_wc_admin_daily' );
 
 /**
  * Activates wc-admin plugin when installed.

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -93,5 +93,8 @@ function wc_admin_plugins_loaded() {
 
 	// Create the Admin pages.
 	require_once dirname( __FILE__ ) . '/lib/admin.php';
+
+	// Admin note providers.
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-new-sales-record.php';
 }
 add_action( 'plugins_loaded', 'wc_admin_plugins_loaded' );


### PR DESCRIPTION
See #176 

Adds/updates an activity panel: inbox: note if the previous day's sales are a new record.

Creates a note that will look like this in the inbox (can't be seen in React until #513 is merged):

<img width="564" alt="screen shot 2018-10-18 at 3 57 37 pm" src="https://user-images.githubusercontent.com/1595739/47188848-a2ca0c80-d2ee-11e8-82a6-af45736b6b4b.png">

To test:
- update_option `woocommerce_sales_record_date` with a date in the past (e.g. `2018-09-22`)
- update_option `woocommerce_sales_record_amount` with a low value (e.g. `10.0`)
- Create a few orders totalling more than that value, complete them, and change their dates to yesterday.
- Switch to this branch if you haven't already
- Deactivate and re-activate the plugin to get the daily scheduled task added (will repeat daily).
- Install and activate the Admin Notes Test Bench https://github.com/automattic/wc-admin-notes-test-bench
- Navigate to wp-admin > Tools > WC Admin Notes Test Bench
- Look for the sales record note.

<img width="1091" alt="screen shot 2018-10-18 at 4 47 55 pm" src="https://user-images.githubusercontent.com/1595739/47190337-a7de8a00-d2f5-11e8-917d-e4599793af14.png">

- If you don't see the note there, install https://wordpress.org/plugins/wp-crontrol/  and navigate to wp-admin > Tools > Cron Events. Look for the wc_admin_daily event and click Run Now.
