### PR TITLE
Use `wc-api` for Reports.

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -5,7 +5,6 @@
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
-import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import { find, get } from 'lodash';
 
@@ -28,6 +27,7 @@ import { Chart } from '@woocommerce/components';
  */
 import { getReportChartData, getTooltipValueFormat } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
+import withSelect from 'wc-api/with-select';
 
 export const DEFAULT_FILTER = 'all';
 

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -5,7 +5,6 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 
 /**
@@ -21,6 +20,7 @@ import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce
 import { getSummaryNumbers } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
 import { calculateDelta, formatValue } from './utils';
+import withSelect from 'wc-api/with-select';
 
 export class ReportSummary extends Component {
 	render() {

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -5,7 +5,6 @@
 import { applyFilters } from '@wordpress/hooks';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 import { get, orderBy } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -20,6 +19,7 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+import withSelect from 'wc-api/with-select';
 
 const TABLE_FILTER = 'woocommerce_admin_report_table';
 

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -17,7 +17,7 @@ import { charts } from './config';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
-import RevenueReportTable from './table';
+// import RevenueReportTable from './table';
 
 export default class RevenueReport extends Component {
 	render() {
@@ -39,7 +39,7 @@ export default class RevenueReport extends Component {
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<RevenueReportTable query={ query } />
+				{ /* <RevenueReportTable query={ query } /> */ }
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -17,7 +17,7 @@ import { charts } from './config';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
-// import RevenueReportTable from './table';
+import RevenueReportTable from './table';
 
 export default class RevenueReport extends Component {
 	render() {
@@ -39,7 +39,7 @@ export default class RevenueReport extends Component {
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				{ /* <RevenueReportTable query={ query } /> */ }
+				<RevenueReportTable query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -6,7 +6,7 @@ import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
-import { get, map } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WooCommerce dependencies

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -6,7 +6,7 @@ import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
-import { get } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -224,7 +224,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { query } = props;
 		const datesFromQuery = getCurrentDates( query );
-		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
 
 		// TODO Support hour here when viewing a single day
 		const tableQuery = {

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -62,29 +62,29 @@ describe( 'getReportChartData()', () => {
 	};
 
 	beforeAll( () => {
-		select( 'wc-admin' ).getReportStats = jest.fn().mockReturnValue( {} );
-		select( 'wc-admin' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-admin' ).isReportStatsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportStats = jest.fn().mockReturnValue( {} );
+		select( 'wc-api' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).isReportStatsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
-		select( 'wc-admin' ).getReportStats.mockRestore();
-		select( 'wc-admin' ).isReportStatsRequesting.mockRestore();
-		select( 'wc-admin' ).isReportStatsError.mockRestore();
+		select( 'wc-api' ).getReportStats.mockRestore();
+		select( 'wc-api' ).isReportStatsRequesting.mockRestore();
+		select( 'wc-api' ).isReportStatsError.mockRestore();
 	} );
 
 	function setGetReportStats( func ) {
-		select( 'wc-admin' ).getReportStats.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).getReportStats.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	function setIsReportStatsRequesting( func ) {
-		select( 'wc-admin' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
+		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
 			func( ...args )
 		);
 	}
 
 	function setIsReportStatsError( func ) {
-		select( 'wc-admin' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if first request is in progress', () => {
@@ -262,29 +262,29 @@ describe( 'getSummaryNumbers()', () => {
 	};
 
 	beforeAll( () => {
-		select( 'wc-admin' ).getReportStats = jest.fn().mockReturnValue( {} );
-		select( 'wc-admin' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-admin' ).isReportStatsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportStats = jest.fn().mockReturnValue( {} );
+		select( 'wc-api' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).isReportStatsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
-		select( 'wc-admin' ).getReportStats.mockRestore();
-		select( 'wc-admin' ).isReportStatsRequesting.mockRestore();
-		select( 'wc-admin' ).isReportStatsError.mockRestore();
+		select( 'wc-api' ).getReportStats.mockRestore();
+		select( 'wc-api' ).isReportStatsRequesting.mockRestore();
+		select( 'wc-api' ).isReportStatsError.mockRestore();
 	} );
 
 	function setGetReportStats( func ) {
-		select( 'wc-admin' ).getReportStats.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).getReportStats.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	function setIsReportStatsRequesting( func ) {
-		select( 'wc-admin' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
+		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
 			func( ...args )
 		);
 	}
 
 	function setIsReportStatsError( func ) {
-		select( 'wc-admin' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if a request is in progress', () => {
@@ -460,29 +460,29 @@ describe( 'getReportTableData()', () => {
 	};
 
 	beforeAll( () => {
-		select( 'wc-admin' ).getReportItems = jest.fn().mockReturnValue( {} );
-		select( 'wc-admin' ).isGetReportItemsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-admin' ).isGetReportItemsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportItems = jest.fn().mockReturnValue( {} );
+		select( 'wc-api' ).isGetReportItemsRequesting = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).isGetReportItemsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
-		select( 'wc-admin' ).getReportItems.mockRestore();
-		select( 'wc-admin' ).isGetReportItemsRequesting.mockRestore();
-		select( 'wc-admin' ).isGetReportItemsError.mockRestore();
+		select( 'wc-api' ).getReportItems.mockRestore();
+		select( 'wc-api' ).isGetReportItemsRequesting.mockRestore();
+		select( 'wc-api' ).isGetReportItemsError.mockRestore();
 	} );
 
 	function setGetReportItems( func ) {
-		select( 'wc-admin' ).getReportItems.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).getReportItems.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	function setIsGetReportItemsRequesting( func ) {
-		select( 'wc-admin' ).isGetReportItemsRequesting.mockImplementation( ( ...args ) =>
+		select( 'wc-api' ).isGetReportItemsRequesting.mockImplementation( ( ...args ) =>
 			func( ...args )
 		);
 	}
 
 	function setIsGetReportItemsError( func ) {
-		select( 'wc-admin' ).isGetReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
+		select( 'wc-api' ).isGetReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if a request is in progress', () => {
@@ -491,12 +491,12 @@ describe( 'getReportTableData()', () => {
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, isRequesting: true } );
-		expect( select( 'wc-admin' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-admin' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
+		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-admin' ).isGetReportItemsError ).toHaveBeenCalledTimes( 0 );
+		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	it( 'returns isError if request errors', () => {
@@ -506,12 +506,12 @@ describe( 'getReportTableData()', () => {
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, isError: true } );
-		expect( select( 'wc-admin' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-admin' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
+		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-admin' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
@@ -526,12 +526,12 @@ describe( 'getReportTableData()', () => {
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, items } );
-		expect( select( 'wc-admin' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-admin' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
+		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-admin' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -461,57 +461,57 @@ describe( 'getReportTableData()', () => {
 
 	beforeAll( () => {
 		select( 'wc-api' ).getReportItems = jest.fn().mockReturnValue( {} );
-		select( 'wc-api' ).isGetReportItemsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-api' ).isGetReportItemsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).isReportItemsRequesting = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).isReportItemsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
 		select( 'wc-api' ).getReportItems.mockRestore();
-		select( 'wc-api' ).isGetReportItemsRequesting.mockRestore();
-		select( 'wc-api' ).isGetReportItemsError.mockRestore();
+		select( 'wc-api' ).isReportItemsRequesting.mockRestore();
+		select( 'wc-api' ).isReportItemsError.mockRestore();
 	} );
 
 	function setGetReportItems( func ) {
 		select( 'wc-api' ).getReportItems.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
-	function setIsGetReportItemsRequesting( func ) {
-		select( 'wc-api' ).isGetReportItemsRequesting.mockImplementation( ( ...args ) =>
+	function setisReportItemsRequesting( func ) {
+		select( 'wc-api' ).isReportItemsRequesting.mockImplementation( ( ...args ) =>
 			func( ...args )
 		);
 	}
 
-	function setIsGetReportItemsError( func ) {
-		select( 'wc-api' ).isGetReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
+	function setisReportItemsError( func ) {
+		select( 'wc-api' ).isReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if a request is in progress', () => {
-		setIsGetReportItemsRequesting( () => true );
+		setisReportItemsRequesting( () => true );
 
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, isRequesting: true } );
 		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenCalledTimes( 0 );
+		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	it( 'returns isError if request errors', () => {
-		setIsGetReportItemsRequesting( () => false );
-		setIsGetReportItemsError( () => true );
+		setisReportItemsRequesting( () => false );
+		setisReportItemsError( () => true );
 
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, isError: true } );
 		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
@@ -519,19 +519,19 @@ describe( 'getReportTableData()', () => {
 
 	it( 'returns results after queries finish', () => {
 		const items = [ { id: 1 }, { id: 2 }, { id: 3 } ];
-		setIsGetReportItemsRequesting( () => false );
-		setIsGetReportItemsError( () => false );
+		setisReportItemsRequesting( () => false );
+		setisReportItemsError( () => false );
 		setGetReportItems( () => items );
 
 		const result = getReportTableData( 'coupons', query, select );
 
 		expect( result ).toEqual( { ...response, query, items } );
 		expect( select( 'wc-api' ).getReportItems ).toHaveBeenLastCalledWith( 'coupons', query );
-		expect( select( 'wc-api' ).isGetReportItemsRequesting ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isReportItemsRequesting ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isGetReportItemsError ).toHaveBeenLastCalledWith(
+		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenLastCalledWith(
 			'coupons',
 			query
 		);

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -296,7 +296,7 @@ export function getReportTableQuery( urlQuery, query ) {
  * @return {Object} Object    Table data response
  */
 export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
-	const { getReportItems, isGetReportItemsRequesting, isGetReportItemsError } = select(
+	const { getReportItems, isReportItemsRequesting, isReportItemsError } = select(
 		'wc-api'
 	);
 
@@ -309,9 +309,9 @@ export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
 	};
 
 	const items = getReportItems( endpoint, tableQuery );
-	if ( isGetReportItemsRequesting( endpoint, tableQuery ) ) {
+	if ( isReportItemsRequesting( endpoint, tableQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( isGetReportItemsError( endpoint, tableQuery ) ) {
+	} else if ( isReportItemsError( endpoint, tableQuery ) ) {
 		return { ...response, isError: true };
 	}
 

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -139,7 +139,7 @@ function getRequestQuery( endpoint, dataType, query ) {
  * @return {Object}  Object containing summary number responses.
  */
 export function getSummaryNumbers( endpoint, query, select ) {
-	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
 	const response = {
 		isRequesting: false,
 		isError: false,

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -182,7 +182,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( endpoint, dataType, query, select ) {
-	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
 
 	const response = {
 		isEmpty: false,

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -297,7 +297,7 @@ export function getReportTableQuery( urlQuery, query ) {
  */
 export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
 	const { getReportItems, isGetReportItemsRequesting, isGetReportItemsError } = select(
-		'wc-admin'
+		'wc-api'
 	);
 
 	const tableQuery = reportsUtils.getReportTableQuery( urlQuery, query );

--- a/client/wc-api/orders/selectors.js
+++ b/client/wc-api/orders/selectors.js
@@ -33,11 +33,7 @@ const isGetOrdersRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'order-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
-	if ( isNil( lastRequested ) ) {
-		return false;
-	}
-
-	if ( isNil( lastReceived ) ) {
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;
 	}
 

--- a/client/wc-api/reports/items/index.js
+++ b/client/wc-api/reports/items/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -26,6 +26,7 @@ const typeEndpointMap = {
 	'report-items-query-categories': 'categories',
 	'report-items-query-coupons': 'coupons',
 	'report-items-query-taxes': 'taxes',
+	'report-items-query-variations': 'variations',
 };
 
 function read( resourceNames, fetch = apiFetch ) {

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -53,7 +53,6 @@ function read( resourceNames, fetch = apiFetch ) {
 		try {
 			const response = await fetch( fetchArgs );
 			const report = await response.json();
-			// TODO: exclude these if using swagger?
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
 			const totalPages = parseInt( response.headers.get( 'x-wp-totalpages' ) );
 

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -39,18 +39,18 @@ function read( resourceNames, fetch = apiFetch ) {
 		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
 
-		let apiPath = NAMESPACE + '/reports/' + endpoint + stringifyQuery( query );
+		const fetchArgs = {
+			parse: false,
+		};
 
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
-			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + stringifyQuery( query );
+			fetchArgs.url = SWAGGERNAMESPACE + 'reports/' + endpoint + stringifyQuery( query );
+		} else {
+			fetchArgs.path = NAMESPACE + '/reports/' + endpoint + stringifyQuery( query );
 		}
 
 		try {
-			const response = await fetch( {
-				parse: false,
-				path: apiPath,
-			} );
-
+			const response = await fetch( fetchArgs );
 			const report = await response.json();
 			// TODO: exclude these if using swagger?
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -1,0 +1,74 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceIdentifier, getResourcePrefix } from '../../utils';
+import { NAMESPACE } from '../../constants';
+import { SWAGGERNAMESPACE } from 'store/constants';
+
+// TODO: Remove once swagger endpoints are phased out.
+const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+
+const typeEndpointMap = {
+	'report-items-query-orders': 'orders',
+	'report-items-query-revenue': 'revenue',
+	'report-items-query-products': 'products',
+	'report-items-query-categories': 'categories',
+	'report-items-query-coupons': 'coupons',
+	'report-items-query-taxes': 'taxes',
+};
+
+function read( resourceNames, fetch = apiFetch ) {
+	const filteredNames = resourceNames.filter( name => {
+		const prefix = getResourcePrefix( name );
+		return Boolean( typeEndpointMap[ prefix ] );
+	} );
+
+	return filteredNames.map( async resourceName => {
+		const prefix = getResourcePrefix( resourceName );
+		const endpoint = typeEndpointMap[ prefix ];
+		const query = getResourceIdentifier( resourceName );
+
+		let apiPath = NAMESPACE + '/reports/' + endpoint + stringifyQuery( query );
+
+		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
+			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + stringifyQuery( query );
+		}
+
+		try {
+			const response = await fetch( {
+				parse: false,
+				path: apiPath,
+			} );
+
+			const report = await response.json();
+			// TODO: exclude these if using swagger?
+			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
+			const totalPages = parseInt( response.headers.get( 'x-wp-totalpages' ) );
+
+			return {
+				[ resourceName ]: {
+					data: report,
+					totalResults,
+					totalPages,
+				},
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/reports/items/selectors.js
+++ b/client/wc-api/reports/items/selectors.js
@@ -17,12 +17,10 @@ const getReportItems = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
 	const resourceName = getResourceName( `report-items-query-${ type }`, query );
-	const data = requireResource( requirement, resourceName ) || {};
-
-	return data;
+	return requireResource( requirement, resourceName ) || {};
 };
 
-const isGetReportItemsRequesting = getResource => ( type, query = {} ) => {
+const isReportItemsRequesting = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-items-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
@@ -33,13 +31,13 @@ const isGetReportItemsRequesting = getResource => ( type, query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isGetReportItemsError = getResource => ( type, query = {} ) => {
+const isReportItemsError = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-items-query-${ type }`, query );
 	return getResource( resourceName ).error;
 };
 
 export default {
 	getReportItems,
-	isGetReportItemsRequesting,
-	isGetReportItemsError,
+	isReportItemsRequesting,
+	isReportItemsError,
 };

--- a/client/wc-api/reports/items/selectors.js
+++ b/client/wc-api/reports/items/selectors.js
@@ -26,11 +26,7 @@ const isGetReportItemsRequesting = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-items-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
-	if ( isNil( lastRequested ) ) {
-		return false;
-	}
-
-	if ( isNil( lastReceived ) ) {
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;
 	}
 

--- a/client/wc-api/reports/items/selectors.js
+++ b/client/wc-api/reports/items/selectors.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../../utils';
+import { DEFAULT_REQUIREMENT } from '../../constants';
+
+const getReportItems = ( getResource, requireResource ) => (
+	type,
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( `report-items-query-${ type }`, query );
+	const data = requireResource( requirement, resourceName ) || {};
+
+	return data;
+};
+
+const isGetReportItemsRequesting = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-items-query-${ type }`, query );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) ) {
+		return false;
+	}
+
+	if ( isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+const isGetReportItemsError = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-items-query-${ type }`, query );
+	return getResource( resourceName ).error;
+};
+
+export default {
+	getReportItems,
+	isGetReportItemsRequesting,
+	isGetReportItemsError,
+};

--- a/client/wc-api/reports/stats/index.js
+++ b/client/wc-api/reports/stats/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -12,7 +12,7 @@ import { stringifyQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { isResourcePrefix, getResourceIdentifier } from '../../utils';
+import { getResourceIdentifier, getResourcePrefix } from '../../utils';
 import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
@@ -20,14 +20,27 @@ const statEndpoints = [ 'orders', 'revenue', 'products' ];
 // TODO: Remove once swagger endpoints are phased out.
 const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
 
+const typeEndpointMap = {
+	'report-stats-query-orders': 'orders',
+	'report-stats-query-revenue': 'revenue',
+	'report-stats-query-products': 'products',
+	'report-stats-query-categories': 'categories',
+	'report-stats-query-coupons': 'coupons',
+	'report-stats-query-taxes': 'taxes',
+};
+
 function read( resourceNames, fetch = apiFetch ) {
-	const filteredNames = resourceNames.filter( name =>
-		isResourcePrefix( name, 'report-stats-query' )
-	);
+	console.log( 'stats read', resourceNames );
+	const filteredNames = resourceNames.filter( name => {
+		const prefix = getResourcePrefix( name );
+		return Boolean( typeEndpointMap[ prefix ] );
+	} );
 
 	return filteredNames.map( async resourceName => {
-		const { endpoint, query } = getResourceIdentifier( resourceName );
-
+		const prefix = getResourcePrefix( resourceName );
+		const endpoint = typeEndpointMap[ prefix ];
+		const query = getResourceIdentifier( resourceName );
+		console.log( '::filtered:: read', resourceName, endpoint, query );
 		let apiPath = endpoint + stringifyQuery( query );
 
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -55,7 +55,6 @@ function read( resourceNames, fetch = apiFetch ) {
 		try {
 			const response = await fetch( fetchArgs );
 			const report = await response.json();
-			// TODO: exclude these if using swagger?
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
 			const totalPages = parseInt( response.headers.get( 'x-wp-totalpages' ) );
 

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -30,7 +30,6 @@ const typeEndpointMap = {
 };
 
 function read( resourceNames, fetch = apiFetch ) {
-	console.log( 'stats read', resourceNames );
 	const filteredNames = resourceNames.filter( name => {
 		const prefix = getResourcePrefix( name );
 		return Boolean( typeEndpointMap[ prefix ] );
@@ -40,7 +39,7 @@ function read( resourceNames, fetch = apiFetch ) {
 		const prefix = getResourcePrefix( resourceName );
 		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
-		console.log( '::filtered:: read', resourceName, endpoint, query );
+
 		let apiPath = endpoint + stringifyQuery( query );
 
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -1,0 +1,67 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { isResourcePrefix, getResourceIdentifier } from '../../utils';
+import { NAMESPACE } from '../../constants';
+import { SWAGGERNAMESPACE } from 'store/constants';
+
+const statEndpoints = [ 'orders', 'revenue', 'products' ];
+// TODO: Remove once swagger endpoints are phased out.
+const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+
+function read( resourceNames, fetch = apiFetch ) {
+	const filteredNames = resourceNames.filter( name =>
+		isResourcePrefix( name, 'report-stats-query' )
+	);
+
+	return filteredNames.map( async resourceName => {
+		const { endpoint, query } = getResourceIdentifier( resourceName );
+
+		let apiPath = endpoint + stringifyQuery( query );
+
+		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
+			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
+		}
+
+		if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
+			apiPath = NAMESPACE + '/reports/' + endpoint + '/stats' + stringifyQuery( query );
+		}
+
+		try {
+			const response = await fetch( {
+				parse: false,
+				path: apiPath,
+			} );
+
+			const report = await response.json();
+			// TODO: exclude these if using swagger?
+			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );
+			const totalPages = parseInt( response.headers.get( 'x-wp-totalpages' ) );
+
+			return {
+				[ resourceName ]: {
+					data: report,
+					totalResults,
+					totalPages,
+				},
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -40,22 +40,20 @@ function read( resourceNames, fetch = apiFetch ) {
 		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
 
-		let apiPath = endpoint + stringifyQuery( query );
+		const fetchArgs = {
+			parse: false,
+		};
 
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
-			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
-		}
-
-		if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
-			apiPath = NAMESPACE + '/reports/' + endpoint + '/stats' + stringifyQuery( query );
+			fetchArgs.url = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
+		} else if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
+			fetchArgs.path = NAMESPACE + '/reports/' + endpoint + '/stats' + stringifyQuery( query );
+		} else {
+			fetchArgs.path = endpoint + stringifyQuery( query );
 		}
 
 		try {
-			const response = await fetch( {
-				parse: false,
-				path: apiPath,
-			} );
-
+			const response = await fetch( fetchArgs );
 			const report = await response.json();
 			// TODO: exclude these if using swagger?
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );

--- a/client/wc-api/reports/stats/selectors.js
+++ b/client/wc-api/reports/stats/selectors.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../../utils';
+import { DEFAULT_REQUIREMENT } from '../../constants';
+
+const getReportStats = ( getResource, requireResource ) => (
+	endpoint,
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+	const data = requireResource( requirement, resourceName ) || {};
+
+	return data;
+};
+
+const isReportStatsRequesting = getResource => ( endpoint, query = {} ) => {
+	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) ) {
+		return false;
+	}
+
+	if ( isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+const isReportStatsError = getResource => ( endpoint, query = {} ) => {
+	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+	return getResource( resourceName ).error;
+};
+
+export default {
+	getReportStats,
+	isReportStatsRequesting,
+	isReportStatsError,
+};

--- a/client/wc-api/reports/stats/selectors.js
+++ b/client/wc-api/reports/stats/selectors.js
@@ -26,11 +26,7 @@ const isReportStatsRequesting = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
-	if ( isNil( lastRequested ) ) {
-		return false;
-	}
-
-	if ( isNil( lastReceived ) ) {
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;
 	}
 

--- a/client/wc-api/reports/stats/selectors.js
+++ b/client/wc-api/reports/stats/selectors.js
@@ -17,7 +17,6 @@ const getReportStats = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
 	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
-	console.log( 'getReportStats', type, query, resourceName );
 	const data = requireResource( requirement, resourceName ) || {};
 
 	return data;

--- a/client/wc-api/reports/stats/selectors.js
+++ b/client/wc-api/reports/stats/selectors.js
@@ -12,18 +12,19 @@ import { getResourceName } from '../../utils';
 import { DEFAULT_REQUIREMENT } from '../../constants';
 
 const getReportStats = ( getResource, requireResource ) => (
-	endpoint,
+	type,
 	query = {},
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
+	console.log( 'getReportStats', type, query, resourceName );
 	const data = requireResource( requirement, resourceName ) || {};
 
 	return data;
 };
 
-const isReportStatsRequesting = getResource => ( endpoint, query = {} ) => {
-	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+const isReportStatsRequesting = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
 	if ( isNil( lastRequested ) ) {
@@ -37,8 +38,8 @@ const isReportStatsRequesting = getResource => ( endpoint, query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isReportStatsError = getResource => ( endpoint, query = {} ) => {
-	const resourceName = getResourceName( 'report-stats-query', { endpoint, query } );
+const isReportStatsError = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
 	return getResource( resourceName ).error;
 };
 

--- a/client/wc-api/utils.js
+++ b/client/wc-api/utils.js
@@ -1,26 +1,16 @@
 /** @format */
-/**
- * External dependencies
- */
-import { isObject } from 'lodash';
 
 export function getResourceName( prefix, identifier ) {
-	const keyList = [];
-	Object.keys( identifier ).forEach( key => {
-		keyList.push( key );
-
-		// whitelist nested object keys
-		if ( isObject( identifier[ key ] ) ) {
-			Array.prototype.push.apply( keyList, Object.keys( identifier[ key ] ) );
-		}
-	} );
-
-	const identifierString = JSON.stringify( identifier, keyList.sort() );
+	const identifierString = JSON.stringify( identifier, Object.keys( identifier ).sort() );
 	return `${ prefix }:${ identifierString }`;
 }
 
+export function getResourcePrefix( resourceName ) {
+	return resourceName.substring( 0, resourceName.indexOf( ':' ) );
+}
+
 export function isResourcePrefix( resourceName, prefix ) {
-	const resourcePrefix = resourceName.substring( 0, resourceName.indexOf( ':' ) );
+	const resourcePrefix = getResourcePrefix( resourceName );
 	return resourcePrefix === prefix;
 }
 

--- a/client/wc-api/utils.js
+++ b/client/wc-api/utils.js
@@ -1,7 +1,21 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
 
 export function getResourceName( prefix, identifier ) {
-	const identifierString = JSON.stringify( identifier, Object.keys( identifier ).sort() );
+	const keyList = [];
+	Object.keys( identifier ).forEach( key => {
+		keyList.push( key );
+
+		// whitelist nested object keys
+		if ( isObject( identifier[ key ] ) ) {
+			Array.prototype.push.apply( keyList, Object.keys( identifier[ key ] ) );
+		}
+	} );
+
+	const identifierString = JSON.stringify( identifier, keyList.sort() );
 	return `${ prefix }:${ identifierString }`;
 }
 

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -5,18 +5,21 @@
  */
 import notes from './notes';
 import orders from './orders';
+import reportStats from './reports/stats';
 
 function createWcApiSpec() {
 	return {
 		selectors: {
 			...notes.selectors,
 			...orders.selectors,
+			...reportStats.selectors,
 		},
 		operations: {
 			read( resourceNames ) {
 				return [
 					...notes.operations.read( resourceNames ),
 					...orders.operations.read( resourceNames ),
+					...reportStats.operations.read( resourceNames ),
 				];
 			},
 		},

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -5,6 +5,7 @@
  */
 import notes from './notes';
 import orders from './orders';
+import reportItems from './reports/items';
 import reportStats from './reports/stats';
 
 function createWcApiSpec() {
@@ -12,6 +13,7 @@ function createWcApiSpec() {
 		selectors: {
 			...notes.selectors,
 			...orders.selectors,
+			...reportItems.selectors,
 			...reportStats.selectors,
 		},
 		operations: {
@@ -19,6 +21,7 @@ function createWcApiSpec() {
 				return [
 					...notes.operations.read( resourceNames ),
 					...orders.operations.read( resourceNames ),
+					...reportItems.operations.read( resourceNames ),
 					...reportStats.operations.read( resourceNames ),
 				];
 			},


### PR DESCRIPTION
Fixes #856.

Introduces `wc-api`/`fresh-data` for Reports in order to solve the `TypeError` issue when fetching multiple pages of report data.

### Detailed test instructions:

* Go to wp-admin > Analytics > Revenue
* Set the Date Range to Last Year
* Verify no console error (cannot read property 'data' of null)
* Visit all other report types and verify function
