### PR TITLE
Update/taxes endpoint hookup/941

### DIFF
--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -133,7 +133,7 @@ export default class TaxesReportTable extends Component {
 			},
 			{
 				label: _n( 'order', 'orders', totals.orders, 'wc-admin' ),
-				value: numberFormat( totals.orders ),
+				value: numberFormat( totals.orders_count ),
 			},
 		];
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -87,7 +87,6 @@ export default class TaxesReportTable extends Component {
 					value: tax_rate_id,
 				},
 				{
-					// @TODO add `rate` once it's returned by the API
 					display: tax_rate.toFixed( 2 ) + '%',
 					value: tax_rate,
 				},

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -115,12 +115,10 @@ export default class TaxesReportTable extends Component {
 		if ( ! totals ) {
 			return [];
 		}
-		// @TODO the number of total rows should come from the API
-		const totalRows = 0;
 		return [
 			{
-				label: _n( 'tax code', 'tax codes', totalRows, 'wc-admin' ),
-				value: numberFormat( totalRows ),
+				label: _n( 'tax code', 'tax codes', totals.tax_codes, 'wc-admin' ),
+				value: numberFormat( totals.tax_codes ),
 			},
 			{
 				label: __( 'total tax', 'wc-admin' ),
@@ -135,8 +133,8 @@ export default class TaxesReportTable extends Component {
 				value: formatCurrency( totals.shipping_tax ),
 			},
 			{
-				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
-				value: numberFormat( totals.orders_count ),
+				label: _n( 'order', 'orders', totals.orders, 'wc-admin' ),
+				value: numberFormat( totals.orders ),
 			},
 		];
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  */
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getTaxCode } from './utils';
 
 /**
  * Internal dependencies
@@ -71,25 +72,24 @@ export default class TaxesReportTable extends Component {
 
 	getRowsContent( taxes ) {
 		return map( taxes, tax => {
-			const { order_tax, orders_count, tax_rate_id, total_tax, shipping_tax } = tax;
+			const { order_tax, orders_count, tax_rate, tax_rate_id, total_tax, shipping_tax } = tax;
 
 			// @TODO must link to the tax detail report
 			const taxLink = (
 				<Link href="" type="wc-admin">
-					{ tax_rate_id }
+					{ getTaxCode( tax ) }
 				</Link>
 			);
 
 			return [
-				// @TODO it should be the tax code, not the tax ID
 				{
 					display: taxLink,
 					value: tax_rate_id,
 				},
 				{
 					// @TODO add `rate` once it's returned by the API
-					display: '',
-					value: '',
+					display: tax_rate.toFixed( 2 ) + '%',
+					value: tax_rate,
 				},
 				{
 					display: formatCurrency( total_tax ),
@@ -153,6 +153,9 @@ export default class TaxesReportTable extends Component {
 				getSummary={ this.getSummary }
 				itemIdField="tax_rate_id"
 				query={ query }
+				tableQuery={ {
+					orderby: query.orderby || 'tax_rate_id',
+				} }
 				title={ __( 'Taxes', 'wc-admin' ) }
 				columnPrefsKey="taxes_report_columns"
 			/>

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -20,7 +20,7 @@ export default {
 	async getReportItems( ...args ) {
 		const [ endpoint, query ] = args.slice( -2 );
 
-		const swaggerEndpoints = [ 'categories', 'coupons', 'customers', 'taxes' ];
+		const swaggerEndpoints = [ 'categories', 'coupons' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			try {
 				const response = await fetch(

--- a/client/store/reports/stats/resolvers.js
+++ b/client/store/reports/stats/resolvers.js
@@ -23,12 +23,12 @@ export default {
 		// TODO: Change to just `getNotes( endpoint, query )`
 		// after Gutenberg plugin uses @wordpress/data 3+
 		const [ endpoint, query ] = args.length === 2 ? args : args.slice( 1, 3 );
-		const statEndpoints = [ 'orders', 'revenue', 'products' ];
+		const statEndpoints = [ 'orders', 'revenue', 'products', 'taxes' ];
 
 		let apiPath = endpoint + stringifyQuery( query );
 
 		// TODO: Remove once swagger endpoints are phased out.
-		const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+		const swaggerEndpoints = [ 'categories', 'coupons' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
 			try {

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -17,7 +17,7 @@ import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
 // TODO: Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'categories', 'coupons', 'customers', 'taxes' ];
+const swaggerEndpoints = [ 'categories', 'coupons', 'customers' ];
 
 const typeEndpointMap = {
 	'report-items-query-orders': 'orders',

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -16,9 +16,9 @@ import { getResourceIdentifier, getResourcePrefix } from '../../utils';
 import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
-const statEndpoints = [ 'orders', 'revenue', 'products' ];
+const statEndpoints = [ 'orders', 'revenue', 'products', 'taxes' ];
 // TODO: Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+const swaggerEndpoints = [ 'categories', 'coupons' ];
 
 const typeEndpointMap = {
 	'report-stats-query-orders': 'orders',

--- a/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
@@ -32,6 +32,36 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 	protected $rest_base = 'reports/taxes/stats';
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_reports_taxes_stats_select_query', array( $this, 'set_default_report_data' ) );
+	}
+
+	/**
+	 * Set the default results to 0 if API returns an empty array
+	 *
+	 * @param Mixed $results Report data.
+	 * @return object
+	 */
+	public function set_default_report_data( $results ) {
+		if ( empty( $results ) ) {
+			$results                       = new stdClass();
+			$results->total                = 0;
+			$results->totals               = new stdClass();
+			$results->totals->tax_codes    = 0;
+			$results->totals->total_tax    = 0;
+			$results->totals->order_tax    = 0;
+			$results->totals->shipping_tax = 0;
+			$results->totals->orders       = 0;
+			$results->intervals            = array();
+			$results->pages                = 1;
+			$results->page_no              = 1;
+		}
+		return $results;
+	}
+
+	/**
 	 * Maps query arguments from the REST request.
 	 *
 	 * @param array $request Request array.

--- a/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
@@ -180,7 +180,7 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'order_count' => array(
+			'orders_count' => array(
 				'description' => __( 'Amount of orders.', 'wc-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),

--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -198,6 +198,10 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );
+
+			$this->update_interval_boundary_dates( $query_args['after'], $query_args['before'], $query_args['interval'], $intervals );
+			$this->create_interval_subtotals( $intervals );
+
 			$data     = (object) array(
 				'totals'    => $totals,
 				'intervals' => $intervals,

--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -30,7 +30,7 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 		'total_tax'    => 'floatval',
 		'order_tax'    => 'floatval',
 		'shipping_tax' => 'floatval',
-		'order_count'  => 'intval',
+		'orders_count' => 'intval',
 	);
 
 	/**
@@ -43,7 +43,7 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 		'total_tax'    => 'SUM(total_tax) AS total_tax',
 		'order_tax'    => 'SUM(order_tax) as order_tax',
 		'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
-		'order_count'  => 'COUNT(DISTINCT order_id) as orders',
+		'orders_count' => 'COUNT(DISTINCT order_id) as orders_count',
 	);
 
 	/**

--- a/tests/api/reports-taxes-stats.php
+++ b/tests/api/reports-taxes-stats.php
@@ -114,7 +114,7 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 16, $tax_report['total_tax'] );
 		$this->assertEquals( 13, $tax_report['order_tax'] );
 		$this->assertEquals( 3, $tax_report['shipping_tax'] );
-		$this->assertEquals( 2, $tax_report['orders'] );
+		$this->assertEquals( 2, $tax_report['orders_count'] );
 	}
 
 	/**
@@ -145,7 +145,7 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 5, count( $totals ) );
 		$this->assertArrayHasKey( 'order_tax', $totals );
-		$this->assertArrayHasKey( 'order_count', $totals );
+		$this->assertArrayHasKey( 'orders_count', $totals );
 		$this->assertArrayHasKey( 'shipping_tax', $totals );
 		$this->assertArrayHasKey( 'tax_codes', $totals );
 		$this->assertArrayHasKey( 'total_tax', $totals );
@@ -162,7 +162,7 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 		$subtotals = $properties['intervals']['items']['properties']['subtotals']['properties'];
 		$this->assertEquals( 5, count( $subtotals ) );
 		$this->assertArrayHasKey( 'order_tax', $totals );
-		$this->assertArrayHasKey( 'order_count', $totals );
+		$this->assertArrayHasKey( 'orders_count', $totals );
 		$this->assertArrayHasKey( 'shipping_tax', $totals );
 		$this->assertArrayHasKey( 'tax_codes', $totals );
 		$this->assertArrayHasKey( 'total_tax', $totals );


### PR DESCRIPTION
Fixes #941 

Depends on #1000 and #1019 - will be rebased pending those PRs.

Hooks up the tax reports to the new endpoint created in #1000 

### Screenshots
<img width="1464" alt="screen shot 2018-12-06 at 4 14 35 pm" src="https://user-images.githubusercontent.com/10561050/49570595-0b8a4880-f972-11e8-886c-add925b8646f.png">

### Detailed test instructions:

1.  Add at least a couple of tax rates under /wp-admin/admin.php?page=wc-settings&tab=tax&section=standard
2.  Add several rows of data into the wp_wc_order_tax_lookup table. This can be any data, but match the tax rate ID to an existing tax rate from step 1 for more thorough testing.
3.  Visit `wp-admin/admin.php?page=wc-admin#/analytics/taxes`.
4.  Check that data for each tax rate is shown properly based on info added from step 2.
5.  Check that tax stat totals are correct.