### PR TITLE
Fixes hover background on first column in tables

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -95,7 +95,8 @@
 	tr:hover,
 	tr:focus-within {
 		background-color: $core-grey-light-200;
-		td {
+		td,
+		th {
 			background: transparent;
 		}
 	}


### PR DESCRIPTION
#631 

When hovering also change background of first column which is a th no a td

### Screenshots

![screen shot 2018-10-26 at 10 14 31 am](https://user-images.githubusercontent.com/6817400/47572012-f39dbe80-d907-11e8-98d5-efa35f86df15.png)

### Detailed test instructions:

- Goto revenue report
- Have date column be sorted
- Hover over first row
- Does hover background overtake first column
