### PR TITLE
Add stock info to Products Report

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { map } from 'lodash';
 
@@ -18,6 +18,7 @@ import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
  */
 import ReportTable from 'analytics/components/report-table';
 import { numberFormat } from 'lib/number';
+import { isLowStock } from './utils';
 
 export default class ProductsReportTable extends Component {
 	constructor() {
@@ -97,10 +98,8 @@ export default class ProductsReportTable extends Component {
 				orders_count,
 				categories = [], // @TODO
 				variations = [], // @TODO
-				stock_status = 'outofstock', // @TODO
-				stock_quantity = '0', // @TODO
 			} = row;
-			const { name } = extended_info;
+			const { name, stock_status, stock_quantity, low_stock_amount } = extended_info;
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',
 				product_includes: product_id,
@@ -150,10 +149,12 @@ export default class ProductsReportTable extends Component {
 					value: variations.length,
 				},
 				{
-					display: (
+					display: isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
 						<Link href={ 'post.php?action=edit&post=' + product_id } type="wp-admin">
-							{ stockStatuses[ stock_status ] }
+							{ _x( 'Low', 'Indication of a low quantity', 'wc-admin' ) }
 						</Link>
+					) : (
+						stockStatuses[ stock_status ]
 					),
 					value: stockStatuses[ stock_status ],
 				},

--- a/client/analytics/report/products/utils.js
+++ b/client/analytics/report/products/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Determine if a product or variation is in low stock.
+ *
+ * @format
+ * @param {number} threshold - The number at which stock is determined to be low.
+ * @returns {boolean} - Whether or not the stock is low.
+ */
+
+export function isLowStock( status, quantity, threshold ) {
+	if ( ! quantity ) {
+		// Sites that don't do inventory tracking will always return false.
+		return false;
+	}
+	return 'instock' === status && quantity <= threshold;
+}

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -175,6 +175,56 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Number of orders product appeared in.', 'wc-admin' ),
 				),
+				'extended_info' => array(
+					'name'       => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product name.', 'wc-admin' ),
+					),
+					'price'      => array(
+						'type'        => 'number',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product price.', 'wc-admin' ),
+					),
+					'image'      => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product image.', 'wc-admin' ),
+					),
+					'permalink'  => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product link.', 'wc-admin' ),
+					),
+					'attributes' => array(
+						'type'        => 'array',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product attributes.', 'wc-admin' ),
+					),
+					'stock_status'  => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory status.', 'wc-admin' ),
+					),
+					'stock_quantity'  => array(
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory quantity.', 'wc-admin' ),
+					),
+					'low_stock_amount'  => array(
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory threshold for low stock.', 'wc-admin' ),
+					),
+				),
 			),
 		);
 

--- a/includes/api/class-wc-admin-rest-reports-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-variations-controller.php
@@ -32,6 +32,15 @@ class WC_Admin_REST_Reports_Variations_Controller extends WC_REST_Reports_Contro
 	protected $rest_base = 'reports/variations';
 
 	/**
+	 * Mapping between external parameter name and name used in query class.
+	 *
+	 * @var array
+	 */
+	protected $param_mapping = array(
+		'products' => 'product_includes',
+	);
+
+	/**
 	 * Get items.
 	 *
 	 * @param WP_REST_Request $request Request data.
@@ -43,7 +52,11 @@ class WC_Admin_REST_Reports_Variations_Controller extends WC_REST_Reports_Contro
 		$registered = array_keys( $this->get_collection_params() );
 		foreach ( $registered as $param_name ) {
 			if ( isset( $request[ $param_name ] ) ) {
-				$args[ $param_name ] = $request[ $param_name ];
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$args[ $param_name ] = $request[ $param_name ];
+				}
 			}
 		}
 
@@ -201,6 +214,24 @@ class WC_Admin_REST_Reports_Variations_Controller extends WC_REST_Reports_Contro
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Product attributes.', 'wc-admin' ),
+					),
+					'stock_status'  => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory status.', 'wc-admin' ),
+					),
+					'stock_quantity'  => array(
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory quantity.', 'wc-admin' ),
+					),
+					'low_stock_amount'  => array(
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product inventory threshold for low stock.', 'wc-admin' ),
 					),
 				),
 			),

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -60,6 +60,9 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'price',
 		'image',
 		'permalink',
+		'stock_status',
+		'stock_quantity',
+		'low_stock_amount',
 	);
 
 	/**
@@ -153,6 +156,10 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 						$value                                = $product->{$function}();
 						$extended_info[ $extended_attribute ] = $value;
 					}
+				}
+				// If there is no set low_stock_amount, use the one in user settings.
+				if ( '' === $extended_info['low_stock_amount'] ) {
+					$extended_info['low_stock_amount'] = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 				}
 				$extended_info = $this->cast_numbers( $extended_info );
 			}

--- a/tests/api/reports-products.php
+++ b/tests/api/reports-products.php
@@ -5,6 +5,13 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Reports Products REST API Test Class
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
 class WC_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -99,10 +106,11 @@ class WC_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 4, count( $properties ) );
+		$this->assertEquals( 5, count( $properties ) );
 		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'items_sold', $properties );
 		$this->assertArrayHasKey( 'gross_revenue', $properties );
 		$this->assertArrayHasKey( 'orders_count', $properties );
+		$this->assertArrayHasKey( 'extended_info', $properties );
 	}
 }

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -1,7 +1,13 @@
 <?php
-
 /**
  * Reports product stats tests.
+ *
+ * @package WooCommerce\Tests\Orders
+ * @todo Finish up unit testing to verify bug-free product reports.
+ */
+
+/**
+ * Reports product stats tests class
  *
  * @package WooCommerce\Tests\Orders
  * @todo Finish up unit testing to verify bug-free product reports.
@@ -63,6 +69,11 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_data, $query->get_data() );
 	}
 
+	/**
+	 * Test the ordering of results by product name
+	 *
+	 * @since 3.5.0
+	 */
 	public function test_order_by_product_name() {
 		WC_Helper_Reports::reset_stats_dbs();
 
@@ -183,7 +194,11 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
 		$product->set_regular_price( 25 );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 25 );
+		$product->set_low_stock_amount( 5 );
 		$product->save();
+
 		$order = WC_Helper_Order::create_order( 1, $product );
 		$order->set_status( 'completed' );
 		$order->set_shipping_total( 10 );
@@ -214,10 +229,13 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 					'gross_revenue' => 100.0, // $25 * 4.
 					'orders_count'  => 1,
 					'extended_info' => array(
-						'name'      => $product->get_name(),
-						'image'     => $product->get_image(),
-						'permalink' => $product->get_permalink(),
-						'price'     => (float) $product->get_price(),
+						'name'             => $product->get_name(),
+						'image'            => $product->get_image(),
+						'permalink'        => $product->get_permalink(),
+						'price'            => (float) $product->get_price(),
+						'stock_status'     => $product->get_stock_status(),
+						'stock_quantity'   => $product->get_stock_quantity() - 4, // subtract the ones purchased.
+						'low_stock_amount' => $product->get_low_stock_amount(),
 					),
 				),
 			),

--- a/tests/reports/class-wc-tests-reports-variations.php
+++ b/tests/reports/class-wc-tests-reports-variations.php
@@ -1,7 +1,13 @@
 <?php
-
 /**
  * Reports order stats tests.
+ *
+ * @package WooCommerce\Tests\Orders
+ * @todo Finish up unit testing to verify bug-free order reports.
+ */
+
+/**
+ * Reports order stats tests class.
  *
  * @package WooCommerce\Tests\Orders
  * @todo Finish up unit testing to verify bug-free order reports.
@@ -91,6 +97,8 @@ class WC_Tests_Reports_Variations extends WC_Unit_Test_Case {
 		$variation->set_parent_id( $product->get_id() );
 		$variation->set_regular_price( 10 );
 		$variation->set_attributes( array( 'pa_color' => 'green' ) );
+		$variation->set_manage_stock( true );
+		$variation->set_stock_quantity( 25 );
 		$variation->save();
 
 		$order = WC_Helper_Order::create_order( 1, $variation );
@@ -120,11 +128,14 @@ class WC_Tests_Reports_Variations extends WC_Unit_Test_Case {
 					'gross_revenue' => 40.0, // $10 * 4.
 					'orders_count'  => 1,
 					'extended_info' => array(
-						'name'       => $product->get_name(),
-						'image'      => $variation->get_image(),
-						'permalink'  => $product->get_permalink(),
-						'price'      => (float) $variation->get_price(),
-						'attributes' => array(
+						'name'             => $variation->get_name(),
+						'image'            => $variation->get_image(),
+						'permalink'        => $variation->get_permalink(),
+						'price'            => (float) $variation->get_price(),
+						'stock_status'     => $variation->get_stock_status(),
+						'stock_quantity'   => $variation->get_stock_quantity() - 4, // subtract the ones purchased.
+						'low_stock_amount' => get_option( 'woocommerce_notify_low_stock_amount' ),
+						'attributes'       => array(
 							0 => array(
 								'id'     => 0,
 								'name'   => 'color',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/936

Add stock quantity, status, and "low" status information to the Product and Product Detail Reports tables.

**Design: ** p6riRB-3dP-p2

### Also fixed here

`/report/variations` extended info was referencing the parent product, not the variation, for things like `permalink` and `image`. So that is fixed here along with relevant unit tests.

### Test

1. Edit a product's stock (_Edit Product > Inventory > Manage stock_).
1. _Products Report_
2. See your product in the table with an updated quantity and status.
3. Edit the "Low stock threshold" to a number above the quantity.
4. See your product in the table with a status of "Low" linked to the product edit page.
5. Repeat for variations of a product.
6. Note: if "manage stock" is turned off, a quantity won't be displayed.

