### PR TITLE
Order data: fix `isGetOrdersRequesting()` for the first request.

### DIFF
--- a/client/wc-api/orders/selectors.js
+++ b/client/wc-api/orders/selectors.js
@@ -1,4 +1,10 @@
 /** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -26,7 +32,16 @@ const getOrdersTotalCount = ( getResource, requireResource ) => (
 const isGetOrdersRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'order-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
-	return lastRequested && lastRequested > lastReceived;
+
+	if ( isNil( lastRequested ) ) {
+		return false;
+	}
+
+	if ( isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
 };
 
 const isGetOrdersError = getResource => ( query = {} ) => {


### PR DESCRIPTION
Ensure a boolean return from `isGetOrdersRequesting()` and handle cases where requests haven’t taken off or responses haven’t been received yet.

Fixes #911 (just for Orders)

The previous logic of `isGetOrdersRequesting()` didn't properly handle the state before the initial Orders request takes flight (where `lastRequested ` and `lastReceived` are both `undefined`)

### Detailed test instructions:

* Create some orders if you don't already have them
* Open WC admin dashboard
* Click Orders
* Verify that the placeholder order is shown during request (use dev tools to slow down your network requests if need be)
* Verify that orders display - note that only "processing" status orders are queried
