### PR TITLE
Add chartMode property to filters configuration

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -8,10 +8,12 @@ import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
+import { find, get } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
+import { flattenFilters } from '@woocommerce/navigation';
 import {
 	getAllowedIntervalsForQuery,
 	getCurrentDates,
@@ -28,17 +30,32 @@ import { Chart, ChartPlaceholder } from 'components';
 import { getReportChartData } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
 
+export const DEFAULT_FILTER = 'all';
+
 class ReportChart extends Component {
+	getAppliedFilter( filterConfig, query ) {
+		const allFilters = flattenFilters( filterConfig.filters );
+		const value = query[ filterConfig.param ] || DEFAULT_FILTER;
+
+		return find( allFilters, { value } );
+	}
+
+	getChartMode() {
+		const { filters, query } = this.props;
+		if ( ! filters ) {
+			return null;
+		}
+		const filterConfig = filters[ 0 ];
+		const appliedFilter = this.getAppliedFilter( filterConfig, query );
+		const appliedFilterParam = get( appliedFilter, [ 'settings', 'param' ] );
+
+		return ! appliedFilterParam || Object.keys( query ).includes( appliedFilterParam )
+			? appliedFilter.chartMode
+			: filterConfig.chartMode;
+	}
+
 	render() {
-		const {
-			comparisonChart,
-			query,
-			itemsLabel,
-			path,
-			primaryData,
-			secondaryData,
-			selectedChart,
-		} = this.props;
+		const { query, itemsLabel, path, primaryData, secondaryData, selectedChart } = this.props;
 
 		if ( primaryData.isError || secondaryData.isError ) {
 			return <ReportError isError />;
@@ -84,6 +101,8 @@ class ReportChart extends Component {
 				},
 			};
 		} );
+		const mode = this.getChartMode();
+		const layout = mode === 'item-comparison' ? 'comparison' : 'standard';
 
 		return (
 			<Chart
@@ -95,8 +114,8 @@ class ReportChart extends Component {
 				type={ getChartTypeForQuery( query ) }
 				allowedIntervals={ allowedIntervals }
 				itemsLabel={ itemsLabel }
-				layout={ comparisonChart ? 'comparison' : 'standard' }
-				mode={ comparisonChart ? 'item-comparison' : 'time-comparison' }
+				layout={ layout }
+				mode={ mode }
 				pointLabelFormat={ formats.pointLabelFormat }
 				tooltipTitle={ selectedChart.label }
 				xFormat={ formats.xFormat }
@@ -109,7 +128,7 @@ class ReportChart extends Component {
 }
 
 ReportChart.propTypes = {
-	comparisonChart: PropTypes.bool,
+	filters: PropTypes.array,
 	itemsLabel: PropTypes.string,
 	path: PropTypes.string.isRequired,
 	primaryData: PropTypes.object.isRequired,

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -33,11 +33,25 @@ import ReportError from 'analytics/components/report-error';
 export const DEFAULT_FILTER = 'all';
 
 export class ReportChart extends Component {
-	getAppliedFilter( filterConfig, query ) {
-		const allFilters = flattenFilters( filterConfig.filters );
-		const value = query[ filterConfig.param ] || DEFAULT_FILTER;
+	getSelectedFilter( filters, query ) {
+		if ( filters.length === 0 ) {
+			return null;
+		}
 
-		return find( allFilters, { value } );
+		const filterConfig = filters.pop();
+
+		if ( filterConfig.showFilters( query ) ) {
+			const allFilters = flattenFilters( filterConfig.filters );
+			const value = query[ filterConfig.param ] || DEFAULT_FILTER;
+			const selectedFilter = find( allFilters, { value } );
+			const selectedFilterParam = get( selectedFilter, [ 'settings', 'param' ] );
+
+			if ( ! selectedFilterParam || Object.keys( query ).includes( selectedFilterParam ) ) {
+				return selectedFilter;
+			}
+		}
+
+		return this.getSelectedFilter( filters, query );
 	}
 
 	getChartMode() {
@@ -45,13 +59,10 @@ export class ReportChart extends Component {
 		if ( ! filters ) {
 			return null;
 		}
-		const filterConfig = filters[ 0 ];
-		const appliedFilter = this.getAppliedFilter( filterConfig, query );
-		const appliedFilterParam = get( appliedFilter, [ 'settings', 'param' ] );
+		const clonedFilters = filters.slice( 0 );
+		const selectedFilter = this.getSelectedFilter( clonedFilters, query );
 
-		return ! appliedFilterParam || Object.keys( query ).includes( appliedFilterParam )
-			? appliedFilter.chartMode
-			: filterConfig.chartMode;
+		return get( selectedFilter, [ 'chartMode' ] );
 	}
 
 	render() {

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -32,7 +32,7 @@ import ReportError from 'analytics/components/report-error';
 
 export const DEFAULT_FILTER = 'all';
 
-class ReportChart extends Component {
+export class ReportChart extends Component {
 	getAppliedFilter( filterConfig, query ) {
 		const allFilters = flattenFilters( filterConfig.filters );
 		const value = query[ filterConfig.param ] || DEFAULT_FILTER;

--- a/client/analytics/components/report-chart/test/index.js
+++ b/client/analytics/components/report-chart/test/index.js
@@ -1,0 +1,111 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { ReportChart } from '../';
+
+jest.mock( 'components', () => ( {
+	...require.requireActual( 'components' ),
+	Chart: () => null,
+} ) );
+
+const path = '/analytics/revenue';
+const data = {
+  data: {
+    intervals: [],
+  },
+  isEmpty: false,
+  isError: false,
+  isRequesting: false,
+};
+const selectedChart = {
+  key: 'gross_revenue',
+  label: 'Gross Revenue',
+  type: 'currency',
+};
+
+describe( 'ReportChart', () => {
+	test( 'should not set the mode prop by default', () => {
+    const reportChart = shallow(
+      <ReportChart
+        path={ path }
+        primaryData={ data }
+        query={ {} }
+        secondaryData={ data }
+        selectedChart={ selectedChart }
+      />
+    );
+    const chart = reportChart.find( 'Chart' );
+
+		expect( chart.props().mode ).toEqual( null );
+		expect( chart.props().layout ).toEqual( 'standard' );
+	} );
+
+	test( 'should set the mode prop depending on the active filter', () => {
+    const filters = [ {
+      param: 'filter',
+      chartMode: 'item-comparison',
+			showFilters: () => true,
+      filters: [
+        {
+					value: 'lorem-ipsum',
+					settings: {
+						param: 'filter2',
+					},
+        },
+      ],
+    } ];
+    const reportChart = shallow(
+      <ReportChart
+        filters={ filters }
+        path={ path }
+        primaryData={ data }
+        query={ { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' } }
+        secondaryData={ data }
+        selectedChart={ selectedChart }
+      />
+    );
+
+    const chart = reportChart.find( 'Chart' );
+
+		expect( chart.props().mode ).toEqual( 'item-comparison' );
+		expect( chart.props().layout ).toEqual( 'comparison' );
+  } );
+
+	test( 'should set the mode prop depending on the active filter or it\'s parent', () => {
+    const filters = [ {
+      param: 'filter',
+      chartMode: 'item-comparison',
+			showFilters: () => true,
+      filters: [
+        {
+					value: 'lorem-ipsum',
+					settings: {
+						param: 'filter2',
+					},
+          chartMode: 'time-comparison',
+        },
+      ],
+    } ];
+    const reportChart = shallow(
+      <ReportChart
+        filters={ filters }
+        path={ path }
+        primaryData={ data }
+        query={ { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' } }
+        secondaryData={ data }
+        selectedChart={ selectedChart }
+      />
+    );
+
+    const chart = reportChart.find( 'Chart' );
+
+		expect( chart.props().mode ).toEqual( 'time-comparison' );
+		expect( chart.props().layout ).toEqual( 'standard' );
+  } );
+} );

--- a/client/analytics/components/report-chart/test/index.js
+++ b/client/analytics/components/report-chart/test/index.js
@@ -16,96 +16,67 @@ jest.mock( 'components', () => ( {
 
 const path = '/analytics/revenue';
 const data = {
-  data: {
-    intervals: [],
-  },
-  isEmpty: false,
-  isError: false,
-  isRequesting: false,
+	data: {
+		intervals: [],
+	},
+	isEmpty: false,
+	isError: false,
+	isRequesting: false,
 };
 const selectedChart = {
-  key: 'gross_revenue',
-  label: 'Gross Revenue',
-  type: 'currency',
+	key: 'gross_revenue',
+	label: 'Gross Revenue',
+	type: 'currency',
 };
 
 describe( 'ReportChart', () => {
 	test( 'should not set the mode prop by default', () => {
-    const reportChart = shallow(
-      <ReportChart
-        path={ path }
-        primaryData={ data }
-        query={ {} }
-        secondaryData={ data }
-        selectedChart={ selectedChart }
-      />
-    );
-    const chart = reportChart.find( 'Chart' );
+		const reportChart = shallow(
+			<ReportChart
+				path={ path }
+				primaryData={ data }
+				query={ {} }
+				secondaryData={ data }
+				selectedChart={ selectedChart }
+			/>
+		);
+		const chart = reportChart.find( 'Chart' );
 
 		expect( chart.props().mode ).toEqual( null );
 		expect( chart.props().layout ).toEqual( 'standard' );
 	} );
 
 	test( 'should set the mode prop depending on the active filter', () => {
-    const filters = [ {
-      param: 'filter',
-      chartMode: 'item-comparison',
-			showFilters: () => true,
-      filters: [
-        {
-					value: 'lorem-ipsum',
-					settings: {
-						param: 'filter2',
+		const filters = [
+			{
+				param: 'filter',
+				showFilters: () => true,
+				filters: [
+					{
+						value: 'lorem-ipsum',
+						chartMode: 'item-comparison',
+						settings: {
+							param: 'filter2',
+						},
 					},
-        },
-      ],
-    } ];
-    const reportChart = shallow(
-      <ReportChart
-        filters={ filters }
-        path={ path }
-        primaryData={ data }
-        query={ { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' } }
-        secondaryData={ data }
-        selectedChart={ selectedChart }
-      />
-    );
+				],
+			},
+		];
+		const query = { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' };
+		const reportChart = shallow(
+			<ReportChart
+				filters={ filters }
+				path={ path }
+				primaryData={ data }
+				query={ query }
+				secondaryData={ data }
+				selectedChart={ selectedChart }
+			/>
+		);
 
-    const chart = reportChart.find( 'Chart' );
+		const chart = reportChart.find( 'Chart' );
 
 		expect( chart.props().mode ).toEqual( 'item-comparison' );
 		expect( chart.props().layout ).toEqual( 'comparison' );
-  } );
-
-	test( 'should set the mode prop depending on the active filter or it\'s parent', () => {
-    const filters = [ {
-      param: 'filter',
-      chartMode: 'item-comparison',
-			showFilters: () => true,
-      filters: [
-        {
-					value: 'lorem-ipsum',
-					settings: {
-						param: 'filter2',
-					},
-          chartMode: 'time-comparison',
-        },
-      ],
-    } ];
-    const reportChart = shallow(
-      <ReportChart
-        filters={ filters }
-        path={ path }
-        primaryData={ data }
-        query={ { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' } }
-        secondaryData={ data }
-        selectedChart={ selectedChart }
-      />
-    );
-
-    const chart = reportChart.find( 'Chart' );
-
-		expect( chart.props().mode ).toEqual( 'time-comparison' );
-		expect( chart.props().layout ).toEqual( 'standard' );
-  } );
+	} );
 } );

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -33,7 +33,6 @@ const filterConfig = {
 	staticParams: [ 'chart' ],
 	param: 'filter',
 	showFilters: () => true,
-	chartMode: 'time-comparison',
 	filters: [
 		{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
 		{
@@ -44,6 +43,7 @@ const filterConfig = {
 				{
 					component: 'Search',
 					value: 'single_product',
+					chartMode: 'item-comparison',
 					path: [ 'select_product' ],
 					settings: {
 						type: 'products',
@@ -118,9 +118,10 @@ const variationsConfig = {
 	staticParams: [ 'filter', 'products' ],
 	param: 'filter-variations',
 	filters: [
-		{ label: __( 'All Variations', 'wc-admin' ), value: 'all' },
+		{ label: __( 'All Variations', 'wc-admin' ), chartMode: 'item-comparison', value: 'all' },
 		{
 			label: __( 'Comparison', 'wc-admin' ),
+			chartMode: 'item-comparison',
 			value: 'compare-variations',
 			settings: {
 				type: 'variations',
@@ -148,11 +149,13 @@ const variationsConfig = {
 		},
 		{
 			label: __( 'Top Variations by Items Sold', 'wc-admin' ),
+			chartMode: 'item-comparison',
 			value: 'top_items',
 			query: { orderby: 'items_sold', order: 'desc' },
 		},
 		{
 			label: __( 'Top Variations by Gross Revenue', 'wc-admin' ),
+			chartMode: 'item-comparison',
 			value: 'top_sales',
 			query: { orderby: 'gross_revenue', order: 'desc' },
 		},

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -33,11 +33,13 @@ const filterConfig = {
 	staticParams: [ 'chart' ],
 	param: 'filter',
 	showFilters: () => true,
+	chartMode: 'time-comparison',
 	filters: [
 		{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
 		{
 			label: __( 'Single Product', 'wc-admin' ),
 			value: 'select_product',
+			chartMode: 'item-comparison',
 			subFilters: [
 				{
 					component: 'Search',
@@ -61,6 +63,7 @@ const filterConfig = {
 		{
 			label: __( 'Product Comparison', 'wc-admin' ),
 			value: 'compare-products',
+			chartMode: 'item-comparison',
 			settings: {
 				type: 'products',
 				param: 'products',
@@ -79,6 +82,7 @@ const filterConfig = {
 		{
 			label: __( 'Product Category Comparison', 'wc-admin' ),
 			value: 'compare-product_cats',
+			chartMode: 'item-comparison',
 			settings: {
 				type: 'product_cats',
 				param: 'categories',
@@ -97,11 +101,13 @@ const filterConfig = {
 		{
 			label: __( 'Top Products by Items Sold', 'wc-admin' ),
 			value: 'top_items',
+			chartMode: 'item-comparison',
 			query: { orderby: 'items_sold', order: 'desc' },
 		},
 		{
 			label: __( 'Top Products by Gross Revenue', 'wc-admin' ),
 			value: 'top_sales',
+			chartMode: 'item-comparison',
 			query: { orderby: 'gross_revenue', order: 'desc' },
 		},
 	],

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -40,7 +40,7 @@ export default class ProductsReport extends Component {
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
-					comparisonChart
+					filters={ filters }
 					charts={ charts }
 					endpoint="products"
 					itemsLabel={ itemsLabel }

--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -241,7 +241,7 @@ if `tooltipTitle` is missing, passed to d3TimeFormat.
 
 ### `tooltipPosition`
 
-- Type: String
+- Type: One of: 'below', 'over'
 - Default: `'over'`
 
 The position where to render the tooltip can be `over` the chart or `below` the chart.

--- a/docs/components/filters.md
+++ b/docs/components/filters.md
@@ -178,6 +178,7 @@ Props
   - param: String - The url paramter this filter will modify.
   - showFilters: Function - Determine if the filter should be shown. Supply a function with the query object as an argument returning a boolean.
   - filters: Array
+  - chartMode: One of: 'item-comparison', 'time-comparison'
   - component: String - A custom component used instead of a button, might have special handling for filtering. TBD, not yet implemented.
   - label: String - The label for this filter. Optional only for custom component filters.
   - path: String - An array representing the "path" to this filter, if nested.

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -250,6 +250,10 @@ FilterPicker.propTypes = {
 		filters: PropTypes.arrayOf(
 			PropTypes.shape( {
 				/**
+				 * The chart display mode to use for charts displayed when this filter is active.
+				 */
+				chartMode: PropTypes.oneOf( [ 'item-comparison', 'time-comparison' ] ),
+				/**
 				 * A custom component used instead of a button, might have special handling for filtering. TBD, not yet implemented.
 				 */
 				component: PropTypes.string,


### PR DESCRIPTION
Fixes #879.

Adds a `chartMode` property to filters configuration so each filter can specify which kind of chart must be shown when it's activated.

### Screenshots
Notice _All Products_ and _Top Products by Items Sold_ have different chart layouts:
![image](https://user-images.githubusercontent.com/3616980/48667460-c0c88f80-ea9b-11e8-8f41-b8f61f2994b6.png)
![image](https://user-images.githubusercontent.com/3616980/48667463-ccb45180-ea9b-11e8-9686-eb8172c7a854.png)


### Detailed test instructions:
- Go to the _Products_ report.
- Try all filters that appear in the dropdown under _Show:_.
- Make sure only the _All Products_ filter displays the time comparison chart layout (legend on top) while all the others have the item comparison chart layout (legend on the left).

 @psealock I'm marking you as a reviewer since you worked a lot with filters and I would like to know your opinion about this PR.