### PR TITLE
Update chart breakpoints

### DIFF
--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -118,7 +118,6 @@ class D3Chart extends Component {
 		const { width } = this.state;
 		const calculatedWidth = width || node.offsetWidth;
 		const calculatedHeight = height || node.offsetHeight;
-		const scale = width / node.offsetWidth;
 		const adjHeight = calculatedHeight - margin.top - margin.bottom;
 		const adjWidth = calculatedWidth - margin.left - margin.right;
 		const uniqueKeys = getUniqueKeys( data );
@@ -142,7 +141,6 @@ class D3Chart extends Component {
 			orderedKeys: newOrderedKeys,
 			pointLabelFormat,
 			parseDate,
-			scale,
 			smallChart,
 			tooltipFormat: d3TimeFormat( tooltipFormat ),
 			tooltipTitle,
@@ -158,7 +156,7 @@ class D3Chart extends Component {
 			xScale,
 			yMax,
 			yScale,
-			yTickOffset: getYTickOffset( adjHeight, scale, yMax ),
+			yTickOffset: getYTickOffset( adjHeight, yMax ),
 			yFormat,
 			valueType,
 		};

--- a/client/components/chart/charts.js
+++ b/client/components/chart/charts.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { timeFormat as d3TimeFormat, utcParse as d3UTCParse } from 'd3-time-format';
 import { select as d3Select } from 'd3-selection';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -105,6 +106,7 @@ class D3Chart extends Component {
 			mode,
 			orderedKeys,
 			pointLabelFormat,
+			smallChart,
 			tooltipFormat,
 			tooltipTitle,
 			type,
@@ -141,6 +143,7 @@ class D3Chart extends Component {
 			pointLabelFormat,
 			parseDate,
 			scale,
+			smallChart,
 			tooltipFormat: d3TimeFormat( tooltipFormat ),
 			tooltipTitle,
 			type,
@@ -287,4 +290,6 @@ D3Chart.defaultProps = {
 	yFormat: '.3s',
 };
 
-export default D3Chart;
+export default withViewportMatch( {
+	smallChart: '< large',
+} )( D3Chart );

--- a/client/components/chart/d3-base/index.js
+++ b/client/components/chart/d3-base/index.js
@@ -32,7 +32,6 @@ export default class D3Base extends Component {
 		drawChart: PropTypes.func.isRequired,
 		getParams: PropTypes.func.isRequired,
 		type: PropTypes.string,
-		width: PropTypes.number,
 	};
 
 	state = {
@@ -41,7 +40,6 @@ export default class D3Base extends Component {
 		drawChart: null,
 		getParams: null,
 		type: null,
-		width: null,
 	};
 
 	chartRef = createRef();
@@ -59,10 +57,6 @@ export default class D3Base extends Component {
 
 		if ( ! isEqual( nextProps.getParams, prevState.getParams ) ) {
 			state = { ...state, getParams: nextProps.getParams };
-		}
-
-		if ( nextProps.width !== prevState.width ) {
-			state = { ...state, width: nextProps.width };
 		}
 
 		if ( nextProps.type !== prevState.type ) {
@@ -86,7 +80,6 @@ export default class D3Base extends Component {
 		return (
 			( nextState.params !== null && ! isEqual( this.state.params, nextState.params ) ) ||
 			! isEqual( this.state.data, nextState.data ) ||
-			this.state.width !== nextState.width ||
 			this.state.type !== nextState.type
 		);
 	}
@@ -129,6 +122,8 @@ export default class D3Base extends Component {
 		const svg = d3Select( this.chartRef.current )
 			.append( 'svg' )
 			.attr( 'viewBox', `0 0 ${ width } ${ height }` )
+			.attr( 'height', height )
+			.attr( 'width', width )
 			.attr( 'preserveAspectRatio', 'xMidYMid meet' );
 
 		if ( className ) {

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -23,7 +23,6 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import D3Chart from './charts';
-import { gap, gaplarge } from 'stylesheets/abstracts/_variables.scss';
 import { H, Section } from 'components/section';
 import Legend from './legend';
 
@@ -60,16 +59,13 @@ function getOrderedKeys( props ) {
 class Chart extends Component {
 	constructor( props ) {
 		super( props );
-		this.chartRef = createRef();
-		const wpBody = document.getElementById( 'wpbody' ).getBoundingClientRect().width;
-		const wpWrap = document.getElementById( 'wpwrap' ).getBoundingClientRect().width;
-		const calcGap = wpWrap > 782 ? gaplarge.match( /\d+/ )[ 0 ] : gap.match( /\d+/ )[ 0 ];
+		this.chartBodyRef = createRef();
 		this.state = {
 			data: props.data,
 			orderedKeys: getOrderedKeys( props ),
 			type: props.type,
 			visibleData: [ ...props.data ],
-			width: wpBody - 2 * calcGap,
+			width: 0,
 		};
 		this.handleTypeToggle = this.handleTypeToggle.bind( this );
 		this.handleLegendToggle = this.handleLegendToggle.bind( this );
@@ -93,6 +89,7 @@ class Chart extends Component {
 	}
 
 	componentDidMount() {
+		this.updateDimensions();
 		window.addEventListener( 'resize', this.updateDimensions );
 	}
 
@@ -140,7 +137,7 @@ class Chart extends Component {
 
 	updateDimensions() {
 		this.setState( {
-			width: this.chartRef.current.offsetWidth,
+			width: this.chartBodyRef.current.offsetWidth,
 		} );
 	}
 
@@ -253,7 +250,7 @@ class Chart extends Component {
 				break;
 		}
 		return (
-			<div className="woocommerce-chart" ref={ this.chartRef }>
+			<div className="woocommerce-chart">
 				<div className="woocommerce-chart__header">
 					<H className="woocommerce-chart__title">{ title }</H>
 					{ isViewportWide && legendDirection === 'row' && legend }
@@ -293,27 +290,30 @@ class Chart extends Component {
 							'woocommerce-chart__body',
 							`woocommerce-chart__body-${ chartDirection }`
 						) }
+						ref={ this.chartBodyRef }
 					>
 						{ isViewportWide && legendDirection === 'column' && legend }
-						<D3Chart
-							colorScheme={ d3InterpolateViridis }
-							data={ visibleData }
-							dateParser={ dateParser }
-							height={ chartHeight }
-							margin={ margin }
-							mode={ mode }
-							orderedKeys={ orderedKeys }
-							pointLabelFormat={ pointLabelFormat }
-							tooltipFormat={ tooltipFormat }
-							tooltipTitle={ tooltipTitle }
-							type={ type }
-							interval={ interval }
-							width={ chartDirection === 'row' ? width - 320 : width }
-							xFormat={ xFormat }
-							x2Format={ x2Format }
-							yFormat={ yFormat }
-							valueType={ valueType }
-						/>
+						{ width > 0 && (
+							<D3Chart
+								colorScheme={ d3InterpolateViridis }
+								data={ visibleData }
+								dateParser={ dateParser }
+								height={ chartHeight }
+								margin={ margin }
+								mode={ mode }
+								orderedKeys={ orderedKeys }
+								pointLabelFormat={ pointLabelFormat }
+								tooltipFormat={ tooltipFormat }
+								tooltipTitle={ tooltipTitle }
+								type={ type }
+								interval={ interval }
+								width={ chartDirection === 'row' ? width - 320 : width }
+								xFormat={ xFormat }
+								x2Format={ x2Format }
+								yFormat={ yFormat }
+								valueType={ valueType }
+							/>
+						) }
 					</div>
 					{ ! isViewportWide && <div className="woocommerce-chart__footer">{ legend }</div> }
 				</Section>

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import { interpolateViridis as d3InterpolateViridis } from 'd3-scale-chromatic';
 import { formatDefaultLocale as d3FormatDefaultLocale } from 'd3-format';
 import Gridicon from 'gridicons';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * WooCommerce dependencies
@@ -25,7 +26,6 @@ import D3Chart from './charts';
 import { gap, gaplarge } from 'stylesheets/abstracts/_variables.scss';
 import { H, Section } from 'components/section';
 import Legend from './legend';
-import { WIDE_BREAKPOINT } from './utils';
 
 d3FormatDefaultLocale( {
 	decimal: '.',
@@ -188,6 +188,20 @@ class Chart extends Component {
 		);
 	}
 
+	getChartHeight() {
+		const { isViewportLarge, isViewportMobile } = this.props;
+
+		if ( isViewportMobile ) {
+			return 180;
+		}
+
+		if ( isViewportLarge ) {
+			return 300;
+		}
+
+		return 220;
+	}
+
 	render() {
 		const { orderedKeys, type, visibleData, width } = this.state;
 		const {
@@ -196,6 +210,7 @@ class Chart extends Component {
 			layout,
 			mode,
 			pointLabelFormat,
+			isViewportWide,
 			title,
 			tooltipFormat,
 			tooltipTitle,
@@ -205,11 +220,9 @@ class Chart extends Component {
 			valueType,
 		} = this.props;
 		let { yFormat } = this.props;
-		const legendDirection = layout === 'standard' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
-		const chartDirection = layout === 'comparison' && width >= WIDE_BREAKPOINT ? 'row' : 'column';
-		let chartHeight = width > 1329 ? 300 : 220;
-		chartHeight = width <= 1329 && width > 783 ? 220 : chartHeight;
-		chartHeight = width <= 783 ? 180 : chartHeight;
+		const legendDirection = layout === 'standard' && isViewportWide ? 'row' : 'column';
+		const chartDirection = layout === 'comparison' && isViewportWide ? 'row' : 'column';
+		const chartHeight = this.getChartHeight();
 		const legend = (
 			<Legend
 				colorScheme={ d3InterpolateViridis }
@@ -243,7 +256,7 @@ class Chart extends Component {
 			<div className="woocommerce-chart" ref={ this.chartRef }>
 				<div className="woocommerce-chart__header">
 					<H className="woocommerce-chart__title">{ title }</H>
-					{ width >= WIDE_BREAKPOINT && legendDirection === 'row' && legend }
+					{ isViewportWide && legendDirection === 'row' && legend }
 					{ this.renderIntervalSelector() }
 					<NavigableMenu
 						className="woocommerce-chart__types"
@@ -281,7 +294,7 @@ class Chart extends Component {
 							`woocommerce-chart__body-${ chartDirection }`
 						) }
 					>
-						{ width >= WIDE_BREAKPOINT && legendDirection === 'column' && legend }
+						{ isViewportWide && legendDirection === 'column' && legend }
 						<D3Chart
 							colorScheme={ d3InterpolateViridis }
 							data={ visibleData }
@@ -302,7 +315,7 @@ class Chart extends Component {
 							valueType={ valueType }
 						/>
 					</div>
-					{ width < WIDE_BREAKPOINT && <div className="woocommerce-chart__footer">{ legend }</div> }
+					{ ! isViewportWide && <div className="woocommerce-chart__footer">{ legend }</div> }
 				</Section>
 			</div>
 		);
@@ -400,4 +413,8 @@ Chart.defaultProps = {
 	interval: 'day',
 };
 
-export default Chart;
+export default withViewportMatch( {
+	isViewportMobile: '< medium',
+	isViewportLarge: '>= large',
+	isViewportWide: '>= wide',
+} )( Chart );

--- a/client/components/chart/legend.scss
+++ b/client/components/chart/legend.scss
@@ -8,6 +8,7 @@
 
 	&.woocommerce-legend__direction-column {
 		border-right: 1px solid $core-grey-light-700;
+		min-width: 320px;
 
 		.woocommerce-chart__footer & {
 			border-right: none;
@@ -24,7 +25,6 @@
 	.woocommerce-legend__direction-column & {
 		flex-direction: column;
 		height: 300px;
-		min-width: 320px;
 		overflow: auto;
 
 		.woocommerce-chart__footer & {
@@ -36,6 +36,8 @@
 	}
 
 	.has-total.woocommerce-legend__direction-column & {
+		height: 250px;
+
 		.woocommerce-chart__footer & {
 			height: auto;
 			max-height: 220px;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -176,6 +176,12 @@
 			}
 		}
 	}
+	.y-axis,
+	.axis-month {
+		.tick text {
+			font-size: 10px;
+		}
+	}
 
 	.focus-grid {
 		line {

--- a/client/components/chart/test/utils.js
+++ b/client/components/chart/test/utils.js
@@ -172,12 +172,9 @@ describe( 'getYScale', () => {
 
 describe( 'getYTickOffset', () => {
 	it( 'properly scale the y values for the y-axis ticks given the height and maximum y value', () => {
-		const testYTickOffset1 = getYTickOffset( 100, 1, testYMax );
+		const testYTickOffset1 = getYTickOffset( 100, testYMax );
 		expect( testYTickOffset1( 0 ) ).toEqual( 112 );
 		expect( testYTickOffset1( testYMax ) ).toEqual( 12 );
-		const testYTickOffset2 = getYTickOffset( 100, 2, testYMax );
-		expect( testYTickOffset2( 0 ) ).toEqual( 124 );
-		expect( testYTickOffset2( testYMax ) ).toEqual( 24 );
 	} );
 } );
 

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -543,19 +543,18 @@ const handleMouseOutLineChart = ( parentNode, params ) => {
 	params.tooltip.style( 'visibility', 'hidden' );
 };
 
-export const WIDE_BREAKPOINT = 960;
-
 const calculateTooltipXPosition = (
 	elementCoords,
 	chartCoords,
 	tooltipSize,
 	tooltipMargin,
-	elementWidthRatio
+	elementWidthRatio,
+	smallChart,
 ) => {
 	const xPosition =
 		elementCoords.left + elementCoords.width * elementWidthRatio + tooltipMargin - chartCoords.left;
 
-	if ( chartCoords.width < WIDE_BREAKPOINT ) {
+	if ( smallChart ) {
 		return Math.max(
 			tooltipMargin,
 			Math.min(
@@ -579,8 +578,8 @@ const calculateTooltipXPosition = (
 	return xPosition;
 };
 
-const calculateTooltipYPosition = ( elementCoords, chartCoords, tooltipSize, tooltipMargin ) => {
-	if ( chartCoords.width < WIDE_BREAKPOINT ) {
+const calculateTooltipYPosition = ( elementCoords, chartCoords, tooltipSize, tooltipMargin, smallChart ) => {
+	if ( smallChart ) {
 		return chartCoords.height;
 	}
 
@@ -592,7 +591,7 @@ const calculateTooltipYPosition = ( elementCoords, chartCoords, tooltipSize, too
 	return yPosition;
 };
 
-const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
+const calculateTooltipPosition = ( element, chart, smallChart, elementWidthRatio = 1 ) => {
 	const elementCoords = element.getBoundingClientRect();
 	const chartCoords = chart.getBoundingClientRect();
 	const tooltipSize = d3Select( '.tooltip' )
@@ -600,7 +599,7 @@ const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 		.getBoundingClientRect();
 	const tooltipMargin = 24;
 
-	if ( chartCoords.width < WIDE_BREAKPOINT ) {
+	if ( smallChart ) {
 		elementWidthRatio = 0;
 	}
 
@@ -610,9 +609,10 @@ const calculateTooltipPosition = ( element, chart, elementWidthRatio = 1 ) => {
 			chartCoords,
 			tooltipSize,
 			tooltipMargin,
-			elementWidthRatio
+			elementWidthRatio,
+			smallChart,
 		),
-		y: calculateTooltipYPosition( elementCoords, chartCoords, tooltipSize, tooltipMargin ),
+		y: calculateTooltipYPosition( elementCoords, chartCoords, tooltipSize, tooltipMargin, smallChart ),
 	};
 };
 
@@ -669,7 +669,7 @@ export const drawLines = ( node, data, params ) => {
 				return `${ label } ${ formatCurrency( d.value ) }`;
 			} )
 			.on( 'focus', ( d, i, nodes ) => {
-				const position = calculateTooltipPosition( d3Event.target, node.node() );
+				const position = calculateTooltipPosition( d3Event.target, node.node(), params.smallChart );
 				handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 			} )
 			.on( 'blur', ( d, i, nodes ) => handleMouseOutLineChart( nodes[ i ].parentNode, params ) );
@@ -717,7 +717,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) => {
 			const elementWidthRatio = i === 0 || i === params.dateSpaces.length - 1 ? 0 : 0.5;
-			const position = calculateTooltipPosition( d3Event.target, node.node(), elementWidthRatio );
+			const position = calculateTooltipPosition( d3Event.target, node.node(), params.smallChart, elementWidthRatio );
 			handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( nodes[ i ].parentNode, params ) );
@@ -782,7 +782,7 @@ export const drawBars = ( node, data, params ) => {
 		} )
 		.on( 'focus', ( d, i, nodes ) => {
 			const targetNode = d.value > 0 ? d3Event.target : d3Event.target.parentNode;
-			const position = calculateTooltipPosition( targetNode, node.node() );
+			const position = calculateTooltipPosition( targetNode, node.node(), params.smallChart );
 			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'blur', ( d, i, nodes ) => handleMouseOutBarChart( nodes[ i ].parentNode, params ) );
@@ -796,7 +796,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'height', params.height )
 		.attr( 'opacity', '0' )
 		.on( 'mouseover', ( d, i, nodes ) => {
-			const position = calculateTooltipPosition( d3Event.target, node.node() );
+			const position = calculateTooltipPosition( d3Event.target, node.node(), params.smallChart );
 			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutBarChart( nodes[ i ].parentNode, params ) );

--- a/client/components/chart/utils.js
+++ b/client/components/chart/utils.js
@@ -188,14 +188,13 @@ export const getYScale = ( height, yMax ) =>
 /**
  * Describes getyTickOffset
  * @param {number} height - calculated height of the charting space
- * @param {number} scale - ratio of the expected width to calculated width (given the viewbox)
  * @param {number} yMax - from `getYMax`
  * @returns {function} the D3 linear scale from 0 to the value from `getYMax`, offset by 12 pixels down
  */
-export const getYTickOffset = ( height, scale, yMax ) =>
+export const getYTickOffset = ( height, yMax ) =>
 	d3ScaleLinear()
 		.domain( [ 0, yMax ] )
-		.rangeRound( [ height + scale * 12, scale * 12 ] );
+		.rangeRound( [ height + 12, 12 ] );
 
 /**
  * Describes getyTickOffset
@@ -417,10 +416,6 @@ export const drawAxis = ( node, params ) => {
 		.call( g => g.select( '.domain' ).remove() );
 
 	node
-		.selectAll( '.axis-month .tick text' )
-		.style( 'font-size', `${ Math.round( params.scale * 10 ) }px` );
-
-	node
 		.append( 'g' )
 		.attr( 'class', 'pipes' )
 		.attr( 'transform', `translate(0, ${ params.height })` )
@@ -454,10 +449,6 @@ export const drawAxis = ( node, params ) => {
 				.tickValues( yGrids )
 				.tickFormat( d => d3Format( params.yFormat )( d !== 0 ? d : 0 ) )
 		);
-
-	node
-		.selectAll( '.y-axis .tick text' )
-		.style( 'font-size', `${ Math.round( params.scale * 10 ) }px` );
 
 	node.selectAll( '.domain' ).remove();
 	node
@@ -549,7 +540,7 @@ const calculateTooltipXPosition = (
 	tooltipSize,
 	tooltipMargin,
 	elementWidthRatio,
-	smallChart,
+	smallChart
 ) => {
 	const xPosition =
 		elementCoords.left + elementCoords.width * elementWidthRatio + tooltipMargin - chartCoords.left;
@@ -578,7 +569,13 @@ const calculateTooltipXPosition = (
 	return xPosition;
 };
 
-const calculateTooltipYPosition = ( elementCoords, chartCoords, tooltipSize, tooltipMargin, smallChart ) => {
+const calculateTooltipYPosition = (
+	elementCoords,
+	chartCoords,
+	tooltipSize,
+	tooltipMargin,
+	smallChart
+) => {
 	if ( smallChart ) {
 		return chartCoords.height;
 	}
@@ -610,9 +607,15 @@ const calculateTooltipPosition = ( element, chart, smallChart, elementWidthRatio
 			tooltipSize,
 			tooltipMargin,
 			elementWidthRatio,
-			smallChart,
+			smallChart
 		),
-		y: calculateTooltipYPosition( elementCoords, chartCoords, tooltipSize, tooltipMargin, smallChart ),
+		y: calculateTooltipYPosition(
+			elementCoords,
+			chartCoords,
+			tooltipSize,
+			tooltipMargin,
+			smallChart
+		),
 	};
 };
 
@@ -717,7 +720,12 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) => {
 			const elementWidthRatio = i === 0 || i === params.dateSpaces.length - 1 ? 0 : 0.5;
-			const position = calculateTooltipPosition( d3Event.target, node.node(), params.smallChart, elementWidthRatio );
+			const position = calculateTooltipPosition(
+				d3Event.target,
+				node.node(),
+				params.smallChart,
+				elementWidthRatio
+			);
 			handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'mouseout', ( d, i, nodes ) => handleMouseOutLineChart( nodes[ i ].parentNode, params ) );

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -23,10 +23,3 @@ $light-gray-500: $core-grey-light-500;
 $dark-gray-300: $core-grey-dark-300;
 $dark-gray-900: $core-grey-dark-900;
 $alert-red: $error-red;
-
-/* stylelint-disable */
-:export {
-	gaplarge: $gap-large;
-	gap: $gap;
-}
-/* stylelint-enable */


### PR DESCRIPTION
Follow up of #816.

* Use `@wordpress/viewport` for chart breakpoints.

* Fix the issue with chart height not matching legend height.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/48444019-6efcce00-e758-11e8-9e28-f5e4cb543e5f.png)

After:
![image](https://user-images.githubusercontent.com/3616980/48443949-4aa0f180-e758-11e8-958f-da97d8fad5be.png)

### Detailed test instructions:
Go to `client/components/chart/legend.js` and replace [this line](https://github.com/woocommerce/wc-admin/blob/master/client/components/chart/legend.js#L83):
```ES6
const showTotalLabel = legendDirection === 'column' && data.length > 5 && itemsLabel;
```
with:
```ES6
const showTotalLabel = legendDirection === 'column' && data.length > 0 && itemsLabel;
```
- Go to the _Products_ report (`/wp-admin/admin.php?page=wc-admin#/analytics/products`).
- Verify the _X products_ label border and the X axis of the legend are rendered at the same distance to the bottom.
- Resize the chart, navigate to other charts, hover the points, switch to the bar chart, etc. and verify nothing broke and there are no regressions.