### PR TITLE
Remove trailing slash on base_dir variable.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -60,7 +60,7 @@ function wc_admin_install() {
  * Adds WooCommerce testing framework classes.
  */
 function wc_test_includes() {
-	$wc_tests_framework_base_dir = wc_dir() . '/tests/';
+	$wc_tests_framework_base_dir = wc_dir() . '/tests';
 
 	// WooCommerce test classes.
 	// Framework.


### PR DESCRIPTION
Fixes #852 

Verify phpunit tests pass either via CI or locally.