### PR TITLE
Allow WC-Admin to activate on WP 5 without Gutenberg plugin active

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 
+### WordPress 5
+
+There is an unresolved bug ( https://github.com/woocommerce/wc-admin/issues/796 ) that prevents us from running with minified script. Until this is resolved, include `define( 'SCRIPT_DEBUG', true );` in your wp-config.
+
 ## Development
 
 After cloning the repo, install dependencies with `npm install`. Now you can build the files using one of these commands:

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -78,8 +78,12 @@ function wc_admin_register_script() {
 	);
 
 	// Set up the text domain and translations.
-	$locale_data = gutenberg_get_jed_locale_data( 'wc-admin' );
-	$content     = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "wc-admin" );';
+	if ( function_exists( 'wp_get_jed_locale_data' ) ) {
+		$locale_data = wp_get_jed_locale_data( 'wc-admin' );
+	} else {
+		$locale_data = gutenberg_get_jed_locale_data( 'wc-admin' );
+	}
+	$content = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "wc-admin" );';
 	wp_add_inline_script( 'wp-i18n', $content, 'after' );
 
 	// Resets lodash to wp-admin's version of lodash.

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -43,7 +43,7 @@ function wc_admin_plugins_notice() {
  * @return bool
  */
 function dependencies_satisfied() {
-	$woocommerce_minimum_met      = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
+	$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
 	if ( ! $woocommerce_minimum_met ) {
 		return false;
 	}

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -43,8 +43,16 @@ function wc_admin_plugins_notice() {
  * @return bool
  */
 function dependencies_satisfied() {
-	return ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' ) )
-			&& class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
+	$woocommerce_minimum_met      = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
+	if ( ! $woocommerce_minimum_met ) {
+		return false;
+	}
+
+	$wordpress_version            = get_bloginfo( 'version' );
+	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
+	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
+
+	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
 }
 
 /**

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -28,12 +28,25 @@ if ( ! defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {
  * Notify users of the plugin requirements
  */
 function wc_admin_plugins_notice() {
-	$message = sprintf(
-		/* translators: 1: URL of Gutenberg plugin, 2: URL of WooCommerce plugin */
-		__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">Gutenberg</a> and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
-		'https://wordpress.org/plugins/gutenberg/',
-		'https://wordpress.org/plugins/woocommerce/'
-	);
+	// The notice varies by WordPress version.
+	$wordpress_version            = get_bloginfo( 'version' );
+	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
+
+	if ( $wordpress_includes_gutenberg ) {
+		$message = sprintf(
+			// TODO: Remove the "and SCRIPT_DEBUG enabled" when https://github.com/woocommerce/wc-admin/issues/796 is fixed.
+			/* translators: URL of WooCommerce plugin */
+			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active and SCRIPT_DEBUG enabled.', 'wc-admin' ),
+			'https://wordpress.org/plugins/woocommerce/'
+		);
+	} else {
+		$message = sprintf(
+			/* translators: 1: URL of Gutenberg plugin, 2: URL of WooCommerce plugin */
+			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">Gutenberg</a> and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
+			'https://wordpress.org/plugins/gutenberg/',
+			'https://wordpress.org/plugins/woocommerce/'
+		);
+	}
 	printf( '<div class="error"><p>%s</p></div>', $message ); /* WPCS: xss ok. */
 }
 
@@ -52,7 +65,11 @@ function dependencies_satisfied() {
 	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
 	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
 
-	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
+	// Right now, there is a bug preventing us from running with WP5 with minified script.
+	// See https://github.com/woocommerce/wc-admin/issues/796 for details.
+	$script_debug_enabled = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+
+	return ( $script_debug_enabled && $wordpress_includes_gutenberg ) || $gutenberg_plugin_active;
 }
 
 /**


### PR DESCRIPTION
Fixes #772 

- Don't rely on GUTENBERG_DEVELOPMENT_MODE or GUTENBERG_VERSION - since those are not present in WordPress 5.
- Don't call `gutenberg_get_jed_locale_data` on WordPress 5 - use `wp_get_jed_locale_data` instead (see https://github.com/WordPress/gutenberg-examples/pull/51 )

### Detailed test instructions:

- Install on WordPress 5
- Make sure you have `define('SCRIPT_DEBUG', true);` - there is a separate issue with the minified scripts on 5.0 that is causing a problem ( #796 )
- Do NOT have the Gutenberg plugin active
- Make sure you can activate this (the WC-Admin) plugin 1) without a fatal error and 2) that the wp-admin > WooCommerce > Dashboard loads properly (including no console errors)

- Install on WordPress 4.9.8
- Do NOT have the Gutenberg plugin active
- Make sure that you cannot activate this (the WC-Admin) plugin
- Install and activate the Gutenberg plugin
- Make sure you can activate this plugin 1) without a fatal error and 2) that the wp-admin > WooCommerce > Dashboard loads properly (including no console errors)
