### PR TITLE
Fix ReportNumber sometimes receiving NaN values

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -25,26 +25,27 @@ import { calculateDelta, formatValue } from './utils';
 export class ReportSummary extends Component {
 	render() {
 		const { charts, query, selectedChart, summaryData } = this.props;
+		const { totals, isError, isRequesting } = summaryData;
 
-		if ( summaryData.isError ) {
+		if ( isError ) {
 			return <ReportError isError />;
 		}
 
-		if ( summaryData.isRequesting ) {
+		if ( isRequesting ) {
 			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
 		}
 
-		const totals = summaryData.totals.primary || {};
-		const secondaryTotals = summaryData.totals.secondary || {};
+		const primaryTotals = totals.primary || {};
+		const secondaryTotals = totals.secondary || {};
 		const { compare } = getDateParamsFromQuery( query );
 
 		const summaryNumbers = charts.map( chart => {
 			const { key, label, type } = chart;
-			const delta = calculateDelta( totals[ key ], secondaryTotals[ key ] );
+			const delta = calculateDelta( primaryTotals[ key ], secondaryTotals[ key ] );
 			const href = getNewPath( { chart: key } );
 			const prevValue = formatValue( type, secondaryTotals[ key ] );
 			const isSelected = selectedChart.key === key;
-			const value = formatValue( type, totals[ key ] );
+			const value = formatValue( type, primaryTotals[ key ] );
 
 			return (
 				<SummaryNumber

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -20,7 +20,7 @@ import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce
  */
 import { getSummaryNumbers } from 'store/reports/utils';
 import ReportError from 'analytics/components/report-error';
-import { getFormattedValues } from './utils';
+import { calculateDelta, formatValue } from './utils';
 
 export class ReportSummary extends Component {
 	render() {
@@ -40,28 +40,26 @@ export class ReportSummary extends Component {
 
 		const summaryNumbers = charts.map( chart => {
 			const { key, label, type } = chart;
-			const isSelected = selectedChart.key === key;
-			const { delta, secondaryValue, value } = getFormattedValues(
-				type,
-				totals[ key ],
-				secondaryTotals[ key ]
-			);
+			const delta = calculateDelta( totals[ key ], secondaryTotals[ key ] );
 			const href = getNewPath( { chart: key } );
+			const prevValue = formatValue( type, secondaryTotals[ key ] );
+			const isSelected = selectedChart.key === key;
+			const value = formatValue( type, totals[ key ] );
 
 			return (
 				<SummaryNumber
 					key={ key }
-					value={ value }
+					delta={ delta }
+					href={ href }
 					label={ label }
-					selected={ isSelected }
-					prevValue={ secondaryValue }
 					prevLabel={
 						'previous_period' === compare
 							? __( 'Previous Period:', 'wc-admin' )
 							: __( 'Previous Year:', 'wc-admin' )
 					}
-					delta={ delta }
-					href={ href }
+					prevValue={ prevValue }
+					selected={ isSelected }
+					value={ value }
 				/>
 			);
 		} );

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -5,14 +5,12 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { map } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 
 /**
  * WooCommerce dependencies
  */
-import { formatCurrency } from '@woocommerce/currency';
 import { getDateParamsFromQuery } from '@woocommerce/date';
 import { getNewPath } from '@woocommerce/navigation';
 import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce/components';
@@ -21,52 +19,33 @@ import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce
  * Internal dependencies
  */
 import { getSummaryNumbers } from 'store/reports/utils';
-import { numberFormat } from 'lib/number';
 import ReportError from 'analytics/components/report-error';
+import { getFormattedValues } from './utils';
 
-class ReportSummary extends Component {
+export class ReportSummary extends Component {
 	render() {
-		const { selectedChart, charts } = this.props;
+		const { charts, query, selectedChart, summaryData } = this.props;
 
-		if ( this.props.summaryNumbers.isError ) {
+		if ( summaryData.isError ) {
 			return <ReportError isError />;
 		}
 
-		if ( this.props.summaryNumbers.isRequesting ) {
+		if ( summaryData.isRequesting ) {
 			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
 		}
 
-		const totals = this.props.summaryNumbers.totals.primary || {};
-		const secondaryTotals = this.props.summaryNumbers.totals.secondary || {};
-		const { compare } = getDateParamsFromQuery( this.props.query );
+		const totals = summaryData.totals.primary || {};
+		const secondaryTotals = summaryData.totals.secondary || {};
+		const { compare } = getDateParamsFromQuery( query );
 
-		const summaryNumbers = map( charts, chart => {
+		const summaryNumbers = charts.map( chart => {
 			const { key, label, type } = chart;
 			const isSelected = selectedChart.key === key;
-			let value = parseFloat( totals[ key ] );
-			let secondaryValue =
-				( secondaryTotals[ key ] && parseFloat( secondaryTotals[ key ] ) ) || undefined;
-
-			let delta = 0;
-			if ( secondaryValue && secondaryValue !== 0 ) {
-				delta = Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
-			}
-
-			switch ( type ) {
-				case 'average':
-					value = Math.round( value );
-					secondaryValue = secondaryValue && Math.round( secondaryValue );
-					break;
-				case 'currency':
-					value = formatCurrency( value );
-					secondaryValue = secondaryValue && formatCurrency( secondaryValue );
-					break;
-				case 'number':
-					value = numberFormat( value );
-					secondaryValue = secondaryValue && numberFormat( secondaryValue );
-					break;
-			}
-
+			const { delta, secondaryValue, value } = getFormattedValues(
+				type,
+				totals[ key ],
+				secondaryTotals[ key ]
+			);
 			const href = getNewPath( { chart: key } );
 
 			return (
@@ -101,10 +80,10 @@ ReportSummary.propTypes = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const { query, endpoint } = props;
-		const summaryNumbers = getSummaryNumbers( endpoint, query, select );
+		const summaryData = getSummaryNumbers( endpoint, query, select );
 
 		return {
-			summaryNumbers,
+			summaryData,
 		};
 	} )
 )( ReportSummary );

--- a/client/analytics/components/report-summary/test/index.js
+++ b/client/analytics/components/report-summary/test/index.js
@@ -1,0 +1,113 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { ReportSummary } from '../';
+
+describe( 'ReportSummary', () => {
+	function renderChart(
+		type,
+		primaryValue,
+		secondaryValue,
+		isError = false,
+		isRequesting = false
+	) {
+		const selectedChart = {
+			key: 'gross_revenue',
+			label: 'Gross Revenue',
+			type,
+		};
+		const charts = [ selectedChart ];
+		const endpoint = 'revenue';
+		const query = {};
+		const summaryData = {
+			totals: {
+				primary: {
+					gross_revenue: primaryValue,
+				},
+				secondary: {
+					gross_revenue: secondaryValue,
+				},
+			},
+			isError,
+			isRequesting,
+		};
+		return mount(
+			<ReportSummary
+				charts={ charts }
+				endpoint={ endpoint }
+				query={ query }
+				selectedChart={ selectedChart }
+				summaryData={ summaryData }
+			/>
+		);
+	}
+
+	test( 'should set the correct prop values for the SummaryNumber components', () => {
+		const reportChart = renderChart( 'number', 1000.5, 500.25 );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryNumber.props().value ).toBe( '1,000.5' );
+		expect( summaryNumber.props().prevValue ).toBe( '500.25' );
+		expect( summaryNumber.props().delta ).toBe( 100 );
+	} );
+
+	test( 'should format currency numbers properly', () => {
+		const reportChart = renderChart( 'currency', 1000.5, 500.25 );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryNumber.props().value ).toBe( '$1,000.50' );
+		expect( summaryNumber.props().prevValue ).toBe( '$500.25' );
+		expect( summaryNumber.props().delta ).toBe( 100 );
+	} );
+
+	test( 'should format average numbers properly', () => {
+		const reportChart = renderChart( 'average', 1000.5, 500.25 );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryNumber.props().value ).toBe( 1001 );
+		expect( summaryNumber.props().prevValue ).toBe( 500 );
+		expect( summaryNumber.props().delta ).toBe( 100 );
+	} );
+
+	test( 'should not break if secondary value is 0', () => {
+		const reportChart = renderChart( 'number', 1000.5, 0 );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryNumber.props().value ).toBe( '1,000.5' );
+		expect( summaryNumber.props().prevValue ).toBe( '0' );
+		expect( summaryNumber.props().delta ).toBe( 0 );
+	} );
+
+	test( 'should not break with null or undefined values', () => {
+		const reportChart = renderChart( 'number', null, undefined );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryNumber.props().value ).toBe( null );
+		expect( summaryNumber.props().prevValue ).toBe( null );
+		expect( summaryNumber.props().delta ).toBe( null );
+	} );
+
+	test( 'should display ReportError when isError is true', () => {
+		const reportChart = renderChart( 'number', null, null, true );
+		const reportError = reportChart.find( 'ReportError' );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( reportError ).toHaveLength( 1 );
+		expect( summaryNumber ).toHaveLength( 0 );
+	} );
+
+	test( 'should display SummaryListPlaceholder when isRequesting is true', () => {
+		const reportChart = renderChart( 'number', null, null, false, true );
+		const summaryListPlaceholder = reportChart.find( 'SummaryListPlaceholder' );
+		const summaryNumber = reportChart.find( 'SummaryNumber' );
+
+		expect( summaryListPlaceholder ).toHaveLength( 1 );
+		expect( summaryNumber ).toHaveLength( 0 );
+	} );
+} );

--- a/client/analytics/components/report-summary/utils.js
+++ b/client/analytics/components/report-summary/utils.js
@@ -29,8 +29,8 @@ export function formatValue( type, value ) {
 	}
 }
 
-export function calculateDelta( value, secondaryValue ) {
-	if ( ! isFinite( value ) || ! isFinite( secondaryValue ) ) {
+export function calculateDelta( primaryValue, secondaryValue ) {
+	if ( ! isFinite( primaryValue ) || ! isFinite( secondaryValue ) ) {
 		return null;
 	}
 
@@ -38,5 +38,5 @@ export function calculateDelta( value, secondaryValue ) {
 		return 0;
 	}
 
-	return Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
+	return Math.round( ( primaryValue - secondaryValue ) / secondaryValue * 100 );
 }

--- a/client/analytics/components/report-summary/utils.js
+++ b/client/analytics/components/report-summary/utils.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { isFinite } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { formatCurrency } from '@woocommerce/currency';
+
+/**
+ * Internal dependencies
+ */
+import { numberFormat } from 'lib/number';
+
+function formatValue( type, value ) {
+	if ( ! isFinite( value ) ) {
+		return null;
+	}
+
+	switch ( type ) {
+		case 'average':
+			return Math.round( value );
+		case 'currency':
+			return formatCurrency( value );
+		case 'number':
+			return numberFormat( value );
+	}
+}
+
+function calculateDelta( value, secondaryValue ) {
+	if ( ! isFinite( value ) || ! isFinite( secondaryValue ) ) {
+		return null;
+	}
+
+	if ( secondaryValue === 0 ) {
+		return 0;
+	}
+
+	return Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
+}
+
+export function getFormattedValues( type, value, secondaryValue ) {
+	return {
+		delta: calculateDelta( value, secondaryValue ),
+		secondaryValue: formatValue( type, secondaryValue ),
+		value: formatValue( type, value ),
+	};
+}

--- a/client/analytics/components/report-summary/utils.js
+++ b/client/analytics/components/report-summary/utils.js
@@ -14,7 +14,7 @@ import { formatCurrency } from '@woocommerce/currency';
  */
 import { numberFormat } from 'lib/number';
 
-function formatValue( type, value ) {
+export function formatValue( type, value ) {
 	if ( ! isFinite( value ) ) {
 		return null;
 	}
@@ -29,7 +29,7 @@ function formatValue( type, value ) {
 	}
 }
 
-function calculateDelta( value, secondaryValue ) {
+export function calculateDelta( value, secondaryValue ) {
 	if ( ! isFinite( value ) || ! isFinite( secondaryValue ) ) {
 		return null;
 	}
@@ -39,12 +39,4 @@ function calculateDelta( value, secondaryValue ) {
 	}
 
 	return Math.round( ( value - secondaryValue ) / secondaryValue * 100 );
-}
-
-export function getFormattedValues( type, value, secondaryValue ) {
-	return {
-		delta: calculateDelta( value, secondaryValue ),
-		secondaryValue: formatValue( type, secondaryValue ),
-		value: formatValue( type, value ),
-	};
 }

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -38,7 +38,7 @@ export { default as SegmentedSelection } from './segmented-selection';
 export { default as SplitButton } from './split-button';
 export { default as SummaryList } from './summary';
 export { default as SummaryListPlaceholder } from './summary/placeholder';
-export { default as SummaryNumber } from './summary/item';
+export { default as SummaryNumber } from './summary/number';
 export { default as Table } from './table/table';
 export { default as TableCard } from './table';
 export { default as EmptyTable } from './table/empty';

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
-import { isUndefined } from 'lodash';
+import { isNil } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -79,7 +79,7 @@ const SummaryNumber = ( {
 					>
 						<Gridicon className="woocommerce-summary__item-delta-icon" icon={ icon } size={ 18 } />
 						<span className="woocommerce-summary__item-delta-value">
-							{ ! isUndefined( delta )
+							{ ! isNil( delta )
 								? sprintf( __( '%d%%', 'wc-admin' ), delta )
 								: __( 'N/A', 'wc-admin' ) }
 						</span>
@@ -88,7 +88,7 @@ const SummaryNumber = ( {
 				<span className="woocommerce-summary__item-prev-label">{ prevLabel }</span>
 				{ ' ' /* Add a real space so the line breaks here, and not in the label text. */ }
 				<span className="woocommerce-summary__item-prev-value">
-					{ ! isUndefined( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
+					{ ! isNil( prevValue ) ? prevValue : __( 'N/A', 'wc-admin' ) }
 				</span>
 
 				{ onToggle ? (
@@ -143,7 +143,7 @@ SummaryNumber.propTypes = {
 	/**
 	 * A string or number value to display - a string is allowed so we can accept currency formatting.
 	 */
-	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
+	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 };
 
 SummaryNumber.defaultProps = {


### PR DESCRIPTION
Fixes #1022 and #1025.

This started as what I thought would be an easy fix for #1022 but I ended up making a refactor of `<ReportSummary>` and adding tests for that component. Hopefully I didn't break anything and it keeps working as expected. :slightly_smiling_face: 

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/49663638-e995d200-fa14-11e8-8104-57e70ade4cbb.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/49661466-bcdebc00-fa0e-11e8-9ac5-d881c2e62fb1.png)


### Detailed test instructions:
- Go to the _Orders_ report and verify there is no error in the console and it shows _0_ values instead of _N/A_ when actually the value is 0 instead of missing.
- Go to the other reports and verify the Summary number on top of the chart render the correct values.