### PR TITLE
Fix resolvers tests giving false positives

### DIFF
--- a/client/store/notes/test/resolvers.js
+++ b/client/store/notes/test/resolvers.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,11 @@ import resolvers from '../resolvers';
 
 const { getNotes } = resolvers;
 
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn().mockReturnValue( {
+		setNotes: jest.fn(),
+	} ),
+} ) );
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getNotes', () => {
@@ -26,17 +32,21 @@ describe( 'getNotes', () => {
 			if ( options.path === '/wc/v3/admin/notes' ) {
 				return Promise.resolve( NOTES_1 );
 			}
-			if ( options.path === '/wc/v3/admin/notes/&page=2' ) {
+			if ( options.path === '/wc/v3/admin/notes?page=2' ) {
 				return Promise.resolve( NOTES_2 );
 			}
 		} );
 	} );
 
 	it( 'returns requested data', async () => {
-		getNotes().then( data => expect( data ).toEqual( NOTES_1 ) );
+		expect.assertions( 1 );
+		await getNotes( {} );
+		expect( dispatch().setNotes ).toHaveBeenCalledWith( NOTES_1, undefined );
 	} );
 
 	it( 'returns requested data for a specific query', async () => {
-		getNotes( { page: 2 } ).then( data => expect( data ).toEqual( NOTES_2 ) );
+		expect.assertions( 1 );
+		await getNotes( {}, { page: 2 } );
+		expect( dispatch().setNotes ).toHaveBeenCalledWith( NOTES_2, { page: 2 } );
 	} );
 } );

--- a/client/store/orders/test/resolvers.js
+++ b/client/store/orders/test/resolvers.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,11 @@ import resolvers from '../resolvers';
 
 const { getOrders } = resolvers;
 
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn().mockReturnValue( {
+		setOrders: jest.fn(),
+	} ),
+} ) );
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getOrders', () => {
@@ -26,17 +32,21 @@ describe( 'getOrders', () => {
 			if ( options.path === '/wc/v3/orders' ) {
 				return Promise.resolve( ORDERS_1 );
 			}
-			if ( options.path === '/wc/v3/orders&orderby=id' ) {
+			if ( options.path === '/wc/v3/orders?orderby=id' ) {
 				return Promise.resolve( ORDERS_2 );
 			}
 		} );
 	} );
 
 	it( 'returns requested report data', async () => {
-		getOrders().then( data => expect( data ).toEqual( ORDERS_1 ) );
+		expect.assertions( 1 );
+		await getOrders( {} );
+		expect( dispatch().setOrders ).toHaveBeenCalledWith( ORDERS_1, undefined );
 	} );
 
 	it( 'returns requested report data for a specific query', async () => {
-		getOrders( { orderby: 'id' } ).then( data => expect( data ).toEqual( ORDERS_2 ) );
+		expect.assertions( 1 );
+		await getOrders( {}, { orderby: 'id' } );
+		expect( dispatch().setOrders ).toHaveBeenCalledWith( ORDERS_2, { orderby: 'id' } );
 	} );
 } );

--- a/client/store/products/test/resolvers.js
+++ b/client/store/products/test/resolvers.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,11 @@ import resolvers from '../resolvers';
 
 const { getProducts } = resolvers;
 
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn().mockReturnValue( {
+		setProducts: jest.fn(),
+	} ),
+} ) );
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getProducts', () => {
@@ -40,20 +46,24 @@ describe( 'getProducts', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v3/products' ) {
+			if ( options.path === '/wc/v3/reports/products' ) {
 				return Promise.resolve( PRODUCTS_1 );
 			}
-			if ( options.path === '/wc/v3/products?orderby=date' ) {
+			if ( options.path === '/wc/v3/reports/products?orderby=date' ) {
 				return Promise.resolve( PRODUCTS_2 );
 			}
 		} );
 	} );
 
 	it( 'returns requested products', async () => {
-		getProducts().then( data => expect( data ).toEqual( PRODUCTS_1 ) );
+		expect.assertions( 1 );
+		await getProducts( {} );
+		expect( dispatch().setProducts ).toHaveBeenCalledWith( PRODUCTS_1, undefined );
 	} );
 
 	it( 'returns requested products for a specific query', async () => {
-		getProducts( { orderby: 'date' } ).then( data => expect( data ).toEqual( PRODUCTS_2 ) );
+		expect.assertions( 1 );
+		await getProducts( {}, { orderby: 'date' } );
+		expect( dispatch().setProducts ).toHaveBeenCalledWith( PRODUCTS_2, { orderby: 'date' } );
 	} );
 } );


### PR DESCRIPTION
Fixes #654.

@psealock noticed resolvers tests were giving false positives, this PR should fix that.

### Detailed test instructions:

 - Run `npm test` and verify tests pass.
 - Modify resolvers tests to make them fail and verify there are no false positives.

### Example modifications to make tests fail
Modify [this line](https://github.com/woocommerce/wc-admin/pull/666/files#diff-7568b97f47327e3efc4f74e97aee1c3cR50) in ` client/store/notes/test/resolvers.js` from:
```ES6
expect( dispatch().setNotes ).toHaveBeenCalledWith( NOTES_2, { page: 2 } );
```
to:
```ES6
expect( dispatch().setNotes ).toHaveBeenCalledWith( NOTES_1, { page: 2 } );
```
----
Modify [this line](https://github.com/woocommerce/wc-admin/pull/666/files#diff-323232275f2eca0c97da4c2adb46d760R49) in `client/store/products/test/resolvers.js` from:
```ES6
if ( options.path === '/wc/v3/reports/products' ) {
```
to:
```ES6
if ( options.path === '/wc/v3/products' ) {
```
Tests should fail in both cases (they weren't failing before).
