### PR TITLE
Add tax stats endpoint

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
@@ -46,7 +46,7 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 		$args['per_page'] = $request['per_page'];
 		$args['orderby']  = $request['orderby'];
 		$args['order']    = $request['order'];
-		$args['code']     = (array) $request['code'];
+		$args['taxes']    = (array) $request['taxes'];
 
 		return $args;
 	}
@@ -59,7 +59,7 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 	 */
 	public function get_items( $request ) {
 		$query_args  = $this->prepare_reports_query( $request );
-		$taxes_query = new WC_Reports_Orders_Stats_Query( $query_args ); // @todo change to correct class.
+		$taxes_query = new WC_Admin_Reports_Taxes_Stats_Query( $query_args );
 		$report_data = $taxes_query->get_data();
 
 		$out_data = array(
@@ -150,8 +150,14 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'orders_count' => array(
-				'description' => __( 'Amount of orders', 'wc-admin' ),
+			'order_count' => array(
+				'description' => __( 'Amount of orders.', 'wc-admin' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'tax_codes' => array(
+				'description' => __( 'Amount of tax codes.', 'wc-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -49,6 +49,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-variations-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-products-stats-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-categories-query.php';
+		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-taxes-stats-query.php';
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
@@ -57,6 +58,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-variations-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-products-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-categories-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-taxes-stats-data-store.php';
 
 		// Data triggers.
 		require_once dirname( __FILE__ ) . '/wc-admin-order-functions.php';
@@ -264,6 +266,7 @@ class WC_Admin_Api_Init {
 				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',
 				'report-products-stats' => 'WC_Admin_Reports_Products_Stats_Data_Store',
 				'report-categories'     => 'WC_Admin_Reports_Categories_Data_Store',
+				'report-taxes-stats'    => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
 				'admin-note'            => 'WC_Admin_Notes_Data_Store',
 			)
 		);

--- a/includes/class-wc-admin-reports-taxes-stats-query.php
+++ b/includes/class-wc-admin-reports-taxes-stats-query.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class for parameter-based Taxes Stats Report querying
+ *
+ * Example usage:
+ * $args = array(
+ *          'before'       => '2018-07-19 00:00:00',
+ *          'after'        => '2018-07-05 00:00:00',
+ *          'page'         => 2,
+ *          'categories'   => array(15, 18),
+ *          'product_ids'  => array(1,2,3)
+ *         );
+ * $report = new WC_Admin_Reports_Taxes_Stats_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Taxes_Query
+ */
+class WC_Admin_Reports_Taxes_Stats_Query extends WC_Admin_Reports_Query {
+
+	/**
+	 * Valid fields for Taxes report.
+	 *
+	 * @return array
+	 */
+	protected function get_default_query_vars() {
+		return array();
+	}
+
+	/**
+	 * Get tax stats data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args = apply_filters( 'woocommerce_reports_taxes_stats_query_args', $this->get_query_vars() );
+
+		$data_store = WC_Data_Store::load( 'report-taxes-stats' );
+		$results    = $data_store->get_data( $args );
+		return apply_filters( 'woocommerce_reports_taxes_stats_select_query', $results, $args );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * WC_Admin_Reports_Taxes_Stats_Data_Store class file.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * WC_Reports_Taxes_Stats_Data_Store.
+ */
+class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+
+	/**
+	 * Table used to get the data.
+	 *
+	 * @var string
+	 */
+	const TABLE_NAME = 'wc_order_tax_lookup';
+
+	/**
+	 * Mapping columns to data type to return correct response types.
+	 *
+	 * @var array
+	 */
+	protected $column_types = array(
+		'tax_codes'    => 'intval',
+		'total_tax'    => 'floatval',
+		'order_tax'    => 'floatval',
+		'shipping_tax' => 'floatval',
+		'order_count'  => 'intval',
+	);
+
+	/**
+	 * SQL columns to select in the db query.
+	 *
+	 * @var array
+	 */
+	protected $report_columns = array(
+		'tax_codes'    => 'COUNT(DISTINCT tax_rate_id) as tax_codes',
+		'total_tax'    => 'SUM(total_tax) AS total_tax',
+		'order_tax'    => 'SUM(order_tax) as order_tax',
+		'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
+		'order_count'  => 'COUNT(DISTINCT order_id) as orders',
+	);
+
+	/**
+	 * Updates the database query with parameters used for Taxes report: categories and order status.
+	 *
+	 * @param array $query_args Query arguments supplied by the user.
+	 * @return array            Array of parameters used for SQL query.
+	 */
+	protected function get_sql_query_params( $query_args ) {
+		global $wpdb;
+
+		$order_tax_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+
+		$sql_query_params = $this->get_time_period_sql_params( $query_args, $order_tax_lookup_table );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_limit_sql_params( $query_args ) );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_order_by_sql_params( $query_args ) );
+
+		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
+			$allowed_taxes                     = implode( ',', $query_args['taxes'] );
+			$sql_query_params['where_clause'] .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
+		}
+
+		return $sql_query_params;
+	}
+
+	/**
+	 * Updates the database query with parameters used for Taxes Stats report
+	 *
+	 * @param array $query_args       Query arguments supplied by the user.
+	 * @param array $totals_params    SQL parameters for the totals query.
+	 * @param array $intervals_params SQL parameters for the intervals query.
+	 */
+	protected function update_sql_query_params( $query_args, &$totals_params, &$intervals_params ) {
+		global $wpdb;
+
+		$taxes_where_clause = '';
+		$taxes_from_clause  = '';
+
+		$order_tax_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+
+		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
+			$allowed_taxes       = implode( ',', $query_args['taxes'] );
+			$taxes_where_clause .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
+		}
+
+		$totals_params                  = array_merge( $totals_params, $this->get_time_period_sql_params( $query_args, $order_tax_lookup_table ) );
+		$totals_params['where_clause'] .= $taxes_where_clause;
+
+		$intervals_params                  = array_merge( $intervals_params, $this->get_intervals_sql_params( $query_args, $order_tax_lookup_table ) );
+		$intervals_params['where_clause'] .= $taxes_where_clause;
+	}
+
+	/**
+	 * Returns the report data based on parameters supplied by the user.
+	 *
+	 * @param array $query_args  Query parameters.
+	 * @return stdClass|WP_Error Data.
+	 */
+	public function get_data( $query_args ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . self::TABLE_NAME;
+		$now        = time();
+		$week_back  = $now - WEEK_IN_SECONDS;
+
+		// These defaults are only partially applied when used via REST API, as that has its own defaults.
+		$defaults   = array(
+			'per_page' => get_option( 'posts_per_page' ),
+			'page'     => 1,
+			'order'    => 'DESC',
+			'orderby'  => 'tax_rate_id',
+			'before'   => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
+			'after'    => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
+			'fields'   => '*',
+			'taxes'    => array(),
+		);
+		$query_args = wp_parse_args( $query_args, $defaults );
+
+		$cache_key = $this->get_cache_key( $query_args );
+		$data      = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $data ) {
+			$selections      = $this->selected_columns( $query_args );
+			$totals_query    = array();
+			$intervals_query = array();
+			$this->update_sql_query_params( $query_args, $totals_query, $intervals_query );
+
+			$db_records_count = (int) $wpdb->get_var(
+				"SELECT COUNT(*) FROM (
+							SELECT
+								{$intervals_query['select_clause']} AS time_interval
+							FROM
+								{$table_name}
+								{$intervals_query['from_clause']}
+							WHERE
+								1=1
+								{$intervals_query['where_time_clause']}
+								{$intervals_query['where_clause']}
+							GROUP BY
+								time_interval
+					  		) AS t"
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			$total_pages = (int) ceil( $db_records_count / $intervals_query['per_page'] );
+			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
+				return array();
+			}
+
+			$totals = $wpdb->get_results(
+				"SELECT
+						{$selections}
+					FROM
+						{$table_name}
+						{$totals_query['from_clause']}
+					WHERE
+						1=1
+						{$totals_query['where_time_clause']}
+						{$totals_query['where_clause']}",
+				ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			if ( null === $totals ) {
+				return new WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
+			}
+
+			if ( '' !== $selections ) {
+				$selections = ', ' . $selections;
+			}
+
+			$intervals = $wpdb->get_results(
+				"SELECT
+							MAX(date_created) AS datetime_anchor,
+							{$intervals_query['select_clause']} AS time_interval
+							{$selections}
+						FROM
+							{$table_name}
+							{$intervals_query['from_clause']}
+						WHERE
+							1=1
+							{$intervals_query['where_time_clause']}
+							{$intervals_query['where_clause']}
+						GROUP BY
+							time_interval
+						ORDER BY
+							{$intervals_query['order_by_clause']}
+						{$intervals_query['limit']}",
+				ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			if ( null === $intervals ) {
+				return new WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
+			}
+
+			$totals = (object) $this->cast_numbers( $totals[0] );
+			$data     = (object) array(
+				'totals'    => $totals,
+				'intervals' => $intervals,
+				'total'     => $db_records_count,
+				'pages'     => $total_pages,
+				'page_no'   => (int) $query_args['page'],
+			);
+
+			wp_cache_set( $cache_key, $data, $this->cache_group );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
+	}
+
+}

--- a/tests/api/reports-taxes-stats.php
+++ b/tests/api/reports-taxes-stats.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Reports Taxes Stats REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+
+/**
+ * WC_Tests_API_Reports_Taxes_Stats
+ */
+class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/reports/taxes/stats';
+
+	/**
+	 * Setup test reports taxes data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 1,
+				'tax_rate'          => '7',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'GA',
+				'tax_rate_name'     => 'TestTax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		// @todo Remove this once order data is synced to wc_order_tax_lookup
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => 1,
+				'tax_rate_id'  => 1,
+				'date_created' => date( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 2,
+				'order_tax'    => 5,
+				'total_tax'    => 7,
+			)
+		);
+		$wpdb->insert(
+			$wpdb->prefix . 'wc_order_tax_lookup',
+			array(
+				'order_id'     => 2,
+				'tax_rate_id'  => 1,
+				'date_created' => date( 'Y-m-d H:i:s' ),
+				'shipping_tax' => 1,
+				'order_tax'    => 8,
+				'total_tax'    => 9,
+			)
+		);
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		$tax_report = reset( $reports );
+
+		$this->assertEquals( 1, $tax_report['tax_codes'] );
+		$this->assertEquals( 16, $tax_report['total_tax'] );
+		$this->assertEquals( 13, $tax_report['order_tax'] );
+		$this->assertEquals( 3, $tax_report['shipping_tax'] );
+		$this->assertEquals( 2, $tax_report['orders'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$totals = $properties['totals']['properties'];
+
+		$this->assertEquals( 5, count( $totals ) );
+		$this->assertArrayHasKey( 'order_tax', $totals );
+		$this->assertArrayHasKey( 'order_count', $totals );
+		$this->assertArrayHasKey( 'shipping_tax', $totals );
+		$this->assertArrayHasKey( 'tax_codes', $totals );
+		$this->assertArrayHasKey( 'total_tax', $totals );
+
+		$intervals = $properties['intervals']['items']['properties'];
+		$this->assertEquals( 6, count( $intervals ) );
+		$this->assertArrayHasKey( 'interval', $intervals );
+		$this->assertArrayHasKey( 'date_start', $intervals );
+		$this->assertArrayHasKey( 'date_start_gmt', $intervals );
+		$this->assertArrayHasKey( 'date_end', $intervals );
+		$this->assertArrayHasKey( 'date_end_gmt', $intervals );
+		$this->assertArrayHasKey( 'subtotals', $intervals );
+
+		$subtotals = $properties['intervals']['items']['properties']['subtotals']['properties'];
+		$this->assertEquals( 5, count( $subtotals ) );
+		$this->assertArrayHasKey( 'order_tax', $totals );
+		$this->assertArrayHasKey( 'order_count', $totals );
+		$this->assertArrayHasKey( 'shipping_tax', $totals );
+		$this->assertArrayHasKey( 'tax_codes', $totals );
+		$this->assertArrayHasKey( 'total_tax', $totals );
+
+	}
+}


### PR DESCRIPTION
Fixes (partially) #844 

Adds in the tax stats endpoints for the tax report summary and charting.

### Screenshots
<img width="562" alt="screen shot 2018-12-07 at 4 38 39 pm" src="https://user-images.githubusercontent.com/10561050/49636854-c5e78180-fa3e-11e8-99ea-aabd96aeb80f.png">

### Detailed test instructions:
1.  Add several rows of data into the `wp_wc_order_tax_lookup` table.  This can be any data and you do not need tax rates added to your WC store to test this.
2.  Make a post request to `wp/wp-json/wc/v3/reports/taxes/stats` with WC Rest API keys.
3.  Make sure you receive accurate data from the request:
    * totals ( order_count, shipping_tax, order_tax, total_tax, tax_codes )
    * intervals
4.  Test with these query params as well
    * before
    * after
    * page
    * per_page
    * orderby
    * order
    * taxes (comma separated tax_rate_ids from the `woocommerce_tax_rates` table
5. Run phpunit tests to make sure they pass.
