### PR TITLE
Add alert when wc-admin build does not exist.

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -50,6 +50,15 @@ function wc_admin_plugins_notice() {
 }
 
 /**
+ * Notify users that the plugin needs to be built
+ */
+function wc_admin_build_notice() {
+	echo '<div class="error"><p>';
+	esc_html_e( 'WooCommerce Admin development mode requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm start</code> to build the files and watch for changes.', 'wc-admin' );
+	echo '</p></div>';
+}
+
+/**
  * Returns true if all dependencies for the wc-admin plugin are loaded.
  *
  * @return bool
@@ -65,6 +74,15 @@ function dependencies_satisfied() {
 	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
 
 	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
+}
+
+/**
+ * Returns true if build file exists.
+ *
+ * @return bool
+ */
+function wc_admin_build_file_exists() {
+	return file_exists( plugin_dir_path( __FILE__ ) . '/dist/app/index.js' );
 }
 
 /**
@@ -123,7 +141,7 @@ function wc_admin_init() {
 	}
 
 	// Only create/update tables on init if WP_DEBUG is true.
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG && wc_admin_build_file_exists() ) {
 		WC_Admin_Api_Init::create_db_tables();
 	}
 }
@@ -135,6 +153,12 @@ add_action( 'init', 'wc_admin_init' );
 function wc_admin_plugins_loaded() {
 	if ( ! dependencies_satisfied() ) {
 		add_action( 'admin_notices', 'wc_admin_plugins_notice' );
+		return;
+	}
+
+	// Verify we have a proper build.
+	if ( ! wc_admin_build_file_exists() && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		add_action( 'admin_notices', 'wc_admin_build_notice' );
 		return;
 	}
 

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -53,7 +53,7 @@ function wc_admin_plugins_notice() {
  * Notify users that the plugin needs to be built
  */
 function wc_admin_build_notice() {
-	$message_one = __( 'You have installed a development version WooCommerce Admin which requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files.', 'wc-admin' );
+	$message_one = __( 'You have installed a development version of WooCommerce Admin which requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files.', 'wc-admin' );
 	$message_two = sprintf(
 		/* translators: 1: URL of GitHub Repository build page */
 		__( 'Or you can download a pre-built version of the plugin by visiting <a href="%1$s">the releases page in the repository</a>.', 'wc-admin' ),
@@ -166,6 +166,11 @@ function wc_admin_plugins_loaded() {
 	// Some common utilities.
 	require_once dirname( __FILE__ ) . '/lib/common.php';
 
+	// Admin note providers.
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-new-sales-record.php';
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-settings-notes.php';
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-woo-subscriptions-notes.php';
+
 	// Verify we have a proper build.
 	if ( ! wc_admin_build_file_exists() ) {
 		add_action( 'admin_notices', 'wc_admin_build_notice' );
@@ -177,11 +182,6 @@ function wc_admin_plugins_loaded() {
 
 	// Create the Admin pages.
 	require_once dirname( __FILE__ ) . '/lib/admin.php';
-
-	// Admin note providers.
-	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-new-sales-record.php';
-	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-settings-notes.php';
-	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-notes-woo-subscriptions-notes.php';
 }
 add_action( 'plugins_loaded', 'wc_admin_plugins_loaded' );
 

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -53,9 +53,13 @@ function wc_admin_plugins_notice() {
  * Notify users that the plugin needs to be built
  */
 function wc_admin_build_notice() {
-	echo '<div class="error"><p>';
-	esc_html_e( 'WooCommerce Admin development mode requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm start</code> to build the files and watch for changes.', 'wc-admin' );
-	echo '</p></div>';
+	$message_one = __( 'You have installed a development version WooCommerce Admin which requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files.', 'wc-admin' );
+	$message_two = sprintf(
+		/* translators: 1: URL of GitHub Repository build page */
+		__( 'Or you can download a pre-built version of the plugin by visiting <a href="%1$s">the releases page in the repository</a>.', 'wc-admin' ),
+		'https://github.com/woocommerce/wc-admin/releases'
+	);
+	printf( '<div class="error"><p>%s %s</p></div>', $message_one, $message_two ); /* WPCS: xss ok. */
 }
 
 /**
@@ -156,17 +160,17 @@ function wc_admin_plugins_loaded() {
 		return;
 	}
 
-	// Verify we have a proper build.
-	if ( ! wc_admin_build_file_exists() && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-		add_action( 'admin_notices', 'wc_admin_build_notice' );
-		return;
-	}
-
 	// Initialize the WC API extensions.
 	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-api-init.php';
 
 	// Some common utilities.
 	require_once dirname( __FILE__ ) . '/lib/common.php';
+
+	// Verify we have a proper build.
+	if ( ! wc_admin_build_file_exists() ) {
+		add_action( 'admin_notices', 'wc_admin_build_notice' );
+		return;
+	}
 
 	// Register script files.
 	require_once dirname( __FILE__ ) . '/lib/client-assets.php';


### PR DESCRIPTION
Fixes #424 

Currently if the repository is cloned to the plugins directory of a WordPress install, and activated without being built, a variety of errors are shown on the screen. This branch borrows logic from the WooCommerce Blocks repository to display an admin_notice when this happens.

### Screenshots

![dashboard woo test wordpress 2018-12-12 09-53-18](https://user-images.githubusercontent.com/22080/49888860-e6c02600-fdf4-11e8-81c8-ccc5672ac210.png)

Updated after feedback:

![image](https://user-images.githubusercontent.com/22080/49956709-c195eb00-feba-11e8-981e-b2f29b09308f.png)

### Detailed test instructions:

- Simulate wc-admin not being built by either `rm`ing your local build directory or doing a fresh clone with `master`
- Activate the plugin, and verify the files not existing errors are shown
- Apply this patch, verify the admin notice is shown
- run `npm start` and verify wc-admin loads as expected