### PR TITLE
IE11: fix table header misalignment

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -36,6 +36,7 @@
 
 .woocommerce-card__header-item {
 	@include set-grid-item-position( 3, 3 );
+	-ms-grid-row-align: center;
 }
 
 .woocommerce-card__action,

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -30,13 +30,12 @@
 
 	button.woocommerce-table__download-button.is-link {
 		padding: 6px $gap-small;
-		color: #000000;
+		color: #000;
 		text-decoration: none;
 		svg {
 			margin-right: $gap-smaller;
-			max-width: 18px;
+			height: 24px;
 			width: 24px;
-			max-width: 24px;
 		}
 	}
 
@@ -130,8 +129,8 @@
 
 	&.is-sorted {
 		background-color: $core-grey-light-100;
-  }
-  
+	}
+
 	&.is-checkbox-column {
 		width: 33px;
 		max-width: 33px;


### PR DESCRIPTION
Fix the table header misalignment in IE11.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/3616980/47217760-b2f2f200-d3a9-11e8-9d48-71469ff8ec96.png)

After:
![image](https://user-images.githubusercontent.com/3616980/47217832-0402e600-d3aa-11e8-83db-8e99bb190456.png)

### Detailed test instructions:

 - With IE11: Go to any page with a table (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/orders?period=custom&compare=previous_period&after=2018-10-02&before=2018-10-12`).
 - Verify the table header looks like in the screenshot.
