### PR TITLE
Add Coupons report table

### DIFF
--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -8,6 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { filters } from './config';
+import CouponsReportTable from './table';
 import { ReportFilters } from '@woocommerce/components';
 
 export default class extends Component {
@@ -17,6 +18,7 @@ export default class extends Component {
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
+				<CouponsReportTable query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -1,0 +1,227 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, _n } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { format as formatDate } from '@wordpress/date';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { get, map, orderBy } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import {
+	appendTimestamp,
+	getCurrentDates,
+	getIntervalForQuery,
+	getDateFormatsForInterval,
+} from '@woocommerce/date';
+import { Link, TableCard } from '@woocommerce/components';
+import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { onQueryChange } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import ReportError from 'analytics/components/report-error';
+import { QUERY_DEFAULTS } from 'store/constants';
+import { getReportChartData, getFilterQuery } from 'store/reports/utils';
+
+class CouponsReportTable extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Coupon Code', 'wc-admin' ),
+				// @TODO it should be the coupon code, not the coupon ID
+				key: 'coupon_id',
+				required: true,
+				isLeftAligned: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				required: true,
+				defaultSort: true,
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'G. Discounted', 'wc-admin' ),
+				key: 'gross_discount',
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Created', 'wc-admin' ),
+				key: 'created',
+				isSortable: true,
+			},
+			{
+				label: __( 'Expires', 'wc-admin' ),
+				key: 'expires',
+				isSortable: true,
+			},
+			{
+				label: __( 'Type', 'wc-admin' ),
+				key: 'type',
+				isSortable: false,
+			},
+		];
+	}
+
+	getRowsContent( coupons ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const { tableFormat } = getDateFormatsForInterval( currentInterval );
+
+		return map( coupons, coupon => {
+			const { coupon_id, gross_discount, orders_count } = coupon;
+
+			// @TODO must link to the coupon detail report
+			const couponLink = (
+				<Link href="" type="wc-admin">
+					{ coupon_id }
+				</Link>
+			);
+
+			const ordersLink = (
+				<Link
+					href={ '/analytics/orders?filter=advanced&code_includes=' + coupon_id }
+					type="wc-admin"
+				>
+					{ orders_count }
+				</Link>
+			);
+
+			return [
+				// @TODO it should be the coupon code, not the coupon ID
+				{
+					display: couponLink,
+					value: coupon_id,
+				},
+				{
+					display: ordersLink,
+					value: orders_count,
+				},
+				{
+					display: formatCurrency( gross_discount ),
+					value: getCurrencyFormatDecimal( gross_discount ),
+				},
+				{
+					// @TODO
+					display: formatDate( tableFormat, '' ),
+					value: '',
+				},
+				{
+					// @TODO
+					display: formatDate( tableFormat, '' ),
+					value: '',
+				},
+				{
+					// @TODO
+					display: '',
+					value: '',
+				},
+			];
+		} );
+	}
+
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+		return [
+			{
+				label: _n( 'coupon', 'coupons', totals.coupons_count, 'wc-admin' ),
+				value: totals.coupons_count,
+			},
+			{
+				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
+				value: totals.orders_count,
+			},
+			{
+				label: __( 'gross discounted', 'wc-admin' ),
+				value: formatCurrency( totals.gross_discount ),
+			},
+		];
+	}
+
+	render() {
+		const { coupons, isTableDataError, isTableDataRequesting, primaryData, query } = this.props;
+
+		const isError = isTableDataError || primaryData.isError;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
+		const isRequesting = isTableDataRequesting || primaryData.isRequesting;
+
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+		};
+
+		const headers = this.getHeadersContent();
+		const orderedCoupons = orderBy( coupons, tableQuery.orderby, tableQuery.order );
+		const rows = this.getRowsContent( orderedCoupons );
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
+		const totalRows = get( primaryData, [ 'data', 'totals', 'coupons_count' ], coupons.length );
+		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
+
+		return (
+			<TableCard
+				title={ __( 'Coupons', 'wc-admin' ) }
+				compareBy={ 'coupon' }
+				ids={ orderedCoupons.map( coupon => coupon.coupon_id ) }
+				rows={ rows }
+				totalRows={ totalRows }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				isLoading={ isRequesting }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ summary }
+				downloadable
+			/>
+		);
+	}
+}
+
+export default compose(
+	withSelect( ( select, props ) => {
+		const { query } = props;
+		const datesFromQuery = getCurrentDates( query );
+		const primaryData = getReportChartData( 'coupons', 'primary', query, select );
+		const filterQuery = getFilterQuery( 'coupons', query );
+
+		const { getCoupons, isGetCouponsError, isGetCouponsRequesting } = select( 'wc-admin' );
+		const tableQuery = {
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+			page: query.page || 1,
+			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
+			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
+			...filterQuery,
+		};
+		const coupons = getCoupons( tableQuery );
+		const isTableDataError = isGetCouponsError( tableQuery );
+		const isTableDataRequesting = isGetCouponsRequesting( tableQuery );
+
+		return {
+			isTableDataError,
+			isTableDataRequesting,
+			coupons,
+			primaryData,
+		};
+	} )
+)( CouponsReportTable );

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -30,10 +30,6 @@ import { QUERY_DEFAULTS } from 'store/constants';
 import { getReportChartData, getFilterQuery } from 'store/reports/utils';
 
 class CouponsReportTable extends Component {
-	constructor( props ) {
-		super( props );
-	}
-
 	getHeadersContent() {
 		return [
 			{

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -180,7 +180,7 @@ class CouponsReportTable extends Component {
 		return (
 			<TableCard
 				title={ __( 'Coupons', 'wc-admin' ) }
-				compareBy={ 'coupon' }
+				compareBy={ 'coupons' }
 				ids={ orderedCoupons.map( coupon => coupon.coupon_id ) }
 				rows={ rows }
 				totalRows={ totalRows }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -31,10 +31,6 @@ import { getReportChartData, getFilterQuery } from 'store/reports/utils';
 import './style.scss';
 
 class OrdersReportTable extends Component {
-	constructor( props ) {
-		super( props );
-	}
-
 	getHeadersContent() {
 		return [
 			{

--- a/client/store/coupons/actions.js
+++ b/client/store/coupons/actions.js
@@ -1,0 +1,17 @@
+/** @format */
+
+export default {
+	setCoupons( coupons, query ) {
+		return {
+			type: 'SET_COUPONS',
+			coupons,
+			query: query || {},
+		};
+	},
+	setCouponsError( query ) {
+		return {
+			type: 'SET_COUPONS_ERROR',
+			query: query || {},
+		};
+	},
+};

--- a/client/store/coupons/index.js
+++ b/client/store/coupons/index.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import actions from './actions';
+import reducer from './reducer';
+import resolvers from './resolvers';
+import selectors from './selectors';
+
+export default {
+	actions,
+	reducer,
+	resolvers,
+	selectors,
+};

--- a/client/store/coupons/reducer.js
+++ b/client/store/coupons/reducer.js
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/utils';
+
+const DEFAULT_STATE = {};
+
+export default function couponsReducer( state = DEFAULT_STATE, action ) {
+	const queryKey = getJsonString( action.query );
+
+	switch ( action.type ) {
+		case 'SET_COUPONS':
+			return merge( {}, state, {
+				[ queryKey ]: action.coupons,
+			} );
+
+		case 'SET_COUPONS_ERROR':
+			return merge( {}, state, {
+				[ queryKey ]: ERROR,
+			} );
+	}
+
+	return state;
+}

--- a/client/store/coupons/resolvers.js
+++ b/client/store/coupons/resolvers.js
@@ -1,0 +1,35 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+// import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+// import { NAMESPACE } from 'store/constants';
+import { SWAGGERNAMESPACE } from 'store/constants';
+
+export default {
+	async getCoupons( ...args ) {
+		const query = args.length === 1 ? args[ 0 ] : args[ 1 ];
+
+		try {
+			// @TODO update the API endpoint once it's ready
+			// const coupons = await apiFetch( { path: NAMESPACE + 'reports/coupons' + stringifyQuery( query ) } );
+			const response = await fetch(
+				SWAGGERNAMESPACE + 'reports/coupons' + stringifyQuery( query )
+			);
+			const coupons = await response.json();
+			dispatch( 'wc-admin' ).setCoupons( coupons, query );
+		} catch ( error ) {
+			dispatch( 'wc-admin' ).setCouponsError( query );
+		}
+	},
+};

--- a/client/store/coupons/selectors.js
+++ b/client/store/coupons/selectors.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getJsonString } from 'store/utils';
+import { ERROR } from 'store/constants';
+
+/**
+ * Returns coupons for a specific query.
+ *
+ * @param  {Object} state     Current state
+ * @param  {Object} query     Report query parameters
+ * @return {Array}            Report details
+ */
+function getCoupons( state, query = {} ) {
+	return get( state, [ 'coupons', getJsonString( query ) ], [] );
+}
+
+export default {
+	getCoupons,
+
+	/**
+	 * Returns true if a getCoupons request is pending.
+	 *
+	 * @param  {Object} state   Current state
+	 * @return {Boolean}        True if the `getCoupons` request is pending, false otherwise
+	 */
+	isGetCouponsRequesting( state, ...args ) {
+		return select( 'core/data' ).isResolving( 'wc-admin', 'getCoupons', args );
+	},
+
+	/**
+	 * Returns true if a getCoupons request has returned an error.
+	 *
+	 * @param  {Object} state     Current state
+	 * @param  {Object} query     Query parameters
+	 * @return {Boolean}          True if the `getCoupons` request has failed, false otherwise
+	 */
+	isGetCouponsError( state, query ) {
+		return ERROR === getCoupons( state, query );
+	},
+};

--- a/client/store/coupons/test/reducer.js
+++ b/client/store/coupons/test/reducer.js
@@ -1,0 +1,80 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import couponsReducer from '../reducer';
+import { getJsonString } from 'store/utils';
+
+describe( 'couponsReducer()', () => {
+	it( 'returns an empty data object by default', () => {
+		const state = couponsReducer( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received coupons data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'orders_count',
+		};
+		const coupons = [ { coupon_id: 1214 }, { coupon_id: 1215 }, { coupon_id: 1216 } ];
+
+		const state = couponsReducer( originalState, {
+			type: 'SET_COUPONS',
+			query,
+			coupons,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( coupons );
+	} );
+
+	it( 'tracks multiple queries in coupons data', () => {
+		const otherQuery = {
+			orderby: 'coupon_id',
+		};
+		const otherQueryKey = getJsonString( otherQuery );
+		const otherCoupons = [ { coupon_id: 1 }, { coupon_id: 2 }, { coupon_id: 3 } ];
+		const otherQueryState = {
+			[ otherQueryKey ]: otherCoupons,
+		};
+		const originalState = deepFreeze( otherQueryState );
+		const query = {
+			orderby: 'orders_count',
+		};
+		const coupons = [ { coupon_id: 1214 }, { coupon_id: 1215 }, { coupon_id: 1216 } ];
+
+		const state = couponsReducer( originalState, {
+			type: 'SET_COUPONS',
+			query,
+			coupons,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( coupons );
+		expect( state[ otherQueryKey ] ).toEqual( otherCoupons );
+	} );
+
+	it( 'returns with received error data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'orders_count',
+		};
+
+		const state = couponsReducer( originalState, {
+			type: 'SET_COUPONS_ERROR',
+			query,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( ERROR );
+	} );
+} );

--- a/client/store/coupons/test/resolvers.js
+++ b/client/store/coupons/test/resolvers.js
@@ -1,0 +1,53 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import resolvers from '../resolvers';
+
+const { getCoupons } = resolvers;
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn().mockReturnValue( {
+		setCoupons: jest.fn(),
+	} ),
+} ) );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// @TODO reactivate tests when we use the correct API routes instead of swaggerhub
+xdescribe( 'getCoupons', () => {
+	const COUPONS_1 = [ { coupon_id: 1214 }, { coupon_id: 1215 }, { coupon_id: 1216 } ];
+
+	const COUPONS_2 = [ { coupon_id: 1 }, { coupon_id: 2 }, { coupon_id: 3 } ];
+
+	beforeAll( () => {
+		apiFetch.mockImplementation( options => {
+			if ( options.path === '/wc/v3/reports/coupons' ) {
+				return Promise.resolve( COUPONS_1 );
+			}
+			if ( options.path === '/wc/v3/reports/coupons?orderby=coupon_id' ) {
+				return Promise.resolve( COUPONS_2 );
+			}
+		} );
+	} );
+
+	it( 'returns requested report data', async () => {
+		expect.assertions( 1 );
+		await getCoupons();
+		expect( dispatch().setCoupons ).toHaveBeenCalledWith( COUPONS_1, undefined );
+	} );
+
+	it( 'returns requested report data for a specific query', async () => {
+		expect.assertions( 1 );
+		await getCoupons( { orderby: 'coupon_id' } );
+		expect( dispatch().setCoupons ).toHaveBeenCalledWith( COUPONS_2, { orderby: 'coupon_id' } );
+	} );
+} );

--- a/client/store/coupons/test/selectors.js
+++ b/client/store/coupons/test/selectors.js
@@ -1,0 +1,92 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/utils';
+import selectors from '../selectors';
+
+const { getCoupons, isGetCouponsRequesting, isGetCouponsError } = selectors;
+jest.mock( '@wordpress/data', () => ( {
+	...require.requireActual( '@wordpress/data' ),
+	select: jest.fn().mockReturnValue( {} ),
+} ) );
+
+const query = { orderby: 'date' };
+const queryKey = getJsonString( query );
+
+describe( 'getCoupons()', () => {
+	it( 'returns an empty array when no coupons are available', () => {
+		const state = deepFreeze( {} );
+		expect( getCoupons( state, query ) ).toEqual( [] );
+	} );
+
+	it( 'returns stored coupons for current query', () => {
+		const coupons = [ { coupon_id: 1214 }, { coupon_id: 1215 }, { coupon_id: 1216 } ];
+		const state = deepFreeze( {
+			coupons: {
+				[ queryKey ]: coupons,
+			},
+		} );
+		expect( getCoupons( state, query ) ).toEqual( coupons );
+	} );
+} );
+
+describe( 'isGetCouponsRequesting()', () => {
+	beforeAll( () => {
+		select( 'core/data' ).isResolving = jest.fn().mockReturnValue( false );
+	} );
+
+	afterAll( () => {
+		select( 'core/data' ).isResolving.mockRestore();
+	} );
+
+	function setIsResolving( isResolving ) {
+		select( 'core/data' ).isResolving.mockImplementation(
+			( reducerKey, selectorName ) =>
+				isResolving && reducerKey === 'wc-admin' && selectorName === 'getCoupons'
+		);
+	}
+
+	it( 'returns false if never requested', () => {
+		const result = isGetCouponsRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if request finished', () => {
+		setIsResolving( false );
+		const result = isGetCouponsRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		setIsResolving( true );
+		const result = isGetCouponsRequesting( query );
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isGetCouponsError()', () => {
+	it( 'returns false by default', () => {
+		const state = deepFreeze( {} );
+		expect( isGetCouponsError( state, query ) ).toEqual( false );
+	} );
+
+	it( 'returns true if ERROR constant is found', () => {
+		const state = deepFreeze( {
+			coupons: {
+				[ queryKey ]: ERROR,
+			},
+		} );
+		expect( isGetCouponsError( state, query ) ).toEqual( true );
+	} );
+} );

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -8,6 +8,7 @@ import { combineReducers, registerStore } from '@wordpress/data';
  * Internal dependencies
  */
 import { applyMiddleware, addThunks } from './middleware';
+import coupons from 'store/coupons';
 import orders from 'store/orders';
 import products from 'store/products';
 import reports from 'store/reports';
@@ -15,6 +16,7 @@ import notes from 'store/notes';
 
 const store = registerStore( 'wc-admin', {
 	reducer: combineReducers( {
+		coupons: coupons.reducer,
 		orders: orders.reducer,
 		products: products.reducer,
 		reports: reports.reducer,
@@ -22,6 +24,7 @@ const store = registerStore( 'wc-admin', {
 	} ),
 
 	actions: {
+		...coupons.actions,
 		...orders.actions,
 		...products.actions,
 		...reports.actions,
@@ -29,6 +32,7 @@ const store = registerStore( 'wc-admin', {
 	},
 
 	selectors: {
+		...coupons.selectors,
 		...orders.selectors,
 		...products.selectors,
 		...reports.selectors,
@@ -36,6 +40,7 @@ const store = registerStore( 'wc-admin', {
 	},
 
 	resolvers: {
+		...coupons.resolvers,
 		...orders.resolvers,
 		...products.resolvers,
 		...reports.resolvers,

--- a/client/store/reports/stats/resolvers.js
+++ b/client/store/reports/stats/resolvers.js
@@ -28,7 +28,7 @@ export default {
 		let apiPath = endpoint + stringifyQuery( query );
 
 		// TODO: Remove once swagger endpoints are phased out.
-		const swaggerEndpoints = [ 'taxes' ];
+		const swaggerEndpoints = [ 'coupons', 'taxes' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
 			try {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -111,6 +111,14 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
+			'title'  => __( 'Coupons', 'wc-admin' ),
+			'parent' => '/analytics/revenue',
+			'path'   => '/analytics/coupons',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
 			'title'  => __( 'Taxes', 'wc-admin' ),
 			'parent' => '/analytics/revenue',
 			'path'   => '/analytics/taxes',


### PR DESCRIPTION
Fixes #835.

This PR creates a table for the Coupons Report.

API calls are made to swaggerhub for now and are marked with `@TODO` comments (see #845).

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/48577769-9b8e2280-e8dd-11e8-8e00-c7ff25e6ccb1.png)

### Detailed test instructions:
- Go to the _Coupons_ report.
- Verify there is a table and interact with it.

### Pending tasks
The search autocompleter is not working because it also depends on the API.