### PR TITLE
Updates wc-admin menu order and entries #624

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -95,14 +95,6 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
-			'title'  => __( 'Products', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/products',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
 			'title'  => __( 'Orders', 'wc-admin' ),
 			'parent' => '/analytics',
 			'path'   => '/analytics/orders',
@@ -111,9 +103,57 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
+			'title'  => __( 'Products', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/products',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Categories', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/categories',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
 			'title'  => __( 'Coupons', 'wc-admin' ),
 			'parent' => '/analytics',
 			'path'   => '/analytics/coupons',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Taxes', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/taxes',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Downloads', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/downloads',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Stock', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/stock',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Customers', 'wc-admin' ),
+			'parent' => '/analytics',
+			'path'   => '/analytics/customers',
 		)
 	);
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -109,54 +109,6 @@ function wc_admin_register_pages() {
 		)
 	);
 
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Categories', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/categories',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Coupons', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/coupons',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Taxes', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/taxes',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Downloads', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/downloads',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Stock', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/stock',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Customers', 'wc-admin' ),
-			'parent' => '/analytics',
-			'path'   => '/analytics/customers',
-		)
-	);
-
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 		wc_admin_register_page(
 			array(


### PR DESCRIPTION
#624

Chnages order and contents of the Analytics menu.

### Screenshots

![screen shot 2018-10-23 at 4 35 36 pm](https://user-images.githubusercontent.com/6817400/47389050-b657e780-d6e1-11e8-8d54-bfa788bebab5.png)

### Detailed test instructions:

 - Open wp-admin
 - Click on analytics
 - Observe order matches that in #624 
