### PR TITLE
Add customer email filter

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -101,6 +101,37 @@ export const advancedFilters = {
 				},
 			},
 		},
+		email: {
+			labels: {
+				add: __( 'Email', 'wc-admin' ),
+				placeholder: __( 'Search customer email', 'wc-admin' ),
+				remove: __( 'Remove customer email filter', 'wc-admin' ),
+				rule: __( 'Select a customer email filter match', 'wc-admin' ),
+				/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+				title: __( 'Email {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select customer email', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to customer emails including a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Includes', 'customer emails', 'wc-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to customer emails excluding a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Excludes', 'customer emails', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'emails',
+				getLabels: getRequestByIdString( NAMESPACE + 'customers', customer => ( {
+					id: customer.id,
+					label: customer.email,
+				} ) ),
+			},
+		},
 	},
 };
 /*eslint-enable max-len*/

--- a/includes/api/class-wc-admin-rest-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-customers-controller.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * REST API Customers Controller
+ *
+ * Handles requests to /customers/*
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Customers controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Customers_Controller
+ */
+class WC_Admin_REST_Customers_Controller extends WC_REST_Customers_Controller {
+
+	// TODO Add support for guests here. See https://wp.me/p7bje6-1dM.
+
+	/**
+	 * Searches emails by partial search instead of a strict match.
+	 * See "search parameters" under https://codex.wordpress.org/Class_Reference/WP_User_Query.
+	 *
+	 * @param array $prepared_args Prepared search filter args from the customer endpoint.
+	 * @param array $request Request/query arguments.
+	 * @return array
+	 */
+	public static function update_search_filters( $prepared_args, $request ) {
+		if ( ! empty( $prepared_args['search_columns'] ) && in_array( 'user_email', $prepared_args['search_columns'] ) && empty( $request['name'] ) ) {
+			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
+		}
+
+		return $prepared_args;
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		// Allow partial email matches.
+		$params['email']['format'] = '';
+		return $params;
+	}
+}
+
+add_filter( 'woocommerce_rest_customer_query', array( 'WC_Admin_REST_Customers_Controller', 'update_search_filters' ), 10, 2 );

--- a/includes/api/class-wc-admin-rest-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-customers-controller.php
@@ -28,10 +28,9 @@ class WC_Admin_REST_Customers_Controller extends WC_REST_Customers_Controller {
 	 * @return array
 	 */
 	public static function update_search_filters( $prepared_args, $request ) {
-		if ( ! empty( $prepared_args['search_columns'] ) && in_array( 'user_email', $prepared_args['search_columns'] ) && empty( $request['name'] ) ) {
+		if ( ! empty( $request['email'] ) ) {
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
-
 		return $prepared_args;
 	}
 
@@ -42,7 +41,8 @@ class WC_Admin_REST_Customers_Controller extends WC_REST_Customers_Controller {
 	 */
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
-		// Allow partial email matches.
+		// Allow partial email matches. Previously, this was of format 'email' which required a strict "test@example.com" format.
+		// This, in combination with `update_search_filters` allows us to do partial searches.
 		$params['email']['format'] = '';
 		return $params;
 	}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -76,6 +76,7 @@ class WC_Admin_Api_Init {
 	 */
 	public function rest_api_init() {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-admin-notes-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
@@ -98,6 +99,7 @@ class WC_Admin_Api_Init {
 
 		$controllers = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
+			'WC_Admin_REST_Customers_Controller',
 			'WC_Admin_REST_Products_Controller',
 			'WC_Admin_REST_Product_Reviews_Controller',
 			'WC_Admin_REST_Reports_Controller',
@@ -165,6 +167,17 @@ class WC_Admin_Api_Init {
 		) {
 			$endpoints['/wc/v3/products'][0] = $endpoints['/wc/v3/products'][2];
 			$endpoints['/wc/v3/products'][1] = $endpoints['/wc/v3/products'][3];
+		}
+
+		// Override /wc/v3/customers.
+		if ( isset( $endpoints['/wc/v3/customers'] )
+			&& isset( $endpoints['/wc/v3/customers'][3] )
+			&& isset( $endpoints['/wc/v3/customers'][2] )
+			&& $endpoints['/wc/v3/customers'][2]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
+			&& $endpoints['/wc/v3/customers'][3]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
+		) {
+			$endpoints['/wc/v3/customers'][0] = $endpoints['/wc/v3/customers'][2];
+			$endpoints['/wc/v3/customers'][1] = $endpoints['/wc/v3/customers'][3];
 		}
 
 		// Override /wc/v3/products/$id.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update `<Table />` to use header keys to denote which columns are shown
 - Add `onColumnsChange` property to `<Table />` which is called when columns are shown/hidden
 - Add country autocompleter to search component
+- Add customer email autocompleter to search component
 - Adding new `<Chart />` component.
 - Added new `showDatePicker` prop to `<Filters />` component which allows to use the filters component without the date picker.
 - Added new taxes and customers autocompleters, and added support for using them within `<Filters />`.

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+
+/**
+ * A customer email completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'emails',
+	className: 'woocommerce-search__emails-result',
+	options( search ) {
+		let payload = '';
+		if ( search ) {
+			const query = {
+				email: search,
+				per_page: 10,
+			};
+			payload = stringifyQuery( query );
+		}
+		return apiFetch( { path: `/wc/v3/customers${ payload }` } );
+	},
+	isDebounced: true,
+	getOptionKeywords( customer ) {
+		return [ customer.email ];
+	},
+	getOptionLabel( customer, query ) {
+		const match = computeSuggestionMatch( customer.email, query ) || {};
+		return [
+			<span key="name" className="woocommerce-search__result-name" aria-label={ customer.email }>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( customer ) {
+		const value = {
+			id: customer.id,
+			label: customer.email,
+		};
+		return value;
+	},
+};

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -53,10 +53,9 @@ export default {
 	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
 	// of replace/insertion, so we can just return the value.
 	getOptionCompletion( customer ) {
-		const value = {
+		return {
 			id: customer.id,
 			label: customer.email,
 		};
-		return value;
 	},
 };

--- a/packages/components/src/search/autocompleters/index.js
+++ b/packages/components/src/search/autocompleters/index.js
@@ -5,6 +5,7 @@
 export { default as countries } from './countries';
 export { default as coupons } from './coupons';
 export { default as customers } from './customers';
+export { default as emails } from './emails';
 export { default as product } from './product';
 export { default as productCategory } from './product-cat';
 export { default as variations } from './variations';

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { countries, coupons, customers, product, productCategory, taxes, variations } from './autocompleters';
+import { countries, coupons, customers, emails, product, productCategory, taxes, variations } from './autocompleters';
 import Tag from '../tag';
 
 /**
@@ -72,6 +72,8 @@ class Search extends Component {
 				return coupons;
 			case 'customers':
 				return customers;
+			case 'emails':
+				return emails;
 			case 'products':
 				return product;
 			case 'product_cats':
@@ -213,6 +215,7 @@ Search.propTypes = {
 		'countries',
 		'coupons',
 		'customers',
+		'emails',
 		'orders',
 		'products',
 		'product_cats',


### PR DESCRIPTION
Fixes #1031.

This PR adds a customer email filter to the customer report. There is an API change to allow the `?email=` query string option to accept partial matches instead of a strict email.

Also note that it uses the current `/v3/customers` endpoint, so this will only be registered customer accounts. Once we have an endpoint that supports guests, which should supersede this one -- see p7bje6-1dM-p2, this should support all customers.

### Screenshots

<img width="910" alt="screen shot 2018-12-14 at 10 28 11 am" src="https://user-images.githubusercontent.com/689165/50013046-2110fb00-ff8e-11e8-9570-46ebe01c423e.png">

### Detailed test instructions:

* Open the customers report
* Add an email filter
* Test the autocompleter, make sure emails show up correctly, and that you can select emails.
* Hit filter, and make sure the query string updates
* Refresh, and make sure the previously selected emails show up

