### PR TITLE
Fixes Ellipsis hover bug in Firefox

### DIFF
--- a/client/components/ellipsis-menu/index.js
+++ b/client/components/ellipsis-menu/index.js
@@ -32,7 +32,7 @@ class EllipsisMenu extends Component {
 					className={ toggleClassname }
 					onClick={ onToggle }
 					icon="ellipsis"
-					label={ label }
+					title={ label }
 					aria-expanded={ isOpen }
 				/>
 			);


### PR DESCRIPTION
Fixes #699

Changes label to title to match other UI. 

### Screenshots

Old
![screen shot 2018-10-29 at 12 10 06 pm](https://user-images.githubusercontent.com/6817400/47663515-99a13100-db73-11e8-996b-d4ddbad1f6a0.png)

New
<img width="112" alt="screen shot 2018-10-29 at 12 09 48 pm" src="https://user-images.githubusercontent.com/6817400/47663526-9efe7b80-db73-11e8-9f36-b455c498921c.png">

### Detailed test instructions:

 - In Firefox, goto:  http://woodash.test/wp-admin/admin.php?page=wc-admin#/analytics/products
 - Hover over Ellipsis on chart
 - If it doesn't move, you must approve.
