### PR TITLE
Fix “uncontrolled input” warning in NumberFilter component.

### DIFF
--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -67,14 +67,14 @@ class NumberFilter extends Component {
 					suffix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
 					className="woocommerce-filters-advanced__input"
 					type="number"
-					value={ value }
+					value={ value || '' }
 					onChange={ onChange }
 				/>
 				: <TextControlWithAffixes
 					prefix={ <span dangerouslySetInnerHTML={ { __html: currencySymbol } } /> }
 					className="woocommerce-filters-advanced__input"
 					type="number"
-					value={ value }
+					value={ value || '' }
 					onChange={ onChange }
 				/>
 			);
@@ -84,7 +84,7 @@ class NumberFilter extends Component {
 			<TextControl
 				className="woocommerce-filters-advanced__input"
 				type="number"
-				value={ value }
+				value={ value || '' }
 				onChange={ onChange }
 			/>
 		);


### PR DESCRIPTION
Fixes #1115.

This PR prevents a `null` from being set for the `value` prop of `NumberFilter` inputs.

### Detailed test instructions:

* Visit the devdocs.
* Add the subtotal filter under the "Advanced Filters."
* Add and remove a value in the input field.
* Verify no "uncontrolled input" warning in the console.
