### PR TITLE
Add customers endpoint to wc-api operations

### DIFF
--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -17,7 +17,7 @@ import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
 // TODO: Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'categories', 'coupons', 'taxes' ];
+const swaggerEndpoints = [ 'categories', 'coupons', 'customers', 'taxes' ];
 
 const typeEndpointMap = {
 	'report-items-query-orders': 'orders',
@@ -27,6 +27,7 @@ const typeEndpointMap = {
 	'report-items-query-coupons': 'coupons',
 	'report-items-query-taxes': 'taxes',
 	'report-items-query-variations': 'variations',
+	'report-items-query-customers': 'customers',
 };
 
 function read( resourceNames, fetch = apiFetch ) {


### PR DESCRIPTION
We merged #1006 (using `wc-api` for endpoints) and #1018 (adding _Customers_ report) in parallel, and I didn't think that would break the _Customers_ report —it's not loading table data in master. :man_facepalming: 

This PR fixes that adding the customers endpoint to `wc-api` operations list.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/49801802-74473b80-fd4b-11e8-9f46-ce8f7c4fe721.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/49801728-3d712580-fd4b-11e8-9a3e-d53ba14c2322.png)


### Detailed test instructions:
- Go to the _Customers_ report.
- Verify table data loads.