### PR TITLE
Rename 'totalCount' to 'totalResults'

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -74,7 +74,7 @@ class ReportTable extends Component {
 		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
 		const orderedItems = orderBy( items.data, query.orderby, query.order );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
-		const totalCount = items.totalCount || 0;
+		const totalResults = items.totalResults || 0;
 		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
 			endpoint: endpoint,
 			headers: getHeadersContent(),
@@ -82,7 +82,7 @@ class ReportTable extends Component {
 			ids: itemIdField ? orderedItems.map( item => item[ itemIdField ] ) : null,
 			rows: getRowsContent( orderedItems ),
 			totals: totals,
-			summary: getSummary ? getSummary( totals, totalCount ) : null,
+			summary: getSummary ? getSummary( totals, totalResults ) : null,
 		} );
 
 		// Hide any headers based on user prefs, if loaded.
@@ -99,7 +99,7 @@ class ReportTable extends Component {
 				rows={ rows }
 				rowsPerPage={ parseInt( query.per_page ) }
 				summary={ summary }
-				totalRows={ totalCount }
+				totalRows={ totalResults }
 				{ ...tableProps }
 			/>
 		);

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -98,15 +98,15 @@ export default class CategoriesReportTable extends Component {
 		} );
 	}
 
-	getSummary( totals, totalCount ) {
+	getSummary( totals, totalResults ) {
 		if ( ! totals ) {
 			return [];
 		}
 
 		return [
 			{
-				label: _n( 'category', 'categories', totalCount, 'wc-admin' ),
-				value: numberFormat( totalCount ),
+				label: _n( 'category', 'categories', totalResults, 'wc-admin' ),
+				value: numberFormat( totalResults ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', totals.items_sold, 'wc-admin' ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -285,7 +285,7 @@ export default compose(
 			tableData: {
 				items: {
 					data: formatTableOrders( orders ),
-					totalCount: ordersTotalCount,
+					totalResults: ordersTotalCount,
 				},
 				isError,
 				isRequesting,

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -162,15 +162,15 @@ class RevenueReportTable extends Component {
 		} );
 	}
 
-	getSummary( totals, totalCount ) {
+	getSummary( totals, totalResults ) {
 		if ( ! totals ) {
 			return [];
 		}
 
 		return [
 			{
-				label: _n( 'day', 'days', totalCount, 'wc-admin' ),
-				value: numberFormat( totalCount ),
+				label: _n( 'day', 'days', totalResults, 'wc-admin' ),
+				value: numberFormat( totalResults ),
 			},
 			{
 				label: _n( 'order', 'orders', totals.orders_count, 'wc-admin' ),
@@ -245,7 +245,7 @@ export default compose(
 			tableData: {
 				items: {
 					data: get( revenueData, [ 'data', 'intervals' ] ),
-					totalCount: get( revenueData, [ 'totalResults' ] ),
+					totalResults: get( revenueData, [ 'totalResults' ] ),
 				},
 				isError,
 				isRequesting,


### PR DESCRIPTION
Fixes pagination in _Products_ table.

We were using inconsistently `totalCount` and `totalResults` in different parts of the codebase. This PR tries to unify that to `totalResults`.

### Detailed test instructions:
- Go to the _Products_ report.
- Verify the table has pagination.
- Verify it stills works in the other reports.
