### PR TITLE
Update order summary in Orders report

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -204,6 +204,9 @@ class OrdersReportTable extends Component {
 	}
 
 	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
 		return [
 			{
 				label: _n( 'order', 'orders', totals.num_items_sold, 'wc-admin' ),
@@ -221,6 +224,10 @@ class OrdersReportTable extends Component {
 					'wc-admin'
 				),
 				value: totals.num_returning_customers,
+			},
+			{
+				label: _n( 'product', 'products', totals.products, 'wc-admin' ),
+				value: totals.products,
 			},
 			{
 				label: _n( 'item sold', 'items sold', totals.num_items_sold, 'wc-admin' ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -210,6 +210,19 @@ class OrdersReportTable extends Component {
 				value: totals.orders_count,
 			},
 			{
+				label: _n( 'new customer', 'new customers', totals.num_new_customers, 'wc-admin' ),
+				value: totals.num_new_customers,
+			},
+			{
+				label: _n(
+					'returning customer',
+					'returning customers',
+					totals.num_returning_customers,
+					'wc-admin'
+				),
+				value: totals.num_returning_customers,
+			},
+			{
 				label: _n( 'item sold', 'items sold', totals.num_items_sold, 'wc-admin' ),
 				value: totals.num_items_sold,
 			},

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
@@ -203,6 +203,27 @@ class OrdersReportTable extends Component {
 		} );
 	}
 
+	getSummary( totals ) {
+		return [
+			{
+				label: _n( 'order', 'orders', totals.num_items_sold, 'wc-admin' ),
+				value: totals.orders_count,
+			},
+			{
+				label: _n( 'item sold', 'items sold', totals.num_items_sold, 'wc-admin' ),
+				value: totals.num_items_sold,
+			},
+			{
+				label: _n( 'coupon', 'coupons', totals.coupons, 'wc-admin' ),
+				value: totals.coupons,
+			},
+			{
+				label: __( 'net revenue', 'wc-admin' ),
+				value: formatCurrency( totals.net_revenue ),
+			},
+		];
+	}
+
 	renderLinks( items = [] ) {
 		return items.map( ( item, i ) => (
 			<Link href={ item.href } key={ i } type="wp-admin">
@@ -242,6 +263,7 @@ class OrdersReportTable extends Component {
 		);
 		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
 		const totalRows = get( primaryData, [ 'data', 'totals', 'orders_count' ], orders.length );
+		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
 
 		return (
 			<TableCard
@@ -253,7 +275,7 @@ class OrdersReportTable extends Component {
 				isLoading={ isRequesting }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }
-				summary={ null }
+				summary={ summary }
 				downloadable
 			/>
 		);

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -298,8 +298,6 @@ class TableCard extends Component {
 					/>
 				) }
 
-				{ summary && <TableSummary data={ summary } /> }
-
 				<Pagination
 					page={ parseInt( query.page ) || 1 }
 					perPage={ rowsPerPage }
@@ -307,6 +305,8 @@ class TableCard extends Component {
 					onPageChange={ onQueryChange( 'page' ) }
 					onPerPageChange={ onQueryChange( 'per_page' ) }
 				/>
+
+				{ summary && <TableSummary data={ summary } /> }
 			</Card>
 		);
 	}

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -277,13 +277,19 @@ th.woocommerce-table__item {
 }
 
 .woocommerce-table__summary {
-	margin: $gap 0;
+	margin: 0;
+	padding: $gap 0;
 	text-align: center;
+	z-index: 1;
+	background: #fff;
+	position: relative;
 }
 
 .woocommerce-table__summary-item {
 	display: inline-block;
 	margin-bottom: 0;
+	margin-left: $gap-smaller;
+	margin-right: $gap-smaller;
 
 	.woocommerce-table__summary-label,
 	.woocommerce-table__summary-value {
@@ -296,10 +302,5 @@ th.woocommerce-table__item {
 
 	.woocommerce-table__summary-value {
 		font-weight: 600;
-	}
-
-	& + .woocommerce-table__summary-item::before {
-		content: '/';
-		margin: 0 $gap-smallest;
 	}
 }

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -308,6 +308,7 @@ class WC_Admin_Api_Init {
 			tax_total double DEFAULT 0 NOT NULL,
 			shipping_total double DEFAULT 0 NOT NULL,
 			net_total double DEFAULT 0 NOT NULL,
+			returning_customer boolean DEFAULT 0 NOT NULL,
 			PRIMARY KEY (order_id),
 			KEY date_created (date_created)
 		  ) $collate;

--- a/includes/class-wc-admin-reports-orders-stats-query.php
+++ b/includes/class-wc-admin-reports-orders-stats-query.php
@@ -36,6 +36,8 @@ class WC_Admin_Reports_Orders_Stats_Query extends WC_Admin_Reports_Query {
 				'avg_order_value',
 				'orders_count',
 				'avg_items_per_order',
+				'num_items_sold',
+				'coupons',
 			),
 		);
 	}

--- a/includes/class-wc-admin-reports-orders-stats-query.php
+++ b/includes/class-wc-admin-reports-orders-stats-query.php
@@ -38,6 +38,8 @@ class WC_Admin_Reports_Orders_Stats_Query extends WC_Admin_Reports_Query {
 				'avg_items_per_order',
 				'num_items_sold',
 				'coupons',
+				'num_returning_customers',
+				'num_new_customers',
 			),
 		);
 	}

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -46,8 +46,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		'net_revenue'             => 'floatval',
 		'avg_items_per_order'     => 'floatval',
 		'avg_order_value'         => 'floatval',
-		'num_returning_customers' => 'floatval',
-		'num_new_customers'       => 'floatval',
+		'num_returning_customers' => 'intval',
+		'num_new_customers'       => 'intval',
 	);
 
 	/**

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -284,16 +284,16 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
 			}
 
-			$unique_products = $wpdb->get_results(
+			$unique_products = $wpdb->get_var(
 				"SELECT
 						COUNT( DISTINCT {$wpdb->prefix}wc_order_product_lookup.product_id )
 					FROM
 						{$wpdb->prefix}wc_order_product_lookup JOIN wp_posts ON {$wpdb->prefix}wc_order_product_lookup.order_id = wp_posts.ID
 					WHERE
 						1=1
-						{$totals_query['where_clause']}", ARRAY_A
+						{$totals_query['where_clause']}"
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
-			$totals[0]['products'] = $unique_products[0]['COUNT( DISTINCT wp_wc_order_product_lookup.product_id )'];
+			$totals[0]['products'] = $unique_products;
 
 			// Specification says these are not included in totals.
 			unset( $totals[0]['date_start'] );

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -284,15 +284,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
 			}
 
-			$unique_products = $wpdb->get_var(
-				"SELECT
-						COUNT( DISTINCT {$wpdb->prefix}wc_order_product_lookup.product_id )
-					FROM
-						{$wpdb->prefix}wc_order_product_lookup JOIN wp_posts ON {$wpdb->prefix}wc_order_product_lookup.order_id = wp_posts.ID
-					WHERE
-						1=1
-						{$totals_query['where_clause']}"
-			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+			$unique_products = $this->get_unique_products( $totals_query['where_clause'] );
 			$totals[0]['products'] = $unique_products;
 
 			// Specification says these are not included in totals.
@@ -372,6 +364,26 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get unique products based on user time query
+	 *
+	 * @param string $where_clause Where clause with date query.
+	 * @return integer Unique product count.
+	 */
+	public function get_unique_products( $where_clause ) {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			"SELECT
+					COUNT( DISTINCT {$wpdb->prefix}wc_order_product_lookup.product_id )
+				FROM
+					{$wpdb->prefix}wc_order_product_lookup JOIN {$wpdb->prefix}posts ON {$wpdb->prefix}wc_order_product_lookup.order_id = {$wpdb->prefix}posts.ID
+				WHERE
+					1=1
+					{$where_clause}"
+		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -284,6 +284,17 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
 			}
 
+			$unique_products = $wpdb->get_results(
+				"SELECT
+						COUNT( DISTINCT {$wpdb->prefix}wc_order_product_lookup.product_id )
+					FROM
+						{$wpdb->prefix}wc_order_product_lookup JOIN wp_posts ON {$wpdb->prefix}wc_order_product_lookup.order_id = wp_posts.ID
+					WHERE
+						1=1
+						{$totals_query['where_clause']}", ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+			$totals[0]['products'] = $unique_products[0]['COUNT( DISTINCT wp_wc_order_product_lookup.product_id )'];
+
 			// Specification says these are not included in totals.
 			unset( $totals[0]['date_start'] );
 			unset( $totals[0]['date_end'] );
@@ -485,23 +496,23 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 	/**
 	 * Check to see if an order's customer has made previous orders or not
-	 * 
-	 * @param $order WC_Order object.
+	 *
+	 * @param array $order WC_Order object.
 	 * @return bool
 	 */
 	protected static function is_returning_customer( $order ) {
 		$customer_id = $order->get_user_id();
 
-		if ( $customer_id === 0 ) {
+		if ( 0 === $customer_id ) {
 			return false;
 		}
 
 		$customer_orders = get_posts( array(
 			'meta_key' => '_customer_user',
 			'meta_value' => $customer_id,
-			'post_type' => 'shop_order', 
+			'post_type' => 'shop_order',
 			'post_status' => array( 'wc-on-hold', 'wc-processing', 'wc-completed' ),
-			'numberposts' => -1
+			'numberposts' => 2,
 		) );
 
 		return count( $customer_orders ) > 1;

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -36,16 +36,18 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	 * @var array
 	 */
 	protected $column_types = array(
-		'orders_count'        => 'intval',
-		'num_items_sold'      => 'intval',
-		'gross_revenue'       => 'floatval',
-		'coupons'             => 'floatval',
-		'refunds'             => 'floatval',
-		'taxes'               => 'floatval',
-		'shipping'            => 'floatval',
-		'net_revenue'         => 'floatval',
-		'avg_items_per_order' => 'floatval',
-		'avg_order_value'     => 'floatval',
+		'orders_count'            => 'intval',
+		'num_items_sold'          => 'intval',
+		'gross_revenue'           => 'floatval',
+		'coupons'                 => 'floatval',
+		'refunds'                 => 'floatval',
+		'taxes'                   => 'floatval',
+		'shipping'                => 'floatval',
+		'net_revenue'             => 'floatval',
+		'avg_items_per_order'     => 'floatval',
+		'avg_order_value'         => 'floatval',
+		'num_returning_customers' => 'floatval',
+		'num_new_customers'       => 'floatval',
 	);
 
 	/**
@@ -54,16 +56,18 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	 * @var array
 	 */
 	protected $report_columns = array(
-		'orders_count'        => 'COUNT(*) as orders_count',
-		'num_items_sold'      => 'SUM(num_items_sold) as num_items_sold',
-		'gross_revenue'       => 'SUM(gross_total) AS gross_revenue',
-		'coupons'             => 'SUM(coupon_total) AS coupons',
-		'refunds'             => 'SUM(refund_total) AS refunds',
-		'taxes'               => 'SUM(tax_total) AS taxes',
-		'shipping'            => 'SUM(shipping_total) AS shipping',
-		'net_revenue'         => 'SUM(net_total) AS net_revenue',
-		'avg_items_per_order' => 'AVG(num_items_sold) AS avg_items_per_order',
-		'avg_order_value'     => 'AVG(gross_total) AS avg_order_value',
+		'orders_count'            => 'COUNT(*) as orders_count',
+		'num_items_sold'          => 'SUM(num_items_sold) as num_items_sold',
+		'gross_revenue'           => 'SUM(gross_total) AS gross_revenue',
+		'coupons'                 => 'SUM(coupon_total) AS coupons',
+		'refunds'                 => 'SUM(refund_total) AS refunds',
+		'taxes'                   => 'SUM(tax_total) AS taxes',
+		'shipping'                => 'SUM(shipping_total) AS shipping',
+		'net_revenue'             => 'SUM(net_total) AS net_revenue',
+		'avg_items_per_order'     => 'AVG(num_items_sold) AS avg_items_per_order',
+		'avg_order_value'         => 'AVG(gross_total) AS avg_order_value',
+		'num_returning_customers' => 'SUM(returning_customer = 1) AS num_returning_customers',
+		'num_new_customers'       => 'SUM(returning_customer = 0) AS num_new_customers',
 	);
 
 	/**
@@ -428,15 +432,16 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		$data = array(
-			'order_id'       => $order->get_id(),
-			'date_created'   => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
-			'num_items_sold' => self::get_num_items_sold( $order ),
-			'gross_total'    => $order->get_total(),
-			'coupon_total'   => $order->get_total_discount(),
-			'refund_total'   => $order->get_total_refunded(),
-			'tax_total'      => $order->get_total_tax(),
-			'shipping_total' => $order->get_shipping_total(),
-			'net_total'      => (float) $order->get_total() - (float) $order->get_total_tax() - (float) $order->get_shipping_total(),
+			'order_id'           => $order->get_id(),
+			'date_created'       => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
+			'num_items_sold'     => self::get_num_items_sold( $order ),
+			'gross_total'        => $order->get_total(),
+			'coupon_total'       => $order->get_total_discount(),
+			'refund_total'       => $order->get_total_refunded(),
+			'tax_total'          => $order->get_total_tax(),
+			'shipping_total'     => $order->get_shipping_total(),
+			'net_total'          => (float) $order->get_total() - (float) $order->get_total_tax() - (float) $order->get_shipping_total(),
+			'returning_customer' => self::is_returning_customer( $order ),
 		);
 
 		// Update or add the information to the DB.
@@ -476,5 +481,29 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		return $num_items;
+	}
+
+	/**
+	 * Check to see if an order's customer has made previous orders or not
+	 * 
+	 * @param $order WC_Order object.
+	 * @return bool
+	 */
+	protected static function is_returning_customer( $order ) {
+		$customer_id = $order->get_user_id();
+
+		if ( $customer_id === 0 ) {
+			return false;
+		}
+
+		$customer_orders = get_posts( array(
+			'meta_key' => '_customer_user',
+			'meta_value' => $customer_id,
+			'post_type' => 'shop_order', 
+			'post_status' => array( 'wc-on-hold', 'wc-processing', 'wc-completed' ),
+			'numberposts' => -1
+		) );
+
+		return count( $customer_orders ) > 1;
 	}
 }

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -519,13 +519,15 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			return false;
 		}
 
-		$customer_orders = get_posts( array(
-			'meta_key' => '_customer_user',
-			'meta_value' => $customer_id,
-			'post_type' => 'shop_order',
-			'post_status' => array( 'wc-on-hold', 'wc-processing', 'wc-completed' ),
-			'numberposts' => 2,
-		) );
+		$customer_orders = get_posts(
+			array(
+				'meta_key'    => '_customer_user', // WPCS: slow query ok.
+				'meta_value'  => $customer_id, // WPCS: slow query ok.
+				'post_type'   => 'shop_order',
+				'post_status' => array( 'wc-on-hold', 'wc-processing', 'wc-completed' ),
+				'numberposts' => 2,
+			)
+		);
 
 		return count( $customer_orders ) > 1;
 	}

--- a/tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/reports/class-wc-tests-reports-orders.php
@@ -45,16 +45,19 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$expected_stats = array(
 			'totals'    => array(
-				'orders_count'        => 1,
-				'num_items_sold'      => 4,
-				'avg_items_per_order' => 4,
-				'avg_order_value'     => 97,
-				'gross_revenue'       => 97,
-				'coupons'             => 20,
-				'refunds'             => 0,
-				'taxes'               => 7,
-				'shipping'            => 10,
-				'net_revenue'         => 80,
+				'orders_count'            => 1,
+				'num_items_sold'          => 4,
+				'avg_items_per_order'     => 4,
+				'avg_order_value'         => 97,
+				'gross_revenue'           => 97,
+				'coupons'                 => 20,
+				'refunds'                 => 0,
+				'taxes'                   => 7,
+				'shipping'                => 10,
+				'net_revenue'             => 80,
+				'num_returning_customers' => 0,
+				'num_new_customers'       => 1,
+				'products'                => '1',
 			),
 			'intervals' => array(
 				array(

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -48,16 +48,19 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		);
 		$expected_stats = array(
 			'totals'    => array(
-				'orders_count'        => 1,
-				'num_items_sold'      => 4,
-				'gross_revenue'       => 97,
-				'coupons'             => 20,
-				'refunds'             => 0,
-				'taxes'               => 7,
-				'shipping'            => 10,
-				'net_revenue'         => 80,
-				'avg_items_per_order' => 4,
-				'avg_order_value'     => 97,
+				'orders_count'            => 1,
+				'num_items_sold'          => 4,
+				'gross_revenue'           => 97,
+				'coupons'                 => 20,
+				'refunds'                 => 0,
+				'taxes'                   => 7,
+				'shipping'                => 10,
+				'net_revenue'             => 80,
+				'avg_items_per_order'     => 4,
+				'avg_order_value'         => 97,
+				'num_returning_customers' => 0,
+				'num_new_customers'       => 1,
+				'products'                => '1',
 			),
 			'intervals' => array(
 				array(


### PR DESCRIPTION
Fixes #559 

Adds in the summary total value fields to the Orders table footer, `returning_customer` column in the stats table, and total values to the API data.

### Screenshots

<img width="1458" alt="screen shot 2018-10-22 at 10 45 09 am" src="https://user-images.githubusercontent.com/10561050/47309664-9f8a9580-d5fa-11e8-8190-b7f8c16887b5.png">

### Detailed test instructions:

1.  Deactivate and reactivate wc-admin plugin so that `wp_wc_order_stats` new table column can be generated.
1.  Visit `/wp-admin/admin.php?page=wc-admin#/analytics/orders`.
2.  Make sure that order stats appear correctly in the footer of the table when changing the timeframe. (note that returning/new customers won't appear retroactively on older orders and will appear as new customers only).

### Notes

* Design changes were discussed with @LevinMedia that included no longer using slashes for table summaries and instead wrapping text from a single line on mobile devices.
* Returning/new customers is tracking by a new bool column `returning_customer` on the `wp_wc_order_stats` table ( https://github.com/woocommerce/wc-admin/blob/1e1327053a639b75effb3db9adbd75d1a2fb327d/includes/class-wc-admin-api-init.php#L309 )
* An additional DB call is made to count unique products in the orders data store ( https://github.com/woocommerce/wc-admin/blob/1e1327053a639b75effb3db9adbd75d1a2fb327d/includes/data-stores/class-wc-admin-reports-orders-data-store.php#L287-L296 )

@claudiosanches @peterfabian Can you take a look at the added DB call and returning customer call and let me know if these look acceptable?