### PR TITLE
Persist time queries when clicking on breadcrumbs links

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -16,6 +16,7 @@ import ReactDom from 'react-dom';
 import './style.scss';
 import ActivityPanel from './activity-panel';
 import { Link } from '@woocommerce/components';
+import { getNewPath, getTimeRelatedQuery } from 'lib/nav-utils';
 
 class Header extends Component {
 	constructor() {
@@ -84,7 +85,10 @@ class Header extends Component {
 					</span>
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = Array.isArray( section ) ? (
-							<Link href={ section[ 0 ] } type={ isEmbedded ? 'wp-admin' : 'wc-admin' }>
+							<Link
+								href={ getNewPath( getTimeRelatedQuery(), section[ 0 ], {} ) }
+								type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
+							>
 								{ section[ 1 ] }
 							</Link>
 						) : (

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -7,6 +7,11 @@ import { parse, stringify } from 'qs';
 import { isEmpty, pick, uniq } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import * as navUtils from './index';
+
+/**
  * Returns a string with the site's wp-admin URL appended. JS version of `admin_url`.
  *
  * @param {String} path Relative path.
@@ -35,7 +40,7 @@ export const stringifyQuery = query => ( isEmpty( query ) ? '' : '?' + stringify
  * @param {Object} query Query containing the parameters.
  * @return {Object} Object containing the time related queries.
  */
-export const getTimeRelatedQuery = ( query = getQuery() ) =>
+export const getTimeRelatedQuery = ( query = navUtils.getQuery() ) =>
 	pick( query, [ 'period', 'compare', 'before', 'after' ] );
 
 /**

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -9,6 +9,7 @@ import { isEmpty, pick, uniq } from 'lodash';
 /**
  * Internal dependencies
  */
+// Import the module into itself. Functions consumed from this import can be mocked in tests.
 import * as navUtils from './index';
 
 /**

--- a/client/lib/nav-utils/index.js
+++ b/client/lib/nav-utils/index.js
@@ -35,7 +35,7 @@ export const stringifyQuery = query => ( isEmpty( query ) ? '' : '?' + stringify
  * @param {Object} query Query containing the parameters.
  * @return {Object} Object containing the time related queries.
  */
-export const getTimeRelatedQuery = query =>
+export const getTimeRelatedQuery = ( query = getQuery() ) =>
 	pick( query, [ 'period', 'compare', 'before', 'after' ] );
 
 /**

--- a/client/lib/nav-utils/test/index.js
+++ b/client/lib/nav-utils/test/index.js
@@ -4,6 +4,18 @@
  */
 import { getTimeRelatedQuery } from '../index';
 
+jest.mock( '../index', () => ( {
+	...require.requireActual( '../index' ),
+	getQuery: jest.fn().mockReturnValue( {
+		filter: 'advanced',
+		product_includes: 127,
+		period: 'year',
+		compare: 'previous_year',
+		after: '2018-02-01',
+		before: '2018-01-01',
+	} ),
+} ) );
+
 describe( 'getTimeRelatedQuery', () => {
 	it( "should return an empty object it the query doesn't contain any time related parameters", () => {
 		const query = {
@@ -32,5 +44,16 @@ describe( 'getTimeRelatedQuery', () => {
 		};
 
 		expect( getTimeRelatedQuery( query ) ).toEqual( timeRelatedQuery );
+	} );
+
+	it( 'should get the query from getQuery() when none is provided in the params', () => {
+		const timeRelatedQuery = {
+			period: 'year',
+			compare: 'previous_year',
+			after: '2018-02-01',
+			before: '2018-01-01',
+		};
+
+		expect( getTimeRelatedQuery() ).toEqual( timeRelatedQuery );
 	} );
 } );


### PR DESCRIPTION
Fixes #718.

### Screenshots
_(this PR shouldn't have produced any visible change)_
![imatge](https://user-images.githubusercontent.com/3616980/47649775-8f386480-db7e-11e8-826b-aab2902c1b29.png)

### Detailed test instructions:
- Go to `/wp-admin/admin.php?page=wc-admin#/analytics/products` and change the time period.
- Click on _Analytics_ in the breadcrumbs of the top bar.
- Verify the time period is still the same.
