### PR TITLE
remove rounded corners from activity bar icon buttons

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -62,6 +62,7 @@
 	.components-icon-button {
 		display: initial;
 		text-indent: 0px;
+		border-radius: 0px;
 	}
 
 	.woocommerce-layout__activity-panel-tab {


### PR DESCRIPTION
Small update to remove the corner radius from the tabs in the activity panel 

**Before:**

<img width="569" alt="screen shot 2018-10-25 at 8 52 19 am" src="https://user-images.githubusercontent.com/4500952/47519807-4497af00-d843-11e8-97c0-3d8118ca177e.png">

**Update:**

<img width="614" alt="screen shot 2018-10-25 at 8 57 58 am" src="https://user-images.githubusercontent.com/4500952/47519825-537e6180-d843-11e8-96ed-faf9b6fd6cd8.png">

note the corners of the highlight under "inbox" are no longer rounded.