### PR TITLE
Update/summary number focus

### DIFF
--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -323,11 +323,8 @@ $inner-border: $core-grey-light-500;
 
 .woocommerce-summary__item {
 	display: block;
-	margin-top: -1px;
-	height: calc(100% + 1px); // prevents 1px jump on focus due to double border issue below
 	padding: $spacing;
 	background-color: $core-grey-light-100;
-	box-shadow: inset 0 1px 0 0 $outer-border;
 	border-bottom: 1px solid $outer-border;
 	border-right: 1px solid $inner-border;
 	text-decoration: none;
@@ -342,19 +339,13 @@ $inner-border: $core-grey-light-500;
 
 	&:focus {
 		// !important to override button styles
-		margin-top: -1px;
-		height: calc(100% + 1px); // Hack to avoid double border
 		box-shadow: inset -1px -1px 0 $core-grey-dark-300, inset 1px 1px 0 $core-grey-dark-300 !important;
 	}
 
 	&.is-selected {
-		margin-top: -1px;
-		height: calc(100% + 1px); // Hack to avoid double border
 
 		&:focus {
 			// !important to override button styles
-			margin-top: -1px;
-			height: calc(100% + 1px); // Hack to avoid double border
 			box-shadow: inset -1px -1px 0 $core-grey-dark-300, inset 1px 0 0 $core-grey-dark-300, inset 0 4px 0 $woocommerce !important;
 		}
 	}

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -344,7 +344,7 @@ $inner-border: $core-grey-light-500;
 		// !important to override button styles
 		margin-top: -1px;
 		height: calc(100% + 1px); // Hack to avoid double border
-		box-shadow: inset -1px -1px 0 $black, inset 1px 1px 0 $core-grey-dark-300 !important;
+		box-shadow: inset -1px -1px 0 $core-grey-dark-300, inset 1px 1px 0 $core-grey-dark-300 !important;
 	}
 
 	&.is-selected {

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -323,9 +323,11 @@ $inner-border: $core-grey-light-500;
 
 .woocommerce-summary__item {
 	display: block;
-	height: 100%;
+	margin-top: -1px;
+	height: calc(100% + 1px); // prevents 1px jump on focus due to double border issue below
 	padding: $spacing;
 	background-color: $core-grey-light-100;
+	box-shadow: inset 0 1px 0 0 $outer-border;
 	border-bottom: 1px solid $outer-border;
 	border-right: 1px solid $inner-border;
 	text-decoration: none;
@@ -340,7 +342,9 @@ $inner-border: $core-grey-light-500;
 
 	&:focus {
 		// !important to override button styles
-		box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black !important;
+		margin-top: -1px;
+		height: calc(100% + 1px); // Hack to avoid double border
+		box-shadow: inset -1px -1px 0 $black, inset 1px 1px 0 $core-grey-dark-300 !important;
 	}
 
 	&.is-selected {
@@ -349,7 +353,9 @@ $inner-border: $core-grey-light-500;
 
 		&:focus {
 			// !important to override button styles
-			box-shadow: inset -2px -2px 0 $black, inset 2px 2px 0 $black, inset 0 4px 0 $woocommerce !important;
+			margin-top: -1px;
+			height: calc(100% + 1px); // Hack to avoid double border
+			box-shadow: inset -1px -1px 0 $core-grey-dark-300, inset 1px 0 0 $core-grey-dark-300, inset 0 4px 0 $woocommerce !important;
 		}
 	}
 


### PR DESCRIPTION
This PR updates the existing summary number focus styles, with lighter, less aggressive styling.

- It reduces the weight from 2px to 1px. 
- It changes the color from black to `$core-grey-dark-300` which is the lightest shade of grey in our color pallet that will maintain a 4.5:1 contrast ratio and meet WCAG 2.0 requirements
- it applies a negative top margin, and height calculation to the summary item, the focus state of the summary item, as well as the selected focus state of the summary item. The new top margin and height calculation prevent the text from shifting vertically, when selecting a new summary number. 

### Screenshots

**Existing styles:**

<img width="1537" alt="screen shot 2018-11-28 at 1 16 31 pm" src="https://user-images.githubusercontent.com/4500952/49183672-57097a80-f312-11e8-819d-6cee697a4a7c.png">

<img width="1531" alt="screen shot 2018-11-28 at 1 16 40 pm" src="https://user-images.githubusercontent.com/4500952/49183716-6c7ea480-f312-11e8-9840-773898188706.png">

**Updated Styles**

<img width="1538" alt="screen shot 2018-11-28 at 1 29 49 pm" src="https://user-images.githubusercontent.com/4500952/49184772-119a7c80-f315-11e8-83ba-e0bb9ce62d99.png">

<img width="1532" alt="screen shot 2018-11-28 at 1 29 21 pm" src="https://user-images.githubusercontent.com/4500952/49184795-1e1ed500-f315-11e8-97b4-77f38633a244.png">


### Detailed test instructions:

1. Open a new report and tab through the various summary numbers. 
2. Note all of the text in the summary number should stay put when a summary number is selected, and or in focus
3. Note new, less aggressive focus styles.  

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
