### PR TITLE
 Add z-index to admin menu wrap to fix menu overlapping

### DIFF
--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -72,6 +72,10 @@
 	}
 }
 
+#adminmenuwrap {
+	z-index: 99992;
+}
+
 // Temporary fix for compability with the Jetpack masterbar
 // See https://github.com/Automattic/jetpack/issues/9608
 // !important rules overwrite some existing !important rules


### PR DESCRIPTION
Fixes #965 

Adds a z-index to the admin wrap to put it above the wc-admin header.  We do this instead of changing the wc-admin header z-index since anything lower will put it underneath the popover-component.

### Screenshots
<img width="368" alt="screen shot 2018-12-10 at 4 29 42 pm" src="https://user-images.githubusercontent.com/10561050/49719689-d8f58e00-fc98-11e8-90fb-0258162c2800.png">
<img width="471" alt="screen shot 2018-12-10 at 4 29 48 pm" src="https://user-images.githubusercontent.com/10561050/49719690-d8f58e00-fc98-11e8-9d13-62900cb46fb6.png">

### Detailed test instructions:

1.  Visit any page with the wc-admin header bar.
2.  Hover over any sidebar menu item (e.g. Posts) and make sure that it displays on top of the wc-admin header.
3.  Hover over the wp admin my account dropdown in the top right and make sure that it also displays on top of the wc-admin header.