### PR TITLE
Add filters for order tables column headers/rows

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { applyFilters } from '@wordpress/hooks';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -19,6 +20,8 @@ import { onQueryChange } from '@woocommerce/navigation';
  */
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
+
+const TABLE_FILTER = 'woocommerce_admin_report_table';
 
 class ReportTable extends Component {
 	render() {
@@ -45,14 +48,18 @@ class ReportTable extends Component {
 		}
 
 		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
-
-		const headers = getHeadersContent();
 		const orderedItems = orderBy( items.data, query.orderby, query.order );
-		const ids = itemIdField ? orderedItems.map( item => item[ itemIdField ] ) : null;
-		const rows = getRowsContent( orderedItems );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
 		const totalCount = items.totalCount || 0;
-		const summary = getSummary ? getSummary( totals, totalCount ) : null;
+		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
+			endpoint: endpoint,
+			headers: getHeadersContent(),
+			orderedItems: orderedItems,
+			ids: itemIdField ? orderedItems.map( item => item[ itemIdField ] ) : null,
+			rows: getRowsContent( orderedItems ),
+			totals: totals,
+			summary: getSummary ? getSummary( totals, totalCount ) : null,
+		} );
 
 		return (
 			<TableCard

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { applyFilters } from '@wordpress/hooks';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
@@ -33,9 +32,6 @@ import ReportTable from 'analytics/components/report-table';
 import { formatTableOrders } from './utils';
 import './style.scss';
 
-const HEADERS_FILTER = 'woocommerce_orders_table_headers';
-const ROWS_FILTER = 'woocommerce_orders_table_rows';
-
 class OrdersReportTable extends Component {
 	constructor() {
 		super();
@@ -46,7 +42,7 @@ class OrdersReportTable extends Component {
 	}
 
 	getHeadersContent() {
-		return applyFilters( HEADERS_FILTER, [
+		return [
 			{
 				label: __( 'Date', 'wc-admin' ),
 				key: 'date',
@@ -103,7 +99,7 @@ class OrdersReportTable extends Component {
 				isSortable: false,
 				isNumeric: true,
 			},
-		] );
+		];
 	}
 
 	getRowsContent( tableData ) {
@@ -137,7 +133,7 @@ class OrdersReportTable extends Component {
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
 			} ) );
 
-			return applyFilters( ROWS_FILTER, [
+			return [
 				{
 					display: formatDate( tableFormat, date ),
 					value: date,
@@ -180,7 +176,7 @@ class OrdersReportTable extends Component {
 					display: formatCurrency( net_revenue, currency ),
 					value: net_revenue,
 				},
-			] );
+			];
 		} );
 	}
 

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -35,6 +35,7 @@ import './style.scss';
 
 const ORDERS_TABLE_HEADERS = 'woocommerce-orders-table-headers';
 const ORDERS_TABLE_DATA = 'woocommerce-orders-table-data';
+const ORDERS_TABLE_ROWS = 'woocommerce-orders-table-rows';
 
 class OrdersReportTable extends Component {
 	constructor() {
@@ -114,7 +115,6 @@ class OrdersReportTable extends Component {
 		const { query } = this.props;
 		const currentInterval = getIntervalForQuery( query );
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
-
 		return map( tableData, row => {
 			const {
 				date,
@@ -142,7 +142,7 @@ class OrdersReportTable extends Component {
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
 			} ) );
 
-			const customRowData = applyFilters( ORDERS_TABLE_DATA, false );
+			const customRowData = applyFilters( ORDERS_TABLE_ROWS, false, row );
 
 			const rowData = [
 				{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -33,8 +33,8 @@ import ReportTable from 'analytics/components/report-table';
 import { formatTableOrders } from './utils';
 import './style.scss';
 
-const HEADERS_FILTER = 'woocommerce-orders-table-headers';
-const ROWS_FILTER = 'woocommerce-orders-table-rows';
+const HEADERS_FILTER = 'woocommerce_orders_table_headers';
+const ROWS_FILTER = 'woocommerce_orders_table_rows';
 
 class OrdersReportTable extends Component {
 	constructor() {

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -33,9 +33,9 @@ import ReportTable from 'analytics/components/report-table';
 import { formatTableOrders } from './utils';
 import './style.scss';
 
-const ORDERS_TABLE_HEADERS = 'woocommerce-orders-table-headers';
-const ORDERS_TABLE_DATA = 'woocommerce-orders-table-data';
-const ORDERS_TABLE_ROWS = 'woocommerce-orders-table-rows';
+const HEADERS_FILTER = 'woocommerce-orders-table-headers';
+const DATA_FILTER = 'woocommerce-orders-table-data';
+const ROWS_FILTER = 'woocommerce-orders-table-rows';
 
 class OrdersReportTable extends Component {
 	constructor() {
@@ -47,7 +47,7 @@ class OrdersReportTable extends Component {
 	}
 
 	getHeadersContent() {
-		const customHeaders = applyFilters( ORDERS_TABLE_HEADERS, false );
+		const customHeaders = applyFilters( HEADERS_FILTER, false );
 
 		const headers = [
 			{
@@ -142,7 +142,7 @@ class OrdersReportTable extends Component {
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
 			} ) );
 
-			const customRowData = applyFilters( ORDERS_TABLE_ROWS, false, row );
+			const customRowData = applyFilters( ROWS_FILTER, false, row );
 
 			const rowData = [
 				{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { Component, Fragment } from '@wordpress/element';
 import { format as formatDate } from '@wordpress/date';
 import { compose } from '@wordpress/compose';
@@ -32,6 +33,9 @@ import ReportTable from 'analytics/components/report-table';
 import { formatTableOrders } from './utils';
 import './style.scss';
 
+const ORDERS_TABLE_HEADERS = 'woocommerce-orders-table-headers';
+const ORDERS_TABLE_DATA = 'woocommerce-orders-table-data';
+
 class OrdersReportTable extends Component {
 	constructor() {
 		super();
@@ -42,7 +46,9 @@ class OrdersReportTable extends Component {
 	}
 
 	getHeadersContent() {
-		return [
+		const customHeaders = applyFilters( ORDERS_TABLE_HEADERS, false );
+
+		const headers = [
 			{
 				label: __( 'Date', 'wc-admin' ),
 				key: 'date',
@@ -100,6 +106,8 @@ class OrdersReportTable extends Component {
 				isNumeric: true,
 			},
 		];
+
+		return customHeaders ? headers.concat( customHeaders ) : headers;
 	}
 
 	getRowsContent( tableData ) {
@@ -134,7 +142,9 @@ class OrdersReportTable extends Component {
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
 			} ) );
 
-			return [
+			const customRowData = applyFilters( ORDERS_TABLE_DATA, false );
+
+			const rowData = [
 				{
 					display: formatDate( tableFormat, date ),
 					value: date,
@@ -178,6 +188,8 @@ class OrdersReportTable extends Component {
 					value: net_revenue,
 				},
 			];
+
+			return customRowData ? rowData.concat( customRowData ) : rowData;
 		} );
 	}
 

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -34,7 +34,6 @@ import { formatTableOrders } from './utils';
 import './style.scss';
 
 const HEADERS_FILTER = 'woocommerce-orders-table-headers';
-const DATA_FILTER = 'woocommerce-orders-table-data';
 const ROWS_FILTER = 'woocommerce-orders-table-rows';
 
 class OrdersReportTable extends Component {
@@ -47,9 +46,7 @@ class OrdersReportTable extends Component {
 	}
 
 	getHeadersContent() {
-		const customHeaders = applyFilters( HEADERS_FILTER, false );
-
-		const headers = [
+		return applyFilters( HEADERS_FILTER, [
 			{
 				label: __( 'Date', 'wc-admin' ),
 				key: 'date',
@@ -106,9 +103,7 @@ class OrdersReportTable extends Component {
 				isSortable: false,
 				isNumeric: true,
 			},
-		];
-
-		return customHeaders ? headers.concat( customHeaders ) : headers;
+		] );
 	}
 
 	getRowsContent( tableData ) {
@@ -142,9 +137,7 @@ class OrdersReportTable extends Component {
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
 			} ) );
 
-			const customRowData = applyFilters( ROWS_FILTER, false, row );
-
-			const rowData = [
+			return applyFilters( ROWS_FILTER, [
 				{
 					display: formatDate( tableFormat, date ),
 					value: date,
@@ -187,9 +180,7 @@ class OrdersReportTable extends Component {
 					display: formatCurrency( net_revenue, currency ),
 					value: net_revenue,
 				},
-			];
-
-			return customRowData ? rowData.concat( customRowData ) : rowData;
+			] );
 		} );
 	}
 

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -47,8 +47,8 @@ class TableCard extends Component {
 		super( props );
 		const { compareBy, query } = props;
 		this.state = {
-			showCols: props.headers.map( ( { hiddenByDefault } ) => ! hiddenByDefault ),
 			selectedRows: getIdsFromQuery( query[ compareBy ] ),
+			showCols: props.headers.map( ( { hiddenByDefault } ) => ! hiddenByDefault ),
 		};
 		this.toggleCols = this.toggleCols.bind( this );
 		this.onClickDownload = this.onClickDownload.bind( this );
@@ -58,13 +58,22 @@ class TableCard extends Component {
 		this.selectAllRows = this.selectAllRows.bind( this );
 	}
 
-	componentDidUpdate( { query: prevQuery } ) {
-		const { compareBy, query } = this.props;
+	componentDidUpdate( { query: prevQuery, headers: prevHeaders } ) {
+		const { compareBy, headers, query } = this.props;
 		const prevIds = getIdsFromQuery( prevQuery[ compareBy ] );
 		const currentIds = getIdsFromQuery( query[ compareBy ] );
 		if ( ! isEqual( prevIds.sort(), currentIds.sort() ) ) {
 			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { selectedRows: currentIds } );
+			this.setState( {
+				selectedRows: currentIds,
+			} );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+		if ( ! isEqual( headers, prevHeaders ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( {
+				showCols: headers.map( ( { hiddenByDefault } ) => ! hiddenByDefault ),
+			} );
 			/* eslint-enable react/no-did-update-set-state */
 		}
 	}


### PR DESCRIPTION
Replay of https://github.com/woocommerce/wc-admin/pull/781:

Adds filters to the orders table to allow inserting custom columns and rows to the order table.

### Screenshots

<img width="387" alt="screen shot 2018-11-05 at 3 57 40 pm" src="https://user-images.githubusercontent.com/10561050/48026265-91b53400-e113-11e8-9d95-2f7483a9b115.png">
<img width="1372" alt="screen shot 2018-11-07 at 11 15 23 am" src="https://user-images.githubusercontent.com/10561050/48144546-1e303580-e27f-11e8-88ac-829f266f50b9.png">


### Detailed test instructions:

1.  Pull in this branch of wc box office - https://github.com/woocommerce/woocommerce-box-office/pull/248
2.  Go to `/wp-admin/admin.php?page=wc-admin#/analytics/orders`
3.  Note the attendees column and correct count if you have any completed orders with event tickets using wc box office.