### PR TITLE
Fix 'categories' value in Categories report table summary

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -51,7 +51,8 @@ class ReportTable extends Component {
 		const ids = itemIdField ? orderedItems.map( item => item[ itemIdField ] ) : null;
 		const rows = getRowsContent( orderedItems );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
-		const summary = getSummary ? getSummary( totals ) : null;
+		const totalCount = items.totalCount || 0;
+		const summary = getSummary ? getSummary( totals, totalCount ) : null;
 
 		return (
 			<TableCard
@@ -63,7 +64,7 @@ class ReportTable extends Component {
 				rows={ rows }
 				rowsPerPage={ parseInt( query.per_page ) }
 				summary={ summary }
-				totalRows={ items.totalCount || 0 }
+				totalRows={ totalCount }
 				{ ...tableProps }
 			/>
 		);

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -98,14 +98,15 @@ export default class CategoriesReportTable extends Component {
 		} );
 	}
 
-	getSummary( totals ) {
+	getSummary( totals, totalCount ) {
 		if ( ! totals ) {
 			return [];
 		}
+
 		return [
 			{
-				label: _n( 'category', 'categories', totals.categories_count, 'wc-admin' ),
-				value: numberFormat( totals.categories_count ),
+				label: _n( 'category', 'categories', totalCount, 'wc-admin' ),
+				value: numberFormat( totalCount ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', totals.items_sold, 'wc-admin' ),

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
@@ -34,6 +34,7 @@ class RevenueReportTable extends Component {
 
 		this.getHeadersContent = this.getHeadersContent.bind( this );
 		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
 	}
 
 	getHeadersContent() {
@@ -161,6 +162,50 @@ class RevenueReportTable extends Component {
 		} );
 	}
 
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+
+		const { tableData } = this.props;
+		const daysCount = tableData.items.totalCount;
+
+		return [
+			{
+				label: _n( 'day', 'days', daysCount, 'wc-admin' ),
+				value: numberFormat( daysCount ),
+			},
+			{
+				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
+				value: numberFormat( totals.orders_count ),
+			},
+			{
+				label: __( 'gross revenue', 'wc-admin' ),
+				value: formatCurrency( totals.gross_revenue ),
+			},
+			{
+				label: __( 'refunds', 'wc-admin' ),
+				value: formatCurrency( totals.refunds ),
+			},
+			{
+				label: __( 'coupons', 'wc-admin' ),
+				value: formatCurrency( totals.coupons ),
+			},
+			{
+				label: __( 'taxes', 'wc-admin' ),
+				value: formatCurrency( totals.taxes ),
+			},
+			{
+				label: __( 'shipping', 'wc-admin' ),
+				value: formatCurrency( totals.shipping ),
+			},
+			{
+				label: __( 'net revenue', 'wc-admin' ),
+				value: formatCurrency( totals.net_revenue ),
+			},
+		];
+	}
+
 	render() {
 		const { query, tableData } = this.props;
 
@@ -169,6 +214,7 @@ class RevenueReportTable extends Component {
 				endpoint="revenue"
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
+				getSummary={ this.getSummary }
 				query={ query }
 				tableData={ tableData }
 				title={ __( 'Revenue', 'wc-admin' ) }

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -162,18 +162,15 @@ class RevenueReportTable extends Component {
 		} );
 	}
 
-	getSummary( totals ) {
+	getSummary( totals, totalCount ) {
 		if ( ! totals ) {
 			return [];
 		}
 
-		const { tableData } = this.props;
-		const daysCount = tableData.items.totalCount;
-
 		return [
 			{
-				label: _n( 'day', 'days', daysCount, 'wc-admin' ),
-				value: numberFormat( daysCount ),
+				label: _n( 'day', 'days', totalCount, 'wc-admin' ),
+				value: numberFormat( totalCount ),
 			},
 			{
 				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),


### PR DESCRIPTION
Follow-up of #994.

Fixes the _Categories_ report table summary count number being undefined.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/49457209-0c737c80-f7b0-11e8-9c39-88152b0c10f4.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/49457004-aedf3000-f7af-11e8-8356-daafce0ef2eb.png)

### Detailed test instructions:
- Go to the _Categories_ report.
- Verify a number appears before _categories_. Currently it's going to be _0_ because it relies in the `X-WP-Total` header, which is missing in SwaggerHub endpoints, but should work when we use our own endpoints.
- Go to the _Revenue_ report.
- Verify the number before _days_ in the table summary still works.