### PR TITLE
Fixes PHP 5.2 compatibility issues

### DIFF
--- a/includes/class-wc-admin-reports-revenue-query.php
+++ b/includes/class-wc-admin-reports-revenue-query.php
@@ -21,8 +21,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Admin_Reports_Revenue_Query extends WC_Admin_Reports_Query {
 
-	const REPORT_NAME = 'report-revenue-stats';
-
 	/**
 	 * Valid fields for Revenue report.
 	 *
@@ -56,8 +54,10 @@ class WC_Admin_Reports_Revenue_Query extends WC_Admin_Reports_Query {
 	 * @return array
 	 */
 	public function get_data() {
-		$args    = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
-		$results = WC_Data_Store::load( $this::REPORT_NAME )->get_data( $args );
+		$args = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
+
+		$data_store = WC_Data_Store::load( 'report-revenue-stats' );
+		$results    = $data_store->get_data( $args );
 		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
 	}
 


### PR DESCRIPTION
#622

Fixes lint issues around a 5.2 PHP Compatibility issues.

Detailed test instructions:
- Load revenue report
- run `npm run lint:php`
- You should not longer see:

```
FILE: /Library/WebServer/Documents/wca/wp-content/plugins/wc-admin/includes/class-wc-admin-reports-revenue-query.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 60 | ERROR | Static class properties and methods, as well as class constants, could not be accessed using a dynamic (variable)
    |       | classname in PHP 5.2 or earlier.
------------------------------------------------------------------------------------------------------------------------------------
```
