### PR TITLE
Add Summary to Products table

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -158,6 +158,30 @@ class ProductsReportTable extends Component {
 		} );
 	}
 
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+		return [
+			{
+				label: _n( 'product sold', 'products sold', totals.products_count, 'wc-admin' ),
+				value: totals.products_count,
+			},
+			{
+				label: _n( 'item sold', 'items sold', totals.items_sold, 'wc-admin' ),
+				value: totals.items_sold,
+			},
+			{
+				label: __( 'gross revenue', 'wc-admin' ),
+				value: formatCurrency( totals.gross_revenue ),
+			},
+			{
+				label: _n( 'orders', 'orders', totals.orders_count, 'wc-admin' ),
+				value: totals.orders_count,
+			},
+		];
+	}
+
 	render() {
 		const { primaryData, tableData } = this.props;
 		const { items, query } = tableData;
@@ -173,6 +197,7 @@ class ProductsReportTable extends Component {
 		const orderedProducts = orderBy( items, query.orderby, query.order );
 		const rows = this.getRowsContent( orderedProducts );
 		const totalRows = get( primaryData, [ 'data', 'totals', 'products_count' ], items.length );
+		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
 
 		const labels = {
 			helpText: __( 'Select at least two products to compare', 'wc-admin' ),
@@ -192,7 +217,7 @@ class ProductsReportTable extends Component {
 				compareBy={ 'products' }
 				onQueryChange={ onQueryChange }
 				query={ query }
-				summary={ null } // @TODO
+				summary={ summary }
 				downloadable
 			/>
 		);

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -20,6 +20,7 @@ import { getNewPath, getPersistedQuery, onQueryChange } from '@woocommerce/navig
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import { numberFormat } from 'lib/number';
 
 class ProductsReportTable extends Component {
 	getHeadersContent() {
@@ -165,11 +166,11 @@ class ProductsReportTable extends Component {
 		return [
 			{
 				label: _n( 'product sold', 'products sold', totals.products_count, 'wc-admin' ),
-				value: totals.products_count,
+				value: numberFormat( totals.products_count ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', totals.items_sold, 'wc-admin' ),
-				value: totals.items_sold,
+				value: numberFormat( totals.items_sold ),
 			},
 			{
 				label: __( 'gross revenue', 'wc-admin' ),
@@ -177,7 +178,7 @@ class ProductsReportTable extends Component {
 			},
 			{
 				label: _n( 'orders', 'orders', totals.orders_count, 'wc-admin' ),
-				value: totals.orders_count,
+				value: numberFormat( totals.orders_count ),
 			},
 		];
 	}


### PR DESCRIPTION
The _Products_ table didn't have a summary yet. This PR fixes that.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/48850181-b1806500-ed6d-11e8-8f98-197ba739a32e.png)

### Detailed test instructions:
- Go to the _Products_ report.
- Verify the table displays the summary in the footer.
