### PR TITLE
Fix spelling of "average" in "average order value" in orders report

### DIFF
--- a/client/analytics/report/orders/chart.js
+++ b/client/analytics/report/orders/chart.js
@@ -28,7 +28,7 @@ class OrdersReportChart extends Component {
 			},
 			{
 				key: 'avg_order_value',
-				label: __( 'Avergae Order Value', 'wc-admin' ),
+				label: __( 'Average Order Value', 'wc-admin' ),
 				type: 'currency',
 			},
 			{


### PR DESCRIPTION
Quick fix of some transposed letters. 