### PR TITLE
Add tax report comparison filters

### DIFF
--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getRequestByIdString } from 'lib/async-requests';
+import { getTaxCode } from './utils';
 import { NAMESPACE } from 'store/constants';
 
 export const charts = [
@@ -50,7 +51,7 @@ export const filters = [
 					param: 'taxes',
 					getLabels: getRequestByIdString( NAMESPACE + 'taxes', tax => ( {
 						id: tax.id,
-						label: tax.country + '-' + tax.state + '-' + tax.name,
+						label: getTaxCode( tax ),
 					} ) ),
 					labels: {
 						helpText: __( 'Select at least two tax codes to compare', 'wc-admin' ),

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -3,9 +3,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
+import { getRequestByIdString } from 'lib/async-requests';
+import { NAMESPACE } from 'store/constants';
 
 export const charts = [
 	{
@@ -36,6 +39,27 @@ export const filters = [
 		staticParams: [ 'chart' ],
 		param: 'filter',
 		showFilters: () => true,
-		filters: [ { label: __( 'All Taxes', 'wc-admin' ), value: 'all' } ],
+		filters: [
+			{ label: __( 'All Taxes', 'wc-admin' ), value: 'all' },
+			{
+				label: __( 'Comparison', 'wc-admin' ),
+				value: 'compare-tax-codes',
+				chartMode: 'item-comparison',
+				settings: {
+					type: 'taxes',
+					param: 'taxes',
+					getLabels: getRequestByIdString( NAMESPACE + 'taxes', tax => ( {
+						id: tax.id,
+						label: tax.country + '-' + tax.state + '-' + tax.name,
+					} ) ),
+					labels: {
+						helpText: __( 'Select at least two tax codes to compare', 'wc-admin' ),
+						placeholder: __( 'Search for tax codes to compare', 'wc-admin' ),
+						title: __( 'Compare Tax Codes', 'wc-admin' ),
+						update: __( 'Compare', 'wc-admin' ),
+					},
+				},
+			},
+		],
 	},
 ];

--- a/client/analytics/report/taxes/utils.js
+++ b/client/analytics/report/taxes/utils.js
@@ -1,0 +1,8 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+export function getTaxCode( tax ) {
+	return [ tax.country, tax.state, tax.name ].join( '-' );
+}

--- a/client/analytics/report/taxes/utils.js
+++ b/client/analytics/report/taxes/utils.js
@@ -2,7 +2,16 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 
 export function getTaxCode( tax ) {
-	return [ tax.country, tax.state, tax.name ].join( '-' );
+	return [ tax.country, tax.state, tax.name || __( 'TAX', 'wc-admin' ), tax.priority ]
+		.map( item =>
+			item
+				.toString()
+				.toUpperCase()
+				.trim()
+		)
+		.filter( Boolean )
+		.join( '-' );
 }

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -13,6 +13,7 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
+import { getTaxCode } from 'analytics/report/taxes/utils';
 
 /**
  * A tax completer.
@@ -21,7 +22,7 @@ import { computeSuggestionMatch } from './utils';
  * @type {Completer}
  */
 export default {
-	name: 'taxes$',
+	name: 'taxes',
 	className: 'woocommerce-search__tax-result',
 	options( search ) {
 		let payload = '';
@@ -36,10 +37,10 @@ export default {
 	},
 	isDebounced: true,
 	getOptionKeywords( tax ) {
-		return [ tax.id, tax.country + '-' + tax.state + '-' + tax.name ];
+		return [ tax.id, getTaxCode( tax ) ];
 	},
 	getOptionLabel( tax, query ) {
-		const match = computeSuggestionMatch( tax.country + '-' + tax.state + '-' + tax.name, query ) || {};
+		const match = computeSuggestionMatch( getTaxCode( tax ), query ) || {};
 		return [
 			<span key="name" className="woocommerce-search__result-name" aria-label={ tax.code }>
 				{ match.suggestionBeforeMatch }
@@ -54,8 +55,8 @@ export default {
 	// of replace/insertion, so we can just return the value.
 	getOptionCompletion( tax ) {
 		const value = {
-			id: tax.tax_rate_id,
-			label: tax.code,
+			id: tax.id,
+			label: getTaxCode( tax ),
 		};
 		return value;
 	},

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -36,10 +36,10 @@ export default {
 	},
 	isDebounced: true,
 	getOptionKeywords( tax ) {
-		return [ tax.code ];
+		return [ tax.id, tax.country + '-' + tax.state + '-' + tax.name ];
 	},
 	getOptionLabel( tax, query ) {
-		const match = computeSuggestionMatch( tax.code, query ) || {};
+		const match = computeSuggestionMatch( tax.country + '-' + tax.state + '-' + tax.name, query ) || {};
 		return [
 			<span key="name" className="woocommerce-search__result-name" aria-label={ tax.code }>
 				{ match.suggestionBeforeMatch }


### PR DESCRIPTION
Fixes #924 

Adds in the comparison filter for taxes per the designs p6riRB-3dT-p2

### Screenshots
<img width="500" alt="screen shot 2018-12-05 at 2 37 05 pm" src="https://user-images.githubusercontent.com/10561050/49494636-41a8c900-f89b-11e8-8551-82de1cca5995.png">

### Detailed test instructions:

1.  Make sure you've added at least 2 tax rates under `wp-admin/admin.php?page=wc-settings&tab=tax&section=standard`
2.  Open `wp-admin/admin.php?page=wc-admin#/analytics/taxes`
3.  Change the filter method to "Comparison" under "Show:"
4.  Select a couple tax rates based on the the tax code (follows the WC format of {country}-{state}-{name}).
5.  Click "Compare."
6.  Note the change in filter params in the URL.

The query is passed to the report table, but will not affect data until #844 is implemented.