### PR TITLE
Update @fresh-data/framework to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "@fresh-data/framework": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.0.tgz",
-      "integrity": "sha512-5+7NKFNmE83nvxxuYAyy3B5QkpuHF97GOprpfvpE15jqcZB68m4hIHRXop6KASsqtCTByWlO/X/JqUxrVmaxdg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.1.tgz",
+      "integrity": "sha512-pCrY2AYZgsGo4/smCNQM2NHf37yPMuzg4RCXHJAnOHIpo6eMgz1jlvlCN4JLxrcdoeEq3uIWMD/3F3k/MefLJQ==",
       "requires": {
         "@babel/runtime-corejs2": "^7.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "webpack-cli": "3.1.2"
   },
   "dependencies": {
-    "@fresh-data/framework": "^0.5.0",
+    "@fresh-data/framework": "^0.5.1",
     "@wordpress/api-fetch": "2.2.2",
     "@wordpress/components": "3.0.0",
     "@wordpress/data": "3.1.0",


### PR DESCRIPTION
Fixes fresh-data bindings to @wordpress/data
See https://github.com/Automattic/fresh-data/pull/125

### Detailed test instructions:

Everything should run normally with this change.
Check the Analytics -> Orders table specifically to ensure operation.
