### PR TITLE
Activity Panel: Inbox: Avoid Notice on Updating a Note: Convert WC_DateTime to timestamps

### DIFF
--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -104,21 +104,33 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		global $wpdb;
 
 		if ( $note->get_id() ) {
+			$date_created = $note->get_date_created();
+			if ( $date_created instanceof WC_DateTime ) {
+				$date_created = gmdate( 'Y-m-d H:i:s', $date_created->getTimestamp() );
+			}
+
+			$date_reminder = $note->get_date_reminder();
+			if ( $date_reminder instanceof WC_DateTime ) {
+				$date_reminder = gmdate( 'Y-m-d H:i:s', $date_reminder->getTimestamp() );
+			}
+
+			$note_columns = array(
+				'name'          => $note->get_name(),
+				'type'          => $note->get_type(),
+				'locale'        => $note->get_locale(),
+				'title'         => $note->get_title(),
+				'content'       => $note->get_content(),
+				'icon'          => $note->get_icon(),
+				'content_data'  => wp_json_encode( $note->get_content_data() ),
+				'status'        => $note->get_status(),
+				'source'        => $note->get_source(),
+				'date_created'  => $date_created,
+				'date_reminder' => $date_reminder,
+			);
+
 			$wpdb->update(
 				$wpdb->prefix . 'woocommerce_admin_notes',
-				array(
-					'name'          => $note->get_name(),
-					'type'          => $note->get_type(),
-					'locale'        => $note->get_locale(),
-					'title'         => $note->get_title(),
-					'content'       => $note->get_content(),
-					'icon'          => $note->get_icon(),
-					'content_data'  => wp_json_encode( $note->get_content_data() ),
-					'status'        => $note->get_status(),
-					'source'        => $note->get_source(),
-					'date_created'  => $note->get_date_created(),
-					'date_reminder' => $note->get_date_reminder(),
-				),
+				$note_columns,
 				array( 'note_id' => $note->get_id() )
 			);
 		}


### PR DESCRIPTION
Fixes #786 

I swear I already fixed this when I saw it during development, but apparently I didn't :)

### Screenshots

### Detailed test instructions:

 - WP_DEBUG true
 - Install and activate the second activity panel example
 - Make sure you do NOT see any notice in your PHP log, and that mysql shows the note content updating on refreshing any wp-admin page, e.g.

```
mysql> select * from wcz_woocommerce_admin_notes;
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
| note_id | name                    | type | locale | title                    | content                          | icon | content_data            | status     | source                  | date_created        | date_reminder |
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
|       2 | wapi-example-plugin-two | info | en_US  | Domain Renewal Coming Up | Your domain expires in 254 days. | info | {"expires_in_days":254} | unactioned | wapi-example-plugin-two | 2018-11-06 21:52:07 | NULL          |
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
1 row in set (0.00 sec)

mysql> select * from wcz_woocommerce_admin_notes;
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
| note_id | name                    | type | locale | title                    | content                          | icon | content_data            | status     | source                  | date_created        | date_reminder |
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
|       2 | wapi-example-plugin-two | info | en_US  | Domain Renewal Coming Up | Your domain expires in 265 days. | info | {"expires_in_days":265} | unactioned | wapi-example-plugin-two | 2018-11-06 21:52:07 | NULL          |
+---------+-------------------------+------+--------+--------------------------+----------------------------------+------+-------------------------+------------+-------------------------+---------------------+---------------+
1 row in set (0.00 sec)
```

