### PR TITLE
Activity Panel: Inbox: Bump notes for expiring subs at certain days-remaining thresholds

### DIFF
--- a/includes/class-wc-admin-notes-woo-subscriptions-notes.php
+++ b/includes/class-wc-admin-notes-woo-subscriptions-notes.php
@@ -298,9 +298,8 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 
 				foreach ( (array) $bump_thresholds as $bump_threshold ) {
 					if ( ( $note_days_until_expiration > $bump_threshold ) && ( $days_until_expiration <= $bump_threshold ) ) {
-						error_log( "note crossed the $bump_threshold days until expiration threshold" );
 						$note->delete();
-						unset( $note );
+						$note = false;
 						continue;
 					}
 				}

--- a/includes/class-wc-admin-notes-woo-subscriptions-notes.php
+++ b/includes/class-wc-admin-notes-woo-subscriptions-notes.php
@@ -19,6 +19,16 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 	const NOTIFY_WHEN_DAYS_LEFT   = 60;
 
 	/**
+	 * We want to bubble up expiration notices when they cross certain age
+	 * thresholds. PHP 5.2 doesn't support constant arrays, so we do this.
+	 *
+	 * @return array
+	 */
+	private function get_bump_thresholds() {
+		return array( 60, 45, 20, 7, 1 ); // days.
+	}
+
+	/**
 	 * Hook all the things.
 	 */
 	public function __construct() {
@@ -70,7 +80,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 			$refresh_notes = false;
 
 			// Did the user just do something on the helper page?.
-			if ( isset( $_GET['wc-helper-status'] ) ) {
+			if ( isset( $_GET['wc-helper-status'] ) ) { // @codingStandardsIgnoreLine.
 				$refresh_notes = true;
 			}
 
@@ -274,10 +284,25 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		if ( $note ) {
 			$content_data = $note->get_content_data();
 			if ( property_exists( $content_data, 'days_until_expiration' ) ) {
+				// Note: There is no reason this property should not exist. This is just defensive programming.
 				$note_days_until_expiration = intval( $content_data->days_until_expiration );
 				if ( $days_until_expiration === $note_days_until_expiration ) {
 					// Note is already up to date. Bail.
 					return;
+				}
+
+				// If we have a note and we are at or have crossed a threshold, we should delete
+				// the old note and create a new one, thereby "bumping" the note to the top of the inbox.
+				$bump_thresholds    = $this->get_bump_thresholds();
+				$crossing_threshold = false;
+
+				foreach ( (array) $bump_thresholds as $bump_threshold ) {
+					if ( ( $note_days_until_expiration > $bump_threshold ) && ( $days_until_expiration <= $bump_threshold ) ) {
+						error_log( "note crossed the $bump_threshold days until expiration threshold" );
+						$note->delete();
+						unset( $note );
+						continue;
+					}
 				}
 			}
 		}
@@ -410,10 +435,12 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 				continue;
 			}
 
-			// If the subscription is not expiring soon, clean up and exit.
-			$expires      = intval( $subscription['expires'] );
-			$time_now_gmt = current_time( 'timestamp', 0 );
-			if ( $expires > $time_now_gmt + self::NOTIFY_WHEN_DAYS_LEFT * DAY_IN_SECONDS ) {
+			// If the subscription is not expiring by the first threshold, clean up and exit.
+			$bump_thresholds = $this->get_bump_thresholds();
+			$first_threshold = DAY_IN_SECONDS * $bump_thresholds[0];
+			$expires         = intval( $subscription['expires'] );
+			$time_now_gmt    = current_time( 'timestamp', 0 );
+			if ( $expires > $time_now_gmt + $first_threshold ) {
 				$this->delete_any_note_for_product_id( $product_id );
 				continue;
 			}


### PR DESCRIPTION
Fixes #711 

### Background of the change

The idea is that when a subscription crosses a 45, 20, 7, or 1 day until expiration threshold, the note for that expiring subscription should be bumped to the top of the inbox.

### Screenshots

<img width="1263" alt="screen shot 2018-11-15 at 1 30 22 pm" src="https://user-images.githubusercontent.com/1595739/48582901-a4312980-e8da-11e8-8cef-d6ff9077b854.png">

### Detailed test instructions

- Initial Setup
  - WP_DEBUG true
  - Tail the PHP error log (tail -f) in a terminal window.
  - You will need admin access to orders on WooCommerce.com in order to be able to complete this test.
  - Install this branch on a site which has (or can have) a connection to WooCommerce.com.
  - HINT: Use `npm run build:release` to build `wc-admin.zip` and then upload that in wp-admin > Plugins > Add New > Upload Plugin.
  - Install and activate the (WooCommerce Admin Notes Test Bench)[https://github.com/Automattic/wc-admin-notes-test-bench]  plugin.
  - HINT: You can download the ZIP directly from that repo and install that. No building is needed.
  - Navigate to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Connect if not already connected.
  - Make sure you have at least one Extension active on the site (e.g. Product Add-Ons).
  - First, make sure the extension is NOT set to auto-renew. If necessary, modify that in the order for that extension on WooCommerce.com before continuing.
  - Modify the order on WooCommerce.com for the extension so that the extension expires in 50 days.
  - Return to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Click on the Update button to fetch the hacked expiration date.
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the "subscription expiring" note and that it reports 50 days to expiration.
  - Navigate to wp-admin > Tools > WooCommerce Admin Notes Test Bench
  - Add a new note (content doesn't matter)
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the new note there, and that it is at the top of the inbox.

Now, do at least one of the following (45, 20, 7, or 1 day bump tests)

- 45 Day Bump
  - Modify the order on WooCommerce.com for the extension so that the extension expires in 45 days.
  - Return to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Click on the Update button to fetch the hacked expiration date.
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the "subscription expiring" note at the top again and that it reports 45 days to expiration.
  - Navigate to wp-admin > Tools > WooCommerce Admin Notes Test Bench
  - Add a new note (content doesn't matter)
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the new note there, and that it is at the top of the inbox.
- 20 Day Bump
  - Modify the order on WooCommerce.com for the extension so that the extension expires in 20 days.
  - Return to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Click on the Update button to fetch the hacked expiration date.
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the "subscription expiring" note at the top again and that it reports 20 days to expiration.
  - Navigate to wp-admin > Tools > WooCommerce Admin Notes Test Bench
  - Add a new note (content doesn't matter)
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the new note there, and that it is at the top of the inbox.
- 7 Day Bump
  - Modify the order on WooCommerce.com for the extension so that the extension expires in 7 days.
  - Return to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Click on the Update button to fetch the hacked expiration date.
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the "subscription expiring" note at the top again and that it reports 7 days to expiration.
  - Navigate to wp-admin > Tools > WooCommerce Admin Notes Test Bench
  - Add a new note (content doesn't matter)
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the new note there, and that it is at the top of the inbox.
- 1 Day Bump
  - Modify the order on WooCommerce.com for the extension so that the extension expires in 1 day (tomorrow).
  - Return to wp-admin > WooCommerce > Extensions > WooCommerce.com Subscriptions.
  - Click on the Update button to fetch the hacked expiration date.
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the "subscription expiring" note at the top again and that it reports 1 day to expiration.
  - Navigate to wp-admin > Tools > WooCommerce Admin Notes Test Bench
  - Add a new note (content doesn't matter)
  - Visit wp-admin > WooCommerce > Dashboard and open the Inbox.
  - Make sure you see the new note there, and that it is at the top of the inbox.
- Make sure the tailed error log shows nothing.
- Profit!
