### PR TITLE
Add missing comma to chart tooltip label

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -437,7 +437,7 @@ export const weekTicksThreshold = 9;
  * @return {String} Current interval.
  */
 export function getDateFormatsForInterval( interval, ticks = 0 ) {
-	let tooltipLabelFormat = '%B %d %Y';
+	let tooltipLabelFormat = '%B %d, %Y';
 	let xFormat = '%Y-%m-%d';
 	let x2Format = '%b %Y';
 	let tableFormat = 'm/d/Y';
@@ -464,7 +464,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 				xFormat = '%b';
 				x2Format = '%Y';
 			}
-			tooltipLabelFormat = __( 'Week of %B %d %Y', 'wc-admin' );
+			tooltipLabelFormat = __( 'Week of %B %d, %Y', 'wc-admin' );
 			break;
 		case 'quarter':
 		case 'month':


### PR DESCRIPTION
Fixes #954.

Add a comma between the `month+date` and the `year` in chart tooltips.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/49655521-77b38d80-fa00-11e8-9cb7-f29eae9fff7d.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/49655491-6a969e80-fa00-11e8-9e64-4b18ef60c887.png)

### Detailed test instructions:
- Go to the _Revenue_ report.
- Hover the dots in the chart.
- Verify there is a comma after the date number.
- Set the interval to `week`.
- Hover the dots in the chart.
- Again, verify there is a comma after the date number.