### PR TITLE
Add unit tests to /reports/variations

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -129,7 +129,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 				$extended_attributes = apply_filters( 'woocommerce_rest_reports_products_extended_attributes', $this->extended_attributes, $product_data );
 				foreach ( $extended_attributes as $extended_attribute ) {
 					$function = 'get_' . $extended_attribute;
-					if ( is_callable( array( $product, $function ) ) ) {
+					if ( is_callable( array( $product, $function ) ) && 'get_price' !== $function ) {
 						$value                                = $product->{$function}();
 						$extended_info[ $extended_attribute ] = $value;
 					}
@@ -137,7 +137,8 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 				$variations = $product->get_available_variations();
 				foreach ( $variations as $variation ) {
 					if ( (int) $variation['variation_id'] === (int) $product_data['variation_id'] ) {
-						$attributes = array();
+						$attributes        = array();
+						$variation_product = wc_get_product( $variation['variation_id'] );
 						foreach ( $variation['attributes'] as $attribute_name => $attribute ) {
 							$name         = str_replace( 'attribute_', '', $attribute_name );
 							$option_term  = get_term_by( 'slug', $attribute, $name );
@@ -148,6 +149,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 							);
 						}
 						$extended_info['attributes'] = $attributes;
+						$extended_info['price']      = $variation_product->get_price();
 					}
 				}
 				$extended_info = $this->cast_numbers( $extended_info );

--- a/tests/api/reports-variations.php
+++ b/tests/api/reports-variations.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Reports Products REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+class WC_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/reports/variations';
+
+	/**
+	 * Setup test reports products data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$variation = new WC_Product_Variation();
+		$variation->set_name( 'Test Variation' );
+		$variation->set_regular_price( 25 );
+		$variation->set_attributes( array( 'color' => 'green' ) );
+		$variation->save();
+
+		$order = WC_Helper_Order::create_order( 1, $variation );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $reports ) );
+
+		$variation_report = reset( $reports );
+
+		$this->assertEquals( $variation->get_id(), $variation_report['variation_id'] );
+		$this->assertEquals( 4, $variation_report['items_sold'] );
+		$this->assertEquals( 1, $variation_report['orders_count'] );
+		$this->assertArrayHasKey( '_links', $variation_report );
+		$this->assertArrayHasKey( 'extended_info', $variation_report );
+		$this->assertArrayHasKey( 'product', $variation_report['_links'] );
+		$this->assertArrayHasKey( 'variation', $variation_report['_links'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 6, count( $properties ) );
+		$this->assertArrayHasKey( 'product_id', $properties );
+		$this->assertArrayHasKey( 'variation_id', $properties );
+		$this->assertArrayHasKey( 'items_sold', $properties );
+		$this->assertArrayHasKey( 'gross_revenue', $properties );
+		$this->assertArrayHasKey( 'orders_count', $properties );
+		$this->assertArrayHasKey( 'extended_info', $properties );
+	}
+}

--- a/tests/reports/class-wc-tests-reports-variations.php
+++ b/tests/reports/class-wc-tests-reports-variations.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Reports order stats tests.
+ *
+ * @package WooCommerce\Tests\Orders
+ * @todo Finish up unit testing to verify bug-free order reports.
+ */
+class WC_Tests_Reports_Variations extends WC_Unit_Test_Case {
+
+	/**
+	 * Test the calculations and querying works correctly for the base case of 1 order.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_populate_and_query() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Product' );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_name( 'Test Variation' );
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_regular_price( 10 );
+		$variation->set_attributes( array( 'pa_color' => 'green' ) );
+		$variation->save();
+
+		$order = WC_Helper_Order::create_order( 1, $variation );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$data_store = new WC_Admin_Reports_Variations_Data_Store();
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() + HOUR_IN_SECONDS );
+		$args       = array(
+			'after'  => $start_time,
+			'before' => $end_time,
+		);
+
+		// Test retrieving the stats through the data store.
+		$data          = $data_store->get_data( $args );
+		$expected_data = (object) array(
+			'total'   => 1,
+			'pages'   => 1,
+			'page_no' => 1,
+			'data'    => array(
+				0 => array(
+					'product_id'    => $product->get_id(),
+					'variation_id'  => $variation->get_id(),
+					'items_sold'    => 4,
+					'gross_revenue' => 40.0, // $10 * 4.
+					'orders_count'  => 1,
+					'extended_info' => new ArrayObject(),
+				),
+			),
+		);
+		$this->assertEquals( $expected_data, $data );
+
+		// Test retrieving the stats through the query class.
+		$query = new WC_Admin_Reports_Variations_Query( $args );
+		$this->assertEquals( $expected_data, $query->get_data() );
+	}
+
+	/**
+	 * Test the extended ifo.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_extended_info() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'pa_color' );
+		$attribute->set_options( explode( WC_DELIMITER, 'green | red' ) );
+		$attribute->set_visible( false );
+		$attribute->set_variation( true );
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_name( 'Test Variation' );
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_regular_price( 10 );
+		$variation->set_attributes( array( 'pa_color' => 'green' ) );
+		$variation->save();
+
+		$order = WC_Helper_Order::create_order( 1, $variation );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$data_store = new WC_Admin_Reports_Variations_Data_Store();
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() + HOUR_IN_SECONDS );
+		$args       = array(
+			'after'         => $start_time,
+			'before'        => $end_time,
+			'extended_info' => 1,
+		);
+
+		// Test retrieving the stats through the data store.
+		$data          = $data_store->get_data( $args );
+		$expected_data = (object) array(
+			'total'   => 1,
+			'pages'   => 1,
+			'page_no' => 1,
+			'data'    => array(
+				0 => array(
+					'product_id'    => $product->get_id(),
+					'variation_id'  => $variation->get_id(),
+					'items_sold'    => 4,
+					'gross_revenue' => 40.0, // $10 * 4.
+					'orders_count'  => 1,
+					'extended_info' => array(
+						'name'       => $product->get_name(),
+						'image'      => $variation->get_image(),
+						'permalink'  => $product->get_permalink(),
+						'price'      => (float) $variation->get_price(),
+						'attributes' => array(
+							0 => array(
+								'id'     => 0,
+								'name'   => 'color',
+								'option' => 'green',
+							),
+						),
+					),
+				),
+			),
+		);
+		$this->assertEquals( $expected_data, $data );
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/934
Continues from https://github.com/woocommerce/wc-admin/pull/930

Adds a test suite similar to the one for `/reports/products`.

## Test

Run `phpunit` 
