### PR TITLE
Add screen reader labels to table headers

### DIFF
--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -38,6 +38,7 @@ export default class CategoriesReportTable extends Component {
 			},
 			{
 				label: __( 'G. Revenue', 'wc-admin' ),
+				screenReaderLabel: __( 'Gross Revenue', 'wc-admin' ),
 				key: 'gross_revenue',
 				isSortable: true,
 				isNumeric: true,

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -49,6 +49,7 @@ export default class CouponsReportTable extends Component {
 			},
 			{
 				label: __( 'G. Discounted', 'wc-admin' ),
+				screenReaderLabel: __( 'Gross Discounted', 'wc-admin' ),
 				key: 'gross_discount',
 				isSortable: true,
 				isNumeric: true,

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -44,6 +44,7 @@ class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
+				screenReaderLabel: __( 'Order ID', 'wc-admin' ),
 				key: 'id',
 				required: true,
 				isSortable: true,
@@ -62,6 +63,7 @@ class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Product(s)', 'wc-admin' ),
+				screenReaderLabel: __( 'Products', 'wc-admin' ),
 				key: 'products',
 				required: false,
 				isSortable: false,
@@ -75,12 +77,14 @@ class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Coupon(s)', 'wc-admin' ),
+				screenReaderLabel: __( 'Coupons', 'wc-admin' ),
 				key: 'coupons',
 				required: false,
 				isSortable: false,
 			},
 			{
 				label: __( 'N. Revenue', 'wc-admin' ),
+				screenReaderLabel: __( 'Net Revenue', 'wc-admin' ),
 				key: 'net_revenue',
 				required: true,
 				isSortable: false,

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -51,6 +51,7 @@ export default class VariationsReportTable extends Component {
 			},
 			{
 				label: __( 'G. Revenue', 'wc-admin' ),
+				screenReaderLabel: __( 'Gross Revenue', 'wc-admin' ),
 				key: 'gross_revenue',
 				required: true,
 				isSortable: true,

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -50,6 +50,7 @@ export default class ProductsReportTable extends Component {
 			},
 			{
 				label: __( 'G. Revenue', 'wc-admin' ),
+				screenReaderLabel: __( 'Gross Revenue', 'wc-admin' ),
 				key: 'gross_revenue',
 				required: true,
 				isSortable: true,

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -295,6 +295,7 @@ Additional CSS classes.
   - key: String - The API parameter name for this column, passed to `orderby` when sorting via API.
   - label: ReactNode - The display label for this column.
   - required: Boolean - Boolean, true if this column should always display in the table (not shown in toggle-able list).
+  - screenReaderLabel: String - The label used for screen readers for this column.
 - Default: `[]`
 
 An array of column headers, as objects.

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -139,7 +139,7 @@ class Table extends Component {
 					<tbody>
 						<tr>
 							{ headers.map( ( header, i ) => {
-								const { cellClassName, isLeftAligned, isSortable, isNumeric, key, label } = header;
+								const { cellClassName, isLeftAligned, isSortable, isNumeric, key, label, screenReaderLabel } = header;
 								const labelId = `header-${ instanceId } -${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', cellClassName, {
@@ -158,8 +158,8 @@ class Table extends Component {
 								// We only sort by ascending if the col is already sorted descending
 								const iconLabel =
 									sortedBy === key && sortDir !== ASC
-										? sprintf( __( 'Sort by %s in ascending order', 'wc-admin' ), label )
-										: sprintf( __( 'Sort by %s in descending order', 'wc-admin' ), label );
+										? sprintf( __( 'Sort by %s in ascending order', 'wc-admin' ), screenReaderLabel )
+										: sprintf( __( 'Sort by %s in descending order', 'wc-admin' ), screenReaderLabel );
 
 								return (
 									<th role="columnheader" scope="col" key={ i } { ...thProps }>
@@ -177,7 +177,10 @@ class Table extends Component {
 													onClick={ this.sortBy( key ) }
 													isDefault
 												>
-													{ label }
+													<span aria-hidden={ Boolean( screenReaderLabel ) }>{ label }</span>
+													{ screenReaderLabel && (
+														<span className="screen-reader-text">{ screenReaderLabel }</span>
+													) }
 												</IconButton>
 												<span className="screen-reader-text" id={ labelId }>
 													{ iconLabel }

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -266,6 +266,10 @@ Table.propTypes = {
 			 * Boolean, true if this column should always display in the table (not shown in toggle-able list).
 			 */
 			required: PropTypes.bool,
+			/**
+			 * The label used for screen readers for this column.
+			 */
+			screenReaderLabel: PropTypes.string,
 		} )
 	),
 	/**


### PR DESCRIPTION
Fixes #859.

In some table headers we are displaying a short form of the label which might be problematic for screen readers (for example _G. Revenue_ instead of _Gross Revenue_. This PR allows the table component to receive a property named `screenReaderLabel` for each header, which will be used for screen readers.

### Detailed test instructions:
- Go to one of the reports modified, for example, the _Products_ report.
- Navigate the page with the `Tab` button and the screen reader on.
- Verify it reads _Gross Revenue_ instead of _G Revenue_ when focusing that header.