### PR TITLE
Fix console errors in DevDocs

### DIFF
--- a/packages/components/src/filters/example.md
+++ b/packages/components/src/filters/example.md
@@ -1,56 +1,91 @@
 ```jsx
 import { ReportFilters } from '@woocommerce/components';
+const { orderStatuses } = wcSettings;
 
 const path = '';
 const query = {};
 const filters = [
-	{ label: 'All Products', value: 'all' },
-	{ label: 'Top Products by Items Sold', value: 'top_items' },
-	{ label: 'Top Products by Gross Sales', value: 'top_sales' },
+	{
+		label: 'Show',
+		staticParams: [ 'chart' ],
+		param: 'filter',
+		showFilters: () => true,
+		filters: [
+			{ label: 'All Orders', value: 'all' },
+			{ label: 'Advanced Filters', value: 'advanced' },
+		],
+	},
 ];
 
 const advancedFilters = {
-	status: {
-		labels: {
-			add: 'Order Status',
-			remove: 'Remove order status filter',
-			rule: 'Select an order status filter match',
-			title: 'Order Status',
-		},
-		rules: [
-			{ value: 'is', label: 'Is' },
-			{ value: 'is_not', label: 'Is Not' },
-		],
-		input: {
-			component: 'SelectControl',
-			options: [
-				{ value: 'pending', label: 'Pending' },
-				{ value: 'processing', label: 'Processing' },
-				{ value: 'on-hold', label: 'On Hold' },
-				{ value: 'completed', label: 'Completed' },
-				{ value: 'refunded', label: 'Refunded' },
-				{ value: 'cancelled', label: 'Cancelled' },
-				{ value: 'failed', label: 'Failed' },
+	title: 'Orders Match {{select /}} Filters',
+	filters: {
+		status: {
+			labels: {
+				add: 'Order Status',
+				remove: 'Remove order status filter',
+				rule: 'Select an order status filter match',
+				title: 'Order Status {{rule /}} {{filter /}}',
+				filter: 'Select an order status',
+			},
+			rules: [
+				{
+					value: 'is',
+					label: 'Is',
+				},
+				{
+					value: 'is_not',
+					label: 'Is Not',
+				},
 			],
+			input: {
+				component: 'SelectControl',
+				options: Object.keys( orderStatuses ).map( key => ( {
+					value: key,
+					label: orderStatuses[ key ],
+				} ) ),
+			},
 		},
-	},
-	product_id: {
-		labels: {
-			add: 'Products',
-			placeholder: 'Search products',
-			remove: 'Remove products filter',
-			rule: 'Select a product filter match',
-			title: 'Product',
+		product: {
+			labels: {
+				add: 'Products',
+				placeholder: 'Search products',
+				remove: 'Remove products filter',
+				rule: 'Select a product filter match',
+				title: 'Product {{rule /}} {{filter /}}',
+				filter:'Select products',
+			},
+			rules: [
+				{
+					value: 'includes',
+					label: 'Includes',
+				},
+				{
+					value: 'excludes',
+					label: 'Excludes',
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'products',
+				getLabels: () => Promise.resolve( [] ),
+			},
 		},
-		rules: [
-			{ value: 'includes', label: 'Includes' },
-			{ value: 'excludes', label: 'Excludes' },
-		],
-		input: {
-			component: 'Search',
-			type: 'products',
-			getLabels: function() {
-				return Promise.resolve( [] );
+		customer: {
+			labels: {
+				add: 'Customer Type',
+				remove: 'Remove customer filter',
+				rule: 'Select a customer filter match',
+				title: 'Customer is {{filter /}}',
+				filter: 'Select a customer type',
+			},
+			input: {
+				component: 'SelectControl',
+				options: [
+					{ value: 'new', label: 'New', },
+					{ value: 'returning', label: 'Returning', },
+				],
+				defaultOption: 'new',
 			},
 		},
 	},

--- a/packages/components/src/table/example.md
+++ b/packages/components/src/table/example.md
@@ -2,7 +2,11 @@
 import { TableCard } from '@woocommerce/components';
 
 const noop = () => {};
-const headers = [ { label: 'Month' }, { label: 'Orders' }, { label: 'Revenue' } ];
+const headers = [
+	{ key: 'month', label: 'Month' },
+	{ key: 'orders', label: 'Orders' },
+	{ key: 'revenue', label: 'Revenue' },
+];
 const rows = [
 	[
 		{ display: 'January', value: 1 },


### PR DESCRIPTION
Fixes #979.

This PR seeks to update the Filters devdocs example config schema to the latest that's actually in use (config largely lifted from the Orders report page).

### Screenshots

**Before:**
![screen shot 2018-12-07 at 5 11 16 pm](https://user-images.githubusercontent.com/63922/49678662-21b40980-fa43-11e8-84ea-2f99bd56b670.png)

**After:**
![screen shot 2018-12-07 at 5 09 55 pm](https://user-images.githubusercontent.com/63922/49678639-fdf0c380-fa42-11e8-8098-08a4c81bfb62.png)

### Detailed test instructions:

- Open DevDocs
- Open console
- Verify no errors
- Verify that Filters example renders and can be interacted with


