### PR TITLE
Use <Link> instead of <a> for Orders table link

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -19,7 +19,6 @@ import {
 } from '@woocommerce/date';
 import { Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
-import { getAdminLink } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -139,7 +138,11 @@ class OrdersReportTable extends Component {
 					value: date,
 				},
 				{
-					display: <a href={ getAdminLink( 'post.php?post=' + id + '&action=edit' ) }>{ id }</a>,
+					display: (
+						<Link href={ 'post.php?post=' + id + '&action=edit' } type="wp-admin">
+							{ id }
+						</Link>
+					),
 					value: id,
 				},
 				{


### PR DESCRIPTION
Tiny PR that replaces an `<a>` link with `<Link>`.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50145625-50877680-02b2-11e9-8814-8abd67f0ea06.png)

### Detailed test instructions:
- Go to the _Orders_ report and click on an Order ID link.
- Verify the link still redirects to something like `/wp-admin/post.php?post=461&action=edit`.