### PR TITLE
Bug: ensure duplicate parts of date removed from x2 ticks

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -402,18 +402,14 @@ export const drawAxis = ( node, params ) => {
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => {
-					let monthDate = d instanceof Date ? d : new Date( d );
+					const monthDate = d instanceof Date ? d : new Date( d );
 					let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
 					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
-					monthDate =
-						i !== 0
-							? compareStrings(
-									params.x2Format( prevMonth ),
-									params.x2Format( monthDate ),
-									params
-								).join( ' ' )
-							: params.x2Format( monthDate );
-					return i === 0 || monthDate !== params.x2Format( prevMonth ) ? monthDate : '';
+					return i === 0
+						? params.x2Format( monthDate )
+						: compareStrings( params.x2Format( prevMonth ), params.x2Format( monthDate ) ).join(
+								' '
+							);
 				} )
 		)
 		.call( g => g.select( '.domain' ).remove() );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/pull/639#pullrequestreview-168007784

Cleans up the implementation of `compareStrings() to remove legacy code not needed anymore.

### Screenshots
![screenshot 2018-10-25 13 53 44](https://user-images.githubusercontent.com/1160732/47498450-9e0cd780-d85d-11e8-9fdc-bbca16323eea.png)


### Detailed test instructions:

 - Select a date range that spans multiple months and years and ensure that parts of the x2 axis aren't duplicated
