### PR TITLE
Hide selected items from autocomplete dropdown

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -128,6 +128,7 @@ class Search extends Component {
 				<Autocomplete
 					completer={ autocompleter }
 					onSelect={ this.selectResult }
+					selected={ selected.map( s => s.id ) }
 					staticResults={ staticResults }
 				>
 					{ ( { listBoxId, activeId, onChange } ) =>

--- a/packages/components/src/search/test/autocomplete.js
+++ b/packages/components/src/search/test/autocomplete.js
@@ -1,0 +1,40 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { Autocomplete } from '../autocomplete';
+
+describe( 'Autocomplete', () => {
+	it( 'doesn\'t return matching excluded elements', () => {
+		const suggestionClassname = 'autocomplete-result';
+		const search = 'lorem';
+		const options = [
+			{ key: '1', label: 'lorem 1', value: { id: '1' } },
+			{ key: '2', label: 'lorem 2', value: { id: '2' } },
+		];
+		const exclude = [ '2' ];
+		const autocomplete = mount(
+			<Autocomplete
+				children={ () => null }
+				className={ suggestionClassname }
+				completer={ {} }
+				selected={ exclude }
+			/>
+		);
+		autocomplete.setState( {
+			options,
+			query: {},
+			search,
+		} );
+
+		autocomplete.instance().search( { target: { value: search } } );
+		autocomplete.update();
+
+		expect( autocomplete.find( '.' + suggestionClassname ).length ).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes #826.

Prevent selected items to appear in the dropdown menu in the `<Search>` component.

### Screenshots
<img src="https://user-images.githubusercontent.com/3616980/49044255-d1ab8c00-f192-11e8-969a-1ba3ffcefd14.png" alt="" width="280" />
<img src="https://user-images.githubusercontent.com/3616980/49044271-da03c700-f192-11e8-8c0d-a5311f4046e6.png" alt="" width="283.5" />
<img src="https://user-images.githubusercontent.com/3616980/49044458-7201b080-f193-11e8-9912-6b772a77abe5.png" alt="" width="234.5" />

### Detailed test instructions:
- Go to a page with a `<Search>` component, for example the _Product_ report selecting _Product Comparison_ as the filter (`/analytics/products?filter=compare-products`).
- Search for a product and select it.
- Search for that product again and verify it doesn't appear in the dropdown list.