### PR TITLE
Persist date params in Products table link

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -11,7 +11,7 @@ import { map, orderBy } from 'lodash';
  */
 import { Card, Link, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { onQueryChange } from 'lib/nav-utils';
+import { getNewPath, getTimeRelatedQuery, onQueryChange } from 'lib/nav-utils';
 import ReportError from 'analytics/components/report-error';
 
 export default class ProductsReportTable extends Component {
@@ -70,6 +70,8 @@ export default class ProductsReportTable extends Component {
 
 	getRowsContent( data = [] ) {
 		const { stockStatuses } = wcSettings;
+		const { query } = this.props;
+		const timeRelatedQuery = getTimeRelatedQuery( query );
 
 		return map( data, row => {
 			const {
@@ -84,6 +86,10 @@ export default class ProductsReportTable extends Component {
 				stock_status = 'outofstock', // @TODO
 				stock_quantity = '0', // @TODO
 			} = row;
+			const ordersLink = getNewPath( timeRelatedQuery, 'orders', {
+				filter: 'advanced',
+				product_includes: product_id,
+			} );
 
 			return [
 				{
@@ -105,7 +111,7 @@ export default class ProductsReportTable extends Component {
 				},
 				{
 					display: (
-						<Link href={ 'orders?filter=advanced&product_includes=' + product_id } type="wc-admin">
+						<Link href={ ordersLink } type="wc-admin">
 							{ orders_count }
 						</Link>
 					),

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, Dropdown, IconButton } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { find, omit, partial, pick, last, get, includes } from 'lodash';
+import { find, omit, partial, last, get, includes } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import AnimationSlider from 'components/animation-slider';
 import DropdownButton from 'components/dropdown-button';
 import Search from 'components/search';
-import { updateQueryString } from 'lib/nav-utils';
+import { getTimeRelatedQuery, updateQueryString } from 'lib/nav-utils';
 import './style.scss';
 
 export const DEFAULT_FILTER = 'all';
@@ -103,12 +103,12 @@ class FilterPicker extends Component {
 	update( value, additionalQueries = {} ) {
 		const { path, query } = this.props;
 		// Keep only time related queries when updating to a new filter
-		const timeRelatedQueries = pick( query, [ 'period', 'compare', 'before', 'after' ] );
+		const timeRelatedQuery = getTimeRelatedQuery( query );
 		const update = {
 			filter: 'all' === value ? undefined : value,
 			...additionalQueries,
 		};
-		updateQueryString( update, path, timeRelatedQueries );
+		updateQueryString( update, path, timeRelatedQuery );
 	}
 
 	onTagChange( filter, onClose, tags ) {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -4,7 +4,7 @@
  */
 import { Component, createElement } from '@wordpress/element';
 import { parse } from 'qs';
-import { find, omitBy, isUndefined, last } from 'lodash';
+import { find, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import Analytics from 'analytics';
 import AnalyticsReport from 'analytics/report';
 import Dashboard from 'dashboard';
 import DevDocs from 'devdocs';
-import { stringifyQuery } from 'lib/nav-utils';
+import { getTimeRelatedQuery, stringifyQuery } from 'lib/nav-utils';
 
 const getPages = () => {
 	const pages = [
@@ -66,9 +66,8 @@ class Controller extends Component {
 }
 
 // Update links in wp-admin menu to persist time related queries
-window.wpNavMenuUrlUpdate = function( page, { period, compare, after, before } ) {
-	const timeRelatedQuery = omitBy( { period, compare, after, before }, isUndefined );
-	const search = stringifyQuery( timeRelatedQuery );
+window.wpNavMenuUrlUpdate = function( page, query ) {
+	const search = stringifyQuery( getTimeRelatedQuery( query ) );
 
 	Array.from(
 		document.querySelectorAll( `#${ page.wpOpenMenu } a, #${ page.wpClosedMenu } a` )

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -4,7 +4,7 @@
  */
 import history from 'lib/history';
 import { parse, stringify } from 'qs';
-import { uniq, isEmpty } from 'lodash';
+import { isEmpty, pick, uniq } from 'lodash';
 
 /**
  * Returns a string with the site's wp-admin URL appended. JS version of `admin_url`.
@@ -28,6 +28,15 @@ export const getPath = () => history.location.pathname;
  * @return {String} Query string.
  */
 export const stringifyQuery = query => ( isEmpty( query ) ? '' : '?' + stringify( query ) );
+
+/**
+ * Gets time related parameters from a query.
+ *
+ * @param {Object} query Query containing the parameters.
+ * @return {Object} Object containing the time related queries.
+ */
+export const getTimeRelatedQuery = query =>
+	pick( query, [ 'period', 'compare', 'before', 'after' ] );
 
 /**
  * Get an array of IDs from a comma-separated query parameter.

--- a/client/lib/nav-utils/test/index.js
+++ b/client/lib/nav-utils/test/index.js
@@ -1,0 +1,36 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getTimeRelatedQuery } from '../index';
+
+describe( 'getTimeRelatedQuery', () => {
+	it( "should return an empty object it the query doesn't contain any time related parameters", () => {
+		const query = {
+			filter: 'advanced',
+			product_includes: 127,
+		};
+		const timeRelatedQuery = {};
+
+		expect( getTimeRelatedQuery( query ) ).toEqual( timeRelatedQuery );
+	} );
+
+	it( 'should return time related parameters', () => {
+		const query = {
+			filter: 'advanced',
+			product_includes: 127,
+			period: 'year',
+			compare: 'previous_year',
+			after: '2018-02-01',
+			before: '2018-01-01',
+		};
+		const timeRelatedQuery = {
+			period: 'year',
+			compare: 'previous_year',
+			after: '2018-02-01',
+			before: '2018-01-01',
+		};
+
+		expect( getTimeRelatedQuery( query ) ).toEqual( timeRelatedQuery );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/pull/619#discussion_r227089391.

The link to the _Orders_ report in the _Products_ table didn't have the time queries.

### Detailed test instructions:

- Go to the _Products_ report `/wp-admin/admin.php?page=wc-admin#/analytics/products`.
- Change the date range.
- Click on a link in the table's _Orders_ column.
- Verify the date range persists.
