### PR TITLE
Chart: updated intervals to use the full year

### DIFF
--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -422,7 +422,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 	let pointLabelFormat = 'F j, Y';
 	let tooltipFormat = '%B %d %Y';
 	let xFormat = '%Y-%m-%d';
-	let x2Format = '%b %y';
+	let x2Format = '%b %Y';
 	let tableFormat = 'm/d/Y';
 
 	switch ( interval ) {
@@ -448,7 +448,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 		case 'month':
 			pointLabelFormat = 'F Y';
 			tooltipFormat = '%B %Y';
-			xFormat = '%b %y';
+			xFormat = '%b %Y';
 			x2Format = '';
 			break;
 		case 'year':


### PR DESCRIPTION
Master Thread: #632 

> Two digit years on the secondary x-axis could be confusing with the dates on the primary x-axis directly above. To minimize the potential for confusion, years should always be expressed in a four-digit form

### Screenshots
Current:
<img width="388" alt="doublelastevent" src="https://user-images.githubusercontent.com/1160732/47356907-ab8f5980-d6c5-11e8-9a76-d8db7a6356b9.png">

PR:
![screenshot 2018-10-23 13 16 11](https://user-images.githubusercontent.com/1160732/47356981-d7aada80-d6c5-11e8-96bc-8c112ba51ed1.png)

### Detailed test instructions:

 - Select multiple date ranges and intervals and ensure the year always appears in four-digit format in the secondary x-axis ticks
