### PR TITLE
Remove duplicated 'Coupons' menu item and reorder them

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -111,6 +111,14 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
+			'title'  => __( 'Categories', 'wc-admin' ),
+			'parent' => '/analytics/revenue',
+			'path'   => '/analytics/categories',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
 			'title'  => __( 'Coupons', 'wc-admin' ),
 			'parent' => '/analytics/revenue',
 			'path'   => '/analytics/coupons',
@@ -122,22 +130,6 @@ function wc_admin_register_pages() {
 			'title'  => __( 'Taxes', 'wc-admin' ),
 			'parent' => '/analytics/revenue',
 			'path'   => '/analytics/taxes',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Coupons', 'wc-admin' ),
-			'parent' => '/analytics/revenue',
-			'path'   => '/analytics/coupons',
-		)
-	);
-
-	wc_admin_register_page(
-		array(
-			'title'  => __( 'Categories', 'wc-admin' ),
-			'parent' => '/analytics/revenue',
-			'path'   => '/analytics/categories',
 		)
 	);
 


### PR DESCRIPTION
Remove duplicate _Coupons_ item in the menu.

Reorder the other items after talking to @LevinMedia.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/48639315-d99c4c80-e998-11e8-82fb-7703286c1a01.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/48639194-7c080000-e998-11e8-9fd2-322dfd1f880f.png)


### Detailed test instructions:

- Open any page under _Analytics_.
- Verify the order is as follows:
```
Revenue
Orders
Products
Categories
Coupons
Taxes
Downloads (doesn't exist yet)
Stock (doesn't exist yet)
Customers (doesn't exist yet)
```