### PR TITLE
Update tabular data header design

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -30,7 +30,8 @@
 	}
 
 	.has-menu.has-action & {
-		grid-template-columns: auto 1fr 48px;
+		grid-gap: $gap-small;
+		grid-template-columns: auto 1fr 24px;
 	}
 }
 
@@ -53,7 +54,7 @@
 }
 
 .woocommerce-card__title {
-	margin: 0 $gap 0 0;
+	margin: 0;
 	// EllipsisMenu is 24px, so to match we add 6px padding around the
 	// heading text, which we know is 18px from line-height.
 	padding: 3px 0;

--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -1,7 +1,14 @@
 /** @format */
 
-.woocommerce-ellipsis-menu__toggle .dashicon {
-	transform: rotate(90deg);
+.woocommerce-ellipsis-menu__toggle {
+	height: 24px;
+	justify-content: center;
+	vertical-align: middle;
+	width: 24px;
+
+	.dashicon {
+		transform: rotate(90deg);
+	}
 }
 
 .woocommerce-ellipsis-menu__popover {

--- a/client/components/filters/compare/button.js
+++ b/client/components/filters/compare/button.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Button, Tooltip } from '@wordpress/components';
 
@@ -11,22 +12,30 @@ import { Button, Tooltip } from '@wordpress/components';
  *
  * @return { object } -
  */
-const CompareButton = ( { count, children, helpText, onClick } ) =>
+const CompareButton = ( { className, count, children, helpText, onClick } ) =>
 	count < 2 ? (
 		<Tooltip text={ helpText }>
-			<span>
+			<span className={ className }>
 				<Button className="woocommerce-compare-button" isDefault disabled={ true }>
 					{ children }
 				</Button>
 			</span>
 		</Tooltip>
 	) : (
-		<Button className="woocommerce-compare-button" isDefault onClick={ onClick }>
+		<Button
+			className={ classnames( 'woocommerce-compare-button', className ) }
+			isDefault
+			onClick={ onClick }
+		>
 			{ children }
 		</Button>
 	);
 
 CompareButton.propTypes = {
+	/**
+	 * Additional CSS classes.
+	 */
+	className: PropTypes.string,
 	/**
 	 * The count of items selected.
 	 */

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -223,6 +223,7 @@ class TableCard extends Component {
 					compareBy && (
 						<CompareButton
 							key="compare"
+							className="woocommerce-table__compare"
 							count={ selectedRows.length }
 							helpText={
 								labels.helpText || __( 'Select at least two items to compare', 'wc-admin' )
@@ -248,7 +249,9 @@ class TableCard extends Component {
 							isLink
 						>
 							<DowloadIcon />
-							{ labels.downloadButton || __( 'Download', 'wc-admin' ) }
+							<span className="woocommerce-table__download-button__label">
+								{ labels.downloadButton || __( 'Download', 'wc-admin' ) }
+							</span>
 						</IconButton>
 					),
 				] }

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -6,7 +6,11 @@
 		position: relative;
 	}
 
-	.woocommerce-card__action,
+	.woocommerce-card__action {
+		justify-self: flex-end;
+		margin: -($gap - 3) 0;
+	}
+
 	.woocommerce-card__menu {
 		justify-self: flex-end;
 	}
@@ -19,9 +23,36 @@
 			width: 100%;
 			grid-template-columns: auto 1fr auto;
 		}
+
+		@include breakpoint( '<1100px' ) {
+			.woocommerce-card__action {
+				grid-area: 1 / 1 / 3 / 4;
+				grid-gap: $gap-small;
+				grid-template-columns: auto 1fr 24px;
+				margin: 0;
+
+				.woocommerce-table__compare {
+					display: flex;
+					grid-area: 2 / 1 / 3 / 2;
+				}
+
+				.woocommerce-search {
+					grid-area: 2 / 2 / 3 / 4;
+					margin-right: 0;
+				}
+
+				.woocommerce-table__download-button {
+					grid-area: 1 / 2 / 2 / 3;
+					justify-self: end;
+					margin: -6px 0;
+				}
+			}
+		}
+
 		.woocommerce-search {
 			margin: 0 $gap;
 		}
+
 		.woocommerce-compare-button {
 			padding: 3px $gap-small;
 			height: auto;
@@ -48,10 +79,21 @@
 		padding: 6px $gap-small;
 		color: #000;
 		text-decoration: none;
+
 		svg {
 			margin-right: $gap-smaller;
 			height: 24px;
 			width: 24px;
+		}
+
+		@include breakpoint( '<782px' ) {
+			svg {
+				margin-right: 0;
+			}
+
+			.woocommerce-table__download-button__label {
+				display: none;
+			}
 		}
 	}
 
@@ -151,7 +193,7 @@
 		width: 33px;
 		max-width: 33px;
 		padding-right: 0;
-		padding-left: 17px;
+		padding-left: $gap;
 		& + th {
 			border-left: 0;
 		}


### PR DESCRIPTION
Fixes #630.

Updates table header to match the designs.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/47562602-55b5ee00-d91f-11e8-8539-51ed6561c03c.png)
![image](https://user-images.githubusercontent.com/3616980/47562615-623a4680-d91f-11e8-8a55-49b36dad781b.png)


After:
![image](https://user-images.githubusercontent.com/3616980/47562572-38811f80-d91f-11e8-92e0-79f10447c2b2.png)
![image](https://user-images.githubusercontent.com/3616980/47562590-459e0e80-d91f-11e8-8b7b-eb2b019134df.png)


### Detailed test instructions:

 - Go to any page with a table (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/products`).
 - Resize the window and verify the design matches the spec and the requirements in #630.
    * _At viewports of less than 1100 px, the compare button and search field should wrap to a new line._
    * _Reduce the download icon + text, to just the download icon at viewports <783px._
    * _The height of the header should match the other card headers (51px when you include the bottom border)._
    * _The tabular data settings button should be contained within a 24px hit area, and there should be 12px gutter between it, and the download button to the left._
