### PR TITLE
Add error message to Top Selling Products table

### DIFF
--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -14,7 +14,7 @@ import { getAdminLink } from 'lib/nav-utils';
 
 class ReportError extends Component {
 	render() {
-		const { isError, isEmpty } = this.props;
+		const { className, isError, isEmpty } = this.props;
 		let title, actionLabel, actionURL, actionCallback;
 
 		if ( isError ) {
@@ -31,6 +31,7 @@ class ReportError extends Component {
 		}
 		return (
 			<EmptyContent
+				className={ className }
 				title={ title }
 				actionLabel={ actionLabel }
 				actionURL={ actionURL }
@@ -41,8 +42,13 @@ class ReportError extends Component {
 }
 
 ReportError.propTypes = {
+	className: PropTypes.string,
 	isError: PropTypes.bool,
 	isEmpty: PropTypes.bool,
+};
+
+ReportError.defaultProps = {
+	className: '',
 };
 
 export default ReportError;

--- a/client/components/empty-content/index.js
+++ b/client/components/empty-content/index.js
@@ -88,9 +88,9 @@ class EmptyContent extends Component {
 	}
 
 	render() {
-		const { title, message, illustration } = this.props;
+		const { className, title, message, illustration } = this.props;
 		return (
-			<div className={ classnames( 'woocommerce-empty-content', this.props.className ) }>
+			<div className={ classnames( 'woocommerce-empty-content', className ) }>
 				{ illustration && this.renderIllustration() }
 				{ title ? <H className="woocommerce-empty-content__title">{ title }</H> : null }
 				{ message ? <p className="woocommerce-empty-content__message">{ message }</p> : null }

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -92,7 +92,7 @@ export class TopSellingProducts extends Component {
 		const title = __( 'Top Selling Products', 'wc-admin' );
 
 		if ( isError ) {
-			return <ReportError isError />;
+			return <ReportError className="woocommerce-top-selling-products" isError />;
 		}
 
 		if ( ! isRequesting && rows.length === 0 ) {

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -19,6 +19,7 @@ import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency'
  */
 import { getAdminLink } from 'lib/nav-utils';
 import { numberFormat } from 'lib/number';
+import ReportError from 'analytics/components/report-error';
 import { NAMESPACE } from 'store/constants';
 import './style.scss';
 
@@ -91,7 +92,7 @@ export class TopSellingProducts extends Component {
 		const title = __( 'Top Selling Products', 'wc-admin' );
 
 		if ( isError ) {
-			// @TODO An error notice should be displayed when there is an error
+			return <ReportError isError />;
 		}
 
 		if ( ! isRequesting && rows.length === 0 ) {

--- a/client/dashboard/top-selling-products/style.scss
+++ b/client/dashboard/top-selling-products/style.scss
@@ -1,5 +1,9 @@
 /** @format */
 .woocommerce-top-selling-products {
+	&.woocommerce-empty-content {
+		margin-bottom: $gap-large;
+	}
+
 	.woocommerce-card__body {
 		padding: 0;
 	}


### PR DESCRIPTION
Fixes #414.

Adds an error message when there was an error retrieving the data for the Top Selling Products table.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/47851973-8b088300-ddda-11e8-9d28-2442a4a4511e.png)

### Detailed test instructions:
- Force the Top Selling Products table to display the error UI modifying [this line](https://github.com/woocommerce/wc-admin/pull/750/files#diff-f083c8ddf4f7c61e09bba4a0108c1569L93):
```ES6
if ( isError ) {
```
to:
```ES6
if ( true || isError ) {
```
- Go to the Dashboard page `/wp-admin/admin.php?page=wc-admin#/` and verify an error component is shown.