### PR TITLE
withSelect: fix for multiple select() calls

### DIFF
--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -19,8 +19,11 @@ function createWcApiStore() {
 		return {
 			selectors: apiClient.getSelectors( componentRequirements ),
 			onComplete: () => {
-				apiClient.clearComponentRequirements( component );
-				apiClient.setComponentRequirements( component, componentRequirements );
+				if ( 0 === componentRequirements.length ) {
+					apiClient.clearComponentRequirements( component );
+				} else {
+					apiClient.setComponentRequirements( component, componentRequirements );
+				}
 			},
 		};
 	}

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -15,18 +15,14 @@ function createWcApiStore() {
 
 	function getComponentSelectors( component ) {
 		const componentRequirements = [];
-		const apiSelectors = apiClient.getSelectors( componentRequirements );
 
-		apiClient.clearComponentRequirements( component );
-
-		return Object.keys( apiSelectors ).reduce( ( componentSelectors, selectorName ) => {
-			componentSelectors[ selectorName ] = ( ...args ) => {
-				const result = apiSelectors[ selectorName ]( ...args );
+		return {
+			selectors: apiClient.getSelectors( componentRequirements ),
+			onComplete: () => {
+				apiClient.clearComponentRequirements( component );
 				apiClient.setComponentRequirements( component, componentRequirements );
-				return result;
-			};
-			return componentSelectors;
-		}, {} );
+			},
+		};
 	}
 
 	return {


### PR DESCRIPTION
This fixes a problem with a fresh-data store implementation that was
cancelling out previous requirements when mapSelectToProps
select( 'wc-api' ) was called more than once.

With this code, the initial `select( 'wc-api' )` no longer clears requirements for a component. The re-setting of components only happens once now and it happens after `mapSelectToProps` returns from the application component.

### Detailed test instructions:

Use #1006 instructions to test this PR.
With this PR, the coupons table should be populating.
