### PR TITLE
Activity Panel: Orders: Hook up to orders data.

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -25,6 +25,7 @@ import {
 	Section,
 } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getAdminLink } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -141,7 +142,10 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 										</div>
 									}
 									actions={
-										<Button isDefault onClick={ noop }>
+										<Button
+											isDefault
+											href={ getAdminLink( 'post.php?action=edit&post=' + order.id ) }
+										>
 											Begin fulfillment
 										</Button>
 									}

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -146,7 +146,7 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 											isDefault
 											href={ getAdminLink( 'post.php?action=edit&post=' + order.id ) }
 										>
-											Begin fulfillment
+											{ __( 'Begin fulfillment' ) }
 										</Button>
 									}
 								>

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -16,6 +16,7 @@ import interpolateComponents from 'interpolate-components';
  */
 import {
 	EllipsisMenu,
+	EmptyContent,
 	Flag,
 	Link,
 	MenuTitle,
@@ -34,7 +35,27 @@ import ActivityOutboundLink from '../activity-outbound-link';
 import { getOrderRefundTotal } from 'lib/order-values';
 import { QUERY_DEFAULTS } from 'store/constants';
 
-function OrdersPanel( { orders, isRequesting } ) {
+function OrdersPanel( { orders, isRequesting, isError } ) {
+	if ( isError ) {
+		const title = __( 'There was an error getting your orders. Please try again.', 'wc-admin' );
+		const actionLabel = __( 'Reload', 'wc-admin' );
+		const actionCallback = () => {
+			// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
+			window.location.reload();
+		};
+
+		return (
+			<Fragment>
+				<EmptyContent
+					title={ title }
+					actionLabel={ actionLabel }
+					actionURL={ null }
+					actionCallback={ actionCallback }
+				/>
+			</Fragment>
+		);
+	}
+
 	const menu = (
 		<EllipsisMenu label="Demo Menu">
 			<MenuTitle>Test</MenuTitle>

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -28,7 +28,7 @@ import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency'
 /**
  * Internal dependencies
  */
-import { ActivityCard } from '../activity-card';
+import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
 import ActivityOutboundLink from '../activity-outbound-link';
 import { getOrderRefundTotal } from 'lib/order-values';
@@ -75,7 +75,12 @@ function OrdersPanel( { orders, isRequesting } ) {
 			<ActivityHeader title={ __( 'Orders', 'wc-admin' ) } menu={ menu } />
 			<Section>
 				{ isRequesting ? (
-					<p>Loading</p>
+					<ActivityCardPlaceholder
+						className="woocommerce-order-activity-card"
+						hasAction
+						hasDate
+						lines={ 2 }
+					/>
 				) : (
 					<Fragment>
 						{ orders.map( ( order, i ) => {

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -6,7 +6,6 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import interpolateComponents from 'interpolate-components';
@@ -35,6 +34,7 @@ import ActivityHeader from '../activity-header';
 import ActivityOutboundLink from '../activity-outbound-link';
 import { getOrderRefundTotal } from 'lib/order-values';
 import { QUERY_DEFAULTS } from 'store/constants';
+import withSelect from 'wc-api/with-select';
 
 function OrdersPanel( { orders, isRequesting, isError } ) {
 	if ( isError ) {
@@ -178,7 +178,7 @@ OrdersPanel.defaultProps = {
 
 export default compose(
 	withSelect( select => {
-		const { getOrders, isGetOrdersError, isGetOrdersRequesting } = select( 'wc-admin' );
+		const { getOrders, isGetOrdersError, isGetOrdersRequesting } = select( 'wc-api' );
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -178,6 +178,7 @@ export default compose(
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
+			status: 'processing',
 		};
 
 		const orders = getOrders( ordersQuery );

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -239,9 +239,20 @@
 	}
 }
 
-.woocommerce-order-activity-card {
-	.woocommerce-activity-card__title {
-		font-weight: normal;
+// Needs the double-class for specificity
+.woocommerce-activity-card.woocommerce-order-activity-card {
+	grid-template-columns: 1fr;
+	grid-template-areas:
+		'header'
+		'body'
+		'actions';
+
+	.woocommerce-activity-card__icon {
+		display: none;
+	}
+
+	.woocommerce-flag {
+		display: inline-block;
 	}
 
 	.woocommerce-activity-card__subtitle {


### PR DESCRIPTION
Resolves https://github.com/woocommerce/wc-admin/issues/935.

Wire up orders panel to data store and tweak order card styling (new styles differ from https://github.com/woocommerce/wc-admin/issues/144).

### Screenshots

![screen shot 2018-11-30 at 3 51 50 pm](https://user-images.githubusercontent.com/63922/49318970-e7cd8b00-f4b7-11e8-9ae0-6a3e20b4c86d.png)

### Detailed test instructions:

- Create some orders if you don't already have them
- Open WC admin dashboard
- Click Orders
- Verify that orders display - note that only "processing" status orders are queried
- Verify that order number and fulfillment button link to order details/edit page
- Refresh
- Toggle browser online status (simulate offline)
- Click Orders
- Verify that error message displays