### PR TITLE
Table Component: Update showcols to use keys

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+- Update `<Table />` to use header keys to denote which columns are shown
+
 # 1.2.0
 
 - Update `Search` to exclude already-selected items

--- a/packages/components/src/table/test/index.js
+++ b/packages/components/src/table/test/index.js
@@ -75,7 +75,7 @@ describe( 'TableCard', () => {
 			/>
 		);
 		tableCard.setState( {
-			showCols: [ true, true, true, true, false, true, true, true ],
+			showCols: [ 'date', 'orders_count', 'gross_revenue', 'refunds', 'taxes', 'shipping', 'net_revenue' ],
 		} );
 
 		const downloadButton = tableCard.findWhere(


### PR DESCRIPTION
This updates the table component to use keys to keep track of which
columns should be visible instead of column indices. This will be
necessary for keeping track of which columns were selected after a
component has been unmounted and re-mounted again later. (e.g. for
persistence or saving of user preferences)

Required to fix #892 

### Detailed test instructions:

1. Run `npm test` and all tests should succeed.
2. Check out and verify table operation within the app that it works 100% the same.
3. Test the CSV download functionality.
