### PR TITLE
Add default report data if empty product data is returned

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -32,6 +32,13 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	protected $rest_base = 'reports/products/stats';
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_reports_products_stats_select_query', array( $this, 'set_default_report_data' ), 10, 2 );
+	}
+
+	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
@@ -211,6 +218,28 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 		);
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Set the default results to 0 if API returns an empty array
+	 *
+	 * @param Mixed $results Report data.
+	 * @param Array $args Product stats query args.
+	 * @return object
+	 */
+	public function set_default_report_data( $results, $args ) {
+		if ( empty( $results ) ) {
+			$results = new stdClass();
+			$results->total = 0;
+			$results->totals = new stdClass();
+			$results->totals->items_sold = 0;
+			$results->totals->gross_revenue = 0;
+			$results->totals->orders_count = 0;
+			$results->intervals = array();
+			$results->pages = 1;
+			$results->page_no = 1;
+		}
+		return $results;
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -35,7 +35,7 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_reports_products_stats_select_query', array( $this, 'set_default_report_data' ), 10, 2 );
+		add_filter( 'woocommerce_reports_products_stats_select_query', array( $this, 'set_default_report_data' ) );
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -224,10 +224,9 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	 * Set the default results to 0 if API returns an empty array
 	 *
 	 * @param Mixed $results Report data.
-	 * @param Array $args Product stats query args.
 	 * @return object
 	 */
-	public function set_default_report_data( $results, $args ) {
+	public function set_default_report_data( $results ) {
 		if ( empty( $results ) ) {
 			$results = new stdClass();
 			$results->total = 0;


### PR DESCRIPTION
Fixes #579 

Fixes the API request and error displayed when a date is set where no order history is available.

### Screenshots

<img width="1113" alt="screen shot 2018-10-18 at 4 49 57 pm" src="https://user-images.githubusercontent.com/10561050/47183430-0146b900-d2f6-11e8-837f-d544cb5bb5ad.png">
<img width="1049" alt="screen shot 2018-10-18 at 4 50 05 pm" src="https://user-images.githubusercontent.com/10561050/47183431-0146b900-d2f6-11e8-830f-f08b34207d08.png">

### Detailed test instructions:

1.  Navigate to `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2.  Select dates where no order history is relevant and verify that empty chart is displayed and no network errors occur.
3.  Select dates where order history is available and verify that relevant chart data shows as expected.