### PR TITLE
Removes phpcs from npm run lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18n:pot": "grunt makepot",
     "i18n:check": "grunt checktextdomain",
     "i18n": "npm run -s i18n:js && npm run -s i18n:php && npm run -s i18n:check && npm run -s i18n:pot",
-    "lint": "npm run lint:js && npm run lint:php",
+    "lint": "npm run lint:js",
     "lint:js": "npm run -s install-if-deps-outdated && eslint client --ext=js,jsx",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
     "precommit": "npm run -s install-if-no-packages && node bin/pre-commit-hook.js",


### PR DESCRIPTION
Removes PHPCS from npm run lint which gets used in Travis CI.  This will make builds work again.

### Detailed test instructions:

 - Did Travis fail?
 - If not, this pr did its job.