### PR TITLE
Extend customers table data with data from WC endpoint

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -85,8 +85,9 @@ ReportTable.propTypes = {
 	 */
 	endpoint: PropTypes.string,
 	/**
-	 * Method names used to load more data for table items. If omitted, no call will
-	 * be made and only the data returned by the reports endpoint will be used.
+	 * Name of the methods available via `select( 'wc-api' )` that will be used to
+	 * load more data for table items. If omitted, no call will be made and only
+	 * the data returned by the reports endpoint will be used.
 	 */
 	extendItemsMethodNames: PropTypes.shape( {
 		isError: PropTypes.string,

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -5,7 +5,7 @@
 import { applyFilters } from '@wordpress/hooks';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { first, get, orderBy } from 'lodash';
+import { get, orderBy } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -20,6 +20,7 @@ import { onQueryChange } from '@woocommerce/navigation';
 import ReportError from 'analytics/components/report-error';
 import { getReportChartData, getReportTableData } from 'store/reports/utils';
 import withSelect from 'wc-api/with-select';
+import { extendTableData } from './utils';
 
 const TABLE_FILTER = 'woocommerce_admin_report_table';
 
@@ -129,56 +130,6 @@ ReportTable.propTypes = {
 ReportTable.defaultProps = {
 	tableData: {},
 	tableQuery: {},
-};
-
-const extendTableData = ( select, props, queriedTableData ) => {
-	const { extendItemsMethodNames, itemIdField, query } = props;
-	const itemsData = queriedTableData.items.data;
-	if (
-		! Array.isArray( itemsData ) ||
-		! itemsData.length ||
-		! extendItemsMethodNames ||
-		! itemIdField
-	) {
-		return queriedTableData;
-	}
-
-	const {
-		[ extendItemsMethodNames.isError ]: isErrorMethod,
-		[ extendItemsMethodNames.isRequesting ]: isRequestingMethod,
-		[ extendItemsMethodNames.load ]: loadMethod,
-	} = select( 'wc-api' );
-	const extendQuery = {
-		include: itemsData.map( item => item[ itemIdField ] ).join( ',' ),
-		per_page: itemsData.length,
-		...query,
-	};
-	const extendedItems = loadMethod( extendQuery );
-	const isExtendedItemsRequesting = isRequestingMethod ? isRequestingMethod( extendQuery ) : false;
-	const isExtendedItemsError = isErrorMethod ? isErrorMethod( extendQuery ) : false;
-
-	const extendedItemsData = itemsData.map( item => {
-		const extendedItemData = first(
-			extendedItems.filter( extendedItem => item.id === extendedItem.id )
-		);
-		return {
-			...item,
-			...extendedItemData,
-		};
-	} );
-
-	const isRequesting = queriedTableData.isRequesting || isExtendedItemsRequesting;
-	const isError = queriedTableData.isError || isExtendedItemsError;
-
-	return {
-		...queriedTableData,
-		isRequesting,
-		isError,
-		items: {
-			...queriedTableData.items,
-			data: extendedItemsData,
-		},
-	};
 };
 
 export default compose(

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -90,7 +90,7 @@ ReportTable.propTypes = {
 	 * the data returned by the reports endpoint will be used.
 	 */
 	extendItemsMethodNames: PropTypes.shape( {
-		isError: PropTypes.string,
+		getError: PropTypes.string,
 		isRequesting: PropTypes.string,
 		load: PropTypes.string,
 	} ),

--- a/client/analytics/components/report-table/utils.js
+++ b/client/analytics/components/report-table/utils.js
@@ -5,7 +5,7 @@
 import { first } from 'lodash';
 
 export function extendTableData( select, props, queriedTableData ) {
-	const { extendItemsMethodNames, itemIdField, query } = props;
+	const { extendItemsMethodNames, itemIdField } = props;
 	const itemsData = queriedTableData.items.data;
 	if (
 		! Array.isArray( itemsData ) ||
@@ -24,7 +24,6 @@ export function extendTableData( select, props, queriedTableData ) {
 	const extendQuery = {
 		include: itemsData.map( item => item[ itemIdField ] ).join( ',' ),
 		per_page: itemsData.length,
-		...query,
 	};
 	const extendedItems = loadMethod( extendQuery );
 	const isExtendedItemsRequesting = isRequestingMethod ? isRequestingMethod( extendQuery ) : false;

--- a/client/analytics/components/report-table/utils.js
+++ b/client/analytics/components/report-table/utils.js
@@ -1,0 +1,55 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { first } from 'lodash';
+
+export function extendTableData( select, props, queriedTableData ) {
+	const { extendItemsMethodNames, itemIdField, query } = props;
+	const itemsData = queriedTableData.items.data;
+	if (
+		! Array.isArray( itemsData ) ||
+		! itemsData.length ||
+		! extendItemsMethodNames ||
+		! itemIdField
+	) {
+		return queriedTableData;
+	}
+
+	const {
+		[ extendItemsMethodNames.isError ]: isErrorMethod,
+		[ extendItemsMethodNames.isRequesting ]: isRequestingMethod,
+		[ extendItemsMethodNames.load ]: loadMethod,
+	} = select( 'wc-api' );
+	const extendQuery = {
+		include: itemsData.map( item => item[ itemIdField ] ).join( ',' ),
+		per_page: itemsData.length,
+		...query,
+	};
+	const extendedItems = loadMethod( extendQuery );
+	const isExtendedItemsRequesting = isRequestingMethod ? isRequestingMethod( extendQuery ) : false;
+	const isExtendedItemsError = isErrorMethod ? isErrorMethod( extendQuery ) : false;
+
+	const extendedItemsData = itemsData.map( item => {
+		const extendedItemData = first(
+			extendedItems.filter( extendedItem => item.id === extendedItem.id )
+		);
+		return {
+			...item,
+			...extendedItemData,
+		};
+	} );
+
+	const isRequesting = queriedTableData.isRequesting || isExtendedItemsRequesting;
+	const isError = queriedTableData.isError || isExtendedItemsError;
+
+	return {
+		...queriedTableData,
+		isRequesting,
+		isError,
+		items: {
+			...queriedTableData.items,
+			data: extendedItemsData,
+		},
+	};
+}

--- a/client/analytics/components/report-table/utils.js
+++ b/client/analytics/components/report-table/utils.js
@@ -17,7 +17,7 @@ export function extendTableData( select, props, queriedTableData ) {
 	}
 
 	const {
-		[ extendItemsMethodNames.isError ]: isErrorMethod,
+		[ extendItemsMethodNames.getError ]: getErrorMethod,
 		[ extendItemsMethodNames.isRequesting ]: isRequestingMethod,
 		[ extendItemsMethodNames.load ]: loadMethod,
 	} = select( 'wc-api' );
@@ -27,7 +27,7 @@ export function extendTableData( select, props, queriedTableData ) {
 	};
 	const extendedItems = loadMethod( extendQuery );
 	const isExtendedItemsRequesting = isRequestingMethod ? isRequestingMethod( extendQuery ) : false;
-	const isExtendedItemsError = isErrorMethod ? isErrorMethod( extendQuery ) : false;
+	const isExtendedItemsError = getErrorMethod ? getErrorMethod( extendQuery ) : false;
 
 	const extendedItemsData = itemsData.map( item => {
 		const extendedItemData = first(

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -99,18 +99,19 @@ export default class CustomersReportTable extends Component {
 		return customers.map( customer => {
 			const {
 				average_order_value,
-				id,
-				city,
-				country,
+				billing,
 				date_last_active,
 				date_sign_up,
 				email,
-				name,
+				first_name,
+				id,
+				last_name,
 				orders_count,
-				postal_code,
 				username,
 				total_spend,
 			} = customer;
+			const { postcode, city, country } = billing || {};
+			const name = `${ first_name } ${ last_name }`;
 
 			const customerNameLink = (
 				<Link href={ 'user-edit.php?user_id=' + id } type="wp-admin">
@@ -160,8 +161,8 @@ export default class CustomersReportTable extends Component {
 					value: city,
 				},
 				{
-					display: postal_code,
-					value: postal_code,
+					display: postcode,
+					value: postcode,
 				},
 			];
 		} );
@@ -174,6 +175,11 @@ export default class CustomersReportTable extends Component {
 			<ReportTable
 				compareBy="customers"
 				endpoint="customers"
+				extendItemsMethodNames={ {
+					load: 'getCustomers',
+					isError: 'isGetCustomersError',
+					isRequesting: 'isGetCustomersRequesting',
+				} }
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				itemIdField="id"

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -66,7 +66,7 @@ export default class CustomersReportTable extends Component {
 			{
 				label: __( 'AOV', 'wc-admin' ),
 				screenReaderLabel: __( 'Average Order Value', 'wc-admin' ),
-				key: 'average_order_value',
+				key: 'avg_order_value',
 				isNumeric: true,
 			},
 			{
@@ -98,7 +98,7 @@ export default class CustomersReportTable extends Component {
 
 		return customers.map( customer => {
 			const {
-				average_order_value,
+				avg_order_value,
 				billing,
 				date_last_active,
 				date_sign_up,
@@ -145,8 +145,8 @@ export default class CustomersReportTable extends Component {
 					value: getCurrencyFormatDecimal( total_spend ),
 				},
 				{
-					display: average_order_value,
-					value: getCurrencyFormatDecimal( average_order_value ),
+					display: formatCurrency( avg_order_value ),
+					value: getCurrencyFormatDecimal( avg_order_value ),
 				},
 				{
 					display: formatDate( formats.tableFormat, date_last_active ),

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -177,7 +177,7 @@ export default class CustomersReportTable extends Component {
 				endpoint="customers"
 				extendItemsMethodNames={ {
 					load: 'getCustomers',
-					isError: 'isGetCustomersError',
+					isError: 'getCustomersError',
 					isRequesting: 'isGetCustomersRequesting',
 				} }
 				getHeadersContent={ this.getHeadersContent }

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -177,7 +177,7 @@ export default class CustomersReportTable extends Component {
 				endpoint="customers"
 				extendItemsMethodNames={ {
 					load: 'getCustomers',
-					isError: 'getCustomersError',
+					getError: 'getCustomersError',
 					isRequesting: 'isGetCustomersRequesting',
 				} }
 				getHeadersContent={ this.getHeadersContent }

--- a/client/wc-api/customers/index.js
+++ b/client/wc-api/customers/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/customers/operations.js
+++ b/client/wc-api/customers/operations.js
@@ -1,0 +1,47 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { isResourcePrefix, getResourceIdentifier, getResourceName } from '../utils';
+import { NAMESPACE } from '../constants';
+
+function read( resourceNames, fetch = apiFetch ) {
+	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'customers-query' ) );
+
+	return filteredNames.map( async resourceName => {
+		const query = getResourceIdentifier( resourceName );
+		const url = `${ NAMESPACE }/customers${ stringifyQuery( query ) }`;
+
+		try {
+			const customers = await fetch( { path: url } );
+			const ids = customers.map( customer => customer.id );
+			const customerResources = customers.reduce( ( resources, customer ) => {
+				resources[ getResourceName( 'customer', customer.id ) ] = { data: customer };
+				return resources;
+			}, {} );
+
+			return {
+				[ resourceName ]: {
+					data: ids,
+				},
+				...customerResources,
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/customers/selectors.js
+++ b/client/wc-api/customers/selectors.js
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+import { DEFAULT_REQUIREMENT } from '../constants';
+
+const getCustomers = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'customers-query', query );
+	const ids = requireResource( requirement, resourceName ).data || [];
+	return ids.map( id => getResource( getResourceName( 'customer', id ) ).data || {} );
+};
+
+const isGetCustomersRequesting = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'customers-query', query );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+const isGetCustomersError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'customers-query', query );
+	return getResource( resourceName ).error;
+};
+
+export default {
+	getCustomers,
+	isGetCustomersRequesting,
+	isGetCustomersError,
+};

--- a/client/wc-api/customers/selectors.js
+++ b/client/wc-api/customers/selectors.js
@@ -20,6 +20,11 @@ const getCustomers = ( getResource, requireResource ) => (
 	return ids.map( id => getResource( getResourceName( 'customer', id ) ).data || {} );
 };
 
+const getCustomersError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'customers-query', query );
+	return getResource( resourceName ).error;
+};
+
 const isGetCustomersRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'customers-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
@@ -31,13 +36,8 @@ const isGetCustomersRequesting = getResource => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isGetCustomersError = getResource => ( query = {} ) => {
-	const resourceName = getResourceName( 'customers-query', query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getCustomers,
+	getCustomersError,
 	isGetCustomersRequesting,
-	isGetCustomersError,
 };

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import customers from './customers';
 import notes from './notes';
 import orders from './orders';
 import reportItems from './reports/items';
@@ -11,6 +12,7 @@ import reportStats from './reports/stats';
 function createWcApiSpec() {
 	return {
 		selectors: {
+			...customers.selectors,
 			...notes.selectors,
 			...orders.selectors,
 			...reportItems.selectors,
@@ -19,6 +21,7 @@ function createWcApiSpec() {
 		operations: {
 			read( resourceNames ) {
 				return [
+					...customers.operations.read( resourceNames ),
 					...notes.operations.read( resourceNames ),
 					...orders.operations.read( resourceNames ),
 					...reportItems.operations.read( resourceNames ),


### PR DESCRIPTION
Part of #918.

This PR adds the ability to the _Customers_ report table to request extended info for each customer using a WC endpoint. It adds a prop to the `<ReportTable>` component named `extendItemsMethodNames`. This prop allows passing a method name that will be used to load more data for each table item. Then, `<ReportTable>` takes care of merging the data from both endpoints.

### Open Questions
The designs display columns for _Country_, _City_ and _Postal Code_, but those values might be different between the Shipping and the Billing addresses. In this PR I'm using the values from the Billing address, thoughts @LevinMedia?

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/49872420-44666980-fe19-11e8-96c2-b7bf1c0d052e.png)

### Detailed test instructions:
Given that we are loading some data from the SwaggerHub endpoint and some other from a WC endpoint, we will have to make one id from both data sets match. That can be done adding this line:
```ES6
itemsData[ 0 ].id = 18;
```
to `client/analytics/components/report-table/utils.js` [line 24](https://github.com/woocommerce/wc-admin/pull/1075/files#diff-7f79b9a09cecd84c214c6ecd1e88433cR24). You will have to modify `18` with a real user id you can get from editing a profile in `/wp-admin/users.php`.

- Go to the _Customers_ report and verify all columns are filled.
- Verify there are no regressions in other reports.