### PR TITLE
Make ChartPlaceholder have the same height than the resulting Chart

### DIFF
--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -312,7 +312,7 @@ class Chart extends Component {
 								<span className="screen-reader-text">
 									{ __( 'Your requested data is loading', 'wc-admin' ) }
 								</span>
-								<ChartPlaceholder />
+								<ChartPlaceholder height={ chartHeight } />
 							</Fragment>
 						) }
 						{ ! isRequesting &&
@@ -433,6 +433,7 @@ Chart.defaultProps = {
 	mode: 'time-comparison',
 	type: 'line',
 	interval: 'day',
+	isRequesting: false,
 };
 
 export default withViewportMatch( {

--- a/client/components/chart/placeholder.js
+++ b/client/components/chart/placeholder.js
@@ -3,14 +3,27 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
 
 /**
  * `ChartPlaceholder` displays a large loading indiciator for use in place of a `Chart` while data is loading.
  */
 class ChartPlaceholder extends Component {
 	render() {
-		return <div className="woocommerce-chart is-placeholder" aria-hidden="true" />;
+		const { height } = this.props;
+
+		return (
+			<div aria-hidden="true" className="woocommerce-chart-placeholder" style={ { height } } />
+		);
 	}
 }
+
+ChartPlaceholder.propTypes = {
+	height: PropTypes.number,
+};
+
+ChartPlaceholder.defaultProps = {
+	height: 0,
+};
 
 export default ChartPlaceholder;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -62,13 +62,12 @@
 	.woocommerce-chart__footer {
 		width: 100%;
 	}
+}
 
-	&.is-placeholder {
-		@include placeholder();
-		height: 200px;
-		width: 100%;
-		padding: 0;
-	}
+.woocommerce-chart-placeholder {
+	@include placeholder();
+	padding: 0;
+	width: 100%;
 }
 
 .woocommerce-chart__interval-select {

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -202,7 +202,7 @@ D3Chart.propTypes = {
 	 */
 	dateParser: PropTypes.string.isRequired,
 	/**
-	 * Relative viewpoirt height of the `svg`.
+	 * Height of the `svg`.
 	 */
 	height: PropTypes.number,
 	/**
@@ -248,7 +248,7 @@ D3Chart.propTypes = {
 	 */
 	type: PropTypes.oneOf( [ 'bar', 'line' ] ),
 	/**
-	 * Relative viewport width of the `svg`.
+	 * Width of the `svg`.
 	 */
 	width: PropTypes.number,
 	/**

--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -36,15 +36,14 @@ The query string represented in object form
 
 ### `tooltipLabelFormat`
 
-- Type: String
+- Type: One of type: string, func
 - Default: `'%B %d, %Y'`
 
-A datetime formatting string to format the date displayed as the title of the toolip
-if `tooltipTitle` is missing, passed to d3TimeFormat.
+A datetime formatting string or overriding function to format the tooltip label.
 
 ### `tooltipValueFormat`
 
-- Type: String | Function
+- Type: One of type: string, func
 - Default: `','`
 
 A number formatting string or function to format the value displayed in the tooltips.
@@ -77,18 +76,10 @@ A datetime formatting string, passed to d3TimeFormat.
 
 A number formatting string, passed to d3Format.
 
-### `layout`
-
-- Type: One of: 'standard', 'comparison', 'compact'
-- Default: `'standard'`
-
-`standard` (default) legend layout in the header or `comparison` moves legend layout
-to the left or 'compact' has the legend below
-
 ### `mode`
 
 - Type: One of: 'item-comparison', 'time-comparison'
-- Default: `'item-comparison'`
+- Default: `'time-comparison'`
 
 `item-comparison` (default) or `time-comparison`, this is used to generate correct
 ARIA properties.
@@ -135,228 +126,24 @@ Allowed intervals to show in a dropdown.
 
 What type of data is to be displayed? Number, Average, String?
 
-`D3Chart` (component)
-=====================
+### `isRequesting`
 
-A simple D3 line and bar chart component for timeseries data in React.
+- Type: Boolean
+- Default: `false`
 
-Props
------
-
-### `className`
-
-- Type: String
-- Default: null
-
-Additional CSS classes.
-
-### `colorScheme`
-
-- Type: Function
-- Default: null
-
-A chromatic color function to be passed down to d3.
-
-### `data`
-
-- Type: Array
-- Default: `[]`
-
-An array of data.
-
-### `dateParser`
-
-- Type: String
-- Default: `'%Y-%m-%dT%H:%M:%S'`
-
-Format to parse dates into d3 time format
-
-### `height`
-
-- Type: Number
-- Default: `200`
-
-Relative viewpoirt height of the `svg`.
-
-### `interval`
-
-- Type: One of: 'hour', 'day', 'week', 'month', 'quarter', 'year'
-- Default: null
-
-Interval specification (hourly, daily, weekly etc.)
-
-### `layout`
-
-- Type: One of: 'standard', 'comparison', 'compact'
-- Default: `'standard'`
-
-`standard` (default) legend layout in the header or `comparison` moves legend layout
-to the left or 'compact' has the legend below
-
-### `pointLabelFormat`
-
-- Type: String
-- Default: null
-
-Date format of the point labels (might be used in tooltips and ARIA properties).
-
-### `margin`
-
-- Type: Object
-  - bottom: Number
-  - left: Number
-  - right: Number
-  - top: Number
-- Default: `{
-    bottom: 30,
-    left: 40,
-    right: 0,
-    top: 20,
-}`
-
-Margins for axis and chart padding.
-
-### `mode`
-
-- Type: One of: 'item-comparison', 'time-comparison'
-- Default: `'item-comparison'`
-
-`items-comparison` (default) or `time-comparison`, this is used to generate correct
-ARIA properties.
-
-### `orderedKeys`
-
-- Type: Array
-- Default: null
-
-The list of labels for this chart.
-
-### `tooltipLabelFormat`
-
-- Type: String
-- Default: `'%B %d, %Y'`
-
-A datetime formatting string to format the date displayed as the title of the toolip
-if `tooltipTitle` is missing, passed to d3TimeFormat.
-
-### `tooltipPosition`
-
-- Type: One of: 'below', 'over'
-- Default: `'over'`
-
-The position where to render the tooltip can be `over` the chart or `below` the chart.
-
-### `tooltipTitle`
-
-- Type: String
-- Default: null
-
-A string to use as a title for the tooltip. Takes preference over `tooltipLabelFormat`.
-
-### `type`
-
-- Type: One of: 'bar', 'line'
-- Default: `'line'`
-
-Chart type of either `line` or `bar`.
-
-### `width`
-
-- Type: Number
-- Default: `600`
-
-Relative viewport width of the `svg`.
-
-### `xFormat`
-
-- Type: String
-- Default: `'%Y-%m-%d'`
-
-A datetime formatting string, passed to d3TimeFormat.
-
-### `x2Format`
-
-- Type: String
-- Default: `''`
-
-A datetime formatting string, passed to d3TimeFormat.
-
-### `yFormat`
-
-- Type: String
-- Default: `'.3s'`
-
-A number formatting string, passed to d3Format.
-
-`Legend` (component)
-====================
-
-A legend specifically designed for the WooCommerce admin charts.
-
-Props
------
-
-### `className`
-
-- Type: String
-- Default: null
-
-Additional CSS classes.
-
-### `colorScheme`
-
-- Type: Function
-- Default: null
-
-A chromatic color function to be passed down to d3.
-
-### `data`
-
-- **Required**
-- Type: Array
-- Default: null
-
-An array of `orderedKeys`.
-
-### `handleLegendToggle`
-
-- Type: Function
-- Default: null
-
-Handles `onClick` event.
-
-### `handleLegendHover`
-
-- Type: Function
-- Default: null
-
-Handles `onMouseEnter`/`onMouseLeave` events.
-
-### `legendDirection`
-
-- Type: One of: 'row', 'column'
-- Default: `'row'`
-
-Display legend items as a `row` or `column` inside a flex-box.
-
-### `itemsLabel`
-
-- Type: String
-- Default: null
-
-Label to describe the legend items. It will be displayed in the legend of
-comparison charts when there are many.
-
-### `valueType`
-
-- Type: String
-- Default: null
-
-What type of data is to be displayed? Number, Average, String?
+Render a chart placeholder to signify an in-flight data request.
 
 `ChartPlaceholder` (component)
 ==============================
 
 `ChartPlaceholder` displays a large loading indiciator for use in place of a `Chart` while data is loading.
+
+Props
+-----
+
+### `height`
+
+- Type: Number
+- Default: `0`
 
 

--- a/docs/components/d3chart.md
+++ b/docs/components/d3chart.md
@@ -1,0 +1,210 @@
+`D3Chart` (component)
+=====================
+
+A simple D3 line and bar chart component for timeseries data in React.
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+Additional CSS classes.
+
+### `colorScheme`
+
+- Type: Function
+- Default: null
+
+A chromatic color function to be passed down to d3.
+
+### `data`
+
+- Type: Array
+- Default: `[]`
+
+An array of data.
+
+### `dateParser`
+
+- Type: String
+- Default: `'%Y-%m-%dT%H:%M:%S'`
+
+Format to parse dates into d3 time format
+
+### `height`
+
+- Type: Number
+- Default: `200`
+
+Height of the `svg`.
+
+### `interval`
+
+- Type: One of: 'hour', 'day', 'week', 'month', 'quarter', 'year'
+- Default: null
+
+Interval specification (hourly, daily, weekly etc.)
+
+### `margin`
+
+- Type: Object
+  - bottom: Number
+  - left: Number
+  - right: Number
+  - top: Number
+- Default: `{
+    bottom: 30,
+    left: 40,
+    right: 0,
+    top: 20,
+}`
+
+Margins for axis and chart padding.
+
+### `mode`
+
+- Type: One of: 'item-comparison', 'time-comparison'
+- Default: `'time-comparison'`
+
+`items-comparison` (default) or `time-comparison`, this is used to generate correct
+ARIA properties.
+
+### `orderedKeys`
+
+- Type: Array
+- Default: null
+
+The list of labels for this chart.
+
+### `tooltipLabelFormat`
+
+- Type: One of type: string, func
+- Default: `'%B %d, %Y'`
+
+A datetime formatting string or overriding function to format the tooltip label.
+
+### `tooltipValueFormat`
+
+- Type: One of type: string, func
+- Default: `','`
+
+A number formatting string or function to format the value displayed in the tooltips.
+
+### `tooltipPosition`
+
+- Type: One of: 'below', 'over'
+- Default: `'over'`
+
+The position where to render the tooltip can be `over` the chart or `below` the chart.
+
+### `tooltipTitle`
+
+- Type: String
+- Default: null
+
+A string to use as a title for the tooltip. Takes preference over `tooltipFormat`.
+
+### `type`
+
+- Type: One of: 'bar', 'line'
+- Default: `'line'`
+
+Chart type of either `line` or `bar`.
+
+### `width`
+
+- Type: Number
+- Default: `600`
+
+Width of the `svg`.
+
+### `xFormat`
+
+- Type: One of type: string, func
+- Default: `'%Y-%m-%d'`
+
+A datetime formatting string or function, passed to d3TimeFormat.
+
+### `x2Format`
+
+- Type: One of type: string, func
+- Default: `''`
+
+A datetime formatting string or function, passed to d3TimeFormat.
+
+### `yFormat`
+
+- Type: One of type: string, func
+- Default: `'.3s'`
+
+A number formatting string or function, passed to d3Format.
+
+`Legend` (component)
+====================
+
+A legend specifically designed for the WooCommerce admin charts.
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+Additional CSS classes.
+
+### `colorScheme`
+
+- Type: Function
+- Default: null
+
+A chromatic color function to be passed down to d3.
+
+### `data`
+
+- **Required**
+- Type: Array
+- Default: null
+
+An array of `orderedKeys`.
+
+### `handleLegendToggle`
+
+- Type: Function
+- Default: null
+
+Handles `onClick` event.
+
+### `handleLegendHover`
+
+- Type: Function
+- Default: null
+
+Handles `onMouseEnter`/`onMouseLeave` events.
+
+### `legendDirection`
+
+- Type: One of: 'row', 'column'
+- Default: `'row'`
+
+Display legend items as a `row` or `column` inside a flex-box.
+
+### `itemsLabel`
+
+- Type: String
+- Default: null
+
+Label to describe the legend items. It will be displayed in the legend of
+comparison charts when there are many.
+
+### `valueType`
+
+- Type: String
+- Default: null
+
+What type of data is to be displayed? Number, Average, String?
+


### PR DESCRIPTION
Fixes #869.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/48922351-c2af9b80-ee6b-11e8-8436-6b84ef5c8687.png)

After:
![image](https://user-images.githubusercontent.com/3616980/48922271-3309ed00-ee6b-11e8-8b19-f6fbb624e911.png)

### Detailed test instructions:
There seems to be a bug that makes stores return `false` for `isReportStatsLoading()` before the data is loaded which I think is related to #854.

So, for now, we will have to force `isRequesting` to be true modifying [this line](https://github.com/woocommerce/wc-admin/blob/master/client/analytics/components/report-chart/index.js#L122) from:
```ES6
isRequesting={ primaryData.isRequesting || secondaryData.isRequesting }
```
to:
```ES6
isRequesting={ true }
```
- Open the _Products_ report in a tab.
- Make the code change described above.
- Open the _Products_ report in another tab (so one will be displaying the chart and the other one the placeholder).
- Verify they have the same height.
- You can repeat the same with different window sizes and comparison charts (setting the filter to _Top Products by Items Sold_ in the _Products_ report, for example).
