### PR TITLE
Makes stylelint config match prettier settings

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -14,6 +14,7 @@
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
 		"string-quotes": "single",
-		"value-keyword-case": null
+		"value-keyword-case": null,
+		"value-list-comma-newline-after": null
 	}
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,7 @@
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
 		"declaration-block-no-duplicate-properties": null,
+		"declaration-colon-newline-after": null,
 		"declaration-property-unit-whitelist": null,
 		"font-weight-notation": null,
 		"max-line-length": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,7 @@
 		"no-duplicate-selectors": null,
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
+		"string-quotes": "single",
 		"value-keyword-case": null
 	}
 }

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -2,7 +2,7 @@
 
 .woocommerce-card {
 	margin-bottom: $gap-large;
-	background: white;
+	background: $white;
 	border: 1px solid $core-grey-light-700;
 
 	@include breakpoint( '<782px' ) {

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -2,7 +2,7 @@
 .woocommerce-chart {
 	margin-top: -$gap;
 	margin-bottom: $gap-large;
-	background: white;
+	background: $white;
 	border: 1px solid $core-grey-light-700;
 	border-top: 0;
 

--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -105,7 +105,7 @@
 		padding-top: $gap;
 		padding-bottom: $gap;
 		z-index: 1;
-		background: white;
+		background: $white;
 		position: relative;
 	}
 }

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -10,7 +10,7 @@
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
-		background: #fff;
+		background: $white;
 		margin: 0;
 		padding: 0;
 		top: -3px;
@@ -167,7 +167,7 @@
 	position: absolute;
 	padding: 1px;
 	background: $core-orange;
-	border: 2px solid white;
+	border: 2px solid $white;
 	width: 4px;
 	height: 4px;
 	display: inline-block;

--- a/client/stylesheets/abstracts/_breakpoints.scss
+++ b/client/stylesheets/abstracts/_breakpoints.scss
@@ -1,5 +1,7 @@
 /** @format */
 
+/* stylelint-disable block-closing-brace-newline-after */
+
 // Breakpoints
 // Forked from https://github.com/Automattic/wp-calypso/blob/46ae24d8800fb85da6acf057a640e60dac988a38/assets/stylesheets/shared/mixins/_breakpoints.scss
 
@@ -55,3 +57,5 @@ $breakpoints: 320px, 400px, 600px, 782px, 960px, 1100px, 1365px;
 		}
 	}
 }
+
+/* stylelint-enable */

--- a/client/stylesheets/abstracts/_breakpoints.scss
+++ b/client/stylesheets/abstracts/_breakpoints.scss
@@ -44,14 +44,14 @@ $breakpoints: 320px, 400px, 600px, 782px, 960px, 1100px, 1365px;
 				@each $breakpoint in $breakpoints {
 					$sizes: $sizes + ' ' + $breakpoint;
 				}
-				@warn "ERROR in breakpoint( #{ $size } ) : You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+				@warn 'ERROR in breakpoint( #{ $size } ) : You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
 			}
 		} @else {
 			$sizes: '';
 			@each $breakpoint in $breakpoints {
 				$sizes: $sizes + ' ' + $breakpoint;
 			}
-			@error "ERROR in breakpoint( #{ $size } ) : Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+			@error 'ERROR in breakpoint( #{ $size } ) : Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
 		}
 	}
 }

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -24,7 +24,9 @@ $dark-gray-300: $core-grey-dark-300;
 $dark-gray-900: $core-grey-dark-900;
 $alert-red: $error-red;
 
+/* stylelint-disable */
 :export {
 	gaplarge: $gap-large;
 	gap: $gap;
 }
+/* stylelint-enable */


### PR DESCRIPTION
Prettier transforms double quotes to single quotes and stylelint fix was transforming single quotes to double quotes.   Stylelint is easier to configure and prettier format is the current standard so I changed Stylelint.

### Detailed test instructions:

 - Make a single quote a double.
 - Run `npm run lint:css`
 - Observe error
 - Run `npm run lint:css-fix` to fix error
