### PR TITLE
Make Orders placeholder table have the correct sorted column

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -225,7 +225,7 @@ export default class OrdersReportTable extends Component {
 		);
 	}
 
-	renderPlaceholderTable() {
+	renderPlaceholderTable( tableQuery ) {
 		const headers = this.getHeadersContent();
 
 		return (
@@ -233,26 +233,24 @@ export default class OrdersReportTable extends Component {
 				title={ __( 'Orders', 'wc-admin' ) }
 				className="woocommerce-analytics__table-placeholder"
 			>
-				<TablePlaceholder caption={ __( 'Orders', 'wc-admin' ) } headers={ headers } />
+				<TablePlaceholder
+					caption={ __( 'Orders', 'wc-admin' ) }
+					headers={ headers }
+					query={ tableQuery }
+				/>
 			</Card>
 		);
 	}
 
-	renderTable() {
-		const { orders, query, totalRows } = this.props;
+	renderTable( tableQuery ) {
+		const { orders, totalRows } = this.props;
 
-		const rowsPerPage = parseInt( query.per_page ) || 25;
+		const rowsPerPage = parseInt( tableQuery.per_page ) || 25;
 		const rows = this.getRowsContent(
-			orderBy( this.formatTableData( orders ), query.orderby || 'date', query.order || 'asc' )
+			orderBy( this.formatTableData( orders ), tableQuery.orderby, tableQuery.order )
 		);
 
 		const headers = this.getHeadersContent();
-
-		const tableQuery = {
-			...query,
-			orderby: query.orderby || 'date',
-			order: query.order || 'asc',
-		};
 
 		return (
 			<TableCard
@@ -270,8 +268,16 @@ export default class OrdersReportTable extends Component {
 	}
 
 	render() {
-		const { isRequesting } = this.props;
+		const { isRequesting, query } = this.props;
 
-		return isRequesting ? this.renderPlaceholderTable() : this.renderTable();
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+		};
+
+		return isRequesting
+			? this.renderPlaceholderTable( tableQuery )
+			: this.renderTable( tableQuery );
 	}
 }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -243,7 +243,7 @@ export default class OrdersReportTable extends Component {
 	}
 
 	renderTable( tableQuery ) {
-		const { orders, totalRows } = this.props;
+		const { orders, query, totalRows } = this.props;
 
 		const rowsPerPage = parseInt( tableQuery.per_page ) || 25;
 		const rows = this.getRowsContent(
@@ -259,7 +259,7 @@ export default class OrdersReportTable extends Component {
 				totalRows={ totalRows }
 				rowsPerPage={ rowsPerPage }
 				headers={ headers }
-				onClickDownload={ this.onDownload( headers, rows, tableQuery ) }
+				onClickDownload={ this.onDownload( headers, rows, query ) }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }
 				summary={ null }


### PR DESCRIPTION
This PR fixes an issue with the Orders placeholder table that was not marking the correct sorted column.

### Screenshots
_(having the table sorted by order id)_
Before:
![image](https://user-images.githubusercontent.com/3616980/47301681-c0191680-d61f-11e8-9d40-699dccbb5e41.png)

After:
![image](https://user-images.githubusercontent.com/3616980/47301700-ca3b1500-d61f-11e8-955f-cf1cc64c47ae.png)


### Detailed test instructions:

 - Go to `/wp-admin/admin.php?page=wc-admin#/analytics/orders?orderby=id&order=desc` (notice the table is ordered by `id`).
 - Verify the placeholder table has the `Order #` column activated, instead of `Date`.

If the placeholder table disappears too fast, you can modify [this line](https://github.com/woocommerce/wc-admin/blob/master/client/analytics/report/orders/table.js#L275) from:
```ES6
return isRequesting ? this.renderPlaceholderTable() : this.renderTable();
```
to
```ES6
return isRequesting || true ? this.renderPlaceholderTable() : this.renderTable();
```
so the placeholder table is rendered forever.