### PR TITLE
refactoring x-axis ticks

### DIFF
--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -442,13 +442,8 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 			}
 			break;
 		case 'week':
-			if ( ticks < weekTicksThreshold ) {
-				xFormat = '%d';
-				xFormat = '%b %Y';
-			} else {
-				xFormat = '%d %b';
-				x2Format = '%Y';
-			}
+			xFormat = '%d';
+			x2Format = '%b %Y';
 			tooltipFormat = __( 'Week of %B %d %Y', 'wc-admin' );
 			break;
 		case 'quarter':


### PR DESCRIPTION
@greenafrican this is the PR I mentioned in slack, for reference: 

This gets the x-axis most of the way to where I want it, per what I was describing at p6riRB-3C9-p2 

I added an if / else to week intervals, similar to what you already had for day intervals. However, I ran into two issues when the interval was set to week and it's using the `else` logic:

1.) I couldn't figure out how to remove duplicate instances of the month from x1

<img width="1520" alt="screen shot 2018-10-25 at 4 56 01 am" src="https://user-images.githubusercontent.com/4500952/47498975-a17b7100-d813-11e8-93be-dc494d1f672d.png">

2.) If we're able to remove the duplicate months from x1, I'd just like to ensure that over longer time periods, we're able to place a tick on the first week of the month. The way it's set up now, some times the first label of a month won't happen until the second week, such as this example with feb:

<img width="1465" alt="screen shot 2018-10-25 at 5 13 41 am" src="https://user-images.githubusercontent.com/4500952/47499816-d4beff80-d815-11e8-837b-2466bbb6c61b.png">
