### PR TITLE
Add Customers Report page

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const dateRangeFilter = {
+	show: false,
+};
+
+export const filters = [
+	{
+		label: __( 'Show', 'wc-admin' ),
+		staticParams: [],
+		param: 'filter',
+		showFilters: () => true,
+		filters: [ { label: __( 'All Registered Customers', 'wc-admin' ), value: 'all' } ],
+	},
+];

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -4,9 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 
-export const dateRangeFilter = {
-	show: false,
-};
+export const showDatePicker = false;
 
 export const filters = [
 	{

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -13,7 +13,7 @@ import { ReportFilters } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { dateRangeFilter, filters } from './config';
+import { filters, showDatePicker } from './config';
 import CustomersReportTable from './table';
 
 export default class CustomersReport extends Component {
@@ -25,8 +25,8 @@ export default class CustomersReport extends Component {
 				<ReportFilters
 					query={ query }
 					path={ path }
-					dateRangeFilter={ dateRangeFilter }
 					filters={ filters }
+					showDatePicker={ showDatePicker }
 				/>
 				<CustomersReportTable query={ query } />
 			</Fragment>

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ReportFilters } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { dateRangeFilter, filters } from './config';
+import CustomersReportTable from './table';
+
+export default class CustomersReport extends Component {
+	render() {
+		const { query, path } = this.props;
+
+		return (
+			<Fragment>
+				<ReportFilters
+					query={ query }
+					path={ path }
+					dateRangeFilter={ dateRangeFilter }
+					filters={ filters }
+				/>
+				<CustomersReportTable query={ query } />
+			</Fragment>
+		);
+	}
+}
+
+CustomersReport.propTypes = {
+	query: PropTypes.object.isRequired,
+};

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -64,8 +64,9 @@ export default class CustomersReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'ADV', 'wc-admin' ),
-				key: 'adv',
+				label: __( 'AOV', 'wc-admin' ),
+				screenReaderLabel: __( 'Average Order Value', 'wc-admin' ),
+				key: 'average_order_value',
 				isNumeric: true,
 			},
 			{
@@ -97,7 +98,7 @@ export default class CustomersReportTable extends Component {
 
 		return customers.map( customer => {
 			const {
-				adv,
+				average_order_value,
 				id,
 				city,
 				country,
@@ -143,8 +144,8 @@ export default class CustomersReportTable extends Component {
 					value: getCurrencyFormatDecimal( total_spend ),
 				},
 				{
-					display: adv,
-					value: adv,
+					display: average_order_value,
+					value: getCurrencyFormatDecimal( average_order_value ),
 				},
 				{
 					display: formatDate( formats.tableFormat, date_last_active ),

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -1,0 +1,184 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { format as formatDate } from '@wordpress/date';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getDateFormatsForInterval, getIntervalForQuery } from '@woocommerce/date';
+import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import ReportTable from 'analytics/components/report-table';
+import { numberFormat } from 'lib/number';
+
+export default class CustomersReportTable extends Component {
+	constructor() {
+		super();
+
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+		this.getRowsContent = this.getRowsContent.bind( this );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Name', 'wc-admin' ),
+				key: 'name',
+				required: true,
+				isLeftAligned: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Username', 'wc-admin' ),
+				key: 'username',
+				hiddenByDefault: true,
+			},
+			{
+				label: __( 'Sign Up', 'wc-admin' ),
+				key: 'date_sign_up',
+				defaultSort: true,
+				isSortable: true,
+			},
+			{
+				label: __( 'Email', 'wc-admin' ),
+				key: 'email',
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Lifetime Spend', 'wc-admin' ),
+				key: 'total_spend',
+				isSortable: true,
+				isNumeric: true,
+			},
+			{
+				label: __( 'ADV', 'wc-admin' ),
+				key: 'adv',
+				isNumeric: true,
+			},
+			{
+				label: __( 'Last Active', 'wc-admin' ),
+				key: 'date_last_active',
+				isSortable: true,
+			},
+			{
+				label: __( 'Country', 'wc-admin' ),
+				key: 'country',
+			},
+			{
+				label: __( 'City', 'wc-admin' ),
+				key: 'city',
+				hiddenByDefault: true,
+			},
+			{
+				label: __( 'Postal Code', 'wc-admin' ),
+				key: 'postal_code',
+				hiddenByDefault: true,
+			},
+		];
+	}
+
+	getRowsContent( customers ) {
+		const { query } = this.props;
+		const currentInterval = getIntervalForQuery( query );
+		const formats = getDateFormatsForInterval( currentInterval );
+
+		return customers.map( customer => {
+			const {
+				adv,
+				id,
+				city,
+				country,
+				date_last_active,
+				date_sign_up,
+				email,
+				name,
+				orders_count,
+				postal_code,
+				username,
+				total_spend,
+			} = customer;
+
+			const customerNameLink = (
+				<Link href={ 'user-edit.php?user_id=' + id } type="wp-admin">
+					{ name }
+				</Link>
+			);
+
+			return [
+				{
+					display: customerNameLink,
+					value: name,
+				},
+				{
+					display: username,
+					value: username,
+				},
+				{
+					display: formatDate( formats.tableFormat, date_sign_up ),
+					value: date_sign_up,
+				},
+				{
+					display: <a href={ 'mailto:' + email }>{ email }</a>,
+					value: email,
+				},
+				{
+					display: numberFormat( orders_count ),
+					value: orders_count,
+				},
+				{
+					display: formatCurrency( total_spend ),
+					value: getCurrencyFormatDecimal( total_spend ),
+				},
+				{
+					display: adv,
+					value: adv,
+				},
+				{
+					display: formatDate( formats.tableFormat, date_last_active ),
+					value: date_last_active,
+				},
+				{
+					display: country,
+					value: country,
+				},
+				{
+					display: city,
+					value: city,
+				},
+				{
+					display: postal_code,
+					value: postal_code,
+				},
+			];
+		} );
+	}
+
+	render() {
+		const { query } = this.props;
+
+		return (
+			<ReportTable
+				compareBy="customers"
+				endpoint="customers"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				itemIdField="id"
+				query={ query }
+				title={ __( 'Registered Customers', 'wc-admin' ) }
+			/>
+		);
+	}
+}

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -24,6 +24,7 @@ import RevenueReport from './revenue';
 import CategoriesReport from './categories';
 import CouponsReport from './coupons';
 import TaxesReport from './taxes';
+import CustomersReport from './customers';
 
 const REPORTS_FILTER = 'woocommerce-reports-list';
 
@@ -58,6 +59,11 @@ const getReports = () => {
 			report: 'taxes',
 			title: __( 'Taxes', 'wc-admin' ),
 			component: TaxesReport,
+		},
+		{
+			report: 'customers',
+			title: __( 'Customers', 'wc-admin' ),
+			component: CustomersReport,
 		},
 	] );
 

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -20,7 +20,7 @@ export default {
 	async getReportItems( ...args ) {
 		const [ endpoint, query ] = args.slice( -2 );
 
-		const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+		const swaggerEndpoints = [ 'categories', 'coupons', 'customers', 'taxes' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			try {
 				const response = await fetch(

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -133,6 +133,14 @@ function wc_admin_register_pages() {
 		)
 	);
 
+	wc_admin_register_page(
+		array(
+			'title'  => __( 'Customers', 'wc-admin' ),
+			'parent' => '/analytics/revenue',
+			'path'   => '/analytics/customers',
+		)
+	);
+
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 		wc_admin_register_page(
 			array(

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -57,13 +57,15 @@ class ReportFilters extends Component {
 	}
 
 	render() {
-		const { filters, query, path } = this.props;
+		const { dateRangeFilter, filters, query, path } = this.props;
 		return (
 			<Fragment>
 				<H className="screen-reader-text">{ __( 'Filters', 'wc-admin' ) }</H>
 				<Section component="div" className="woocommerce-filters">
 					<div className="woocommerce-filters__basic-filters">
-						<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
+						{ dateRangeFilter.show && (
+							<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
+						) }
 						{ filters.map( config => {
 							if ( config.showFilters( query ) ) {
 								return (
@@ -90,6 +92,15 @@ ReportFilters.propTypes = {
 	 */
 	advancedFilters: PropTypes.object,
 	/**
+	 * Config options for the date range picker.
+	 */
+	dateRangeFilter: PropTypes.shape( {
+		/**
+		 * Whether the date range filter must be shown.
+		 */
+		show: PropTypes.bool,
+	} ),
+	/**
 	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 	 */
 	filters: PropTypes.array,
@@ -105,6 +116,9 @@ ReportFilters.propTypes = {
 
 ReportFilters.defaultProps = {
 	advancedFilters: {},
+	dateRangeFilter: {
+		show: true,
+	},
 	filters: [],
 	query: {},
 };

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -57,13 +57,13 @@ class ReportFilters extends Component {
 	}
 
 	render() {
-		const { dateRangeFilter, filters, query, path } = this.props;
+		const { filters, query, path, showDatePicker } = this.props;
 		return (
 			<Fragment>
 				<H className="screen-reader-text">{ __( 'Filters', 'wc-admin' ) }</H>
 				<Section component="div" className="woocommerce-filters">
 					<div className="woocommerce-filters__basic-filters">
-						{ dateRangeFilter.show && (
+						{ showDatePicker && (
 							<DatePicker key={ JSON.stringify( query ) } query={ query } path={ path } />
 						) }
 						{ filters.map( config => {
@@ -92,15 +92,6 @@ ReportFilters.propTypes = {
 	 */
 	advancedFilters: PropTypes.object,
 	/**
-	 * Config options for the date range picker.
-	 */
-	dateRangeFilter: PropTypes.shape( {
-		/**
-		 * Whether the date range filter must be shown.
-		 */
-		show: PropTypes.bool,
-	} ),
-	/**
 	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
 	 */
 	filters: PropTypes.array,
@@ -112,15 +103,17 @@ ReportFilters.propTypes = {
 	 * The query string represented in object form
 	 */
 	query: PropTypes.object,
+	/**
+	 * Whether the date picker must be shown..
+	 */
+	showDatePicker: PropTypes.bool,
 };
 
 ReportFilters.defaultProps = {
 	advancedFilters: {},
-	dateRangeFilter: {
-		show: true,
-	},
 	filters: [],
 	query: {},
+	showDatePicker: true,
 };
 
 export default ReportFilters;

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+
+/**
+ * A customer completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'customers',
+	className: 'woocommerce-search__customers-result',
+	options( search ) {
+		let payload = '';
+		if ( search ) {
+			const query = {
+				search,
+				per_page: 10,
+			};
+			payload = stringifyQuery( query );
+		}
+		return apiFetch( { path: `/wc/v3/customers${ payload }` } );
+	},
+	isDebounced: true,
+	getOptionKeywords( customer ) {
+		return [ customer.name ];
+	},
+	getOptionLabel( customer, query ) {
+		const match = computeSuggestionMatch( customer.name, query ) || {};
+		return [
+			<span key="name" className="woocommerce-search__result-name" aria-label={ customer.name }>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( customer ) {
+		const value = {
+			id: customer.id,
+			label: customer.name,
+		};
+		return value;
+	},
+};

--- a/packages/components/src/search/autocompleters/index.js
+++ b/packages/components/src/search/autocompleters/index.js
@@ -3,6 +3,7 @@
  * Export all autocompleters
  */
 export { default as coupons } from './coupons';
+export { default as customers } from './customers';
 export { default as product } from './product';
 export { default as productCategory } from './product-cat';
 export { default as variations } from './variations';

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { coupons, product, productCategory, taxes, variations } from './autocompleters';
+import { coupons, customers, product, productCategory, taxes, variations } from './autocompleters';
 import Tag from '../tag';
 
 /**
@@ -76,6 +76,8 @@ class Search extends Component {
 				return taxes;
 			case 'variations':
 				return variations;
+			case 'customers':
+				return customers;
 			default:
 				return {};
 		}


### PR DESCRIPTION
Part of #918.

This PR creates the _Customers_ report page with a table connected to the SwaggerHub endpoint.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/49615054-f6151e80-f971-11e8-8d67-e19d0ed7fac2.png)

### Detailed test instructions:
- Go to the _Customers_ report.
- Verify there is a table with the correct columns.
- Verify the date range filter is hidden.

### Follow-up work
- Load more data for each _Customer_ from the ` /wc/v3/customers` endpoint.
- Table summary.