### PR TITLE
Make sure D3Base always updates when width changes

### DIFF
--- a/client/components/d3chart/d3-base/index.js
+++ b/client/components/d3chart/d3-base/index.js
@@ -29,12 +29,11 @@ export default class D3Base extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.getUpdatedParams = this.getUpdatedParams.bind( this );
 		this.chartRef = createRef();
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'resize', this.getUpdatedParams );
+		window.addEventListener( 'resize', this.drawChart );
 
 		this.drawUpdatedChart();
 	}
@@ -43,6 +42,7 @@ export default class D3Base extends Component {
 		return (
 			this.props.className !== nextProps.className ||
 			! isEqual( this.props.data, nextProps.data ) ||
+			this.props.height !== nextProps.height ||
 			this.props.type !== nextProps.type ||
 			this.props.width !== nextProps.width
 		);
@@ -53,7 +53,7 @@ export default class D3Base extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.getUpdatedParams );
+		window.removeEventListener( 'resize', this.drawChart );
 
 		this.deleteChart();
 	}
@@ -69,15 +69,12 @@ export default class D3Base extends Component {
 	 */
 	drawUpdatedChart() {
 		const { drawChart } = this.props;
-		const params = this.getUpdatedParams();
-
-		const svg = this.getContainer( params );
-		drawChart( svg, params, this.props.width );
+		const svg = this.getContainer();
+		drawChart( svg );
 	}
 
-	getContainer( params ) {
-		const { className } = this.props;
-		const { height, width } = params;
+	getContainer() {
+		const { className, height, width } = this.props;
 
 		this.deleteChart();
 
@@ -95,11 +92,6 @@ export default class D3Base extends Component {
 		return svg.append( 'g' );
 	}
 
-	getUpdatedParams() {
-		const { getParams } = this.props;
-		return getParams( this.chartRef.current );
-	}
-
 	render() {
 		return (
 			<div className={ classNames( 'd3-base', this.props.className ) } ref={ this.chartRef } />
@@ -111,6 +103,5 @@ D3Base.propTypes = {
 	className: PropTypes.string,
 	data: PropTypes.any, // required to detect changes in data
 	drawChart: PropTypes.func.isRequired,
-	getParams: PropTypes.func.isRequired,
 	type: PropTypes.string,
 };

--- a/client/components/d3chart/d3-base/index.js
+++ b/client/components/d3chart/d3-base/index.js
@@ -33,8 +33,6 @@ export default class D3Base extends Component {
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'resize', this.drawChart );
-
 		this.drawUpdatedChart();
 	}
 
@@ -54,8 +52,6 @@ export default class D3Base extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.drawChart );
-
 		this.deleteChart();
 	}
 

--- a/client/components/d3chart/d3-base/index.js
+++ b/client/components/d3chart/d3-base/index.js
@@ -42,6 +42,7 @@ export default class D3Base extends Component {
 		return (
 			this.props.className !== nextProps.className ||
 			! isEqual( this.props.data, nextProps.data ) ||
+			this.props.drawChart !== nextProps.drawChart ||
 			this.props.height !== nextProps.height ||
 			this.props.type !== nextProps.type ||
 			this.props.width !== nextProps.width

--- a/client/components/d3chart/d3-base/index.js
+++ b/client/components/d3chart/d3-base/index.js
@@ -26,7 +26,12 @@ import './style.scss';
  * phase' (i.e. in 'componentDidMount' and 'componentDidUpdate' methods).
  */
 export default class D3Base extends Component {
-	chartRef = createRef();
+	constructor( props ) {
+		super( props );
+
+		this.getUpdatedParams = this.getUpdatedParams.bind( this );
+		this.chartRef = createRef();
+	}
 
 	componentDidMount() {
 		window.addEventListener( 'resize', this.getUpdatedParams );

--- a/client/components/d3chart/d3-base/test/index.js
+++ b/client/components/d3chart/d3-base/test/index.js
@@ -15,13 +15,12 @@ describe( 'D3base', () => {
 	const shallowWithoutLifecycle = arg => shallow( arg, { disableLifecycleMethods: true } );
 
 	test( 'should have d3Base class', () => {
-		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } getParams={ noop } /> );
+		const base = shallowWithoutLifecycle( <D3Base drawChart={ noop } /> );
 		expect( base.find( '.d3-base' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render an svg', () => {
-		const getParams = () => ( { width: 100, height: 100 } );
-		const base = mount( <D3Base drawChart={ noop } getParams={ getParams } /> );
+		const base = mount( <D3Base drawChart={ noop } height="100" width="100" /> );
 		expect( base.render().find( 'svg' ) ).toHaveLength( 1 );
 	} );
 
@@ -29,22 +28,7 @@ describe( 'D3base', () => {
 		const drawChart = svg => {
 			return svg.append( 'circle' );
 		};
-		const getParams = () => ( {
-			width: 100,
-			height: 100,
-		} );
-		const base = mount( <D3Base drawChart={ drawChart } getParams={ getParams } /> );
-		expect( base.render().find( 'circle' ) ).toHaveLength( 1 );
-	} );
-
-	test( 'should pass a property of getParams output to drawChart function', () => {
-		const getParams = () => ( {
-			tagName: 'circle',
-		} );
-		const drawChart = ( svg, params ) => {
-			return svg.append( params.tagName );
-		};
-		const base = mount( <D3Base drawChart={ drawChart } getParams={ getParams } /> );
+		const base = mount( <D3Base drawChart={ drawChart } height="100" width="100" /> );
 		expect( base.render().find( 'circle' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -128,7 +128,6 @@ class D3Chart extends Component {
 			adjWidth,
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
-			height,
 			line: getLine( xLineScale, yScale ),
 			lineData,
 			margin,

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -71,11 +71,11 @@ class D3Chart extends Component {
 	}
 
 	drawChart( node ) {
-		const { data, height, margin, type, width } = this.props;
+		const { data, margin, type } = this.props;
 		const params = this.getParams();
 		const adjParams = Object.assign( {}, params, {
-			height: height - margin.top - margin.bottom,
-			width: width - margin.left - margin.right,
+			height: params.adjHeight,
+			width: params.adjWidth,
 			tooltip: d3Select( this.tooltipRef.current ),
 			valueType: params.valueType,
 		} );
@@ -124,6 +124,8 @@ class D3Chart extends Component {
 		const xScale = getXScale( uniqueDates, adjWidth );
 		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
 		return {
+			adjHeight,
+			adjWidth,
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
 			height,

--- a/client/components/d3chart/index.js
+++ b/client/components/d3chart/index.js
@@ -47,17 +47,13 @@ class D3Chart extends Component {
 		this.state = {
 			allData: this.getAllData( props ),
 			type: props.type,
-			width: props.width,
 		};
 		this.tooltipRef = createRef();
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { type, width } = this.props;
+		const { type } = this.props;
 		/* eslint-disable react/no-did-update-set-state */
-		if ( width !== prevProps.width ) {
-			this.setState( { width } );
-		}
 		const nextAllData = this.getAllData( this.props );
 		if ( ! isEqual( [ ...nextAllData ].sort(), [ ...prevState.allData ].sort() ) ) {
 			this.setState( { allData: nextAllData } );
@@ -74,27 +70,27 @@ class D3Chart extends Component {
 		return [ ...props.data, ...orderedKeys ];
 	}
 
-	drawChart( node, params ) {
-		const { data, margin, type } = this.props;
+	drawChart( node ) {
+		const { data, height, margin, type, width } = this.props;
+		const params = this.getParams();
+		const adjParams = Object.assign( {}, params, {
+			height: height - margin.top - margin.bottom,
+			width: width - margin.left - margin.right,
+			tooltip: d3Select( this.tooltipRef.current ),
+			valueType: params.valueType,
+		} );
+
 		const g = node
 			.attr( 'id', 'chart' )
 			.append( 'g' )
 			.attr( 'transform', `translate(${ margin.left },${ margin.top })` );
 
-		const adjParams = Object.assign( {}, params, {
-			height: params.height - margin.top - margin.bottom,
-			width: params.width - margin.left - margin.right,
-			tooltip: d3Select( this.tooltipRef.current ),
-			valueType: params.valueType,
-		} );
 		drawAxis( g, adjParams );
 		type === 'line' && drawLines( g, data, adjParams );
 		type === 'bar' && drawBars( g, data, adjParams );
-
-		return node;
 	}
 
-	getParams( node ) {
+	getParams() {
 		const {
 			colorScheme,
 			data,
@@ -109,16 +105,14 @@ class D3Chart extends Component {
 			tooltipValueFormat,
 			tooltipTitle,
 			type,
+			width,
 			xFormat,
 			x2Format,
 			yFormat,
 			valueType,
 		} = this.props;
-		const { width } = this.state;
-		const calculatedWidth = width && width > 0 ? width : node.offsetWidth;
-		const calculatedHeight = height || node.offsetHeight;
-		const adjHeight = calculatedHeight - margin.top - margin.bottom;
-		const adjWidth = calculatedWidth - margin.left - margin.right;
+		const adjHeight = height - margin.top - margin.bottom;
+		const adjWidth = width - margin.left - margin.right;
 		const uniqueKeys = getUniqueKeys( data );
 		const newOrderedKeys = orderedKeys || getOrderedKeys( data, uniqueKeys );
 		const lineData = getLineData( data, newOrderedKeys );
@@ -132,7 +126,7 @@ class D3Chart extends Component {
 		return {
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
-			height: calculatedHeight,
+			height,
 			line: getLine( xLineScale, yScale ),
 			lineData,
 			margin,
@@ -146,7 +140,6 @@ class D3Chart extends Component {
 			type,
 			uniqueDates,
 			uniqueKeys,
-			width: calculatedWidth,
 			xFormat: getFormatter( xFormat, d3TimeFormat ),
 			x2Format: getFormatter( x2Format, d3TimeFormat ),
 			xGroupScale: getXGroupScale( orderedKeys, xScale ),
@@ -174,9 +167,9 @@ class D3Chart extends Component {
 					className={ classNames( this.props.className ) }
 					data={ this.state.allData }
 					drawChart={ this.drawChart }
-					getParams={ this.getParams }
+					height={ this.props.height }
 					type={ this.state.type }
-					width={ this.state.width }
+					width={ this.props.width }
 				/>
 				<div className="d3-chart__tooltip" ref={ this.tooltipRef } />
 			</div>


### PR DESCRIPTION
Fixes #907.

In some circumstances, `D3Base` was not redrawing the chart even thought the width of the chart changed.

This PR fixes that, removes the state from `D3Base` and moves the `propTypes` at the bottom of the component, as we have in most of the other components.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/49243844-fb9fc100-f3d3-11e8-8268-c84f99e3cee0.png)

### Detailed test instructions:
- Go to the _Products_ report.
- Change the filter to _Top Products by Items Sold_.
- Notice the chart doesn't overflow.
- Reload the page.
- Change the filter to _All Products_.
- Notice the chart covers the available space.
