### PR TITLE
Bug: noticed a new NaN error caused by attempt to draw chart with empty data

### DIFF
--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { formatDefaultLocale as d3FormatDefaultLocale } from 'd3-format';
-import { get, isEqual, partial } from 'lodash';
+import { get, isEmpty, isEqual, partial } from 'lodash';
 import Gridicon from 'gridicons';
 import { IconButton, NavigableMenu, SelectControl } from '@wordpress/components';
 import { interpolateViridis as d3InterpolateViridis } from 'd3-scale-chromatic';
@@ -263,6 +263,7 @@ class Chart extends Component {
 				yFormat = '.0f';
 				break;
 		}
+		const showChart = ! isRequesting && ! isEmpty( visibleData );
 		return (
 			<div className="woocommerce-chart">
 				<div className="woocommerce-chart__header">
@@ -307,7 +308,7 @@ class Chart extends Component {
 						ref={ this.chartBodyRef }
 					>
 						{ isViewportWide && legendDirection === 'column' && legend }
-						{ isRequesting && (
+						{ ! showChart && (
 							<Fragment>
 								<span className="screen-reader-text">
 									{ __( 'Your requested data is loading', 'wc-admin' ) }
@@ -315,7 +316,7 @@ class Chart extends Component {
 								<ChartPlaceholder />
 							</Fragment>
 						) }
-						{ ! isRequesting &&
+						{ showChart &&
 							width > 0 && (
 								<D3Chart
 									colorScheme={ d3InterpolateViridis }

--- a/client/components/chart/index.js
+++ b/client/components/chart/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { formatDefaultLocale as d3FormatDefaultLocale } from 'd3-format';
-import { get, isEmpty, isEqual, partial } from 'lodash';
+import { get, isEqual, partial } from 'lodash';
 import Gridicon from 'gridicons';
 import { IconButton, NavigableMenu, SelectControl } from '@wordpress/components';
 import { interpolateViridis as d3InterpolateViridis } from 'd3-scale-chromatic';
@@ -263,7 +263,6 @@ class Chart extends Component {
 				yFormat = '.0f';
 				break;
 		}
-		const showChart = ! isRequesting && ! isEmpty( visibleData );
 		return (
 			<div className="woocommerce-chart">
 				<div className="woocommerce-chart__header">
@@ -308,7 +307,7 @@ class Chart extends Component {
 						ref={ this.chartBodyRef }
 					>
 						{ isViewportWide && legendDirection === 'column' && legend }
-						{ ! showChart && (
+						{ isRequesting && (
 							<Fragment>
 								<span className="screen-reader-text">
 									{ __( 'Your requested data is loading', 'wc-admin' ) }
@@ -316,7 +315,7 @@ class Chart extends Component {
 								<ChartPlaceholder />
 							</Fragment>
 						) }
-						{ showChart &&
+						{ ! isRequesting &&
 							width > 0 && (
 								<D3Chart
 									colorScheme={ d3InterpolateViridis }

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import { Component, createRef } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -162,7 +162,7 @@ class D3Chart extends Component {
 	}
 
 	render() {
-		if ( ! this.props.data ) {
+		if ( isEmpty( this.props.data ) ) {
 			return null; // TODO: improve messaging
 		}
 		return (


### PR DESCRIPTION
I noticed an error while reviewing #908 where the chart is being called with an empty data array.

### Screenshots
![screenshot 2018-11-23 10 12 26](https://user-images.githubusercontent.com/1160732/48933823-5df74e00-ef0a-11e8-88fa-d7a1dcdd209e.png)

### Detailed test instructions:

- Go to _Products Report_ 
- Change to an interval that isn't cached
- Ensure there aren't any `NaN` errors in the console

