### PR TITLE
Do not attempt to run table setup without dependency check first

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -98,6 +98,10 @@ register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'deactivate_wc_admin_plugin' )
  * update automatically.
  */
 function wc_admin_init() {
+	if ( ! dependencies_satisfied() ) {
+		return;
+	}
+
 	// Only create/update tables on init if WP_DEBUG is true.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		WC_Admin_Api_Init::create_db_tables();


### PR DESCRIPTION
Fixes #771 

We should run the dependency check in the init hook since it is possible that the plugin is in the process of activating, but will fail to complete activation due to a missing dependency (and then when we attempt to use the api init class, it is not present, and then boom.)

### Screenshots

### Detailed test instructions:

 - Install this branch on a site with the Gutenberg plugin deactivated
 - Activate this plugin
 - Make sure activation does not result in a Fatal Error
