### PR TITLE
Add isLoading prop to TableCard

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -12,14 +12,7 @@ import { get, map, orderBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	Card,
-	Link,
-	OrderStatus,
-	TableCard,
-	TablePlaceholder,
-	ViewMoreList,
-} from '@woocommerce/components';
+import { Link, OrderStatus, TableCard, ViewMoreList } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import {
 	appendTimestamp,
@@ -223,55 +216,8 @@ class OrdersReportTable extends Component {
 		);
 	}
 
-	renderPlaceholderTable( tableQuery ) {
-		const headers = this.getHeadersContent();
-
-		return (
-			<Card
-				title={ __( 'Orders', 'wc-admin' ) }
-				className="woocommerce-analytics__table-placeholder"
-			>
-				<TablePlaceholder
-					caption={ __( 'Orders', 'wc-admin' ) }
-					headers={ headers }
-					query={ tableQuery }
-				/>
-			</Card>
-		);
-	}
-
-	renderTable( tableQuery ) {
-		const { orders, primaryData } = this.props;
-
-		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
-		const rows = this.getRowsContent(
-			orderBy( this.formatTableData( orders ), tableQuery.orderby, tableQuery.order )
-		);
-		const totalRows = get(
-			primaryData,
-			[ 'data', 'totals', 'orders_count' ],
-			Object.keys( orders ).length
-		);
-
-		const headers = this.getHeadersContent();
-
-		return (
-			<TableCard
-				title={ __( 'Orders', 'wc-admin' ) }
-				rows={ rows }
-				totalRows={ totalRows }
-				rowsPerPage={ rowsPerPage }
-				headers={ headers }
-				onQueryChange={ onQueryChange }
-				query={ tableQuery }
-				summary={ null }
-				downloadable
-			/>
-		);
-	}
-
 	render() {
-		const { isTableDataError, isTableDataRequesting, primaryData, query } = this.props;
+		const { isTableDataError, isTableDataRequesting, primaryData, query, orders } = this.props;
 		const isError = isTableDataError || primaryData.isError;
 
 		if ( isError ) {
@@ -286,11 +232,27 @@ class OrdersReportTable extends Component {
 			order: query.order || 'asc',
 		};
 
-		if ( isRequesting ) {
-			return this.renderPlaceholderTable( tableQuery );
-		}
+		const headers = this.getHeadersContent();
+		const rows = this.getRowsContent(
+			orderBy( this.formatTableData( orders ), tableQuery.orderby, tableQuery.order )
+		);
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
+		const totalRows = get( primaryData, [ 'data', 'totals', 'orders_count' ], orders.length );
 
-		return this.renderTable( tableQuery );
+		return (
+			<TableCard
+				title={ __( 'Orders', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ totalRows }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				isLoading={ isRequesting }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ null }
+				downloadable
+			/>
+		);
 	}
 }
 

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -11,7 +11,7 @@ import { get, map, orderBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Card, Link, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Link, TableCard } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
 import { appendTimestamp, getCurrentDates } from 'lib/date';
 import { getNewPath, getTimeRelatedQuery, onQueryChange } from 'lib/nav-utils';
@@ -148,36 +148,22 @@ class ProductsReportTable extends Component {
 		} );
 	}
 
-	renderPlaceholderTable( tableQuery ) {
+	render() {
+		const { isProductsError, isProductsRequesting, primaryData, products, tableQuery } = this.props;
+		const isError = isProductsError || primaryData.isError;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
+		const isRequesting = isProductsRequesting || primaryData.isRequesting;
+
 		const headers = this.getHeadersContent();
-
-		return (
-			<Card
-				title={ __( 'Products', 'wc-admin' ) }
-				className="woocommerce-analytics__table-placeholder"
-			>
-				<TablePlaceholder
-					caption={ __( 'Products', 'wc-admin' ) }
-					headers={ headers }
-					query={ tableQuery }
-				/>
-			</Card>
-		);
-	}
-
-	renderTable( tableQuery ) {
-		const { products, primaryData } = this.props;
-
-		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
 		const orderedProducts = orderBy( products, tableQuery.orderby, tableQuery.order );
 		const rows = this.getRowsContent( orderedProducts );
-		const totalRows = get(
-			primaryData,
-			[ 'data', 'totals', 'products_count' ],
-			Object.keys( products ).length
-		);
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
+		const totalRows = get( primaryData, [ 'data', 'totals', 'products_count' ], products.length );
 
-		const headers = this.getHeadersContent();
 		const labels = {
 			helpText: __( 'Select at least two products to compare', 'wc-admin' ),
 			placeholder: __( 'Search by product name or SKU', 'wc-admin' ),
@@ -192,6 +178,7 @@ class ProductsReportTable extends Component {
 				headers={ headers }
 				labels={ labels }
 				ids={ orderedProducts.map( p => p.product_id ) }
+				isLoading={ isRequesting }
 				compareBy={ 'product' }
 				onQueryChange={ onQueryChange }
 				query={ tableQuery }
@@ -200,24 +187,8 @@ class ProductsReportTable extends Component {
 			/>
 		);
 	}
-
-	render() {
-		const { isProductsError, isProductsRequesting, primaryData, tableQuery } = this.props;
-		const isError = isProductsError || primaryData.isError;
-
-		if ( isError ) {
-			return <ReportError isError />;
-		}
-
-		const isRequesting = isProductsRequesting || primaryData.isRequesting;
-
-		if ( isRequesting ) {
-			return this.renderPlaceholderTable( tableQuery );
-		}
-
-		return this.renderTable( tableQuery );
-	}
 }
+
 export default compose(
 	withSelect( ( select, props ) => {
 		const { query } = props;

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -12,9 +12,14 @@ import { get, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Card, Link, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Link, TableCard } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
-import { appendTimestamp, getCurrentDates, getDateFormatsForInterval, getIntervalForQuery } from 'lib/date';
+import {
+	appendTimestamp,
+	getCurrentDates,
+	getDateFormatsForInterval,
+	getIntervalForQuery,
+} from 'lib/date';
 import { onQueryChange } from 'lib/nav-utils';
 import ReportError from 'analytics/components/report-error';
 import { QUERY_DEFAULTS } from 'store/constants';
@@ -145,51 +150,8 @@ class RevenueReportTable extends Component {
 		} );
 	}
 
-	renderPlaceholderTable( tableQuery ) {
-		const headers = this.getHeadersContent();
-
-		return (
-			<Card
-				title={ __( 'Revenue', 'wc-admin' ) }
-				className="woocommerce-analytics__table-placeholder"
-			>
-				<TablePlaceholder
-					caption={ __( 'Revenue', 'wc-admin' ) }
-					headers={ headers }
-					query={ tableQuery }
-				/>
-			</Card>
-		);
-	}
-
-	renderTable( tableQuery ) {
-		const { tableData } = this.props;
-
-		const rowsPerPage =
-			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) ||
-			QUERY_DEFAULTS.pageSize;
-		const rows = this.getRowsContent( tableData.data.intervals );
-		const totalRows = get( tableData, [ 'totalResults' ], 0 );
-
-		const headers = this.getHeadersContent();
-
-		return (
-			<TableCard
-				title={ __( 'Revenue', 'wc-admin' ) }
-				rows={ rows }
-				totalRows={ totalRows }
-				rowsPerPage={ rowsPerPage }
-				headers={ headers }
-				onQueryChange={ onQueryChange }
-				query={ tableQuery }
-				summary={ null }
-				downloadable
-			/>
-		);
-	}
-
 	render() {
-		const { isTableDataError, isTableDataRequesting, query } = this.props;
+		const { isTableDataError, isTableDataRequesting, query, tableData } = this.props;
 
 		if ( isTableDataError ) {
 			return <ReportError isError />;
@@ -201,11 +163,27 @@ class RevenueReportTable extends Component {
 			order: query.order || 'asc',
 		};
 
-		if ( isTableDataRequesting ) {
-			return this.renderPlaceholderTable( tableQuery );
-		}
+		const headers = this.getHeadersContent();
+		const rows = this.getRowsContent( get( tableData, [ 'data', 'intervals' ], [] ) );
+		const rowsPerPage =
+			( tableQuery && tableQuery.per_page && parseInt( tableQuery.per_page ) ) ||
+			QUERY_DEFAULTS.pageSize;
+		const totalRows = get( tableData, [ 'totalResults' ], Object.keys( rows ).length );
 
-		return this.renderTable( tableQuery );
+		return (
+			<TableCard
+				title={ __( 'Revenue', 'wc-admin' ) }
+				rows={ rows }
+				totalRows={ totalRows }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				isLoading={ isTableDataRequesting }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ null }
+				downloadable
+			/>
+		);
 	}
 }
 

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -24,6 +24,7 @@ import MenuTitle from 'components/ellipsis-menu/menu-title';
 import Pagination from 'components/pagination';
 import Search from 'components/search';
 import Table from './table';
+import TablePlaceholder from './placeholder';
 import TableSummary from './summary';
 
 /**
@@ -168,9 +169,9 @@ class TableCard extends Component {
 	}
 
 	getAllCheckbox() {
-		const { ids = [] } = this.props;
+		const { ids = [], isLoading } = this.props;
 		const { selectedRows } = this.state;
-		const isAllChecked = ids.length === selectedRows.length;
+		const isAllChecked = ! isLoading && ids.length === selectedRows.length;
 		return {
 			cellClassName: 'is-checkbox-column',
 			label: (
@@ -190,6 +191,7 @@ class TableCard extends Component {
 			compareBy,
 			downloadable,
 			labels = {},
+			isLoading,
 			onClickDownload,
 			onQueryChange,
 			query,
@@ -245,6 +247,7 @@ class TableCard extends Component {
 						<IconButton
 							key="download"
 							className="woocommerce-table__download-button"
+							disabled={ isLoading }
 							onClick={ this.onClickDownload }
 							isLink
 						>
@@ -275,14 +278,24 @@ class TableCard extends Component {
 					</EllipsisMenu>
 				}
 			>
-				<Table
-					rows={ rows }
-					headers={ headers }
-					rowHeader={ rowHeader }
-					caption={ title }
-					query={ query }
-					onSort={ onQueryChange( 'sort' ) }
-				/>
+				{ isLoading ? (
+					<TablePlaceholder
+						numberOfRows={ rowsPerPage }
+						headers={ headers }
+						rowHeader={ rowHeader }
+						caption={ title }
+						query={ query }
+					/>
+				) : (
+					<Table
+						rows={ rows }
+						headers={ headers }
+						rowHeader={ rowHeader }
+						caption={ title }
+						query={ query }
+						onSort={ onQueryChange( 'sort' ) }
+					/>
+				) }
 
 				{ summary && <TableSummary data={ summary } /> }
 
@@ -329,6 +342,11 @@ TableCard.propTypes = {
 	 * A list of IDs, matching to the row list so that ids[ 0 ] contains the object ID for the object displayed in row[ 0 ].
 	 */
 	ids: PropTypes.arrayOf( PropTypes.number ),
+	/**
+	 * Defines if the table contents are loading.
+	 * It will display `TablePlaceholder` component instead of `Table` if that's the case.
+	 */
+	isLoading: PropTypes.bool,
 	/**
 	 * A function which returns a callback function to update the query string for a given `param`.
 	 */
@@ -386,6 +404,7 @@ TableCard.propTypes = {
 
 TableCard.defaultProps = {
 	downloadable: false,
+	isLoading: false,
 	onQueryChange: noop,
 	query: {},
 	rowHeader: 0,

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -285,6 +285,7 @@ class TableCard extends Component {
 						rowHeader={ rowHeader }
 						caption={ title }
 						query={ query }
+						onSort={ onQueryChange( 'sort' ) }
 					/>
 				) : (
 					<Table

--- a/client/components/table/index.js
+++ b/client/components/table/index.js
@@ -169,9 +169,9 @@ class TableCard extends Component {
 	}
 
 	getAllCheckbox() {
-		const { ids = [], isLoading } = this.props;
+		const { ids = [] } = this.props;
 		const { selectedRows } = this.state;
-		const isAllChecked = ! isLoading && ids.length === selectedRows.length;
+		const isAllChecked = ids.length > 0 && ids.length === selectedRows.length;
 		return {
 			cellClassName: 'is-checkbox-column',
 			label: (

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -16,23 +16,12 @@ import Table from './table';
  */
 class TablePlaceholder extends Component {
 	render() {
-		const { caption, headers, numberOfRows, query } = this.props;
-		const filteredHeaders = headers.filter( header => ! header.hiddenByDefault );
+		const { numberOfRows, ...tableProps } = this.props;
 		const rows = range( numberOfRows ).map( () =>
-			filteredHeaders.map( () => ( { display: <span className="is-placeholder" /> } ) )
+			this.props.headers.map( () => ( { display: <span className="is-placeholder" /> } ) )
 		);
 
-		return (
-			<Table
-				ariaHidden={ true }
-				caption={ caption }
-				classNames="is-loading"
-				headers={ filteredHeaders }
-				rowHeader={ false }
-				rows={ rows }
-				query={ query }
-			/>
-		);
+		return <Table ariaHidden={ true } classNames="is-loading" rows={ rows } { ...tableProps } />;
 	}
 }
 

--- a/client/components/table/placeholder.js
+++ b/client/components/table/placeholder.js
@@ -54,7 +54,7 @@ TablePlaceholder.propTypes = {
 			defaultSort: PropTypes.bool,
 			isSortable: PropTypes.bool,
 			key: PropTypes.string,
-			label: PropTypes.string,
+			label: PropTypes.node,
 			required: PropTypes.bool,
 		} )
 	),

--- a/client/components/table/test/index.js
+++ b/client/components/table/test/index.js
@@ -5,7 +5,7 @@
  */
 import fetch from 'node-fetch';
 import moment from 'moment';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -24,6 +24,37 @@ jest.mock( 'lib/csv', () => ( {
 window.fetch = fetch;
 
 describe( 'TableCard', () => {
+	test( 'should render placeholder table while loading', () => {
+		const tableCard = shallow(
+			<TableCard
+				title="Revenue"
+				headers={ mockHeaders }
+				isLoading={ true }
+				rows={ [] }
+				rowsPerPage={ 5 }
+				totalRows={ 5 }
+			/>
+		);
+
+		expect( tableCard.find( 'TablePlaceholder' ).length ).toBe( 1 );
+	} );
+
+	test( 'should not render placeholder table when not loading', () => {
+		const tableCard = mount(
+			<TableCard
+				title="Revenue"
+				headers={ mockHeaders }
+				isLoading={ false }
+				rows={ mockData }
+				rowsPerPage={ 5 }
+				totalRows={ 5 }
+			/>
+		);
+
+		expect( tableCard.find( 'Table' ).length ).toBe( 1 );
+		expect( tableCard.find( 'TablePlaceholder' ).length ).toBe( 0 );
+	} );
+
 	test( 'should save CSV when clicking on download', () => {
 		global.Blob = ( content, options ) => ( { content, options } );
 

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Card, EmptyTable, Table, TablePlaceholder } from '@woocommerce/components';
+import { Card, EmptyTable, TableCard } from '@woocommerce/components';
 import { getAdminLink } from 'lib/nav-utils';
 import { numberFormat } from 'lib/number';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency';
@@ -80,38 +80,38 @@ export class TopSellingProducts extends Component {
 		} );
 	}
 
-	getCardContents( title ) {
+	render() {
 		const { data, isRequesting, isError } = this.props;
 
 		const rows = isRequesting || isError ? [] : this.getRowsContent( data );
-		const headers = this.getHeadersContent();
-
-		if ( isRequesting ) {
-			return <TablePlaceholder caption={ title } headers={ headers } />;
-		}
+		const title = __( 'Top Selling Products', 'wc-admin' );
 
 		if ( isError ) {
 			// @TODO An error notice should be displayed when there is an error
 		}
 
-		if ( rows.length === 0 ) {
+		if ( ! isRequesting && rows.length === 0 ) {
 			return (
-				<EmptyTable>
-					{ __( 'When new orders arrive, popular products will be listed here.', 'wc-admin' ) }
-				</EmptyTable>
+				<Card title={ title } className="woocommerce-top-selling-products">
+					<EmptyTable>
+						{ __( 'When new orders arrive, popular products will be listed here.', 'wc-admin' ) }
+					</EmptyTable>
+				</Card>
 			);
 		}
 
-		return <Table caption={ title } rows={ rows } headers={ headers } />;
-	}
-
-	render() {
-		const title = __( 'Top Selling Products', 'wc-admin' );
+		const headers = this.getHeadersContent();
 
 		return (
-			<Card title={ title } className="woocommerce-top-selling-products">
-				{ this.getCardContents( title ) }
-			</Card>
+			<TableCard
+				className="woocommerce-top-selling-products"
+				headers={ headers }
+				isLoading={ isRequesting }
+				rows={ rows }
+				rowsPerPage={ 5 }
+				title={ title }
+				totalRows={ 5 }
+			/>
 		);
 	}
 }

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -19,17 +19,10 @@ import mockData from '../__mocks__/top-selling-products-mock-data';
 // are not available on TestRenderer.
 jest.mock( '@woocommerce/components', () => ( {
 	...require.requireActual( '@woocommerce/components' ),
-	Table: () => null,
-	TablePlaceholder: () => null,
+	TableCard: () => null,
 } ) );
 
 describe( 'TopSellingProducts', () => {
-	test( 'should render placeholder table while requesting', () => {
-		const topSellingProducts = shallow( <TopSellingProducts data={ {} } isRequesting={ true } /> );
-
-		expect( topSellingProducts.find( 'TablePlaceholder' ).length ).toBe( 1 );
-	} );
-
 	test( 'should render empty message when there are no rows', () => {
 		const topSellingProducts = shallow( <TopSellingProducts data={ {} } /> );
 
@@ -38,7 +31,7 @@ describe( 'TopSellingProducts', () => {
 
 	test( 'should render correct data in the table', () => {
 		const topSellingProducts = shallow( <TopSellingProducts data={ mockData } /> );
-		const table = topSellingProducts.find( 'Table' );
+		const table = topSellingProducts.find( 'TableCard' );
 		const firstRow = table.props().rows[ 0 ];
 
 		expect( firstRow[ 0 ].value ).toBe( mockData[ 0 ].name );


### PR DESCRIPTION
Depends on #707.

This PR adds an `isLoading` prop to `<TableCard>` which will render `<TablePlaceholder>` instead of `<Table>` when set to true.

In parallel, now it was easier to make `Table` and `TablePlaceholder` components to have the same props. So `TablePlaceholder` will be a much better approximation of what `Table` will look like when it's loaded: number of rows, actions and menus, summary, etc.

### Screenshots
Before:
![imatge](https://user-images.githubusercontent.com/3616980/47618007-0eba2b00-dace-11e8-92f1-4b1cc7ebe87a.png)

After:
![imatge](https://user-images.githubusercontent.com/3616980/47618011-25f91880-dace-11e8-92db-46a01c557e66.png)

### Detailed test instructions:

- Go to a page with a table (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/products`).
- Verify the table placeholder appears when it's loading (including when changing pages or sorting) and it has the same actions, menus, number of rows, etc. than the resulting table.
