### PR TITLE
Create QUERY_DEFAULTS object with default values for queries

### DIFF
--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -16,6 +16,7 @@ import { EmptyContent, ReportFilters } from '@woocommerce/components';
 import { filters, advancedFilterConfig } from './config';
 import { getAdminLink } from 'lib/nav-utils';
 import { appendTimestamp, getCurrentDates } from 'lib/date';
+import { QUERY_DEFAULTS } from 'store/constants';
 import { getReportChartData } from 'store/reports/utils';
 import OrdersReportChart from './chart';
 import OrdersReportTable from './table';
@@ -105,7 +106,7 @@ export default compose(
 			orderby: query.orderby || 'date',
 			order: query.order || 'asc',
 			page: query.page || 1,
-			per_page: query.per_page || 25,
+			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 			status: [ 'processing', 'on-hold', 'completed' ],

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -21,6 +21,7 @@ import {
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getIntervalForQuery, getDateFormatsForInterval } from 'lib/date';
 import { getAdminLink, onQueryChange } from 'lib/nav-utils';
+import { QUERY_DEFAULTS } from 'store/constants';
 import './style.scss';
 
 export default class OrdersReportTable extends Component {
@@ -233,7 +234,7 @@ export default class OrdersReportTable extends Component {
 	renderTable( tableQuery ) {
 		const { orders, totalRows } = this.props;
 
-		const rowsPerPage = parseInt( tableQuery.per_page ) || 25;
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
 		const rows = this.getRowsContent(
 			orderBy( this.formatTableData( orders ), tableQuery.orderby, tableQuery.order )
 		);

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -13,6 +13,7 @@ import { get } from 'lodash';
 import { filters } from './config';
 import { ReportFilters } from '@woocommerce/components';
 import { appendTimestamp, getCurrentDates } from 'lib/date';
+import { QUERY_DEFAULTS } from 'store/constants';
 import { getReportChartData } from 'store/reports/utils';
 import ProductsReportChart from './chart';
 import ProductsReportTable from './table';
@@ -59,7 +60,7 @@ export default compose(
 			orderby: query.orderby || 'items_sold',
 			order: query.order || 'desc',
 			page: query.page || 1,
-			per_page: query.per_page || 25,
+			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 			extended_product_info: true,

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -13,6 +13,7 @@ import { Card, Link, TableCard, TablePlaceholder } from '@woocommerce/components
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getNewPath, getTimeRelatedQuery, onQueryChange } from 'lib/nav-utils';
 import ReportError from 'analytics/components/report-error';
+import { QUERY_DEFAULTS } from 'store/constants';
 
 export default class ProductsReportTable extends Component {
 	getHeadersContent() {
@@ -163,7 +164,7 @@ export default class ProductsReportTable extends Component {
 	renderTable( tableQuery ) {
 		const { products, totalRows } = this.props;
 
-		const rowsPerPage = parseInt( tableQuery.per_page ) || 25;
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
 		const orderedProducts = orderBy( products, tableQuery.orderby, tableQuery.order );
 		const rows = this.getRowsContent( orderedProducts );
 

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -13,6 +13,7 @@ import { get } from 'lodash';
  */
 import { ReportFilters } from '@woocommerce/components';
 import { appendTimestamp, getCurrentDates } from 'lib/date';
+import { QUERY_DEFAULTS } from 'store/constants';
 import RevenueReportChart from './chart';
 import RevenueReportTable from './table';
 
@@ -58,7 +59,7 @@ export default compose(
 			orderby: query.orderby || 'date',
 			order: query.order || 'asc',
 			page: query.page || 1,
-			per_page: query.per_page || 25,
+			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		};

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -15,6 +15,7 @@ import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
 import { onQueryChange } from 'lib/nav-utils';
 import ReportError from 'analytics/components/report-error';
+import { QUERY_DEFAULTS } from 'store/constants';
 
 export default class RevenueReportTable extends Component {
 	getHeadersContent() {
@@ -163,7 +164,8 @@ export default class RevenueReportTable extends Component {
 		const { tableData, totalRows } = this.props;
 
 		const rowsPerPage =
-			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) || 25;
+			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) ||
+			QUERY_DEFAULTS.pageSize;
 		const rows = this.getRowsContent( tableData.data.intervals );
 
 		const headers = this.getHeadersContent();

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -16,6 +16,7 @@ import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
 import { EmptyContent, Section } from '@woocommerce/components';
 import sanitizeHTML from 'lib/sanitize-html';
+import { QUERY_DEFAULTS } from 'store/constants';
 
 class InboxPanel extends Component {
 	render() {
@@ -91,7 +92,7 @@ export default compose(
 		const { getNotes, isGetNotesError, isGetNotesRequesting } = select( 'wc-admin' );
 		const inboxQuery = {
 			page: 1,
-			per_page: 25,
+			per_page: QUERY_DEFAULTS.pageSize,
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/client/lib/date/index.js
+++ b/client/lib/date/index.js
@@ -7,9 +7,12 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { getSettings, format as formatDate } from '@wordpress/date';
 
+/**
+ * Internal dependencies
+ */
+import { QUERY_DEFAULTS } from 'store/constants';
+
 export const isoDateFormat = 'YYYY-MM-DD';
-const DEFAULT_PERIOD = 'month';
-const DEFAULT_COMPARE = 'previous_year';
 
 /**
  * DateValue Object
@@ -260,8 +263,8 @@ function getDateValue( period, compare, after, before ) {
  */
 export const getDateParamsFromQuery = ( { period, compare, after, before } ) => {
 	return {
-		period: period || DEFAULT_PERIOD,
-		compare: compare || DEFAULT_COMPARE,
+		period: period || QUERY_DEFAULTS.period,
+		compare: compare || QUERY_DEFAULTS.compare,
 		after: after ? moment( after ) : null,
 		before: before ? moment( before ) : null,
 	};

--- a/client/store/constants.js
+++ b/client/store/constants.js
@@ -7,3 +7,9 @@ export const ERROR = 'ERROR';
 
 // WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter
 export const MAX_PER_PAGE = 100;
+
+export const QUERY_DEFAULTS = {
+	pageSize: 25,
+	period: 'month',
+	compare: 'previous_year',
+};


### PR DESCRIPTION
Fixes #634.

Stores the default page size and default period and compare values in a QUERY_DEFAULTS global.

### Detailed test instructions:
- Go to _Analytics_ pages (_Revenue_, _Orders_ and _Products_) and verify:
  - the default date range is still 'Month to Date' and the comparison period is previous year
  - the default table size is still 25
 - Verify there are no regressions.
