### PR TITLE
Variations: Add table data

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -116,7 +116,8 @@ ReportTable.defaultProps = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const { endpoint, getSummary, query, tableQuery } = props;
-		const primaryData = getSummary ? getReportChartData( endpoint, 'primary', query, select ) : {};
+		const chartEndpoint = 'variations' === endpoint ? 'products' : endpoint;
+		const primaryData = getSummary ? getReportChartData( chartEndpoint, 'primary', query, select ) : {};
 		const tableData = getReportTableData( endpoint, query, select, tableQuery );
 
 		return {

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -20,7 +20,7 @@ export default {
 	async getReportItems( ...args ) {
 		const [ endpoint, query ] = args.slice( -2 );
 
-		const swaggerEndpoints = [ 'categories', 'coupons', 'taxes', 'variations' ];
+		const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			try {
 				const response = await fetch(


### PR DESCRIPTION
Continues from #930 

Hook up the Variations table in Product Detail report to the new `/reports/variations` endpoint.

![screen shot 2018-11-29 at 12 45 39 pm](https://user-images.githubusercontent.com/1922453/49190382-ff811280-f3d6-11e8-85dc-37c7f3e06752.png)

## Caveats

* Summary numbers at the bottom of the table will show product data. When segmentation by variation comes, we can fix this.
* The chart reflects all data for the product, not just variations. Again, we're waiting on segmentation.

## Questions

* Variation Title: Since we don’t filter products by single variation, where does this link to?
* Orders Count: Since we don’t advanced filter the orders report by variation,  where does this link to?

cc @LevinMedia 

## Test

1. Create some orders for a product with variations (Hoodie works if you have sample data)
1. _Products Report_
2. Single Product > Hoodie
3. See the Orders of variations appear
4. Sort columns, use Variations filters