### PR TITLE
Use numberFormat() to format all non-currency numbers in tables

### DIFF
--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -22,6 +22,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import { numberFormat } from 'lib/number';
 
 class CouponsReportTable extends Component {
 	getHeadersContent() {
@@ -86,7 +87,7 @@ class CouponsReportTable extends Component {
 					href={ '/analytics/orders?filter=advanced&code_includes=' + coupon_id }
 					type="wc-admin"
 				>
-					{ orders_count }
+					{ numberFormat( orders_count ) }
 				</Link>
 			);
 
@@ -130,11 +131,11 @@ class CouponsReportTable extends Component {
 		return [
 			{
 				label: _n( 'coupon', 'coupons', totals.coupons_count, 'wc-admin' ),
-				value: totals.coupons_count,
+				value: numberFormat( totals.coupons_count ),
 			},
 			{
 				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
-				value: totals.orders_count,
+				value: numberFormat( totals.orders_count ),
 			},
 			{
 				label: __( 'gross discounted', 'wc-admin' ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -28,6 +28,7 @@ import { getAdminLink, onQueryChange } from '@woocommerce/navigation';
 import ReportError from 'analytics/components/report-error';
 import { QUERY_DEFAULTS } from 'store/constants';
 import { getReportChartData, getFilterQuery } from 'store/reports/utils';
+import { numberFormat } from 'lib/number';
 import './style.scss';
 
 class OrdersReportTable extends Component {
@@ -184,7 +185,7 @@ class OrdersReportTable extends Component {
 					value: products.map( product => product.label ).join( ' ' ),
 				},
 				{
-					display: items_sold,
+					display: numberFormat( items_sold ),
 					value: items_sold,
 				},
 				{
@@ -206,11 +207,11 @@ class OrdersReportTable extends Component {
 		return [
 			{
 				label: _n( 'order', 'orders', totals.num_items_sold, 'wc-admin' ),
-				value: totals.orders_count,
+				value: numberFormat( totals.orders_count ),
 			},
 			{
 				label: _n( 'new customer', 'new customers', totals.num_new_customers, 'wc-admin' ),
-				value: totals.num_new_customers,
+				value: numberFormat( totals.num_new_customers ),
 			},
 			{
 				label: _n(
@@ -219,19 +220,19 @@ class OrdersReportTable extends Component {
 					totals.num_returning_customers,
 					'wc-admin'
 				),
-				value: totals.num_returning_customers,
+				value: numberFormat( totals.num_returning_customers ),
 			},
 			{
 				label: _n( 'product', 'products', totals.products, 'wc-admin' ),
-				value: totals.products,
+				value: numberFormat( totals.products ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', totals.num_items_sold, 'wc-admin' ),
-				value: totals.num_items_sold,
+				value: numberFormat( totals.num_items_sold ),
 			},
 			{
 				label: _n( 'coupon', 'coupons', totals.coupons, 'wc-admin' ),
-				value: totals.coupons,
+				value: numberFormat( totals.coupons ),
 			},
 			{
 				label: __( 'net revenue', 'wc-admin' ),

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -20,6 +20,7 @@ import { getNewPath, getPersistedQuery, onQueryChange } from '@woocommerce/navig
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import { numberFormat } from 'lib/number';
 
 class ProductsReportTable extends Component {
 	getHeadersContent() {
@@ -117,7 +118,7 @@ class ProductsReportTable extends Component {
 					value: sku,
 				},
 				{
-					display: items_sold,
+					display: numberFormat( items_sold ),
 					value: items_sold,
 				},
 				{
@@ -139,7 +140,7 @@ class ProductsReportTable extends Component {
 					value: Array.isArray( categories ) ? categories.map( cat => cat.name ).join( ', ' ) : '',
 				},
 				{
-					display: variations.length,
+					display: numberFormat( variations.length ),
 					value: variations.length,
 				},
 				{
@@ -151,7 +152,7 @@ class ProductsReportTable extends Component {
 					value: stockStatuses[ stock_status ],
 				},
 				{
-					display: stock_quantity,
+					display: numberFormat( stock_quantity ),
 					value: stock_quantity,
 				},
 			];

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -27,6 +27,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import ReportError from 'analytics/components/report-error';
 import { QUERY_DEFAULTS } from 'store/constants';
+import { numberFormat } from 'lib/number';
 
 class RevenueReportTable extends Component {
 	getHeadersContent() {
@@ -114,7 +115,7 @@ class RevenueReportTable extends Component {
 					href={ 'edit.php?post_type=shop_order&m=' + formatDate( 'Ymd', row.date_start ) }
 					type="wp-admin"
 				>
-					{ orders_count }
+					{ numberFormat( orders_count ) }
 				</Link>
 			);
 			return [

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -20,6 +20,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import { numberFormat } from 'lib/number';
 
 class TaxesReportTable extends Component {
 	getHeadersContent() {
@@ -99,7 +100,7 @@ class TaxesReportTable extends Component {
 					value: getCurrencyFormatDecimal( shipping_tax ),
 				},
 				{
-					display: orders_count,
+					display: numberFormat( orders_count ),
 					value: orders_count,
 				},
 			];
@@ -115,7 +116,7 @@ class TaxesReportTable extends Component {
 		return [
 			{
 				label: _n( 'tax code', 'tax codes', totalRows, 'wc-admin' ),
-				value: totalRows,
+				value: numberFormat( totalRows ),
 			},
 			{
 				label: __( 'total tax', 'wc-admin' ),
@@ -131,7 +132,7 @@ class TaxesReportTable extends Component {
 			},
 			{
 				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
-				value: totals.orders_count,
+				value: numberFormat( totals.orders_count ),
 			},
 		];
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/pull/904#discussion_r236018943.

Tables were displaying many numbers in rows and summaries which could be formatted with `numberFormat()`.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3616980/48960807-6d3fc100-ef35-11e8-865d-9a8647ed50cd.png)

After:
![image](https://user-images.githubusercontent.com/3616980/48960785-484b4e00-ef35-11e8-9ccc-a8df6dd78015.png)

### Detailed test instructions:
- Go to every report page and verify table numbers are correctly formatted.

Note that numbers <=999 look the same when they are formatted and they are not, so it might make sense to modify some of them in the code.