### PR TITLE
Don't include hidden columns when downloading a table as CSV

### DIFF
--- a/client/components/table/__mocks__/table-mock-csv.js
+++ b/client/components/table/__mocks__/table-mock-csv.js
@@ -1,5 +1,5 @@
 /** @format */
 
-export default `Date,Orders,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
-2018-10-01 00:00:00,1,411,0,0,0,0,411
-2018-10-02 00:00:00,0,0,0,0,0,0,0`;
+export default `Date,Orders,Gross Revenue,Refunds,Taxes,Shipping,Net Revenue
+2018-10-01 00:00:00,1,411,0,0,0,411
+2018-10-02 00:00:00,0,0,0,0,0,0`;

--- a/client/components/table/__mocks__/table-mock-data.js
+++ b/client/components/table/__mocks__/table-mock-data.js
@@ -19,8 +19,8 @@ export default [
 			value: 0,
 		},
 		{
-			display: '€0.00',
-			value: 0,
+			display: '€10.00',
+			value: 10,
 		},
 		{
 			display: '€0.00',

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -83,12 +83,15 @@ class TableCard extends Component {
 
 	onClickDownload() {
 		const { headers, query, onClickDownload, rows, title } = this.props;
+		const { showCols } = this.state;
+		const visibleHeaders = headers.filter( ( header, i ) => showCols[ i ] );
+		const visibleRows = rows.map( row => row.filter( ( cell, i ) => showCols[ i ] ) );
 
 		// @TODO The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).
 		downloadCSVFile(
 			generateCSVFileName( title, query ),
-			generateCSVDataFromTable( headers, rows )
+			generateCSVDataFromTable( visibleHeaders, visibleRows )
 		);
 
 		if ( onClickDownload ) {

--- a/client/components/table/test/index.js
+++ b/client/components/table/test/index.js
@@ -40,6 +40,9 @@ describe( 'TableCard', () => {
 				downloadable
 			/>
 		);
+		tableCard.setState( {
+			showCols: [ true, true, true, true, false, true, true, true ],
+		} );
 
 		const downloadButton = tableCard.findWhere(
 			node => node.props().className === 'woocommerce-table__download-button'


### PR DESCRIPTION
Fixes #621.

Downloading tables while a column was hidden, was still including that column in the generated CSV file. This PR fixes that.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/47423657-e8228a00-d785-11e8-82cc-3e19ca46a849.png)


### Detailed test instructions:

- Go to a page with a table (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/products`).
- Hide some columns with the top right button.
- Download the table and verify the hidden columns are not included in the CSV.
