### PR TITLE
IE11: Fix table header actions layout

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -26,6 +26,24 @@
 			display: grid;
 			width: 100%;
 			grid-template-columns: auto 1fr auto;
+
+			.woocommerce-table__compare {
+				align-self: center;
+				grid-column-start: 1;
+				grid-column-end: 2;
+			}
+
+			.woocommerce-search {
+				align-self: center;
+				grid-column-start: 2;
+				grid-column-end: 3;
+			}
+
+			.woocommerce-table__download-button {
+				align-self: center;
+				grid-column-start: 3;
+				grid-column-end: 4;
+			}
 		}
 
 		@include breakpoint( '<1100px' ) {


### PR DESCRIPTION
Part of #243.

Table header actions layout was broken in IE11. This PR should improve it.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/47859775-54893300-ddef-11e8-9c47-549b9e2edd17.png)

After:
![image](https://user-images.githubusercontent.com/3616980/47859601-f5c3b980-ddee-11e8-8c58-34f81dfd935f.png)

### Detailed test instructions:
- Go to _Products_ report (`/wp-admin/admin.php?page=wc-admin#/analytics/products`) with IE11.
- Verify the table header is well formatted.
