### PR TITLE
Reverse the order highlighted points are rendered in charts

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -653,7 +653,7 @@ export const drawLines = ( node, data, params ) => {
 
 	focusGrid
 		.selectAll( 'circle' )
-		.data( d => d.values )
+		.data( d => d.values.reverse() )
 		.enter()
 		.append( 'circle' )
 		.attr( 'r', dotRadius + 2 )


### PR DESCRIPTION
Tiny PR that fixes #700.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/47564420-43d74980-d925-11e8-8407-7d3ff0bc956a.png)

After:
![image](https://user-images.githubusercontent.com/3616980/47564438-50f43880-d925-11e8-9a59-13d87acf7018.png)

### Detailed test instructions:

1. Go to any page with a chart (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/products`).
2. Hover a point in the chart where both lines overlap and make sure the highlighted point is the one from the line that is rendered on top.
