### PR TITLE
Fixes PHP errors caused by linting fixes

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -65,8 +65,9 @@ function wc_admin_get_embed_breadcrumbs() {
 		'wc-settings' => 'general',
 		'wc-status'   => 'status',
 	);
+	$tab             = '';
 	$get_tab         = isset( $_GET['tab'] ) && sanitize_text_field( wp_unslash( $_GET['tab'] ) );
-	if ( ! isset( $_GET['page'] ) ) {
+	if ( isset( $_GET['page'] ) ) {
 		if ( in_array( wp_unslash( $_GET['page'] ), array_keys( $pages_with_tabs ) ) ) {
 			$tab = ! empty( $get_tab ) ? $get_tab . '-' : $pages_with_tabs[ $get_page ] . '-';
 		}


### PR DESCRIPTION
Fixes #648 

Fixes PHP errors caused by linting clean ups

### Detailed test instructions:

 - Goto wp-admin
 - Do you get PHP errors?
