### PR TITLE
Hook up coupon report to new REST endpoint

### DIFF
--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -12,13 +12,13 @@ import { NAMESPACE } from 'store/constants';
 
 export const charts = [
 	{
-		key: 'discounted_orders',
+		key: 'orders_count',
 		label: __( 'Discounted Orders', 'wc-admin' ),
 		type: 'number',
 	},
 	{
-		key: 'coupons',
-		label: __( 'Gross Discounted', 'wc-admin' ),
+		key: 'amount',
+		label: __( 'Amount', 'wc-admin' ),
 		type: 'currency',
 	},
 ];
@@ -48,7 +48,7 @@ export const filters = [
 				},
 			},
 			{ label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ), value: 'top_orders' },
-			{ label: __( 'Top Coupons by Gross Discounted', 'wc-admin' ), value: 'top_discount' },
+			{ label: __( 'Top Coupons by Amount Discounted', 'wc-admin' ), value: 'top_discount' },
 		],
 	},
 ];

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -28,13 +28,13 @@ export default class CouponsReport extends Component {
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
 					charts={ charts }
-					endpoint="orders"
+					endpoint="coupons"
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
 					charts={ charts }
-					endpoint="orders"
+					endpoint="coupons"
 					path={ path }
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -33,11 +33,9 @@ export default class CouponsReportTable extends Component {
 		return [
 			{
 				label: __( 'Coupon Code', 'wc-admin' ),
-				// @TODO it should be the coupon code, not the coupon ID
 				key: 'coupon_id',
 				required: true,
 				isLeftAligned: true,
-				isSortable: true,
 			},
 			{
 				label: __( 'Orders', 'wc-admin' ),
@@ -48,26 +46,22 @@ export default class CouponsReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'G. Discounted', 'wc-admin' ),
-				screenReaderLabel: __( 'Gross Discounted', 'wc-admin' ),
-				key: 'gross_discount',
+				label: __( 'Amount Discounted', 'wc-admin' ),
+				key: 'amount',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
 				label: __( 'Created', 'wc-admin' ),
 				key: 'created',
-				isSortable: true,
 			},
 			{
 				label: __( 'Expires', 'wc-admin' ),
 				key: 'expires',
-				isSortable: true,
 			},
 			{
 				label: __( 'Type', 'wc-admin' ),
 				key: 'type',
-				isSortable: false,
 			},
 		];
 	}
@@ -78,12 +72,13 @@ export default class CouponsReportTable extends Component {
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 
 		return map( coupons, coupon => {
-			const { coupon_id, gross_discount, orders_count } = coupon;
+			const { amount, coupon_id, extended_info, orders_count } = coupon;
+			const { code, date_created, date_expires, discount_type } = extended_info;
 
 			// @TODO must link to the coupon detail report
 			const couponLink = (
 				<Link href="" type="wc-admin">
-					{ coupon_id }
+					{ code }
 				</Link>
 			);
 
@@ -97,33 +92,29 @@ export default class CouponsReportTable extends Component {
 			);
 
 			return [
-				// @TODO it should be the coupon code, not the coupon ID
 				{
 					display: couponLink,
-					value: coupon_id,
+					value: code,
 				},
 				{
 					display: ordersLink,
 					value: orders_count,
 				},
 				{
-					display: formatCurrency( gross_discount ),
-					value: getCurrencyFormatDecimal( gross_discount ),
+					display: formatCurrency( amount ),
+					value: getCurrencyFormatDecimal( amount ),
 				},
 				{
-					// @TODO
-					display: formatDate( tableFormat, '' ),
-					value: '',
+					display: formatDate( tableFormat, date_created ),
+					value: date_created,
 				},
 				{
-					// @TODO
-					display: formatDate( tableFormat, '' ),
-					value: '',
+					display: date_expires ? formatDate( tableFormat, date_expires ) : __( 'N/A', 'wc-admin' ),
+					value: date_expires,
 				},
 				{
-					// @TODO
-					display: '',
-					value: '',
+					display: this.getCouponType( discount_type ),
+					value: discount_type,
 				},
 			];
 		} );
@@ -143,10 +134,19 @@ export default class CouponsReportTable extends Component {
 				value: numberFormat( totals.orders_count ),
 			},
 			{
-				label: __( 'gross discounted', 'wc-admin' ),
-				value: formatCurrency( totals.gross_discount ),
+				label: __( 'amount discounted', 'wc-admin' ),
+				value: formatCurrency( totals.amount ),
 			},
 		];
+	}
+
+	getCouponType( discount_type ) {
+		const couponTypes = {
+			percent: __( 'Percentage', 'wc-admin' ),
+			fixed_cart: __( 'Fixed cart', 'wc-admin' ),
+			fixed_product: __( 'Fixed product', 'wc-admin' ),
+		};
+		return couponTypes[ discount_type ];
 	}
 
 	render() {
@@ -161,6 +161,11 @@ export default class CouponsReportTable extends Component {
 				getSummary={ this.getSummary }
 				itemIdField="coupon_id"
 				query={ query }
+				tableQuery={ {
+					orderby: query.orderby || 'coupon_id',
+					order: query.order || 'asc',
+					extended_info: true,
+				} }
 				title={ __( 'Coupons', 'wc-admin' ) }
 				columnPrefsKey="coupons_report_columns"
 			/>

--- a/client/store/reports/items/resolvers.js
+++ b/client/store/reports/items/resolvers.js
@@ -20,22 +20,6 @@ export default {
 	async getReportItems( ...args ) {
 		const [ endpoint, query ] = args.slice( -2 );
 
-		const swaggerEndpoints = [ 'coupons' ];
-		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
-			try {
-				const response = await fetch(
-					SWAGGERNAMESPACE + 'reports/' + endpoint + stringifyQuery( query )
-				);
-				const itemsData = await response.json();
-
-				dispatch( 'wc-admin' ).setReportItems( endpoint, query, itemsData );
-			} catch ( error ) {
-				dispatch( 'wc-admin' ).setReportItemsError( endpoint, query );
-			}
-
-			return;
-		}
-
 		try {
 			const response = await apiFetch( {
 				parse: false,

--- a/client/store/reports/stats/resolvers.js
+++ b/client/store/reports/stats/resolvers.js
@@ -28,7 +28,7 @@ export default {
 		let apiPath = endpoint + stringifyQuery( query );
 
 		// TODO: Remove once swagger endpoints are phased out.
-		const swaggerEndpoints = [ 'categories', 'coupons' ];
+		const swaggerEndpoints = [ 'categories' ];
 		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
 			apiPath = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
 			try {

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -17,7 +17,7 @@ import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
 // TODO: Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'coupons', 'customers', 'downloads' ];
+const swaggerEndpoints = [ 'customers', 'downloads' ];
 
 const typeEndpointMap = {
 	'report-items-query-orders': 'orders',

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -16,9 +16,9 @@ import { getResourceIdentifier, getResourcePrefix } from '../../utils';
 import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
-const statEndpoints = [ 'orders', 'revenue', 'products', 'taxes' ];
+const statEndpoints = [ 'orders', 'revenue', 'products', 'taxes', 'coupons' ];
 // TODO: Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'categories', 'coupons', 'downloads' ];
+const swaggerEndpoints = [ 'categories', 'downloads' ];
 
 const typeEndpointMap = {
 	'report-stats-query-orders': 'orders',


### PR DESCRIPTION
Fixes #940 

Hooks up the coupons report to the new REST endpoints.

Branched from, blocked by, and will be rebased pending merge of #1010 

### Screenshots
<img width="1452" alt="screen shot 2018-12-18 at 1 31 49 pm" src="https://user-images.githubusercontent.com/10561050/50134089-6d7b7400-02c9-11e9-8ccb-5dab01ac1022.png">

### Detailed test instructions:

1.  Create a few coupon codes to test if you don't already have some readily available. `/wp-admin/edit.php?post_type=shop_coupon`
2.  Create a few test orders using the various coupon codes.
3.  Check that stats on the coupons report reflect the correct amounts. `wp-admin/admin.php?page=wc-admin#/analytics/coupons`

### Questions
* Sorting for extended info columns (Coupon Code, Created, Expires, and Type) won't work with the existing data store.  Do we want to open a separate issue to address these or is sorting not important for those columns?
* Expiration date won't always be filled in.  I've added "N/A" if it's not since we've used this same pattern in other areas.  Does that sound okay @LevinMedia?
<img width="240" alt="screen shot 2018-12-18 at 1 30 45 pm" src="https://user-images.githubusercontent.com/10561050/50134210-eb3f7f80-02c9-11e9-97a6-f4c3763cab29.png">
