### PR TITLE
Fix error on dashboard.

### DIFF
--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { get, map } from 'lodash';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -20,7 +19,7 @@ import { getAdminLink } from '@woocommerce/navigation';
  */
 import { numberFormat } from 'lib/number';
 import ReportError from 'analytics/components/report-error';
-import { NAMESPACE } from 'store/constants';
+import withSelect from 'wc-api/with-select';
 import './style.scss';
 
 export class TopSellingProducts extends Component {
@@ -123,8 +122,8 @@ export class TopSellingProducts extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-admin' );
-		const endpoint = NAMESPACE + 'reports/products';
+		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
+		const endpoint = 'products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
 		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };

--- a/client/dashboard/top-selling-products/index.js
+++ b/client/dashboard/top-selling-products/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { get, map } from 'lodash';
 import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -19,7 +20,7 @@ import { getAdminLink } from '@woocommerce/navigation';
  */
 import { numberFormat } from 'lib/number';
 import ReportError from 'analytics/components/report-error';
-import withSelect from 'wc-api/with-select';
+import { NAMESPACE } from 'store/constants';
 import './style.scss';
 
 export class TopSellingProducts extends Component {
@@ -122,15 +123,15 @@ export class TopSellingProducts extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
-		const endpoint = 'products';
+		const { getReportStats, isReportStatsRequesting, isReportStatsError } = select( 'wc-admin' );
+		const endpoint = NAMESPACE + 'reports/products';
 		// @TODO We will need to add the date parameters from the Date Picker
 		// { after: '2018-04-22', before: '2018-05-06' }
 		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		const stats = getReportStats( endpoint, query );
 		const isRequesting = isReportStatsRequesting( endpoint, query );
-		const isError = Boolean( getReportStatsError( endpoint, query ) );
+		const isError = isReportStatsError( endpoint, query );
 
 		return { data: get( stats, 'data', [] ), isRequesting, isError };
 	} )

--- a/client/dashboard/top-selling-products/test/index.js
+++ b/client/dashboard/top-selling-products/test/index.js
@@ -50,14 +50,14 @@ describe( 'TopSellingProducts', () => {
 	test( 'should load report stats from API', () => {
 		const getReportStatsMock = jest.fn().mockReturnValue( { data: mockData } );
 		const isReportStatsRequestingMock = jest.fn().mockReturnValue( false );
-		const getReportStatsErrorMock = jest.fn().mockReturnValue( undefined );
+		const isReportStatsErrorMock = jest.fn().mockReturnValue( false );
 		const registry = createRegistry();
 		registry.registerStore( 'wc-admin', {
 			reducer: () => {},
 			selectors: {
 				getReportStats: getReportStatsMock,
 				isReportStatsRequesting: isReportStatsRequestingMock,
-				getReportStatsError: getReportStatsErrorMock,
+				isReportStatsError: isReportStatsErrorMock,
 			},
 		} );
 		const topSellingProductsWrapper = TestRenderer.create(
@@ -74,8 +74,8 @@ describe( 'TopSellingProducts', () => {
 		expect( getReportStatsMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
 		expect( isReportStatsRequestingMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
 		expect( isReportStatsRequestingMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
-		expect( getReportStatsErrorMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
-		expect( getReportStatsErrorMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
+		expect( isReportStatsErrorMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );
+		expect( isReportStatsErrorMock.mock.calls[ 0 ][ 2 ] ).toEqual( query );
 		expect( topSellingProducts.props.data ).toBe( mockData );
 	} );
 } );


### PR DESCRIPTION
Currently on `master` when attempting to load up the dashboard, the following error is shown:

![revenue analytics woo test woocommerce 2018-12-18 10-42-13](https://user-images.githubusercontent.com/22080/50176147-7cefc280-02b3-11e9-99c7-e5332f59a9b4.png)

This branch fixes the issue by using the wc-api `withSelect`. Please note there still seems to be some bugs here due to product names via extended-info not appearing as expected, but this branch at least returns the dashboard to a usable state.

__To Test__
- checkout `master` verify the dashboard is broken
- checkout this branch, verify the dashboard will load