### PR TITLE
Sync order status on refund delete

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -95,6 +95,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		// TODO: this is required as order update skips save_post.
 		add_action( 'clean_post_cache', array( __CLASS__, 'sync_order' ) );
 		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'sync_order' ) );
+		add_action( 'woocommerce_refund_deleted', array( __CLASS__, 'sync_on_refund_delete' ), 10, 2 );
 
 		if ( ! self::$background_process ) {
 			self::$background_process = new WC_Admin_Order_Stats_Background_Process();
@@ -412,6 +413,16 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		self::update( $order );
+	}
+
+	/**
+	 * Syncs order information when a refund is deleted.
+	 *
+	 * @param int $refund_id Refund ID.
+	 * @param int $order_id Order ID.
+	 */
+	public static function sync_on_refund_delete( $refund_id, $order_id ) {
+		self::sync_order( $order_id );
 	}
 
 	/**

--- a/includes/wc-admin-order-functions.php
+++ b/includes/wc-admin-order-functions.php
@@ -99,6 +99,17 @@ function wc_admin_get_order_refund_items( $order ) {
 }
 
 /**
+ * Runs the sync function for order product lookup table on refund delete.
+ *
+ * @param int $refund_id Refund ID.
+ * @param int $order_id Order ID.
+ */
+function wc_admin_order_product_sync_on_refund_delete( $refund_id, $order_id ) {
+	wc_admin_order_product_lookup_entry( $order_id );
+}
+add_action( 'woocommerce_refund_deleted', 'wc_admin_order_product_sync_on_refund_delete', 10, 2 );
+
+/**
  * Make an entry in the wc_order_tax_lookup table for an order.
  *
  * @since 3.5.0


### PR DESCRIPTION
Fixes #1073 

Updates order stats after manually deleting a refund.

### Screenshots
<img width="1190" alt="screen shot 2018-12-12 at 3 38 39 pm" src="https://user-images.githubusercontent.com/10561050/49859717-37567400-fe33-11e8-8155-d65438adb32a.png">

### Detailed test instructions:

#### Order stats

1.  Add a refund to any order.
2.  Check that the order stats reflect the refund. `/wp-admin/admin.php?page=wc-admin#/analytics/orders`
3.  Delete the refund using the 'x' on the order page.
4.  Check that the order stats are updated to reflect the refund being removed.

#### Product stats

1.  Add a refund to any order.
2.  Check that the order stats reflect the refund. `/wp-admin/admin.php?page=wc-admin#/analytics/products`
3.  Delete the refund using the 'x' on the order page.
4.  Check that the product stats are updated to reflect the refund being removed.
