### PR TITLE
Fix screen reader label IDs

### DIFF
--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -140,7 +140,7 @@ class Table extends Component {
 						<tr>
 							{ headers.map( ( header, i ) => {
 								const { cellClassName, isLeftAligned, isSortable, isNumeric, key, label, screenReaderLabel } = header;
-								const labelId = `header-${ instanceId } -${ i }`;
+								const labelId = `header-${ instanceId }-${ i }`;
 								const thProps = {
 									className: classnames( 'woocommerce-table__header', cellClassName, {
 										'is-left-aligned': isLeftAligned,


### PR DESCRIPTION
Fixes #1068 

Tiny fix for the space in the screen reader text ID.

### Before
<img width="452" alt="screen shot 2018-12-12 at 11 30 06 am" src="https://user-images.githubusercontent.com/10561050/49848750-8ab7ca80-fe11-11e8-82d2-c23e21036056.png">

### After
<img width="390" alt="screen shot 2018-12-12 at 1 26 24 pm" src="https://user-images.githubusercontent.com/10561050/49848754-8be8f780-fe11-11e8-8ad9-484b02bea468.png">

### Detailed test instructions:

Open any report page and inspect to make sure the space has been removed in the `screen-reader-text` ID.
