### PR TITLE
Added zero-padding to hours coming from the db.

### DIFF
--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -45,7 +45,7 @@ class WC_Admin_Reports_Interval {
 		}
 
 		$mysql_date_format_mapping = array(
-			'hour'    => "DATE_FORMAT(date_created, '%Y-%m-%d %k')",
+			'hour'    => "DATE_FORMAT(date_created, '%Y-%m-%d %H')",
 			'day'     => "DATE_FORMAT(date_created, '%Y-%m-%d')",
 			'week'    => $week_format,
 			'month'   => "DATE_FORMAT(date_created, '%Y-%m')",

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -44,6 +44,7 @@ class WC_Admin_Reports_Interval {
 
 		}
 
+		// Whenever this is changed, double check method time_interval_id to make sure they are in sync.
 		$mysql_date_format_mapping = array(
 			'hour'    => "DATE_FORMAT(date_created, '%Y-%m-%d %H')",
 			'day'     => "DATE_FORMAT(date_created, '%Y-%m-%d')",
@@ -131,6 +132,7 @@ class WC_Admin_Reports_Interval {
 	 * @return string
 	 */
 	public static function time_interval_id( $time_interval, $datetime ) {
+		// Whenever this is changed, double check method db_datetime_format to make sure they are in sync.
 		$php_time_format_for = array(
 			'hour'    => 'Y-m-d H',
 			'day'     => 'Y-m-d',


### PR DESCRIPTION
Fixes #482 

MySQL date/time format needs to be in sync with PHP date/time format. 
Before the fix, the MySQL db returned non-zero-padded hours while PHP used zero-padded hours, which caused problems when aligning intervals for the result.

### Screenshots
N/A

### Detailed test instructions:

 - Create an order before 10:00 UTC on day X, e.g. 9:00
 - Let it trickle to stats table
 - Query revenue/stats endpoint for the day X, interval=hour
 - Before the change, it's possible that you see an entry for both `"interval": "X 09",` and `"interval": "X 9",`, where the latter has invalid `date_start` and `date_end`.
 - After the change, you should see only one entry for each hour and data correctly filled for the interval.