### PR TITLE
Component - chart: more than 9 weeks of ticks change xFormat to months & x2Format to yrs

### DIFF
--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -374,6 +374,14 @@ export const compareStrings = ( s1, s2, splitChar = ' ' ) => {
 
 export const drawAxis = ( node, params ) => {
 	const xScale = params.type === 'line' ? params.xLineScale : params.xScale;
+	const removeDuplicateDates = ( d, i, ticks, formatter ) => {
+		const monthDate = d instanceof Date ? d : new Date( d );
+		let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
+		prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
+		return i === 0
+			? formatter( monthDate )
+			: compareStrings( formatter( prevMonth ), formatter( monthDate ) ).join( ' ' );
+	};
 
 	const yGrids = [];
 	for ( let i = 0; i < 4; i++ ) {
@@ -390,7 +398,7 @@ export const drawAxis = ( node, params ) => {
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
-				.tickFormat( d => params.xFormat( d instanceof Date ? d : new Date( d ) ) )
+				.tickFormat( ( d, i ) => removeDuplicateDates( d, i, ticks, params.xFormat ) )
 		);
 
 	node
@@ -401,16 +409,7 @@ export const drawAxis = ( node, params ) => {
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
-				.tickFormat( ( d, i ) => {
-					const monthDate = d instanceof Date ? d : new Date( d );
-					let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
-					prevMonth = prevMonth instanceof Date ? prevMonth : new Date( prevMonth );
-					return i === 0
-						? params.x2Format( monthDate )
-						: compareStrings( params.x2Format( prevMonth ), params.x2Format( monthDate ) ).join(
-								' '
-							);
-				} )
+				.tickFormat( ( d, i ) => removeDuplicateDates( d, i, ticks, params.x2Format ) )
 		)
 		.call( g => g.select( '.domain' ).remove() );
 

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -19,7 +19,7 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * WooCommerce dependencies
  */
-import { dayTicksThreshold } from '@woocommerce/date';
+import { dayTicksThreshold, weekTicksThreshold } from '@woocommerce/date';
 import { formatCurrency } from '@woocommerce/currency';
 
 /**
@@ -303,7 +303,10 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 export const getXTicks = ( uniqueDates, width, layout, interval ) => {
 	const maxTicks = calculateMaxXTicks( width, layout );
 
-	if ( uniqueDates.length >= dayTicksThreshold && interval === 'day' ) {
+	if (
+		( uniqueDates.length >= dayTicksThreshold && interval === 'day' ) ||
+		( uniqueDates.length >= weekTicksThreshold && interval === 'week' )
+	) {
 		uniqueDates = getFirstDatePerMonth( uniqueDates );
 	}
 	if ( uniqueDates.length <= maxTicks ) {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -412,7 +412,7 @@ export function getIntervalForQuery( query ) {
 }
 
 export const dayTicksThreshold = 63;
-export const weekTicksThreshold = 7;
+export const weekTicksThreshold = 9;
 
 /**
  * Returns date formats for the current interval.
@@ -445,8 +445,13 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 			}
 			break;
 		case 'week':
-			xFormat = '%d';
-			x2Format = '%b %Y';
+			if ( ticks < weekTicksThreshold ) {
+				xFormat = '%d';
+				x2Format = '%b %Y';
+			} else {
+				xFormat = '%b';
+				x2Format = '%Y';
+			}
 			tooltipFormat = __( 'Week of %B %d %Y', 'wc-admin' );
 			break;
 		case 'quarter':


### PR DESCRIPTION
Fixes #632 

Continuation of the work done in #685 and @LevinMedia 's feedback here: https://github.com/woocommerce/wc-admin/pull/685#issuecomment-434059061 We've changed the `xFormat` to months and the `x2Format` to years when there are more than 9 weeks (63 days) of x1 ticks.

### Screenshots
ticks > 9 weeks (63 days)
![screenshot 2018-11-06 16 01 23](https://user-images.githubusercontent.com/1160732/48069306-ce4d6200-e1dd-11e8-86f1-5bcece578f18.png)

ticks < 9 weeks (63 days)
![screenshot 2018-11-06 16 14 50](https://user-images.githubusercontent.com/1160732/48069833-1faa2100-e1df-11e8-96d0-e30750fa5858.png)


### Detailed test instructions:

 - Go to Analytics >> Revenue
 - Select 'Last Quarter' compared to 'Previous Quarter'
 - Change the chart interval to 'By Week'
 - Ensure months are shown in the x1 axis and years in the x2 axis and that there aren't duplicates in the x1 axis 
