### PR TITLE
Move Revenue table to its own component

### DIFF
--- a/client/analytics/report/revenue/chart.js
+++ b/client/analytics/report/revenue/chart.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 
-class OrdersReportChart extends Component {
+class RevenueReportChart extends Component {
 	getCharts() {
 		return [
 			{
@@ -81,8 +81,8 @@ class OrdersReportChart extends Component {
 	}
 }
 
-OrdersReportChart.propTypes = {
+RevenueReportChart.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default OrdersReportChart;
+export default RevenueReportChart;

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -2,216 +2,39 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { format as formatDate } from '@wordpress/date';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { withSelect } from '@wordpress/data';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { Card, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
-import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
-import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { getAdminLink, onQueryChange } from 'lib/nav-utils';
-import { appendTimestamp, getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
-import OrdersReportChart from './chart';
+import { ReportFilters } from '@woocommerce/components';
+import { appendTimestamp, getCurrentDates } from 'lib/date';
+import RevenueReportChart from './chart';
+import RevenueReportTable from './table';
 
 export class RevenueReport extends Component {
 	constructor() {
 		super();
-		this.onDownload = this.onDownload.bind( this );
-	}
-
-	onDownload( headers, rows, query ) {
-		// @TODO The current implementation only downloads the contents displayed in the table.
-		// Another solution is required when the data set is larger (see #311).
-		return () => {
-			downloadCSVFile(
-				generateCSVFileName( 'revenue', query ),
-				generateCSVDataFromTable( headers, rows )
-			);
-		};
-	}
-
-	getHeadersContent() {
-		return [
-			{
-				label: __( 'Date', 'wc-admin' ),
-				key: 'date',
-				required: true,
-				defaultSort: true,
-				isLeftAligned: true,
-				isSortable: true,
-			},
-			{
-				label: __( 'Orders', 'wc-admin' ),
-				key: 'orders_count',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Gross Revenue', 'wc-admin' ),
-				key: 'gross_revenue',
-				required: true,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Refunds', 'wc-admin' ),
-				key: 'refunds',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Coupons', 'wc-admin' ),
-				key: 'coupons',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Taxes', 'wc-admin' ),
-				key: 'taxes',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Shipping', 'wc-admin' ),
-				key: 'shipping',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-			{
-				label: __( 'Net Revenue', 'wc-admin' ),
-				key: 'net_revenue',
-				required: false,
-				isSortable: true,
-				isNumeric: true,
-			},
-		];
-	}
-
-	getRowsContent( data = [] ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
-		const formats = getDateFormatsForInterval( currentInterval );
-
-		return map( data, row => {
-			const {
-				coupons,
-				gross_revenue,
-				net_revenue,
-				orders_count,
-				refunds,
-				shipping,
-				taxes,
-			} = row.subtotals;
-
-			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
-			// we need to know which kind of report this is, and parse the `label` to get this row's date
-			const orderLink = (
-				<a
-					href={ getAdminLink(
-						'edit.php?post_type=shop_order&m=' + formatDate( 'Ymd', row.date_start )
-					) }
-				>
-					{ orders_count }
-				</a>
-			);
-			return [
-				{
-					display: formatDate( formats.tableFormat, row.date_start ),
-					value: row.date_start,
-				},
-				{
-					display: orderLink,
-					value: Number( orders_count ),
-				},
-				{
-					display: formatCurrency( gross_revenue ),
-					value: getCurrencyFormatDecimal( gross_revenue ),
-				},
-				{
-					display: formatCurrency( refunds ),
-					value: getCurrencyFormatDecimal( refunds ),
-				},
-				{
-					display: formatCurrency( coupons ),
-					value: getCurrencyFormatDecimal( coupons ),
-				},
-				{
-					display: formatCurrency( taxes ),
-					value: getCurrencyFormatDecimal( taxes ),
-				},
-				{
-					display: formatCurrency( shipping ),
-					value: getCurrencyFormatDecimal( shipping ),
-				},
-				{
-					display: formatCurrency( net_revenue ),
-					value: getCurrencyFormatDecimal( net_revenue ),
-				},
-			];
-		} );
-	}
-
-	renderTable() {
-		const { isTableDataRequesting, tableData, tableQuery } = this.props;
-		const headers = this.getHeadersContent();
-
-		if ( isTableDataRequesting ) {
-			return (
-				<Card
-					title={ __( 'Revenue', 'wc-admin' ) }
-					className="woocommerce-analytics__table-placeholder"
-				>
-					<TablePlaceholder
-						caption={ __( 'Revenue', 'wc-admin' ) }
-						headers={ headers }
-						query={ tableQuery }
-					/>
-				</Card>
-			);
-		}
-
-		const intervals = tableData.data.intervals;
-		const rows = this.getRowsContent( intervals );
-
-		const rowsPerPage =
-			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) || 25;
-
-		return (
-			<TableCard
-				title={ __( 'Revenue', 'wc-admin' ) }
-				rows={ rows }
-				totalRows={ tableData.totalResults }
-				rowsPerPage={ rowsPerPage }
-				headers={ headers }
-				onClickDownload={ this.onDownload( headers, rows, tableQuery ) }
-				onQueryChange={ onQueryChange }
-				query={ tableQuery }
-				summary={ null }
-			/>
-		);
 	}
 
 	render() {
-		const { path, query } = this.props;
+		const { isTableDataError, isTableDataRequesting, path, query, tableData } = this.props;
 
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } />
-
-				<OrdersReportChart query={ query } />
-				{ this.renderTable() }
+				<RevenueReportChart query={ query } />
+				<RevenueReportTable
+					isError={ isTableDataError }
+					isRequesting={ isTableDataRequesting }
+					tableData={ tableData }
+					query={ query }
+					totalRows={ get( tableData, [ 'totalResults' ], 0 ) }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -18,10 +18,6 @@ import { onQueryChange } from 'lib/nav-utils';
 import ReportError from 'analytics/components/report-error';
 
 export default class RevenueReportTable extends Component {
-	constructor( props ) {
-		super( props );
-	}
-
 	onDownload( headers, rows, query ) {
 		// @TODO The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -1,0 +1,221 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { format as formatDate } from '@wordpress/date';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Card, Link, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { downloadCSVFile, generateCSVDataFromTable, generateCSVFileName } from 'lib/csv';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
+import { getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
+import { onQueryChange } from 'lib/nav-utils';
+import ReportError from 'analytics/components/report-error';
+
+export default class RevenueReportTable extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	onDownload( headers, rows, query ) {
+		// @TODO The current implementation only downloads the contents displayed in the table.
+		// Another solution is required when the data set is larger (see #311).
+		return () => {
+			downloadCSVFile(
+				generateCSVFileName( 'revenue', query ),
+				generateCSVDataFromTable( headers, rows )
+			);
+		};
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Date', 'wc-admin' ),
+				key: 'date',
+				required: true,
+				defaultSort: true,
+				isLeftAligned: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Gross Revenue', 'wc-admin' ),
+				key: 'gross_revenue',
+				required: true,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Refunds', 'wc-admin' ),
+				key: 'refunds',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Coupons', 'wc-admin' ),
+				key: 'coupons',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Taxes', 'wc-admin' ),
+				key: 'taxes',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Shipping', 'wc-admin' ),
+				key: 'shipping',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Net Revenue', 'wc-admin' ),
+				key: 'net_revenue',
+				required: false,
+				isSortable: true,
+				isNumeric: true,
+			},
+		];
+	}
+
+	getRowsContent( data = [] ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const formats = getDateFormatsForInterval( currentInterval );
+
+		return map( data, row => {
+			const {
+				coupons,
+				gross_revenue,
+				net_revenue,
+				orders_count,
+				refunds,
+				shipping,
+				taxes,
+			} = row.subtotals;
+
+			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
+			// we need to know which kind of report this is, and parse the `label` to get this row's date
+			const orderLink = (
+				<Link
+					href={ 'edit.php?post_type=shop_order&m=' + formatDate( 'Ymd', row.date_start ) }
+					type="wp-admin"
+				>
+					{ orders_count }
+				</Link>
+			);
+			return [
+				{
+					display: formatDate( formats.tableFormat, row.date_start ),
+					value: row.date_start,
+				},
+				{
+					display: orderLink,
+					value: Number( orders_count ),
+				},
+				{
+					display: formatCurrency( gross_revenue ),
+					value: getCurrencyFormatDecimal( gross_revenue ),
+				},
+				{
+					display: formatCurrency( refunds ),
+					value: getCurrencyFormatDecimal( refunds ),
+				},
+				{
+					display: formatCurrency( coupons ),
+					value: getCurrencyFormatDecimal( coupons ),
+				},
+				{
+					display: formatCurrency( taxes ),
+					value: getCurrencyFormatDecimal( taxes ),
+				},
+				{
+					display: formatCurrency( shipping ),
+					value: getCurrencyFormatDecimal( shipping ),
+				},
+				{
+					display: formatCurrency( net_revenue ),
+					value: getCurrencyFormatDecimal( net_revenue ),
+				},
+			];
+		} );
+	}
+
+	renderPlaceholderTable( tableQuery ) {
+		const headers = this.getHeadersContent();
+
+		return (
+			<Card
+				title={ __( 'Revenue', 'wc-admin' ) }
+				className="woocommerce-analytics__table-placeholder"
+			>
+				<TablePlaceholder
+					caption={ __( 'Revenue', 'wc-admin' ) }
+					headers={ headers }
+					query={ tableQuery }
+				/>
+			</Card>
+		);
+	}
+
+	renderTable( tableQuery ) {
+		const { tableData, query, totalRows } = this.props;
+
+		const rowsPerPage =
+			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) || 25;
+		const rows = this.getRowsContent( tableData.data.intervals );
+
+		const headers = this.getHeadersContent();
+
+		return (
+			<TableCard
+				title={ __( 'Revenue', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ totalRows }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				onClickDownload={ this.onDownload( headers, rows, query ) }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ null }
+			/>
+		);
+	}
+
+	render() {
+		const { isError, isRequesting, query } = this.props;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+		};
+
+		if ( isRequesting ) {
+			return this.renderPlaceholderTable( tableQuery );
+		}
+
+		return this.renderTable( tableQuery );
+	}
+}

--- a/client/analytics/report/revenue/test/table.js
+++ b/client/analytics/report/revenue/test/table.js
@@ -11,7 +11,7 @@ import { TableCard } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { RevenueReport } from '../';
+import RevenueReportTable from '../table';
 import mockData from '../__mocks__/revenue-mock-data';
 import mockCSV from '../__mocks__/revenue-mock-csv';
 import { downloadCSVFile } from 'lib/csv';
@@ -23,36 +23,25 @@ jest.mock( 'lib/csv', () => ( {
 
 window.fetch = fetch;
 
-describe( 'RevenueReport', () => {
+describe( 'RevenueReportTable', () => {
 	test( 'should save CSV when clicking on download', () => {
 		global.Blob = ( content, options ) => ( { content, options } );
 
-		const primaryData = {
+		const tableData = {
 			data: mockData,
-			totalResults: 7,
-			totalPages: 1,
 		};
 
-		const summaryNumbers = {
-			totals: {
-				primary: {},
-				secondary: {},
-			},
-		};
-
-		const revenueReport = shallow(
-			<RevenueReport
-				params={ { report: 'revenue' } }
-				path="/analytics/revenue"
+		const revenueReportTable = shallow(
+			<RevenueReportTable
+				isError={ false }
+				isRequesting={ false }
+				tableData={ tableData }
 				query={ {} }
-				summaryNumbers={ summaryNumbers }
-				primaryData={ primaryData }
-				tableData={ primaryData }
-				secondaryData={ primaryData }
+				totalRows={ mockData.intervals.length }
 			/>
 		);
 
-		const tableCard = revenueReport.find( TableCard );
+		const tableCard = revenueReportTable.find( TableCard );
 		tableCard.props().onClickDownload();
 
 		expect( downloadCSVFile ).toHaveBeenCalledWith(


### PR DESCRIPTION
Move _Revenue_ report table to its own component, in a similar way to how it's done in _Orders_ and _Products_ reports.

### Screenshots
_(this PR shouldn't produce any visible change)_
![image](https://user-images.githubusercontent.com/3616980/47306157-eba1fe00-d62b-11e8-8c87-b20bbb772bef.png)

### Detailed test instructions:

- Go to the _Revenue_ analytics page (`/wp-admin/admin.php?page=wc-admin#/analytics/revenue`).
- Test the table: sorting, using pagination, downloading...
- Verify there are no regressions.
