### PR TITLE
Remove order statuses "wc-" prefix

### DIFF
--- a/packages/components/src/order-status/index.js
+++ b/packages/components/src/order-status/index.js
@@ -18,7 +18,7 @@ const OrderStatus = ( { order, className } ) => {
 	const indicatorClasses = classnames( 'woocommerce-order-status__indicator', {
 		[ 'is-' + status ]: true,
 	} );
-	const label = orderStatuses[ 'wc-' + status ] || status;
+	const label = orderStatuses[ status ] || status;
 	return (
 		<div className={ classes }>
 			<span className={ indicatorClasses } />

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -49,13 +49,13 @@ global.wcSettings = {
 		dow: 0,
 	},
 	orderStatuses: {
-		'wc-pending': 'Pending payment',
-		'wc-processing': 'Processing',
-		'wc-on-hold': 'On hold',
-		'wc-completed': 'Completed',
-		'wc-cancelled': 'Cancelled',
-		'wc-refunded': 'Refunded',
-		'wc-failed': 'Failed',
+		pending: 'Pending payment',
+		processing: 'Processing',
+		'on-hold': 'On hold',
+		completed: 'Completed',
+		cancelled: 'Cancelled',
+		refunded: 'Refunded',
+		failed: 'Failed',
 	},
 };
 


### PR DESCRIPTION
#943 assumes order statuses without the `wc-` prefix. Elsewhere in the app we use statuses without the prefix as well. 

This PR changes `wcSettings.orderStatuses` such that object keys are stripped of `wc-`.

## Test

Ensure no regressions are experienced with stuff related to order statuses.

1. Go to _Products Report_ and see the order statuses correctly displayed in the table.
2. In the console, check `wcSettings.orderStatuses` to see if it looks OK.