### PR TITLE
Add customer numeric filters

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -166,6 +166,81 @@ export const advancedFilters = {
 				} ) ),
 			},
 		},
+		order_count: {
+			labels: {
+				add: 'No. of Orders',
+				remove: 'Remove order  filter',
+				rule: 'Select an order count filter match',
+				title: 'No. of Orders {{rule /}} {{filter /}}',
+			},
+			rules: [
+				{
+					value: 'max',
+					label: 'Less Than',
+				},
+				{
+					value: 'min',
+					label: 'More Than',
+				},
+				{
+					value: 'between',
+					label: 'Between',
+				},
+			],
+			input: {
+				component: 'Number',
+			},
+		},
+		total_spend: {
+			labels: {
+				add: 'Total Spend',
+				remove: 'Remove total spend filter',
+				rule: 'Select a total spend filter match',
+				title: 'Total Spend {{rule /}} {{filter /}}',
+			},
+			rules: [
+				{
+					value: 'max',
+					label: 'Less Than',
+				},
+				{
+					value: 'min',
+					label: 'More Than',
+				},
+				{
+					value: 'between',
+					label: 'Between',
+				},
+			],
+			input: {
+				component: 'Number',
+			},
+		},
+		avg_order_value: {
+			labels: {
+				add: 'AOV',
+				remove: 'Remove average older value filter',
+				rule: 'Select an average order value filter match',
+				title: 'AOV {{rule /}} {{filter /}}',
+			},
+			rules: [
+				{
+					value: 'max',
+					label: 'Less Than',
+				},
+				{
+					value: 'min',
+					label: 'More Than',
+				},
+				{
+					value: 'between',
+					label: 'Between',
+				},
+			],
+			input: {
+				component: 'Number',
+			},
+		},
 	},
 };
 /*eslint-enable max-len*/

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -168,23 +168,26 @@ export const advancedFilters = {
 		},
 		order_count: {
 			labels: {
-				add: 'No. of Orders',
-				remove: 'Remove order  filter',
-				rule: 'Select an order count filter match',
-				title: 'No. of Orders {{rule /}} {{filter /}}',
+				add: __( 'No. of Orders', 'wc-admin' ),
+				remove: __( 'Remove order  filter', 'wc-admin' ),
+				rule: __( 'Select an order count filter match', 'wc-admin' ),
+				title: __( 'No. of Orders {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
 					value: 'max',
-					label: 'Less Than',
+					/* translators: Sentence fragment, logical, "Less Than" refers to number of orders a customer has placed, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Less Than', 'number of orders', 'wc-admin' ),
 				},
 				{
 					value: 'min',
-					label: 'More Than',
+					/* translators: Sentence fragment, logical, "More Than" refers to number of orders a customer has placed, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'More Than', 'number of orders', 'wc-admin' ),
 				},
 				{
 					value: 'between',
-					label: 'Between',
+					/* translators: Sentence fragment, logical, "Between" refers to number of orders a customer has placed, between two given integers. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Between', 'number of orders', 'wc-admin' ),
 				},
 			],
 			input: {
@@ -193,52 +196,61 @@ export const advancedFilters = {
 		},
 		total_spend: {
 			labels: {
-				add: 'Total Spend',
-				remove: 'Remove total spend filter',
-				rule: 'Select a total spend filter match',
-				title: 'Total Spend {{rule /}} {{filter /}}',
+				add: __( 'Total Spend', 'wc-admin' ),
+				remove: __( 'Remove total spend filter', 'wc-admin' ),
+				rule: __( 'Select a total spend filter match', 'wc-admin' ),
+				title: __( 'Total Spend {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
 					value: 'max',
-					label: 'Less Than',
+					/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Less Than', 'total spend by customer', 'wc-admin' ),
 				},
 				{
 					value: 'min',
-					label: 'More Than',
+					/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'More Than', 'total spend by customer', 'wc-admin' ),
 				},
 				{
 					value: 'between',
-					label: 'Between',
+					/* translators: Sentence fragment, logical, "Between" refers to total spending by a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Between', 'total spend by customer', 'wc-admin' ),
 				},
 			],
 			input: {
 				component: 'Number',
+				type: 'currency',
 			},
 		},
 		avg_order_value: {
 			labels: {
-				add: 'AOV',
-				remove: 'Remove average older value filter',
-				rule: 'Select an average order value filter match',
-				title: 'AOV {{rule /}} {{filter /}}',
+				add: __( 'AOV', 'wc-admin' ),
+				remove: __( 'Remove average older value filter', 'wc-admin' ),
+				rule: __( 'Select an average order value filter match', 'wc-admin' ),
+				title: __( 'AOV {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
 					value: 'max',
-					label: 'Less Than',
+					/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Less Than', 'average order value of customer', 'wc-admin' ),
 				},
 				{
 					value: 'min',
-					label: 'More Than',
+					/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+
+					label: _x( 'More Than', 'average order value of customer', 'wc-admin' ),
 				},
 				{
 					value: 'between',
-					label: 'Between',
+					/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Between', 'average order value of customer', 'wc-admin' ),
 				},
 			],
 			input: {
 				component: 'Number',
+				type: 'currency',
 			},
 		},
 	},

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -219,8 +219,7 @@ export const advancedFilters = {
 				},
 			],
 			input: {
-				component: 'Number',
-				type: 'currency',
+				component: 'Currency',
 			},
 		},
 		avg_order_value: {
@@ -249,8 +248,7 @@ export const advancedFilters = {
 				},
 			],
 			input: {
-				component: 'Number',
-				type: 'currency',
+				component: 'Currency',
 			},
 		},
 	},

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -38,23 +38,26 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['name']                = $request['name'];
-		$args['username']            = $request['username'];
-		$args['email']               = $request['email'];
-		$args['country']             = $request['country'];
-		$args['last_active_before']  = $request['last_active_before'];
-		$args['last_active_after']   = $request['last_active_after'];
-		$args['order_count_min']     = $request['order_count_min'];
-		$args['order_count_max']     = $request['order_count_max'];
-		$args['total_spend_min']     = $request['total_spend_min'];
-		$args['total_spend_max']     = $request['total_spend_max'];
-		$args['avg_order_value_min'] = $request['avg_order_value_min'];
-		$args['avg_order_value_max'] = $request['avg_order_value_max'];
+		$args                            = array();
+		$args['before']                  = $request['before'];
+		$args['after']                   = $request['after'];
+		$args['page']                    = $request['page'];
+		$args['per_page']                = $request['per_page'];
+		$args['name']                    = $request['name'];
+		$args['username']                = $request['username'];
+		$args['email']                   = $request['email'];
+		$args['country']                 = $request['country'];
+		$args['last_active_before']      = $request['last_active_before'];
+		$args['last_active_after']       = $request['last_active_after'];
+		$args['order_count_min']         = $request['order_count_min'];
+		$args['order_count_max']         = $request['order_count_max'];
+		$args['order_count_between']     = $request['order_count_between'];
+		$args['total_spend_min']         = $request['total_spend_min'];
+		$args['total_spend_max']         = $request['total_spend_max'];
+		$args['total_spend_between']     = $request['total_spend_between'];
+		$args['avg_order_value_min']     = $request['avg_order_value_min'];
+		$args['avg_order_value_max']     = $request['avg_order_value_max'];
+		$args['avg_order_value_between'] = $request['avg_order_value_between'];
 		return $args;
 	}
 
@@ -204,21 +207,21 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                        = array();
-		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['before']              = array(
+		$params                            = array();
+		$params['context']                 = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['before']                  = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']               = array(
+		$params['after']                   = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['page']                = array(
+		$params['page']                    = array(
 			'description'       => __( 'Current page of the collection.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -226,7 +229,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']            = array(
+		$params['per_page']                = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -235,68 +238,83 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']                = array(
+		$params['name']                    = array(
 			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username']            = array(
+		$params['username']                = array(
 			'description'       => __( 'Limit response to objects with a specfic username.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email']               = array(
+		$params['email']                   = array(
 			'description'       => __( 'Limit response to objects equal to an email.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['country']             = array(
+		$params['country']                 = array(
 			'description'       => __( 'Limit response to objects with a specfic country.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['last_active_before']  = array(
+		$params['last_active_before']      = array(
 			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['last_active_after']   = array(
+		$params['last_active_after']       = array(
 			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_count_min']     = array(
+		$params['order_count_min']         = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_count_max']     = array(
+		$params['order_count_max']         = array(
 			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['total_spend_min']     = array(
+		$params['order_count_between']     = array(
+			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['total_spend_max']     = array(
+		$params['total_spend_max']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['avg_order_value_min'] = array(
+		$params['total_spend_between']     = array(
+			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['avg_order_value_max'] = array(
+		$params['avg_order_value_max']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'wc-admin' ),
 			'type'              => 'number',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['avg_order_value_between'] = array(
+			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
+			'type'              => 'array',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $params;

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -201,6 +201,15 @@ class AdvancedFilters extends Component {
 										query={ query }
 									/>
 								) }
+								{ 'Currency' === input.component && (
+									<NumberFilter
+										filter={ filter }
+										config={ { ...config.filters[ key ], ...{ input: { type: 'currency', component: 'Currency' } } } }
+										onFilterChange={ this.onFilterChange }
+										isEnglish={ isEnglish }
+										query={ query }
+									/>
+								) }
 								<IconButton
 									className="woocommerce-filters-advanced__remove"
 									label={ labels.remove }


### PR DESCRIPTION
Fixes #1034 

Adds in the AOV, Total Spend, and Order Count filters to the customers report.

Testing is blocked by #1115

### Screenshots
<img width="440" alt="screen shot 2018-12-18 at 6 04 42 pm" src="https://user-images.githubusercontent.com/10561050/50146730-6c5d3d80-02ef-11e9-9fc9-a7dcc13d09b3.png">

### Detailed test instructions:

1. Visit `wp-admin/admin.php?page=wc-admin#/analytics/customers`.
2. Add the 3 filters (AOV/Total Spend/No. of Orders).
3. Add amounts for less than, more than, and between.
4.  Check that the respective params are added to the URL on filter.
