### PR TITLE
Update table gradient code to be more similar to chart legend gradient code

### DIFF
--- a/client/components/table/style.scss
+++ b/client/components/table/style.scss
@@ -144,11 +144,13 @@
 		width: 41px;
 		height: 100%;
 		background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
-		visibility: hidden;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.3s;
 	}
 
 	&.is-scrollable::after {
-		visibility: visible;
+		opacity: 1;
 	}
 
 	table {

--- a/client/components/table/table.js
+++ b/client/components/table/table.js
@@ -95,7 +95,7 @@ class Table extends Component {
 		const table = this.container.current;
 		const scrolledToEnd = table.scrollWidth - table.scrollLeft <= table.offsetWidth;
 		this.setState( {
-			isScrollable: scrolledToEnd ? false : true,
+			isScrollable: ! scrolledToEnd,
 		} );
 	};
 
@@ -110,9 +110,9 @@ class Table extends Component {
 			rowHeader,
 			rows,
 		} = this.props;
-		const { tabIndex } = this.state;
+		const { isScrollable, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
-			'is-scrollable': this.state.isScrollable,
+			'is-scrollable': isScrollable,
 		} );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
 		const sortDir = query.order || DESC;


### PR DESCRIPTION
While working on #816 I added a gradient at the bottom of the chart legend to make it clear it's scrollable and I based my code on the same gradient we have in the tables. But made a couple of small code improvements that I'm backporting now to the table gradient code.

### Screenshots
_(this PR shouldn't have created any visual change other than adding a transition)_
![image](https://user-images.githubusercontent.com/3616980/48349693-95344800-e64a-11e8-9d16-ab33b77376fb.png)


### Detailed test instructions:
- Go to a page with a table (eg: `/wp-admin/admin.php?page=wc-admin#/analytics/revenue`).
- Resize the viewport so the gradient appears.
- Make sure there are no regressions and it's still displayed as usual and hidden when you reach the end of the table.