### PR TITLE
Remove the SCRIPT_DEBUG:true requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 
-### WordPress 5
-
-There is an unresolved bug ( https://github.com/woocommerce/wc-admin/issues/796 ) that prevents us from running with minified script. Until this is resolved, include `define( 'SCRIPT_DEBUG', true );` in your wp-config.
-
 ## Development
 
 After cloning the repo, install dependencies with `npm install`. Now you can build the files using one of these commands:

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -34,9 +34,8 @@ function wc_admin_plugins_notice() {
 
 	if ( $wordpress_includes_gutenberg ) {
 		$message = sprintf(
-			// TODO: Remove the "and SCRIPT_DEBUG enabled" when https://github.com/woocommerce/wc-admin/issues/796 is fixed.
 			/* translators: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active and SCRIPT_DEBUG enabled.', 'wc-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
 			'https://wordpress.org/plugins/woocommerce/'
 		);
 	} else {
@@ -65,11 +64,7 @@ function dependencies_satisfied() {
 	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
 	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
 
-	// Right now, there is a bug preventing us from running with WP5 with minified script.
-	// See https://github.com/woocommerce/wc-admin/issues/796 for details.
-	$script_debug_enabled = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-
-	return ( $script_debug_enabled && $wordpress_includes_gutenberg ) || $gutenberg_plugin_active;
+	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
 }
 
 /**


### PR DESCRIPTION
Fixes #796 

As of WP 5.0-beta3-43878 SCRIPT_DEBUG is no longer required to avoid the regeneratorRuntime Javascript asplosion.

### Detailed test instructions:

- Make sure SCRIPT_DEBUG is not true/defined
- Deactivate and activate this plugin, and ensure you are able to do so.
- Deactivate WooCommerce itself and ensure the alert doesn't mention SCRIPT_DEBUG anymore
- Make sure the README no longer mentions SCRIPT_DEBUG as a WP 5 requirement
