### PR TITLE
Chart: remove year from x2-axis tick if present in previous tick

### DIFF
--- a/client/components/chart/test/utils.js
+++ b/client/components/chart/test/utils.js
@@ -11,6 +11,7 @@ import { utcParse as d3UTCParse } from 'd3-time-format';
  */
 import dummyOrders from './fixtures/dummy';
 import {
+	compareStrings,
 	getDateSpaces,
 	getOrderedKeys,
 	getLineData,
@@ -192,5 +193,13 @@ describe( 'getdateSpaces', () => {
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].date ).toEqual( '2018-06-04T00:00:00' );
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].start ).toEqual( 90 );
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].width ).toEqual( 10 );
+	} );
+} );
+
+describe( 'compareStrings', () => {
+	it( 'return an array of unique words from s2 that dont appear in base string', () => {
+		expect( compareStrings( 'Jul 2018', 'Aug 2018' ).join( ' ' ) ).toEqual( 'Aug' );
+		expect( compareStrings( 'Jul 2017', 'Aug 2018' ).join( ' ' ) ).toEqual( 'Aug 2018' );
+		expect( compareStrings( 'Jul 2017', 'Jul 2018' ).join( ' ' ) ).toEqual( '2018' );
 	} );
 } );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -357,6 +357,20 @@ export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
 		};
 	} );
 
+export const compareStrings = ( s1, s2, params, splitChar ) => {
+	splitChar = typeof splitChar === 'undefined' ? ' ' : splitChar;
+	let string1 = new Array();
+	let string2 = new Array();
+	string1 = s1.split( splitChar );
+	string2 = s2.split( splitChar );
+	const diff = new Array();
+	const long = s1.length > s2.length ? string1 : string2;
+	for ( let x = 0; x < long.length; x++ ) {
+		string1[ x ] !== string2[ x ] && diff.push( string2[ x ] );
+	}
+	return diff;
+};
+
 export const drawAxis = ( node, params ) => {
 	const xScale = params.type === 'line' ? params.xLineScale : params.xScale;
 
@@ -387,12 +401,18 @@ export const drawAxis = ( node, params ) => {
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => {
-					const monthDate = d instanceof Date ? d : new Date( d );
+					let monthDate = d instanceof Date ? d : new Date( d );
 					let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
 					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
-					return i === 0 || params.x2Format( monthDate ) !== params.x2Format( prevMonth )
-						? params.x2Format( monthDate )
-						: '';
+					monthDate =
+						i !== 0
+							? compareStrings(
+									params.x2Format( prevMonth ),
+									params.x2Format( monthDate ),
+									params
+								).join( ' ' )
+							: params.x2Format( monthDate );
+					return i === 0 || monthDate !== params.x2Format( prevMonth ) ? monthDate : '';
 				} )
 		)
 		.call( g => g.select( '.domain' ).remove() );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -357,6 +357,13 @@ export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
 		};
 	} );
 
+/**
+ * Compares 2 strings and returns a list of words that are unique from s2
+ * @param {string} s1 - base string to compare against
+ * @param {string} s2 - string to compare against the base string
+ * @param {string} splitChar - character to use to deliminate words
+ * @returns {array} of unique words that appear in s2 but not in s1, the base string
+ */
 export const compareStrings = ( s1, s2, splitChar = ' ' ) => {
 	const string1 = s1.split( splitChar );
 	const string2 = s2.split( splitChar );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -357,12 +357,9 @@ export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
 		};
 	} );
 
-export const compareStrings = ( s1, s2, params, splitChar ) => {
-	splitChar = typeof splitChar === 'undefined' ? ' ' : splitChar;
-	let string1 = new Array();
-	let string2 = new Array();
-	string1 = s1.split( splitChar );
-	string2 = s2.split( splitChar );
+export const compareStrings = ( s1, s2, splitChar = ' ' ) => {
+	const string1 = s1.split( splitChar );
+	const string2 = s2.split( splitChar );
 	const diff = new Array();
 	const long = s1.length > s2.length ? string1 : string2;
 	for ( let x = 0; x < long.length; x++ ) {


### PR DESCRIPTION
Fixes #632 

> Including the year each month isn’t necessary. We only need to include the year once for each year we display, such as in this example:

<img width="388" alt="screen-shot-2018-10-22-at-9-06-57-am" src="https://user-images.githubusercontent.com/1160732/47360941-04182400-d6d1-11e8-8478-a769f7104473.png">

PR Screenshot:
![screenshot 2018-10-23 14 22 46](https://user-images.githubusercontent.com/1160732/47360979-1eea9880-d6d1-11e8-9e1b-b9fdb6a8378a.png)


### Detailed test instructions:

 - Select a date range that includes multiple months and even across a year-end and confirm that the year isn't duplicated in each tick until it changes

