### PR TITLE
Add screen reader labels to table headers which are not buttons

### DIFF
--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -161,6 +161,15 @@ class Table extends Component {
 										? sprintf( __( 'Sort by %s in ascending order', 'wc-admin' ), screenReaderLabel )
 										: sprintf( __( 'Sort by %s in descending order', 'wc-admin' ), screenReaderLabel );
 
+								const textLabel = (
+									<Fragment>
+										<span aria-hidden={ Boolean( screenReaderLabel ) }>{ label }</span>
+										{ screenReaderLabel && (
+											<span className="screen-reader-text">{ screenReaderLabel }</span>
+										) }
+									</Fragment>
+								);
+
 								return (
 									<th role="columnheader" scope="col" key={ i } { ...thProps }>
 										{ isSortable ? (
@@ -177,17 +186,14 @@ class Table extends Component {
 													onClick={ this.sortBy( key ) }
 													isDefault
 												>
-													<span aria-hidden={ Boolean( screenReaderLabel ) }>{ label }</span>
-													{ screenReaderLabel && (
-														<span className="screen-reader-text">{ screenReaderLabel }</span>
-													) }
+													{ textLabel }
 												</IconButton>
 												<span className="screen-reader-text" id={ labelId }>
 													{ iconLabel }
 												</span>
 											</Fragment>
 										) : (
-											label
+											textLabel
 										) }
 									</th>
 								);


### PR DESCRIPTION
Same as #964, but that one only affected table headers which are buttons while this PR will affect all table headers.

### Detailed test instructions:
Testing is blocked by  #1061.
- Go to the _Customers_ report with the screen reader on.
- Navigate the page with your screen reader shortcuts/commands until you reach the _AOV_ cell.
  - Orca (GNU/Linux) commands can be found here: https://help.gnome.org/users/orca/stable/commands_structural_navigation.html.en#tables
  - I don't know the ones for Voice Over (Mac OS), maybe this page is useful: https://help.apple.com/voiceover/mac/10.14/#/vo27958
- Verify it reads _Average Order Value_ instead of _AOV_ when that header is selected.
