### PR TITLE
Uses PHPCBF to autofix warnings and errors

### DIFF
--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -36,7 +36,9 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
@@ -47,7 +49,9 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d-]+)', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d-]+)',
+			array(
 				'args'   => array(
 					'id' => array(
 						'description' => __( 'Unique ID for the resource.', 'wc-admin' ),
@@ -171,14 +175,16 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
-		$response->add_links( array(
-			'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $data['id'] ) ),
-			),
-			'collection' => array(
-				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-			),
-		) );
+		$response->add_links(
+			array(
+				'self'       => array(
+					'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $data['id'] ) ),
+				),
+				'collection' => array(
+					'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+				),
+			)
+		);
 		/**
 		 * Filter a note returned from the API.
 		 *

--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -35,15 +35,19 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 	 * Register the routes for reports.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => $this->get_collection_params(),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -154,14 +158,16 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
-		$response->add_links( array(
-			'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $report->slug ) ),
-			),
-			'collection' => array(
-				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-			),
-		) );
+		$response->add_links(
+			array(
+				'self'       => array(
+					'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $report->slug ) ),
+				),
+				'collection' => array(
+					'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+				),
+			)
+		);
 
 		/**
 		 * Filter a report returned from the API.

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -73,7 +73,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'customers' => array(),
 		);
 		foreach ( $report_data->customers as $customer_data ) {
-			$item_data = $this->prepare_item_for_response( (object) $customer_data, $request );
+			$item_data               = $this->prepare_item_for_response( (object) $customer_data, $request );
 			$out_data['customers'][] = $item_data;
 		}
 		$response = rest_ensure_response( $out_data );
@@ -204,21 +204,21 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params             = array();
-		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['before']   = array(
+		$params                        = array();
+		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['before']              = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']    = array(
+		$params['after']               = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['page']     = array(
+		$params['page']                = array(
 			'description'       => __( 'Current page of the collection.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -226,7 +226,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page'] = array(
+		$params['per_page']            = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -235,66 +235,66 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']    = array(
+		$params['name']                = array(
 			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username']    = array(
+		$params['username']            = array(
 			'description'       => __( 'Limit response to objects with a specfic username.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email']    = array(
+		$params['email']               = array(
 			'description'       => __( 'Limit response to objects equal to an email.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['country']    = array(
+		$params['country']             = array(
 			'description'       => __( 'Limit response to objects with a specfic country.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['last_active_before']    = array(
+		$params['last_active_before']  = array(
 			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['last_active_after']    = array(
+		$params['last_active_after']   = array(
 			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_count_min']    = array(
+		$params['order_count_min']     = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_count_max']    = array(
+		$params['order_count_max']     = array(
 			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['total_spend_min']    = array(
+		$params['total_spend_min']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['total_spend_max']    = array(
+		$params['total_spend_max']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['avg_order_value_min']    = array(
+		$params['avg_order_value_min'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['avg_order_value_max']    = array(
+		$params['avg_order_value_max'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -138,13 +138,13 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 			'title'      => 'report_products',
 			'type'       => 'object',
 			'properties' => array(
-				'product_id' => array(
+				'product_id'    => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Product ID.', 'wc-admin' ),
 				),
-				'items_sold' => array(
+				'items_sold'    => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
@@ -156,7 +156,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Total gross revenue of all items sold.', 'wc-admin' ),
 				),
-				'orders_count' => array(
+				'orders_count'  => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
@@ -174,9 +174,9 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params               = array();
-		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']       = array(
+		$params                          = array();
+		$params['context']               = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']                  = array(
 			'description'       => __( 'Current page of the collection.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -184,7 +184,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']   = array(
+		$params['per_page']              = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -193,26 +193,26 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']      = array(
+		$params['after']                 = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']     = array(
+		$params['before']                = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']      = array(
+		$params['order']                 = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']    = array(
+		$params['orderby']               = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'date',
@@ -224,7 +224,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['categories'] = array(
+		$params['categories']            = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -233,7 +233,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 				'type' => 'integer',
 			),
 		);
-		$params['products']   = array(
+		$params['products']              = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -126,9 +126,9 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	 */
 	public function get_item_schema() {
 		$totals = array(
-			'items_sold' => array(
+			'items_sold'    => array(
 				'description' => __( 'Number of items sold.', 'wc-admin' ),
-				'type' => 'integer',
+				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
@@ -138,9 +138,9 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'orders_count' => array(
+			'orders_count'  => array(
 				'description' => __( 'Number of orders.', 'wc-admin' ),
-				'type' => 'integer',
+				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
@@ -219,9 +219,9 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params             = array();
-		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']     = array(
+		$params               = array();
+		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']       = array(
 			'description'       => __( 'Current page of the collection.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -229,7 +229,7 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page'] = array(
+		$params['per_page']   = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -238,26 +238,26 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']    = array(
+		$params['after']      = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']   = array(
+		$params['before']     = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']    = array(
+		$params['order']      = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']  = array(
+		$params['orderby']    = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'date',
@@ -274,7 +274,7 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['interval'] = array(
+		$params['interval']   = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'week',

--- a/includes/api/class-wc-admin-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-admin-rest-system-status-tools-controller.php
@@ -50,7 +50,7 @@ class WC_Admin_REST_System_Status_Tools_Controller extends WC_REST_System_Status
 	 * @return array
 	 */
 	public function execute_tool( $tool ) {
-		$ran = true;
+		$ran     = true;
 		$message = '';
 
 		switch ( $tool ) {

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -192,10 +192,12 @@ class WC_Admin_Api_Init {
 
 		$orders = get_transient( 'wc_update_350_all_orders' );
 		if ( false === $orders ) {
-			$orders = wc_get_orders( array(
-				'limit'  => -1,
-				'return' => 'ids',
-			) );
+			$orders = wc_get_orders(
+				array(
+					'limit'  => -1,
+					'return' => 'ids',
+				)
+			);
 			set_transient( 'wc_update_350_all_orders', $orders, DAY_IN_SECONDS );
 		}
 

--- a/includes/class-wc-admin-reports-categories-query.php
+++ b/includes/class-wc-admin-reports-categories-query.php
@@ -20,7 +20,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Categories_Query
- *
  */
 class WC_Admin_Reports_Categories_Query extends WC_Admin_Reports_Query {
 

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -118,7 +118,7 @@ class WC_Admin_Reports_Interval {
 		if ( 1 === $first_day_of_week ) {
 			$week_number = (int) $datetime->format( 'W' );
 		} else {
-			$week_number = WC_Admin_Reports_Interval::simple_week_number( $datetime, $first_day_of_week );
+			$week_number = self::simple_week_number( $datetime, $first_day_of_week );
 		}
 		return $week_number;
 	}
@@ -136,7 +136,7 @@ class WC_Admin_Reports_Interval {
 			'day'     => 'Y-m-d',
 			'week'    => 'o-W',
 			'month'   => 'Y-m',
-			'quarter' => 'Y-' . WC_Admin_Reports_Interval::quarter( $datetime ),
+			'quarter' => 'Y-' . self::quarter( $datetime ),
 			'year'    => 'Y',
 		);
 
@@ -144,7 +144,7 @@ class WC_Admin_Reports_Interval {
 		$first_day_of_week = absint( get_option( 'start_of_week' ) );
 
 		if ( 'week' === $time_interval && 1 !== $first_day_of_week ) {
-			$week_no = WC_Admin_Reports_Interval::simple_week_number( $datetime, $first_day_of_week );
+			$week_no = self::simple_week_number( $datetime, $first_day_of_week );
 			$week_no = str_pad( $week_no, 2, '0', STR_PAD_LEFT );
 			$year_no = $datetime->format( 'Y' );
 			return "$year_no-$week_no";
@@ -176,7 +176,7 @@ class WC_Admin_Reports_Interval {
 				// TODO: optimize? approximately day count / 7, but year end is tricky, a week can have fewer days.
 				$week_count = 0;
 				do {
-					$start_datetime = WC_Admin_Reports_Interval::next_week_start( $start_datetime );
+					$start_datetime = self::next_week_start( $start_datetime );
 					$week_count++;
 				} while ( $start_datetime <= $end_datetime );
 				return $week_count;
@@ -192,7 +192,7 @@ class WC_Admin_Reports_Interval {
 				// Year diff in quarters: (end_year - start_year - 1) * 4.
 				$year_diff_in_quarters = ( (int) $end_datetime->format( 'Y' ) - (int) $start_datetime->format( 'Y' ) - 1 ) * 4;
 				// All the quarters in end_date year plus quarters from X to 4 in the start_date year.
-				$quarter_diff = WC_Admin_Reports_Interval::quarter( $end_datetime ) + ( 4 - WC_Admin_Reports_Interval::quarter( $start_datetime ) );
+				$quarter_diff = self::quarter( $end_datetime ) + ( 4 - self::quarter( $start_datetime ) );
 				// Add quarters for number of years between end_date and start_date.
 				$quarter_diff += $year_diff_in_quarters + 1;
 				return $quarter_diff;
@@ -257,11 +257,11 @@ class WC_Admin_Reports_Interval {
 	 */
 	public static function next_week_start( $datetime, $reversed = false ) {
 		$first_day_of_week = absint( get_option( 'start_of_week' ) );
-		$initial_week_no   = WC_Admin_Reports_Interval::week_number( $datetime, $first_day_of_week );
+		$initial_week_no   = self::week_number( $datetime, $first_day_of_week );
 
 		do {
-			$datetime        = WC_Admin_Reports_Interval::next_day_start( $datetime, $reversed );
-			$current_week_no = WC_Admin_Reports_Interval::week_number( $datetime, $first_day_of_week );
+			$datetime        = self::next_day_start( $datetime, $reversed );
+			$current_week_no = self::week_number( $datetime, $first_day_of_week );
 		} while ( $current_week_no === $initial_week_no );
 
 		// The week boundary is actually next midnight when going in reverse, so set it to day -1 at 23:59:59.
@@ -401,9 +401,9 @@ class WC_Admin_Reports_Interval {
 	 * @return DateTime
 	 */
 	public static function iterate( $datetime, $time_interval, $reversed = false ) {
-//		$result_datetime           =
-//		$result_timestamp_adjusted = $result_datetime->format( 'U' ) - 1;
-//		$result_datetime->setTimestamp( $result_timestamp_adjusted );
+		// $result_datetime           =
+		// $result_timestamp_adjusted = $result_datetime->format( 'U' ) - 1;
+		// $result_datetime->setTimestamp( $result_timestamp_adjusted );
 		return call_user_func( array( __CLASS__, "next_{$time_interval}_start" ), $datetime, $reversed );
 	}
 

--- a/includes/class-wc-admin-reports-orders-stats-query.php
+++ b/includes/class-wc-admin-reports-orders-stats-query.php
@@ -15,14 +15,12 @@
  * $mydata = $report->get_data();
  *
  * @package  WooCommerce Admin/Classes
-
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Orders_Stats_Query
- *
  */
 class WC_Admin_Reports_Orders_Stats_Query extends WC_Admin_Reports_Query {
 

--- a/includes/class-wc-admin-reports-products-query.php
+++ b/includes/class-wc-admin-reports-products-query.php
@@ -14,14 +14,12 @@
  * $mydata = $report->get_data();
  *
  * @package  WooCommerce Admin/Classes
-
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Products_Query
- *
  */
 class WC_Admin_Reports_Products_Query extends WC_Admin_Reports_Query {
 

--- a/includes/class-wc-admin-reports-products-stats-query.php
+++ b/includes/class-wc-admin-reports-products-stats-query.php
@@ -20,7 +20,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Products_Query
- *
  */
 class WC_Admin_Reports_Products_Stats_Query extends WC_Admin_Reports_Query {
 

--- a/includes/class-wc-admin-reports-revenue-query.php
+++ b/includes/class-wc-admin-reports-revenue-query.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Revenue_Query
- *
  */
 class WC_Admin_Reports_Revenue_Query extends WC_Admin_Reports_Query {
 
@@ -38,7 +37,7 @@ class WC_Admin_Reports_Revenue_Query extends WC_Admin_Reports_Query {
 			'before'   => '',
 			'after'    => '',
 			'interval' => 'week',
-			'fields' => array(
+			'fields'   => array(
 				'orders_count',
 				'num_items_sold',
 				'gross_revenue',

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -105,7 +105,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( $note->get_id() ) {
 			$wpdb->update(
-				$wpdb->prefix . 'woocommerce_admin_notes', array(
+				$wpdb->prefix . 'woocommerce_admin_notes',
+				array(
 					'name'          => $note->get_name(),
 					'type'          => $note->get_type(),
 					'locale'        => $note->get_locale(),
@@ -117,7 +118,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 					'source'        => $note->get_source(),
 					'date_created'  => $note->get_date_created(),
 					'date_reminder' => $note->get_date_reminder(),
-				), array( 'note_id' => $note->get_id() )
+				),
+				array( 'note_id' => $note->get_id() )
 			);
 		}
 
@@ -183,7 +185,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_note_actions', array( 'note_id' => $note->get_id() ) );
 		foreach ( $note->get_actions( 'edit' ) as $action ) {
 			$wpdb->insert(
-				$wpdb->prefix . 'woocommerce_admin_note_actions', array(
+				$wpdb->prefix . 'woocommerce_admin_note_actions',
+				array(
 					'note_id' => $note->get_id(),
 					'name'    => $action->name,
 					'label'   => $action->label,

--- a/includes/data-stores/class-wc-admin-reports-categories-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-categories-data-store.php
@@ -165,7 +165,7 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 		$week_back  = $now - WEEK_IN_SECONDS;
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
-		$defaults   = array(
+		$defaults = array(
 			'per_page'     => get_option( 'posts_per_page' ),
 			'page'         => 1,
 			'order'        => 'DESC',
@@ -207,7 +207,8 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 						{$sql_query_params['where_clause']}
 					GROUP BY
 						product_id
-					", ARRAY_A
+					",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $products_data ) {

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -382,7 +382,7 @@ class WC_Admin_Reports_Data_Store {
 		foreach ( $intervals as $key => $interval ) {
 			$datetime = new DateTime( $interval['datetime_anchor'] );
 
-			$prev_start           = WC_Admin_Reports_Interval::iterate( $datetime, $time_interval, true );
+			$prev_start = WC_Admin_Reports_Interval::iterate( $datetime, $time_interval, true );
 			// TODO: not sure if the +1/-1 here are correct, especially as they are applied before the ?: below.
 			$prev_start_timestamp = (int) $prev_start->format( 'U' ) + 1;
 			$prev_start->setTimestamp( $prev_start_timestamp );
@@ -535,10 +535,12 @@ class WC_Admin_Reports_Data_Store {
 	 * @return array|stdClass
 	 */
 	protected function get_products_by_cat_ids( $categories ) {
-		$product_categories = get_categories( array(
-			'hide_empty' => 0,
-			'taxonomy'   => 'product_cat',
-		) );
+		$product_categories = get_categories(
+			array(
+				'hide_empty' => 0,
+				'taxonomy'   => 'product_cat',
+			)
+		);
 		$cat_slugs          = array();
 		$categories         = array_flip( $categories );
 		foreach ( $product_categories as $product_cat ) {

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -273,7 +273,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 						{$totals_query['from_clause']}
 					WHERE
 						1=1
-						{$totals_query['where_clause']}", ARRAY_A
+						{$totals_query['where_clause']}",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
@@ -327,7 +328,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 							time_interval
 						ORDER BY
 							{$intervals_query['order_by_clause']}
-						{$intervals_query['limit']}", ARRAY_A
+						{$intervals_query['limit']}",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
@@ -366,12 +368,14 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		// This needs to be updated to work in batches instead of getting all orders, as
 		// that will not work well on DBs with more than a few hundred orders.
-		$order_ids = wc_get_orders( array(
-			'limit'  => -1,
-			'status' => parent::get_report_order_statuses(),
-			'type'   => 'shop_order',
-			'return' => 'ids',
-		) );
+		$order_ids = wc_get_orders(
+			array(
+				'limit'  => -1,
+				'status' => parent::get_report_order_statuses(),
+				'type'   => 'shop_order',
+				'return' => 'ids',
+			)
+		);
 
 		foreach ( $order_ids as $id ) {
 			self::$background_process->push_to_queue( $id );
@@ -414,9 +418,12 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		if ( ! in_array( $order->get_status(), parent::get_report_order_statuses(), true ) ) {
-			$wpdb->delete( $table_name, array(
-				'order_id' => $order->get_id(),
-			) );
+			$wpdb->delete(
+				$table_name,
+				array(
+					'order_id' => $order->get_id(),
+				)
+			);
 			return;
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -115,7 +115,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 */
 	protected function include_extended_product_info( &$products_data ) {
 		foreach ( $products_data as $key => $product_data ) {
-			$product = wc_get_product( $product_data['product_id'] );
+			$product             = wc_get_product( $product_data['product_id'] );
 			$extended_attributes = apply_filters( 'woocommerce_rest_reports_products_extended_attributes', $this->extended_attributes, $product_data );
 			foreach ( $extended_attributes as $extended_attribute ) {
 				$function = 'get_' . $extended_attribute;
@@ -141,7 +141,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		$week_back  = $now - WEEK_IN_SECONDS;
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
-		$defaults   = array(
+		$defaults = array(
 			'per_page'              => get_option( 'posts_per_page' ),
 			'page'                  => 1,
 			'order'                 => 'DESC',
@@ -200,7 +200,8 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 					ORDER BY
 						{$sql_query_params['order_by_clause']}
 					{$sql_query_params['limit']}
-					", ARRAY_A
+					",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $product_data ) {

--- a/includes/data-stores/class-wc-admin-reports-products-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-stats-data-store.php
@@ -91,7 +91,7 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 		$week_back  = $now - WEEK_IN_SECONDS;
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
-		$defaults   = array(
+		$defaults = array(
 			'per_page'     => get_option( 'posts_per_page' ),
 			'page'         => 1,
 			'order'        => 'DESC',
@@ -144,7 +144,8 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 						{$totals_query['from_clause']}
 					WHERE
 						1=1
-						{$totals_query['where_clause']}", ARRAY_A
+						{$totals_query['where_clause']}",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $totals ) {
@@ -170,7 +171,8 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 							time_interval
 						ORDER BY
 							{$intervals_query['order_by_clause']}
-						{$intervals_query['limit']}", ARRAY_A
+						{$intervals_query['limit']}",
+				ARRAY_A
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -79,36 +79,46 @@ function wc_admin_register_pages() {
 		56 // After WooCommerce & Product menu items.
 	);
 
-	wc_admin_register_page( array(
-		'title'  => __( 'Revenue', 'wc-admin' ),
-		'parent' => '/analytics',
-		'path'   => '/analytics/revenue',
-	) );
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Revenue', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/revenue',
+		)
+	);
 
-	wc_admin_register_page( array(
-		'title'  => __( 'Products', 'wc-admin' ),
-		'parent' => '/analytics',
-		'path'   => '/analytics/products',
-	) );
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Products', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/products',
+		)
+	);
 
-	wc_admin_register_page( array(
-		'title'  => __( 'Orders', 'wc-admin' ),
-		'parent' => '/analytics',
-		'path'   => '/analytics/orders',
-	) );
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Orders', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/orders',
+		)
+	);
 
-	wc_admin_register_page( array(
-		'title'  => __( 'Coupons', 'wc-admin' ),
-		'parent' => '/analytics',
-		'path'   => '/analytics/coupons',
-	) );
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Coupons', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/coupons',
+		)
+	);
 
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-		wc_admin_register_page( array(
-			'title'  => 'DevDocs',
-			'parent' => 'woocommerce', // Exposed on the main menu for now.
-			'path'   => '/devdocs',
-		) );
+		wc_admin_register_page(
+			array(
+				'title'  => 'DevDocs',
+				'parent' => 'woocommerce', // Exposed on the main menu for now.
+				'path'   => '/devdocs',
+			)
+		);
 	}
 }
 add_action( 'admin_menu', 'wc_admin_register_pages' );
@@ -171,7 +181,7 @@ function wc_admin_admin_body_class( $admin_body_class = '' ) {
 		return $admin_body_class;
 	}
 
-	$classes = explode( ' ', trim( $admin_body_class ) );
+	$classes   = explode( ' ', trim( $admin_body_class ) );
 	$classes[] = 'woocommerce-page';
 	if ( wc_admin_is_embed_enabled_wc_page() ) {
 		$classes[] = 'woocommerce-embed-page';
@@ -211,28 +221,28 @@ function wc_admin_admin_title( $admin_title ) {
 		$pieces   = array();
 
 		foreach ( $sections as $section ) {
-			$pieces[] = is_array( $section ) ? $section[ 1 ] : $section;
+			$pieces[] = is_array( $section ) ? $section[1] : $section;
 		}
 
 		$pieces = array_reverse( $pieces );
-		$title = implode( ' &lsaquo; ', $pieces );
+		$title  = implode( ' &lsaquo; ', $pieces );
 	} else {
 		$title = __( 'Dashboard', 'wc-admin' );
 	}
 
 	return sprintf( __( '%1$s &lsaquo; %2$s &#8212; WooCommerce', 'wc-admin' ), $title, get_bloginfo( 'name' ) );
 }
-add_filter( 'admin_title',  'wc_admin_admin_title' );
+add_filter( 'admin_title', 'wc_admin_admin_title' );
 
 /**
  * Set up a div for the app to render into.
  */
-function wc_admin_page(){
+function wc_admin_page() {
 	?>
 	<div class="wrap">
 		<div id="root"></div>
 	</div>
-<?php
+	<?php
 }
 
 /**
@@ -250,7 +260,7 @@ function woocommerce_embed_page_header() {
 	$sections    = is_array( $sections ) ? $sections : array( $sections );
 	$breadcrumbs = '';
 	foreach ( $sections as $section ) {
-		$piece = is_array( $section ) ? '<a href="' . esc_url( admin_url( $section[ 0 ] ) ) .'">' . $section[ 1 ] . '</a>' : $section;
+		$piece        = is_array( $section ) ? '<a href="' . esc_url( admin_url( $section[0] ) ) . '">' . $section[1] . '</a>' : $section;
 		$breadcrumbs .= '<span>' . $piece . '</span>';
 	}
 	?>

--- a/lib/common.php
+++ b/lib/common.php
@@ -7,7 +7,7 @@
  * @return string Root path to the gutenberg custom fields plugin.
  */
 function wc_admin_dir_path( $file = '' ) {
-	return plugin_dir_path( dirname(__FILE__ ) ) . $file;
+	return plugin_dir_path( dirname( __FILE__ ) ) . $file;
 }
 
 /**
@@ -38,7 +38,7 @@ function wc_admin_get_current_screen_id() {
 	}
 	$current_screen_id = $current_screen->action ? $current_screen->action . '-' . $current_screen->id : $current_screen->id;
 
-	if ( ! empty( $_GET['taxonomy' ] ) && ! empty( $_GET['post_type'] ) && 'product' === $_GET['post_type'] ) {
+	if ( ! empty( $_GET['taxonomy'] ) && ! empty( $_GET['post_type'] ) && 'product' === $_GET['post_type'] ) {
 		$current_screen_id = 'product_page_product_attributes';
 	}
 
@@ -59,137 +59,139 @@ function wc_admin_get_embed_breadcrumbs() {
 		'wc-settings' => 'general',
 		'wc-status'   => 'status',
 	);
-	$tab = '';
-	if ( ! empty( $_GET['page' ] ) ) {
+	$tab             = '';
+	if ( ! empty( $_GET['page'] ) ) {
 		if ( in_array( $_GET['page'], array_keys( $pages_with_tabs ) ) ) {
 			$tab = ! empty( $_GET['tab'] ) ? $_GET['tab'] . '-' : $pages_with_tabs[ $_GET['page'] ] . '-';
 		}
 	}
 
-	$breadcrumbs = apply_filters( 'wc_admin_get_breadcrumbs', array(
-		'edit-shop_order' => __( 'Orders', 'wc-admin' ),
-		'add-shop_order'  => array(
-			array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' )
-		),
-		'shop_order'     => array(
-			array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
-			__( 'Edit Order', 'wc-admin' )
-		),
-		'edit-shop_coupon' => __( 'Coupons', 'wc-admin' ),
-		'add-shop_coupon'  => array(
-			array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' )
-		),
-		'shop_coupon' => array(
-			array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
-			__( 'Edit Coupon', 'wc-admin' )
-		),
-		'woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) )
-		),
-		'orders-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Orders', 'wc-admin' )
-		),
-		'customers-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Customers', 'wc-admin' )
-		),
-		'stock-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Stock', 'wc-admin' )
-		),
-		'taxes-woocommerce_page_wc-reports' => array(
-			array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
-			__( 'Taxes', 'wc-admin' )
-		),
-		'woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) )
-		),
-		'general-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'General', 'wc-admin' ),
-		),
-		'products-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Products', 'wc-admin' ),
-		),
-		'tax-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Tax', 'wc-admin' ),
-		),
-		'shipping-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Shipping', 'wc-admin' ),
-		),
-		'checkout-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Payments', 'wc-admin' ),
-		),
-		'email-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Emails', 'wc-admin' ),
-		),
-		'advanced-woocommerce_page_wc-settings' => array(
-			array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
-			__( 'Advanced', 'wc-admin' ),
-		),
-		'woocommerce_page_wc-status'  => array(
-			__( 'Status', 'wc-admin' ),
-		),
-		'status-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'System Status', 'wc-admin' ),
-		),
-		'tools-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'Tools', 'wc-admin' ),
-		),
-		'logs-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'Logs', 'wc-admin' ),
-		),
-		'connect-woocommerce_page_wc-status'  => array(
-			array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
-			__( 'WooCommerce Services Status', 'wc-admin' ),
-		),
-		'woocommerce_page_wc-addons' => __( 'Extensions', 'wc-admin' ),
-		'edit-product' => __( 'Products', 'wc-admin' ),
-		'product_page_product_importer'  => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Import', 'wc-admin' ),
-		),
-		'product_page_product_exporter' =>  array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Export', 'wc-admin' ),
-		),
-		'add-product' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Add New', 'wc-admin' ),
-		),
-		'product' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Edit Product', 'wc-admin' ),
-		),
-		'edit-product_cat' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Categories', 'wc-admin' ),
-		),
-		'edit-product_tag' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Tags', 'wc-admin' ),
-		),
-		'product_page_product_attributes' => array(
-			array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
-			__( 'Attributes', 'wc-admin' ),
-		),
-	) );
+	$breadcrumbs = apply_filters(
+		'wc_admin_get_breadcrumbs',
+		array(
+			'edit-shop_order'                       => __( 'Orders', 'wc-admin' ),
+			'add-shop_order'                        => array(
+				array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
+				__( 'Add New', 'wc-admin' ),
+			),
+			'shop_order'                            => array(
+				array( '/edit.php?post_type=shop_order', __( 'Orders', 'wc-admin' ) ),
+				__( 'Edit Order', 'wc-admin' ),
+			),
+			'edit-shop_coupon'                      => __( 'Coupons', 'wc-admin' ),
+			'add-shop_coupon'                       => array(
+				array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
+				__( 'Add New', 'wc-admin' ),
+			),
+			'shop_coupon'                           => array(
+				array( 'edit.php?post_type=shop_coupon', __( 'Coupons', 'wc-admin' ) ),
+				__( 'Edit Coupon', 'wc-admin' ),
+			),
+			'woocommerce_page_wc-reports'           => array(
+				array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
+			),
+			'orders-woocommerce_page_wc-reports'    => array(
+				array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
+				__( 'Orders', 'wc-admin' ),
+			),
+			'customers-woocommerce_page_wc-reports' => array(
+				array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
+				__( 'Customers', 'wc-admin' ),
+			),
+			'stock-woocommerce_page_wc-reports'     => array(
+				array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
+				__( 'Stock', 'wc-admin' ),
+			),
+			'taxes-woocommerce_page_wc-reports'     => array(
+				array( 'admin.php?page=wc-reports', __( 'Reports', 'wc-admin' ) ),
+				__( 'Taxes', 'wc-admin' ),
+			),
+			'woocommerce_page_wc-settings'          => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+			),
+			'general-woocommerce_page_wc-settings'  => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'General', 'wc-admin' ),
+			),
+			'products-woocommerce_page_wc-settings' => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Products', 'wc-admin' ),
+			),
+			'tax-woocommerce_page_wc-settings'      => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Tax', 'wc-admin' ),
+			),
+			'shipping-woocommerce_page_wc-settings' => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Shipping', 'wc-admin' ),
+			),
+			'checkout-woocommerce_page_wc-settings' => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Payments', 'wc-admin' ),
+			),
+			'email-woocommerce_page_wc-settings'    => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Emails', 'wc-admin' ),
+			),
+			'advanced-woocommerce_page_wc-settings' => array(
+				array( 'admin.php?page=wc-settings', __( 'Settings', 'wc-admin' ) ),
+				__( 'Advanced', 'wc-admin' ),
+			),
+			'woocommerce_page_wc-status'            => array(
+				__( 'Status', 'wc-admin' ),
+			),
+			'status-woocommerce_page_wc-status'     => array(
+				array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
+				__( 'System Status', 'wc-admin' ),
+			),
+			'tools-woocommerce_page_wc-status'      => array(
+				array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
+				__( 'Tools', 'wc-admin' ),
+			),
+			'logs-woocommerce_page_wc-status'       => array(
+				array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
+				__( 'Logs', 'wc-admin' ),
+			),
+			'connect-woocommerce_page_wc-status'    => array(
+				array( 'admin.php?page=wc-status', __( 'Status', 'wc-admin' ) ),
+				__( 'WooCommerce Services Status', 'wc-admin' ),
+			),
+			'woocommerce_page_wc-addons'            => __( 'Extensions', 'wc-admin' ),
+			'edit-product'                          => __( 'Products', 'wc-admin' ),
+			'product_page_product_importer'         => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Import', 'wc-admin' ),
+			),
+			'product_page_product_exporter'         => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Export', 'wc-admin' ),
+			),
+			'add-product'                           => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Add New', 'wc-admin' ),
+			),
+			'product'                               => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Edit Product', 'wc-admin' ),
+			),
+			'edit-product_cat'                      => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Categories', 'wc-admin' ),
+			),
+			'edit-product_tag'                      => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Tags', 'wc-admin' ),
+			),
+			'product_page_product_attributes'       => array(
+				array( 'edit.php?post_type=product', __( 'Products', 'wc-admin' ) ),
+				__( 'Attributes', 'wc-admin' ),
+			),
+		)
+	);
 
-
-	if ( ! empty ( $breadcrumbs[ $tab . $current_screen_id ] ) ) {
+	if ( ! empty( $breadcrumbs[ $tab . $current_screen_id ] ) ) {
 		return $breadcrumbs[ $tab . $current_screen_id ];
-	} else if ( ! empty( $breadcrumbs[ $current_screen_id ] ) ) {
+	} elseif ( ! empty( $breadcrumbs[ $current_screen_id ] ) ) {
 		return $breadcrumbs[ $current_screen_id ];
 	} else {
 		return '';
@@ -197,10 +199,10 @@ function wc_admin_get_embed_breadcrumbs() {
 }
 
 /**
-  * `wc_admin_get_embed_enabled_screen_ids`,  `wc_admin_get_embed_enabled_plugin_screen_ids`,
-  * `wc_admin_get_embed_enabled_screen_ids` should be considered temporary functions for the feature plugin.
-  *  This is separate from WC's screen_id functions so that extensions explictly have to opt-in to the feature plugin.
-  *  TODO When merging to core, we should explore a better API for opting into the new header for extensions.
+ * `wc_admin_get_embed_enabled_screen_ids`,  `wc_admin_get_embed_enabled_plugin_screen_ids`,
+ * `wc_admin_get_embed_enabled_screen_ids` should be considered temporary functions for the feature plugin.
+ *  This is separate from WC's screen_id functions so that extensions explictly have to opt-in to the feature plugin.
+ *  TODO When merging to core, we should explore a better API for opting into the new header for extensions.
  */
 function wc_admin_get_embed_enabled_core_screen_ids() {
 	$screens = array(
@@ -257,7 +259,8 @@ function wc_admin_currency_settings() {
 	$code = get_woocommerce_currency();
 
 	return apply_filters(
-		'wc_currency_settings', array(
+		'wc_currency_settings',
+		array(
 			'code'      => $code,
 			'precision' => wc_get_price_decimals(),
 			'symbol'    => get_woocommerce_currency_symbol( $code ),

--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -70,17 +70,19 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 		WC_Admin_Reports_Orders_Data_Store::update( $order );
 
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
-		$request->set_query_params( array(
-			'before' => date( 'Y-m-d H:00:00', $time + DAY_IN_SECONDS ),
-			'after' => date( 'Y-m-d H:00:00', $time - DAY_IN_SECONDS ),
-			'interval' => 'day',
-		) );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d H:00:00', $time + DAY_IN_SECONDS ),
+				'after'    => date( 'Y-m-d H:00:00', $time - DAY_IN_SECONDS ),
+				'interval' => 'day',
+			)
+		);
 
 		$response = $this->server->dispatch( $request );
 		$reports  = $response->get_data();
 
 		$expected_reports = array(
-			'totals' => array(
+			'totals'    => array(
 				'items_sold'     => 4,
 				'gross_revenue'  => 100.0,
 				'orders_count'   => 1,

--- a/tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/reports/class-wc-tests-reports-orders.php
@@ -86,7 +86,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
 
 		// Test retrieving the stats through the query class.
-		$query = new WC_Admin_Reports_Orders_Stats_Query( $args );
+		$query          = new WC_Admin_Reports_Orders_Stats_Query( $args );
 		$expected_stats = array(
 			'totals'    => array(
 				'net_revenue'         => 80,

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -35,7 +35,7 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$data_store = new WC_Admin_Reports_Products_Data_Store();
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() + HOUR_IN_SECONDS );
-		$args = array(
+		$args       = array(
 			'after'  => $start_time,
 			'before' => $end_time,
 		);

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -39,15 +39,15 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		$data_store::update( $order );
 
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
-		$end_time = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );
 
-		$args = array(
+		$args           = array(
 			'interval' => 'hour',
 			'after'    => $start_time,
 			'before'   => $end_time,
 		);
 		$expected_stats = array(
-			'totals' => array(
+			'totals'    => array(
 				'orders_count'        => 1,
 				'num_items_sold'      => 4,
 				'gross_revenue'       => 97,
@@ -80,9 +80,9 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 					),
 				),
 			),
-			'total'   => 1,
-			'pages'   => 1,
-			'page_no' => 1,
+			'total'     => 1,
+			'pages'     => 1,
+			'page_no'   => 1,
 		);
 
 		// Test retrieving the stats from the data store.
@@ -90,15 +90,15 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 
 		// Test retrieving the stats through the query class.
 		$expected_stats = array(
-			'totals' => array(
-				'orders_count'        => 1,
-				'num_items_sold'      => 4,
-				'gross_revenue'       => 97,
-				'coupons'             => 20,
-				'refunds'             => 0,
-				'taxes'               => 7,
-				'shipping'            => 10,
-				'net_revenue'         => 80,
+			'totals'    => array(
+				'orders_count'   => 1,
+				'num_items_sold' => 4,
+				'gross_revenue'  => 97,
+				'coupons'        => 20,
+				'refunds'        => 0,
+				'taxes'          => 7,
+				'shipping'       => 10,
+				'net_revenue'    => 80,
 			),
 			'intervals' => array(
 				array(
@@ -108,22 +108,22 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 					'date_end'       => $end_time,
 					'date_end_gmt'   => $end_time,
 					'subtotals'      => array(
-						'orders_count'        => 1,
-						'num_items_sold'      => 4,
-						'gross_revenue'       => 97,
-						'coupons'             => 20,
-						'refunds'             => 0,
-						'taxes'               => 7,
-						'shipping'            => 10,
-						'net_revenue'         => 80,
+						'orders_count'   => 1,
+						'num_items_sold' => 4,
+						'gross_revenue'  => 97,
+						'coupons'        => 20,
+						'refunds'        => 0,
+						'taxes'          => 7,
+						'shipping'       => 10,
+						'net_revenue'    => 80,
 					),
 				),
 			),
-			'total'   => 1,
-			'pages'   => 1,
-			'page_no' => 1,
+			'total'     => 1,
+			'pages'     => 1,
+			'page_no'   => 1,
 		);
-		$query = new WC_Admin_Reports_Revenue_Query( $args );
+		$query          = new WC_Admin_Reports_Revenue_Query( $args );
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $query->get_data() ), true ) );
 	}
 


### PR DESCRIPTION
Uses PHPCBF to fix all autofixable errors and warnings in the project. 202 in 25 files

### Detailed test instructions:

 - From the command line run PHPCBF: ./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)
 - Was anything fixed? It should not have been.
