### PR TITLE
Added support for ordering by product name in products endpoint.

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -221,6 +221,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 				'gross_revenue',
 				'orders_count',
 				'items_sold',
+				'product_name',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -62,6 +62,33 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'permalink',
 	);
 
+	/**
+	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return array
+	 */
+	protected function get_order_by_sql_params( $query_args ) {
+		global $wpdb;
+		$order_product_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+
+		$sql_query['order_by_clause'] = '';
+		if ( isset( $query_args['orderby'] ) ) {
+			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
+		}
+		// Order by product name requires extra JOIN.
+		if ( false !== strpos( $sql_query['order_by_clause'], '_products' ) ) {
+			$sql_query['from_clause'] .= " JOIN {$wpdb->prefix}posts AS _products ON {$order_product_lookup_table}.product_id = _products.ID";
+		}
+
+		if ( isset( $query_args['order'] ) ) {
+			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
+		} else {
+			$sql_query['order_by_clause'] .= ' DESC';
+		}
+
+		return $sql_query;
+	}
 
 	/**
 	 * Updates the database query with parameters used for Products report: categories and order status.
@@ -87,8 +114,8 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		if ( is_array( $query_args['order_status'] ) && count( $query_args['order_status'] ) > 0 ) {
 			$statuses = array_map( array( $this, 'normalize_order_status' ), $query_args['order_status'] );
 
-			$sql_query_params['from_clause']  .= " JOIN {$wpdb->prefix}posts ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}posts.ID";
-			$sql_query_params['where_clause'] .= " AND {$wpdb->prefix}posts.post_status IN ( '" . implode( "','", $statuses ) . "' ) ";
+			$sql_query_params['from_clause']  .= " JOIN {$wpdb->prefix}posts AS _orders ON {$order_product_lookup_table}.order_id = _orders.ID";
+			$sql_query_params['where_clause'] .= " AND _orders.post_status IN ( '" . implode( "','", $statuses ) . "' ) ";
 		}
 
 		return $sql_query_params;
@@ -103,6 +130,9 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	protected function normalize_order_by( $order_by ) {
 		if ( 'date' === $order_by ) {
 			return 'date_created';
+		}
+		if ( 'product_name' === $order_by ) {
+			return '_products.post_title';
 		}
 
 		return $order_by;


### PR DESCRIPTION
Fixes #740.

Adds support to sort response from `/products` by product name.

### Screenshots

### Detailed test instructions:

Try http://local.wordpress.test/wp-json/wc/v3/reports/products/?before=2018-11-22T04:21:35&after=2018-01-15T04:21:35&interval=day&orderby=product_name&extended_product_info=1&order=asc
it should correctly sort products by product name.


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
