### PR TITLE
Call wp_set_script_translations when possible

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -72,19 +72,28 @@ function wc_admin_register_script() {
 	wp_register_script(
 		WC_ADMIN_APP,
 		wc_admin_url( "dist/{$entry}/index.js" ),
-		array( 'wc-components', 'wc-navigation', 'wp-date', 'wp-html-entities', 'wp-keycodes' ),
+		array( 'wc-components', 'wc-navigation', 'wp-date', 'wp-html-entities', 'wp-keycodes', 'wp-i18n' ),
 		filemtime( wc_admin_dir_path( "dist/{$entry}/index.js" ) ),
 		true
 	);
 
 	// Set up the text domain and translations.
+	// The old way (pre WP5 RC1).
 	if ( function_exists( 'wp_get_jed_locale_data' ) ) {
 		$locale_data = wp_get_jed_locale_data( 'wc-admin' );
-	} else {
+	} elseif ( function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 		$locale_data = gutenberg_get_jed_locale_data( 'wc-admin' );
+	} else {
+		$locale_data = '';
 	}
-	$content = 'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ', "wc-admin" );';
-	wp_add_inline_script( 'wp-i18n', $content, 'after' );
+	if ( ! empty( $locale_data ) ) {
+		$content = 'wp.i18n.setLocaleData( ' . wp_json_encode( $locale_data ) . ', "wc-admin" );';
+		wp_add_inline_script( 'wp-i18n', $content, 'after' );
+	}
+	// The new way (WP5 RC1 and later).
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( WC_ADMIN_APP, 'wc-admin' );
+	}
 
 	// Resets lodash to wp-admin's version of lodash.
 	wp_add_inline_script(


### PR DESCRIPTION
Fixes #937 

See https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/

### Detailed test instructions:

- `npm run build:release` this branch
- Install the ZIP on a on WordPress 5 5.0-RC1-43944 or later site which is NOT running the Gutenberg plugin.
- Activate this plugin
- Make sure no kaboom

Also ref:
https://make.wordpress.org/core/2018/11/09/5-0-javascript-language-packs-are-here-%F0%9F%8E%89/
https://core.trac.wordpress.org/ticket/45111
https://core.trac.wordpress.org/ticket/45161
https://github.com/WordPress/WordPress/commit/f2dc6be77687816b266bc87adab3848dd6b66709