### PR TITLE
Chart: remove last x-axis tick in an uneven series

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -264,7 +264,7 @@ const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 		ticks.push( uniqueDates[ idx ] );
 	}
 
-	// If the first or last date is missing from the ticks array, add it back in.
+	// If the first date is missing from the ticks array, add it back in.
 	if ( ticks[ 0 ] !== uniqueDates[ 0 ] ) {
 		ticks.unshift( uniqueDates[ 0 ] );
 	}

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -268,9 +268,6 @@ const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 	if ( ticks[ 0 ] !== uniqueDates[ 0 ] ) {
 		ticks.unshift( uniqueDates[ 0 ] );
 	}
-	if ( ticks[ ticks.length - 1 ] !== uniqueDates[ uniqueDates.length - 1 ] ) {
-		ticks.push( uniqueDates[ uniqueDates.length - 1 ] );
-	}
 
 	return ticks;
 };


### PR DESCRIPTION
Fixes #633 

Small change to remove code that ensures that the last tick is always present, even in an uneven series of ticks.

### Screenshots
Current Version
<img width="388" alt="doublelastevent" src="https://user-images.githubusercontent.com/1160732/47354157-4c7a1680-d6be-11e8-8db6-51badb9e6e64.png">

PR
![screenshot 2018-10-23 12 23 32](https://user-images.githubusercontent.com/1160732/47354231-80553c00-d6be-11e8-9320-7f1c7986d4f4.png)

### Detailed test instructions:

 - Go to wp-admin/admin.php?page=wc-admin#/analytics/revenue
 - Select a date range that will result in an uneven number of x-ticks, for example, July 1st to Aug 31st.
