### PR TITLE
Activity Panel: Inbox: Highlight new items in the inbox

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -74,7 +74,7 @@ class InboxPanel extends Component {
 								title={ note.title }
 								date={ note.date_created }
 								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-								unread={ 'unread' === note.status }
+								unread={ true }
 								actions={ getButtonsFromActions( note.actions ) }
 							>
 								<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />


### PR DESCRIPTION
See #176 

Highlights new items in the inbox. Work in progress.

Uses `register_rest_field` to add a `wc_admin_inbox_closed_timestamp` field to the `/wp-json/wp/v2/users/{USERID}` core WordPress endpoint and then 1) uses that when rendering inbox notes to decide whether they are read or not and 2) UPDATEs that field on closing the inbox.

Also includes a redux store for `/wp-json/wp/v2/users/`

### Screenshots

### Detailed test instructions:

- Ex: Open page `url`
- Click XYZ…

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
