### PR TITLE
Fixed PHP 5.2 compatibility

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-categories-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-categories-data-store.php
@@ -262,4 +262,14 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 		return $data;
 	}
 
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
 }

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -283,17 +283,6 @@ class WC_Admin_Reports_Data_Store {
 	}
 
 	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		// TODO: this is not working in PHP 5.2 (but revenue class has static methods, so it cannot use object property).
-		return 'woocommerce_' . $this::TABLE_NAME . '_' . md5( wp_json_encode( $params ) ); // phpcs:ignore PHPCompatibility.Syntax.NewDynamicAccessToStatic
-	}
-
-	/**
 	 * Casts strings returned from the database to appropriate data types for output.
 	 *
 	 * @param array $array Associative array of values extracted from the database.

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -531,4 +531,14 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		return count( $customer_orders ) > 1;
 	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
 }

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -261,4 +261,14 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		return $data;
 	}
 
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
 }

--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -261,4 +261,14 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 		return $data;
 	}
 
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
 }


### PR DESCRIPTION
This PR should fix compatibility problems with PHP 5.2.

### Screenshots
N/A.

### Detailed test instructions:

Run `cd wc-admin && ./vendor/bin/phpcs --extensions=php --ignore=*/languages/* .` to check there are no version-related errors.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
