### PR TITLE
Activity Panel: Inbox: When the user updates WooCommerce, add a note alerting that the store notice setting has moved

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -111,6 +111,10 @@
 	& > * + * {
 		margin-left: 0.5em;
 	}
+
+	a.components-button.is-button {
+		color: $gray-text;
+	}
 }
 
 .woocommerce-activity-card.is-loading {

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -46,7 +46,7 @@ class InboxPanel extends Component {
 				return [];
 			}
 			return actions.map( action => (
-				<Button disabled isDefault href={ action.url }>
+				<Button isDefault href={ action.url }>
 					{ action.label }
 				</Button>
 			) );

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -153,6 +153,26 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	}
 
 	/**
+	 * Prepare a path or query for serialization to the client.
+	 *
+	 * @param string $query The query, path, or URL to transform.
+	 * @return string A fully formed URL.
+	 */
+	public function prepare_query_for_response( $query ) {
+		if ( 'https://' === substr( $query, 0, 8 ) ) {
+			return $query;
+		}
+		if ( 'http://' === substr( $query, 0, 7 ) ) {
+			return $query;
+		}
+		if ( '?' === substr( $query, 0, 1 ) ) {
+			return admin_url( 'admin.php' . $query );
+		}
+
+		return admin_url( $query );
+	}
+
+	/**
 	 * Prepare a note object for serialization.
 	 *
 	 * @param array           $data Note data.
@@ -170,6 +190,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$data['content']           = stripslashes( $data['content'] );
 		foreach ( (array) $data['actions'] as $key => $value ) {
 			$data['actions'][ $key ]->label = stripslashes( $data['actions'][ $key ]->label );
+			$data['actions'][ $key ]->url   = $this->prepare_query_for_response( $data['actions'][ $key ]->query );
 		}
 		$data = $this->filter_response_by_context( $data, $context );
 

--- a/includes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/class-wc-admin-notes-new-sales-record.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_New_Sales_Record
  */
 class WC_Admin_Notes_New_Sales_Record {
+	const NOTE_NAME                = 'wc-admin-new-sales-record';
 	const RECORD_DATE_OPTION_KEY   = 'woocommerce_sales_record_date'; // ISO 8601 (YYYY-MM-DD) date.
 	const RECORD_AMOUNT_OPTION_KEY = 'woocommerce_sales_record_amount';
 
@@ -82,9 +83,8 @@ class WC_Admin_Notes_New_Sales_Record {
 				'new_record_amt'  => $total,
 			);
 
-			$name = 'wc-admin-new-sales-record';
 			// We only want one sales record note at any time in the inbox, so we delete any other first.
-			WC_Admin_Notes::delete_notes_with_name( $name );
+			WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
 
 			// And now, create our new note.
 			$note = new WC_Admin_Note();
@@ -93,7 +93,7 @@ class WC_Admin_Notes_New_Sales_Record {
 			$note->set_content_data( $content_data );
 			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 			$note->set_icon( 'trophy' );
-			$note->set_name( $name );
+			$note->set_name( self::NOTE_NAME );
 			$note->set_source( 'wc-admin' );
 			$note->add_action( 'view-report', __( 'View report', 'wc-admin' ), '?page=wc-admin#/analytics' );
 			$note->save();

--- a/includes/class-wc-admin-notes-settings-notes.php
+++ b/includes/class-wc-admin-notes-settings-notes.php
@@ -46,7 +46,7 @@ class WC_Admin_Notes_Settings_Notes {
 		$note->add_action(
 			'open-customizer',
 			__( 'Open Customizer', 'wc-admin' ),
-			'?page=wc-admin'
+			'customize.php'
 		);
 		$note->save();
 	}

--- a/includes/class-wc-admin-notes-settings-notes.php
+++ b/includes/class-wc-admin-notes-settings-notes.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Admin (Dashboard) Settings Moved Note Provider.
+ *
+ * Adds notes to the merchant's inbox concerning settings that have moved.
+ *
+ * @package WooCommerce Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Settings_Notes
+ */
+class WC_Admin_Notes_Settings_Notes {
+	/**
+	 * Add notes for each setting that has moved.
+	 */
+	public static function add_notes_for_settings_that_have_moved() {
+		self::possibly_add_notice_setting_moved_note();
+	}
+
+	/**
+	 * Possibly add a notice setting moved note.
+	 */
+	protected static function possibly_add_notice_setting_moved_note() {
+		$name = 'wc-admin-store-notice-setting-moved';
+
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( $name );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		// Otherwise, create our new note.
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Looking for the Store Notice setting?', 'wc-admin' ) );
+		$note->set_content( __( 'It can now be found in the Customizer.', 'wc-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( $name );
+		$note->set_source( 'wc-admin' );
+		$note->add_action(
+			'open-customizer',
+			__( 'Open Customizer', 'wc-admin' ),
+			'?page=wc-admin'
+		);
+		$note->save();
+	}
+}

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -70,7 +70,6 @@ function activate_wc_admin_plugin() {
 	if ( ! wp_next_scheduled( 'wc_admin_daily' ) ) {
 		wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
 	}
-
 }
 register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'activate_wc_admin_plugin' );
 

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -70,6 +70,7 @@ function activate_wc_admin_plugin() {
 	if ( ! wp_next_scheduled( 'wc_admin_daily' ) ) {
 		wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
 	}
+
 }
 register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'activate_wc_admin_plugin' );
 
@@ -115,5 +116,14 @@ function wc_admin_plugins_loaded() {
 
 	// Admin note providers.
 	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-new-sales-record.php';
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-settings-notes.php';
 }
 add_action( 'plugins_loaded', 'wc_admin_plugins_loaded' );
+
+/**
+ * Things to do after WooCommerce updates.
+ */
+function wc_admin_woocommerce_updated() {
+	WC_Admin_Notes_Settings_Notes::add_notes_for_settings_that_have_moved();
+}
+add_action( 'woocommerce_updated', 'wc_admin_woocommerce_updated' );


### PR DESCRIPTION
See #176 

Hooks into WooCommerce update. On updating WooCommerce, adds a "store notice setting has moved" note to the merchant's inbox if one isn't already in their inbox.

### Screenshots

<img width="604" alt="screen shot 2018-10-23 at 10 31 28 am" src="https://user-images.githubusercontent.com/1595739/47379290-547e8a00-d6af-11e8-94a8-e003bd2de18b.png">

### Detailed test instructions:

- To avoid having to update WooCommerce (which will be a pain), instead, modify class-wc-install.php in woocommerce as follows. (Note: check_version is called on every WooCommerce request.)
- Then, visit `/wp-admin/admin.php?page=wc-admin#/` and look in your inbox.
- Note: All actions will be enabled in a subsequent PR.

```
	/**
	 * Check WooCommerce version and run the updater is required.
	 *
	 * This check is done on all requests and runs if the versions do not match.
	 */
	public static function check_version() {
		//if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( get_option( 'woocommerce_version' ), WC()->version, '<' ) ) {
		//	self::install();
			do_action( 'woocommerce_updated' );
		//}
	}
```

Note: I also DRYd includes/class-wc-admin-notes-new-sales-record.php a little in this PR.