### PR TITLE
Move all CSS related to ActivityCard into the activity-card/style.scss file

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -184,3 +184,84 @@
 		}
 	}
 }
+
+// Needs the double-class for specificity
+.woocommerce-activity-card.woocommerce-order-activity-card {
+	grid-template-columns: 1fr;
+	grid-template-areas:
+		'header'
+		'body'
+		'actions';
+
+	.woocommerce-activity-card__icon {
+		display: none;
+	}
+
+	.woocommerce-flag {
+		display: inline-block;
+	}
+
+	.woocommerce-activity-card__subtitle {
+		span + span::before {
+			content: ' \2022 ';
+		}
+	}
+}
+
+// Needs the double-class for specificity
+.woocommerce-activity-card.woocommerce-inbox-activity-card {
+	grid-template-columns: 72px 1fr;
+
+	@include breakpoint( '<782px' ) {
+		grid-template-columns: 64px 1fr;
+	}
+
+	.woocommerce-activity-card__header {
+		margin-bottom: $gap-small;
+	}
+}
+
+.woocommerce-review-activity-card {
+	.woocommerce-review-activity-card__verified {
+		margin-left: $gap-small;
+		display: inline-flex;
+		position: relative;
+		top: $gap-smallest;
+		color: $valid-green;
+		@include font-size( 12 );
+
+		.gridicon {
+			margin-right: $gap-smallest;
+			fill: $valid-green;
+		}
+	}
+
+	.woocommerce-review-activity-card__image-overlay {
+		margin-left: -$gap-large;
+		img.woocommerce-gravatar {
+			left: $gap-large;
+			position: relative;
+			top: -42px;
+			border: 2px solid $white;
+		}
+	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-review-activity-card__image-overlay {
+			margin-top: $gap-smallest;
+		}
+
+		.woocommerce-activity-card__icon img.woocommerce-gravatar {
+			margin-left: 0;
+			width: 18px;
+			height: 18px;
+			left: 32px;
+			top: -28px;
+		}
+
+		.woocommerce-activity-card__icon img.woocommerce-product-image {
+			width: 38px;
+			height: 38px;
+		}
+	}
+}

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -239,29 +239,6 @@
 	}
 }
 
-// Needs the double-class for specificity
-.woocommerce-activity-card.woocommerce-order-activity-card {
-	grid-template-columns: 1fr;
-	grid-template-areas:
-		'header'
-		'body'
-		'actions';
-
-	.woocommerce-activity-card__icon {
-		display: none;
-	}
-
-	.woocommerce-flag {
-		display: inline-block;
-	}
-
-	.woocommerce-activity-card__subtitle {
-		span + span::before {
-			content: ' \2022 ';
-		}
-	}
-}
-
 .woocommerce-layout__activity-panel-avatar-flag-overlay {
 	position: relative;
 	top: -$gap-small;
@@ -270,64 +247,6 @@
 		position: relative;
 		top: 16px;
 		border: 2px solid $white;
-	}
-}
-
-// Needs the double-class for specificity
-.woocommerce-activity-card.woocommerce-inbox-activity-card {
-	grid-template-columns: 72px 1fr;
-
-	@include breakpoint( '<782px' ) {
-		grid-template-columns: 64px 1fr;
-	}
-
-	.woocommerce-activity-card__header {
-		margin-bottom: $gap-small;
-	}
-}
-
-.woocommerce-review-activity-card {
-	.woocommerce-review-activity-card__verified {
-		margin-left: $gap-small;
-		display: inline-flex;
-		position: relative;
-		top: $gap-smallest;
-		color: $valid-green;
-		@include font-size( 12 );
-
-		.gridicon {
-			margin-right: $gap-smallest;
-			fill: $valid-green;
-		}
-	}
-
-	.woocommerce-review-activity-card__image-overlay {
-		margin-left: -$gap-large;
-		img.woocommerce-gravatar {
-			left: $gap-large;
-			position: relative;
-			top: -42px;
-			border: 2px solid $white;
-		}
-	}
-
-	@include breakpoint( '<782px' ) {
-		.woocommerce-review-activity-card__image-overlay {
-			margin-top: $gap-smallest;
-		}
-
-		.woocommerce-activity-card__icon img.woocommerce-gravatar {
-			margin-left: 0;
-			width: 18px;
-			height: 18px;
-			left: 32px;
-			top: -28px;
-		}
-
-		.woocommerce-activity-card__icon img.woocommerce-product-image {
-			width: 38px;
-			height: 38px;
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes #983.

This PR moves the CSS relative to the `<ActivityCard>` component from `client/header/activity-panel/style.scss` to `client/header/activity-panel/activity-card/style.scss`.

Autoprefixer was outputting a warning because the CSS from `activity-panel/style.scss` was refering to CSS grid areas that were defined in `activity-panel/activity-card/style.scss`.

My first idea was just to silence the warnings, because the CSS was perfectly valid. But thinking it twice, moving the styles from one file to another not only makes the warning to disappear, but I think keeps the code more organized.

### Detailed test instructions:
- Run `npm start` and verify the `Can not find grid areas: header, body, actions` warning disappeared.
- Verify there are no regressions regarding the styles.
