### PR TITLE
Add `TextControlWithAffixes` component

### DIFF
--- a/client/devdocs/examples.json
+++ b/client/devdocs/examples.json
@@ -23,5 +23,6 @@
   { "component": "Summary", "render": "MySummaryList" },
   { "component": "Table" },
   { "component": "Tag" },
+  { "component": "TextControlWithAffixes" },
   { "component": "ViewMoreList" }
 ]

--- a/docs/components/_sidebar.md
+++ b/docs/components/_sidebar.md
@@ -27,4 +27,5 @@
   * [Summary](components/summary.md)
   * [Table](components/table.md)
   * [Tag](components/tag.md)
+  * [TextControlWithAffixes](components/text-control-with-affixes.md)
   * [ViewMoreList](components/view-more-list.md)

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -65,6 +65,13 @@ It will display `TablePlaceholder` component instead of `Table` if that's the ca
 
 A function which returns a callback function to update the query string for a given `param`.
 
+### `onColumnsChange`
+
+- Type: Function
+- Default: `noop`
+
+A function which returns a callback function which is called upon the user changing the visiblity of columns.
+
 ### `downloadable`
 
 - Type: Boolean

--- a/docs/components/text-control-with-affixes.md
+++ b/docs/components/text-control-with-affixes.md
@@ -1,0 +1,71 @@
+Text Control With Affixes
+============================
+
+This component is essentially a wrapper (really a reimplementation) around the TextControl component that adds support for affixes, i.e. the ability to display a fixed part either at the beginning or at the end of the text input.
+
+
+
+Props
+-----
+
+The set of props accepted by the component will be specified below.
+Props not included in this set will be applied to the input element.
+
+### `label`
+
+If this property is added, a label will be generated using label property as the content.
+
+- Type: `String`
+
+### `help`
+
+If this property is added, a help text will be generated using help property as the content.
+
+- Type: `String`
+
+### `type`
+
+Type of the input element to render. Defaults to "text".
+
+- Type: `String`
+- Default: "text"
+
+### `value`
+
+The current value of the input.
+
+- **Required**
+- Type: `String`
+
+### `className`
+
+The class that will be added with "components-base-control" to the classes of the wrapper div.
+If no className is passed only components-base-control is used.
+
+- Type: `String`
+
+### `onChange`
+
+A function that receives the value of the input.
+
+- **Required**
+- Type: `function`
+
+### `prefix`
+
+Markup to be inserted at the beginning of the input.
+
+- Type: ReactNode
+
+### `suffix`
+
+Markup to be appended at the end of the input.
+
+- Type: ReactNode
+
+### `noWrap`
+
+A flag that prevents the prefix and suffix from wrapping when the component is displayed on small viewports. This basically disables the corresponding breakpoint.
+
+- Type: Boolean
+- Default: null

--- a/docs/components/text-control-with-affixes.md
+++ b/docs/components/text-control-with-affixes.md
@@ -1,64 +1,69 @@
-Text Control With Affixes
-============================
+`TextControlWithAffixes` (component)
+====================================
 
-This component is essentially a wrapper (really a reimplementation) around the TextControl component that adds support for affixes, i.e. the ability to display a fixed part either at the beginning or at the end of the text input.
-
-
+This component is essentially a wrapper (really a reimplementation) around the
+TextControl component that adds support for affixes, i.e. the ability to display
+a fixed part either at the beginning or at the end of the text input.
 
 Props
 -----
 
-The set of props accepted by the component will be specified below.
-Props not included in this set will be applied to the input element.
-
 ### `label`
+
+- Type: String
+- Default: null
 
 If this property is added, a label will be generated using label property as the content.
 
-- Type: `String`
-
 ### `help`
+
+- Type: String
+- Default: null
 
 If this property is added, a help text will be generated using help property as the content.
 
-- Type: `String`
-
 ### `type`
+
+- Type: String
+- Default: `'text'`
 
 Type of the input element to render. Defaults to "text".
 
-- Type: `String`
-- Default: "text"
-
 ### `value`
+
+- **Required**
+- Type: String
+- Default: null
 
 The current value of the input.
 
-- **Required**
-- Type: `String`
-
 ### `className`
+
+- Type: String
+- Default: null
 
 The class that will be added with "components-base-control" to the classes of the wrapper div.
 If no className is passed only components-base-control is used.
 
-- Type: `String`
-
 ### `onChange`
+
+- **Required**
+- Type: Function
+- Default: null
 
 A function that receives the value of the input.
 
-- **Required**
-- Type: `function`
-
 ### `prefix`
+
+- Type: ReactNode
+- Default: null
 
 Markup to be inserted at the beginning of the input.
 
-- Type: ReactNode
-
 ### `suffix`
+
+- Type: ReactNode
+- Default: null
 
 Markup to be appended at the end of the input.
 
-- Type: ReactNode

--- a/docs/components/text-control-with-affixes.md
+++ b/docs/components/text-control-with-affixes.md
@@ -62,10 +62,3 @@ Markup to be inserted at the beginning of the input.
 Markup to be appended at the end of the input.
 
 - Type: ReactNode
-
-### `noWrap`
-
-A flag that prevents the prefix and suffix from wrapping when the component is displayed on small viewports. This basically disables the corresponding breakpoint.
-
-- Type: Boolean
-- Default: null

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -45,5 +45,6 @@ export { default as EmptyTable } from './table/empty';
 export { default as TablePlaceholder } from './table/placeholder';
 export { default as TableSummary } from './table/summary';
 export { default as Tag } from './tag';
+export { default as TextControlWithAffixes } from './text-control-with-affixes';
 export { default as useFilters } from './higher-order/use-filters';
 export { default as ViewMoreList } from './view-more-list';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -28,4 +28,5 @@
 @import 'summary/style.scss';
 @import 'table/style.scss';
 @import 'tag/style.scss';
+@import 'text-control-with-affixes/style.scss';
 @import 'view-more-list/style.scss';

--- a/packages/components/src/text-control-with-affixes/example.md
+++ b/packages/components/src/text-control-with-affixes/example.md
@@ -1,0 +1,21 @@
+```jsx
+import { TextControlWithAffixes } from '@woocommerce/components';
+
+const MyTextControlWithAffixes = () => (
+    <div>
+        <TextControlWithAffixes
+            prefix="Prefix"
+            placeholder="Placeholder text..."
+        />
+        <TextControlWithAffixes
+            prefix="Prefix"
+            suffix="Suffix"
+            placeholder="Placeholder text..."
+        />
+        <TextControlWithAffixes
+            suffix="Suffix"
+            placeholder="Placeholder text..."
+        />
+    </div>
+);
+```

--- a/packages/components/src/text-control-with-affixes/example.md
+++ b/packages/components/src/text-control-with-affixes/example.md
@@ -5,26 +5,41 @@ const MyTextControlWithAffixes = withState( {
 	first: '',
 	second: '',
 	third: '',
-} )( ( { first, second, third, setState } ) => (
+	fourth: '',
+	fifth: '',
+} )( ( { first, second, third, fourth, fifth, setState } ) => (
 	<div>
 		<TextControlWithAffixes
-			prefix="Prefix"
-			placeholder="Placeholder text..."
+			label="Text field without affixes"
 			value={ first }
+			placeholder="Placeholder"
 			onChange={ value => setState( { first: value } ) }
 		/>
 		<TextControlWithAffixes
-			prefix="Prefix"
-			suffix="Suffix"
-			placeholder="Placeholder text..."
+			prefix="$"
+			label="Text field with a prefix"
 			value={ second }
 			onChange={ value => setState( { second: value } ) }
 		/>
 		<TextControlWithAffixes
+			prefix="Prefix"
 			suffix="Suffix"
-			placeholder="Placeholder text..."
+			label="Text field with both affixes"
 			value={ third }
 			onChange={ value => setState( { third: value } ) }
+		/>
+		<TextControlWithAffixes
+			suffix="%"
+			label="Text field with a suffix"
+			value={ fourth }
+			onChange={ value => setState( { fourth: value } ) }
+		/>
+		<TextControlWithAffixes
+			prefix="$"
+			label="Text field with prefix and help text"
+			value={ fifth }
+			onChange={ value => setState( { fifth: value } ) }
+			help="This is some help text."
 		/>
 	</div>
 ) );

--- a/packages/components/src/text-control-with-affixes/example.md
+++ b/packages/components/src/text-control-with-affixes/example.md
@@ -3,29 +3,29 @@ import { TextControlWithAffixes } from '@woocommerce/components';
 
 const MyTextControlWithAffixes = withState( {
 	first: '',
-    second: '',
-    third: '',
+	second: '',
+	third: '',
 } )( ( { first, second, third, setState } ) => (
-    <div>
-        <TextControlWithAffixes
-            prefix="Prefix"
-            placeholder="Placeholder text..."
-            value={ first }
-            onChange={ value => setState( { first: value } ) }
-        />
-        <TextControlWithAffixes
-            prefix="Prefix"
-            suffix="Suffix"
-            placeholder="Placeholder text..."
-            value={ second }
-            onChange={ value => setState( { second: value } ) }
-        />
-        <TextControlWithAffixes
-            suffix="Suffix"
-            placeholder="Placeholder text..."
-            value={ third }
-            onChange={ value => setState( { third: value } ) }
-        />
-    </div>
+	<div>
+		<TextControlWithAffixes
+			prefix="Prefix"
+			placeholder="Placeholder text..."
+			value={ first }
+			onChange={ value => setState( { first: value } ) }
+		/>
+		<TextControlWithAffixes
+			prefix="Prefix"
+			suffix="Suffix"
+			placeholder="Placeholder text..."
+			value={ second }
+			onChange={ value => setState( { second: value } ) }
+		/>
+		<TextControlWithAffixes
+			suffix="Suffix"
+			placeholder="Placeholder text..."
+			value={ third }
+			onChange={ value => setState( { third: value } ) }
+		/>
+	</div>
 ) );
 ```

--- a/packages/components/src/text-control-with-affixes/example.md
+++ b/packages/components/src/text-control-with-affixes/example.md
@@ -1,21 +1,31 @@
 ```jsx
 import { TextControlWithAffixes } from '@woocommerce/components';
 
-const MyTextControlWithAffixes = () => (
+const MyTextControlWithAffixes = withState( {
+	first: '',
+    second: '',
+    third: '',
+} )( ( { first, second, third, setState } ) => (
     <div>
         <TextControlWithAffixes
             prefix="Prefix"
             placeholder="Placeholder text..."
+            value={ first }
+            onChange={ value => setState( { first: value } ) }
         />
         <TextControlWithAffixes
             prefix="Prefix"
             suffix="Suffix"
             placeholder="Placeholder text..."
+            value={ second }
+            onChange={ value => setState( { second: value } ) }
         />
         <TextControlWithAffixes
             suffix="Suffix"
             placeholder="Placeholder text..."
+            value={ third }
+            onChange={ value => setState( { third: value } ) }
         />
     </div>
-);
+) );
 ```

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -13,82 +13,82 @@ import { withInstanceId } from '@wordpress/compose';
  * a fixed part either at the beginning or at the end of the text input.
  */
 class TextControlWithAffixes extends Component {
-    render() {
-        const {
-            label,
-            value,
-            help,
-            className,
-            instanceId,
-            onChange,
-            prefix,
-            suffix,
-            type,
-            ...props
-        } = this.props;
+	render() {
+		const {
+			label,
+			value,
+			help,
+			className,
+			instanceId,
+			onChange,
+			prefix,
+			suffix,
+			type,
+			...props
+		} = this.props;
 
-        const id = `inspector-text-control-with-affixes-${ instanceId }`;
-        const onChangeValue = ( event ) => onChange( event.target.value );
+		const id = `inspector-text-control-with-affixes-${ instanceId }`;
+		const onChangeValue = ( event ) => onChange( event.target.value );
 
-        return (
-            <BaseControl label={ label } id={ id } help={ help } className={ className }>
-                <div className="text-control-with-affixes">
-                    { prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
+		return (
+			<BaseControl label={ label } id={ id } help={ help } className={ className }>
+				<div className="text-control-with-affixes">
+					{ prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
 
-                    <input className="components-text-control__input"
-                        type={ type }
-                        id={ id }
-                        value={ value }
-                        onChange={ onChangeValue }
-                        aria-describedby={ !! help ? id + '__help' : undefined }
-                        { ...props }
-                    />
+					<input className="components-text-control__input"
+						type={ type }
+						id={ id }
+						value={ value }
+						onChange={ onChangeValue }
+						aria-describedby={ !! help ? id + '__help' : undefined }
+						{ ...props }
+					/>
 
-                    { suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
-                </div>
-            </BaseControl>
-        );
-    }
+					{ suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
+				</div>
+			</BaseControl>
+		);
+	}
 }
 
 TextControlWithAffixes.defaultProps = {
-    type: 'text',
+	type: 'text',
 };
 
 TextControlWithAffixes.propTypes = {
-    /**
-     * If this property is added, a label will be generated using label property as the content.
-     */
-    label: PropTypes.string,
-    /**
-     * If this property is added, a help text will be generated using help property as the content.
-     */
-    help: PropTypes.string,
-    /**
-     * Type of the input element to render. Defaults to "text".
-     */
-    type: PropTypes.string,
-    /**
-     * The current value of the input.
-     */
-    value: PropTypes.string.isRequired,
-    /**
-     * The class that will be added with "components-base-control" to the classes of the wrapper div.
-     * If no className is passed only components-base-control is used.
-     */
-    className: PropTypes.string,
-    /**
-     * A function that receives the value of the input.
-     */
-    onChange: PropTypes.func.isRequired,
-    /**
-     * Markup to be inserted at the beginning of the input.
-     */
-    prefix: PropTypes.node,
-    /**
-     * Markup to be appended at the end of the input.
-     */
-    suffix: PropTypes.node,
+	/**
+	 * If this property is added, a label will be generated using label property as the content.
+	 */
+	label: PropTypes.string,
+	/**
+	 * If this property is added, a help text will be generated using help property as the content.
+	 */
+	help: PropTypes.string,
+	/**
+	 * Type of the input element to render. Defaults to "text".
+	 */
+	type: PropTypes.string,
+	/**
+	 * The current value of the input.
+	 */
+	value: PropTypes.string.isRequired,
+	/**
+	 * The class that will be added with "components-base-control" to the classes of the wrapper div.
+	 * If no className is passed only components-base-control is used.
+	 */
+	className: PropTypes.string,
+	/**
+	 * A function that receives the value of the input.
+	 */
+	onChange: PropTypes.func.isRequired,
+	/**
+	 * Markup to be inserted at the beginning of the input.
+	 */
+	prefix: PropTypes.node,
+	/**
+	 * Markup to be appended at the end of the input.
+	 */
+	suffix: PropTypes.node,
 };
 
 export default withInstanceId( TextControlWithAffixes );

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -4,7 +4,6 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { BaseControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -17,7 +16,6 @@ class TextControlWithAffixes extends Component {
             className,
             instanceId,
             onChange,
-            noWrap,
             prefix,
             suffix,
             type = 'text',
@@ -29,7 +27,7 @@ class TextControlWithAffixes extends Component {
 
         return (
             <BaseControl label={ label } id={ id } help={ help } className={ className }>
-                <div className={ classNames( 'text-control-with-affixes', { 'no-wrap': noWrap } ) }>
+                <div className="text-control-with-affixes">
                     { prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
 
                     <input className="components-text-control__input"
@@ -49,7 +47,6 @@ class TextControlWithAffixes extends Component {
 }
 
 TextControlWithAffixes.propTypes = {
-    noWrap: PropTypes.bool,
     prefix: PropTypes.node,
     suffix: PropTypes.node,
 };

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -1,0 +1,32 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { TextControl } from '@wordpress/components';
+
+class TextControlWithAffixes extends Component {
+	render() {
+		const { noWrap, prefix, suffix, ...rest } = this.props;
+
+		return (
+			<div className={ classNames( 'text-control-with-affixes', { 'no-wrap': noWrap } ) }>
+				{ prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
+
+				<TextControl { ...rest } />
+
+				{ suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
+			</div>
+		);
+	}
+}
+
+TextControlWithAffixes.propTypes = {
+    noWrap: PropTypes.bool,
+    prefix: PropTypes.node,
+    suffix: PropTypes.node,
+};
+
+export default TextControlWithAffixes;

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -5,22 +5,47 @@
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TextControl } from '@wordpress/components';
+import { BaseControl } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
 
 class TextControlWithAffixes extends Component {
-	render() {
-		const { noWrap, prefix, suffix, ...rest } = this.props;
+    render() {
+        const {
+            label,
+            value,
+            help,
+            className,
+            instanceId,
+            onChange,
+            noWrap,
+            prefix,
+            suffix,
+            type = 'text',
+            ...props
+        } = this.props;
 
-		return (
-			<div className={ classNames( 'text-control-with-affixes', { 'no-wrap': noWrap } ) }>
-				{ prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
+        const id = `inspector-text-control-with-affixes-${ instanceId }`;
+        const onChangeValue = ( event ) => onChange( event.target.value );
 
-				<TextControl { ...rest } />
+        return (
+            <BaseControl label={ label } id={ id } help={ help } className={ className }>
+                <div className={ classNames( 'text-control-with-affixes', { 'no-wrap': noWrap } ) }>
+                    { prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
 
-				{ suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
-			</div>
-		);
-	}
+                    <input className="components-text-control__input"
+                        type={ type }
+                        id={ id }
+                        value={ value }
+                        onChange={ onChangeValue }
+                        aria-describedby={ !! help ? id + '__help' : undefined }
+                        { ...props }
+                    />
+
+                    { suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
+                </div>
+            </BaseControl>
+        );
+    }
 }
 
 TextControlWithAffixes.propTypes = {
@@ -29,4 +54,4 @@ TextControlWithAffixes.propTypes = {
     suffix: PropTypes.node,
 };
 
-export default TextControlWithAffixes;
+export default withInstanceId( TextControlWithAffixes );

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -29,22 +29,47 @@ class TextControlWithAffixes extends Component {
 
 		const id = `inspector-text-control-with-affixes-${ instanceId }`;
 		const onChangeValue = ( event ) => onChange( event.target.value );
+		const describedby = [];
+		if ( help ) {
+			describedby.push( `${ id }__help` );
+		}
+		if ( prefix ) {
+			describedby.push( `${ id }__prefix` );
+		}
+		if ( suffix ) {
+			describedby.push( `${ id }__suffix` );
+		}
 
 		return (
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
 				<div className="text-control-with-affixes">
-					{ prefix && <span className="text-control-with-affixes__prefix">{ prefix }</span> }
+					{ prefix && (
+						<span
+							id={ `${ id }__prefix` }
+							className="text-control-with-affixes__prefix"
+						>
+							{ prefix }
+						</span>
+					) }
 
-					<input className="components-text-control__input"
+					<input
+						className="components-text-control__input"
 						type={ type }
 						id={ id }
 						value={ value }
 						onChange={ onChangeValue }
-						aria-describedby={ !! help ? id + '__help' : undefined }
+						aria-describedby={ describedby.join( ' ' ) }
 						{ ...props }
 					/>
 
-					{ suffix && <span className="text-control-with-affixes__suffix">{ suffix }</span> }
+					{ suffix && (
+						<span
+							id={ `${ id }__suffix` }
+							className="text-control-with-affixes__suffix"
+						>
+							{ suffix }
+						</span>
+					) }
 				</div>
 			</BaseControl>
 		);

--- a/packages/components/src/text-control-with-affixes/index.js
+++ b/packages/components/src/text-control-with-affixes/index.js
@@ -7,6 +7,11 @@ import PropTypes from 'prop-types';
 import { BaseControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 
+/**
+ * This component is essentially a wrapper (really a reimplementation) around the
+ * TextControl component that adds support for affixes, i.e. the ability to display
+ * a fixed part either at the beginning or at the end of the text input.
+ */
 class TextControlWithAffixes extends Component {
     render() {
         const {
@@ -18,7 +23,7 @@ class TextControlWithAffixes extends Component {
             onChange,
             prefix,
             suffix,
-            type = 'text',
+            type,
             ...props
         } = this.props;
 
@@ -46,8 +51,43 @@ class TextControlWithAffixes extends Component {
     }
 }
 
+TextControlWithAffixes.defaultProps = {
+    type: 'text',
+};
+
 TextControlWithAffixes.propTypes = {
+    /**
+     * If this property is added, a label will be generated using label property as the content.
+     */
+    label: PropTypes.string,
+    /**
+     * If this property is added, a help text will be generated using help property as the content.
+     */
+    help: PropTypes.string,
+    /**
+     * Type of the input element to render. Defaults to "text".
+     */
+    type: PropTypes.string,
+    /**
+     * The current value of the input.
+     */
+    value: PropTypes.string.isRequired,
+    /**
+     * The class that will be added with "components-base-control" to the classes of the wrapper div.
+     * If no className is passed only components-base-control is used.
+     */
+    className: PropTypes.string,
+    /**
+     * A function that receives the value of the input.
+     */
+    onChange: PropTypes.func.isRequired,
+    /**
+     * Markup to be inserted at the beginning of the input.
+     */
     prefix: PropTypes.node,
+    /**
+     * Markup to be appended at the end of the input.
+     */
     suffix: PropTypes.node,
 };
 

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -2,13 +2,47 @@
 	display: inline-flex;
 	flex-direction: column;
     width: 100%;
+
+    :nth-child(1) {
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+    }
+
+    :nth-last-child(1) {
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
     
     &.no-wrap {
-		flex-direction: row;
-	}
+        flex-direction: row;
+        
+        :nth-child(1) {
+            border-top-right-radius: 0;
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+        }
+    
+        :nth-last-child(1) {
+            border-bottom-left-radius: 0;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
+    }
 
-    @include breakpoint( ">320px" ) {
-		flex-direction: row;
+    @include breakpoint( ">400px" ) {
+        flex-direction: row;
+        
+        :nth-child(1) {
+            border-top-right-radius: 0;
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
+        }
+    
+        :nth-last-child(1) {
+            border-bottom-left-radius: 0;
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
     }
 
     input[type="email"],
@@ -37,15 +71,11 @@
 }
 
 @mixin no-prefix-wrap() {
-	border-bottom-left-radius: 4px;
 	border-right: none;
-	border-top-right-radius: 0;
 }
 
 @mixin no-suffix-wrap() {
-	border-bottom-left-radius: 0;
 	border-left: none;
-	border-top-right-radius: 4px;
 }
 
 .text-control-with-affixes__prefix,
@@ -62,10 +92,7 @@
 }
 
 .text-control-with-affixes__prefix {
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-
-	@include breakpoint( "<320px" ) {
+	@include breakpoint( "<400px" ) {
 		:not( .no-wrap ) > & {
 			border-bottom: none;
 		}
@@ -75,7 +102,7 @@
 		@include no-prefix-wrap();
 	}
 
-	@include breakpoint( ">320px" ) {
+	@include breakpoint( ">400px" ) {
 		@include no-prefix-wrap();
 	}
 
@@ -92,10 +119,7 @@
 }
 
 .text-control-with-affixes__suffix {
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
-
-	@include breakpoint( "<320px" ) {
+	@include breakpoint( "<400px" ) {
 		:not( .no-wrap ) > & {
 			border-top: none;
 		}
@@ -105,7 +129,7 @@
 		@include no-suffix-wrap();
 	}
 
-	@include breakpoint( ">320px" ) {
+	@include breakpoint( ">400px" ) {
 		@include no-suffix-wrap();
     }
 }

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -1,49 +1,19 @@
 .text-control-with-affixes {
 	display: inline-flex;
-	flex-direction: column;
+	flex-direction: row;
     width: 100%;
 
-    :nth-child(1) {
-        border-top-left-radius: 4px;
-        border-top-right-radius: 4px;
-    }
+	:nth-child(1) {
+		border-top-right-radius: 0;
+		border-top-left-radius: 4px;
+		border-bottom-left-radius: 4px;
+	}
 
-    :nth-last-child(1) {
-        border-bottom-left-radius: 4px;
-        border-bottom-right-radius: 4px;
-    }
-    
-    &.no-wrap {
-        flex-direction: row;
-        
-        :nth-child(1) {
-            border-top-right-radius: 0;
-            border-top-left-radius: 4px;
-            border-bottom-left-radius: 4px;
-        }
-    
-        :nth-last-child(1) {
-            border-bottom-left-radius: 0;
-            border-top-right-radius: 4px;
-            border-bottom-right-radius: 4px;
-        }
-    }
-
-    @include breakpoint( ">400px" ) {
-        flex-direction: row;
-        
-        :nth-child(1) {
-            border-top-right-radius: 0;
-            border-top-left-radius: 4px;
-            border-bottom-left-radius: 4px;
-        }
-    
-        :nth-last-child(1) {
-            border-bottom-left-radius: 0;
-            border-top-right-radius: 4px;
-            border-bottom-right-radius: 4px;
-        }
-    }
+	:nth-last-child(1) {
+		border-bottom-left-radius: 0;
+		border-top-right-radius: 4px;
+		border-bottom-right-radius: 4px;
+	}
 
     input[type="email"],
     input[type="password"],
@@ -63,18 +33,10 @@
     }
 }
 
-@mixin no-prefix-wrap() {
-	border-right: none;
-}
-
-@mixin no-suffix-wrap() {
-	border-left: none;
-}
-
 .text-control-with-affixes__prefix,
 .text-control-with-affixes__suffix {
 	position: relative;
-	background: $core-grey-light-100;
+	background: $white;
 	border: 1px solid $core-grey-light-500;
 	color: $gray-text;
 	padding: 7px 14px;
@@ -85,19 +47,7 @@
 }
 
 .text-control-with-affixes__prefix {
-	@include breakpoint( "<400px" ) {
-		:not( .no-wrap ) > & {
-			border-bottom: none;
-		}
-	}
-
-	.no-wrap > & {
-		@include no-prefix-wrap();
-	}
-
-	@include breakpoint( ">400px" ) {
-		@include no-prefix-wrap();
-	}
+	border-right: none;
 
 	& + input[type="email"],
 	& + input[type="password"],
@@ -112,17 +62,5 @@
 }
 
 .text-control-with-affixes__suffix {
-	@include breakpoint( "<400px" ) {
-		:not( .no-wrap ) > & {
-			border-top: none;
-		}
-	}
-
-	.no-wrap > & {
-		@include no-suffix-wrap();
-	}
-
-	@include breakpoint( ">400px" ) {
-		@include no-suffix-wrap();
-    }
+	border-left: none;
 }

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -1,24 +1,25 @@
 .text-control-with-affixes {
 	display: inline-flex;
 	flex-direction: column;
-	width: 100%;
-
-	&.no-wrap {
+    width: 100%;
+    
+    &.no-wrap {
 		flex-direction: row;
 	}
 
-	@include breakpoint( ">480px" ) {
+    @include breakpoint( ">320px" ) {
 		flex-direction: row;
-	}
+    }
 
-	input[type="email"],
-	input[type="password"],
-	input[type="url"],
-	input[type="text"],
-	input[type="number"] {
-		flex-grow: 1;
+    input[type="email"],
+    input[type="password"],
+    input[type="url"],
+    input[type="text"],
+    input[type="number"] {
+        flex-grow: 1;
+        margin: 0;
 
-		&:focus {
+        &:focus {
 			// Fixes the right border of the box shadow displayed when this input element is focused which appears as
 			// cut off when this input has a suffix, or is stuck to another element that has a higher stacking order
 			// (fix found at http://stackoverflow.com/a/24728957)
@@ -29,14 +30,14 @@
 			border-right-width: 0;
 
 			& + .text-control-with-affixes__suffix {
-				border-left: 1px solid $gray-lighten-20;
+				border-left: 1px solid $core-grey-light-500;
 			}
 		}
-	}
+    }
 }
 
 @mixin no-prefix-wrap() {
-	border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 4px;
 	border-right: none;
 	border-top-right-radius: 0;
 }
@@ -44,27 +45,27 @@
 @mixin no-suffix-wrap() {
 	border-bottom-left-radius: 0;
 	border-left: none;
-	border-top-right-radius: 2px;
+	border-top-right-radius: 4px;
 }
 
 .text-control-with-affixes__prefix,
 .text-control-with-affixes__suffix {
 	position: relative;
-	background: $gray-light;
-	border: 1px solid $gray-lighten-20;
-	color: $gray-darken-20;
-	padding: 8px 14px;
+	background: $core-grey-light-100;
+	border: 1px solid $core-grey-light-500;
+	color: $gray-text;
+	padding: 7px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
-	font-size: 16px;
+	font-size: 14px;
 	line-height: 1.5;
 }
 
 .text-control-with-affixes__prefix {
-	border-top-left-radius: 2px;
-	border-top-right-radius: 2px;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( "<320px" ) {
 		:not( .no-wrap ) > & {
 			border-bottom: none;
 		}
@@ -74,7 +75,7 @@
 		@include no-prefix-wrap();
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">320px" ) {
 		@include no-prefix-wrap();
 	}
 
@@ -84,17 +85,17 @@
 	& + input[type="text"],
 	& + input[type="number"] {
 		&:disabled {
-			border-left-color: $gray-lighten-20;
+			border-left-color: $core-grey-light-500;
 			border-right-width: 1px;
 		}
 	}
 }
 
 .text-control-with-affixes__suffix {
-	border-bottom-left-radius: 2px;
-	border-bottom-right-radius: 2px;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( "<320px" ) {
 		:not( .no-wrap ) > & {
 			border-top: none;
 		}
@@ -104,7 +105,7 @@
 		@include no-suffix-wrap();
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">320px" ) {
 		@include no-suffix-wrap();
-	}
+    }
 }

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -1,0 +1,110 @@
+.text-control-with-affixes {
+	display: inline-flex;
+	flex-direction: column;
+	width: 100%;
+
+	&.no-wrap {
+		flex-direction: row;
+	}
+
+	@include breakpoint( ">480px" ) {
+		flex-direction: row;
+	}
+
+	input[type="email"],
+	input[type="password"],
+	input[type="url"],
+	input[type="text"],
+	input[type="number"] {
+		flex-grow: 1;
+
+		&:focus {
+			// Fixes the right border of the box shadow displayed when this input element is focused which appears as
+			// cut off when this input has a suffix, or is stuck to another element that has a higher stacking order
+			// (fix found at http://stackoverflow.com/a/24728957)
+			transform: scale( 1 );
+		}
+
+		&:disabled {
+			border-right-width: 0;
+
+			& + .text-control-with-affixes__suffix {
+				border-left: 1px solid $gray-lighten-20;
+			}
+		}
+	}
+}
+
+@mixin no-prefix-wrap() {
+	border-bottom-left-radius: 2px;
+	border-right: none;
+	border-top-right-radius: 0;
+}
+
+@mixin no-suffix-wrap() {
+	border-bottom-left-radius: 0;
+	border-left: none;
+	border-top-right-radius: 2px;
+}
+
+.text-control-with-affixes__prefix,
+.text-control-with-affixes__suffix {
+	position: relative;
+	background: $gray-light;
+	border: 1px solid $gray-lighten-20;
+	color: $gray-darken-20;
+	padding: 8px 14px;
+	white-space: nowrap;
+	flex: 1 0 auto;
+	font-size: 16px;
+	line-height: 1.5;
+}
+
+.text-control-with-affixes__prefix {
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+
+	@include breakpoint( "<480px" ) {
+		:not( .no-wrap ) > & {
+			border-bottom: none;
+		}
+	}
+
+	.no-wrap > & {
+		@include no-prefix-wrap();
+	}
+
+	@include breakpoint( ">480px" ) {
+		@include no-prefix-wrap();
+	}
+
+	& + input[type="email"],
+	& + input[type="password"],
+	& + input[type="url"],
+	& + input[type="text"],
+	& + input[type="number"] {
+		&:disabled {
+			border-left-color: $gray-lighten-20;
+			border-right-width: 1px;
+		}
+	}
+}
+
+.text-control-with-affixes__suffix {
+	border-bottom-left-radius: 2px;
+	border-bottom-right-radius: 2px;
+
+	@include breakpoint( "<480px" ) {
+		:not( .no-wrap ) > & {
+			border-top: none;
+		}
+	}
+
+	.no-wrap > & {
+		@include no-suffix-wrap();
+	}
+
+	@include breakpoint( ">480px" ) {
+		@include no-suffix-wrap();
+	}
+}

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -1,7 +1,7 @@
 .text-control-with-affixes {
 	display: inline-flex;
 	flex-direction: row;
-    width: 100%;
+	width: 100%;
 
 	:nth-child(1) {
 		border-top-right-radius: 0;
@@ -15,13 +15,13 @@
 		border-bottom-right-radius: 4px;
 	}
 
-    input[type="email"],
-    input[type="password"],
-    input[type="url"],
-    input[type="text"],
-    input[type="number"] {
-        flex-grow: 1;
-        margin: 0;
+	input[type='email'],
+	input[type='password'],
+	input[type='url'],
+	input[type='text'],
+	input[type='number'] {
+		flex-grow: 1;
+		margin: 0;
 
 		&:disabled {
 			border-right-width: 0;
@@ -30,7 +30,7 @@
 				border-left: 1px solid $core-grey-light-500;
 			}
 		}
-    }
+	}
 }
 
 .text-control-with-affixes__prefix,
@@ -49,11 +49,11 @@
 .text-control-with-affixes__prefix {
 	border-right: none;
 
-	& + input[type="email"],
-	& + input[type="password"],
-	& + input[type="url"],
-	& + input[type="text"],
-	& + input[type="number"] {
+	& + input[type='email'],
+	& + input[type='password'],
+	& + input[type='url'],
+	& + input[type='text'],
+	& + input[type='number'] {
 		&:disabled {
 			border-left-color: $core-grey-light-500;
 			border-right-width: 1px;

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -53,13 +53,6 @@
         flex-grow: 1;
         margin: 0;
 
-        &:focus {
-			// Fixes the right border of the box shadow displayed when this input element is focused which appears as
-			// cut off when this input has a suffix, or is stuck to another element that has a higher stacking order
-			// (fix found at http://stackoverflow.com/a/24728957)
-			transform: scale( 1 );
-		}
-
 		&:disabled {
 			border-right-width: 0;
 


### PR DESCRIPTION
Yeah, this branch name isn't great. 😅 

This PR seeks to add a `<TextControlWithAffixes />` component that can be used to implement the currency-prefixed controls in https://github.com/woocommerce/wc-admin/issues/1028. See below:

![](https://user-images.githubusercontent.com/22080/49666582-602ed180-fa0d-11e8-823a-08b018a920fd.png)

The component is essentially a rewrite of [`TextControl`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/text-control) that incorporates the affixes from [`FormTextInputWithAffixes`](https://github.com/Automattic/wp-calypso/tree/master/client/components/forms/form-text-input-with-affixes).

### Screenshots

![screen shot 2018-12-12 at 1 29 56 pm](https://user-images.githubusercontent.com/63922/49897197-ae2f4500-fe12-11e8-8e89-ee6e3d4c7dd1.png)

### Detailed test instructions:

- Open devdocs and scroll to `TextControlWithAffixes`
- Click the component name and review full documentation
- Check that component renders well in multiple viewport sizes and devices
- Modify the example code and try out different props?

_Note: specifically requesting an accessibility review from @ryelle as discussed in Slack_