### PR TITLE
Trigger sync_order on order stats table when refunding

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -94,6 +94,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		add_action( 'save_post', array( __CLASS__, 'sync_order' ) );
 		// TODO: this is required as order update skips save_post.
 		add_action( 'clean_post_cache', array( __CLASS__, 'sync_order' ) );
+		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'sync_order' ) );
 
 		if ( ! self::$background_process ) {
 			self::$background_process = new WC_Admin_Order_Stats_Background_Process();


### PR DESCRIPTION
Fixes #989 

Automatically updates the `wc_order_stats` table when a refund occurs since this bypasses the original `save_post` hook.

### Screenshots
<img width="694" alt="screen shot 2018-12-04 at 12 34 45 pm" src="https://user-images.githubusercontent.com/10561050/49419266-0934bc80-f7c1-11e8-87a0-fc789cd4dc82.png">

### Detailed test instructions:

1. Visit any order in the dashboard.
2. Refund any amount in that order.
3. Check that the `refund_total` column is updated to reflect the refunded amount.
