### PR TITLE
Fix item refunds report data

### DIFF
--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -16,7 +16,7 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 	global $wpdb;
 
 	$order = wc_get_order( $order_id );
-	if ( ! $order ) {
+	if ( ! $order || 'shop_order_refund' === $order->get_type() ) {
 		return;
 	}
 

--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -36,7 +36,7 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 	foreach ( $order->get_items() as $order_item ) {
 		$order_item_id     = $order_item->get_id();
 		$quantity_refunded = isset( $refunds[ $order_item_id ] ) ? $refunds[ $order_item_id ]['quantity'] : 0;
-		$amount_refunded   = isset( $refunds[ $order_item_id ] ) ? $refunds[ $order_item_id ]['amount'] : 0;
+		$amount_refunded   = isset( $refunds[ $order_item_id ] ) ? $refunds[ $order_item_id ]['subtotal'] : 0;
 
 		if ( $quantity_refunded >= $order_item->get_quantity( 'edit' ) ) {
 			$wpdb->delete(
@@ -93,7 +93,7 @@ function wc_admin_get_order_refund_items( $order ) {
 				$refunded_line_items[ $line_item_id ]['subtotal'] = 0;
 			}
 			$refunded_line_items[ $line_item_id ]['quantity'] += absint( $refunded_item['quantity'] );
-			$refunded_line_items[ $line_item_id ]['subtotal'] += absint( $refunded_item['subtotal'] );
+			$refunded_line_items[ $line_item_id ]['subtotal'] += abs( $refunded_item['subtotal'] );
 		}
 	}
 	return $refunded_line_items;

--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -20,35 +20,80 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 		return;
 	}
 
+	$refunds = wc_admin_get_order_refund_items( $order );
+
 	foreach ( $order->get_items() as $order_item ) {
-		$wpdb->replace(
-			$wpdb->prefix . 'wc_order_product_lookup',
-			array(
-				'order_item_id'       => $order_item->get_id(),
-				'order_id'            => $order->get_id(),
-				'product_id'          => $order_item->get_product_id( 'edit' ),
-				'variation_id'        => $order_item->get_variation_id( 'edit' ),
-				'customer_id'         => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
-				'product_qty'         => $order_item->get_quantity( 'edit' ),
-				'product_net_revenue' => $order_item->get_subtotal( 'edit' ),
-				'date_created'        => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
-			),
-			array(
-				'%d',
-				'%d',
-				'%d',
-				'%d',
-				'%d',
-				'%d',
-				'%f',
-				'%s',
-			)
-		);
+		$quantity_refunded = isset( $refunds['line_items'][ $order_item->get_id() ] ) ? $refunds['line_items'][ $order_item->get_id() ] : 0;
+		if ( $quantity_refunded >= $order_item->get_quantity( 'edit' ) ) {
+			$wpdb->delete(
+				$wpdb->prefix . 'wc_order_product_lookup',
+				array( 'order_item_id' => $order_item->get_id() ),
+				array( '%d' )
+			);
+		} else {
+			$wpdb->replace(
+				$wpdb->prefix . 'wc_order_product_lookup',
+				array(
+					'order_item_id'         => $order_item->get_id(),
+					'order_id'              => $order->get_id(),
+					'product_id'            => $order_item->get_product_id( 'edit' ),
+					'variation_id'          => $order_item->get_variation_id( 'edit' ),
+					'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
+					'product_qty'           => $order_item->get_quantity( 'edit' ) - $quantity_refunded,
+					'product_gross_revenue' => $order_item->get_subtotal( 'edit' ) - $refunds['total'],
+					'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
+				),
+				array(
+					'%d',
+					'%d',
+					'%d',
+					'%d',
+					'%d',
+					'%d',
+					'%f',
+					'%s',
+				)
+			);
+		}
 	}
 }
 // TODO: maybe replace these with woocommerce_create_order, woocommerce_update_order, woocommerce_trash_order, woocommerce_delete_order, as clean_post_cache might be called in other circumstances and trigger too many updates?
 add_action( 'save_post', 'wc_admin_order_product_lookup_entry', 10, 1 );
 add_action( 'clean_post_cache', 'wc_admin_order_product_lookup_entry', 10, 1 );
+
+/**
+ * Get total refund amount and line items refunded.
+ *
+ * @param object $order WC_Order.
+ * @return array Order total for single items and line items.
+ */
+function wc_admin_get_order_refund_items( $order ) {
+	$refunds             = $order->get_refunds();
+	$refunded_amount     = 0;
+	$refunded_line_items = array();
+	$single_item_order   = ( 1 === count( $order->get_items() ) );
+	foreach ( $refunds as $refund ) {
+		$refunded_items = $refund->get_items();
+		if ( empty( $refunded_items ) ) {
+			// Refund applied to single item orders based.
+			if ( $single_item_order ) {
+				$refunded_amount = $refund->get_amount();
+			}
+		} else {
+			// Append items to array for removal.
+			foreach ( $refunded_items as $refunded_item ) {
+				$line_item_id                          = wc_get_order_item_meta( $refunded_item->get_id(), '_refunded_item_id', true );
+				// @TODO: Add refunded amount for single item in the event of partial refund or qty > 1.
+				$refunded_line_items[ $line_item_id ]  = isset( $refunded_line_items[ $line_item_id ] ) ? $refunded_line_items[ $line_item_id ] : 0;
+				$refunded_line_items[ $line_item_id ] += abs( $refunded_item['quantity'] );
+			}
+		}
+	}
+	return array(
+		'total'      => $refunded_amount,
+		'line_items' => $refunded_line_items,
+	);
+}
 
 /**
  * Make an entry in the wc_order_tax_lookup table for an order.

--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -20,10 +20,18 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 		return;
 	}
 
+	if ( 'refunded' === $order->get_status() ) {
+		$wpdb->delete(
+			$wpdb->prefix . 'wc_order_product_lookup',
+			array( 'order_id' => $order->get_id() )
+		);
+		return;
+	}
+
 	$refunds = wc_admin_get_order_refund_items( $order );
 
 	foreach ( $order->get_items() as $order_item ) {
-		$quantity_refunded = isset( $refunds['line_items'][ $order_item->get_id() ] ) ? $refunds['line_items'][ $order_item->get_id() ] : 0;
+		$quantity_refunded = isset( $refunds[ $order_item->get_id() ] ) ? $refunds[ $order_item->get_id() ] : 0;
 		if ( $quantity_refunded >= $order_item->get_quantity( 'edit' ) ) {
 			$wpdb->delete(
 				$wpdb->prefix . 'wc_order_product_lookup',
@@ -40,7 +48,7 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 					'variation_id'          => $order_item->get_variation_id( 'edit' ),
 					'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
 					'product_qty'           => $order_item->get_quantity( 'edit' ) - $quantity_refunded,
-					'product_gross_revenue' => $order_item->get_subtotal( 'edit' ) - $refunds['total'],
+					'product_gross_revenue' => $order_item->get_subtotal( 'edit' ),
 					'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 				),
 				array(
@@ -59,40 +67,27 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 }
 // TODO: maybe replace these with woocommerce_create_order, woocommerce_update_order, woocommerce_trash_order, woocommerce_delete_order, as clean_post_cache might be called in other circumstances and trigger too many updates?
 add_action( 'save_post', 'wc_admin_order_product_lookup_entry', 10, 1 );
+add_action( 'woocommerce_order_refunded', 'wc_admin_order_product_lookup_entry' );
 add_action( 'clean_post_cache', 'wc_admin_order_product_lookup_entry', 10, 1 );
 
 /**
  * Get total refund amount and line items refunded.
  *
  * @param object $order WC_Order.
- * @return array Order total for single items and line items.
+ * @return array Refunded line items with line item ID as key.
  */
 function wc_admin_get_order_refund_items( $order ) {
 	$refunds             = $order->get_refunds();
-	$refunded_amount     = 0;
 	$refunded_line_items = array();
 	$single_item_order   = ( 1 === count( $order->get_items() ) );
 	foreach ( $refunds as $refund ) {
-		$refunded_items = $refund->get_items();
-		if ( empty( $refunded_items ) ) {
-			// Refund applied to single item orders based.
-			if ( $single_item_order ) {
-				$refunded_amount = $refund->get_amount();
-			}
-		} else {
-			// Append items to array for removal.
-			foreach ( $refunded_items as $refunded_item ) {
-				$line_item_id                          = wc_get_order_item_meta( $refunded_item->get_id(), '_refunded_item_id', true );
-				// @TODO: Add refunded amount for single item in the event of partial refund or qty > 1.
-				$refunded_line_items[ $line_item_id ]  = isset( $refunded_line_items[ $line_item_id ] ) ? $refunded_line_items[ $line_item_id ] : 0;
-				$refunded_line_items[ $line_item_id ] += abs( $refunded_item['quantity'] );
-			}
+		foreach ( $refund->get_items() as $refunded_item ) {
+			$line_item_id                          = wc_get_order_item_meta( $refunded_item->get_id(), '_refunded_item_id', true );
+			$refunded_line_items[ $line_item_id ]  = isset( $refunded_line_items[ $line_item_id ] ) ? $refunded_line_items[ $line_item_id ] : 0;
+			$refunded_line_items[ $line_item_id ] += absint( $refunded_item['quantity'] );
 		}
 	}
-	return array(
-		'total'      => $refunded_amount,
-		'line_items' => $refunded_line_items,
-	);
+	return $refunded_line_items;
 }
 
 /**

--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -37,7 +37,6 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 		$order_item_id     = $order_item->get_id();
 		$quantity_refunded = isset( $refunds[ $order_item_id ] ) ? $refunds[ $order_item_id ]['quantity'] : 0;
 		$amount_refunded   = isset( $refunds[ $order_item_id ] ) ? $refunds[ $order_item_id ]['subtotal'] : 0;
-
 		if ( $quantity_refunded >= $order_item->get_quantity( 'edit' ) ) {
 			$wpdb->delete(
 				$wpdb->prefix . 'wc_order_product_lookup',
@@ -48,14 +47,14 @@ function wc_admin_order_product_lookup_entry( $order_id ) {
 			$wpdb->replace(
 				$wpdb->prefix . 'wc_order_product_lookup',
 				array(
-					'order_item_id'         => $order_item_id,
-					'order_id'              => $order->get_id(),
-					'product_id'            => $order_item->get_product_id( 'edit' ),
-					'variation_id'          => $order_item->get_variation_id( 'edit' ),
-					'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
-					'product_qty'           => $order_item->get_quantity( 'edit' ) - $quantity_refunded,
-					'product_gross_revenue' => $order_item->get_subtotal( 'edit' ) - $amount_refunded,
-					'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
+					'order_item_id'       => $order_item_id,
+					'order_id'            => $order->get_id(),
+					'product_id'          => $order_item->get_product_id( 'edit' ),
+					'variation_id'        => $order_item->get_variation_id( 'edit' ),
+					'customer_id'         => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
+					'product_qty'         => $order_item->get_quantity( 'edit' ) - $quantity_refunded,
+					'product_net_revenue' => $order_item->get_subtotal( 'edit' ) - $amount_refunded,
+					'date_created'        => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 				),
 				array(
 					'%d',


### PR DESCRIPTION
Fixes #1024

This PR:
* Fixes the bug where refunding items throws an error and modifies.
* Modifies`wc_order_product_lookup` stats based on refunds given.  Detailed discussion on how refunds should be issued - p7bje6-1dV-p2
* Syncs the `wc_order_product_lookup` table when refunds are processed.

### Screenshots
<img width="1185" alt="screen shot 2018-12-11 at 7 04 59 pm" src="https://user-images.githubusercontent.com/10561050/49796445-acfd0a00-fd77-11e8-91b7-eea1d33695cc.png">

### Detailed test instructions:

1.  Visit any order in your dashboard.
2.  Try the following with various orders:
    * Refund a line item with a qty of 1 by inputting a quantity next to it in the field.  This item should be removed from the Product report.
    * Refund a partial qty from a line item that has more than 1 qty.  This item should still show in the Product report with a reduced quantity.
    * Refund an amount without specifying a quantity.  No adjustment should be made to the product reports revenue.
    * Set an order status to "Refunded."  All products in this order should be removed from the Product report.