### PR TITLE
Remove use of deprecated @wordpress/date getSettings()

### DIFF
--- a/client/devdocs/example.js
+++ b/client/devdocs/example.js
@@ -8,7 +8,7 @@ import { LiveError, LivePreview, LiveProvider } from 'react-live';
 // Used to provide scope in LivePreview
 import { addFilter } from '@wordpress/hooks';
 import { withState } from '@wordpress/compose';
-import { getSettings } from '@wordpress/date';
+import { __experimentalGetSettings } from '@wordpress/date';
 import * as wpComponents from '@wordpress/components';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
@@ -59,7 +59,7 @@ class Example extends Component {
 			...pkgComponents,
 			Component,
 			withState,
-			getSettings,
+			getSettings: __experimentalGetSettings,
 			PropTypes,
 			addFilter,
 			Gridicon,

--- a/client/devdocs/example.js
+++ b/client/devdocs/example.js
@@ -8,7 +8,6 @@ import { LiveError, LivePreview, LiveProvider } from 'react-live';
 // Used to provide scope in LivePreview
 import { addFilter } from '@wordpress/hooks';
 import { withState } from '@wordpress/compose';
-import { __experimentalGetSettings } from '@wordpress/date';
 import * as wpComponents from '@wordpress/components';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
@@ -59,7 +58,6 @@ class Example extends Component {
 			...pkgComponents,
 			Component,
 			withState,
-			getSettings: __experimentalGetSettings,
 			PropTypes,
 			addFilter,
 			Gridicon,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -130,6 +130,8 @@ function format_order_statuses( $statuses ) {
  * Output the wcSettings global before printing any script tags.
  */
 function wc_admin_print_script_settings() {
+	global $wp_locale;
+
 	// Add Tracks script to the DOM if tracking is opted in, and Jetpack is installed/activated.
 	$tracking_enabled = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
 	$tracking_script  = '';
@@ -179,6 +181,10 @@ function wc_admin_print_script_settings() {
 		'siteTitle'        => get_bloginfo( 'name' ),
 		'trackingEnabled'  => $tracking_enabled,
 		'dataEndpoints'    => array(),
+		'l10n'             => array(
+			'userLocale'    => get_user_locale(),
+			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+		),
 	);
 
 	foreach ( $preload_data_endpoints as $key => $endpoint ) {

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+- Remove deprecated @wordpress/date::getSettings() usage.
+
 # 1.0.3
 
 - Fix missing comma seperator in date inside tooltips.

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/date",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "WooCommerce date utilities.",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,7 +5,7 @@
 import moment from 'moment';
 import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { getSettings, format as formatDate } from '@wordpress/date';
+import { __experimentalGetSettings, format as formatDate } from '@wordpress/date';
 
 const QUERY_DEFAULTS = {
 	pageSize: 25,
@@ -492,7 +492,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
  */
 export function loadLocaleData() {
 	const { date } = wcSettings;
-	const settings = getSettings();
+	const settings = __experimentalGetSettings();
 	const userLocale = settings.l10n.locale;
 	const { weekdaysShort } = settings.l10n;
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,7 +5,7 @@
 import moment from 'moment';
 import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { __experimentalGetSettings, format as formatDate } from '@wordpress/date';
+import { format as formatDate } from '@wordpress/date';
 
 const QUERY_DEFAULTS = {
 	pageSize: 25,
@@ -491,10 +491,8 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
  * we can use that data and enhance it with additional translations
  */
 export function loadLocaleData() {
-	const { date } = wcSettings;
-	const settings = __experimentalGetSettings();
-	const userLocale = settings.l10n.locale;
-	const { weekdaysShort } = settings.l10n;
+	const { date, l10n } = wcSettings;
+	const { userLocale, weekdaysShort } = l10n;
 
 	// Keep the default Momentjs English settings for any English
 	if ( ! userLocale.match( /en_/ ) ) {

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -3,8 +3,6 @@
  * External dependencies
  */
 import moment from 'moment';
-import { setSettings } from '@wordpress/date';
-import { setLocaleData } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -457,125 +455,28 @@ describe( 'getRangeLabel', () => {
 describe( 'loadLocaleData', () => {
 	beforeEach( () => {
 		// Reset to default settings
-		setSettings( {
-			l10n: {
-				locale: 'en_US',
-				months: [
-					'January',
-					'February',
-					'March',
-					'April',
-					'May',
-					'June',
-					'July',
-					'August',
-					'September',
-					'October',
-					'November',
-					'December',
-				],
-				monthsShort: [
-					'Jan',
-					'Feb',
-					'Mar',
-					'Apr',
-					'May',
-					'Jun',
-					'Jul',
-					'Aug',
-					'Sep',
-					'Oct',
-					'Nov',
-					'Dec',
-				],
-				weekdays: [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ],
-				weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
-				meridiem: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM' },
-				relative: { future: ' % s from now', past: '% s ago' },
-			},
-			formats: {
-				time: 'g: i a',
-				date: 'F j, Y',
-				datetime: 'F j, Y g: i a',
-			},
-			timezone: { offset: '0', string: '' },
-		} );
-
-		wcSettings = {
-			adminUrl: 'https://vagrant.local/wp/wp-admin/',
-			siteLocale: 'en-US',
-			currency: { code: 'USD', precision: 2, symbol: '&#36;' },
-			date: {
-				dow: 0,
-			},
+		wcSettings.date.dow = 0;
+		wcSettings.l10n = {
+			userLocale: 'en_US',
+			weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
 		};
 	} );
-
-	function setToFrancais() {
-		setSettings( {
-			l10n: {
-				locale: 'fr_FR',
-				months: [
-					'janvier',
-					'f\u00e9vrier',
-					'mars',
-					'avril',
-					'mai',
-					'juin',
-					'juillet',
-					'ao\u00fbt',
-					'septembre',
-					'octobre',
-					'novembre',
-					'd\u00e9cembre',
-				],
-				monthsShort: [
-					'Jan',
-					'F\u00e9v',
-					'Mar',
-					'Avr',
-					'Mai',
-					'Juin',
-					'Juil',
-					'Ao\u00fbt',
-					'Sep',
-					'Oct',
-					'Nov',
-					'D\u00e9c',
-				],
-				weekdays: [ 'dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi' ],
-				weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
-				meridiem: { am: ' ', pm: ' ', AM: ' ', PM: ' ' },
-				relative: { future: '%s \u00e0 partir de maintenant', past: 'Il y a %s' },
-			},
-			formats: { time: 'g:i a', date: 'F j, Y', datetime: 'j F Y G \\h i \\m\\i\\n' },
-			timezone: { offset: '0', string: '' },
-		} );
-		setLocaleData( { '': { domain: 'wc-admin', lang: 'fr_FR' } }, 'wc-admin' );
-	}
 
 	it( 'should leave default momentjs data unchanged for english languages', () => {
 		loadLocaleData();
 		expect( moment.locale() ).toBe( 'en' );
 	} );
 
-	it( "should load french data on user locale 'fr-FR'", () => {
-		setToFrancais();
-		loadLocaleData();
-		expect( moment.localeData()._months[ 0 ] ).toBe( 'janvier' );
-	} );
-
-	it( "should load translated longDateFormats on user locale 'fr-FR'", () => {
-		setToFrancais();
-		loadLocaleData();
-		expect( moment.localeData()._longDateFormat.LL ).not.toBe( 'F j, Y' );
-	} );
-
-	it( "should load start of week on user locale 'fr-FR'", () => {
-		setToFrancais();
+	it( "should load locale data on user locale other than 'en-*'", () => {
 		wcSettings.date.dow = 5;
+		wcSettings.l10n = {
+			userLocale: 'fr_FR',
+			weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
+		};
+
 		loadLocaleData();
-		expect( moment.localeData()._week.dow ).toBe( 5 );
+		expect( moment.localeData().weekdaysMin() ).toEqual( wcSettings.l10n.weekdaysShort );
+		expect( moment.localeData().firstDayOfWeek() ).toBe( wcSettings.date.dow );
 	} );
 } );
 

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -57,6 +57,10 @@ global.wcSettings = {
 		refunded: 'Refunded',
 		failed: 'Failed',
 	},
+	l10n: {
+		userLocale: 'en_US',
+		weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+	},
 };
 
 setLocaleData( { '': { domain: 'wc-admin', lang: 'en_US' } }, 'wc-admin' );


### PR DESCRIPTION
Fixes #807.

See: https://github.com/WordPress/gutenberg/pull/10636

### Detailed test instructions:

1. Install and activate wc-admin
1. Open your developer console
1. Navigate to wp-admin > WooCommerce > Dashboad
1. Verify that no `wp.date` deprecation warning is present
