### PR TITLE
Add autolabeler to automatically label PRs

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,3 @@
+Packages: [ "/packages/*", "lerna.json" ]
+Components: /packages/components
+Build: [ "/.*", "*.config.js", "bin/*", "composer.json", "Gruntfile.js",  "lerna.json", "package.json" ]


### PR DESCRIPTION
This PR configures [autolabeler](https://github.com/probot/autolabeler) to automatically label PRs with edits to matched files. This sets up the following rules:

- Any changes to `/packages` adds the **Packages** label
- Any changes to `/packages/components` adds the **Components** label
- Any changes to config or build process files adds the **Build** label

We could probably automate a few others, like **REST API**, **Documentation**, etc– but the **Components** & **Packages** labels are most important so we can track changes between release versions.