### PR TITLE
Updating changelogs for npm release.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Update `<Table />` to use header keys to denote which columns are shown
 - Add `onColumnsChange` property to `<Table />` which is called when columns are shown/hidden
 - Add country autocompleter to search component
+- Adding new `<Chart />` component.
+- Added new `showDatePicker` prop to `<Filters />` component which allows to use the filters component without the date picker.
+- Added new customers autocompleter, and added support for using it within 
 
 # 1.2.0
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,10 @@
 - Add country autocompleter to search component
 - Adding new `<Chart />` component.
 - Added new `showDatePicker` prop to `<Filters />` component which allows to use the filters component without the date picker.
-- Added new customers autocompleter, and added support for using it within 
+- Added new taxes and customers autocompleters, and added support for using them within `<Filters />`.
+- Bug fix for `<SummaryNumber />` returning N/A instead of zero.
+- Bug fix for screen reader label IDs in `<Table />` header.
+- Added new component `<TextControlWithAffixes />`.
 
 # 1.2.0
 

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+- Fix missing comma seperator in date inside tooltips.
+
 # 1.0.2
 
 - Add `getChartTypeForQuery` function to ensure chart type is always `bar` or `line`


### PR DESCRIPTION
I am prepping to do a new release of a few of our npm packages, components, and date seem to be the ones that have had changes since the last release.  I tried to go in and backfill some missing changelog entries for the two packages prior to release.
