### PR TITLE
 Use ReportTable in Revenue report

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -61,7 +61,7 @@ class ReportTable extends Component {
 				isLoading={ isRequesting }
 				onQueryChange={ onQueryChange }
 				rows={ rows }
-				rowsPerPage={ query.per_page }
+				rowsPerPage={ parseInt( query.per_page ) }
 				summary={ summary }
 				totalRows={ items.totalCount || 0 }
 				{ ...tableProps }


### PR DESCRIPTION
Similar to #968.

This PR makes the _Revenue_ report to use the `ReportTable` component to render the table. This way, all reports will be using the same component to render the table.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/49402569-d8487f00-f70f-11e8-9171-984d610e5b2b.png)

### Detailed test instructions:
- Go to the _Revenue report_.
- Verify everything related to the table is still working fine (pagination, sorting, etc.).