### PR TITLE
Fixes PHP 5.2 compatibility issues

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -290,7 +290,7 @@ class WC_Admin_Reports_Data_Store {
 	 */
 	protected function get_cache_key( $params ) {
 		// TODO: this is not working in PHP 5.2 (but revenue class has static methods, so it cannot use object property).
-		return 'woocommerce_' . $this::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**


### PR DESCRIPTION
#622

Fixes lint issues around a 5.2 PHP Compatibility issues.

Detailed test instructions:
- Do reports load?
- run `npm run lint:php`

You should not see: 
```
FILE: /Users/jonathanbelcher/Local Sites/woodash/app/public/wp-content/plugins/wc-admin/includes/data-stores/class-wc-admin-reports-data-store.php
292 | ERROR | Static class properties and methods, as well as class constants, could not be accessed using a dynamic (variable) classname in PHP 5.2 or earlier.
```