### PR TITLE
Fix wrong default data structure in 'getReportTableData'

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -118,7 +118,7 @@ ReportTable.propTypes = {
 };
 
 ReportTable.defaultProps = {
-	tableData: null,
+	tableData: {},
 	tableQuery: {},
 };
 

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -451,7 +451,9 @@ describe( 'getReportTableData()', () => {
 	const response = {
 		isError: false,
 		isRequesting: false,
-		items: [],
+		items: {
+			data: [],
+		},
 	};
 
 	const query = {

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -305,7 +305,9 @@ export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
 		query: tableQuery,
 		isRequesting: false,
 		isError: false,
-		items: [],
+		items: {
+			data: [],
+		},
 	};
 
 	const items = getReportItems( endpoint, tableQuery );


### PR DESCRIPTION
Found this while reviewing #1006.

By default, `getReportTableData` was returning `items` as an array, but it's actually an object with a property `data`, which contains the array of items.

`items` can also contain `totalCount` and `totalPages`, but I think it's ok leaving those undefined because they are integers.

### Detailed test instructions:
- Go to any report and verify table is still working and there are no regressions.