### PR TITLE
Chart: persist orderedKeys when requesting data

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
@@ -26,7 +25,7 @@ import {
 /**
  * Internal dependencies
  */
-import { Chart, ChartPlaceholder } from 'components';
+import { Chart } from 'components';
 import { getReportChartData, getTooltipValueFormat } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
 
@@ -70,17 +69,6 @@ export class ReportChart extends Component {
 
 		if ( primaryData.isError || secondaryData.isError ) {
 			return <ReportError isError />;
-		}
-
-		if ( primaryData.isRequesting || secondaryData.isRequesting ) {
-			return (
-				<Fragment>
-					<span className="screen-reader-text">
-						{ __( 'Your requested data is loading', 'wc-admin' ) }
-					</span>
-					<ChartPlaceholder />
-				</Fragment>
-			);
 		}
 
 		const currentInterval = getIntervalForQuery( query );
@@ -131,6 +119,7 @@ export class ReportChart extends Component {
 				x2Format={ formats.x2Format }
 				dateParser={ '%Y-%m-%dT%H:%M:%S' }
 				valueType={ selectedChart.type }
+				isRequesting={ primaryData.isRequesting || secondaryData.isRequesting }
 			/>
 		);
 	}


### PR DESCRIPTION
Fixes #674 
Follows #901 

Make selection/un-selection of chart time series persistent when data is being fetched.

### Test

1. Go to a report with a long enough period to allow more than one interval (day, week).
2. De-select a time series
3. Select a different interval whose data is not already in state. 
4. When data arrives and the chart populates, confirm the de-selected series is still deselected.

**Note:** It seems that the selector `isReportStatsRequesting` isn't so reliable as a detector of an in-flight request. It often returns false several moments before data actually arrives, resulting in a chart looking like this:

<img width="712" alt="screen shot 2018-11-22 at 1 46 04 pm" src="https://user-images.githubusercontent.com/1922453/48875393-bae8fa80-ee5d-11e8-9dbd-22499c1f0447.png">

Has anyone else experienced this?