### PR TITLE
Activity Panel: Inbox: Filter update and error notes out of the inbox

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -93,6 +93,7 @@ export default compose(
 		const inboxQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
+			type: 'info,warning',
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -109,6 +109,12 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 			'page'     => $page,
 		);
 
+		$type = isset( $request['type'] ) ? $request['type'] : '';
+		$type = sanitize_text_field( trim( $type ) );
+		if ( ! empty( $type ) ) {
+			$args['type'] = $type;
+		}
+
 		$notes = WC_Admin_Notes::get_notes( 'edit', $args );
 
 		$data = array();

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -110,7 +110,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		$type = isset( $request['type'] ) ? $request['type'] : '';
-		$type = sanitize_text_field( trim( $type ) );
+		$type = sanitize_text_field( $type );
 		if ( ! empty( $type ) ) {
 			$args['type'] = $type;
 		}

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -112,12 +112,14 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	public function test_get_warning_notes() {
 		wp_set_current_user( $this->user );
 
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'type' => 'warning' ) );
+		$response = $this->server->dispatch( $request );
 		$notes    = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 1, count( $notes ) );
-		$this->assertEquals( $notes[0]->title, 'PHPUNIT_TEST_NOTE_2_TITLE' );
+		$this->assertEquals( $notes[0]['title'], 'PHPUNIT_TEST_NOTE_2_TITLE' );
 	}
 
 	/**

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -105,6 +105,22 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting notes of a certain type.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_warning_notes() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $notes ) );
+		$this->assertEquals( $notes[0]->title, 'PHPUNIT_TEST_NOTE_2_TITLE' );
+	}
+
+	/**
 	 * Test getting lots of notes without permission. It should fail.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
Fixes #722

Filters the inbox so that error and update notes do NOT appear. (They belong in the as-yet-not-implemented Store Alerts component.)

### Detailed test instructions:

- Use the https://github.com/Automattic/wc-admin-notes-test-bench plugin to add notes of all four types.
- Navigate to wp-admin > WooCommerce > Dashboard > Inbox
- Make sure the error and update notes do NOT appear
- Make sure the info and warning notes DO appear
- Run the phpunit tests and make sure they pass
- You can run `WC_Tests_API_Admin_Notes::test_get_warning_notes` separately if so desired.
- You can also play with this in Postman:

<img width="968" alt="screen shot 2018-11-19 at 3 56 29 pm" src="https://user-images.githubusercontent.com/1595739/48742480-ee384900-ec13-11e8-8b50-b19428e295d8.png">
