### PR TITLE
wc-api: Add user meta for UI preferences

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -26,10 +26,14 @@ const TABLE_FILTER = 'woocommerce_admin_report_table';
 
 class ReportTable extends Component {
 	onColumnsChange = columns => {
-		const userDataFields = {
-			revenue_report_columns: columns,
-		};
-		this.props.updateCurrentUserData( userDataFields );
+		const { columnPrefsKey } = this.props;
+
+		if ( columnPrefsKey ) {
+			const userDataFields = {
+				[ columnPrefsKey ]: columns,
+			};
+			this.props.updateCurrentUserData( userDataFields );
+		}
 	};
 
 	filterShownHeaders = ( headers, shownKeys ) => {
@@ -106,6 +110,10 @@ class ReportTable extends Component {
 
 ReportTable.propTypes = {
 	/**
+	 * The key for user preferences settings for column visibility.
+	 */
+	columnPrefsKey: PropTypes.string,
+	/**
 	 * The endpoint to use in API calls.
 	 */
 	endpoint: PropTypes.string,
@@ -150,21 +158,26 @@ ReportTable.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, getSummary, query, tableData, tableQuery } = props;
+		const { endpoint, getSummary, query, tableData, tableQuery, columnPrefsKey } = props;
 		const chartEndpoint = 'variations' === endpoint ? 'products' : endpoint;
 		const primaryData = getSummary
 			? getReportChartData( chartEndpoint, 'primary', query, select )
 			: {};
 		const queriedTableData = tableData || getReportTableData( endpoint, query, select, tableQuery );
 
-		const { getCurrentUserData } = select( 'wc-api' );
-		const userData = getCurrentUserData();
-
-		return {
+		const selectProps = {
 			primaryData,
 			tableData: queriedTableData,
-			userPrefColumns: userData.revenue_report_columns,
 		};
+
+		if ( columnPrefsKey ) {
+			const { getCurrentUserData } = select( 'wc-api' );
+			const userData = getCurrentUserData();
+
+			selectProps.userPrefColumns = userData[ columnPrefsKey ];
+		}
+
+		return selectProps;
 	} ),
 	withDispatch( dispatch => {
 		const { updateCurrentUserData } = dispatch( 'wc-api' );

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -215,7 +215,7 @@ class RevenueReportTable extends Component {
 				query={ query }
 				tableData={ tableData }
 				title={ __( 'Revenue', 'wc-admin' ) }
-				columnPrefs="revenue_report_columns"
+				columnPrefsKey="revenue_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -215,6 +215,7 @@ class RevenueReportTable extends Component {
 				query={ query }
 				tableData={ tableData }
 				title={ __( 'Revenue', 'wc-admin' ) }
+				columnPrefs="revenue_report_columns"
 			/>
 		);
 	}

--- a/client/wc-api/user/index.js
+++ b/client/wc-api/user/index.js
@@ -1,0 +1,13 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+import mutations from './mutations';
+
+export default {
+	operations,
+	selectors,
+	mutations,
+};

--- a/client/wc-api/user/mutations.js
+++ b/client/wc-api/user/mutations.js
@@ -1,0 +1,10 @@
+/** @format */
+
+const updateCurrentUserData = operations => userDataFields => {
+	const resourceKey = 'current-user-data';
+	operations.update( [ resourceKey ], { [ resourceKey ]: userDataFields } );
+};
+
+export default {
+	updateCurrentUserData,
+};

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { mapValues, pick } from 'lodash';
+
+function read( resourceNames, fetch = apiFetch ) {
+	return [ ...readCurrentUserData( resourceNames, fetch ) ];
+}
+
+function update( resourceNames, data, fetch = apiFetch ) {
+	return [ ...updateCurrentUserData( resourceNames, data, fetch ) ];
+}
+
+function readCurrentUserData( resourceNames, fetch ) {
+	if ( resourceNames.includes( 'current-user-data' ) ) {
+		const url = '/wp/v2/users/me?context=edit';
+
+		return [
+			fetch( { path: url } )
+				.then( user => {
+					const userData = mapValues( user.woocommerce_meta, JSON.parse );
+					return { [ 'current-user-data' ]: { data: userData } };
+				} )
+				.catch( error => {
+					return { [ 'current-user-data' ]: { error } };
+				} ),
+		];
+	}
+}
+
+function updateCurrentUserData( resourceNames, data, fetch ) {
+	const resourceName = 'current-user-data';
+	const userDataFields = [ 'revenue_report_columns' ];
+
+	if ( resourceNames.includes( resourceName ) ) {
+		const url = '/wp/v2/users/me';
+		const userData = pick( data[ resourceName ], userDataFields );
+		const meta = mapValues( userData, JSON.stringify );
+		const user = { woocommerce_meta: meta };
+
+		return [
+			fetch( { path: url, method: 'POST', data: user } )
+				.then( updatedUserData => {
+					return { [ resourceName ]: { data: updatedUserData.woocommerce_meta } };
+				} )
+				.catch( error => {
+					return { [ resourceName ]: { error } };
+				} ),
+		];
+	}
+}
+
+export default {
+	read,
+	update,
+};

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -29,6 +29,7 @@ function readCurrentUserData( resourceNames, fetch ) {
 				} ),
 		];
 	}
+	return [];
 }
 
 function updateCurrentUserData( resourceNames, data, fetch ) {
@@ -51,6 +52,7 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 				} ),
 		];
 	}
+	return [];
 }
 
 export default {

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_REQUIREMENT } from '../constants';
+
+const getCurrentUserData = ( getResource, requireResource ) => (
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	return requireResource( requirement, 'current-user-data' ).data || {};
+};
+
+export default {
+	getCurrentUserData,
+};

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -8,15 +8,20 @@ import orders from './orders';
 import reportItems from './reports/items';
 import reportStats from './reports/stats';
 import reviews from './reviews';
+import user from './user';
 
 function createWcApiSpec() {
 	return {
+		mutations: {
+			...user.mutations,
+		},
 		selectors: {
 			...notes.selectors,
 			...orders.selectors,
 			...reportItems.selectors,
 			...reportStats.selectors,
 			...reviews.selectors,
+			...user.selectors,
 		},
 		operations: {
 			read( resourceNames ) {
@@ -26,7 +31,11 @@ function createWcApiSpec() {
 					...reportItems.operations.read( resourceNames ),
 					...reportStats.operations.read( resourceNames ),
 					...reviews.operations.read( resourceNames ),
+					...user.operations.read( resourceNames ),
 				];
+			},
+			update( resourceNames, data ) {
+				return [ ...user.operations.update( resourceNames, data ) ];
 			},
 		},
 	};

--- a/client/wc-api/with-select.js
+++ b/client/wc-api/with-select.js
@@ -43,9 +43,9 @@ const withSelect = mapSelectToProps =>
 				super( props );
 
 				this.onStoreChange = this.onStoreChange.bind( this );
-
 				this.subscribe( props.registry );
 
+				this.onUnmounts = {};
 				this.mergeProps = this.getNextMergeProps( props );
 			}
 
@@ -59,6 +59,7 @@ const withSelect = mapSelectToProps =>
 			getNextMergeProps( props ) {
 				const storeSelectors = {};
 				const onCompletes = [];
+				const onUnmounts = {};
 				const componentContext = { component: this };
 
 				const getStoreFromRegistry = ( key, registry, context ) => {
@@ -69,8 +70,9 @@ const withSelect = mapSelectToProps =>
 					if ( isFunction( selectorsForKey ) ) {
 						// This store has special handling for its selectors.
 						// We give it a context, and we check for a "resolve"
-						const { selectors, onComplete } = selectorsForKey( context );
+						const { selectors, onComplete, onUnmount } = selectorsForKey( context );
 						onComplete && onCompletes.push( onComplete );
+						onUnmount && ( onUnmounts[ key ] = onUnmount );
 						storeSelectors[ key ] = selectors;
 					} else {
 						storeSelectors[ key ] = selectorsForKey;
@@ -107,6 +109,7 @@ const withSelect = mapSelectToProps =>
 			componentWillUnmount() {
 				this.canRunSelection = false;
 				this.unsubscribe();
+				Object.keys( this.onUnmounts ).forEach( key => this.onUnmounts[ key ]() );
 			}
 
 			shouldComponentUpdate( nextProps, nextState ) {

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -39,8 +39,8 @@ function createWcApiStore() {
 			return getComponentSelectors( component );
 		},
 		getActions() {
-			// TODO: Add mutations here.
-			return {};
+			const mutations = apiClient.getMutations();
+			return mutations;
 		},
 		subscribe: apiClient.subscribe,
 	};

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -338,5 +338,73 @@ function woocommerce_embed_page_header() {
 	</div>
 	<?php
 }
-
 add_action( 'in_admin_header', 'woocommerce_embed_page_header' );
+
+/**
+ * Registers WooCommerce specific user data to the Wordpress user API.
+ */
+function wc_admin_register_user_data() {
+	register_rest_field(
+		'user',
+		'woocommerce_meta',
+		array(
+			'get_callback'    => 'wc_admin_get_user_data_values',
+			'update_callback' => 'wc_admin_update_user_data_values',
+			'schema' => null,
+		)
+	);
+}
+ add_action( 'rest_api_init', 'wc_admin_register_user_data' );
+
+ /**
+  * We store some WooCommerce specific user meta attached to users endpoint,
+  * so that we can track certain preferences or values such as the inbox activity panel last open time.
+  * Additional fields can be added in the function below, and then used via wc-admin's currentUser data.
+  *
+  * @return array Fields to expose over the WP user endpoint.
+  */
+function wc_admin_get_user_data_fields() {
+	$user_data_fields = array(
+		'revenue_report_columns',
+	);
+
+	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );
+}
+
+ /**
+  * For all the registered user data fields (  wc_admin_get_user_data_fields ), fetch the data
+  * for returning via the REST API.
+  *
+  * @param WP_User $user Current user.
+  */
+function wc_admin_get_user_data_values( $user ) {
+	$values = array();
+	foreach ( wc_admin_get_user_data_fields() as $field ) {
+		$values[ $field ] = get_user_meta( $user['id'], 'woocommerce_meta_' . $field, true );
+	}
+	return $values;
+}
+
+ /**
+  * For all the registered user data fields (  wc_admin_get_user_data_fields ), update the data
+  * for the REST API.
+  *
+  * @param array   $values   The new values for the meta.
+  * @param WP_User $user     The current user.
+  * @param string  $field_id The field id for the user meta.
+  */
+function wc_admin_update_user_data_values( $values, $user, $field_id ) {
+	if ( empty( $values ) || ! is_array( $values ) || 'woocommerce_meta' !== $field_id ) {
+		return;
+	}
+	$fields  = wc_admin_get_user_data_fields();
+	$updates = array();
+	foreach ( $values as $field => $value ) {
+		if ( in_array( $field, $fields ) ) {
+			$updates[ $field ] = $value;
+			update_user_meta( $user->ID, 'woocommerce_meta_' . $field, $value );
+		}
+	}
+
+	return $updates;
+}

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -341,7 +341,7 @@ function woocommerce_embed_page_header() {
 add_action( 'in_admin_header', 'woocommerce_embed_page_header' );
 
 /**
- * Registers WooCommerce specific user data to the Wordpress user API.
+ * Registers WooCommerce specific user data to the WordPress user API.
  */
 function wc_admin_register_user_data() {
 	register_rest_field(
@@ -350,19 +350,19 @@ function wc_admin_register_user_data() {
 		array(
 			'get_callback'    => 'wc_admin_get_user_data_values',
 			'update_callback' => 'wc_admin_update_user_data_values',
-			'schema' => null,
+			'schema'          => null,
 		)
 	);
 }
  add_action( 'rest_api_init', 'wc_admin_register_user_data' );
 
- /**
-  * We store some WooCommerce specific user meta attached to users endpoint,
-  * so that we can track certain preferences or values such as the inbox activity panel last open time.
-  * Additional fields can be added in the function below, and then used via wc-admin's currentUser data.
-  *
-  * @return array Fields to expose over the WP user endpoint.
-  */
+/**
+ * We store some WooCommerce specific user meta attached to users endpoint,
+ * so that we can track certain preferences or values such as the inbox activity panel last open time.
+ * Additional fields can be added in the function below, and then used via wc-admin's currentUser data.
+ *
+ * @return array Fields to expose over the WP user endpoint.
+ */
 function wc_admin_get_user_data_fields() {
 	$user_data_fields = array(
 		'revenue_report_columns',
@@ -371,12 +371,12 @@ function wc_admin_get_user_data_fields() {
 	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );
 }
 
- /**
-  * For all the registered user data fields (  wc_admin_get_user_data_fields ), fetch the data
-  * for returning via the REST API.
-  *
-  * @param WP_User $user Current user.
-  */
+/**
+ * For all the registered user data fields (  wc_admin_get_user_data_fields ), fetch the data
+ * for returning via the REST API.
+ *
+ * @param WP_User $user Current user.
+ */
 function wc_admin_get_user_data_values( $user ) {
 	$values = array();
 	foreach ( wc_admin_get_user_data_fields() as $field ) {
@@ -385,14 +385,14 @@ function wc_admin_get_user_data_values( $user ) {
 	return $values;
 }
 
- /**
-  * For all the registered user data fields (  wc_admin_get_user_data_fields ), update the data
-  * for the REST API.
-  *
-  * @param array   $values   The new values for the meta.
-  * @param WP_User $user     The current user.
-  * @param string  $field_id The field id for the user meta.
-  */
+/**
+ * For all the registered user data fields (  wc_admin_get_user_data_fields ), update the data
+ * for the REST API.
+ *
+ * @param array   $values   The new values for the meta.
+ * @param WP_User $user     The current user.
+ * @param string  $field_id The field id for the user meta.
+ */
 function wc_admin_update_user_data_values( $values, $user, $field_id ) {
 	if ( empty( $values ) || ! is_array( $values ) || 'woocommerce_meta' !== $field_id ) {
 		return;
@@ -400,7 +400,7 @@ function wc_admin_update_user_data_values( $values, $user, $field_id ) {
 	$fields  = wc_admin_get_user_data_fields();
 	$updates = array();
 	foreach ( $values as $field => $value ) {
-		if ( in_array( $field, $fields ) ) {
+		if ( in_array( $field, $fields, true ) ) {
 			$updates[ $field ] = $value;
 			update_user_meta( $user->ID, 'woocommerce_meta_' . $field, $value );
 		}

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -380,7 +380,7 @@ function wc_admin_get_user_data_fields() {
 function wc_admin_get_user_data_values( $user ) {
 	$values = array();
 	foreach ( wc_admin_get_user_data_fields() as $field ) {
-		$values[ $field ] = get_user_meta( $user['id'], 'woocommerce_meta_' . $field, true );
+		$values[ $field ] = get_user_meta( $user['id'], 'wc_admin_' . $field, true );
 	}
 	return $values;
 }
@@ -402,7 +402,7 @@ function wc_admin_update_user_data_values( $values, $user, $field_id ) {
 	foreach ( $values as $field => $value ) {
 		if ( in_array( $field, $fields, true ) ) {
 			$updates[ $field ] = $value;
-			update_user_meta( $user->ID, 'woocommerce_meta_' . $field, $value );
+			update_user_meta( $user->ID, 'wc_admin_' . $field, $value );
 		}
 	}
 


### PR DESCRIPTION
Fixes #892 

This adds wc-api code to store UI preferences and provides one example
of updating the revenue table to save column preferences.

### Detailed test instructions:

1. Go to Analytics -> Revenue.
2. Toggle some columns off.
3. Close browser tab.
4. Open another browser tab and go to Analytics -> Revenue (or use another browser, etc)
5. Observe that the same columns are toggled off.

For more detailed testing, open dev console network tab and look for "me?context=edit" requests and "me" POST requests.
