### PR TITLE
Add a note about using SwaggerHub in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,6 @@ _Replace this with a good description of your changes & reasoning._
 
 - Ex: Open page `url`
 - Click XYZ…
+
+<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
+be sure to detail parts affected in Release Notes --->


### PR DESCRIPTION
Adds a section in the pull request template to include use of SwaggerHub api's in the release notes.
