### PR TITLE
Components: Remove import from local files

### DIFF
--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -13,7 +13,6 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
-import { NAMESPACE } from 'store/constants';
 
 /**
  * A tax completer.
@@ -33,7 +32,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `${ NAMESPACE }taxes${ payload }` } );
+		return apiFetch( { path: `/wc/v3/taxes${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( tax ) {


### PR DESCRIPTION
Looks like more local imports got merged with #881 – Since these are exported packages, they can’t rely on any local files. We should be using just the string `/wc/v3/` , instead of the undefined NAMESPACE constant. See #876 for the previous fix.

**To test**

You need an external project, but if you have one, you can run `npm link` from the components dir, and then `npm link @woocommerce/components` from the external project. That project should have errors with master, but be fixed here.