### PR TITLE
Filters: Add Variations extra filters

### DIFF
--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -11,23 +11,31 @@ import { getRequestByIdString } from 'lib/async-requests';
 import { NAMESPACE } from 'store/constants';
 
 export const filters = [
-	{ label: __( 'All Coupons', 'wc-admin' ), value: 'all' },
 	{
-		label: __( 'Comparison', 'wc-admin' ),
-		value: 'compare',
-		settings: {
-			type: 'coupons',
-			param: 'coupon',
-			getLabels: getRequestByIdString( NAMESPACE + 'coupons', coupon => ( {
-				id: coupon.id,
-				label: coupon.code,
-			} ) ),
-			labels: {
-				title: __( 'Compare Coupon Codes', 'wc-admin' ),
-				update: __( 'Compare', 'wc-admin' ),
+		label: __( 'Show', 'wc-admin' ),
+		staticParams: [],
+		param: 'filter',
+		showFilters: () => true,
+		filters: [
+			{ label: __( 'All Coupons', 'wc-admin' ), value: 'all' },
+			{
+				label: __( 'Comparison', 'wc-admin' ),
+				value: 'compare',
+				settings: {
+					type: 'coupons',
+					param: 'coupon',
+					getLabels: getRequestByIdString( NAMESPACE + 'coupons', coupon => ( {
+						id: coupon.id,
+						label: coupon.code,
+					} ) ),
+					labels: {
+						title: __( 'Compare Coupon Codes', 'wc-admin' ),
+						update: __( 'Compare', 'wc-admin' ),
+					},
+				},
 			},
-		},
+			{ label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ), value: 'top_orders' },
+			{ label: __( 'Top Coupons by Gross Discounted', 'wc-admin' ), value: 'top_discount' },
+		],
 	},
-	{ label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ), value: 'top_orders' },
-	{ label: __( 'Top Coupons by Gross Discounted', 'wc-admin' ), value: 'top_discount' },
 ];

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -13,8 +13,16 @@ import { NAMESPACE } from 'store/constants';
 const { orderStatuses } = wcSettings;
 
 export const filters = [
-	{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
-	{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
+	{
+		label: __( 'Show', 'wc-admin' ),
+		staticParams: [],
+		param: 'filter',
+		showFilters: () => true,
+		filters: [
+			{ label: __( 'All Orders', 'wc-admin' ), value: 'all' },
+			{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
+		],
+	},
 ];
 
 /*eslint-disable max-len*/

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -27,7 +27,7 @@ export default class OrdersReport extends Component {
 					query={ query }
 					path={ path }
 					filters={ filters }
-					advancedConfig={ advancedFilters }
+					advancedFilters={ advancedFilters }
 				/>
 				<OrdersReportChart query={ query } />
 				<OrdersReportTable query={ query } />

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -10,75 +10,121 @@ import { __ } from '@wordpress/i18n';
 import { getRequestByIdString } from 'lib/async-requests';
 import { NAMESPACE } from 'store/constants';
 
-export const filters = [
-	{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
-	{
-		label: __( 'Single Product', 'wc-admin' ),
-		value: 'select_product',
-		subFilters: [
-			{
-				component: 'Search',
-				value: 'single_product',
-				path: [ 'select_product' ],
-				settings: {
-					type: 'products',
-					param: 'products',
-					getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
-						id: product.id,
-						label: product.name,
-					} ) ),
-					labels: {
-						placeholder: __( 'Type to search for a product', 'wc-admin' ),
-						button: __( 'Single Product', 'wc-admin' ),
+const filterConfig = {
+	label: __( 'Show', 'wc-admin' ),
+	staticParams: [],
+	param: 'filter',
+	showFilters: () => true,
+	filters: [
+		{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
+		{
+			label: __( 'Single Product', 'wc-admin' ),
+			value: 'select_product',
+			subFilters: [
+				{
+					component: 'Search',
+					value: 'single_product',
+					path: [ 'select_product' ],
+					settings: {
+						type: 'products',
+						param: 'products',
+						getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
+							id: product.id,
+							label: product.name,
+						} ) ),
+						labels: {
+							placeholder: __( 'Type to search for a product', 'wc-admin' ),
+							button: __( 'Single Product', 'wc-admin' ),
+						},
 					},
 				},
-			},
-		],
-	},
-	{
-		label: __( 'Product Comparison', 'wc-admin' ),
-		value: 'compare-product',
-		settings: {
-			type: 'products',
-			param: 'products',
-			getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
-				id: product.id,
-				label: product.name,
-			} ) ),
-			labels: {
-				helpText: __( 'Select at least two products to compare', 'wc-admin' ),
-				placeholder: __( 'Search for products to compare', 'wc-admin' ),
-				title: __( 'Compare Products', 'wc-admin' ),
-				update: __( 'Compare', 'wc-admin' ),
+			],
+		},
+		{
+			label: __( 'Product Comparison', 'wc-admin' ),
+			value: 'compare-product',
+			settings: {
+				type: 'products',
+				param: 'products',
+				getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
+					id: product.id,
+					label: product.name,
+				} ) ),
+				labels: {
+					helpText: __( 'Select at least two products to compare', 'wc-admin' ),
+					placeholder: __( 'Search for products to compare', 'wc-admin' ),
+					title: __( 'Compare Products', 'wc-admin' ),
+					update: __( 'Compare', 'wc-admin' ),
+				},
 			},
 		},
-	},
-	{
-		label: __( 'Product Category Comparison', 'wc-admin' ),
-		value: 'compare-product_cat',
-		settings: {
-			type: 'product_cats',
-			param: 'categories',
-			getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
-				id: category.id,
-				label: category.name,
-			} ) ),
-			labels: {
-				helpText: __( 'Select at least two product categories to compare', 'wc-admin' ),
-				placeholder: __( 'Search for product categories to compare', 'wc-admin' ),
-				title: __( 'Compare Product Categories', 'wc-admin' ),
-				update: __( 'Compare', 'wc-admin' ),
+		{
+			label: __( 'Product Category Comparison', 'wc-admin' ),
+			value: 'compare-product_cat',
+			settings: {
+				type: 'product_cats',
+				param: 'categories',
+				getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
+					id: category.id,
+					label: category.name,
+				} ) ),
+				labels: {
+					helpText: __( 'Select at least two product categories to compare', 'wc-admin' ),
+					placeholder: __( 'Search for product categories to compare', 'wc-admin' ),
+					title: __( 'Compare Product Categories', 'wc-admin' ),
+					update: __( 'Compare', 'wc-admin' ),
+				},
 			},
 		},
-	},
-	{
-		label: __( 'Top Products by Items Sold', 'wc-admin' ),
-		value: 'top_items',
-		query: { orderby: 'items_sold', order: 'desc' },
-	},
-	{
-		label: __( 'Top Products by Gross Revenue', 'wc-admin' ),
-		value: 'top_sales',
-		query: { orderby: 'gross_revenue', order: 'desc' },
-	},
-];
+		{
+			label: __( 'Top Products by Items Sold', 'wc-admin' ),
+			value: 'top_items',
+			query: { orderby: 'items_sold', order: 'desc' },
+		},
+		{
+			label: __( 'Top Products by Gross Revenue', 'wc-admin' ),
+			value: 'top_sales',
+			query: { orderby: 'gross_revenue', order: 'desc' },
+		},
+	],
+};
+
+const variationsConfig = {
+	showFilters: query => 'single_product' === query.filter && !! query.products,
+	staticParams: [ 'filter', 'products' ],
+	param: 'filter-variations',
+	filters: [
+		{ label: __( 'All Variations', 'wc-admin' ), value: 'all' },
+		{
+			label: __( 'Comparison', 'wc-admin' ),
+			value: 'compare',
+			settings: {
+				// @TODO create a variations autocompleter
+				type: 'products',
+				param: 'variations',
+				getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
+					id: product.id,
+					label: product.name,
+				} ) ),
+				labels: {
+					helpText: __( 'Select at least two variations to compare', 'wc-admin' ),
+					placeholder: __( 'Search for variations to compare', 'wc-admin' ),
+					title: __( 'Compare Variations', 'wc-admin' ),
+					update: __( 'Compare', 'wc-admin' ),
+				},
+			},
+		},
+		{
+			label: __( 'Top Variations by Items Sold', 'wc-admin' ),
+			value: 'top_items',
+			query: { orderby: 'items_sold', order: 'desc' },
+		},
+		{
+			label: __( 'Top Variations by Gross Revenue', 'wc-admin' ),
+			value: 'top_sales',
+			query: { orderby: 'gross_revenue', order: 'desc' },
+		},
+	],
+};
+
+export const filters = [ filterConfig, variationsConfig ];

--- a/client/components/filters/date/index.js
+++ b/client/components/filters/date/index.js
@@ -126,8 +126,8 @@ class DatePicker extends Component {
 			beforeError,
 		} = this.state;
 		return (
-			<div className="woocommerce-filters-date">
-				<p>{ __( 'Date Range', 'wc-admin' ) }:</p>
+			<div className="woocommerce-filters-filter">
+				<span className="woocommerce-filters-label">{ __( 'Date Range', 'wc-admin' ) }:</span>
 				<Dropdown
 					ref={ this.dropdownRef }
 					contentClassName="woocommerce-filters-date__content"

--- a/client/components/filters/index.js
+++ b/client/components/filters/index.js
@@ -24,28 +24,34 @@ import './style.scss';
  * @return { object } -
  */
 class ReportFilters extends Component {
-	renderCard() {
-		const { advancedConfig, filters, query, path } = this.props;
-		if ( ! query.filter ) {
+	constructor() {
+		super();
+		this.renderCard = this.renderCard.bind( this );
+	}
+
+	renderCard( config ) {
+		const { advancedFilters, query, path } = this.props;
+		const { filters, param } = config;
+		if ( ! query[ param ] ) {
 			return null;
 		}
 
-		if ( 0 === query.filter.indexOf( 'compare' ) ) {
-			const filter = find( filters, { value: query.filter } );
+		if ( 0 === query[ param ].indexOf( 'compare' ) ) {
+			const filter = find( filters, { value: query[ param ] } );
 			if ( ! filter ) {
 				return null;
 			}
 			const { settings = {} } = filter;
 			return (
-				<div className="woocommerce-filters__advanced-filters">
+				<div key={ param } className="woocommerce-filters__advanced-filters">
 					<CompareFilter path={ path } query={ query } { ...settings } />
 				</div>
 			);
 		}
-		if ( 'advanced' === query.filter ) {
+		if ( 'advanced' === query[ param ] ) {
 			return (
-				<div className="woocommerce-filters__advanced-filters">
-					<AdvancedFilters config={ advancedConfig } path={ path } query={ query } />
+				<div key={ param } className="woocommerce-filters__advanced-filters">
+					<AdvancedFilters config={ advancedFilters } path={ path } query={ query } />
 				</div>
 			);
 		}
@@ -59,11 +65,20 @@ class ReportFilters extends Component {
 				<Section component="div" className="woocommerce-filters">
 					<div className="woocommerce-filters__basic-filters">
 						<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
-						{ !! filters.length && (
-							<FilterPicker filters={ filters } query={ query } path={ path } />
-						) }
+						{ filters.map( config => {
+							if ( config.showFilters( query ) ) {
+								return (
+									<FilterPicker
+										key={ config.param }
+										config={ config }
+										query={ query }
+										path={ path }
+									/>
+								);
+							}
+						} ) }
 					</div>
-					{ this.renderCard() }
+					{ filters.map( this.renderCard ) }
 				</Section>
 			</Fragment>
 		);
@@ -74,7 +89,7 @@ ReportFilters.propTypes = {
 	/**
 	 * Config option passed through to `AdvancedFilters`
 	 */
-	advancedConfig: PropTypes.object,
+	advancedFilters: PropTypes.object,
 	/**
 	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 	 */
@@ -90,7 +105,7 @@ ReportFilters.propTypes = {
 };
 
 ReportFilters.defaultProps = {
-	advancedConfig: {},
+	advancedFilters: {},
 	filters: [],
 	query: {},
 };

--- a/client/components/filters/style.scss
+++ b/client/components/filters/style.scss
@@ -1,38 +1,53 @@
 /** @format */
 
 .woocommerce-filters {
-	.woocommerce-filters__basic-filters {
-		display: flex;
-		margin-bottom: $gap-large;
-
-		> div {
-			margin-right: $gap-large;
-		}
-
-		@include breakpoint( '<1100px' ) {
-			flex-direction: column;
-
-			> div {
-				margin-right: 0;
-			}
-		}
-	}
-
 	.components-base-control__field {
 		margin-bottom: 0;
 	}
 }
 
-.woocommerce-filters-date,
+.woocommerce-filters__basic-filters {
+	display: flex;
+	margin-bottom: $gap-large;
+
+	@include breakpoint( '<1100px' ) {
+		flex-direction: column;
+	}
+}
+
 .woocommerce-filters-filter {
 	width: 33.3%;
+	padding: 0 $gap-small;
+	min-height: 82px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+
+	&:first-child {
+		padding-left: 0;
+	}
+
+	&:last-child {
+		padding-right: 0;
+	}
 
 	@include breakpoint( '<1100px' ) {
 		width: 50%;
+		padding: 0;
+		min-height: 78px;
 	}
 
 	@include breakpoint( '<782px' ) {
 		width: 100%;
+	}
+}
+
+.woocommerce-filters-label {
+	margin: 7px 0;
+	display: block;
+
+	@include breakpoint( '<1100px' ) {
+		margin: 5px 0;
 	}
 }
 

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -343,12 +343,19 @@ describe( 'getFilterQuery', () => {
 	 * Mock the orders config
 	 */
 	const filters = [
-		{ value: 'top_meal', query: { lunch: 'burritos' } },
-		{ value: 'top_dessert', query: { dinner: 'ice_cream' } },
-		{ value: 'compare-cuisines', settings: { param: 'region' } },
 		{
-			value: 'food_destination',
-			subFilters: [ { value: 'choose_a_european_city', settings: { param: 'european_cities' } } ],
+			param: 'filter',
+			filters: [
+				{ value: 'top_meal', query: { lunch: 'burritos' } },
+				{ value: 'top_dessert', query: { dinner: 'ice_cream' } },
+				{ value: 'compare-cuisines', settings: { param: 'region' } },
+				{
+					value: 'food_destination',
+					subFilters: [
+						{ value: 'choose_a_european_city', settings: { param: 'european_cities' } },
+					],
+				},
+			],
 		},
 	];
 

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -27,15 +27,23 @@ const reportConfigs = {
 };
 
 export function getFilterQuery( endpoint, query ) {
-	const { filter } = query;
+	if ( reportConfigs[ endpoint ] ) {
+		const { filters = [], advancedFilters = {} } = reportConfigs[ endpoint ];
+		return filters
+			.map( filter => getQueryFromConfig( filter, advancedFilters, query ) )
+			.reduce( ( result, configQuery ) => Object.assign( result, configQuery ), {} );
+	}
+	return {};
+}
 
-	if ( ! filter ) {
+export function getQueryFromConfig( config, advancedFilters, query ) {
+	const queryValue = query[ config.param ];
+
+	if ( ! queryValue ) {
 		return {};
 	}
 
-	const { filters = [], advancedFilters = {} } = reportConfigs[ endpoint ];
-
-	if ( 'advanced' === filter ) {
+	if ( 'advanced' === queryValue ) {
 		const activeFilters = getActiveFiltersFromQuery( query, advancedFilters.filters );
 
 		if ( activeFilters.length === 0 ) {
@@ -52,14 +60,14 @@ export function getFilterQuery( endpoint, query ) {
 		);
 	}
 
-	const filterConfig = find( flatenFilters( filters ), { value: filter } );
+	const filter = find( flatenFilters( config.filters ), { value: queryValue } );
 
-	if ( ! filterConfig ) {
+	if ( ! filter ) {
 		return {};
 	}
 
-	if ( filterConfig.settings && filterConfig.settings.param ) {
-		const { param } = filterConfig.settings;
+	if ( filter.settings && filter.settings.param ) {
+		const { param } = filter.settings;
 
 		if ( query[ param ] ) {
 			return {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/681

Add Variations filter for Product Detail
**Designs:** p6riRB-3dP-p2

![screen shot 2018-10-30 at 4 59 43 pm](https://user-images.githubusercontent.com/1922453/47695092-50c9a500-dc65-11e8-84e6-409f783589bd.png)

Changes here include a change to the filter configs because more information is required, eg url parameter "filter" v. "filter-variations" or a label "Show:" v. no label. As a result, I needed to do some renaming to avoid things like `filter.filters`.

## Testing

1. `/wp-admin/admin.php?page=wc-admin#/analytics/products`.
2. Filter to Single Product and select one from the autocomplete.
3. See the Variations filter appear.
4. Try all the filters including "Compare".
5. Make sure the url query parameters update accordingly.
6. Make sure results appear in Network requests for data.
7. Poke around for any possible regressions on other reports.


