### PR TITLE
Remove lodash noConflict

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -95,15 +95,6 @@ function wc_admin_register_script() {
 		wp_set_script_translations( WC_ADMIN_APP, 'wc-admin' );
 	}
 
-	// Resets lodash to wp-admin's version of lodash.
-	if ( 'embedded' === $entry ) {
-		wp_add_inline_script(
-			WC_ADMIN_APP,
-			'_ = _.noConflict();',
-			'after'
-		);
-	}
-
 	wp_register_style(
 		'wc-components',
 		wc_admin_url( 'dist/components/style.css' ),


### PR DESCRIPTION
After reading https://make.wordpress.org/core/2018/12/06/javascript-packages-and-interoperability-in-5-0-and-beyond/ and doing some more testing, it looks like we don't need the noConflict call after all, in conjunction with the webpack change I added previously.

To Test:
* Test with WordPress 5.0+ now that it is out
* Close any currently running `npm start` process and re-run `npm install` and `npm start`
* Clear cache
* Open the orders page, hopefully see no JS warnings
* Open the WordPress.com notification dropdown

See #1023.