### PR TITLE
Fix zero filling when ordered by not-date ASC

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -172,12 +172,17 @@ class WC_Admin_Reports_Data_Store {
 	 * @param int      $db_interval_count Database interval count.
 	 * @param int      $expected_interval_count Expected interval count on the output.
 	 * @param string   $order_by Order by field.
+	 * @param string   $order    Ordering: ASC or DESC.
 	 */
-	protected function remove_extra_records( &$data, $page_no, $items_per_page, $db_interval_count, $expected_interval_count, $order_by ) {
+	protected function remove_extra_records( &$data, $page_no, $items_per_page, $db_interval_count, $expected_interval_count, $order_by, $order ) {
 		if ( 'date' === strtolower( $order_by ) ) {
 			$offset = 0;
 		} else {
-			$offset = ( $page_no - 1 ) * $items_per_page - $db_interval_count;
+			if ( 'asc' === strtolower( $order ) ) {
+				$offset = ( $page_no - 1 ) * $items_per_page;
+			} else {
+				$offset = ( $page_no - 1 ) * $items_per_page - $db_interval_count;
+			}
 			$offset = $offset < 0 ? 0 : $offset;
 		}
 		$count = $expected_interval_count - ( $page_no - 1 ) * $items_per_page;

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -76,6 +76,15 @@ class WC_Admin_Reports_Data_Store {
 			// TODO: should return WP_Error here perhaps?
 		}
 		if ( $a[ $this->order_by ] === $b[ $this->order_by ] ) {
+			// As relative order is undefined in case of equality in usort, second-level sorting by date needs to be enforced
+			// so that paging is stable.
+			if ( $a['time_interval'] === $b['time_interval'] ) {
+				return 0; // This should never happen.
+			} elseif ( $a['time_interval'] > $b['time_interval'] ) {
+				return 1;
+			} elseif ( $a['time_interval'] < $b['time_interval'] ) {
+				return -1;
+			}
 			return 0;
 		} elseif ( $a[ $this->order_by ] > $b[ $this->order_by ] ) {
 			return strtolower( $this->order ) === 'desc' ? -1 : 1;

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -397,7 +397,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			if ( $this->intervals_missing( $expected_interval_count, $db_interval_count, $intervals_query['per_page'], $query_args['page'], $query_args['order'], $query_args['orderby'], count( $intervals ) ) ) {
 				$this->fill_in_missing_intervals( $db_intervals, $query_args['adj_after'], $query_args['adj_before'], $query_args['interval'], $data );
 				$this->sort_intervals( $data, $query_args['orderby'], $query_args['order'] );
-				$this->remove_extra_records( $data, $query_args['page'], $intervals_query['per_page'], $db_interval_count, $expected_interval_count, $query_args['orderby'] );
+				$this->remove_extra_records( $data, $query_args['page'], $intervals_query['per_page'], $db_interval_count, $expected_interval_count, $query_args['orderby'], $query_args['order'] );
 			} else {
 				$this->update_interval_boundary_dates( $query_args['after'], $query_args['before'], $query_args['interval'], $data->intervals );
 			}


### PR DESCRIPTION
Fixes #1012 

Removing extra intervals after zero-filling was not using correct offset in case of ordering by something other than date in ascending order.

### Screenshots

### Detailed test instructions:

Make sure zero-filling works correctly using different ordering:
- by date desc
- by date asc
- by [sth else] desc
- by [sth else] asc

In all cases test multiple scenarios, e.g. when the db records are first/last on page 1 of 1, when db records are first/last on page 1/2 of 2, etc. 


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
