### PR TITLE
Added zero padding to hours in unit tests.

### DIFF
--- a/tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/reports/class-wc-tests-reports-orders.php
@@ -61,7 +61,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			),
 			'intervals' => array(
 				array(
-					'interval'       => date( 'Y-m-d G', $order->get_date_created()->getOffsetTimestamp() ),
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getOffsetTimestamp() ),
 					'date_start'     => $start_time,
 					'date_start_gmt' => $start_time,
 					'date_end'       => $end_time,
@@ -106,7 +106,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			),
 			'intervals' => array(
 				array(
-					'interval'       => date( 'Y-m-d G', $order->get_date_created()->getOffsetTimestamp() ),
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getOffsetTimestamp() ),
 					'date_start'     => $start_time,
 					'date_start_gmt' => $start_time,
 					'date_end'       => $end_time,

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -64,7 +64,7 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 			),
 			'intervals' => array(
 				array(
-					'interval'       => date( 'Y-m-d G', $order->get_date_created()->getTimestamp() ),
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getTimestamp() ),
 					'date_start'     => $start_time,
 					'date_start_gmt' => $start_time,
 					'date_end'       => $end_time,
@@ -108,7 +108,7 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 			),
 			'intervals' => array(
 				array(
-					'interval'       => date( 'Y-m-d G', $order->get_date_created()->getTimestamp() ),
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getTimestamp() ),
 					'date_start'     => $start_time,
 					'date_start_gmt' => $start_time,
 					'date_end'       => $end_time,


### PR DESCRIPTION
Fixes #857 

Fixes failing PHP Unit tests after updated in #687.

