### PR TITLE
Update summary number focus styles

### DIFF
--- a/client/components/summary/style.scss
+++ b/client/components/summary/style.scss
@@ -340,7 +340,7 @@ $inner-border: $core-grey-light-500;
 
 	&:focus {
 		// !important to override button styles
-		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black !important;
+		box-shadow: inset -1px -1px 0 $core-grey-dark-500, inset 1px 1px 0 $core-grey-dark-500 !important;
 	}
 
 	&.is-selected {
@@ -349,7 +349,8 @@ $inner-border: $core-grey-light-500;
 
 		&:focus {
 			// !important to override button styles
-			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce !important;
+			box-shadow: inset -1px -1px 0 $core-grey-dark-500, inset 1px 1px 0 $core-grey-dark-500,
+				inset 0 5px 0 $woocommerce !important;
 		}
 	}
 


### PR DESCRIPTION
Per a design review with @josemarques we've to decided to make the focus styles on the summary numbers less intense. The Weight has been reduced from 2px to 1px and the color from `$black` to `$core-grey-dark-500`

Additionally, when a summary number is selected, the highlight at the top of the container becomes 5px rather than 4px to offset the weight of the inset focus.

### Screenshots

**Before**

![screen recording 2018-10-31 at 11 19 am](https://user-images.githubusercontent.com/4500952/47811481-1adafe00-dd03-11e8-8928-590b24ebd253.gif)

**After**

![screen recording 2018-10-31 at 11 13 am](https://user-images.githubusercontent.com/4500952/47811508-2d553780-dd03-11e8-8990-bbe0b68cc161.gif)
