### PR TITLE
Fix some PHP notices when accessing WC Settings screen

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -66,10 +66,11 @@ function wc_admin_get_embed_breadcrumbs() {
 		'wc-status'   => 'status',
 	);
 	$tab             = '';
-	$get_tab         = isset( $_GET['tab'] ) && sanitize_text_field( wp_unslash( $_GET['tab'] ) );
+	$get_tab         = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
 	if ( isset( $_GET['page'] ) ) {
-		if ( in_array( wp_unslash( $_GET['page'] ), array_keys( $pages_with_tabs ) ) ) {
-			$tab = ! empty( $get_tab ) ? $get_tab . '-' : $pages_with_tabs[ $get_page ] . '-';
+		$page = wp_unslash( $_GET['page'] );
+		if ( in_array( $page, array_keys( $pages_with_tabs ) ) ) {
+			$tab = ! empty( $get_tab ) ? $get_tab . '-' : $pages_with_tabs[ $page ] . '-';
 		}
 	}
 

--- a/lib/common.php
+++ b/lib/common.php
@@ -68,7 +68,7 @@ function wc_admin_get_embed_breadcrumbs() {
 	$tab             = '';
 	$get_tab         = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
 	if ( isset( $_GET['page'] ) ) {
-		$page = wp_unslash( $_GET['page'] );
+		$page = sanitize_text_field( wp_unslash( $_GET['page'] ) );
 		if ( in_array( $page, array_keys( $pages_with_tabs ) ) ) {
 			$tab = ! empty( $get_tab ) ? $get_tab . '-' : $pages_with_tabs[ $page ] . '-';
 		}


### PR DESCRIPTION
Latest master produces some PHP notices when accessing the Settings screen.

### Screenshots

<img width="1197" alt="screen shot 2018-11-13 at 09 55 07" src="https://user-images.githubusercontent.com/1620929/48401779-4231c200-e72a-11e8-8b59-b7346bf9c185.png">

### Detailed test instructions:

- Open WC Settings page
