### PR TITLE
Don't encode search text in autocompleters before stringifying it

### DIFF
--- a/packages/components/src/search/autocompleters/coupons.js
+++ b/packages/components/src/search/autocompleters/coupons.js
@@ -27,7 +27,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search: encodeURIComponent( search ),
+				search,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/packages/components/src/search/autocompleters/product-cat.js
+++ b/packages/components/src/search/autocompleters/product-cat.js
@@ -27,7 +27,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search: encodeURIComponent( search ),
+				search,
 				per_page: 10,
 				orderby: 'count',
 			};

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -28,7 +28,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search: encodeURIComponent( search ),
+				search,
 				per_page: 10,
 				orderby: 'popularity',
 			};

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -27,7 +27,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search: encodeURIComponent( search ),
+				search,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -43,7 +43,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search: encodeURIComponent( search ),
+				search,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );


### PR DESCRIPTION
Fixes #827.

We were encoding the search parameters twice, that broke searching for item names with special characters like spaces.

The fact is that `stringifyQuery()` calls `qs.stringify()` ([#](https://github.com/ljharb/qs#stringifying)) which by default already encodes the output, so there is no need to encode it before.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/49188909-ff7b0700-f331-11e8-8cd6-7d0369a37841.png)

### Detailed test instructions:
- Go to the _Products_ report and select the _Single Product_ filter.
- Start writing the name of a product which contains spaces.
- Verify the product appears even when you write the space and the following letter in the search box.
- In the same search input, try breaking the search, for example, writing `?orderby=name` and verify via the Chrome devtools that's encoded to `%3Forderby%3Dname
`. So users' input is encoded before it's send to the server.