### PR TITLE
Add taxes endpoint and data store

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -152,9 +152,33 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'tax_rate'  => array(
+				'name'         => array(
+					'description' => __( 'Tax rate name.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'tax_rate'     => array(
 					'description' => __( 'Tax rate.', 'wc-admin' ),
 					'type'        => 'number',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'country'      => array(
+					'description' => __( 'Country.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'state'        => array(
+					'description' => __( 'State.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'priority'        => array(
+					'description' => __( 'Priority.', 'wc-admin' ),
+					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -233,6 +233,10 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 			'enum'              => array(
 				'name',
 				'tax_rate_id',
+				'rate',
+				'order_tax',
+				'total_tax',
+				'shipping_tax',
 				'orders_count',
 			),
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -152,6 +152,12 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'tax_rate'  => array(
+					'description' => __( 'Tax rate.', 'wc-admin' ),
+					'type'        => 'number',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'total_tax'    => array(
 					'description' => __( 'Total tax.', 'wc-admin' ),
 					'type'        => 'number',

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -63,7 +63,7 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 		$data = array();
 
 		foreach ( $report_data->data as $tax_data ) {
-			$item   = $this->prepare_item_for_response( $tax_data, $request );
+			$item   = $this->prepare_item_for_response( (object) $tax_data, $request );
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -45,6 +45,7 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 		$args['per_page'] = $request['per_page'];
 		$args['orderby']  = $request['orderby'];
 		$args['order']    = $request['order'];
+		$args['taxes']    = $request['taxes'];
 
 		return $args;
 	}
@@ -271,24 +272,10 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['interval'] = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'wc-admin' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['code']     = array(
-			'description'       => __( 'Limit result set to items assigned one or more code.', 'wc-admin' ),
+		$params['taxes']    = array(
+			'description'       => __( 'Limit result set to items assigned one or more tax rates.', 'wc-admin' ),
 			'type'              => 'array',
-			'sanitize_callback' => 'wp_parse_slug_list',
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
 				'type' => 'string',

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -49,6 +49,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-variations-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-products-stats-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-categories-query.php';
+		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-taxes-query.php';
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
@@ -57,6 +58,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-variations-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-products-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-categories-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-taxes-data-store.php';
 
 		// Data triggers.
 		require_once dirname( __FILE__ ) . '/wc-admin-order-functions.php';
@@ -264,6 +266,7 @@ class WC_Admin_Api_Init {
 				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',
 				'report-products-stats' => 'WC_Admin_Reports_Products_Stats_Data_Store',
 				'report-categories'     => 'WC_Admin_Reports_Categories_Data_Store',
+				'report-taxes'          => 'WC_Admin_Reports_Taxes_Data_Store',
 				'admin-note'            => 'WC_Admin_Notes_Data_Store',
 			)
 		);

--- a/includes/class-wc-admin-reports-taxes-query.php
+++ b/includes/class-wc-admin-reports-taxes-query.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class for parameter-based Taxes Report querying
+ *
+ * Example usage:
+ * $args = array(
+ *          'before'       => '2018-07-19 00:00:00',
+ *          'after'        => '2018-07-05 00:00:00',
+ *          'page'         => 2,
+ *          'taxes'        => array(1,2,3)
+ *         );
+ * $report = new WC_Admin_Reports_Taxes_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Taxes_Query
+ */
+class WC_Admin_Reports_Taxes_Query extends WC_Admin_Reports_Query {
+
+	/**
+	 * Valid fields for Taxes report.
+	 *
+	 * @return array
+	 */
+	protected function get_default_query_vars() {
+		return array();
+	}
+
+	/**
+	 * Get product data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args = apply_filters( 'woocommerce_reports_taxes_query_args', $this->get_query_vars() );
+
+		$data_store = WC_Data_Store::load( 'report-taxes' );
+		$results    = $data_store->get_data( $args );
+		return apply_filters( 'woocommerce_reports_taxes_select_query', $results, $args );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -80,6 +80,27 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	}
 
 	/**
+	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return array
+	 */
+	protected function get_order_by_sql_params( $query_args ) {
+		$sql_query['order_by_clause'] = '';
+		if ( isset( $query_args['orderby'] ) ) {
+			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
+		}
+
+		if ( isset( $query_args['order'] ) ) {
+			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
+		} else {
+			$sql_query['order_by_clause'] .= ' DESC';
+		}
+
+		return $sql_query;
+	}
+
+	/**
 	 * Returns the report data based on parameters supplied by the user.
 	 *
 	 * @param array $query_args  Query parameters.
@@ -97,7 +118,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 			'per_page' => get_option( 'posts_per_page' ),
 			'page'     => 1,
 			'order'    => 'DESC',
-			'orderby'  => 'date',
+			'orderby'  => 'tax_rate_id',
 			'before'   => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
 			'after'    => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
 			'fields'   => '*',
@@ -183,6 +204,22 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	protected function get_cache_key( $params ) {
 		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
+	/**
+	 * Maps ordering specified by the user to columns in the database/fields in the data.
+	 *
+	 * @param string $order_by Sorting criterion.
+	 * @return string
+	 */
+	protected function normalize_order_by( $order_by ) {
+		global $wpdb;
+
+		if ( 'rate' === $order_by ) {
+			return $wpdb->prefix . 'woocommerce_tax_rates.tax_rate';
+		}
+
+		return $order_by;
 	}
 
 }

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -26,7 +26,11 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	protected $column_types = array(
 		'tax_rate_id'  => 'intval',
-		'tax_rate'    => 'floatval',
+		'name'         => 'strval',
+		'tax_rate'     => 'floatval',
+		'country'      => 'strval',
+		'state'        => 'strval',
+		'priority'     => 'intval',
 		'total_tax'    => 'floatval',
 		'order_tax'    => 'floatval',
 		'shipping_tax' => 'floatval',
@@ -40,7 +44,11 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	protected $report_columns = array(
 		'tax_rate_id'  => 'tax_rate_id',
+		'name'         => 'tax_rate_name as name',
 		'tax_rate'     => 'tax_rate',
+		'country'      => 'tax_rate_country as country',
+		'state'        => 'tax_rate_state as state',
+		'priority'     => 'tax_rate_priority as priority',
 		'total_tax'    => 'SUM(total_tax) as total_tax',
 		'order_tax'    => 'SUM(order_tax) as order_tax',
 		'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -26,6 +26,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	protected $column_types = array(
 		'tax_rate_id'  => 'intval',
+		'tax_rate'    => 'floatval',
 		'total_tax'    => 'floatval',
 		'order_tax'    => 'floatval',
 		'shipping_tax' => 'floatval',
@@ -39,6 +40,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	protected $report_columns = array(
 		'tax_rate_id'  => 'tax_rate_id',
+		'tax_rate'     => 'tax_rate',
 		'total_tax'    => 'SUM(total_tax) as total_tax',
 		'order_tax'    => 'SUM(order_tax) as order_tax',
 		'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * WC_Admin_Reports_Taxes_Data_Store class file.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Taxes_Data_Store.
+ */
+class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+
+	/**
+	 * Table used to get the data.
+	 *
+	 * @var string
+	 */
+	const TABLE_NAME = 'wc_order_tax_lookup';
+
+	/**
+	 * Mapping columns to data type to return correct response types.
+	 *
+	 * @var array
+	 */
+	protected $column_types = array(
+		'tax_rate_id'  => 'intval',
+		'total_tax'    => 'floatval',
+		'order_tax'    => 'floatval',
+		'shipping_tax' => 'floatval',
+		'orders_count' => 'intval',
+	);
+
+	/**
+	 * SQL columns to select in the db query and their mapping to SQL code.
+	 *
+	 * @var array
+	 */
+	protected $report_columns = array(
+		'tax_rate_id'  => 'tax_rate_id',
+		'total_tax'    => 'SUM(total_tax) as total_tax',
+		'order_tax'    => 'SUM(order_tax) as order_tax',
+		'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
+		'orders_count' => 'COUNT(DISTINCT order_id) as orders_count',
+	);
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		global $wpdb;
+		$table_name                          = $wpdb->prefix . self::TABLE_NAME;
+		$this->report_columns['tax_rate_id'] = $table_name . '.' . $this->report_columns['tax_rate_id'];
+	}
+
+	/**
+	 * Updates the database query with parameters used for Taxes report: categories and order status.
+	 *
+	 * @param array $query_args Query arguments supplied by the user.
+	 * @return array            Array of parameters used for SQL query.
+	 */
+	protected function get_sql_query_params( $query_args ) {
+		global $wpdb;
+
+		$order_tax_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+
+		$sql_query_params = $this->get_time_period_sql_params( $query_args, $order_tax_lookup_table );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_limit_sql_params( $query_args ) );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_order_by_sql_params( $query_args ) );
+
+		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
+			$allowed_taxes                     = esc_sql( implode( ',', $query_args['taxes'] ) );
+			$sql_query_params['where_clause'] .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
+		}
+
+		$sql_query_params['from_clause'] .= " JOIN {$wpdb->prefix}woocommerce_tax_rates ON {$order_tax_lookup_table}.tax_rate_id = {$wpdb->prefix}woocommerce_tax_rates.tax_rate_id";
+
+		return $sql_query_params;
+	}
+
+	/**
+	 * Returns the report data based on parameters supplied by the user.
+	 *
+	 * @param array $query_args  Query parameters.
+	 * @return stdClass|WP_Error Data.
+	 */
+	public function get_data( $query_args ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . self::TABLE_NAME;
+		$now        = time();
+		$week_back  = $now - WEEK_IN_SECONDS;
+
+		// These defaults are only partially applied when used via REST API, as that has its own defaults.
+		$defaults   = array(
+			'per_page' => get_option( 'posts_per_page' ),
+			'page'     => 1,
+			'order'    => 'DESC',
+			'orderby'  => 'date',
+			'before'   => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
+			'after'    => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
+			'fields'   => '*',
+			'taxes'    => array(),
+		);
+		$query_args = wp_parse_args( $query_args, $defaults );
+
+		$cache_key = $this->get_cache_key( $query_args );
+		$data      = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $data ) {
+			$data = (object) array(
+				'data'    => array(),
+				'total'   => 0,
+				'pages'   => 0,
+				'page_no' => 0,
+			);
+
+			$selections       = $this->selected_columns( $query_args );
+			$sql_query_params = $this->get_sql_query_params( $query_args );
+
+			$db_records_count = (int) $wpdb->get_var(
+				"SELECT COUNT(*) FROM (
+							SELECT
+								{$table_name}.tax_rate_id
+							FROM
+								{$table_name}
+								{$sql_query_params['from_clause']}
+							WHERE
+								1=1
+								{$sql_query_params['where_clause']}
+							GROUP BY
+								{$table_name}.tax_rate_id
+					  		) AS tt"
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			$total_pages = (int) ceil( $db_records_count / $sql_query_params['per_page'] );
+			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
+				return $data;
+			}
+
+			$tax_data = $wpdb->get_results(
+				"SELECT
+						{$selections}
+					FROM
+						{$table_name}
+						{$sql_query_params['from_clause']}
+					WHERE
+						1=1
+						{$sql_query_params['where_clause']}
+					GROUP BY
+						{$table_name}.tax_rate_id
+					ORDER BY
+						{$sql_query_params['order_by_clause']}
+					{$sql_query_params['limit']}
+					",
+				ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			if ( null === $tax_data ) {
+				return $data;
+			}
+
+			$tax_data = array_map( array( $this, 'cast_numbers' ), $tax_data );
+			$data     = (object) array(
+				'data'    => $tax_data,
+				'total'   => $db_records_count,
+				'pages'   => $total_pages,
+				'page_no' => (int) $query_args['page'],
+			);
+
+			wp_cache_set( $cache_key, $data, $this->cache_group );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -80,7 +80,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 		$sql_query_params = array_merge( $sql_query_params, $this->get_order_by_sql_params( $query_args ) );
 
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
-			$allowed_taxes                     = esc_sql( implode( ',', $query_args['taxes'] ) );
+			$allowed_taxes                     = implode( ',', $query_args['taxes'] );
 			$sql_query_params['where_clause'] .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
 		}
 
@@ -159,6 +159,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 								{$sql_query_params['from_clause']}
 							WHERE
 								1=1
+								{$sql_query_params['where_time_clause']}
 								{$sql_query_params['where_clause']}
 							GROUP BY
 								{$table_name}.tax_rate_id

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -179,6 +179,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 						{$sql_query_params['from_clause']}
 					WHERE
 						1=1
+						{$sql_query_params['where_time_clause']}
 						{$sql_query_params['where_clause']}
 					GROUP BY
 						{$table_name}.tax_rate_id

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -61,6 +61,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	public function __construct() {
 		global $wpdb;
 		$table_name                          = $wpdb->prefix . self::TABLE_NAME;
+		// Avoid ambigious column tax_rate_id in SQL query.
 		$this->report_columns['tax_rate_id'] = $table_name . '.' . $this->report_columns['tax_rate_id'];
 	}
 

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -94,6 +94,7 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 		$tax_report = reset( $reports );
 
 		$this->assertEquals( 1, $tax_report['tax_rate_id'] );
+		$this->assertEquals( 7, $tax_report['tax_rate'] );
 		$this->assertEquals( 7, $tax_report['total_tax'] );
 		$this->assertEquals( 5, $tax_report['order_tax'] );
 		$this->assertEquals( 2, $tax_report['shipping_tax'] );
@@ -124,8 +125,9 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 5, count( $properties ) );
+		$this->assertEquals( 6, count( $properties ) );
 		$this->assertArrayHasKey( 'tax_rate_id', $properties );
+		$this->assertArrayHasKey( 'tax_rate', $properties );
 		$this->assertArrayHasKey( 'total_tax', $properties );
 		$this->assertArrayHasKey( 'order_tax', $properties );
 		$this->assertArrayHasKey( 'shipping_tax', $properties );

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Reports Taxes REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/reports/taxes';
+
+	/**
+	 * Setup test reports taxes data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 1,
+				'tax_rate'          => '7',
+				'tax_rate_name'     => 'TestTax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		// @todo Remove this once order data is synced to wc_order_tax_lookup
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => 1,
+				'tax_rate_id'  => 1,
+				'date_created' => date( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 2,
+				'order_tax'    => 5,
+				'total_tax'    => 7,
+			)
+		);
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $reports ) );
+
+		$tax_report = reset( $reports );
+
+		$this->assertEquals( 1, $tax_report['tax_rate_id'] );
+		$this->assertEquals( 7, $tax_report['total_tax'] );
+		$this->assertEquals( 5, $tax_report['order_tax'] );
+		$this->assertEquals( 2, $tax_report['shipping_tax'] );
+		$this->assertEquals( 1, $tax_report['orders_count'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 5, count( $properties ) );
+		$this->assertArrayHasKey( 'tax_rate_id', $properties );
+		$this->assertArrayHasKey( 'total_tax', $properties );
+		$this->assertArrayHasKey( 'order_tax', $properties );
+		$this->assertArrayHasKey( 'shipping_tax', $properties );
+		$this->assertArrayHasKey( 'orders_count', $properties );
+	}
+}

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -61,6 +61,8 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 			array(
 				'tax_rate_id'       => 1,
 				'tax_rate'          => '7',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'GA',
 				'tax_rate_name'     => 'TestTax',
 				'tax_rate_priority' => 1,
 				'tax_rate_order'    => 1,
@@ -94,7 +96,10 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 		$tax_report = reset( $reports );
 
 		$this->assertEquals( 1, $tax_report['tax_rate_id'] );
+		$this->assertEquals( 'TestTax', $tax_report['name'] );
 		$this->assertEquals( 7, $tax_report['tax_rate'] );
+		$this->assertEquals( 'US', $tax_report['country'] );
+		$this->assertEquals( 'GA', $tax_report['state'] );
 		$this->assertEquals( 7, $tax_report['total_tax'] );
 		$this->assertEquals( 5, $tax_report['order_tax'] );
 		$this->assertEquals( 2, $tax_report['shipping_tax'] );
@@ -125,9 +130,13 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 6, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'tax_rate_id', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'tax_rate', $properties );
+		$this->assertArrayHasKey( 'country', $properties );
+		$this->assertArrayHasKey( 'state', $properties );
+		$this->assertArrayHasKey( 'priority', $properties );
 		$this->assertArrayHasKey( 'total_tax', $properties );
 		$this->assertArrayHasKey( 'order_tax', $properties );
 		$this->assertArrayHasKey( 'shipping_tax', $properties );

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * WC_Tests_API_Reports_Taxes
+ */
 class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 
 	/**


### PR DESCRIPTION
Fixes (partially) #844 

Adds in the endpoint for the taxes report table.

### Screenshots
<img width="559" alt="screen shot 2018-12-07 at 8 56 45 am" src="https://user-images.githubusercontent.com/10561050/49620960-2c987b00-f9fe-11e8-8861-3c8306b51263.png">

### Detailed test instructions:

1.  Add at least a couple of tax rates under `/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard`
2.  Add several rows of data into the `wp_wc_order_tax_lookup` table.  This can be any data, but match the tax rate ID to an existing tax rate from step 1 for more thorough testing.
3.  Make a post request to `wp/wp-json/wc/v3/reports/taxes` with WC Rest API keys.
4.  Make sure you receive accurate data from the request for these fields:
    * tax_rate_id
    * name
    * country
    * state
    * priority
    * total_tax
    * order_tax
    * shipping_tax
    * orders_count
    * _links
5.  Test with these query params as well
    * before
    * after
    * page
    * per_page
    * orderby
    * order
    * taxes (comma separated tax_rate_ids from the `woocommerce_tax_rates` table
6. Run phpunit tests to make sure they pass.

### Todo
This PR is already very large, so it's being broken down into smaller pieces.
* Tax report hookup
* Tax report stats
* Tax report stats hookup
* `wp_wc_order_tax_lookup` syncing