### PR TITLE
Get wp-polyfill-ecmascript to load earlier

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -34,9 +34,8 @@ function wc_admin_plugins_notice() {
 
 	if ( $wordpress_includes_gutenberg ) {
 		$message = sprintf(
-			// TODO: Remove the "and SCRIPT_DEBUG enabled" when https://github.com/woocommerce/wc-admin/issues/796 is fixed.
 			/* translators: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active and SCRIPT_DEBUG enabled.', 'wc-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
 			'https://wordpress.org/plugins/woocommerce/'
 		);
 	} else {
@@ -65,11 +64,7 @@ function dependencies_satisfied() {
 	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
 	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
 
-	// Right now, there is a bug preventing us from running with WP5 with minified script.
-	// See https://github.com/woocommerce/wc-admin/issues/796 for details.
-	$script_debug_enabled = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-
-	return ( $script_debug_enabled && $wordpress_includes_gutenberg ) || $gutenberg_plugin_active;
+	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
 }
 
 /**


### PR DESCRIPTION
Fixes #796

Work in progress.

Borrows an approach from https://github.com/WordPress/gutenberg/pull/9794/files#diff-620130744b6b73b822a3df609671d930R102 to get the ecmascript polyfill to load apart from loadscripts

### Detailed test instructions:

WP 5
- Install on WP 5
- Do NOT have SCRIPTS_DEBUG enabled
- Do NOT have Gutenberg installed nor active
- Make sure you can load the wp-admin > WooCommerce > Dashboard without a `regeneratorRuntime is not defined` error
- Repeat with SCRIPTS_DEBUG enabled

WP 4.9.x
- Install on WP 4.9.x
- Repeat with WP4 and Gutenberg active
- Repeat with SCRIPTS_DEBUG disabled

Note: Also cleans up a few PHPCS goodies in the affected files.