### PR TITLE
Update npm versions and build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:update-snapshots": "jest --updateSnapshot --config tests/js/jest.config.json",
     "docs": "node ./bin/generate-docs",
     "publish:check": "npm run build:packages && lerna updated",
-    "publish:dev": "npm run build:packages && lerna publish --npm-tag next",
+    "publish:dev": "npm run build:packages && lerna publish from-package --npm-tag next",
     "publish:prod": "npm run build:packages && lerna publish from-package"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/components",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "UI components for WooCommerce.",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",
@@ -22,9 +22,9 @@
   "react-native": "src/index",
   "dependencies": {
     "@babel/runtime-corejs2": "7.2.0",
-    "@woocommerce/csv-export": "^1.0.0",
+    "@woocommerce/csv-export": "^1.0.1",
     "@woocommerce/currency": "^1.0.0",
-    "@woocommerce/date": "^1.0.2",
+    "@woocommerce/date": "^1.0.3",
     "@woocommerce/navigation": "^1.1.0",
     "@wordpress/components": "3.0.0",
     "@wordpress/compose": "3.0.0",

--- a/packages/csv-export/package.json
+++ b/packages/csv-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/csv-export",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WooCommerce utility library to convert data to CSV files.",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Per some feedback from [Ben in slack](https://a8c.slack.com/archives/C9K5T0XSP/p1544822558289800) - this changes our build script to use `lerna publish from-package` to get around the issues of pushing tags to `master`. On this branch I ran `lerna version` which did the tag creation and the package.json updates below.

I still need to run `publish:prod` but guessing that should be done from `master` once this branch is merged.