### PR TITLE
Run dbdelta on init, at least as long as this is a separate plugin

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -93,6 +93,16 @@ function deactivate_wc_admin_plugin() {
 register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'deactivate_wc_admin_plugin' );
 
 /**
+ * Update the database tables if needed. This hooked function does NOT need to
+ * be ported to WooCommerce's code base - WC_Install will do this on plugin
+ * update automatically.
+ */
+function wc_admin_init() {
+	WC_Admin_Api_Init::create_db_tables();
+}
+add_action( 'init', 'wc_admin_init' );
+
+/**
  * Set up the plugin, only if we can detect both Gutenberg and WooCommerce
  */
 function wc_admin_plugins_loaded() {

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -98,7 +98,10 @@ register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'deactivate_wc_admin_plugin' )
  * update automatically.
  */
 function wc_admin_init() {
-	WC_Admin_Api_Init::create_db_tables();
+	// Only create/update tables on init if WP_DEBUG is true.
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		WC_Admin_Api_Init::create_db_tables();
+	}
 }
 add_action( 'init', 'wc_admin_init' );
 


### PR DESCRIPTION
Fixes #531 

WooCommerce has a robust updater that we will be leveraging when this codebase becomes part of it. For now, let's run dbdelta on init.

### Screenshots

### Detailed test instructions:

 - Check out the master branch.
 - Modify the database schema in class-wc-admin-api-init.php in some way, e.g. change the name column in woocommerce_admin_note_actions from varchar(255) to varchar(200)
- Deactivate and activate the wc-admin plugin to get dbdelta to run
- Launch mysql and describe the woocommerce_admin_note_actions table. Make sure woocommerce_admin_note_actions is now varchar(200)
- Check out this branch
- Navigate to anywhere on the site
- Describe the woocommerce_admin_note_actions table again. Make sure the name column is back to  varchar(255)

```
mysql> use wordpress1;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> describe wca_woocommerce_admin_notes;
+---------------+---------------------+------+-----+---------------------+----------------+
| Field         | Type                | Null | Key | Default             | Extra          |
+---------------+---------------------+------+-----+---------------------+----------------+
| note_id       | bigint(20) unsigned | NO   | PRI | NULL                | auto_increment |
| name          | varchar(200)        | NO   |     | NULL                |                |
| type          | varchar(20)         | NO   |     | NULL                |                |
| locale        | varchar(20)         | NO   |     | NULL                |                |
| title         | longtext            | NO   |     | NULL                |                |
| content       | longtext            | NO   |     | NULL                |                |
| icon          | varchar(200)        | NO   |     | NULL                |                |
| content_data  | longtext            | YES  |     | NULL                |                |
| status        | varchar(200)        | NO   |     | NULL                |                |
| source        | varchar(200)        | NO   |     | NULL                |                |
| date_created  | datetime            | NO   |     | 0000-00-00 00:00:00 |                |
| date_reminder | datetime            | YES  |     | NULL                |                |
+---------------+---------------------+------+-----+---------------------+----------------+
12 rows in set (0.00 sec)

```