### PR TITLE
Fix Activity Panel on existing WooCommerce pages

### DIFF
--- a/client/embedded.js
+++ b/client/embedded.js
@@ -10,6 +10,8 @@ import { Provider as SlotFillProvider } from 'react-slot-fill';
  */
 import './stylesheets/_embedded.scss';
 import { EmbedLayout } from './layout';
+import 'store';
+import 'wc-api/wp-data-store';
 
 render(
 	<SlotFillProvider>

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -7,7 +7,7 @@ import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
-import { withSelect } from '@wordpress/data';
+import withSelect from 'wc-api/with-select';
 
 /**
  * Internal dependencies
@@ -89,7 +89,7 @@ class InboxPanel extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getNotes, isGetNotesError, isGetNotesRequesting } = select( 'wc-admin' );
+		const { getNotes, isGetNotesError, isGetNotesRequesting } = select( 'wc-api' );
 		const inboxQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -12,7 +12,7 @@
 	position: fixed;
 	width: 100%;
 	top: 32px;
-	z-index: 99999; /* component-popover is 99990 */
+	z-index: 99991; /* higer than component-popover (99990), lower than notification dropdown at 99999 */
 
 	&.is-scrolled {
 		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -12,7 +12,7 @@
 	position: fixed;
 	width: 100%;
 	top: 32px;
-	z-index: 99991; /* higer than component-popover (99990), lower than notification dropdown at 99999 */
+	z-index: 99991; /* higher than component-popover (99990), lower than notification dropdown at 99999 */
 
 	&.is-scrolled {
 		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -80,4 +80,16 @@
 			margin-top: 32px;
 		}
 	}
+
+	.woocommerce-layout__activity-panel-mobile-toggle {
+		@include breakpoint( '>782px' ) {
+			display: none;
+		}
+	}
+
+	.woocommerce-activity-card__actions {
+		a.components-button.is-button {
+			color: $gray-text;
+		}
+	}
 }

--- a/client/wc-api/notes/index.js
+++ b/client/wc-api/notes/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/notes/operations.js
+++ b/client/wc-api/notes/operations.js
@@ -1,0 +1,76 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { isResourcePrefix, getResourceIdentifier, getResourceName } from '../utils';
+import { NAMESPACE } from '../constants';
+
+function read( resourceNames, fetch = apiFetch ) {
+	return [ ...readNotes( resourceNames, fetch ), ...readNoteQueries( resourceNames, fetch ) ];
+}
+
+function readNoteQueries( resourceNames, fetch ) {
+	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'note-query' ) );
+
+	return filteredNames.map( async resourceName => {
+		const query = getResourceIdentifier( resourceName );
+		const url = `${ NAMESPACE }/admin/notes${ stringifyQuery( query ) }`;
+
+		try {
+			const response = await fetch( {
+				parse: false,
+				path: url,
+			} );
+
+			const notes = await response.json();
+			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
+			const ids = notes.map( note => note.id );
+			const noteResources = notes.reduce( ( resources, note ) => {
+				resources[ getResourceName( 'note', note.id ) ] = { data: note };
+				return resources;
+			}, {} );
+
+			return {
+				[ resourceName ]: {
+					data: ids,
+					totalCount,
+				},
+				...noteResources,
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+function readNotes( resourceNames, fetch ) {
+	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'note' ) );
+	return filteredNames.map( resourceName => readNote( resourceName, fetch ) );
+}
+
+function readNote( resourceName, fetch ) {
+	const id = getResourceIdentifier( resourceName );
+	const url = `${ NAMESPACE }/admin/notes/${ id }`;
+
+	return fetch( { path: url } )
+		.then( note => {
+			return { [ resourceName ]: { data: note } };
+		} )
+		.catch( error => {
+			return { [ resourceName ]: { error } };
+		} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/notes/selectors.js
+++ b/client/wc-api/notes/selectors.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+import { DEFAULT_REQUIREMENT } from '../constants';
+
+const getNotes = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'note-query', query );
+	const ids = requireResource( requirement, resourceName ).data || [];
+	const notes = ids.map( id => getResource( getResourceName( 'note', id ) ).data || {} );
+	return notes;
+};
+
+const isGetNotesRequesting = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'note-query', query );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) ) {
+		return false;
+	}
+
+	if ( isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+const isGetNotesError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'note-query', query );
+	return getResource( resourceName ).error;
+};
+
+export default {
+	getNotes,
+	isGetNotesRequesting,
+	isGetNotesError,
+};

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -3,16 +3,21 @@
 /**
  * Internal dependencies
  */
+import notes from './notes';
 import orders from './orders';
 
 function createWcApiSpec() {
 	return {
 		selectors: {
+			...notes.selectors,
 			...orders.selectors,
 		},
 		operations: {
 			read( resourceNames ) {
-				return [ ...orders.operations.read( resourceNames ) ];
+				return [
+					...notes.operations.read( resourceNames ),
+					...orders.operations.read( resourceNames ),
+				];
 			},
 		},
 	};

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -96,11 +96,13 @@ function wc_admin_register_script() {
 	}
 
 	// Resets lodash to wp-admin's version of lodash.
-	wp_add_inline_script(
-		WC_ADMIN_APP,
-		'_.noConflict();',
-		'after'
-	);
+	if ( 'embedded' === $entry ) {
+		wp_add_inline_script(
+			WC_ADMIN_APP,
+			'_ = _.noConflict();',
+			'after'
+		);
+	}
 
 	wp_register_style(
 		'wc-components',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,11 @@ const webpackConfig = {
 	module: {
 		rules: [
 			{
+				parser: {
+					amd: false,
+				},
+			},
+			{
 				test: /\.jsx?$/,
 				loader: 'babel-loader',
 				exclude: /node_modules/,


### PR DESCRIPTION
Fixes #726.
Fixes #738.

This PR fixes a few issues with embedding activity panel on existing WooCommerce pages.

First, it fixes the `Uncaught TypeError` errors that occurs when trying to open notes or orders. This is because the API scripts were not being loaded in the embedded app entry point. It also moves notes over to using Fresh Data to match the orders panel.

Next, it fixes an issue where underscore and lodash where clashing which broke the WordPress.com notifications toolbar. There is a webpack change. Funnily enough, WCS made a similar change that I found through Googleing :). https://github.com/Automattic/woocommerce-services/pull/1522.

Then a few minor CSS issues are fixed. For example, the .com notifications panel getting covered by wc-admin when open.

<img width="1545" alt="screen shot 2018-12-05 at 2 03 20 pm" src="https://user-images.githubusercontent.com/689165/49537281-90a02f80-f896-11e8-9d97-3d9b62c80fd5.png">

### Detailed test instructions:

* If you don't have any wc-admin notifications in your Inbox, you can force one to show by opening `wc-admin.php` and changing `add_action( 'woocommerce_updated', 'wc_admin_woocommerce_updated' );` to `add_action( 'init', 'wc_admin_woocommerce_updated' );`. Refresh, and then change the line back.
* Test opening various activity panel tabs on any existing WooCommerce page. Also test opening the WordPress.com notifications toolbar.
* Repeat on a dashboard or analytics page.
