### PR TITLE
Rework advanced filters screen reader text generation

### DIFF
--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -13,8 +13,12 @@ import { sprintf, __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
-import { formatCurrency } from '@woocommerce/currency';
 import { textContent } from './utils';
+
+/**
+ * WooCommerce dependencies
+ */
+import { formatCurrency } from '@woocommerce/currency';
 
 class NumberFilter extends Component {
 	getBetweenString() {

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -7,7 +7,7 @@ import { SelectControl, TextControl } from '@wordpress/components';
 import { get, find, partial } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
-import { _x } from '@wordpress/i18n';
+import { sprintf, __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,6 +28,14 @@ class NumberFilter extends Component {
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let [ rangeStart, rangeEnd ] = ( filter.value || '' ).split( ',' );
+
+		// Return the filter label if we're missing input(s)
+		if (
+			! rangeStart ||
+			( 'between' === rule.value && ! rangeEnd )
+		) {
+			return get( config, [ 'labels', 'add' ] );
+		}
 
 		if ( 'currency' === inputType ) {
 			rangeStart = formatCurrency( rangeStart );
@@ -50,13 +58,14 @@ class NumberFilter extends Component {
 		return interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
+				ariaHide: <span />,
 				filter: <span>{ filterStr }</span>,
 				rule: <span>{ rule.label }</span>,
 			},
 		} );
 	}
 
-	getFormControl( type, value, onChange ) {
+	getFormControl( { type, value, label, onChange } ) {
 		if ( 'currency' === type ) {
 			const currencySymbol = get( wcSettings, [ 'currency', 'symbol' ] );
 			const symbolPosition = get( wcSettings, [ 'currency', 'position' ] );
@@ -68,6 +77,7 @@ class NumberFilter extends Component {
 					className="woocommerce-filters-advanced__input"
 					type="number"
 					value={ value || '' }
+					aria-label={ label }
 					onChange={ onChange }
 				/>
 				: <TextControlWithAffixes
@@ -75,6 +85,7 @@ class NumberFilter extends Component {
 					className="woocommerce-filters-advanced__input"
 					type="number"
 					value={ value || '' }
+					aria-label={ label }
 					onChange={ onChange }
 				/>
 			);
@@ -85,6 +96,7 @@ class NumberFilter extends Component {
 				className="woocommerce-filters-advanced__input"
 				type="number"
 				value={ value || '' }
+				aria-label={ label }
 				onChange={ onChange }
 			/>
 		);
@@ -105,11 +117,24 @@ class NumberFilter extends Component {
 			onFilterChange( filter.key, 'value', rangeStart || rangeEnd );
 		}
 
-		return this.getFormControl(
-			inputType,
-			rangeStart || rangeEnd,
-			partial( onFilterChange, filter.key, 'value' )
-		);
+		let labelFormat = '';
+
+		if ( 'lessthan' === filter.rule ) {
+			/* eslint-disable-next-line max-len */
+			/* translators: Sentence fragment, "maximum amount" refers to a numeric value the field must be less than. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+			labelFormat = _x( '%(field)s maximum amount', 'maximum value input', 'wc-admin' );
+		} else {
+			/* eslint-disable-next-line max-len */
+			/* translators: Sentence fragment, "minimum amount" refers to a numeric value the field must be more than. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+			labelFormat = _x( '%(field)s minimum amount', 'minimum value input', 'wc-admin' );
+		}
+
+		return this.getFormControl( {
+			type: inputType,
+			value: rangeStart || rangeEnd,
+			label: sprintf( labelFormat, { field: get( config, [ 'labels', 'add' ] ) } ),
+			onChange: partial( onFilterChange, filter.key, 'value' ),
+		} );
 	}
 
 	getRangeInput() {
@@ -130,9 +155,29 @@ class NumberFilter extends Component {
 		return interpolateComponents( {
 			mixedString: this.getBetweenString(),
 			components: {
-				rangeStart: this.getFormControl( inputType, rangeStart, rangeStartOnChange ),
-				rangeEnd: this.getFormControl( inputType, rangeEnd, rangeEndOnChange ),
-				span: <span className="separator" />,
+				rangeStart: this.getFormControl( {
+					type: inputType,
+					value: rangeStart,
+					label: sprintf(
+						/* eslint-disable-next-line max-len */
+						/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+						__( '%(field)s range start', 'wc-admin' ),
+						{ field: get( config, [ 'labels', 'add' ] ) }
+					),
+					onChange: rangeStartOnChange,
+				} ),
+				rangeEnd: this.getFormControl( {
+					type: inputType,
+					value: rangeEnd,
+					label: sprintf(
+						/* eslint-disable-next-line max-len */
+						/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+						__( '%(field)s range end', 'wc-admin' ),
+						{ field: get( config, [ 'labels', 'add' ] ) }
+					),
+					onChange: rangeEndOnChange,
+				} ),
+				span: <span aria-hidden className="separator" />,
 			},
 		} );
 	}
@@ -145,6 +190,7 @@ class NumberFilter extends Component {
 		const children = interpolateComponents( {
 			mixedString: labels.title,
 			components: {
+				ariaHide: <span aria-hidden />,
 				rule: (
 					<SelectControl
 						className="woocommerce-filters-advanced__rule"

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { withSpokenMessages, SelectControl, TextControl } from '@wordpress/components';
+import { SelectControl, TextControl } from '@wordpress/components';
 import { get, find, partial } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
@@ -14,24 +14,9 @@ import { sprintf, __, _x } from '@wordpress/i18n';
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
 import { formatCurrency } from '@woocommerce/currency';
-import { ariaHideStrings, textContent } from './utils';
+import { textContent } from './utils';
 
 class NumberFilter extends Component {
-	componentDidUpdate() {
-		const { config, debouncedSpeak, filter } = this.props;
-		const [ rangeStart, rangeEnd ] = ( filter.value || '' ).split( ',' );
-
-		if ( 'between' === filter.rule && ( ! rangeStart || ! rangeEnd ) ) {
-			return;
-		}
-
-		if ( ! rangeStart ) {
-			return;
-		}
-
-		debouncedSpeak( this.getScreenReaderText( filter, config ) );
-	}
-
 	getBetweenString() {
 		return _x(
 			'{{rangeStart /}}{{span}} and {{/span}}{{rangeEnd /}}',
@@ -45,7 +30,7 @@ class NumberFilter extends Component {
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let [ rangeStart, rangeEnd ] = ( filter.value || '' ).split( ',' );
 
-		// Return the filter label if we're missing input(s)
+		// Return nothing if we're missing input(s)
 		if (
 			! rangeStart ||
 			( 'between' === rule.value && ! rangeEnd )
@@ -192,7 +177,7 @@ class NumberFilter extends Component {
 					),
 					onChange: rangeEndOnChange,
 				} ),
-				span: <span aria-hidden className="separator" />,
+				span: <span className="separator" />,
 			},
 		} );
 	}
@@ -202,7 +187,7 @@ class NumberFilter extends Component {
 		const { key, rule } = filter;
 		const { labels, rules } = config;
 
-		const children = ariaHideStrings( interpolateComponents( {
+		const children = interpolateComponents( {
 			mixedString: labels.title,
 			components: {
 				rule: (
@@ -224,7 +209,10 @@ class NumberFilter extends Component {
 					</div>
 				),
 			},
-		} ) );
+		} );
+
+		const screenReaderText = this.getScreenReaderText( filter, config );
+
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset tabIndex="0">
@@ -238,10 +226,15 @@ class NumberFilter extends Component {
 				>
 					{ children }
 				</div>
+				{ screenReaderText && (
+					<span className="screen-reader-text">
+						{ screenReaderText }
+					</span>
+				) }
 			</fieldset>
 		);
 		/*eslint-enable jsx-a11y/no-noninteractive-tabindex*/
 	}
 }
 
-export default withSpokenMessages( NumberFilter );
+export default NumberFilter;

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -214,7 +214,7 @@ class NumberFilter extends Component {
 		return (
 			<fieldset tabIndex="0">
 				<legend className="screen-reader-text">
-					{ this.getLegend( filter, config ) }
+					{ labels.add || '' }
 				</legend>
 				<div
 					className={ classnames( 'woocommerce-filters-advanced__fieldset', {

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { SelectControl, TextControl } from '@wordpress/components';
+import { withSpokenMessages, SelectControl, TextControl } from '@wordpress/components';
 import { get, find, partial } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
@@ -14,18 +14,33 @@ import { sprintf, __, _x } from '@wordpress/i18n';
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
 import { formatCurrency } from '@woocommerce/currency';
-import { ariaHideStrings } from './utils';
+import { ariaHideStrings, textContent } from './utils';
 
 class NumberFilter extends Component {
+	componentDidUpdate() {
+		const { config, debouncedSpeak, filter } = this.props;
+		const [ rangeStart, rangeEnd ] = ( filter.value || '' ).split( ',' );
+
+		if ( 'between' === filter.rule && ( ! rangeStart || ! rangeEnd ) ) {
+			return;
+		}
+
+		if ( ! rangeStart ) {
+			return;
+		}
+
+		debouncedSpeak( this.getScreenReaderText( filter, config ) );
+	}
+
 	getBetweenString() {
 		return _x(
-			'{{rangeStart /}}{{span}}and{{/span}}{{rangeEnd /}}',
+			'{{rangeStart /}}{{span}} and {{/span}}{{rangeEnd /}}',
 			'Numerical range inputs arranged on a single line',
 			'wc-admin'
 		);
 	}
 
-	getLegend( filter, config ) {
+	getScreenReaderText( filter, config ) {
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let [ rangeStart, rangeEnd ] = ( filter.value || '' ).split( ',' );
@@ -35,7 +50,7 @@ class NumberFilter extends Component {
 			! rangeStart ||
 			( 'between' === rule.value && ! rangeEnd )
 		) {
-			return get( config, [ 'labels', 'add' ] );
+			return '';
 		}
 
 		if ( 'currency' === inputType ) {
@@ -56,13 +71,13 @@ class NumberFilter extends Component {
 			} );
 		}
 
-		return interpolateComponents( {
+		return textContent( interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
-				filter: <span>{ filterStr }</span>,
-				rule: <span>{ rule.label }</span>,
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
 			},
-		} );
+		} ) );
 	}
 
 	getFormControl( { type, value, label, onChange } ) {
@@ -229,4 +244,4 @@ class NumberFilter extends Component {
 	}
 }
 
-export default NumberFilter;
+export default withSpokenMessages( NumberFilter );

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -14,6 +14,7 @@ import { sprintf, __, _x } from '@wordpress/i18n';
  */
 import TextControlWithAffixes from '../../text-control-with-affixes';
 import { formatCurrency } from '@woocommerce/currency';
+import { ariaHideStrings } from './utils';
 
 class NumberFilter extends Component {
 	getBetweenString() {
@@ -58,7 +59,6 @@ class NumberFilter extends Component {
 		return interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
-				ariaHide: <span />,
 				filter: <span>{ filterStr }</span>,
 				rule: <span>{ rule.label }</span>,
 			},
@@ -187,10 +187,9 @@ class NumberFilter extends Component {
 		const { key, rule } = filter;
 		const { labels, rules } = config;
 
-		const children = interpolateComponents( {
+		const children = ariaHideStrings( interpolateComponents( {
 			mixedString: labels.title,
 			components: {
-				ariaHide: <span aria-hidden />,
 				rule: (
 					<SelectControl
 						className="woocommerce-filters-advanced__rule"
@@ -210,7 +209,7 @@ class NumberFilter extends Component {
 					</div>
 				),
 			},
-		} );
+		} ) );
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset tabIndex="0">

--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { find, isEqual, partial } from 'lodash';
 import PropTypes from 'prop-types';
@@ -13,6 +13,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Search from '../../search';
+import { textContent } from './utils';
 
 class SearchFilter extends Component {
 	constructor( { filter, config, query } ) {
@@ -51,18 +52,23 @@ class SearchFilter extends Component {
 		onFilterChange( filter.key, 'value', idList );
 	}
 
-	getLegend( filter, config ) {
+	getScreenReaderText( filter, config ) {
 		const { selected } = this.state;
+
+		if ( 0 === selected.length ) {
+			return '';
+		}
+
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		const filterStr = selected.map( item => item.label ).join( ', ' );
 
-		return interpolateComponents( {
+		return textContent( interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
-				filter: <span>{ filterStr }</span>,
-				rule: <span>{ rule.label }</span>,
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
 			},
-		} );
+		} ) );
 	}
 
 	render() {
@@ -95,11 +101,14 @@ class SearchFilter extends Component {
 				),
 			},
 		} );
+
+		const screenReaderText = this.getScreenReaderText( filter, config );
+
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset tabIndex="0">
 				<legend className="screen-reader-text">
-					{ this.getLegend( filter, config, selected ) }
+					{ labels.add || '' }
 				</legend>
 				<div
 					className={ classnames( 'woocommerce-filters-advanced__fieldset', {
@@ -108,6 +117,11 @@ class SearchFilter extends Component {
 				>
 					{ children }
 				</div>
+				{ screenReaderText && (
+					<span className="screen-reader-text">
+						{ screenReaderText }
+					</span>
+				) }
 			</fieldset>
 		);
 		/*eslint-enable jsx-a11y/no-noninteractive-tabindex*/

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -2,12 +2,17 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { SelectControl, Spinner } from '@wordpress/components';
 import { find, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { textContent } from './utils';
 
 /**
  * WooCommerce dependencies
@@ -41,16 +46,21 @@ class SelectFilter extends Component {
 		return options;
 	}
 
-	getLegend( filter, config ) {
+	getScreenReaderText( filter, config ) {
+		if ( '' === filter.value ) {
+			return '';
+		}
+
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		const value = find( config.input.options, { value: filter.value } ) || {};
-		return interpolateComponents( {
+
+		return textContent( interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
-				filter: <span>{ value.label }</span>,
-				rule: <span>{ rule.label }</span>,
+				filter: <Fragment>{ value.label }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
 			},
-		} );
+		} ) );
 	}
 
 	render() {
@@ -83,10 +93,15 @@ class SelectFilter extends Component {
 				),
 			},
 		} );
+
+		const screenReaderText = this.getScreenReaderText( filter, config );
+
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset tabIndex="0">
-				<legend className="screen-reader-text">{ this.getLegend( filter, config ) }</legend>
+				<legend className="screen-reader-text">
+					{ labels.add || '' }
+				</legend>
 				<div
 					className={ classnames( 'woocommerce-filters-advanced__fieldset', {
 						'is-english': isEnglish,
@@ -94,6 +109,11 @@ class SelectFilter extends Component {
 				>
 					{ children }
 				</div>
+				{ screenReaderText && (
+					<span className="screen-reader-text">
+						{ screenReaderText }
+					</span>
+				) }
 			</fieldset>
 		);
 		/*eslint-enable jsx-a11y/no-noninteractive-tabindex*/

--- a/packages/components/src/filters/advanced/test/utils.js
+++ b/packages/components/src/filters/advanced/test/utils.js
@@ -4,7 +4,7 @@
 import { textContent } from '../utils';
 
 describe( 'textContent()', () => {
-	test( 'should be got text `Hello World`', () => {
+	test( 'should get text `Hello World`', () => {
 		const component = (
 			<div>
 				<h1>Hello</h1> World

--- a/packages/components/src/filters/advanced/test/utils.js
+++ b/packages/components/src/filters/advanced/test/utils.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { textContent } from '../utils';
+
+describe( 'textContent()', () => {
+	test( 'should be got text `Hello World`', () => {
+		const component = (
+			<div>
+				<h1>Hello</h1> World
+			</div>
+		);
+
+		expect( textContent( component ) ).toBe( 'Hello World' );
+	} );
+
+	test( 'render variable', () => {
+		const component = (
+			<div>
+				<h1>Hello</h1> { 'World' + '2' }
+			</div>
+		);
+
+		expect( textContent( component ) ).toBe( 'Hello World2' );
+	} );
+
+	test( 'render variable2', () => {
+		const component = (
+			<div>
+				<h1>Hello</h1> { 1 + 1 }
+			</div>
+		);
+
+		expect( textContent( component ) ).toBe( 'Hello 2' );
+	} );
+
+	test( 'should output empty string', () => {
+		const component = ( <div /> );
+
+		expect( textContent( component ) ).toBe( '' );
+	} );
+
+	test( 'array children', () => {
+		const component = (
+			<div>
+				<h1>Hello</h1> World
+				{
+					[ 'a', <h2 key="b">b</h2> ]
+				}
+			</div>
+		);
+
+		expect( textContent( component ) ).toBe( 'Hello Worldab' );
+	} );
+
+	test( 'array children with null', () => {
+		const component = (
+			<div>
+				<h1>Hello</h1> World
+				{
+					[ 'a', null ]
+				}
+			</div>
+		);
+
+		expect( textContent( component ) ).toBe( 'Hello Worlda' );
+	} );
+
+	test( 'array component', () => {
+		const component = ( [
+			<h1>a</h1>,
+			'b',
+			'c',
+			(
+				<div>
+					<h2>x</h2>y
+				</div>
+			),
+		] );
+
+		expect( textContent( component ) ).toBe( 'abcxy' );
+	} );
+} );

--- a/packages/components/src/filters/advanced/utils.js
+++ b/packages/components/src/filters/advanced/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isArray, isString } from 'lodash';
+import { isArray, isNumber, isString } from 'lodash';
 
 /**
  * Hide all bare strings from the accessibility tree.
@@ -21,4 +21,36 @@ export function ariaHideStrings( components ) {
         ? <span aria-hidden>{ component }</span>
         : component
     ) );
+}
+
+/**
+ * DOM Node.textContent for React components
+ * See: https://github.com/rwu823/react-addons-text-content/blob/master/src/index.js
+ *
+ * @param {Array<string|ReactNode>} components array of components
+ *
+ * @returns {string} concatenated text content of all nodes
+ */
+export function textContent( components ) {
+    let text = '';
+
+    const toText = ( component ) => {
+        if ( isString( component ) || isNumber( component ) ) {
+            text += component;
+        } else if ( isArray( component ) ) {
+            component.forEach( toText );
+        } else if ( component && component.props ) {
+            const { children } = component.props;
+
+            if ( isArray( children ) ) {
+                children.forEach( toText );
+            } else {
+                toText( children );
+            }
+        }
+    };
+
+    toText( components );
+
+    return text;
 }

--- a/packages/components/src/filters/advanced/utils.js
+++ b/packages/components/src/filters/advanced/utils.js
@@ -4,26 +4,6 @@
 import { isArray, isNumber, isString } from 'lodash';
 
 /**
- * Hide all bare strings from the accessibility tree.
- * Intended to process the result of interpolateComponents().
- *
- * @param {Array<string|ReactNode>} components array of components
- *
- * @returns {Array<string|ReactNode>} array of processed components
- */
-export function ariaHideStrings( components ) {
-    if ( ! isArray( components ) ) {
-        return components;
-    }
-
-    return components.map( component => (
-        isString( component ) && component.trim()
-        ? <span aria-hidden>{ component }</span>
-        : component
-    ) );
-}
-
-/**
  * DOM Node.textContent for React components
  * See: https://github.com/rwu823/react-addons-text-content/blob/master/src/index.js
  *
@@ -32,25 +12,25 @@ export function ariaHideStrings( components ) {
  * @returns {string} concatenated text content of all nodes
  */
 export function textContent( components ) {
-    let text = '';
+	let text = '';
 
-    const toText = ( component ) => {
-        if ( isString( component ) || isNumber( component ) ) {
-            text += component;
-        } else if ( isArray( component ) ) {
-            component.forEach( toText );
-        } else if ( component && component.props ) {
-            const { children } = component.props;
+	const toText = ( component ) => {
+		if ( isString( component ) || isNumber( component ) ) {
+			text += component;
+		} else if ( isArray( component ) ) {
+			component.forEach( toText );
+		} else if ( component && component.props ) {
+			const { children } = component.props;
 
-            if ( isArray( children ) ) {
-                children.forEach( toText );
-            } else {
-                toText( children );
-            }
-        }
-    };
+			if ( isArray( children ) ) {
+				children.forEach( toText );
+			} else {
+				toText( children );
+			}
+		}
+	};
 
-    toText( components );
+	toText( components );
 
-    return text;
+	return text;
 }

--- a/packages/components/src/filters/advanced/utils.js
+++ b/packages/components/src/filters/advanced/utils.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { isArray, isString } from 'lodash';
+
+/**
+ * Hide all bare strings from the accessibility tree.
+ * Intended to process the result of interpolateComponents().
+ *
+ * @param {Array<string|ReactNode>} components array of components
+ *
+ * @returns {Array<string|ReactNode>} array of processed components
+ */
+export function ariaHideStrings( components ) {
+    if ( ! isArray( components ) ) {
+        return components;
+    }
+
+    return components.map( component => (
+        isString( component ) && component.trim()
+        ? <span aria-hidden>{ component }</span>
+        : component
+    ) );
+}

--- a/packages/components/src/filters/example.md
+++ b/packages/components/src/filters/example.md
@@ -93,7 +93,7 @@ const advancedFilters = {
 				add: 'Item Quantity',
 				remove: 'Remove item quantity filter',
 				rule: 'Select an item quantity filter match',
-				title: '{{ariaHide}}Item Quantity is {{/ariaHide}}{{rule /}} {{filter /}}',
+				title: 'Item Quantity is {{rule /}} {{filter /}}',
 			},
 			rules: [
 				{

--- a/packages/components/src/filters/example.md
+++ b/packages/components/src/filters/example.md
@@ -93,7 +93,7 @@ const advancedFilters = {
 				add: 'Item Quantity',
 				remove: 'Remove item quantity filter',
 				rule: 'Select an item quantity filter match',
-				title: 'Item Quantity is {{rule /}} {{filter /}}',
+				title: '{{ariaHide}}Item Quantity is {{/ariaHide}}{{rule /}} {{filter /}}',
 			},
 			rules: [
 				{


### PR DESCRIPTION
Based on conversation here: https://github.com/woocommerce/wc-admin/pull/1089#discussion_r241843856

**This PR seeks to:**
* Only describe full filter if all values are set
* Describe each input more precisely

**Notes:**

There is an opportunity to DRY up the markup in the render of `NumberFilter`, `SearchFilter`, and `SelectFilter`, but I've left that undone as it might be a premature optimization. I can certainly turn that into another component if we decide that's cleanup worth doing.

Also, this PR adds a utility method called `textContent()`. It's essentially [`react-addons-text-content`](https://github.com/rwu823/react-addons-text-content/blob/master/src/index.js) - I made the decision to just copy pasta the code into our project since the dependency is rather small and hasn't been updated in 3 years.

**To test:**
* Navigate to devdocs, filters component
* Add a filter of each type (order status, products, item quantity)
* Verify that the `<legend>` for each doesn't change when interacting the the component
* Verify that a `<div>` with class `screen-reader-text` is rendered only when all of the filter inputs have values