### PR TITLE
Add Taxes report table

### DIFF
--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -17,6 +17,8 @@ import { charts, filters } from './config';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
+import TaxesReportTable from './table';
+
 export default class TaxesReport extends Component {
 	render() {
 		const { query, path } = this.props;
@@ -36,6 +38,7 @@ export default class TaxesReport extends Component {
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
+				<TaxesReportTable query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -112,9 +112,9 @@ class TaxesReportTable extends Component {
 		if ( ! totals ) {
 			return [];
 		}
+		// @TODO the number of total rows should come from the API
 		const totalRows = 0;
 		return [
-			// @TODO
 			{
 				label: _n( 'tax code', 'tax codes', totalRows, 'wc-admin' ),
 				value: totalRows,

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -28,7 +28,7 @@ class TaxesReportTable extends Component {
 		return [
 			{
 				label: __( 'Tax Code', 'wc-admin' ),
-				// @TODO it should be the tax rate code, not the ID
+				// @TODO it should be the tax code, not the ID
 				key: 'tax_rate_id',
 				required: true,
 				isLeftAligned: true,

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -1,0 +1,212 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, _n } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { get, map, orderBy } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
+import { Link, TableCard } from '@woocommerce/components';
+import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { onQueryChange } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import ReportError from 'analytics/components/report-error';
+import { QUERY_DEFAULTS } from 'store/constants';
+import { getReportChartData, getFilterQuery } from 'store/reports/utils';
+
+class TaxesReportTable extends Component {
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Tax Code', 'wc-admin' ),
+				// @TODO it should be the tax rate code, not the ID
+				key: 'tax_rate_id',
+				required: true,
+				isLeftAligned: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Rate', 'wc-admin' ),
+				key: 'rate',
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Total Tax', 'wc-admin' ),
+				key: 'total_tax',
+				isSortable: true,
+			},
+			{
+				label: __( 'Order Tax', 'wc-admin' ),
+				key: 'order_tax',
+				isSortable: true,
+			},
+			{
+				label: __( 'Shipping Tax', 'wc-admin' ),
+				key: 'shipping_tax',
+				isSortable: true,
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				required: true,
+				defaultSort: true,
+				isSortable: true,
+				isNumeric: true,
+			},
+		];
+	}
+
+	getRowsContent( taxes ) {
+		return map( taxes, tax => {
+			const { order_tax, orders_count, tax_rate_id, total_tax, shipping_tax } = tax;
+
+			// @TODO must link to the tax detail report
+			const taxLink = (
+				<Link href="" type="wc-admin">
+					{ tax_rate_id }
+				</Link>
+			);
+
+			return [
+				// @TODO it should be the tax code, not the tax ID
+				{
+					display: taxLink,
+					value: tax_rate_id,
+				},
+				{
+					// @TODO add `rate` once it's returned by the API
+					display: '',
+					value: '',
+				},
+				{
+					display: formatCurrency( total_tax ),
+					value: getCurrencyFormatDecimal( total_tax ),
+				},
+				{
+					display: formatCurrency( order_tax ),
+					value: getCurrencyFormatDecimal( order_tax ),
+				},
+				{
+					display: formatCurrency( shipping_tax ),
+					value: getCurrencyFormatDecimal( shipping_tax ),
+				},
+				{
+					display: orders_count,
+					value: orders_count,
+				},
+			];
+		} );
+	}
+
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+		const totalRows = 0;
+		return [
+			// @TODO
+			{
+				label: _n( 'tax code', 'tax codes', totalRows, 'wc-admin' ),
+				value: totalRows,
+			},
+			{
+				label: __( 'total tax', 'wc-admin' ),
+				value: formatCurrency( totals.total_tax ),
+			},
+			{
+				label: __( 'order tax', 'wc-admin' ),
+				value: formatCurrency( totals.order_tax ),
+			},
+			{
+				label: __( 'shipping tax', 'wc-admin' ),
+				value: formatCurrency( totals.shipping_tax ),
+			},
+			{
+				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
+				value: totals.orders_count,
+			},
+		];
+	}
+
+	render() {
+		const { taxes, isTableDataError, isTableDataRequesting, primaryData, query } = this.props;
+
+		const isError = isTableDataError || primaryData.isError;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
+		const isRequesting = isTableDataRequesting || primaryData.isRequesting;
+
+		const tableQuery = {
+			...query,
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+		};
+
+		const headers = this.getHeadersContent();
+		const orderedTaxes = orderBy( taxes, tableQuery.orderby, tableQuery.order );
+		const rows = this.getRowsContent( orderedTaxes );
+		const rowsPerPage = parseInt( tableQuery.per_page ) || QUERY_DEFAULTS.pageSize;
+		const totalRows = get( primaryData, [ 'data', 'totals', 'taxes_count' ], taxes.length );
+		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
+
+		return (
+			<TableCard
+				title={ __( 'Taxes', 'wc-admin' ) }
+				compareBy={ 'taxes' }
+				ids={ orderedTaxes.map( tax => tax.tax_rate_id ) }
+				rows={ rows }
+				totalRows={ totalRows }
+				rowsPerPage={ rowsPerPage }
+				headers={ headers }
+				isLoading={ isRequesting }
+				onQueryChange={ onQueryChange }
+				query={ tableQuery }
+				summary={ summary }
+				downloadable
+			/>
+		);
+	}
+}
+
+export default compose(
+	withSelect( ( select, props ) => {
+		const { query } = props;
+		const datesFromQuery = getCurrentDates( query );
+		const primaryData = getReportChartData( 'taxes', 'primary', query, select );
+		const filterQuery = getFilterQuery( 'taxes', query );
+
+		const { getTaxes, isGetTaxesError, isGetTaxesRequesting } = select( 'wc-admin' );
+		const tableQuery = {
+			orderby: query.orderby || 'date',
+			order: query.order || 'asc',
+			page: query.page || 1,
+			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
+			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
+			...filterQuery,
+		};
+		const taxes = getTaxes( tableQuery );
+		const isTableDataError = isGetTaxesError( tableQuery );
+		const isTableDataRequesting = isGetTaxesRequesting( tableQuery );
+
+		return {
+			isTableDataError,
+			isTableDataRequesting,
+			taxes,
+			primaryData,
+		};
+	} )
+)( TaxesReportTable );

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -13,6 +13,7 @@ import orders from 'store/orders';
 import products from 'store/products';
 import reports from 'store/reports';
 import notes from 'store/notes';
+import taxes from 'store/taxes';
 
 const store = registerStore( 'wc-admin', {
 	reducer: combineReducers( {
@@ -21,6 +22,7 @@ const store = registerStore( 'wc-admin', {
 		products: products.reducer,
 		reports: reports.reducer,
 		notes: notes.reducer,
+		taxes: taxes.reducer,
 	} ),
 
 	actions: {
@@ -29,6 +31,7 @@ const store = registerStore( 'wc-admin', {
 		...products.actions,
 		...reports.actions,
 		...notes.actions,
+		...taxes.actions,
 	},
 
 	selectors: {
@@ -37,6 +40,7 @@ const store = registerStore( 'wc-admin', {
 		...products.selectors,
 		...reports.selectors,
 		...notes.selectors,
+		...taxes.selectors,
 	},
 
 	resolvers: {
@@ -45,6 +49,7 @@ const store = registerStore( 'wc-admin', {
 		...products.resolvers,
 		...reports.resolvers,
 		...notes.resolvers,
+		...taxes.resolvers,
 	},
 } );
 

--- a/client/store/taxes/actions.js
+++ b/client/store/taxes/actions.js
@@ -1,0 +1,17 @@
+/** @format */
+
+export default {
+	setTaxes( taxes, query ) {
+		return {
+			type: 'SET_TAXES',
+			taxes,
+			query: query || {},
+		};
+	},
+	setTaxesError( query ) {
+		return {
+			type: 'SET_TAXES_ERROR',
+			query: query || {},
+		};
+	},
+};

--- a/client/store/taxes/index.js
+++ b/client/store/taxes/index.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import actions from './actions';
+import reducer from './reducer';
+import resolvers from './resolvers';
+import selectors from './selectors';
+
+export default {
+	actions,
+	reducer,
+	resolvers,
+	selectors,
+};

--- a/client/store/taxes/reducer.js
+++ b/client/store/taxes/reducer.js
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/utils';
+
+const DEFAULT_STATE = {};
+
+export default function taxesReducer( state = DEFAULT_STATE, action ) {
+	const queryKey = getJsonString( action.query );
+
+	switch ( action.type ) {
+		case 'SET_TAXES':
+			return merge( {}, state, {
+				[ queryKey ]: action.taxes,
+			} );
+
+		case 'SET_TAXES_ERROR':
+			return merge( {}, state, {
+				[ queryKey ]: ERROR,
+			} );
+	}
+
+	return state;
+}

--- a/client/store/taxes/resolvers.js
+++ b/client/store/taxes/resolvers.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+// import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+// import { NAMESPACE } from 'store/constants';
+import { SWAGGERNAMESPACE } from 'store/constants';
+
+export default {
+	async getTaxes( ...args ) {
+		const query = args.length === 1 ? args[ 0 ] : args[ 1 ];
+
+		try {
+			// @TODO update the API endpoint once it's ready
+			// const taxes = await apiFetch( { path: NAMESPACE + 'reports/taxes' + stringifyQuery( query ) } );
+			const response = await fetch( SWAGGERNAMESPACE + 'reports/taxes' + stringifyQuery( query ) );
+			const taxes = await response.json();
+			dispatch( 'wc-admin' ).setTaxes( taxes, query );
+		} catch ( error ) {
+			dispatch( 'wc-admin' ).setTaxesError( query );
+		}
+	},
+};

--- a/client/store/taxes/selectors.js
+++ b/client/store/taxes/selectors.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getJsonString } from 'store/utils';
+import { ERROR } from 'store/constants';
+
+/**
+ * Returns taxes for a specific query.
+ *
+ * @param  {Object} state     Current state
+ * @param  {Object} query     Report query parameters
+ * @return {Array}            Report details
+ */
+function getTaxes( state, query = {} ) {
+	return get( state, [ 'taxes', getJsonString( query ) ], [] );
+}
+
+export default {
+	getTaxes,
+
+	/**
+	 * Returns true if a getTaxes request is pending.
+	 *
+	 * @param  {Object} state   Current state
+	 * @return {Boolean}        True if the `getTaxes` request is pending, false otherwise
+	 */
+	isGetTaxesRequesting( state, ...args ) {
+		return select( 'core/data' ).isResolving( 'wc-admin', 'getTaxes', args );
+	},
+
+	/**
+	 * Returns true if a getTaxes request has returned an error.
+	 *
+	 * @param  {Object} state     Current state
+	 * @param  {Object} query     Query parameters
+	 * @return {Boolean}          True if the `getTaxes` request has failed, false otherwise
+	 */
+	isGetTaxesError( state, query ) {
+		return ERROR === getTaxes( state, query );
+	},
+};

--- a/client/store/taxes/test/reducer.js
+++ b/client/store/taxes/test/reducer.js
@@ -39,7 +39,7 @@ describe( 'taxesReducer()', () => {
 
 	it( 'tracks multiple queries in taxes data', () => {
 		const otherQuery = {
-			orderby: 'id',
+			orderby: 'tax_rate_id',
 		};
 		const otherQueryKey = getJsonString( otherQuery );
 		const otherTaxes = [ { tax_rate_id: 1 }, { tax_rate_id: 2 }, { tax_rate_id: 3 } ];

--- a/client/store/taxes/test/reducer.js
+++ b/client/store/taxes/test/reducer.js
@@ -1,0 +1,80 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import taxesReducer from '../reducer';
+import { getJsonString } from 'store/utils';
+
+describe( 'taxesReducer()', () => {
+	it( 'returns an empty data object by default', () => {
+		const state = taxesReducer( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received taxes data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'orders_count',
+		};
+		const taxes = [ { tax_rate_id: 1214 }, { tax_rate_id: 1215 }, { tax_rate_id: 1216 } ];
+
+		const state = taxesReducer( originalState, {
+			type: 'SET_TAXES',
+			query,
+			taxes,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( taxes );
+	} );
+
+	it( 'tracks multiple queries in taxes data', () => {
+		const otherQuery = {
+			orderby: 'id',
+		};
+		const otherQueryKey = getJsonString( otherQuery );
+		const otherTaxes = [ { tax_rate_id: 1 }, { tax_rate_id: 2 }, { tax_rate_id: 3 } ];
+		const otherQueryState = {
+			[ otherQueryKey ]: otherTaxes,
+		};
+		const originalState = deepFreeze( otherQueryState );
+		const query = {
+			orderby: 'orders_count',
+		};
+		const taxes = [ { tax_rate_id: 1214 }, { tax_rate_id: 1215 }, { tax_rate_id: 1216 } ];
+
+		const state = taxesReducer( originalState, {
+			type: 'SET_TAXES',
+			query,
+			taxes,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( taxes );
+		expect( state[ otherQueryKey ] ).toEqual( otherTaxes );
+	} );
+
+	it( 'returns with received error data', () => {
+		const originalState = deepFreeze( {} );
+		const query = {
+			orderby: 'orders_count',
+		};
+
+		const state = taxesReducer( originalState, {
+			type: 'SET_TAXES_ERROR',
+			query,
+		} );
+
+		const queryKey = getJsonString( query );
+		expect( state[ queryKey ] ).toEqual( ERROR );
+	} );
+} );

--- a/client/store/taxes/test/resolvers.js
+++ b/client/store/taxes/test/resolvers.js
@@ -33,7 +33,7 @@ xdescribe( 'getTaxes', () => {
 			if ( options.path === '/wc/v3/reports/taxes' ) {
 				return Promise.resolve( TAXES_1 );
 			}
-			if ( options.path === '/wc/v3/reports/taxes?orderby=id' ) {
+			if ( options.path === '/wc/v3/reports/taxes?orderby=tax_rate_id' ) {
 				return Promise.resolve( TAXES_2 );
 			}
 		} );

--- a/client/store/taxes/test/resolvers.js
+++ b/client/store/taxes/test/resolvers.js
@@ -1,0 +1,53 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import resolvers from '../resolvers';
+
+const { getTaxes } = resolvers;
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn().mockReturnValue( {
+		setTaxes: jest.fn(),
+	} ),
+} ) );
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// @TODO reactivate tests when we use the correct API routes instead of swaggerhub
+xdescribe( 'getTaxes', () => {
+	const TAXES_1 = [ { tax_rate_id: 1214 }, { tax_rate_id: 1215 }, { tax_rate_id: 1216 } ];
+
+	const TAXES_2 = [ { tax_rate_id: 1 }, { tax_rate_id: 2 }, { tax_rate_id: 3 } ];
+
+	beforeAll( () => {
+		apiFetch.mockImplementation( options => {
+			if ( options.path === '/wc/v3/reports/taxes' ) {
+				return Promise.resolve( TAXES_1 );
+			}
+			if ( options.path === '/wc/v3/reports/taxes?orderby=id' ) {
+				return Promise.resolve( TAXES_2 );
+			}
+		} );
+	} );
+
+	it( 'returns requested report data', async () => {
+		expect.assertions( 1 );
+		await getTaxes();
+		expect( dispatch().setTaxes ).toHaveBeenCalledWith( TAXES_1, undefined );
+	} );
+
+	it( 'returns requested report data for a specific query', async () => {
+		expect.assertions( 1 );
+		await getTaxes( { orderby: 'tax_rate_id' } );
+		expect( dispatch().setTaxes ).toHaveBeenCalledWith( TAXES_2, { orderby: 'tax_rate_id' } );
+	} );
+} );

--- a/client/store/taxes/test/selectors.js
+++ b/client/store/taxes/test/selectors.js
@@ -1,0 +1,92 @@
+/*
+* @format
+*/
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ERROR } from 'store/constants';
+import { getJsonString } from 'store/utils';
+import selectors from '../selectors';
+
+const { getTaxes, isGetTaxesRequesting, isGetTaxesError } = selectors;
+jest.mock( '@wordpress/data', () => ( {
+	...require.requireActual( '@wordpress/data' ),
+	select: jest.fn().mockReturnValue( {} ),
+} ) );
+
+const query = { orderby: 'date' };
+const queryKey = getJsonString( query );
+
+describe( 'getTaxes()', () => {
+	it( 'returns an empty array when no taxes are available', () => {
+		const state = deepFreeze( {} );
+		expect( getTaxes( state, query ) ).toEqual( [] );
+	} );
+
+	it( 'returns stored taxes for current query', () => {
+		const taxes = [ { tax_rate_id: 1214 }, { tax_rate_id: 1215 }, { tax_rate_id: 1216 } ];
+		const state = deepFreeze( {
+			taxes: {
+				[ queryKey ]: taxes,
+			},
+		} );
+		expect( getTaxes( state, query ) ).toEqual( taxes );
+	} );
+} );
+
+describe( 'isGetTaxesRequesting()', () => {
+	beforeAll( () => {
+		select( 'core/data' ).isResolving = jest.fn().mockReturnValue( false );
+	} );
+
+	afterAll( () => {
+		select( 'core/data' ).isResolving.mockRestore();
+	} );
+
+	function setIsResolving( isResolving ) {
+		select( 'core/data' ).isResolving.mockImplementation(
+			( reducerKey, selectorName ) =>
+				isResolving && reducerKey === 'wc-admin' && selectorName === 'getTaxes'
+		);
+	}
+
+	it( 'returns false if never requested', () => {
+		const result = isGetTaxesRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if request finished', () => {
+		setIsResolving( false );
+		const result = isGetTaxesRequesting( query );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		setIsResolving( true );
+		const result = isGetTaxesRequesting( query );
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'isGetTaxesError()', () => {
+	it( 'returns false by default', () => {
+		const state = deepFreeze( {} );
+		expect( isGetTaxesError( state, query ) ).toEqual( false );
+	} );
+
+	it( 'returns true if ERROR constant is found', () => {
+		const state = deepFreeze( {
+			taxes: {
+				[ queryKey ]: ERROR,
+			},
+		} );
+		expect( isGetTaxesError( state, query ) ).toEqual( true );
+	} );
+} );

--- a/client/store/taxes/test/selectors.js
+++ b/client/store/taxes/test/selectors.js
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn().mockReturnValue( {} ),
 } ) );
 
-const query = { orderby: 'date' };
+const query = { orderby: 'tax_rate_id' };
 const queryKey = getJsonString( query );
 
 describe( 'getTaxes()', () => {

--- a/packages/components/src/search/autocompleters/index.js
+++ b/packages/components/src/search/autocompleters/index.js
@@ -6,3 +6,4 @@ export { default as coupons } from './coupons';
 export { default as product } from './product';
 export { default as productCategory } from './product-cat';
 export { default as variations } from './variations';
+export { default as taxes } from './taxes';

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -1,0 +1,63 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+import { NAMESPACE } from 'store/constants';
+
+/**
+ * A tax completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'taxes$',
+	className: 'woocommerce-search__tax-result',
+	options( search ) {
+		let payload = '';
+		if ( search ) {
+			const query = {
+				search: encodeURIComponent( search ),
+				per_page: 10,
+			};
+			payload = stringifyQuery( query );
+		}
+		return apiFetch( { path: `${ NAMESPACE }taxes${ payload }` } );
+	},
+	isDebounced: true,
+	getOptionKeywords( tax ) {
+		return [ tax.code ];
+	},
+	getOptionLabel( tax, query ) {
+		const match = computeSuggestionMatch( tax.code, query ) || {};
+		return [
+			<span key="name" className="woocommerce-search__result-name" aria-label={ tax.code }>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( tax ) {
+		const value = {
+			id: tax.tax_rate_id,
+			label: tax.code,
+		};
+		return value;
+	},
+};

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { product, productCategory, coupons, variations } from './autocompleters';
+import { coupons, product, productCategory, taxes, variations } from './autocompleters';
 import Tag from '../tag';
 
 /**
@@ -72,6 +72,8 @@ class Search extends Component {
 				return productCategory;
 			case 'coupons':
 				return coupons;
+			case 'taxes':
+				return taxes;
 			case 'variations':
 				return variations;
 			default:
@@ -204,6 +206,7 @@ Search.propTypes = {
 		'orders',
 		'customers',
 		'coupons',
+		'taxes',
 		'variations',
 	] ).isRequired,
 	/**


### PR DESCRIPTION
Fixes #875.

This PR creates a table for the Taxes Report.

API calls are made to swaggerhub for now and are marked with `@TODO` comments (see #844).

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/48577769-9b8e2280-e8dd-11e8-8e00-c7ff25e6ccb1.png)

### Detailed test instructions:
- Go to the _Taxes_ report.
- Verify there is a table and interact with it.

### Pending tasks
The search autocompleter is not working because it also depends on the API.
