### PR TITLE
Fix: date params were no longer persisted when navigating pages

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -21,31 +21,31 @@ const getPages = () => {
 			container: Dashboard,
 			path: '/',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics',
+			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		},
 		{
 			container: Analytics,
 			path: '/analytics',
-			wpOpenMenu: 'toplevel_page_wc-admin--analytics',
+			wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
 			wpClosedMenu: 'toplevel_page_woocommerce',
 		},
 		{
 			container: AnalyticsReport,
 			path: '/analytics/:report',
-			wpOpenMenu: 'toplevel_page_wc-admin--analytics',
+			wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
 			wpClosedMenu: 'toplevel_page_woocommerce',
 		},
 		{
 			container: DevDocs,
 			path: '/devdocs',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics',
+			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		},
 		{
 			container: DevDocs,
 			path: '/devdocs/:component',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics',
+			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		},
 	];
 
@@ -105,26 +105,21 @@ window.wpNavMenuClassChange = function( page ) {
 	} );
 
 	const pageHash = window.location.hash.split( '?' )[ 0 ];
-	const currentItems = document.querySelectorAll( `li > a[href$="${ pageHash }"]` );
+	const currentItemsSelector =
+		pageHash === '#/'
+			? `li > a[href$="${ pageHash }"], li > a[href*="${ pageHash }?"]`
+			: `li > a[href*="${ pageHash }"]`;
+	const currentItems = document.querySelectorAll( currentItemsSelector );
 
 	Array.from( currentItems ).forEach( function( item ) {
 		item.parentElement.classList.add( 'current' );
 	} );
 
-	// Make revenue the default url
-	if ( page.wpOpenMenu === 'toplevel_page_wc-admin--analytics' ) {
-		page.wpOpenMenu = 'toplevel_page_wc-admin--analytics-revenue';
-	}
 	const currentMenu = document.querySelector( '#' + page.wpOpenMenu );
 	currentMenu.classList.remove( 'wp-not-current-submenu' );
 	currentMenu.classList.add( 'wp-has-current-submenu' );
 	currentMenu.classList.add( 'wp-menu-open' );
 	currentMenu.classList.add( 'current' );
-
-	// Make revenue the default url
-	if ( page.wpClosedMenu === 'toplevel_page_wc-admin--analytics' ) {
-		page.wpClosedMenu = 'toplevel_page_wc-admin--analytics-revenue';
-	}
 
 	// Sometimes navigating from the subMenu to Dashboard does not close subMenu
 	const closedMenu = document.querySelector( '#' + page.wpClosedMenu );


### PR DESCRIPTION
When trying to reproduce #663, I noticed date params persistence was broken in master. This PR should fix that (some changes to the selector that highlights the links was required too).

### Detailed test instructions:

- Go to any page of `wc-admin`.
- Change the time range and verify the links are still correctly highlighted.
- Navigate to another page and verify the time range persisted and links are correctly highlighted too.

cc @belcherj you did some modifications to that part of the code recently, so you might want to take a look and make sure I'm not breaking anything new :slightly_smiling_face: 
