### PR TITLE
Change link focus area in table links

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -59,18 +59,12 @@
 
 	> a:only-child {
 		display: block;
-		margin: ($gap*-1) ($gap-large*-1);
-		padding: $gap $gap-large;
 	}
 
 	a {
 		&:hover,
 		&:focus {
 			color: $woocommerce-700;
-		}
-
-		&:focus {
-			box-shadow: none;
 		}
 	}
 


### PR DESCRIPTION
Fixes #449 

Creates an outline (purple box shadow) around link text inside tables.  Changes were discussed on Slack from the original issue at #449 to use a purple box shadow that only wrapped the text and not the entire table cell.

Note that while this change will highlight just the text portion of the link, it also reduces the clickable area of the link from the entire cell to just the text.

### Screenshots

<img width="188" alt="screen shot 2018-10-17 at 7 07 01 pm" src="https://user-images.githubusercontent.com/10561050/47155611-1c440980-d2b3-11e8-8c08-255b7f5250c8.png">

### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`
2.  Click on order table links to verify purple box-shadow outline is wrapping just the text