### PR TITLE
Table: Add onColumnsChange

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.3.0
 
 - Update `<Table />` to use header keys to denote which columns are shown
+- Add `onColumnsChange` property to `<Table />` which is called when columns are shown/hidden
 
 # 1.2.0
 


### PR DESCRIPTION
This adds an `onColumnsChange` property which is called when the column
visibility is toggled on the table. It also cleans up a bit of the
showCols code and fixes an incorrect update in the component update.

### Detailed test instructions:

Test via #1057 