### PR TITLE
IE11: fix tooltip not correctly positioned in charts

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -518,20 +518,23 @@ const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 	const tooltipMargin = 24;
 
 	let xPosition =
-		elementCoords.x + elementCoords.width * elementWidthRatio + tooltipMargin - chartCoords.x;
-	let yPosition = elementCoords.y + tooltipMargin - chartCoords.y;
+		elementCoords.left + elementCoords.width * elementWidthRatio + tooltipMargin - chartCoords.left;
+	let yPosition = elementCoords.top + tooltipMargin - chartCoords.top;
 	if ( xPosition + tooltipSize.width + tooltipMargin > chartCoords.width ) {
 		xPosition = Math.max(
 			0,
-			elementCoords.x +
+			elementCoords.left +
 				elementCoords.width * ( 1 - elementWidthRatio ) -
 				tooltipSize.width -
 				tooltipMargin -
-				chartCoords.x
+				chartCoords.left
 		);
 	}
 	if ( yPosition + tooltipSize.height + tooltipMargin > chartCoords.height ) {
-		yPosition = Math.max( 0, elementCoords.y - tooltipSize.height - tooltipMargin - chartCoords.y );
+		yPosition = Math.max(
+			0,
+			elementCoords.top - tooltipSize.height - tooltipMargin - chartCoords.top
+		);
 	}
 
 	return { x: xPosition, y: yPosition };


### PR DESCRIPTION
Fix tooltip not correctly positioned in charts. Reason was that `getBoundingClientRect()` doesn't return `x` and `y` values in IE11, but `left` and `top` are equivalent and work in all browsers.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/3616980/47217487-cd789b80-d3a8-11e8-87dd-154b805841db.png)

After:
![image](https://user-images.githubusercontent.com/3616980/47217470-bc2f8f00-d3a8-11e8-85a2-1231343cc83a.png)

### Detailed test instructions:

 - With IE11: Go to any page with a chart (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/orders?period=custom&compare=previous_period&after=2018-10-02&before=2018-10-12`).
 - Verify the tooltip appears inside the chart area.
