### PR TITLE
Default charts to 'time-comparison'

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -57,7 +57,7 @@ export class ReportChart extends Component {
 	getChartMode() {
 		const { filters, query } = this.props;
 		if ( ! filters ) {
-			return null;
+			return;
 		}
 		const clonedFilters = filters.slice( 0 );
 		const selectedFilter = this.getSelectedFilter( clonedFilters, query );

--- a/client/analytics/components/report-chart/test/index.js
+++ b/client/analytics/components/report-chart/test/index.js
@@ -42,7 +42,7 @@ describe( 'ReportChart', () => {
 		);
 		const chart = reportChart.find( 'Chart' );
 
-		expect( chart.props().mode ).toEqual( null );
+		expect( chart.props().mode ).toBeUndefined();
 	} );
 
 	test( 'should set the mode prop depending on the active filter', () => {

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -406,7 +406,7 @@ Chart.defaultProps = {
 	xFormat: '%d',
 	x2Format: '%b %Y',
 	yFormat: '$.3s',
-	mode: 'item-comparison',
+	mode: 'time-comparison',
 	type: 'line',
 	interval: 'day',
 };

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -275,7 +275,7 @@ D3Chart.defaultProps = {
 		right: 0,
 		top: 20,
 	},
-	mode: 'item-comparison',
+	mode: 'time-comparison',
 	tooltipPosition: 'over',
 	tooltipLabelFormat: '%B %d, %Y',
 	tooltipValueFormat: ',',


### PR DESCRIPTION
Charts were defaulting to `item-comparison`, but they should default to `time-comparison`.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/48873309-c7644900-edb2-11e8-84ed-fba54d387ed0.png)

After:
![image](https://user-images.githubusercontent.com/3616980/48873333-e19e2700-edb2-11e8-87b3-7198bffb8e59.png)


### Detailed test instructions:
- Go to the _Revenue_ report.
- Make sure the chart is shown correctly (like the second screenshot).