### PR TITLE
REST API: Group extended_info for /reports/products

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -91,7 +91,7 @@ export default class ProductsReportTable extends Component {
 			const {
 				product_id,
 				sku = '', // @TODO
-				name,
+				extended_info,
 				items_sold,
 				gross_revenue,
 				orders_count,
@@ -100,6 +100,7 @@ export default class ProductsReportTable extends Component {
 				stock_status = 'outofstock', // @TODO
 				stock_quantity = '0', // @TODO
 			} = row;
+			const { name } = extended_info;
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',
 				product_includes: product_id,
@@ -209,7 +210,7 @@ export default class ProductsReportTable extends Component {
 				tableQuery={ {
 					orderby: query.orderby || 'items_sold',
 					order: query.order || 'desc',
-					extended_product_info: true,
+					extended_info: true,
 				} }
 				title={ __( 'Products', 'wc-admin' ) }
 			/>

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -127,7 +127,7 @@ export default compose(
 		const endpoint = NAMESPACE + 'reports/products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
-		const query = { orderby: 'items_sold', per_page: 5, extended_product_info: 1 };
+		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -68,7 +68,7 @@ describe( 'TopSellingProducts', () => {
 		const topSellingProducts = topSellingProductsWrapper.root.findByType( TopSellingProducts );
 
 		const endpoint = '/wc/v3/reports/products';
-		const query = { orderby: 'items_sold', per_page: 5, extended_product_info: 1 };
+		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
 		expect( getReportStatsMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -243,7 +243,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 				'type' => 'integer',
 			),
 		);
-		$params['extended_product_info'] = array(
+		$params['extended_info'] = array(
 			'description'       => __( 'Add additional piece of info about each product to the report.', 'wc-admin' ),
 			'type'              => 'boolean',
 			'default'           => false,

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -142,18 +142,24 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 * Enriches the product data with attributes specified by the extended_attributes.
 	 *
 	 * @param array $products_data Product data.
+	 * @param array $query_args  Query parameters.
 	 */
-	protected function include_extended_product_info( &$products_data ) {
+	protected function include_extended_info( &$products_data, $query_args ) {
 		foreach ( $products_data as $key => $product_data ) {
-			$product             = wc_get_product( $product_data['product_id'] );
-			$extended_attributes = apply_filters( 'woocommerce_rest_reports_products_extended_attributes', $this->extended_attributes, $product_data );
-			foreach ( $extended_attributes as $extended_attribute ) {
-				$function = 'get_' . $extended_attribute;
-				if ( is_callable( array( $product, $function ) ) ) {
-					$value                                        = $product->{$function}();
-					$products_data[ $key ][ $extended_attribute ] = $value;
+			$extended_info = new ArrayObject();
+			if ( $query_args['extended_info'] ) {
+				$product             = wc_get_product( $product_data['product_id'] );
+				$extended_attributes = apply_filters( 'woocommerce_rest_reports_products_extended_attributes', $this->extended_attributes, $product_data );
+				foreach ( $extended_attributes as $extended_attribute ) {
+					$function = 'get_' . $extended_attribute;
+					if ( is_callable( array( $product, $function ) ) ) {
+						$value                                = $product->{$function}();
+						$extended_info[ $extended_attribute ] = $value;
+					}
 				}
+				$extended_info = $this->cast_numbers( $extended_info );
 			}
+			$products_data[ $key ]['extended_info'] = $extended_info;
 		}
 	}
 
@@ -172,18 +178,18 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
 		$defaults = array(
-			'per_page'              => get_option( 'posts_per_page' ),
-			'page'                  => 1,
-			'order'                 => 'DESC',
-			'orderby'               => 'date',
-			'before'                => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
-			'after'                 => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
-			'fields'                => '*',
-			'categories'            => array(),
-			'products'              => array(),
-			'extended_product_info' => false,
+			'per_page'      => get_option( 'posts_per_page' ),
+			'page'          => 1,
+			'order'         => 'DESC',
+			'orderby'       => 'date',
+			'before'        => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
+			'after'         => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
+			'fields'        => '*',
+			'categories'    => array(),
+			'products'      => array(),
+			'extended_info' => false,
 			// This is not a parameter for products reports per se, but we want to only take into account selected order types.
-			'order_status'          => parent::get_report_order_statuses(),
+			'order_status'  => parent::get_report_order_statuses(),
 
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
@@ -192,7 +198,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		$data      = wp_cache_get( $cache_key, $this->cache_group );
 
 		if ( false === $data ) {
-			$data         = (object) array(
+			$data = (object) array(
 				'data'    => array(),
 				'total'   => 0,
 				'pages'   => 0,
@@ -244,9 +250,8 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 				return $data;
 			}
 
-			if ( $query_args['extended_product_info'] ) {
-				$this->include_extended_product_info( $product_data );
-			}
+			$this->include_extended_info( $product_data, $query_args );
+
 			$product_data = array_map( array( $this, 'cast_numbers' ), $product_data );
 			$data         = (object) array(
 				'data'    => $product_data,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/933

When passing the `extended_info` flag as a REST query parameter, the response includes additional information in the `extended_info` property instead of scattering several properties in the top level of the object.

* Change query parameter `extended_product_info` to `extended_info`.
* Return `extended_info: {}` when the query parameter is not passed.
* Make corresponding client side changes.

## Test

1. _Products Report_.
2. Ensure no errors happen when viewing the table.
