### PR TITLE
Packages: Remove imports from file that doesn’t exist in packages

### DIFF
--- a/packages/components/src/search/autocompleters/coupons.js
+++ b/packages/components/src/search/autocompleters/coupons.js
@@ -13,7 +13,6 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
-import { NAMESPACE } from 'store/constants';
 
 /**
  * A coupon completer.
@@ -33,7 +32,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `${ NAMESPACE }coupons${ payload }` } );
+		return apiFetch( { path: `/wc/v3/coupons${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( coupon ) {

--- a/packages/components/src/search/autocompleters/product-cat.js
+++ b/packages/components/src/search/autocompleters/product-cat.js
@@ -13,7 +13,6 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
-import { NAMESPACE } from 'store/constants';
 
 /**
  * A product categories completer.
@@ -34,7 +33,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `${ NAMESPACE }products/categories${ payload }` } );
+		return apiFetch( { path: `/wc/v3/products/categories${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( cat ) {

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -14,7 +14,6 @@ import { stringifyQuery } from '@woocommerce/navigation';
  */
 import { computeSuggestionMatch } from './utils';
 import ProductImage from '../../product-image';
-import { NAMESPACE } from 'store/constants';
 
 /**
  * A products completer.
@@ -35,7 +34,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `${ NAMESPACE }products${ payload }` } );
+		return apiFetch( { path: `/wc/v3/products${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( product ) {

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -14,7 +14,6 @@ import { stringifyQuery, getQuery } from '@woocommerce/navigation';
  */
 import { computeSuggestionMatch } from './utils';
 import ProductImage from '../../product-image';
-import { NAMESPACE } from 'store/constants';
 
 /**
  * Create a variation name by concatenating each of the variation's
@@ -53,7 +52,7 @@ export default {
 		if ( ! product || product.includes( ',' ) ) {
 			console.warn( 'Invalid product id supplied to Variations autocompleter' );
 		}
-		return apiFetch( { path: `${ NAMESPACE }products/${ product }/variations${ payload }` } );
+		return apiFetch( { path: `/wc/v3/products/${ product }/variations${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( variation ) {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -7,10 +7,11 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { getSettings, format as formatDate } from '@wordpress/date';
 
-/**
- * Internal dependencies
- */
-import { QUERY_DEFAULTS } from 'store/constants';
+const QUERY_DEFAULTS = {
+	pageSize: 25,
+	period: 'month',
+	compare: 'previous_year',
+};
 
 export const isoDateFormat = 'YYYY-MM-DD';
 


### PR DESCRIPTION
Fixes #873 – Trying to use packages in an external project triggers an error, because we try to import from `store` files that don't exist outside of wc-admin. This PR removes those imports. For `NAMESPACE` we just use `/wc/v3/` directly, and for `DEFAULT_QUERY` we define a local constant.

**To test**

Not sure how best to test this without a local project, but I tested it by running `npm link` in each package, then `npm link @woocommerce/components` & `npm link @woocommerce/date` in the woo blocks plugin, which then let me run webpack to successfully build the project.

Perhaps just a code-review 👀  would be enough.