### PR TITLE
Change renovate to a once-weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
     "config:base"
   ],
   "lockFileMaintenance": { "enabled": true },
-  "ignoreDeps": ["phpunit/phpunit"]
+  "ignoreDeps": ["phpunit/phpunit"],
+  "schedule": ["before 3am on wednesday"]
 }


### PR DESCRIPTION
This updates the renovate config [to use a weekly schedule](https://renovatebot.com/docs/configuration-options/#schedule). This means, I think, that renovate will only check for package updates once a week, between 12am-3am UTC each Wednesday.

I think this'll make the porter's job a bit easier, since renovate PRs will only be coming in one day, you can test/merge them all at once. It's set to Wednesday to allow for catch-up on mon/tue, but we can change the day if we want.

If renovate is still too noisy with scheduling, we could also try [Package Grouping,](https://renovatebot.com/docs/noise-reduction/) but they warn this makes it harder to track down breaking packages.

**To test**

I think we just need to merge and hope? If it works, we shouldn't hear from renovate until next Wednesday.