### PR TITLE
Fix charts redirecting to previous path when changing interval value

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -79,6 +79,7 @@ class ReportChart extends Component {
 		return (
 			<Chart
 				path={ path }
+				query={ query }
 				data={ chartData }
 				title={ selectedChart.label }
 				interval={ currentInterval }

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -29,7 +29,7 @@ import ReportError from 'analytics/components/report-error';
 
 class ReportChart extends Component {
 	render() {
-		const { primaryData, secondaryData, selectedChart, query } = this.props;
+		const { path, primaryData, secondaryData, selectedChart, query } = this.props;
 
 		if ( primaryData.isError || secondaryData.isError ) {
 			return <ReportError isError />;
@@ -75,8 +75,10 @@ class ReportChart extends Component {
 				},
 			};
 		} );
+
 		return (
 			<Chart
+				path={ path }
 				data={ chartData }
 				title={ selectedChart.label }
 				interval={ currentInterval }
@@ -94,10 +96,11 @@ class ReportChart extends Component {
 }
 
 ReportChart.propTypes = {
+	path: PropTypes.string.isRequired,
 	primaryData: PropTypes.object.isRequired,
+	query: PropTypes.object.isRequired,
 	secondaryData: PropTypes.object.isRequired,
 	selectedChart: PropTypes.object.isRequired,
-	query: PropTypes.object.isRequired,
 };
 
 export default compose(

--- a/client/analytics/report/orders/chart.js
+++ b/client/analytics/report/orders/chart.js
@@ -51,7 +51,7 @@ class OrdersReportChart extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { path, query } = this.props;
 		return (
 			<Fragment>
 				<ReportSummary
@@ -63,6 +63,7 @@ class OrdersReportChart extends Component {
 				<ReportChart
 					charts={ this.getCharts() }
 					endpoint="orders"
+					path={ path }
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
 				/>
@@ -72,6 +73,7 @@ class OrdersReportChart extends Component {
 }
 
 OrdersReportChart.propTypes = {
+	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
 

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -15,7 +15,7 @@ const { orderStatuses } = wcSettings;
 export const filters = [
 	{
 		label: __( 'Show', 'wc-admin' ),
-		staticParams: [],
+		staticParams: [ 'chart' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -29,7 +29,7 @@ export default class OrdersReport extends Component {
 					filters={ filters }
 					advancedFilters={ advancedFilters }
 				/>
-				<OrdersReportChart query={ query } />
+				<OrdersReportChart query={ query } path={ path } />
 				<OrdersReportTable query={ query } />
 			</Fragment>
 		);

--- a/client/analytics/report/products/chart.js
+++ b/client/analytics/report/products/chart.js
@@ -46,7 +46,7 @@ class ProductsReportChart extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { path, query } = this.props;
 		return (
 			<Fragment>
 				<ReportSummary
@@ -58,6 +58,7 @@ class ProductsReportChart extends Component {
 				<ReportChart
 					charts={ this.getCharts() }
 					endpoint="products"
+					path={ path }
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
 				/>
@@ -67,6 +68,7 @@ class ProductsReportChart extends Component {
 }
 
 ProductsReportChart.propTypes = {
+	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
 

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -12,7 +12,7 @@ import { NAMESPACE } from 'store/constants';
 
 const filterConfig = {
 	label: __( 'Show', 'wc-admin' ),
-	staticParams: [],
+	staticParams: [ 'chart' ],
 	param: 'filter',
 	showFilters: () => true,
 	filters: [

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -24,7 +24,7 @@ export default class ProductsReport extends Component {
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
-				<ProductsReportChart query={ query } />
+				<ProductsReportChart query={ query } path={ path } />
 				<ProductsReportTable query={ query } />
 			</Fragment>
 		);

--- a/client/analytics/report/revenue/chart.js
+++ b/client/analytics/report/revenue/chart.js
@@ -61,7 +61,7 @@ class RevenueReportChart extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { path, query } = this.props;
 		return (
 			<Fragment>
 				<ReportSummary
@@ -73,6 +73,7 @@ class RevenueReportChart extends Component {
 				<ReportChart
 					charts={ this.getCharts() }
 					endpoint="revenue"
+					path={ path }
 					query={ query }
 					selectedChart={ this.getSelectedChart() }
 				/>
@@ -82,6 +83,7 @@ class RevenueReportChart extends Component {
 }
 
 RevenueReportChart.propTypes = {
+	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
 

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -23,7 +23,7 @@ export default class RevenueReport extends Component {
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } />
-				<RevenueReportChart query={ query } />
+				<RevenueReportChart query={ query } path={ path } />
 				<RevenueReportTable query={ query } />
 			</Fragment>
 		);

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -73,6 +73,7 @@ class Chart extends Component {
 		this.handleLegendHover = this.handleLegendHover.bind( this );
 		this.updateDimensions = this.updateDimensions.bind( this );
 		this.getVisibleData = this.getVisibleData.bind( this );
+		this.setInterval = this.setInterval.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -152,7 +153,8 @@ class Chart extends Component {
 	}
 
 	setInterval( interval ) {
-		updateQueryString( { interval } );
+		const { path } = this.props;
+		updateQueryString( { interval }, path );
 	}
 
 	renderIntervalSelector() {
@@ -312,6 +314,10 @@ Chart.propTypes = {
 	 * Format to parse dates into d3 time format
 	 */
 	dateParser: PropTypes.string.isRequired,
+	/**
+	 * Current path
+	 */
+	path: PropTypes.string,
 	/**
 	 * Date format of the point labels (might be used in tooltips and ARIA properties).
 	 */

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -153,8 +153,8 @@ class Chart extends Component {
 	}
 
 	setInterval( interval ) {
-		const { path } = this.props;
-		updateQueryString( { interval }, path );
+		const { path, query } = this.props;
+		updateQueryString( { interval }, path, query );
 	}
 
 	renderIntervalSelector() {
@@ -322,6 +322,10 @@ Chart.propTypes = {
 	 * Date format of the point labels (might be used in tooltips and ARIA properties).
 	 */
 	pointLabelFormat: PropTypes.string,
+	/**
+	 * The query string represented in object form
+	 */
+	query: PropTypes.object,
 	/**
 	 * A datetime formatting string to format the date displayed as the title of the toolip
 	 * if `tooltipTitle` is missing, passed to d3TimeFormat.


### PR DESCRIPTION
Fixes #663 and #704.

I have to say I don't understand yet where that bug came from. The problem was that calling `getPath()` (which is called by `updateQueryString()`) inside the `<Chart>` component returns the previous location instead of the current one.

The solution I found is passing down the `path` prop and using that one to generate the new route when changing the interval. We are also passing down the path for `<ReportFilters>` and React Router [docs](https://reacttraining.com/react-router/web/api/history/history-is-mutable) also seem to recommend using the `path` prop instead of relying on the history object to get the current path, so I think the proposed solution is good.

But if somebody has a better understanding of React Router/this specific problem or has any idea of a better solution, feel free to propose it. :slightly_smiling_face: 

### Detailed test instructions:

- On master, go to the _Revenue_ report.
- Navigate to the _Orders_ report.
- Change the chart interval from _day_ to _week_.
- Note the report **no longer** reloads as the _Revenue_ report.
