### PR TITLE
Orders Report: Fix key prop warning.

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -209,8 +209,8 @@ export default class OrdersReportTable extends Component {
 	}
 
 	renderLinks( items = [] ) {
-		return items.map( item => (
-			<Link href={ item.href } type={ 'wp-admin' }>
+		return items.map( ( item, i ) => (
+			<Link href={ item.href } key={ i } type={ 'wp-admin' }>
 				{ item.label }
 			</Link>
 		) );


### PR DESCRIPTION
During some PR testing I was getting a key warning on the Orders report

### Screenshots

![orders analytics woo test woocommerce 2018-10-18 12-47-30](https://user-images.githubusercontent.com/22080/47180405-6342f680-d2d5-11e8-8068-f4caee3379bd.png)

### Detailed test instructions:

 - Open the orders report, select a date range where an order has more than one item included in it
 - Note the error in the console
 - Apply this branch, and repeat the steps and no error should be shown
