### PR TITLE
Add/variations autocompleter

### DIFF
--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -99,13 +99,21 @@ const variationsConfig = {
 			label: __( 'Comparison', 'wc-admin' ),
 			value: 'compare',
 			settings: {
-				// @TODO create a variations autocompleter
-				type: 'products',
+				type: 'variations',
 				param: 'variations',
-				getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
-					id: product.id,
-					label: product.name,
-				} ) ),
+				getLabels: getRequestByIdString(
+					query => NAMESPACE + `products/${ query.products }/variations`,
+					variation => {
+						return {
+							id: variation.id,
+							label: variation.attributes.reduce(
+								( desc, attribute, index, arr ) =>
+									desc + `${ attribute.option }${ arr.length === index + 1 ? '' : ', ' }`,
+								''
+							),
+						};
+					}
+				),
 				labels: {
 					helpText: __( 'Select at least two variations to compare', 'wc-admin' ),
 					placeholder: __( 'Search for variations to compare', 'wc-admin' ),

--- a/client/components/filters/advanced/index.js
+++ b/client/components/filters/advanced/index.js
@@ -148,7 +148,7 @@ class AdvancedFilters extends Component {
 	}
 
 	render() {
-		const { config } = this.props;
+		const { config, query } = this.props;
 		const { activeFilters, match } = this.state;
 		const availableFilterKeys = this.getAvailableFilterKeys();
 		const updateHref = this.getUpdateHref( activeFilters, match );
@@ -176,6 +176,7 @@ class AdvancedFilters extends Component {
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }
 										isEnglish={ isEnglish }
+										query={ query }
 									/>
 								) }
 								<IconButton

--- a/client/components/filters/advanced/search-filter.js
+++ b/client/components/filters/advanced/search-filter.js
@@ -15,7 +15,7 @@ import classnames from 'classnames';
 import Search from 'components/search';
 
 class SearchFilter extends Component {
-	constructor( { filter, config } ) {
+	constructor( { filter, config, query } ) {
 		super( ...arguments );
 		this.onSearchChange = this.onSearchChange.bind( this );
 		this.state = {
@@ -25,7 +25,7 @@ class SearchFilter extends Component {
 		this.updateLabels = this.updateLabels.bind( this );
 
 		if ( filter.value.length ) {
-			config.input.getLabels( filter.value ).then( this.updateLabels );
+			config.input.getLabels( filter.value, query ).then( this.updateLabels );
 		}
 	}
 
@@ -130,6 +130,10 @@ SearchFilter.propTypes = {
 	 * Function to be called on update.
 	 */
 	onFilterChange: PropTypes.func.isRequired,
+	/**
+	 * The query string represented in object form.
+	 */
+	query: PropTypes.object,
 };
 
 export default SearchFilter;

--- a/client/components/filters/compare/index.js
+++ b/client/components/filters/compare/index.js
@@ -35,7 +35,7 @@ class CompareFilter extends Component {
 		this.updateLabels = this.updateLabels.bind( this );
 
 		if ( query[ param ] ) {
-			getLabels( query[ param ] ).then( this.updateLabels );
+			getLabels( query[ param ], query ).then( this.updateLabels );
 		}
 	}
 
@@ -52,7 +52,7 @@ class CompareFilter extends Component {
 		const prevIds = getIdsFromQuery( prevQuery[ param ] );
 		const currentIds = getIdsFromQuery( query[ param ] );
 		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
-			getLabels( query[ param ] ).then( this.updateLabels );
+			getLabels( query[ param ], query ).then( this.updateLabels );
 		}
 	}
 

--- a/client/components/filters/filter/index.js
+++ b/client/components/filters/filter/index.js
@@ -49,7 +49,7 @@ class FilterPicker extends Component {
 		if ( selectedFilter.settings && selectedFilter.settings.getLabels ) {
 			const { query } = this.props;
 			const { param: filterParam, getLabels } = selectedFilter.settings;
-			getLabels( query[ filterParam ] ).then( this.updateSelectedTag );
+			getLabels( query[ filterParam ], query ).then( this.updateSelectedTag );
 		}
 	}
 

--- a/client/components/search/autocompleters/index.js
+++ b/client/components/search/autocompleters/index.js
@@ -5,3 +5,4 @@
 export { default as product } from './product';
 export { default as productCategory } from './product-cat';
 export { default as coupons } from './coupons';
+export { default as variations } from './variations';

--- a/client/components/search/autocompleters/variations.js
+++ b/client/components/search/autocompleters/variations.js
@@ -1,0 +1,82 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+import { stringifyQuery, getQuery } from '@woocommerce/navigation';
+import { NAMESPACE } from 'store/constants';
+
+/**
+ * Create a variation name by concatenating each of the variation's
+ * attribute option strings.
+ *
+ * @param {object} variation - variation returned by the api
+ * @returns {string} - variation name
+ */
+function getVariationName( variation ) {
+	return variation.attributes.reduce(
+		( desc, attribute, index, arr ) =>
+			desc + `${ attribute.option }${ arr.length === index + 1 ? '' : ', ' }`,
+		''
+	);
+}
+
+/**
+ * A products completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'products',
+	className: 'woocommerce-search__product-result',
+	options( search ) {
+		let payload = '';
+		if ( search ) {
+			const query = {
+				search: encodeURIComponent( search ),
+				per_page: 10,
+			};
+			payload = stringifyQuery( query );
+		}
+		const product = getQuery().products;
+		if ( ! product || product.includes( ',' ) ) {
+			console.warn( 'Invalid product id supplied to Variations autocompleter' );
+		}
+		return apiFetch( { path: `${ NAMESPACE }products/${ product }/variations${ payload }` } );
+	},
+	isDebounced: true,
+	getOptionKeywords( variation ) {
+		return [ getVariationName( variation ) ];
+	},
+	getOptionLabel( variation, query ) {
+		const match = computeSuggestionMatch( getVariationName( variation ), query ) || {};
+		return [
+			// @TODO: make VariationsImage, modify ProductImage, or leave as is?
+			<span
+				key="name"
+				className="woocommerce-search__result-name"
+				aria-label={ variation.description }
+			>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( variation ) {
+		return {
+			id: variation.id,
+			label: getVariationName( variation ),
+		};
+	},
+};

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { product, productCategory, coupons } from './autocompleters';
+import { product, productCategory, coupons, variations } from './autocompleters';
 import Tag from 'components/tag';
 import './style.scss';
 
@@ -73,6 +73,8 @@ class Search extends Component {
 				return productCategory;
 			case 'coupons':
 				return coupons;
+			case 'variations':
+				return variations;
 			default:
 				return {};
 		}
@@ -197,8 +199,14 @@ Search.propTypes = {
 	/**
 	 * The object type to be used in searching.
 	 */
-	type: PropTypes.oneOf( [ 'products', 'product_cats', 'orders', 'customers', 'coupons' ] )
-		.isRequired,
+	type: PropTypes.oneOf( [
+		'products',
+		'product_cats',
+		'orders',
+		'customers',
+		'coupons',
+		'variations',
+	] ).isRequired,
 	/**
 	 * A placeholder for the search input.
 	 */

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -14,12 +14,13 @@ import { getIdsFromQuery, stringifyQuery } from '@woocommerce/navigation';
  * Get a function that accepts ids as they are found in url parameter and
  * returns a promise with an optional method applied to results
  *
- * @param {string} path - api path
+ * @param {string|function} path - api path string or a function of the query returning api path string
  * @param {Function} [handleData] - function applied to each iteration of data
  * @returns {Function} - a function of ids returning a promise
  */
 export function getRequestByIdString( path, handleData = identity ) {
-	return function( queryString = '' ) {
+	return function( queryString = '', query ) {
+		const pathString = 'function' === typeof path ? path( query ) : path;
 		const idList = getIdsFromQuery( queryString );
 		if ( idList.length < 1 ) {
 			return Promise.resolve( [] );
@@ -28,6 +29,6 @@ export function getRequestByIdString( path, handleData = identity ) {
 			include: idList.join( ',' ),
 			per_page: idList.length,
 		} );
-		return apiFetch( { path: path + payload } ).then( data => data.map( handleData ) );
+		return apiFetch( { path: pathString + payload } ).then( data => data.map( handleData ) );
 	};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,7 +3293,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -4157,7 +4157,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -7058,7 +7058,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "requires": {
         "acorn": "^5.5.0",
@@ -7110,7 +7110,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -7861,14 +7861,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7883,20 +7881,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8013,8 +8008,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -8026,7 +8020,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8041,7 +8034,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8049,14 +8041,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8075,7 +8065,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8156,8 +8145,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8169,7 +8157,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8291,7 +8278,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -19584,7 +19570,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
         "cliui": "^4.0.0",


### PR DESCRIPTION
Create a Variations autocompleter for the `<Search />` component.

## Testing

1. Choose a product with variations, or add variations to a product
2. Go to the Products Report
3. Filter by Single Product and choose your product
4. Filter Variations by Comparison
5. Search/select variations of your product

## Variation names

Variations don't have labels, so this PR creates them by concatenating a variation's attribute `option`.

<img width="468" alt="screen shot 2018-11-02 at 10 55 47 am" src="https://user-images.githubusercontent.com/1922453/47932121-05dea600-de8e-11e8-8d7d-d6765552f662.png">

If the variation options aren't descriptive, it could read oddly. cc @LevinMedia if he has a better idea.

## `getRequestByIdString` function changed

Since variations require the product parameter to construct the API path, getRequestByIdString now also accepts a function of the query as its first parameter instead of just a string.


