### PR TITLE
Add file doc block to fix linting issue

### DIFF
--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Order Functions
+ *
+ * @package  WooCommerce Admin
+ */
 
 /**
  * Make an entry in the wc_admin_order_product_lookup table for an order.


### PR DESCRIPTION
#622

Adds doc block to fix this issue:


FILE: /Users/jonathanbelcher/Local Sites/woodash/app/public/wp-content/plugins/wc-admin/includes/wc-admin-order-functions.php
FOUND 1 ERROR AFFECTING 1 LINE

  1 | ERROR | Missing file doc comment

### Detailed test instructions:

 - Run: `npm run php:lint`
 - Does the above error appear
