### PR TITLE
Hide Clear filter button when no filters are selected

### DIFF
--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -229,9 +229,11 @@ class AdvancedFilters extends Component {
 							{ __( 'Filter', 'wc-admin' ) }
 						</Link>
 					) }
-					<Link type="wc-admin" href={ this.getUpdateHref( [] ) } onClick={ this.clearFilters }>
-						{ __( 'Clear all filters', 'wc-admin' ) }
-					</Link>
+					{ activeFilters.length > 0 && (
+						<Link type="wc-admin" href={ this.getUpdateHref( [] ) } onClick={ this.clearFilters }>
+							{ __( 'Clear all filters', 'wc-admin' ) }
+						</Link>
+					) }
 				</div>
 			</Card>
 		);

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -4,6 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { Button } from '@wordpress/components';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -12,8 +13,7 @@ import PropTypes from 'prop-types';
  */
 import Card from 'components/card';
 import CompareButton from './button';
-import Link from 'components/link';
-import { getIdsFromQuery, getNewPath, updateQueryString } from 'lib/nav-utils';
+import { getIdsFromQuery, updateQueryString } from 'lib/nav-utils';
 import Search from 'components/search';
 
 /**
@@ -54,7 +54,12 @@ class CompareFilter extends Component {
 
 	clearQuery() {
 		const { param, path, query } = this.props;
-		return getNewPath( { [ param ]: undefined }, path, query );
+
+		this.setState( {
+			selected: [],
+		} );
+
+		updateQueryString( { [ param ]: undefined }, path, query );
 	}
 
 	updateLabels( selected ) {
@@ -91,9 +96,11 @@ class CompareFilter extends Component {
 					>
 						{ labels.update }
 					</CompareButton>
-					<Link type="wc-admin" href={ this.clearQuery() }>
-						{ __( 'Clear all', 'wc-admin' ) }
-					</Link>
+					{ selected.length > 0 && (
+						<Button isLink={ true } onClick={ this.clearQuery }>
+							{ __( 'Clear all', 'wc-admin' ) }
+						</Button>
+					) }
 				</div>
 			</Card>
 		);


### PR DESCRIPTION
Part of #682.

This PR adds several fixes:
- Hides the _Clear all_ button in _Compare Products_ card (Products report) when there are no products selected.
- Hides the _Clear all filters_ button in _Advanced filters_ card (Orders report) when there are no filters selected.
- Updates the _Clear all_ button in _Compare Products_ card (Products report) so it clears the selected products even when the comparison was not done yet (aka the user pressed _Clear all_ before pressing _Compare_).

### Screenshots
`/wp-admin/admin.php?page=wc-admin#/analytics/products?filter=compare-product`
![imatge](https://user-images.githubusercontent.com/3616980/47734751-3d213d00-dc6b-11e8-9701-b1e6e0b6a58a.png)

`/wp-admin/admin.php?page=wc-admin#/analytics/orders?filter=advanced`
![imatge](https://user-images.githubusercontent.com/3616980/47734779-4f9b7680-dc6b-11e8-877f-7866aa8dbd59.png)



### Detailed test instructions:
- Go to `/wp-admin/admin.php?page=wc-admin#/analytics/products?filter=compare-product` and verify there isn't a _Clear all_ button visible.
- Add a product using the search box.
- Verify the _Clear all_ button appears.
- Click on it.
- Verify the selected product and the _Clear all_ button disappeared.

---

- Go to `/wp-admin/admin.php?page=wc-admin#/analytics/orders?filter=advanced` and verify there isn't a _Clear all filters_ button visible.
- Add a filter using the _Add a filter_ button.
- Verify the _Clear all filters_ button appears.
- Click on it.
- Verify the filter and the _Clear all filters_ button disappeared.
