### PR TITLE
i18n: Inject translations when the i18n lib is included

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -71,7 +71,7 @@ function wc_admin_register_script() {
 	// Set up the text domain and translations.
 	$locale_data = gutenberg_get_jed_locale_data( 'wc-admin' );
 	$content     = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "wc-admin" );';
-	wp_add_inline_script( 'wc-components', $content, 'before' );
+	wp_add_inline_script( 'wp-i18n', $content, 'after' );
 
 	// Resets lodash to wp-admin's version of lodash.
 	wp_add_inline_script(


### PR DESCRIPTION
Fixes #775 – wc-date uses i18n, but the locale isn't loaded until wc-components is enqueued. Now we set up the locale after including `wp-i18n`, to ensure our locale is always there.

**To test**

- Load up any wc-admin page
- There should not be any console error about jed/ domain `wc-admin`.