### PR TITLE
Update Renovate Configuration: Ignore PHPUnit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "lockFileMaintenance": { "enabled": true }
+  "lockFileMaintenance": { "enabled": true },
+  "ignoreDeps": ["phpunit/phpunit"]
 }


### PR DESCRIPTION
This PR attempts to disable PHPUnit from automatically being upgraded. We've gotten a few notices about upgrading to PHPUnit 7. https://renovatebot.com/docs/configuration-options/#ignoredeps

See https://github.com/woocommerce/wc-admin/pull/991 and https://github.com/woocommerce/wc-admin/pull/870

WordPress is currently only compatible with PHPUnit 6 and under:

https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/

> The latest release of PHPUnit is 7.x, WordPress currently is only compatible with the 6.x release

**Testing Directions:**

I can't find a good way to test this except to merge and see if it works 🤷‍♂️. 

https://renovatebot.com/docs/reconfigure-renovate/ seems to imply that Renovate should have posted something here, but it doesn't seem to work. Since this doesn't affect anything else -- I think we can just merge and see if it prevents another PR from being opened.
