### PR TITLE
Remove unneeded leading whitespace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ _Replace this with a good description of your changes & reasoning._
 
 ### Detailed test instructions:
 
- - Ex: Open page `url`
- - Click XYZ…
+- Ex: Open page `url`
+- Click XYZ…


### PR DESCRIPTION
This has made it difficult to quick create test instructions since I have to add a leading space before every step.

### Detailed test instructions:

 - No testing needed