### PR TITLE
Remove unnecessary opacity values from charts code

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -610,8 +610,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'x1', d => params.xLineScale( new Date( d.date ) ) )
 		.attr( 'y1', 0 )
 		.attr( 'x2', d => params.xLineScale( new Date( d.date ) ) )
-		.attr( 'y2', params.height )
-		.style( 'opacity', 1 );
+		.attr( 'y2', params.height );
 
 	focusGrid
 		.selectAll( 'circle' )
@@ -622,7 +621,6 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'fill', d => getColor( d.key, params ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', 4 )
-		.style( 'opacity', 1 )
 		.attr( 'cx', d => params.xLineScale( new Date( d.date ) ) )
 		.attr( 'cy', d => params.yScale( d.value ) );
 


### PR DESCRIPTION
Tiny PR that fixes https://github.com/woocommerce/wc-admin/pull/468#discussion_r220962545.

By default, opacity is 1 so there is no need to specify it in the code.

### Screenshot
(It should look the same than before applying this PR).
![image](https://user-images.githubusercontent.com/3616980/47150120-e19f9880-d2d5-11e8-9e54-ccf2c4853fa0.png)

### Detailed test instructions:

 - Go to any page with a chart (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/revenue?period=week&compare=previous_period`)
 - Try hovering chart points.
- Verify there isn't any regression.
