### PR TITLE
Merge report tables

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -31,10 +31,10 @@ class ReportTable extends Component {
 			tableData,
 			totalsCountField,
 			// These two props are not used in the render function, but are destructured
-			// so they are not included in the `props` variable.
+			// so they are not included in the `tableProps` variable.
 			endpoint,
 			tableQuery,
-			...props
+			...tableProps
 		} = this.props;
 
 		const { items, query } = tableData;
@@ -66,7 +66,7 @@ class ReportTable extends Component {
 				rowsPerPage={ query.per_page }
 				summary={ summary }
 				totalRows={ totalRows }
-				{ ...props }
+				{ ...tableProps }
 			/>
 		);
 	}

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -1,0 +1,138 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { get, orderBy } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { TableCard } from '@woocommerce/components';
+import { onQueryChange } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import ReportError from 'analytics/components/report-error';
+import { getReportChartData, getReportTableData } from 'store/reports/utils';
+
+class ReportTable extends Component {
+	render() {
+		const {
+			getHeadersContent,
+			getRowsContent,
+			getSummary,
+			itemIdField,
+			primaryData,
+			tableData,
+			totalsCountField,
+			// These two props are not used in the render function, but are destructured
+			// so they are not included in the `props` variable.
+			endpoint,
+			tableQuery,
+			...props
+		} = this.props;
+
+		const { items, query } = tableData;
+
+		const isError = tableData.isError || primaryData.isError;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
+		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
+
+		const headers = getHeadersContent();
+		const orderedItems = orderBy( items, query.orderby, query.order );
+		const ids = orderedItems.map( item => item[ itemIdField ] );
+		const rows = getRowsContent( orderedItems );
+		const totals = get( primaryData, [ 'data', 'totals' ], null );
+		const totalRows = get( totals, [ totalsCountField ], items.length );
+		const summary = getSummary( totals );
+
+		return (
+			<TableCard
+				downloadable
+				headers={ headers }
+				ids={ ids }
+				isLoading={ isRequesting }
+				onQueryChange={ onQueryChange }
+				rows={ rows }
+				rowsPerPage={ query.per_page }
+				summary={ summary }
+				totalRows={ totalRows }
+				{ ...props }
+			/>
+		);
+	}
+}
+
+ReportTable.propTypes = {
+	/**
+	 * The endpoint to use in API calls.
+	 */
+	endpoint: PropTypes.string.isRequired,
+	/**
+	 * A function that returns the headers object to build the table.
+	 */
+	getHeadersContent: PropTypes.func.isRequired,
+	/**
+	 * A function that returns the rows array to build the table.
+	 */
+	getRowsContent: PropTypes.func.isRequired,
+	/**
+	 * A function that returns the summary object to build the table.
+	 */
+	getSummary: PropTypes.func,
+	/**
+	 * The name of the property in the item object which contains the id.
+	 */
+	itemIdField: PropTypes.string.isRequired,
+	/**
+	 * Primary data of that report.
+	 */
+	primaryData: PropTypes.object.isRequired,
+	/**
+	 * Table data of that report.
+	 */
+	tableData: PropTypes.object.isRequired,
+	/**
+	 * Properties to be added to the query sent to the report table endpoint.
+	 */
+	tableQuery: PropTypes.object,
+	/**
+	 * String to display as the title of the table.
+	 */
+	title: PropTypes.string.isRequired,
+	/**
+	 * Name of the property in the primary data totals object which contains the
+	 * total number of items.
+	 */
+	totalsCountField: PropTypes.string,
+};
+
+ReportTable.defaultProps = {
+	getSummary: () => null,
+	tableQuery: {},
+	totalsCountField: '',
+};
+
+export default compose(
+	withSelect( ( select, props ) => {
+		const { endpoint, query, tableQuery } = props;
+		// @TODO allow loading the primary data for the variations table once #926 is fixed.
+		const primaryData =
+			endpoint === 'variations' ? {} : getReportChartData( endpoint, 'primary', query, select );
+		const tableData = getReportTableData( endpoint, query, select, tableQuery );
+
+		return {
+			primaryData,
+			tableData,
+		};
+	} )
+)( ReportTable );

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -52,8 +52,8 @@ class ReportTable extends Component {
 		const ids = orderedItems.map( item => item[ itemIdField ] );
 		const rows = getRowsContent( orderedItems );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
-		const totalRows = get( totals, [ totalsCountField ], items.length );
 		const summary = getSummary( totals );
+		const totalRows = get( totals, [ totalsCountField ], items.length );
 
 		return (
 			<TableCard

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -5,25 +5,29 @@
 import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
-import { get, map, orderBy } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
 import { getIntervalForQuery, getDateFormatsForInterval } from '@woocommerce/date';
-import { Link, TableCard } from '@woocommerce/components';
+import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { onQueryChange } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
-import ReportError from 'analytics/components/report-error';
-import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import ReportTable from 'analytics/components/report-table';
 
-class CouponsReportTable extends Component {
+export default class CouponsReportTable extends Component {
+	constructor() {
+		super();
+
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
+	}
+
 	getHeadersContent() {
 		return [
 			{
@@ -144,51 +148,20 @@ class CouponsReportTable extends Component {
 	}
 
 	render() {
-		const { tableData, primaryData } = this.props;
-		const { items, query } = tableData;
-
-		const isError = tableData.isError || primaryData.isError;
-
-		if ( isError ) {
-			return <ReportError isError />;
-		}
-
-		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
-
-		const headers = this.getHeadersContent();
-		const orderedCoupons = orderBy( items, query.orderby, query.order );
-		const rows = this.getRowsContent( orderedCoupons );
-		const totalRows = get( primaryData, [ 'data', 'totals', 'coupons_count' ], items.length );
-		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
+		const { query } = this.props;
 
 		return (
-			<TableCard
-				title={ __( 'Coupons', 'wc-admin' ) }
-				compareBy={ 'coupons' }
-				ids={ orderedCoupons.map( coupon => coupon.coupon_id ) }
-				rows={ rows }
-				totalRows={ totalRows }
-				rowsPerPage={ query.per_page }
-				headers={ headers }
-				isLoading={ isRequesting }
-				onQueryChange={ onQueryChange }
+			<ReportTable
+				compareBy="coupons"
+				endpoint="coupons"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				getSummary={ this.getSummary }
+				itemIdField="coupon_id"
 				query={ query }
-				summary={ summary }
-				downloadable
+				totalsCountField="coupons_count"
+				title={ __( 'Coupons', 'wc-admin' ) }
 			/>
 		);
 	}
 }
-
-export default compose(
-	withSelect( ( select, props ) => {
-		const { query } = props;
-		const primaryData = getReportChartData( 'coupons', 'primary', query, select );
-		const tableData = getReportTableData( 'coupons', query, select );
-
-		return {
-			primaryData,
-			tableData,
-		};
-	} )
-)( CouponsReportTable );

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -4,24 +4,28 @@
  */
 import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
-import { get, map, orderBy } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { Link, TableCard } from '@woocommerce/components';
+import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { onQueryChange } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
-import ReportError from 'analytics/components/report-error';
-import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import ReportTable from 'analytics/components/report-table';
 
-class TaxesReportTable extends Component {
+export default class TaxesReportTable extends Component {
+	constructor() {
+		super();
+
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
+	}
+
 	getHeadersContent() {
 		return [
 			{
@@ -137,51 +141,20 @@ class TaxesReportTable extends Component {
 	}
 
 	render() {
-		const { primaryData, tableData } = this.props;
-		const { items, query } = tableData;
-
-		const isError = tableData.isError || primaryData.isError;
-
-		if ( isError ) {
-			return <ReportError isError />;
-		}
-
-		const isRequesting = tableData.isLoading || primaryData.isRequesting;
-
-		const headers = this.getHeadersContent();
-		const orderedTaxes = orderBy( items, query.orderby, query.order );
-		const rows = this.getRowsContent( orderedTaxes );
-		const totalRows = get( primaryData, [ 'data', 'totals', 'taxes_count' ], items.length );
-		const summary = primaryData.data.totals ? this.getSummary( primaryData.data.totals ) : null;
+		const { query } = this.props;
 
 		return (
-			<TableCard
-				title={ __( 'Taxes', 'wc-admin' ) }
-				compareBy={ 'taxes' }
-				ids={ orderedTaxes.map( tax => tax.tax_rate_id ) }
-				rows={ rows }
-				totalRows={ totalRows }
-				rowsPerPage={ query.per_page }
-				headers={ headers }
-				isLoading={ isRequesting }
-				onQueryChange={ onQueryChange }
+			<ReportTable
+				compareBy="taxes"
+				endpoint="taxes"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				getSummary={ this.getSummary }
+				itemIdField="tax_rate_id"
 				query={ query }
-				summary={ summary }
-				downloadable
+				totalsCountField="taxes_count"
+				title={ __( 'Taxes', 'wc-admin' ) }
 			/>
 		);
 	}
 }
-
-export default compose(
-	withSelect( ( select, props ) => {
-		const { query } = props;
-		const primaryData = getReportChartData( 'taxes', 'primary', query, select );
-		const tableData = getReportTableData( 'taxes', query, select );
-
-		return {
-			primaryData,
-			tableData,
-		};
-	} )
-)( TaxesReportTable );

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -98,7 +98,7 @@ class Table extends Component {
 		this.setState( {
 			isScrollable: ! scrolledToEnd,
 		} );
-	};
+	}
 
 	render() {
 		const {


### PR DESCRIPTION
Follow-up of #896.

As we did with `<ReportChart>`, I merged most report tables into a single component `<ReportTable>`. Tables are a little bit different than charts because every report needs a different method to render table headers, rows and summary, but I still think this will make creating future report tables easier.

### Screenshots
_(there shouldn't be any visible change)_

### Detailed test instructions:
- Go to the _Categories_, _Coupons_, _Products_ (including the filter combination that displays the _Variations_ table). and _Taxes_ reports.
- Interact with tables: sorting, using pagination, downloading the CSV, hidding/showing columns, etc.
  _Notice:_ from those tables, only the _Products_ one has real data, all the others use SwaggerHub to render placeholder entries.
- Verify there are no regressions.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
