### PR TITLE
Remove unnecessary IF clause in reports/utils.js

### DIFF
--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -226,12 +226,11 @@ export function getReportChartData( endpoint, dataType, query, select ) {
 				isFetching = false;
 				break;
 			}
-			if ( ! isReportStatsRequesting( endpoint, nextQuery ) ) {
-				pagedData.push( _data );
-				if ( i === totalPages ) {
-					isFetching = false;
-					break;
-				}
+
+			pagedData.push( _data );
+			if ( i === totalPages ) {
+				isFetching = false;
+				break;
 			}
 		}
 


### PR DESCRIPTION
This is a tiny PR of a code improvement I found while working on #908. It looks like in `reports/utils.js` we have an unnecessary IF clause that could be removed.

It's checking if `! isReportStatsRequesting( endpoint, nextQuery )` but it will always evaluate to `true` because [few lines above](https://github.com/woocommerce/wc-admin/pull/909/files#diff-4b4f2ba5d6b8b9dae827e4e2c8062323R221) we have this:
```ES6
if ( isReportStatsRequesting( endpoint, nextQuery ) ) {
	continue;
}
```