### PR TITLE
Update checkbox column styling

### DIFF
--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -152,6 +152,7 @@ class TableCard extends Component {
 		const { selectedRows } = this.state;
 		const isAllChecked = ids.length === selectedRows.length;
 		return {
+			cellClassName: 'is-checkbox-column',
 			label: (
 				<input
 					type="checkbox"

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -130,6 +130,16 @@
 	&.is-numeric .is-placeholder {
 		max-width: 40px;
 	}
+
+	&.is-checkbox-column {
+		width: 33px;
+		max-width: 33px;
+		padding-right: 0;
+		padding-left: 17px;
+		& + th {
+			border-left: 0;
+		}
+	}
 }
 
 th.woocommerce-table__item {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -138,10 +138,10 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { isLeftAligned, isSortable, isNumeric, key, label } = header;
+								const { cellClassName, isLeftAligned, isSortable, isNumeric, key, label } = header;
 								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
-									className: classnames( 'woocommerce-table__header', {
+									className: classnames( 'woocommerce-table__header', cellClassName, {
 										'is-left-aligned': isLeftAligned,
 										'is-sortable': isSortable,
 										'is-sorted': sortedBy === key,
@@ -192,10 +192,10 @@ class Table extends Component {
 						{ rows.map( ( row, i ) => (
 							<tr key={ i }>
 								{ row.map( ( cell, j ) => {
-									const { isLeftAligned, isNumeric } = headers[ j ];
+									const { cellClassName, isLeftAligned, isNumeric } = headers[ j ];
 									const isHeader = rowHeader === j;
 									const Cell = isHeader ? 'th' : 'td';
-									const cellClasses = classnames( 'woocommerce-table__item', {
+									const cellClasses = classnames( 'woocommerce-table__item', cellClassName, {
 										'is-left-aligned': isLeftAligned,
 										'is-numeric': isNumeric,
 									} );


### PR DESCRIPTION
Fixes #447 

This PR updates the checkbox styling to match the tabular component data design and reduces padding around the checkbox column.

It also adds in a `cellClassName` property to all table cells to allow passing in custom CSS classes.

### Screenshots

<img width="349" alt="screen shot 2018-10-18 at 11 59 09 am" src="https://user-images.githubusercontent.com/10561050/47167833-633ef880-d2cd-11e8-92eb-fa020b40bff7.png">

### Detailed test instructions:

1.  Navigate to `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2.  Check that checkbox column width is reduced and styling matches above screenshot
