### PR TITLE
Table: add missing CSS bracket

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -38,7 +38,8 @@
 			width: 24px;
 			max-width: 24px;
 		}
-    
+	}
+
 	.woocommerce-pagination {
 		padding-top: $gap;
 		padding-bottom: $gap;


### PR DESCRIPTION
A bracket somehow went missing in one of the latest changes. 

![screen shot 2018-10-18 at 3 56 40 pm](https://user-images.githubusercontent.com/1922453/47128707-dc027c80-d2ee-11e8-8752-8d13c277618d.png)

I'm simply going to merge this so master branch works
