### PR TITLE
Removed force update in tests

### DIFF
--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -71,8 +71,6 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		WC_Admin_Reports_Orders_Data_Store::update( $order );
-
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(

--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Class WC_Tests_API_Reports_Products_Stats
+ */
 class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 
 	/**

--- a/tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/reports/class-wc-tests-reports-orders.php
@@ -42,7 +42,6 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 
 		$data_store = new WC_Admin_Reports_Orders_Data_Store();
-		$data_store::update( $order );
 
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );

--- a/tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/reports/class-wc-tests-reports-orders.php
@@ -1,10 +1,12 @@
 <?php
-
 /**
  * Reports order stats tests.
  *
  * @package WooCommerce\Tests\Orders
- * @todo Finish up unit testing to verify bug-free order reports.
+ */
+
+/**
+ * Class WC_Tests_Reports_Orders
  */
 class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 
@@ -1558,7 +1560,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Product includes, negative filter for 2 product: ' . $wpdb->last_query );
 
 		// Combinations: match all
-		// status_is + product_includes
+		// status_is + product_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -1630,7 +1632,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + coupon_includes
+		// status_is + coupon_includes.
 		$query_args = array(
 			'after'           => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'          => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -1706,7 +1708,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// product_includes + coupon_includes
+		// product_includes + coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -1778,7 +1780,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + product_includes + coupon_includes
+		// status_is + product_includes + coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -1853,7 +1855,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + status_is_not + product_includes
+		// status_is + status_is_not + product_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -1932,7 +1934,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + status_is_not + product_includes + product_excludes
+		// status_is + status_is_not + product_includes + product_excludes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2012,7 +2014,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + status_is_not + product_includes + product_excludes + coupon_includes
+		// status_is + status_is_not + product_includes + product_excludes + coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2094,7 +2096,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is + status_is_not + product_includes + product_excludes + coupon_includes + coupon_excludes
+		// status_is + status_is_not + product_includes + product_excludes + coupon_includes + coupon_excludes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2181,7 +2183,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
 		// Combinations: match any
-		// status_is + status_is_not, all orders
+		// status_is + status_is_not, all orders.
 		$query_args = array(
 			'after'         => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'        => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2258,7 +2260,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR product_includes
+		// status_is OR product_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2335,7 +2337,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR coupon_includes
+		// status_is OR coupon_includes.
 		$query_args = array(
 			'after'           => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'          => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2412,7 +2414,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR coupon_excludes
+		// status_is OR coupon_excludes.
 		$query_args = array(
 			'after'           => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'          => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2489,7 +2491,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// product_includes OR coupon_includes
+		// product_includes OR coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2566,7 +2568,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR product_includes OR coupon_includes
+		// status_is OR product_includes OR coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2646,7 +2648,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR status_is_not OR product_includes
+		// status_is OR status_is_not OR product_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2729,7 +2731,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR status_is_not OR product_includes OR product_excludes
+		// status_is OR status_is_not OR product_includes OR product_excludes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2812,7 +2814,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes
+		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
@@ -2898,7 +2900,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'No filters' );
 
-		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes OR coupon_excludes
+		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes OR coupon_excludes.
 		$query_args = array(
 			'after'            => $current_hour->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'           => $now->format( WC_Admin_Reports_Interval::$sql_datetime_format ),

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -1,10 +1,13 @@
 <?php
-
 /**
  * Reports order stats tests.
  *
  * @package WooCommerce\Tests\Orders
  * @todo Finish up unit testing to verify bug-free order reports.
+ */
+
+/**
+ * Class WC_Admin_Tests_Reports_Revenue_Stats
  */
 class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 
@@ -132,116 +135,4 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		$query          = new WC_Admin_Reports_Revenue_Query( $args );
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $query->get_data() ), true ) );
 	}
-
-	/**
-	 * Test the calculations and querying works correctly for the case of multiple orders.
-	 */
-	/*public function test_populate_and_query_multiple_intervals() {
-		// Populate all of the data.
-		$product1 = new WC_Product_Simple();
-		$product1->set_name( 'Test Product' );
-		$product1->set_regular_price( 25 );
-		$product1->save();
-
-		$product2 = new WC_Product_Simple();
-		$product2->set_name( 'Test Product 2' );
-		$product2->set_regular_price( 10 );
-		$product2->save();
-
-		$order1_time = time() - ( 2 * HOUR_IN_SECONDS );
-
-		$order1 = WC_Helper_Order::create_order( 1, $product1 );
-		$order1->set_date_created( $order1_time );
-		$order1->set_status( 'completed' );
-		$order1->set_shipping_total( 10 );
-		$order1->set_discount_total( 20 );
-		$order1->set_discount_tax( 0 );
-		$order1->set_cart_tax( 5 );
-		$order1->set_shipping_tax( 2 );
-		$order1->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
-		$order1->save();
-
-		$order2_time = time() - HOUR_IN_SECONDS + 1;
-
-		$order2 = WC_Helper_Order::create_order( 1, $product2 );
-		$order2->set_date_created( $order2_time );
-		$order2->set_status( 'processing' );
-		$order2->set_shipping_total( 5 );
-		$order2->set_discount_total( 0 );
-		$order2->set_discount_tax( 0 );
-		$order2->set_cart_tax( 3 );
-		$order2->set_shipping_tax( 1 );
-		$order2->set_total( 49 ); // $10x4 products + $5 shipping + $4 tax.
-		$order2->save();
-
-		// Test the calculations.
-		$start_time = $order1_time;
-		$end_time = $order2_time + HOUR_IN_SECONDS;
-
-		// Test aggregate raw summary data for both orders.
-		$data = WC_Order_Stats::summarize_orders( $start_time, $end_time );
-		$expected_data = array(
-			'num_orders'            => 2,
-			'num_items_sold'        => 8,
-			'orders_gross_total'    => 146.0,
-			'orders_coupon_total'   => 20.0,
-			'orders_refund_total'   => 0,
-			'orders_tax_total'      => 11.0,
-			'orders_shipping_total' => 15.0,
-			'orders_net_total'      => 120.0,
-		);
-		$this->assertEquals( $expected_data, $data );
-
-		// Calculate stats for each hour and save to DB.
-		$data = WC_Order_Stats::summarize_orders( $order1_time, $order1_time + HOUR_IN_SECONDS );
-		WC_Order_Stats::update( $order1_time, $data );
-		$data = WC_Order_Stats::summarize_orders( $order2_time, $order2_time + HOUR_IN_SECONDS );
-		WC_Order_Stats::update( $order2_time, $data );
-
-		// Test querying by hourly intervals.
-		$stats = WC_Order_Stats::query( $start_time, $end_time );
-		$first_hour_stats = $stats[0];
-		$expected_first_hour_stats = array(
-			'start_time'            => date( 'Y-m-d H:00:00', $order1_time ),
-			'num_orders'            => 1,
-			'num_items_sold'        => 4,
-			'orders_gross_total'    => 97,
-			'orders_coupon_total'   => 20,
-			'orders_refund_total'   => 0,
-			'orders_tax_total'      => 7,
-			'orders_shipping_total' => 10,
-			'orders_net_total'      => 80,
-		);
-		$this->assertEquals( $expected_first_hour_stats, $first_hour_stats );
-
-		$second_hour_stats = $stats[1];
-		$expected_second_hour_stats = array(
-			'start_time'            => date( 'Y-m-d H:00:00', $order2_time ),
-			'num_orders'            => 1,
-			'num_items_sold'        => 4,
-			'orders_gross_total'    => 49,
-			'orders_coupon_total'   => 0,
-			'orders_refund_total'   => 0,
-			'orders_tax_total'      => 4,
-			'orders_shipping_total' => 5,
-			'orders_net_total'      => 40,
-		);
-		$this->assertEquals( $expected_second_hour_stats, $second_hour_stats );
-
-		// Test querying by a weekly interval.
-		$stats = WC_Order_Stats::query( $start_time, $end_time, array( 'interval' => 'week' ) );
-		$first_week_stats = $stats[0];
-		$expected_first_week_stats = array(
-			'start_time'            => date( 'Y-m-d H:00:00', $order1_time ),
-			'num_orders'            => '2',
-			'num_items_sold'        => '8',
-			'orders_gross_total'    => '146',
-			'orders_coupon_total'   => '20',
-			'orders_refund_total'   => '0',
-			'orders_tax_total'      => '11',
-			'orders_shipping_total' => '15',
-			'orders_net_total'      => '120',
-		);
-		$this->assertEquals( $expected_first_week_stats, $first_week_stats );
-	}*/
 }

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -39,7 +39,6 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 
 		// /reports/revenue/stats is mapped to Orders_Data_Store.
 		$data_store = new WC_Admin_Reports_Orders_Data_Store();
-		$data_store::update( $order );
 
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );


### PR DESCRIPTION
Same as code in general, tests should also check whether the lookups are updated correctly without explicitly needing to call update on data stores. This PR removes explicit updates on data stores in tests.

### Detailed test instructions:

This branch should test successfully.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
