### PR TITLE
Stock report

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -24,6 +24,7 @@ import RevenueReport from './revenue';
 import CategoriesReport from './categories';
 import CouponsReport from './coupons';
 import TaxesReport from './taxes';
+import StockReport from './stock';
 import CustomersReport from './customers';
 
 const REPORTS_FILTER = 'woocommerce-reports-list';
@@ -59,6 +60,11 @@ const getReports = () => {
 			report: 'taxes',
 			title: __( 'Taxes', 'wc-admin' ),
 			component: TaxesReport,
+		},
+		{
+			report: 'stock',
+			title: __( 'Stock', 'wc-admin' ),
+			component: StockReport,
 		},
 		{
 			report: 'customers',

--- a/client/analytics/report/stock/config.js
+++ b/client/analytics/report/stock/config.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const showDatePicker = false;
+
+export const filters = [
+	{
+		label: __( 'Show', 'wc-admin' ),
+		staticParams: [],
+		param: 'type',
+		showFilters: () => true,
+		filters: [
+			{ label: __( 'All Products', 'wc-admin' ), value: 'all' },
+			{ label: __( 'Out of Stock', 'wc-admin' ), value: 'outofstock' },
+			{ label: __( 'Low Stock', 'wc-admin' ), value: 'lowstock' },
+			{ label: __( 'In Stock', 'wc-admin' ), value: 'instock' },
+		],
+	},
+];

--- a/client/analytics/report/stock/index.js
+++ b/client/analytics/report/stock/index.js
@@ -16,7 +16,7 @@ import { ReportFilters } from '@woocommerce/components';
 import { showDatePicker, filters } from './config';
 import StockReportTable from './table';
 
-export default class CouponsReport extends Component {
+export default class StockReport extends Component {
 	render() {
 		const { query, path } = this.props;
 
@@ -34,6 +34,6 @@ export default class CouponsReport extends Component {
 	}
 }
 
-CouponsReport.propTypes = {
+StockReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };

--- a/client/analytics/report/stock/index.js
+++ b/client/analytics/report/stock/index.js
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ReportFilters } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { showDatePicker, filters } from './config';
+import StockReportTable from './table';
+
+export default class CouponsReport extends Component {
+	render() {
+		const { query, path } = this.props;
+
+		return (
+			<Fragment>
+				<ReportFilters
+					query={ query }
+					path={ path }
+					showDatePicker={ showDatePicker }
+					filters={ filters }
+				/>
+				<StockReportTable query={ query } />
+			</Fragment>
+		);
+	}
+}
+
+CouponsReport.propTypes = {
+	query: PropTypes.object.isRequired,
+};

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -35,11 +35,6 @@ export default class StockReportTable extends Component {
 				isLeftAligned: true,
 			},
 			{
-				label: __( 'Parent', 'wc-admin' ),
-				key: 'parent',
-				required: true,
-			},
-			{
 				label: __( 'SKU', 'wc-admin' ),
 				key: 'sku',
 			},
@@ -63,18 +58,17 @@ export default class StockReportTable extends Component {
 
 		return products.map( product => {
 			const { id, name, parent_id, sku, stock_quantity, stock_status } = product;
-			const isVariation = id > 0 && parent_id > 0;
-			const itemName = isVariation ? id : name; // @TODO it should be variation name instead of id
-			const parentName = isVariation ? name : null;
 
 			const productDetailLink = getNewPath( persistedQuery, 'products', {
 				filter: 'single_product',
-				products: id,
+				products: parent_id || id,
 			} );
+
+			const formattedName = name.replace( ' - ', ' / ' );
 
 			const nameLink = (
 				<Link href={ productDetailLink } type="wc-admin">
-					{ itemName }
+					{ formattedName }
 				</Link>
 			);
 
@@ -87,11 +81,7 @@ export default class StockReportTable extends Component {
 			return [
 				{
 					display: nameLink,
-					value: itemName,
-				},
-				{
-					display: parentName,
-					value: parentName,
+					value: formattedName,
 				},
 				{
 					display: sku,

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -33,13 +33,11 @@ export default class StockReportTable extends Component {
 				key: 'product_variation',
 				required: true,
 				isLeftAligned: true,
-				isSortable: true,
 			},
 			{
 				label: __( 'Parent', 'wc-admin' ),
 				key: 'parent',
 				required: true,
-				isSortable: true,
 			},
 			{
 				label: __( 'SKU', 'wc-admin' ),
@@ -48,7 +46,6 @@ export default class StockReportTable extends Component {
 			{
 				label: __( 'Status', 'wc-admin' ),
 				key: 'stock_status',
-				isSortable: true,
 			},
 			{
 				label: __( 'Stock', 'wc-admin' ),
@@ -65,7 +62,10 @@ export default class StockReportTable extends Component {
 		const { stockStatuses } = wcSettings;
 
 		return products.map( product => {
-			const { id, parent_id, sku, stock_quantity, stock_status } = product;
+			const { id, name, parent_id, sku, stock_quantity, stock_status } = product;
+			const isVariation = id > 0 && parent_id > 0;
+			const itemName = isVariation ? id : name; // @TODO it should be variation name instead of id
+			const parentName = isVariation ? name : null;
 
 			const productDetailLink = getNewPath( persistedQuery, 'products', {
 				filter: 'single_product',
@@ -74,7 +74,7 @@ export default class StockReportTable extends Component {
 
 			const nameLink = (
 				<Link href={ productDetailLink } type="wc-admin">
-					{ id }
+					{ itemName }
 				</Link>
 			);
 
@@ -86,12 +86,12 @@ export default class StockReportTable extends Component {
 
 			return [
 				{
-					display: nameLink, // @TODO display name instead of id
-					value: id,
+					display: nameLink,
+					value: itemName,
 				},
 				{
-					display: parent_id, // @TODO display name instead of id
-					value: parent_id,
+					display: parentName,
+					value: parentName,
 				},
 				{
 					display: sku,

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -1,0 +1,155 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, _n } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Link } from '@woocommerce/components';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import ReportTable from 'analytics/components/report-table';
+import { numberFormat } from 'lib/number';
+
+export default class StockReportTable extends Component {
+	constructor() {
+		super();
+
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Product / Variation', 'wc-admin' ),
+				key: 'product_variation',
+				required: true,
+				isLeftAligned: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Parent', 'wc-admin' ),
+				key: 'parent',
+				required: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'SKU', 'wc-admin' ),
+				key: 'sku',
+			},
+			{
+				label: __( 'Status', 'wc-admin' ),
+				key: 'stock_status',
+				isSortable: true,
+			},
+			{
+				label: __( 'Stock', 'wc-admin' ),
+				key: 'stock_quantity',
+				isSortable: true,
+				defaultSort: true,
+			},
+		];
+	}
+
+	getRowsContent( products ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
+		const { stockStatuses } = wcSettings;
+
+		return products.map( product => {
+			const { id, parent_id, sku, stock_quantity, stock_status } = product;
+
+			const productDetailLink = getNewPath( persistedQuery, 'products', {
+				filter: 'single_product',
+				products: id,
+			} );
+
+			const nameLink = (
+				<Link href={ productDetailLink } type="wc-admin">
+					{ id }
+				</Link>
+			);
+
+			const stockStatusLink = (
+				<Link href={ 'post.php?action=edit&post=' + id } type="wc-admin">
+					{ stockStatuses[ stock_status ] }
+				</Link>
+			);
+
+			return [
+				{
+					display: nameLink, // @TODO display name instead of id
+					value: id,
+				},
+				{
+					display: parent_id, // @TODO display name instead of id
+					value: parent_id,
+				},
+				{
+					display: sku,
+					value: sku,
+				},
+				{
+					display: stockStatusLink, // @TODO
+					value: stock_status,
+				},
+				{
+					display: numberFormat( stock_quantity ),
+					value: stock_quantity,
+				},
+			];
+		} );
+	}
+
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+		return [
+			{
+				label: _n( 'product', 'products', totals.products, 'wc-admin' ),
+				value: numberFormat( totals.products ),
+			},
+			{
+				label: __( 'out of stock', totals.out_of_stock, 'wc-admin' ),
+				value: numberFormat( totals.out_of_stock ),
+			},
+			{
+				label: __( 'low stock', totals.low_stock, 'wc-admin' ),
+				value: numberFormat( totals.low_stock ),
+			},
+			{
+				label: __( 'in stock', totals.in_stock, 'wc-admin' ),
+				value: numberFormat( totals.in_stock ),
+			},
+		];
+	}
+
+	render() {
+		const { query } = this.props;
+
+		return (
+			<ReportTable
+				endpoint="stock"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				// getSummary={ this.getSummary }
+				query={ query }
+				tableQuery={ {
+					orderby: query.orderby || 'date', // @TODO
+					order: query.order || 'desc',
+					type: query.type || 'all',
+				} }
+				title={ __( 'Stock', 'wc-admin' ) }
+			/>
+		);
+	}
+}

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -73,7 +73,7 @@ export default class StockReportTable extends Component {
 			);
 
 			const stockStatusLink = (
-				<Link href={ 'post.php?action=edit&post=' + id } type="wc-admin">
+				<Link href={ 'post.php?action=edit&post=' + parent_id || id } type="wp-admin">
 					{ stockStatuses[ stock_status ] }
 				</Link>
 			);
@@ -88,7 +88,7 @@ export default class StockReportTable extends Component {
 					value: sku,
 				},
 				{
-					display: stockStatusLink, // @TODO
+					display: stockStatusLink,
 					value: stock_status,
 				},
 				{

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -134,7 +134,7 @@ export default class StockReportTable extends Component {
 				// getSummary={ this.getSummary }
 				query={ query }
 				tableQuery={ {
-					orderby: query.orderby || 'date', // @TODO
+					orderby: query.orderby || 'stock_quantity',
 					order: query.order || 'desc',
 					type: query.type || 'all',
 				} }

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -28,6 +28,7 @@ const typeEndpointMap = {
 	'report-items-query-taxes': 'taxes',
 	'report-items-query-variations': 'variations',
 	'report-items-query-customers': 'customers',
+	'report-items-query-stock': 'stock',
 };
 
 function read( resourceNames, fetch = apiFetch ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -135,6 +135,14 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
+			'title'  => __( 'Stock', 'wc-admin' ),
+			'parent' => '/analytics/revenue',
+			'path'   => '/analytics/stock',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
 			'title'  => __( 'Customers', 'wc-admin' ),
 			'parent' => '/analytics/revenue',
 			'path'   => '/analytics/customers',

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -92,15 +92,6 @@ ReportFilters.propTypes = {
 	 */
 	advancedFilters: PropTypes.object,
 	/**
-	 * Config options for the date range picker.
-	 */
-	dateRangeFilter: PropTypes.shape( {
-		/**
-		 * Whether the date range filter must be shown.
-		 */
-		show: PropTypes.bool,
-	} ),
-	/**
 	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 	 */
 	filters: PropTypes.array,
@@ -120,9 +111,6 @@ ReportFilters.propTypes = {
 
 ReportFilters.defaultProps = {
 	advancedFilters: {},
-	dateRangeFilter: {
-		show: true,
-	},
 	filters: [],
 	query: {},
 	showDatePicker: true,

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -92,6 +92,15 @@ ReportFilters.propTypes = {
 	 */
 	advancedFilters: PropTypes.object,
 	/**
+	 * Config options for the date range picker.
+	 */
+	dateRangeFilter: PropTypes.shape( {
+		/**
+		 * Whether the date range filter must be shown.
+		 */
+		show: PropTypes.bool,
+	} ),
+	/**
 	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 	 */
 	filters: PropTypes.array,
@@ -111,6 +120,9 @@ ReportFilters.propTypes = {
 
 ReportFilters.defaultProps = {
 	advancedFilters: {},
+	dateRangeFilter: {
+		show: true,
+	},
 	filters: [],
 	query: {},
 	showDatePicker: true,


### PR DESCRIPTION
Fixes #921 and part of #920.

Adds a _Stock_ report page & table.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50017564-be8b1f80-ffcc-11e8-9d88-587d41ed2088.png)

### Detailed test instructions:
- Go to the _Stock_ report.
- Verify the table lists products and variations and interacting with it works fine.
- Use the filter on top of the page and verify it works.

### Pending work
- Display table summary (being tracked in #920).
- Pagination doesn't work, but will be fixed once #1093 is merged.