### PR TITLE
Simplified compound expression to fix code for older PHP versions.

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -389,7 +389,8 @@ class WC_Admin_Reports_Data_Store {
 			$prev_start->setTimestamp( $prev_start_timestamp );
 			if ( $datetime_start ) {
 				$start_datetime                  = new DateTime( $datetime_start );
-				$intervals[ $key ]['date_start'] = ( $prev_start < $start_datetime ? $start_datetime : $prev_start )->format( 'Y-m-d H:i:s' );
+				$date_start                      = $prev_start < $start_datetime ? $start_datetime : $prev_start;
+				$intervals[ $key ]['date_start'] = $date_start->format( 'Y-m-d H:i:s' );
 			} else {
 				$intervals[ $key ]['date_start'] = $prev_start->format( 'Y-m-d H:i:s' );
 			}
@@ -399,7 +400,8 @@ class WC_Admin_Reports_Data_Store {
 			$next_end->setTimestamp( $next_end_timestamp );
 			if ( $datetime_end ) {
 				$end_datetime                  = new DateTime( $datetime_end );
-				$intervals[ $key ]['date_end'] = ( $next_end > $end_datetime ? $end_datetime : $next_end )->format( 'Y-m-d H:i:s' );
+				$date_end                      = $next_end > $end_datetime ? $end_datetime : $next_end;
+				$intervals[ $key ]['date_end'] = $date_end->format( 'Y-m-d H:i:s' );
 			} else {
 				$intervals[ $key ]['date_end'] = $next_end->format( 'Y-m-d H:i:s' );
 			}


### PR DESCRIPTION
Fixes #691 

Older PHP versions don't support compound expression when accessing object methods, throwing T_OBJECT_OPERATOR. This change separates method call step from object selection step to support older PHP versions.

Note: the PHP CS problem will be solved in a separate PR.

### Screenshots
N/A
### Detailed test instructions:

 - Create a test site running PHP <= 5.6 
 - Install & activate wc-admin
 - Before the change, activation would throw the error
 - After the fix is applied, plugin should be activated correctly.
