### PR TITLE
Use correct variable to set singular/plural translation in Orders table summary

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -187,7 +187,7 @@ class OrdersReportTable extends Component {
 		}
 		return [
 			{
-				label: _n( 'order', 'orders', totals.num_items_sold, 'wc-admin' ),
+				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
 				value: numberFormat( totals.orders_count ),
 			},
 			{


### PR DESCRIPTION
Tiny PR that fixes the _order_/_orders_ translation using the wrong variable to decide if the singular or plural should be used.

### Screenshots
_Before: (taken from a screenshot posted by @jeffstieler in Slack, notice it says **2 order**)_
![image](https://user-images.githubusercontent.com/3616980/49536824-16b77880-f88d-11e8-859e-7e61da478024.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/49536659-af99c400-f88c-11e8-9b7a-5e117bbb6439.png)

### Detailed test instructions:
The issue is a bit hard to reproduce, because you need to have several orders but only one product sold, but given that the code change is pretty small, I think these steps are more than enough to test:
- Go to the _Orders_ report and make sure more than one order appears in the table.
- Verify the first item in the table summary is _orders_ instead of _order_.
- Change the dates so only one order appears in the table.
- Verify the first item in the table summary is _order_ instead of _orders_.