### PR TITLE
Add column visibility prefs to all tables

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -42,10 +42,8 @@ class ReportTable extends Component {
 		}
 
 		return headers.map( header => {
-			if ( shownKeys.includes( header.key ) ) {
-				return header;
-			}
-			return { ...header, hiddenByDefault: true };
+			const hidden = ! shownKeys.includes( header.key );
+			return { ...header, hiddenByDefault: hidden };
 		} );
 	};
 

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -136,6 +136,7 @@ export default class CategoriesReportTable extends Component {
 				itemIdField="category_id"
 				query={ query }
 				title={ __( 'Categories', 'wc-admin' ) }
+				columnPrefsKey="categories_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -162,6 +162,7 @@ export default class CouponsReportTable extends Component {
 				itemIdField="coupon_id"
 				query={ query }
 				title={ __( 'Coupons', 'wc-admin' ) }
+				columnPrefsKey="coupons_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -179,6 +179,7 @@ export default class CustomersReportTable extends Component {
 				itemIdField="id"
 				query={ query }
 				title={ __( 'Registered Customers', 'wc-admin' ) }
+				columnPrefsKey="customers_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -250,6 +250,7 @@ class OrdersReportTable extends Component {
 				query={ query }
 				tableData={ tableData }
 				title={ __( 'Orders', 'wc-admin' ) }
+				columnPrefsKey="orders_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -178,6 +178,7 @@ export default class VariationsReportTable extends Component {
 					extended_info: true,
 				} }
 				title={ __( 'Variations', 'wc-admin' ) }
+				columnPrefsKey="variations_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -214,6 +214,7 @@ export default class ProductsReportTable extends Component {
 					extended_info: true,
 				} }
 				title={ __( 'Products', 'wc-admin' ) }
+				columnPrefsKey="products_report_columns"
 			/>
 		);
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -154,6 +154,7 @@ export default class TaxesReportTable extends Component {
 				itemIdField="tax_rate_id"
 				query={ query }
 				title={ __( 'Taxes', 'wc-admin' ) }
+				columnPrefsKey="taxes_report_columns"
 			/>
 		);
 	}

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -21,11 +21,16 @@ function readCurrentUserData( resourceNames, fetch ) {
 		return [
 			fetch( { path: url } )
 				.then( user => {
-					const userData = mapValues( user.woocommerce_meta, JSON.parse );
+					const userData = mapValues( user.woocommerce_meta, data => {
+						if ( ! data || 0 === data.length ) {
+							return '';
+						}
+						return JSON.parse( data );
+					} );
 					return { [ 'current-user-data' ]: { data: userData } };
 				} )
 				.catch( error => {
-					return { [ 'current-user-data' ]: { error } };
+					return { [ 'current-user-data' ]: { error: String( error.message ) } };
 				} ),
 		];
 	}
@@ -34,7 +39,16 @@ function readCurrentUserData( resourceNames, fetch ) {
 
 function updateCurrentUserData( resourceNames, data, fetch ) {
 	const resourceName = 'current-user-data';
-	const userDataFields = [ 'revenue_report_columns' ];
+	const userDataFields = [
+		'categories_report_columns',
+		'coupons_report_columns',
+		'customers_report_columns',
+		'orders_report_columns',
+		'products_report_columns',
+		'revenue_report_columns',
+		'taxes_report_columns',
+		'variations_report_columns',
+	];
 
 	if ( resourceNames.includes( resourceName ) ) {
 		const url = '/wp/v2/users/me';

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -20,15 +20,7 @@ function readCurrentUserData( resourceNames, fetch ) {
 
 		return [
 			fetch( { path: url } )
-				.then( user => {
-					const userData = mapValues( user.woocommerce_meta, data => {
-						if ( ! data || 0 === data.length ) {
-							return '';
-						}
-						return JSON.parse( data );
-					} );
-					return { [ 'current-user-data' ]: { data: userData } };
-				} )
+				.then( userToUserDataResource )
 				.catch( error => {
 					return { [ 'current-user-data' ]: { error: String( error.message ) } };
 				} ),
@@ -58,15 +50,23 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 
 		return [
 			fetch( { path: url, method: 'POST', data: user } )
-				.then( updatedUserData => {
-					return { [ resourceName ]: { data: updatedUserData.woocommerce_meta } };
-				} )
+				.then( userToUserDataResource )
 				.catch( error => {
 					return { [ resourceName ]: { error } };
 				} ),
 		];
 	}
 	return [];
+}
+
+function userToUserDataResource( user ) {
+	const userData = mapValues( user.woocommerce_meta, data => {
+		if ( ! data || 0 === data.length ) {
+			return '';
+		}
+		return JSON.parse( data );
+	} );
+	return { [ 'current-user-data' ]: { data: userData } };
 }
 
 export default {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -365,7 +365,14 @@ function wc_admin_register_user_data() {
  */
 function wc_admin_get_user_data_fields() {
 	$user_data_fields = array(
+		'categories_report_columns',
+		'coupons_report_columns',
+		'customers_report_columns',
+		'orders_report_columns',
+		'products_report_columns',
 		'revenue_report_columns',
+		'taxes_report_columns',
+		'variations_report_columns',
 	);
 
 	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );


### PR DESCRIPTION
This adds the column visibility prefs from #1057 to the rest of the analytics tables.

This also has a couple of small fixes:

1. Overrides default hidden columns when a user has set a preference.
2. Better operation handling of response data from API.

# Testing Instructions

1. Go through each table in each report and hide/show columns.
2. Click Refresh and go through each one again to ensure columns are hidden and shown the way you selected previously.
