### PR TITLE
Adds PHPCS autofixer command to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "npm run lint:js",
     "lint:js": "npm run -s install-if-deps-outdated && eslint client --ext=js,jsx",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
-    "lint:php:fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
+    "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
     "precommit": "npm run -s install-if-no-packages && node bin/pre-commit-hook.js",
     "prepush": "npm run -s install-if-no-packages && node bin/pre-push-hook.js",
     "pretest": "npm run -s install-if-no-packages",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "npm run lint:js",
     "lint:js": "npm run -s install-if-deps-outdated && eslint client --ext=js,jsx",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
+    "lint:php:fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
     "precommit": "npm run -s install-if-no-packages && node bin/pre-commit-hook.js",
     "prepush": "npm run -s install-if-no-packages && node bin/pre-push-hook.js",
     "pretest": "npm run -s install-if-no-packages",


### PR DESCRIPTION
Adds a command to run the PHP auto-fixing command: `npm run php:lint-fix`

It has to be lint-fix as npm scripts doesn't like two colons in a command.

### Detailed test instructions:

 - Run `npm run php:lint-fix`
