### PR TITLE
Add util to packages to fix build.

### DIFF
--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -12,8 +12,7 @@ import { stringifyQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { computeSuggestionMatch } from './utils';
-import { getTaxCode } from 'analytics/report/taxes/utils';
+import { computeSuggestionMatch, getTaxCode } from './utils';
 
 /**
  * A tax completer.

--- a/packages/components/src/search/autocompleters/utils.js
+++ b/packages/components/src/search/autocompleters/utils.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Parse a string suggestion, split apart by where the first matching query is.
  * Used to display matched partial in bold.
  *
@@ -18,4 +23,16 @@ export function computeSuggestionMatch( suggestion, query ) {
 		suggestionMatch: suggestion.substring( indexOfMatch, indexOfMatch + query.length ),
 		suggestionAfterMatch: suggestion.substring( indexOfMatch + query.length ),
 	};
+}
+
+export function getTaxCode( tax ) {
+	return [ tax.country, tax.state, tax.name || __( 'TAX', 'wc-admin' ), tax.priority ]
+		.map( item =>
+			item
+				.toString()
+				.toUpperCase()
+				.trim()
+		)
+		.filter( Boolean )
+		.join( '-' );
 }


### PR DESCRIPTION
This is a follow-up to #1017, which was a re-do of #999 😅 and here I'm adding the `getTaxCode` util method to the utils that are part of the built version of the components to fix the lerna builds ( sorry @ryelle! )

To Test:
Follow the instructions in #999