### PR TITLE
Add base downloads report page

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -4,8 +4,12 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { getRequestByIdString } from '../../../lib/async-requests';
-import { NAMESPACE } from '../../../store/constants';
+
+/**
+ * Internal dependencies
+ */
+import { getRequestByIdString } from 'lib/async-requests';
+import { NAMESPACE } from 'store/constants';
 
 export const filters = [
 	{

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -1,0 +1,67 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getRequestByIdString } from 'lib/async-requests';
+import { NAMESPACE } from 'store/constants';
+
+export const filters = [
+	{
+		label: __( 'Show', 'wc-admin' ),
+		staticParams: [],
+		param: 'filter',
+		showFilters: () => true,
+		filters: [
+			{ label: __( 'All Downloads', 'wc-admin' ), value: 'all' },
+			{ label: __( 'Advanced Filters', 'wc-admin' ), value: 'advanced' },
+		],
+	},
+];
+
+/*eslint-disable max-len*/
+export const advancedFilters = {
+	title: _x(
+		'Downloads Match {{select /}} Filters',
+		'A sentence describing filters for Downloads. See screen shot for context: https://cloudup.com/ccxhyH2mEDg',
+		'wc-admin'
+	),
+	filters: {
+		product: {
+			labels: {
+				add: __( 'Product', 'wc-admin' ),
+				placeholder: __( 'Search', 'wc-admin' ),
+				remove: __( 'Remove product filter', 'wc-admin' ),
+				rule: __( 'Select a product filter match', 'wc-admin' ),
+				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
+				title: __( 'Product {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select product', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to products including a given product(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Includes', 'products', 'wc-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to products excluding a products(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Excludes', 'products', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'products',
+				getLabels: getRequestByIdString( NAMESPACE + 'products', product => ( {
+					id: product.id,
+					label: product.name,
+				} ) ),
+			},
+		},
+	},
+};
+/*eslint-enable max-len*/

--- a/client/analytics/report/downloads/index.js
+++ b/client/analytics/report/downloads/index.js
@@ -1,0 +1,38 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ReportFilters } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { filters, advancedFilters } from './config';
+
+export default class DownloadsReport extends Component {
+	render() {
+		const { query, path } = this.props;
+
+		return (
+			<Fragment>
+				<ReportFilters
+					query={ query }
+					path={ path }
+					filters={ filters }
+					showDatePicker={ false }
+					advancedFilters={ advancedFilters }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+DownloadsReport.propTypes = {
+	query: PropTypes.object.isRequired,
+};

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -24,6 +24,7 @@ import RevenueReport from './revenue';
 import CategoriesReport from './categories';
 import CouponsReport from './coupons';
 import TaxesReport from './taxes';
+import DownloadsReport from './downloads';
 import StockReport from './stock';
 import CustomersReport from './customers';
 
@@ -60,6 +61,11 @@ const getReports = () => {
 			report: 'taxes',
 			title: __( 'Taxes', 'wc-admin' ),
 			component: TaxesReport,
+		},
+		{
+			report: 'downloads',
+			title: __( 'Downloads', 'wc-admin' ),
+			component: DownloadsReport,
 		},
 		{
 			report: 'stock',

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -135,6 +135,14 @@ function wc_admin_register_pages() {
 
 	wc_admin_register_page(
 		array(
+			'title'  => __( 'Downloads', 'wc-admin' ),
+			'parent' => '/analytics/revenue',
+			'path'   => '/analytics/downloads',
+		)
+	);
+
+	wc_admin_register_page(
+		array(
 			'title'  => __( 'Stock', 'wc-admin' ),
 			'parent' => '/analytics/revenue',
 			'path'   => '/analytics/stock',


### PR DESCRIPTION
Closes #922.

This PR adds a base page for the downloads report. It adds a menu item and a filter selector. Other filters and pieces of the page will be added in child tasks of #173.

### Screenshots

<img width="1090" alt="screen shot 2018-12-17 at 2 01 01 pm" src="https://user-images.githubusercontent.com/689165/50109955-1dd47400-0207-11e9-9050-2ee153153b16.png">

### Detailed test instructions:

* Verify that you see a downloads item under the analytics menu
* Verify that clicking the menu item takes you to a page with a filter dropdown. Verify you can use the products filter.