### PR TITLE
Add Advanced Numerical Value Filter

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -272,6 +272,7 @@ function wc_admin_currency_settings() {
 			'code'      => $code,
 			'precision' => wc_get_price_decimals(),
 			'symbol'    => get_woocommerce_currency_symbol( $code ),
+			'position'  => get_option( 'woocommerce_currency_pos' ),
 		)
 	);
 }

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -27,6 +27,7 @@ import Card from '../../card';
 import Link from '../../link';
 import SelectFilter from './select-filter';
 import SearchFilter from './search-filter';
+import NumberFilter from './number-filter';
 
 const matches = [
 	{ value: 'all', label: __( 'All', 'wc-admin' ) },
@@ -171,6 +172,15 @@ class AdvancedFilters extends Component {
 								) }
 								{ 'Search' === input.component && (
 									<SearchFilter
+										filter={ filter }
+										config={ config.filters[ key ] }
+										onFilterChange={ this.onFilterChange }
+										isEnglish={ isEnglish }
+										query={ query }
+									/>
+								) }
+								{ 'Number' === input.component && (
+									<NumberFilter
 										filter={ filter }
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -10,9 +10,27 @@ import classnames from 'classnames';
 import { _x } from '@wordpress/i18n';
 
 class NumberFilter extends Component {
+	getBetweenString() {
+		return _x(
+			'{{moreThan /}} and {{lessThan /}}',
+			'Numerical range inputs arranged on a single line',
+			'wc-admin'
+		);
+	}
 	getLegend( filter, config ) {
 		const rule = find( config.rules, { value: filter.rule } ) || {};
-		const filterStr = '';
+		let filterStr = filter.value || '';
+
+		if ( 'between' === rule.value ) {
+			const [ moreThan, lessThan ] = filterStr.split( ',' );
+			filterStr = interpolateComponents( {
+				mixedString: this.getBetweenString(),
+				components: {
+					moreThan: <Fragment>{ moreThan }</Fragment>,
+					lessThan: <Fragment>{ lessThan }</Fragment>,
+				},
+			} );
+		}
 
 		return interpolateComponents( {
 			mixedString: config.labels.title,
@@ -57,11 +75,7 @@ class NumberFilter extends Component {
 		};
 
 		return interpolateComponents( {
-			mixedString: _x(
-				'{{moreThan /}} and {{lessThan /}}',
-				'Numerical range inputs arranged on a single line',
-				'wc-admin'
-			),
+			mixedString: this.getBetweenString(),
 			components: {
 				lessThan: (
 					<TextControl
@@ -91,17 +105,17 @@ class NumberFilter extends Component {
 		const children = interpolateComponents( {
 			mixedString: labels.title,
 			components: {
+				rule: (
+					<SelectControl
+						className="woocommerce-filters-advanced__rule"
+						options={ rules }
+						value={ rule }
+						onChange={ partial( onFilterChange, key, 'rule' ) }
+						aria-label={ labels.rule }
+					/>
+				),
 				filter: (
-					<Fragment>
-						<SelectControl
-							className="woocommerce-filters-advanced__rule"
-							options={ rules }
-							value={ rule }
-							onChange={ partial( onFilterChange, key, 'rule' ) }
-							aria-label={ labels.rule }
-						/>
-						<div>{ this.getFilterInput() }</div>
-					</Fragment>
+					<div>{ this.getFilterInput() }</div>
 				),
 			},
 		} );

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -10,29 +10,6 @@ import classnames from 'classnames';
 import { _x } from '@wordpress/i18n';
 
 class NumberFilter extends Component {
-	constructor( { config } ) {
-		super( ...arguments );
-
-		this.rules = config.rules || [
-			{
-				value: 'lessthan',
-				/* translators: Sentence fragment, logical "Less Than" (x < 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
-				label: _x( 'Less Than', 'number', 'wc-admin' ),
-			},
-			{
-				value: 'morethan',
-				/* translators: Sentence fragment, logical "More Than" (x > 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
-				label: _x( 'More Than', 'number', 'wc-admin' ),
-			},
-			{
-				value: 'between',
-				/* eslint-disable-next-line max-len */
-				/* translators: Sentence fragment, logical "Between" (1 < x < 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
-				label: _x( 'Between', 'number', 'wc-admin' ),
-			},
-		];
-	}
-
 	getLegend( filter, config ) {
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		const filterStr = '';
@@ -79,7 +56,11 @@ class NumberFilter extends Component {
 		};
 
 		return interpolateComponents( {
-			mixedString: '{{moreThan /}} and {{lessThan /}}',
+			mixedString: _x(
+				'{{moreThan /}} and {{lessThan /}}',
+				'Numerical range inputs arranged on a single line',
+				'wc-admin'
+			),
 			components: {
 				lessThan: (
 					<TextControl
@@ -102,7 +83,7 @@ class NumberFilter extends Component {
 	render() {
 		const { config, filter, onFilterChange, isEnglish } = this.props;
 		const { key, rule } = filter;
-		const { labels } = config;
+		const { labels, rules } = config;
 
 		const children = interpolateComponents( {
 			mixedString: labels.title,
@@ -111,7 +92,7 @@ class NumberFilter extends Component {
 					<Fragment>
 						<SelectControl
 							className="woocommerce-filters-advanced__rule"
-							options={ this.rules }
+							options={ rules }
 							value={ rule }
 							onChange={ partial( onFilterChange, key, 'rule' ) }
 							aria-label={ labels.rule }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -33,6 +33,7 @@ class NumberFilter extends Component {
 
 		return (
 			<TextControl
+				className="woocommerce-filters-advanced__input-numeric-range"
 				type="number"
 				value={ value }
 				onChange={ partial( onFilterChange, filter.key, 'value' ) }
@@ -64,6 +65,7 @@ class NumberFilter extends Component {
 			components: {
 				lessThan: (
 					<TextControl
+						className="woocommerce-filters-advanced__input-numeric-range"
 						type="number"
 						value={ lessThan }
 						onChange={ lessThanOnChange }
@@ -71,6 +73,7 @@ class NumberFilter extends Component {
 				),
 				moreThan: (
 					<TextControl
+						className="woocommerce-filters-advanced__input-numeric-range"
 						type="number"
 						value={ moreThan }
 						onChange={ moreThanOnChange }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -4,10 +4,15 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { SelectControl, TextControl } from '@wordpress/components';
-import { find, partial } from 'lodash';
+import { get, find, partial } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
 import { _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import TextControlWithAffixes from '../../text-control-with-affixes';
 
 class NumberFilter extends Component {
 	getBetweenString() {
@@ -42,15 +47,24 @@ class NumberFilter extends Component {
 	}
 
 	getFilterInput() {
-		const { filter, onFilterChange } = this.props;
+		const { config, filter, onFilterChange } = this.props;
 		const { rule, value } = filter;
+		const inputType = get( config, [ 'input', 'type' ], 'number' );
 
 		if ( 'between' === rule ) {
 			return this.getRangeInput();
 		}
 
 		return (
-			<TextControl
+			'currency' === inputType
+			? <TextControlWithAffixes
+				prefix="$"
+				className="woocommerce-filters-advanced__input-numeric-range"
+				type="number"
+				value={ value }
+				onChange={ partial( onFilterChange, filter.key, 'value' ) }
+			/>
+			: <TextControl
 				className="woocommerce-filters-advanced__input-numeric-range"
 				type="number"
 				value={ value }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -1,0 +1,143 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { SelectControl, TextControl } from '@wordpress/components';
+import { find, partial } from 'lodash';
+import interpolateComponents from 'interpolate-components';
+import classnames from 'classnames';
+import { _x } from '@wordpress/i18n';
+
+class NumberFilter extends Component {
+	constructor( { config } ) {
+		super( ...arguments );
+
+		this.rules = config.rules || [
+			{
+				value: 'lessthan',
+				/* translators: Sentence fragment, logical "Less Than" (x < 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
+				label: _x( 'Less Than', 'number', 'wc-admin' ),
+			},
+			{
+				value: 'morethan',
+				/* translators: Sentence fragment, logical "More Than" (x > 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
+				label: _x( 'More Than', 'number', 'wc-admin' ),
+			},
+			{
+				value: 'between',
+				/* eslint-disable-next-line max-len */
+				/* translators: Sentence fragment, logical "Between" (1 < x < 10). Screenshot for context: https://cloudup.com/cZaDYBpzqsN */
+				label: _x( 'Between', 'number', 'wc-admin' ),
+			},
+		];
+	}
+
+	getLegend( filter, config ) {
+		const rule = find( config.rules, { value: filter.rule } ) || {};
+		const filterStr = '';
+
+		return interpolateComponents( {
+			mixedString: config.labels.title,
+			components: {
+				filter: <span>{ filterStr }</span>,
+				rule: <span>{ rule.label }</span>,
+			},
+		} );
+	}
+
+	getFilterInput() {
+		const { filter, onFilterChange } = this.props;
+		const { rule, value } = filter;
+
+		if ( 'between' === rule ) {
+			return this.getRangeInput();
+		}
+
+		return (
+			<TextControl
+				type="number"
+				value={ value }
+				onChange={ partial( onFilterChange, filter.key, 'value' ) }
+			/>
+		);
+	}
+
+	getRangeInput() {
+		const { filter, onFilterChange } = this.props;
+		const { value } = filter;
+		const [ moreThan, lessThan ] = ( value || '' ).split( ',' );
+
+		const moreThanOnChange = ( newMoreThan ) => {
+			const newValue = [ newMoreThan, lessThan ].join( ',' );
+			onFilterChange( filter.key, 'value', newValue );
+		};
+
+		const lessThanOnChange = ( newLessThan ) => {
+			const newValue = [ moreThan, newLessThan ].join( ',' );
+			onFilterChange( filter.key, 'value', newValue );
+		};
+
+		return interpolateComponents( {
+			mixedString: '{{moreThan /}} and {{lessThan /}}',
+			components: {
+				lessThan: (
+					<TextControl
+						type="number"
+						value={ lessThan }
+						onChange={ lessThanOnChange }
+					/>
+				),
+				moreThan: (
+					<TextControl
+						type="number"
+						value={ moreThan }
+						onChange={ moreThanOnChange }
+					/>
+				),
+			},
+		} );
+	}
+
+	render() {
+		const { config, filter, onFilterChange, isEnglish } = this.props;
+		const { key, rule } = filter;
+		const { labels } = config;
+
+		const children = interpolateComponents( {
+			mixedString: labels.title,
+			components: {
+				filter: (
+					<Fragment>
+						<SelectControl
+							className="woocommerce-filters-advanced__rule"
+							options={ this.rules }
+							value={ rule }
+							onChange={ partial( onFilterChange, key, 'rule' ) }
+							aria-label={ labels.rule }
+						/>
+						<div>{ this.getFilterInput() }</div>
+					</Fragment>
+				),
+			},
+		} );
+		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
+		return (
+			<fieldset tabIndex="0">
+				<legend className="screen-reader-text">
+					{ this.getLegend( filter, config ) }
+				</legend>
+				<div
+					className={ classnames( 'woocommerce-filters-advanced__fieldset', {
+						'is-english': isEnglish,
+					} ) }
+				>
+					{ children }
+				</div>
+			</fieldset>
+		);
+		/*eslint-enable jsx-a11y/no-noninteractive-tabindex*/
+	}
+}
+
+export default NumberFilter;

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -13,6 +13,7 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
+import { formatCurrency } from '../../../../currency/src';
 
 class NumberFilter extends Component {
 	getBetweenString() {
@@ -24,11 +25,18 @@ class NumberFilter extends Component {
 	}
 
 	getLegend( filter, config ) {
+		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let filterStr = filter.value || '';
 
 		if ( 'between' === rule.value ) {
-			const [ moreThan, lessThan ] = filterStr.split( ',' );
+			let [ moreThan, lessThan ] = filterStr.split( ',' );
+
+			if ( 'currency' === inputType ) {
+				moreThan = formatCurrency( moreThan );
+				lessThan = formatCurrency( lessThan );
+			}
+
 			filterStr = interpolateComponents( {
 				mixedString: this.getBetweenString(),
 				components: {
@@ -36,6 +44,8 @@ class NumberFilter extends Component {
 					lessThan: <Fragment>{ lessThan }</Fragment>,
 				},
 			} );
+		} else if ( 'currency' === inputType ) { // need to format a single input value as currency
+			filterStr = formatCurrency( filterStr );
 		}
 
 		return interpolateComponents( {

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -18,7 +18,7 @@ import { formatCurrency } from '../../../../currency/src';
 class NumberFilter extends Component {
 	getBetweenString() {
 		return _x(
-			'{{moreThan /}} and {{lessThan /}}',
+			'{{moreThan /}}{{span}}and{{/span}}{{lessThan /}}',
 			'Numerical range inputs arranged on a single line',
 			'wc-admin'
 		);
@@ -42,6 +42,7 @@ class NumberFilter extends Component {
 				components: {
 					moreThan: <Fragment>{ moreThan }</Fragment>,
 					lessThan: <Fragment>{ lessThan }</Fragment>,
+					span: <Fragment />,
 				},
 			} );
 		} else if ( 'currency' === inputType ) { // need to format a single input value as currency
@@ -66,14 +67,14 @@ class NumberFilter extends Component {
 				0 === symbolPosition.indexOf( 'right' )
 				? <TextControlWithAffixes
 					suffix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
-					className="woocommerce-filters-advanced__input-numeric-range"
+					className="woocommerce-filters-advanced__input"
 					type="number"
 					value={ value }
 					onChange={ onChange }
 				/>
 				: <TextControlWithAffixes
 					prefix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
-					className="woocommerce-filters-advanced__input-numeric-range"
+					className="woocommerce-filters-advanced__input"
 					type="number"
 					value={ value }
 					onChange={ onChange }
@@ -83,7 +84,7 @@ class NumberFilter extends Component {
 
 		return (
 			<TextControl
-				className="woocommerce-filters-advanced__input-numeric-range"
+				className="woocommerce-filters-advanced__input"
 				type="number"
 				value={ value }
 				onChange={ onChange }
@@ -136,6 +137,7 @@ class NumberFilter extends Component {
 			components: {
 				lessThan: this.getFormControl( inputType, lessThan, lessThanOnChange ),
 				moreThan: this.getFormControl( inputType, moreThan, moreThanOnChange ),
+				span: <span className="separator" />,
 			},
 		} );
 	}
@@ -158,7 +160,13 @@ class NumberFilter extends Component {
 					/>
 				),
 				filter: (
-					<div>{ this.getFilterInputs() }</div>
+					<div
+						className={ classnames( 'woocommerce-filters-advanced__input-numeric-range', {
+							'is-between': 'between' === rule,
+						} ) }
+					>
+						{ this.getFilterInputs() }
+					</div>
 				),
 			},
 		} );

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -48,18 +48,31 @@ class NumberFilter extends Component {
 	}
 
 	getFormControl( type, value, onChange ) {
-		const currencySymbol = get( wcSettings, [ 'currency', 'symbol' ] );
+		if ( 'currency' === type ) {
+			const currencySymbol = get( wcSettings, [ 'currency', 'symbol' ] );
+			const symbolPosition = get( wcSettings, [ 'currency', 'position' ] );
+
+			return (
+				0 === symbolPosition.indexOf( 'right' )
+				? <TextControlWithAffixes
+					suffix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
+					className="woocommerce-filters-advanced__input-numeric-range"
+					type="number"
+					value={ value }
+					onChange={ onChange }
+				/>
+				: <TextControlWithAffixes
+					prefix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
+					className="woocommerce-filters-advanced__input-numeric-range"
+					type="number"
+					value={ value }
+					onChange={ onChange }
+				/>
+			);
+		}
 
 		return (
-			'currency' === type
-			? <TextControlWithAffixes
-				prefix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
-				className="woocommerce-filters-advanced__input-numeric-range"
-				type="number"
-				value={ value }
-				onChange={ onChange }
-			/>
-			: <TextControl
+			<TextControl
 				className="woocommerce-filters-advanced__input-numeric-range"
 				type="number"
 				value={ value }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -22,6 +22,7 @@ class NumberFilter extends Component {
 			'wc-admin'
 		);
 	}
+
 	getLegend( filter, config ) {
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let filterStr = filter.value || '';
@@ -46,7 +47,28 @@ class NumberFilter extends Component {
 		} );
 	}
 
-	getFilterInput() {
+	getFormControl( type, value, onChange ) {
+		const currencySymbol = get( wcSettings, [ 'currency', 'symbol' ] );
+
+		return (
+			'currency' === type
+			? <TextControlWithAffixes
+				prefix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
+				className="woocommerce-filters-advanced__input-numeric-range"
+				type="number"
+				value={ value }
+				onChange={ onChange }
+			/>
+			: <TextControl
+				className="woocommerce-filters-advanced__input-numeric-range"
+				type="number"
+				value={ value }
+				onChange={ onChange }
+			/>
+		);
+	}
+
+	getFilterInputs() {
 		const { config, filter, onFilterChange } = this.props;
 		const { rule, value } = filter;
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
@@ -55,26 +77,16 @@ class NumberFilter extends Component {
 			return this.getRangeInput();
 		}
 
-		return (
-			'currency' === inputType
-			? <TextControlWithAffixes
-				prefix="$"
-				className="woocommerce-filters-advanced__input-numeric-range"
-				type="number"
-				value={ value }
-				onChange={ partial( onFilterChange, filter.key, 'value' ) }
-			/>
-			: <TextControl
-				className="woocommerce-filters-advanced__input-numeric-range"
-				type="number"
-				value={ value }
-				onChange={ partial( onFilterChange, filter.key, 'value' ) }
-			/>
+		return this.getFormControl(
+			inputType,
+			value,
+			partial( onFilterChange, filter.key, 'value' )
 		);
 	}
 
 	getRangeInput() {
-		const { filter, onFilterChange } = this.props;
+		const { config, filter, onFilterChange } = this.props;
+		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const { value } = filter;
 		const [ moreThan, lessThan ] = ( value || '' ).split( ',' );
 
@@ -91,22 +103,8 @@ class NumberFilter extends Component {
 		return interpolateComponents( {
 			mixedString: this.getBetweenString(),
 			components: {
-				lessThan: (
-					<TextControl
-						className="woocommerce-filters-advanced__input-numeric-range"
-						type="number"
-						value={ lessThan }
-						onChange={ lessThanOnChange }
-					/>
-				),
-				moreThan: (
-					<TextControl
-						className="woocommerce-filters-advanced__input-numeric-range"
-						type="number"
-						value={ moreThan }
-						onChange={ moreThanOnChange }
-					/>
-				),
+				lessThan: this.getFormControl( inputType, lessThan, lessThanOnChange ),
+				moreThan: this.getFormControl( inputType, moreThan, moreThanOnChange ),
 			},
 		} );
 	}
@@ -129,7 +127,7 @@ class NumberFilter extends Component {
 					/>
 				),
 				filter: (
-					<div>{ this.getFilterInput() }</div>
+					<div>{ this.getFilterInputs() }</div>
 				),
 			},
 		} );

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -13,7 +13,7 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
-import { formatCurrency } from '../../../../currency/src';
+import { formatCurrency } from '@woocommerce/currency';
 
 class NumberFilter extends Component {
 	getBetweenString() {

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -77,9 +77,17 @@ class NumberFilter extends Component {
 			return this.getRangeInput();
 		}
 
+		let inputValue = value;
+
+		if ( value && value.indexOf( ',' ) > -1 ) {
+			const [ moreThan, lessThan ] = value.split( ',' );
+			inputValue = 'lessthan' === rule ? lessThan : moreThan;
+			onFilterChange( filter.key, 'value', inputValue );
+		}
+
 		return this.getFormControl(
 			inputType,
-			value,
+			inputValue,
 			partial( onFilterChange, filter.key, 'value' )
 		);
 	}

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -171,3 +171,12 @@
 		}
 	}
 }
+
+.woocommerce-filters-advanced__input-numeric-range {
+	display: inline-block;
+
+	input {
+		height: 38px;
+		border-radius: 4px;
+	}
+}

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -177,6 +177,5 @@
 
 	input {
 		height: 38px;
-		border-radius: 4px;
 	}
 }

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -173,9 +173,24 @@
 }
 
 .woocommerce-filters-advanced__input-numeric-range {
-	display: inline-block;
+	align-items: center;
+	display: grid;
+	grid-template-columns: 1fr;
+
+	&.is-between {
+		grid-template-columns: 1fr 36px 1fr;
+	}
 
 	input {
 		height: 38px;
+		margin: 0;
+	}
+
+	.separator {
+		padding: 0 8px;
+
+		@include breakpoint( '<782px' ) {
+			padding: 0;
+		}
 	}
 }

--- a/packages/components/src/filters/example.md
+++ b/packages/components/src/filters/example.md
@@ -88,6 +88,57 @@ const advancedFilters = {
 				defaultOption: 'new',
 			},
 		},
+		quantity: {
+			labels: {
+				add: 'Item Quantity',
+				remove: 'Remove item quantity filter',
+				rule: 'Select an item quantity filter match',
+				title: 'Item Quantity is {{rule /}} {{filter /}}',
+			},
+			rules: [
+				{
+					value: 'lessthan',
+					label: 'Less Than',
+				},
+				{
+					value: 'morethan',
+					label: 'More Than',
+				},
+				{
+					value: 'between',
+					label: 'Between',
+				},
+			],
+			input: {
+				component: 'Number',
+			},
+		},
+		subtotal: {
+			labels: {
+				add: 'Subtotal',
+				remove: 'Remove subtotal filter',
+				rule: 'Select a subtotal filter match',
+				title: 'Subtotal is {{rule /}} {{filter /}}',
+			},
+			rules: [
+				{
+					value: 'lessthan',
+					label: 'Less Than',
+				},
+				{
+					value: 'morethan',
+					label: 'More Than',
+				},
+				{
+					value: 'between',
+					label: 'Between',
+				},
+			],
+			input: {
+				component: 'Number',
+				type: 'currency',
+			},
+		},
 	},
 };
 

--- a/packages/components/src/text-control-with-affixes/style.scss
+++ b/packages/components/src/text-control-with-affixes/style.scss
@@ -3,18 +3,6 @@
 	flex-direction: row;
 	width: 100%;
 
-	:nth-child(1) {
-		border-top-right-radius: 0;
-		border-top-left-radius: 4px;
-		border-bottom-left-radius: 4px;
-	}
-
-	:nth-last-child(1) {
-		border-bottom-left-radius: 0;
-		border-top-right-radius: 4px;
-		border-bottom-right-radius: 4px;
-	}
-
 	input[type='email'],
 	input[type='password'],
 	input[type='url'],


### PR DESCRIPTION
Fixes #1028.

This PR adds a `'Number'` component type to advanced filtering. It has an optional `type` parameter that can be `'currency'` to create an input affixed with the store's currency symbol.

**Note: this PR removes the rounded corners from `TextControlWithAffixes`.**

### Screenshots

![screen shot 2018-12-14 at 10 00 31 am](https://user-images.githubusercontent.com/63922/50016718-35052e80-ff87-11e8-84dc-404d5588ee77.png)


### Detailed test instructions:

- Go to WooCommerce > Devdocs
- Scroll to Advanced Filters
- Add both "item quantity" and "subtotal" filters
- Note that subtotal inputs have the store's currency symbol (and position respects the store's currency symbol position option (WooCommerce > Settings > General > Currency Position))
- Verify that the query string is sensibly generated based on the input values (note: the "between" mode will comma delimit the two input values)
- Verify that the legend text generated is sensible (check while interacting) 

