### PR TITLE
Use X-WP-Total header to set the total number of items in tables

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -37,7 +37,6 @@ class ReportTable extends Component {
 		} = this.props;
 
 		const { items, query } = tableData;
-		const { data: itemsData, totalResults } = items;
 
 		const isError = tableData.isError || primaryData.isError;
 
@@ -48,7 +47,7 @@ class ReportTable extends Component {
 		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
 
 		const headers = getHeadersContent();
-		const orderedItems = orderBy( itemsData, query.orderby, query.order );
+		const orderedItems = orderBy( items.data, query.orderby, query.order );
 		const ids = orderedItems.map( item => item[ itemIdField ] );
 		const rows = getRowsContent( orderedItems );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
@@ -64,7 +63,7 @@ class ReportTable extends Component {
 				rows={ rows }
 				rowsPerPage={ query.per_page }
 				summary={ summary }
-				totalRows={ totalResults || 0 }
+				totalRows={ items.totalCount || 0 }
 				{ ...tableProps }
 			/>
 		);

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -51,7 +51,7 @@ class ReportTable extends Component {
 		const ids = orderedItems.map( item => item[ itemIdField ] );
 		const rows = getRowsContent( orderedItems );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
-		const summary = getSummary( totals );
+		const summary = getSummary ? getSummary( totals ) : null;
 
 		return (
 			<TableCard
@@ -110,7 +110,6 @@ ReportTable.propTypes = {
 };
 
 ReportTable.defaultProps = {
-	getSummary: () => null,
 	tableQuery: {},
 };
 

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -133,7 +133,6 @@ export default class CategoriesReportTable extends Component {
 				getSummary={ this.getSummary }
 				itemIdField="category_id"
 				query={ query }
-				totalsCountField="categories_count"
 				title={ __( 'Categories', 'wc-admin' ) }
 			/>
 		);

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -160,7 +160,6 @@ export default class CouponsReportTable extends Component {
 				getSummary={ this.getSummary }
 				itemIdField="coupon_id"
 				query={ query }
-				totalsCountField="coupons_count"
 				title={ __( 'Coupons', 'wc-admin' ) }
 			/>
 		);

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -210,7 +210,6 @@ export default class ProductsReportTable extends Component {
 					order: query.order || 'desc',
 					extended_product_info: true,
 				} }
-				totalsCountField="products_count"
 				title={ __( 'Products', 'wc-admin' ) }
 			/>
 		);

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -153,7 +153,6 @@ export default class TaxesReportTable extends Component {
 				getSummary={ this.getSummary }
 				itemIdField="tax_rate_id"
 				query={ query }
-				totalsCountField="taxes_count"
 				title={ __( 'Taxes', 'wc-admin' ) }
 			/>
 		);

--- a/client/store/reports/items/actions.js
+++ b/client/store/reports/items/actions.js
@@ -1,13 +1,13 @@
 /** @format */
 
 export default {
-	setReportItems( endpoint, items, query, totalResults ) {
+	setReportItems( endpoint, query, data, totalCount ) {
 		return {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
-			items,
 			query: query || {},
-			totalResults,
+			data,
+			totalCount,
 		};
 	},
 	setReportItemsError( endpoint, query ) {

--- a/client/store/reports/items/actions.js
+++ b/client/store/reports/items/actions.js
@@ -1,12 +1,13 @@
 /** @format */
 
 export default {
-	setReportItems( endpoint, items, query ) {
+	setReportItems( endpoint, items, query, totalResults ) {
 		return {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
 			items,
 			query: query || {},
+			totalResults,
 		};
 	},
 	setReportItemsError( endpoint, query ) {

--- a/client/store/reports/items/reducer.js
+++ b/client/store/reports/items/reducer.js
@@ -21,8 +21,8 @@ export default function reportItemsReducer( state = DEFAULT_STATE, action ) {
 			return merge( {}, state, {
 				[ action.endpoint ]: {
 					[ queryKey ]: {
-						data: action.items,
-						totalResults: action.totalResults,
+						data: action.data,
+						totalCount: action.totalCount,
 					},
 				},
 			} );

--- a/client/store/reports/items/reducer.js
+++ b/client/store/reports/items/reducer.js
@@ -20,7 +20,10 @@ export default function reportItemsReducer( state = DEFAULT_STATE, action ) {
 		case 'SET_REPORT_ITEMS':
 			return merge( {}, state, {
 				[ action.endpoint ]: {
-					[ queryKey ]: action.items,
+					[ queryKey ]: {
+						data: action.items,
+						totalResults: action.totalResults,
+					},
 				},
 			} );
 

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -37,11 +37,14 @@ export default {
 		}
 
 		try {
-			const items = await apiFetch( {
+			const response = await apiFetch( {
+				parse: false,
 				path: NAMESPACE + 'reports/' + endpoint + stringifyQuery( query ),
 			} );
 
-			dispatch( 'wc-admin' ).setReportItems( endpoint, items, query );
+			const items = await response.json();
+			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
+			dispatch( 'wc-admin' ).setReportItems( endpoint, items, query, totalResults );
 		} catch ( error ) {
 			dispatch( 'wc-admin' ).setReportItemsError( endpoint, query );
 		}

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -26,9 +26,9 @@ export default {
 				const response = await fetch(
 					SWAGGERNAMESPACE + 'reports/' + endpoint + stringifyQuery( query )
 				);
-				const items = await response.json();
+				const itemsData = await response.json();
 
-				dispatch( 'wc-admin' ).setReportItems( endpoint, items, query );
+				dispatch( 'wc-admin' ).setReportItems( endpoint, query, itemsData );
 			} catch ( error ) {
 				dispatch( 'wc-admin' ).setReportItemsError( endpoint, query );
 			}
@@ -42,9 +42,9 @@ export default {
 				path: NAMESPACE + 'reports/' + endpoint + stringifyQuery( query ),
 			} );
 
-			const items = await response.json();
-			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
-			dispatch( 'wc-admin' ).setReportItems( endpoint, items, query, totalResults );
+			const itemsData = await response.json();
+			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
+			dispatch( 'wc-admin' ).setReportItems( endpoint, query, itemsData, totalCount );
 		} catch ( error ) {
 			dispatch( 'wc-admin' ).setReportItemsError( endpoint, query );
 		}

--- a/client/store/reports/items/selectors.js
+++ b/client/store/reports/items/selectors.js
@@ -21,7 +21,7 @@ import { getJsonString } from 'store/utils';
  * @return {Object}           Report details
  */
 function getReportItems( state, endpoint, query = {} ) {
-	return get( state, [ 'reports', 'items', endpoint, getJsonString( query ) ], [] );
+	return get( state, [ 'reports', 'items', endpoint, getJsonString( query ) ], {} );
 }
 
 export default {

--- a/client/store/reports/items/selectors.js
+++ b/client/store/reports/items/selectors.js
@@ -21,7 +21,7 @@ import { getJsonString } from 'store/utils';
  * @return {Object}           Report details
  */
 function getReportItems( state, endpoint, query = {} ) {
-	return get( state, [ 'reports', 'items', endpoint, getJsonString( query ) ], {} );
+	return get( state, [ 'reports', 'items', endpoint, getJsonString( query ) ], { data: [] } );
 }
 
 export default {

--- a/client/store/reports/items/test/reducer.js
+++ b/client/store/reports/items/test/reducer.js
@@ -37,7 +37,7 @@ describe( 'reportItemsReducer()', () => {
 		} );
 
 		const queryKey = getJsonString( query );
-		expect( state[ endpoint ][ queryKey ] ).toEqual( items );
+		expect( state[ endpoint ][ queryKey ].data ).toEqual( items );
 	} );
 
 	it( 'tracks multiple queries in items data', () => {
@@ -48,7 +48,9 @@ describe( 'reportItemsReducer()', () => {
 		const otherItems = [ { id: 1 }, { id: 2 }, { id: 3 } ];
 		const otherQueryState = {
 			[ endpoint ]: {
-				[ otherQueryKey ]: otherItems,
+				[ otherQueryKey ]: {
+					data: otherItems,
+				},
 			},
 		};
 		const originalState = deepFreeze( otherQueryState );
@@ -65,8 +67,8 @@ describe( 'reportItemsReducer()', () => {
 		} );
 
 		const queryKey = getJsonString( query );
-		expect( state[ endpoint ][ queryKey ] ).toEqual( items );
-		expect( state[ endpoint ][ otherQueryKey ] ).toEqual( otherItems );
+		expect( state[ endpoint ][ queryKey ].data ).toEqual( items );
+		expect( state[ endpoint ][ otherQueryKey ].data ).toEqual( otherItems );
 	} );
 
 	it( 'returns with received error data', () => {

--- a/client/store/reports/items/test/reducer.js
+++ b/client/store/reports/items/test/reducer.js
@@ -27,17 +27,22 @@ describe( 'reportItemsReducer()', () => {
 		const query = {
 			orderby: 'orders_count',
 		};
-		const items = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
 
 		const state = reportItemsReducer( originalState, {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
 			query,
-			items,
+			data: itemsData,
+			totalCount: itemsData.length,
 		} );
 
 		const queryKey = getJsonString( query );
-		expect( state[ endpoint ][ queryKey ].data ).toEqual( items );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( {
+			data: itemsData,
+			totalCount: itemsData.length,
+		} );
+		expect( state[ endpoint ][ queryKey ].totalCount ).toEqual( itemsData.length );
 	} );
 
 	it( 'tracks multiple queries in items data', () => {
@@ -45,11 +50,12 @@ describe( 'reportItemsReducer()', () => {
 			orderby: 'id',
 		};
 		const otherQueryKey = getJsonString( otherQuery );
-		const otherItems = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+		const otherItemsData = [ { id: 1 }, { id: 2 }, { id: 3 } ];
 		const otherQueryState = {
 			[ endpoint ]: {
 				[ otherQueryKey ]: {
-					data: otherItems,
+					data: otherItemsData,
+					totalCount: otherItemsData.length,
 				},
 			},
 		};
@@ -57,18 +63,25 @@ describe( 'reportItemsReducer()', () => {
 		const query = {
 			orderby: 'orders_count',
 		};
-		const items = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
 
 		const state = reportItemsReducer( originalState, {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
 			query,
-			items,
+			data: itemsData,
+			totalCount: itemsData.length,
 		} );
 
 		const queryKey = getJsonString( query );
-		expect( state[ endpoint ][ queryKey ].data ).toEqual( items );
-		expect( state[ endpoint ][ otherQueryKey ].data ).toEqual( otherItems );
+		expect( state[ endpoint ][ queryKey ] ).toEqual( {
+			data: itemsData,
+			totalCount: itemsData.length,
+		} );
+		expect( state[ endpoint ][ otherQueryKey ] ).toEqual( {
+			data: otherItemsData,
+			totalCount: otherItemsData.length,
+		} );
 	} );
 
 	it( 'returns with received error data', () => {

--- a/client/store/reports/items/test/reducer.js
+++ b/client/store/reports/items/test/reducer.js
@@ -28,21 +28,21 @@ describe( 'reportItemsReducer()', () => {
 			orderby: 'orders_count',
 		};
 		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsTotalCount = 50;
 
 		const state = reportItemsReducer( originalState, {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
 			query,
 			data: itemsData,
-			totalCount: itemsData.length,
+			totalCount: itemsTotalCount,
 		} );
 
 		const queryKey = getJsonString( query );
 		expect( state[ endpoint ][ queryKey ] ).toEqual( {
 			data: itemsData,
-			totalCount: itemsData.length,
+			totalCount: itemsTotalCount,
 		} );
-		expect( state[ endpoint ][ queryKey ].totalCount ).toEqual( itemsData.length );
 	} );
 
 	it( 'tracks multiple queries in items data', () => {
@@ -51,11 +51,12 @@ describe( 'reportItemsReducer()', () => {
 		};
 		const otherQueryKey = getJsonString( otherQuery );
 		const otherItemsData = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+		const otherItemsTotalCount = 70;
 		const otherQueryState = {
 			[ endpoint ]: {
 				[ otherQueryKey ]: {
 					data: otherItemsData,
-					totalCount: otherItemsData.length,
+					totalCount: otherItemsTotalCount,
 				},
 			},
 		};
@@ -64,23 +65,24 @@ describe( 'reportItemsReducer()', () => {
 			orderby: 'orders_count',
 		};
 		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsTotalCount = 50;
 
 		const state = reportItemsReducer( originalState, {
 			type: 'SET_REPORT_ITEMS',
 			endpoint,
 			query,
 			data: itemsData,
-			totalCount: itemsData.length,
+			totalCount: itemsTotalCount,
 		} );
 
 		const queryKey = getJsonString( query );
 		expect( state[ endpoint ][ queryKey ] ).toEqual( {
 			data: itemsData,
-			totalCount: itemsData.length,
+			totalCount: itemsTotalCount,
 		} );
 		expect( state[ endpoint ][ otherQueryKey ] ).toEqual( {
 			data: otherItemsData,
-			totalCount: otherItemsData.length,
+			totalCount: otherItemsTotalCount,
 		} );
 	} );
 

--- a/client/store/reports/items/test/resolvers.js
+++ b/client/store/reports/items/test/resolvers.js
@@ -53,8 +53,8 @@ describe( 'getReportItems', () => {
 		await getReportItems( endpoint );
 		expect( dispatch().setReportItems ).toHaveBeenCalledWith(
 			endpoint,
-			ITEMS_1,
 			undefined,
+			ITEMS_1,
 			ITEMS_1.length
 		);
 	} );
@@ -64,8 +64,8 @@ describe( 'getReportItems', () => {
 		await getReportItems( endpoint, { orderby: 'id' } );
 		expect( dispatch().setReportItems ).toHaveBeenCalledWith(
 			endpoint,
-			ITEMS_2,
 			{ orderby: 'id' },
+			ITEMS_2,
 			ITEMS_2.length
 		);
 	} );

--- a/client/store/reports/items/test/resolvers.js
+++ b/client/store/reports/items/test/resolvers.js
@@ -30,10 +30,20 @@ describe( 'getReportItems', () => {
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
 			if ( options.path === `/wc/v3/reports/${ endpoint }` ) {
-				return Promise.resolve( ITEMS_1 );
+				return Promise.resolve( {
+					headers: {
+						get: () => ITEMS_1.length,
+					},
+					json: () => Promise.resolve( ITEMS_1 ),
+				} );
 			}
 			if ( options.path === `/wc/v3/reports/${ endpoint }?orderby=id` ) {
-				return Promise.resolve( ITEMS_2 );
+				return Promise.resolve( {
+					headers: {
+						get: () => ITEMS_2.length,
+					},
+					json: () => Promise.resolve( ITEMS_2 ),
+				} );
 			}
 		} );
 	} );
@@ -41,12 +51,22 @@ describe( 'getReportItems', () => {
 	it( 'returns requested report data', async () => {
 		expect.assertions( 1 );
 		await getReportItems( endpoint );
-		expect( dispatch().setReportItems ).toHaveBeenCalledWith( endpoint, ITEMS_1, undefined );
+		expect( dispatch().setReportItems ).toHaveBeenCalledWith(
+			endpoint,
+			ITEMS_1,
+			undefined,
+			ITEMS_1.length
+		);
 	} );
 
 	it( 'returns requested report data for a specific query', async () => {
 		expect.assertions( 1 );
 		await getReportItems( endpoint, { orderby: 'id' } );
-		expect( dispatch().setReportItems ).toHaveBeenCalledWith( endpoint, ITEMS_2, { orderby: 'id' } );
+		expect( dispatch().setReportItems ).toHaveBeenCalledWith(
+			endpoint,
+			ITEMS_2,
+			{ orderby: 'id' },
+			ITEMS_2.length
+		);
 	} );
 } );

--- a/client/store/reports/items/test/resolvers.js
+++ b/client/store/reports/items/test/resolvers.js
@@ -24,7 +24,9 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 describe( 'getReportItems', () => {
 	const ITEMS_1 = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+	const ITEMS_1_COUNT = 50;
 	const ITEMS_2 = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+	const ITEMS_2_COUNT = 75;
 	const endpoint = 'products';
 
 	beforeAll( () => {
@@ -32,7 +34,7 @@ describe( 'getReportItems', () => {
 			if ( options.path === `/wc/v3/reports/${ endpoint }` ) {
 				return Promise.resolve( {
 					headers: {
-						get: () => ITEMS_1.length,
+						get: () => ITEMS_1_COUNT,
 					},
 					json: () => Promise.resolve( ITEMS_1 ),
 				} );
@@ -40,7 +42,7 @@ describe( 'getReportItems', () => {
 			if ( options.path === `/wc/v3/reports/${ endpoint }?orderby=id` ) {
 				return Promise.resolve( {
 					headers: {
-						get: () => ITEMS_2.length,
+						get: () => ITEMS_2_COUNT,
 					},
 					json: () => Promise.resolve( ITEMS_2 ),
 				} );
@@ -55,7 +57,7 @@ describe( 'getReportItems', () => {
 			endpoint,
 			undefined,
 			ITEMS_1,
-			ITEMS_1.length
+			ITEMS_1_COUNT
 		);
 	} );
 
@@ -66,7 +68,7 @@ describe( 'getReportItems', () => {
 			endpoint,
 			{ orderby: 'id' },
 			ITEMS_2,
-			ITEMS_2.length
+			ITEMS_2_COUNT
 		);
 	} );
 } );

--- a/client/store/reports/items/test/selectors.js
+++ b/client/store/reports/items/test/selectors.js
@@ -32,10 +32,10 @@ describe( 'getReportItems()', () => {
 	} );
 
 	it( 'returns stored items for current query', () => {
-		const items = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
 		const queryState = {
-			data: items,
-			totalResults: items.length,
+			data: itemsData,
+			totalCount: itemsData.length,
 		};
 		const state = deepFreeze( {
 			reports: {

--- a/client/store/reports/items/test/selectors.js
+++ b/client/store/reports/items/test/selectors.js
@@ -33,9 +33,10 @@ describe( 'getReportItems()', () => {
 
 	it( 'returns stored items for current query', () => {
 		const itemsData = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const itemsTotalCount = 50;
 		const queryState = {
 			data: itemsData,
-			totalCount: itemsData.length,
+			totalCount: itemsTotalCount,
 		};
 		const state = deepFreeze( {
 			reports: {

--- a/client/store/reports/items/test/selectors.js
+++ b/client/store/reports/items/test/selectors.js
@@ -26,23 +26,27 @@ const queryKey = getJsonString( query );
 const endpoint = 'coupons';
 
 describe( 'getReportItems()', () => {
-	it( 'returns an empty array when no items are available', () => {
+	it( 'returns an empty object when no items are available', () => {
 		const state = deepFreeze( {} );
-		expect( getReportItems( state, endpoint, query ) ).toEqual( [] );
+		expect( getReportItems( state, endpoint, query ) ).toEqual( {} );
 	} );
 
 	it( 'returns stored items for current query', () => {
 		const items = [ { id: 1214 }, { id: 1215 }, { id: 1216 } ];
+		const queryState = {
+			data: items,
+			totalResults: items.length,
+		};
 		const state = deepFreeze( {
 			reports: {
 				items: {
 					[ endpoint ]: {
-						[ queryKey ]: items,
+						[ queryKey ]: queryState,
 					},
 				},
 			},
 		} );
-		expect( getReportItems( state, endpoint, query ) ).toEqual( items );
+		expect( getReportItems( state, endpoint, query ) ).toEqual( queryState );
 	} );
 } );
 

--- a/client/store/reports/items/test/selectors.js
+++ b/client/store/reports/items/test/selectors.js
@@ -28,7 +28,7 @@ const endpoint = 'coupons';
 describe( 'getReportItems()', () => {
 	it( 'returns an empty object when no items are available', () => {
 		const state = deepFreeze( {} );
-		expect( getReportItems( state, endpoint, query ) ).toEqual( {} );
+		expect( getReportItems( state, endpoint, query ) ).toEqual( { data: [] } );
 	} );
 
 	it( 'returns stored items for current query', () => {


### PR DESCRIPTION
From discussion in #900, we will use `X-WP-Total` response header to set the total number of items in tables.

### Detailed test instructions:

This will affect all tables that use the tables store, but for now only the _Products_ table uses real data from the API.

- Go to the _Products_ report.
- Make sure the number of total items shown in the summary (_X products sold_) matches the number of rows in the table.
- Verify also that pagination works as expected.