### PR TITLE
ChartData: fix typo in primary/secondary data

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -100,7 +100,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { query, endpoint } = props;
 		const primaryData = getReportChartData( endpoint, 'primary', query, select );
-		const secondaryData = getReportChartData( endpoint, 'primary', query, select );
+		const secondaryData = getReportChartData( endpoint, 'secondary', query, select );
 		return {
 			primaryData,
 			secondaryData,


### PR DESCRIPTION
Whoops, I introduced a bug in https://github.com/woocommerce/wc-admin/pull/565 that gather primary data for both primary and secondary time periods

![screen shot 2018-10-19 at 10 13 00 am](https://user-images.githubusercontent.com/1922453/47184757-05bbb200-d388-11e8-98d7-46d71d39917e.png)

This fixes the c/p error.