### PR TITLE
Add/product detail link

### DIFF
--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -115,7 +115,7 @@ const variationsConfig = {
 		{ label: __( 'All Variations', 'wc-admin' ), value: 'all' },
 		{
 			label: __( 'Comparison', 'wc-admin' ),
-			value: 'compare',
+			value: 'compare-variations',
 			settings: {
 				type: 'variations',
 				param: 'variations',

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -99,11 +99,18 @@ class ProductsReportTable extends Component {
 				filter: 'advanced',
 				product_includes: product_id,
 			} );
+			const productDetailLink = getNewPath( timeRelatedQuery, 'products', {
+				filter: 'single_product',
+				products: product_id,
+			} );
 
 			return [
 				{
-					// @TODO Must link to the product detail report.
-					display: name,
+					display: (
+						<Link href={ productDetailLink } type="wc-admin">
+							{ name }
+						</Link>
+					),
 					value: name,
 				},
 				{

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -51,6 +51,20 @@ class FilterPicker extends Component {
 		}
 	}
 
+	componentDidUpdate( { query: prevQuery } ) {
+		const { query: nextQuery, config } = this.props;
+		if ( prevQuery[ config.param ] !== nextQuery[ [ config.param ] ] ) {
+			const selectedFilter = this.getFilter();
+			if ( selectedFilter && 'Search' === selectedFilter.component ) {
+				/* eslint-disable react/no-did-update-set-state */
+				this.setState( { nav: selectedFilter.path || [] } );
+				/* eslint-enable react/no-did-update-set-state */
+				const { param: filterParam, getLabels } = selectedFilter.settings;
+				getLabels( nextQuery[ filterParam ], nextQuery ).then( this.updateSelectedTag );
+			}
+		}
+	}
+
 	updateSelectedTag( tags ) {
 		this.setState( { selectedTag: tags[ 0 ] } );
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/813

Item titles in the Product Reports table need to link to the relevant Product Detail page.

![screen shot 2018-11-13 at 2 09 19 pm](https://user-images.githubusercontent.com/1922453/48384125-c2b5ea00-e74d-11e8-82d9-13783eed9e39.png)

## Test

1. `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2. Scroll to the Products Table and see item titles linked.
3. Click on a title and see the filters update to "Single Product" with the correct product populated.
