### PR TITLE
Components: Add missing dependency from components package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,6 +45,7 @@
     "d3-shape": "^1.2.2",
     "d3-time-format": "^2.1.3",
     "gridicons": "3.1.1",
+    "interpolate-components": "1.1.1",
     "lodash": "^4.17.11",
     "moment": "^2.22.1",
     "prop-types": "15.6.2",


### PR DESCRIPTION
The `@woocommerce/components` package requires `interpolate-components`, but this wasn't provided in the package.json. This caused an error in compiling in external projects using the components. This PR adds the package back to the dependency list.

**To test**

- Check out woocommerce-gutenberg-products-block
- Remove [`interpolate-components` from the package.json](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/package.json#L50)
- run `npm install` & `npm run build`
- Expect: it should successfully install and build without errors.
