### PR TITLE
Rename 'isError' methods to 'getError' when they return an object instead of a boolean

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -262,7 +262,7 @@ export default compose(
 		const datesFromQuery = getCurrentDates( query );
 		const filterQuery = getFilterQuery( 'orders', query );
 
-		const { getOrders, getOrdersTotalCount, isGetOrdersError, isGetOrdersRequesting } = select(
+		const { getOrders, getOrdersTotalCount, getOrdersError, isGetOrdersRequesting } = select(
 			'wc-api'
 		);
 
@@ -278,7 +278,7 @@ export default compose(
 		};
 		const orders = getOrders( tableQuery );
 		const ordersTotalCount = getOrdersTotalCount( tableQuery );
-		const isError = isGetOrdersError( tableQuery );
+		const isError = Boolean( getOrdersError( tableQuery ) );
 		const isRequesting = isGetOrdersRequesting( tableQuery );
 
 		return {

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -225,7 +225,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { query } = props;
 		const datesFromQuery = getCurrentDates( query );
-		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
+		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 
 		// TODO Support hour here when viewing a single day
 		const tableQuery = {
@@ -238,7 +238,7 @@ export default compose(
 			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		};
 		const revenueData = getReportStats( 'revenue', tableQuery );
-		const isError = isReportStatsError( 'revenue', tableQuery );
+		const isError = Boolean( getReportStatsError( 'revenue', tableQuery ) );
 		const isRequesting = isReportStatsRequesting( 'revenue', tableQuery );
 
 		return {

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -123,7 +123,7 @@ export class TopSellingProducts extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-admin' );
 		const endpoint = NAMESPACE + 'reports/products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
@@ -131,7 +131,7 @@ export default compose(
 
 		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );
-		const isError = isReportStatsError( endpoint, query );
+		const isError = Boolean( getReportStatsError( endpoint, query ) );
 
 		return { data: get( stats, 'data', [] ), isRequesting, isError };
 	} )

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -50,14 +50,14 @@ describe( 'TopSellingProducts', () => {
 	test( 'should load report stats from API', () => {
 		const getReportStatsMock = jest.fn().mockReturnValue( { data: mockData } );
 		const isReportStatsRequestingMock = jest.fn().mockReturnValue( false );
-		const isReportStatsErrorMock = jest.fn().mockReturnValue( false );
+		const getReportStatsErrorMock = jest.fn().mockReturnValue( undefined );
 		const registry = createRegistry();
 		registry.registerStore( 'wc-admin', {
 			reducer: () => {},
 			selectors: {
 				getReportStats: getReportStatsMock,
 				isReportStatsRequesting: isReportStatsRequestingMock,
-				isReportStatsError: isReportStatsErrorMock,
+				getReportStatsError: getReportStatsErrorMock,
 			},
 		} );
 		const topSellingProductsWrapper = TestRenderer.create(
@@ -74,8 +74,8 @@ describe( 'TopSellingProducts', () => {
 		expect( getReportStatsMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
 		expect( isReportStatsRequestingMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
 		expect( isReportStatsRequestingMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
-		expect( isReportStatsErrorMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
-		expect( isReportStatsErrorMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
+		expect( getReportStatsErrorMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
+		expect( getReportStatsErrorMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
 		expect( topSellingProducts.props.data ).toBe( mockData );
 	} );
 } );

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -89,7 +89,7 @@ class InboxPanel extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getNotes, isGetNotesError, isGetNotesRequesting } = select( 'wc-api' );
+		const { getNotes, getNotesError, isGetNotesRequesting } = select( 'wc-api' );
 		const inboxQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
@@ -97,7 +97,7 @@ export default compose(
 		};
 
 		const notes = getNotes( inboxQuery );
-		const isError = isGetNotesError( inboxQuery );
+		const isError = Boolean( getNotesError( inboxQuery ) );
 		const isRequesting = isGetNotesRequesting( inboxQuery );
 
 		return { notes, isError, isRequesting };

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -178,7 +178,7 @@ OrdersPanel.defaultProps = {
 
 export default compose(
 	withSelect( select => {
-		const { getOrders, isGetOrdersError, isGetOrdersRequesting } = select( 'wc-api' );
+		const { getOrders, getOrdersError, isGetOrdersRequesting } = select( 'wc-api' );
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
@@ -186,7 +186,7 @@ export default compose(
 		};
 
 		const orders = getOrders( ordersQuery );
-		const isError = isGetOrdersError( ordersQuery );
+		const isError = Boolean( getOrdersError( ordersQuery ) );
 		const isRequesting = isGetOrdersRequesting( ordersQuery );
 
 		return { orders, isError, isRequesting };

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -172,7 +172,7 @@ ReviewsPanel.defaultProps = {
 
 export default compose(
 	withSelect( select => {
-		const { getReviews, isGetReviewsError, isGetReviewsRequesting } = select( 'wc-api' );
+		const { getReviews, getReviewsError, isGetReviewsRequesting } = select( 'wc-api' );
 		const reviewsQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
@@ -180,7 +180,7 @@ export default compose(
 		};
 
 		const reviews = getReviews( reviewsQuery );
-		const isError = isGetReviewsError( reviewsQuery );
+		const isError = Boolean( getReviewsError( reviewsQuery ) );
 		const isRequesting = isGetReviewsRequesting( reviewsQuery );
 
 		return { reviews, isError, isRequesting };

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -64,13 +64,13 @@ describe( 'getReportChartData()', () => {
 	beforeAll( () => {
 		select( 'wc-api' ).getReportStats = jest.fn().mockReturnValue( {} );
 		select( 'wc-api' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-api' ).isReportStatsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportStatsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
 		select( 'wc-api' ).getReportStats.mockRestore();
 		select( 'wc-api' ).isReportStatsRequesting.mockRestore();
-		select( 'wc-api' ).isReportStatsError.mockRestore();
+		select( 'wc-api' ).getReportStatsError.mockRestore();
 	} );
 
 	function setGetReportStats( func ) {
@@ -78,13 +78,11 @@ describe( 'getReportChartData()', () => {
 	}
 
 	function setIsReportStatsRequesting( func ) {
-		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
-			func( ...args )
-		);
+		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
-	function setIsReportStatsError( func ) {
-		select( 'wc-api' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
+	function setGetReportStatsError( func ) {
+		select( 'wc-api' ).getReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if first request is in progress', () => {
@@ -99,8 +97,8 @@ describe( 'getReportChartData()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return true;
+		setGetReportStatsError( () => {
+			return { error: 'Error' };
 		} );
 		const result = getReportChartData( 'revenue', 'primary', {}, select );
 		expect( result ).toEqual( { ...response, isError: true } );
@@ -127,8 +125,8 @@ describe( 'getReportChartData()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return false;
+		setGetReportStatsError( () => {
+			return undefined;
 		} );
 		setGetReportStats( () => {
 			return {
@@ -161,8 +159,8 @@ describe( 'getReportChartData()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return false;
+		setGetReportStatsError( () => {
+			return undefined;
 		} );
 		setGetReportStats( ( endpoint, query ) => {
 			if ( 2 === query.page ) {
@@ -202,8 +200,8 @@ describe( 'getReportChartData()', () => {
 			}
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return false;
+		setGetReportStatsError( () => {
+			return undefined;
 		} );
 
 		const result = getReportChartData( 'revenue', 'primary', {}, select );
@@ -214,11 +212,11 @@ describe( 'getReportChartData()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( ( endpoint, query ) => {
+		setGetReportStatsError( ( endpoint, query ) => {
 			if ( 2 === query.page ) {
-				return true;
+				return { error: 'Error' };
 			}
-			return false;
+			return undefined;
 		} );
 		const result = getReportChartData( 'revenue', 'primary', {}, select );
 		expect( result ).toEqual( { ...response, isError: true } );
@@ -228,8 +226,8 @@ describe( 'getReportChartData()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return false;
+		setGetReportStatsError( () => {
+			return undefined;
 		} );
 		setGetReportStats( () => {
 			return {
@@ -264,13 +262,13 @@ describe( 'getSummaryNumbers()', () => {
 	beforeAll( () => {
 		select( 'wc-api' ).getReportStats = jest.fn().mockReturnValue( {} );
 		select( 'wc-api' ).isReportStatsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-api' ).isReportStatsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportStatsError = jest.fn().mockReturnValue( false );
 	} );
 
 	afterAll( () => {
 		select( 'wc-api' ).getReportStats.mockRestore();
 		select( 'wc-api' ).isReportStatsRequesting.mockRestore();
-		select( 'wc-api' ).isReportStatsError.mockRestore();
+		select( 'wc-api' ).getReportStatsError.mockRestore();
 	} );
 
 	function setGetReportStats( func ) {
@@ -278,13 +276,11 @@ describe( 'getSummaryNumbers()', () => {
 	}
 
 	function setIsReportStatsRequesting( func ) {
-		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) =>
-			func( ...args )
-		);
+		select( 'wc-api' ).isReportStatsRequesting.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
-	function setIsReportStatsError( func ) {
-		select( 'wc-api' ).isReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
+	function setGetReportStatsError( func ) {
+		select( 'wc-api' ).getReportStatsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if a request is in progress', () => {
@@ -299,8 +295,8 @@ describe( 'getSummaryNumbers()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return true;
+		setGetReportStatsError( () => {
+			return { error: 'Error' };
 		} );
 		const result = getSummaryNumbers( 'revenue', query, select );
 		expect( result ).toEqual( { ...response, isError: true } );
@@ -321,8 +317,8 @@ describe( 'getSummaryNumbers()', () => {
 		setIsReportStatsRequesting( () => {
 			return false;
 		} );
-		setIsReportStatsError( () => {
-			return false;
+		setGetReportStatsError( () => {
+			return undefined;
 		} );
 		setGetReportStats( () => {
 			return {
@@ -464,31 +460,29 @@ describe( 'getReportTableData()', () => {
 	beforeAll( () => {
 		select( 'wc-api' ).getReportItems = jest.fn().mockReturnValue( {} );
 		select( 'wc-api' ).isReportItemsRequesting = jest.fn().mockReturnValue( false );
-		select( 'wc-api' ).isReportItemsError = jest.fn().mockReturnValue( false );
+		select( 'wc-api' ).getReportItemsError = jest.fn().mockReturnValue( undefined );
 	} );
 
 	afterAll( () => {
 		select( 'wc-api' ).getReportItems.mockRestore();
 		select( 'wc-api' ).isReportItemsRequesting.mockRestore();
-		select( 'wc-api' ).isReportItemsError.mockRestore();
+		select( 'wc-api' ).getReportItemsError.mockRestore();
 	} );
 
 	function setGetReportItems( func ) {
 		select( 'wc-api' ).getReportItems.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
-	function setisReportItemsRequesting( func ) {
-		select( 'wc-api' ).isReportItemsRequesting.mockImplementation( ( ...args ) =>
-			func( ...args )
-		);
+	function setIsReportItemsRequesting( func ) {
+		select( 'wc-api' ).isReportItemsRequesting.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
-	function setisReportItemsError( func ) {
-		select( 'wc-api' ).isReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
+	function setGetReportItemsError( func ) {
+		select( 'wc-api' ).getReportItemsError.mockImplementation( ( ...args ) => func( ...args ) );
 	}
 
 	it( 'returns isRequesting if a request is in progress', () => {
-		setisReportItemsRequesting( () => true );
+		setIsReportItemsRequesting( () => true );
 
 		const result = getReportTableData( 'coupons', query, select );
 
@@ -498,12 +492,12 @@ describe( 'getReportTableData()', () => {
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenCalledTimes( 0 );
+		expect( select( 'wc-api' ).getReportItemsError ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	it( 'returns isError if request errors', () => {
-		setisReportItemsRequesting( () => false );
-		setisReportItemsError( () => true );
+		setIsReportItemsRequesting( () => false );
+		setGetReportItemsError( () => ( { error: 'Error' } ) );
 
 		const result = getReportTableData( 'coupons', query, select );
 
@@ -513,16 +507,13 @@ describe( 'getReportTableData()', () => {
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenLastCalledWith(
-			'coupons',
-			query
-		);
+		expect( select( 'wc-api' ).getReportItemsError ).toHaveBeenLastCalledWith( 'coupons', query );
 	} );
 
 	it( 'returns results after queries finish', () => {
 		const items = [ { id: 1 }, { id: 2 }, { id: 3 } ];
-		setisReportItemsRequesting( () => false );
-		setisReportItemsError( () => false );
+		setIsReportItemsRequesting( () => false );
+		setGetReportItemsError( () => undefined );
 		setGetReportItems( () => items );
 
 		const result = getReportTableData( 'coupons', query, select );
@@ -533,9 +524,6 @@ describe( 'getReportTableData()', () => {
 			'coupons',
 			query
 		);
-		expect( select( 'wc-api' ).isReportItemsError ).toHaveBeenLastCalledWith(
-			'coupons',
-			query
-		);
+		expect( select( 'wc-api' ).getReportItemsError ).toHaveBeenLastCalledWith( 'coupons', query );
 	} );
 } );

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -141,7 +141,7 @@ function getRequestQuery( endpoint, dataType, query ) {
  * @return {Object}  Object containing summary number responses.
  */
 export function getSummaryNumbers( endpoint, query, select ) {
-	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
+	const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 	const response = {
 		isRequesting: false,
 		isError: false,
@@ -155,7 +155,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
 	const primary = getReportStats( endpoint, primaryQuery );
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( isReportStatsError( endpoint, primaryQuery ) ) {
+	} else if ( getReportStatsError( endpoint, primaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
@@ -165,7 +165,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
 	const secondary = getReportStats( endpoint, secondaryQuery );
 	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( isReportStatsError( endpoint, secondaryQuery ) ) {
+	} else if ( getReportStatsError( endpoint, secondaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
@@ -184,7 +184,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( endpoint, dataType, query, select ) {
-	const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-api' );
+	const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 
 	const response = {
 		isEmpty: false,
@@ -201,7 +201,7 @@ export function getReportChartData( endpoint, dataType, query, select ) {
 
 	if ( isReportStatsRequesting( endpoint, requestQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( isReportStatsError( endpoint, requestQuery ) ) {
+	} else if ( getReportStatsError( endpoint, requestQuery ) ) {
 		return { ...response, isError: true };
 	} else if ( isReportDataEmpty( stats ) ) {
 		return { ...response, isEmpty: true };
@@ -224,7 +224,7 @@ export function getReportChartData( endpoint, dataType, query, select ) {
 			if ( isReportStatsRequesting( endpoint, nextQuery ) ) {
 				continue;
 			}
-			if ( isReportStatsError( endpoint, nextQuery ) ) {
+			if ( getReportStatsError( endpoint, nextQuery ) ) {
 				isError = true;
 				isFetching = false;
 				break;
@@ -298,7 +298,7 @@ export function getReportTableQuery( endpoint, urlQuery, query ) {
  * @return {Object} Object    Table data response
  */
 export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
-	const { getReportItems, isReportItemsRequesting, isReportItemsError } = select( 'wc-api' );
+	const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
 
 	const tableQuery = reportsUtils.getReportTableQuery( endpoint, urlQuery, query );
 	const response = {
@@ -313,7 +313,7 @@ export function getReportTableData( endpoint, urlQuery, select, query = {} ) {
 	const items = getReportItems( endpoint, tableQuery );
 	if ( isReportItemsRequesting( endpoint, tableQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( isReportItemsError( endpoint, tableQuery ) ) {
+	} else if ( getReportItemsError( endpoint, tableQuery ) ) {
 		return { ...response, isError: true };
 	}
 

--- a/client/wc-api/notes/selectors.js
+++ b/client/wc-api/notes/selectors.js
@@ -21,6 +21,11 @@ const getNotes = ( getResource, requireResource ) => (
 	return notes;
 };
 
+const getNotesError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'note-query', query );
+	return getResource( resourceName ).error;
+};
+
 const isGetNotesRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'note-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
@@ -36,13 +41,8 @@ const isGetNotesRequesting = getResource => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isGetNotesError = getResource => ( query = {} ) => {
-	const resourceName = getResourceName( 'note-query', query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getNotes,
+	getNotesError,
 	isGetNotesRequesting,
-	isGetNotesError,
 };

--- a/client/wc-api/orders/selectors.js
+++ b/client/wc-api/orders/selectors.js
@@ -21,6 +21,11 @@ const getOrders = ( getResource, requireResource ) => (
 	return orders;
 };
 
+const getOrdersError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'order-query', query );
+	return getResource( resourceName ).error;
+};
+
 const getOrdersTotalCount = ( getResource, requireResource ) => (
 	query = {},
 	requirement = DEFAULT_REQUIREMENT
@@ -40,14 +45,9 @@ const isGetOrdersRequesting = getResource => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isGetOrdersError = getResource => ( query = {} ) => {
-	const resourceName = getResourceName( 'order-query', query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getOrders,
+	getOrdersError,
 	getOrdersTotalCount,
 	isGetOrdersRequesting,
-	isGetOrdersError,
 };

--- a/client/wc-api/reports/items/selectors.js
+++ b/client/wc-api/reports/items/selectors.js
@@ -20,6 +20,11 @@ const getReportItems = ( getResource, requireResource ) => (
 	return requireResource( requirement, resourceName ) || {};
 };
 
+const getReportItemsError = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-items-query-${ type }`, query );
+	return getResource( resourceName ).error;
+};
+
 const isReportItemsRequesting = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-items-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
@@ -31,13 +36,8 @@ const isReportItemsRequesting = getResource => ( type, query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isReportItemsError = getResource => ( type, query = {} ) => {
-	const resourceName = getResourceName( `report-items-query-${ type }`, query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getReportItems,
+	getReportItemsError,
 	isReportItemsRequesting,
-	isReportItemsError,
 };

--- a/client/wc-api/reports/stats/selectors.js
+++ b/client/wc-api/reports/stats/selectors.js
@@ -22,6 +22,11 @@ const getReportStats = ( getResource, requireResource ) => (
 	return data;
 };
 
+const getReportStatsError = getResource => ( type, query = {} ) => {
+	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
+	return getResource( resourceName ).error;
+};
+
 const isReportStatsRequesting = getResource => ( type, query = {} ) => {
 	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
@@ -33,13 +38,8 @@ const isReportStatsRequesting = getResource => ( type, query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isReportStatsError = getResource => ( type, query = {} ) => {
-	const resourceName = getResourceName( `report-stats-query-${ type }`, query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getReportStats,
+	getReportStatsError,
 	isReportStatsRequesting,
-	isReportStatsError,
 };

--- a/client/wc-api/reviews/selectors.js
+++ b/client/wc-api/reviews/selectors.js
@@ -29,6 +29,11 @@ const getReviewsTotalCount = ( getResource, requireResource ) => (
 	return requireResource( requirement, resourceName ).totalCount || 0;
 };
 
+const getReviewsError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'review-query', query );
+	return getResource( resourceName ).error;
+};
+
 const isGetReviewsRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'review-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
@@ -40,14 +45,9 @@ const isGetReviewsRequesting = getResource => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isGetReviewsError = getResource => ( query = {} ) => {
-	const resourceName = getResourceName( 'review-query', query );
-	return getResource( resourceName ).error;
-};
-
 export default {
 	getReviews,
+	getReviewsError,
 	getReviewsTotalCount,
 	isGetReviewsRequesting,
-	isGetReviewsError,
 };


### PR DESCRIPTION
Follow-up of the discussion in https://github.com/woocommerce/wc-admin/pull/1075#discussion_r241866256.

We had many selectors named `isGetOrdersError`, `isReportItemsError`, etc. that were returning an error object instead of a boolean. This PR renames them to `getOrdersError`, `getReportItemsError`...

A follow-up discussion would be if we want to display those errors in the UI in some way or make the UI react to different kind of errors in different ways. But for now, this PR keeps the same behavior as before and only uses the error objects to check if an error occurred.

### Detailed test instructions:
This PR modifies all error selectors so the best way to test would be faking an error in each one of them.

For example, modifying:
```ES6
const url = `${ NAMESPACE }/orders${ stringifyQuery( query ) }`;
```
to:
```ES6
const url = `${ NAMESPACE }/lorem-ipsum${ stringifyQuery( query ) }`;
```
in `client/wc-api/orders/operations.js` and then verifying the error is correctly shown in the _Orders_ report.

Also, verifying that when the URL is the correct one, no error is displayed in the UI.