### PR TITLE
Add product categories wc-api and breadcrumbs

### DIFF
--- a/client/analytics/report/categories/breadcrumbs.js
+++ b/client/analytics/report/categories/breadcrumbs.js
@@ -1,0 +1,67 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { first, last } from 'lodash';
+import { Spinner } from '@wordpress/components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Link } from '@woocommerce/components';
+
+export default class CategoryBreadcrumbs extends Component {
+	getCategoryAncestorIds( category, categories ) {
+		const ancestors = [];
+		let parent = category.parent;
+		while ( parent ) {
+			ancestors.unshift( parent );
+			parent = categories[ parent ].parent;
+		}
+		return ancestors;
+	}
+
+	getCategoryAncestors( category, categories ) {
+		const ancestorIds = this.getCategoryAncestorIds( category, categories );
+
+		if ( ! ancestorIds.length ) {
+			return;
+		}
+		if ( ancestorIds.length === 1 ) {
+			return categories[ first( ancestorIds ) ].name + ' › ';
+		}
+		if ( ancestorIds.length === 2 ) {
+			return (
+				categories[ first( ancestorIds ) ].name +
+				' › ' +
+				categories[ last( ancestorIds ) ].name +
+				' › '
+			);
+		}
+		return (
+			categories[ first( ancestorIds ) ].name +
+			' … ' +
+			categories[ last( ancestorIds ) ].name +
+			' › '
+		);
+	}
+
+	render() {
+		const { categories, category } = this.props;
+
+		return category ? (
+			<div className="woocommerce-table__breadcrumbs">
+				{ this.getCategoryAncestors( category, categories ) }
+				<Link
+					href={ 'term.php?taxonomy=product_cat&post_type=product&tag_ID=' + category.id }
+					type="wp-admin"
+				>
+					{ category.name }
+				</Link>
+			</div>
+		) : (
+			<Spinner />
+		);
+	}
+}

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -150,7 +150,7 @@ export default compose(
 	withSelect( select => {
 		const { getCategories, getCategoriesError, isGetCategoriesRequesting } = select( 'wc-api' );
 		const categoriesQuery = {
-			per_page: 100,
+			per_page: server.php_int_max, // eslint-disable-line
 		};
 
 		const categories = getCategories( categoriesQuery );

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -149,13 +149,10 @@ class CategoriesReportTable extends Component {
 export default compose(
 	withSelect( select => {
 		const { getCategories, getCategoriesError, isGetCategoriesRequesting } = select( 'wc-api' );
-		const categoriesQuery = {
-			per_page: server.php_int_max, // eslint-disable-line
-		};
 
-		const categories = getCategories( categoriesQuery );
-		const isError = Boolean( getCategoriesError( categoriesQuery ) );
-		const isRequesting = isGetCategoriesRequesting( categoriesQuery );
+		const categories = getCategories();
+		const isError = Boolean( getCategoriesError() );
+		const isRequesting = isGetCategoriesRequesting();
 
 		return { categories, isError, isRequesting };
 	} )

--- a/client/analytics/report/products/style.scss
+++ b/client/analytics/report/products/style.scss
@@ -1,0 +1,16 @@
+/** @format */
+
+.woocommerce-table__product-categories {
+	> .woocommerce-table__breadcrumbs {
+		display: inline-block;
+		margin-right: $gap-small;
+	}
+	.components-popover__content {
+		padding: 0 $gap;
+		text-align: left;
+	}
+	.components-popover__content .woocommerce-table__breadcrumbs {
+		margin-top: $gap-small;
+		margin-bottom: $gap-small;
+	}
+}

--- a/client/wc-api/categories/index.js
+++ b/client/wc-api/categories/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/categories/operations.js
+++ b/client/wc-api/categories/operations.js
@@ -1,0 +1,54 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { isResourcePrefix, getResourceIdentifier, getResourceName } from '../utils';
+
+function read( resourceNames, fetch = apiFetch ) {
+	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'category-query' ) );
+
+	return filteredNames.map( async resourceName => {
+		const query = getResourceIdentifier( resourceName );
+		const url = `/wp/v2/product_cat${ stringifyQuery( query ) }`;
+
+		try {
+			const response = await fetch( {
+				parse: false,
+				path: url,
+			} );
+
+			const categories = await response.json();
+			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
+			const ids = categories.map( category => category.id );
+			const categoryResources = categories.reduce( ( resources, category ) => {
+				resources[ getResourceName( 'category', category.id ) ] = { data: category };
+				return resources;
+			}, {} );
+
+			return {
+				[ resourceName ]: {
+					data: ids,
+					totalCount,
+				},
+				...categoryResources,
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/categories/operations.js
+++ b/client/wc-api/categories/operations.js
@@ -20,7 +20,7 @@ function read( resourceNames, fetch = apiFetch ) {
 
 	return filteredNames.map( async resourceName => {
 		const query = getResourceIdentifier( resourceName );
-		const url = `/wp/v2/product_cat${ stringifyQuery( query ) }`;
+		const url = `/wc/v3/products/categories${ stringifyQuery( query ) }`;
 
 		try {
 			const response = await fetch( {

--- a/client/wc-api/categories/selectors.js
+++ b/client/wc-api/categories/selectors.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+import { DEFAULT_REQUIREMENT } from '../constants';
+
+const getCategories = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'category-query', query );
+	const ids = requireResource( requirement, resourceName ).data || [];
+	const categories = ids.reduce(
+		( acc, id ) => ( {
+			...acc,
+			[ id ]: getResource( getResourceName( 'category', id ) ).data || {},
+		} ),
+		{}
+	);
+	return categories;
+};
+
+const getCategoriesTotalCount = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'category-query', query );
+	return requireResource( requirement, resourceName ).totalCount || 0;
+};
+
+const getCategoriesError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'category-query', query );
+	return getResource( resourceName ).error;
+};
+
+const isGetCategoriesRequesting = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'category-query', query );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+export default {
+	getCategories,
+	getCategoriesError,
+	getCategoriesTotalCount,
+	isGetCategoriesRequesting,
+};

--- a/client/wc-api/categories/selectors.js
+++ b/client/wc-api/categories/selectors.js
@@ -27,12 +27,9 @@ const getCategories = ( getResource, requireResource ) => (
 	return categories;
 };
 
-const getCategoriesTotalCount = ( getResource, requireResource ) => (
-	query = {},
-	requirement = DEFAULT_REQUIREMENT
-) => {
+const getCategoriesTotalCount = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'category-query', query );
-	return requireResource( requirement, resourceName ).totalCount || 0;
+	return getResource( resourceName ).totalCount || 0;
 };
 
 const getCategoriesError = getResource => ( query = {} ) => {

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import categories from './categories';
 import customers from './customers';
 import notes from './notes';
 import orders from './orders';
@@ -17,6 +18,7 @@ function createWcApiSpec() {
 			...user.mutations,
 		},
 		selectors: {
+			...categories.selectors,
 			...customers.selectors,
 			...notes.selectors,
 			...orders.selectors,
@@ -28,6 +30,7 @@ function createWcApiSpec() {
 		operations: {
 			read( resourceNames ) {
 				return [
+					...categories.operations.read( resourceNames ),
 					...customers.operations.read( resourceNames ),
 					...notes.operations.read( resourceNames ),
 					...orders.operations.read( resourceNames ),

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -31,6 +31,8 @@ class WC_Admin_Api_Init {
 		add_action( 'woocommerce_after_register_post_type', array( 'WC_Admin_Api_Init', 'orders_data_store_init' ), 20 );
 		// Add taxonomy support for product categories.
 		add_filter( 'woocommerce_taxonomy_args_product_cat', array( 'WC_Admin_Api_Init', 'show_product_categories_in_rest' ) );
+		// Increase per_page limit in REST response.
+		add_filter( 'rest_product_cat_collection_params', array( 'WC_Admin_Api_Init', 'increase_per_page_limit' ) );
 	}
 
 	/**
@@ -481,6 +483,17 @@ class WC_Admin_Api_Init {
 	public static function show_product_categories_in_rest( $args ) {
 		$args['show_in_rest'] = true;
 		return $args;
+	}
+
+	/**
+	 * Increase per page limit for product categories
+	 *
+	 * @param array $query_params Rest query params.
+	 * @return array
+	 */
+	public static function increase_per_page_limit( $query_params ) {
+		$query_params['per_page']['maximum'] = PHP_INT_MAX;
+		return $query_params;
 	}
 
 }

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -32,7 +32,7 @@ class WC_Admin_Api_Init {
 		// Add taxonomy support for product categories.
 		add_filter( 'woocommerce_taxonomy_args_product_cat', array( 'WC_Admin_Api_Init', 'show_product_categories_in_rest' ) );
 		// Increase per_page limit in REST response.
-		add_filter( 'rest_product_cat_collection_params', array( 'WC_Admin_Api_Init', 'increase_per_page_limit' ) );
+		add_filter( 'woocommerce_rest_product_cat_query', array( 'WC_Admin_Api_Init', 'increase_per_page_limit' ) );
 	}
 
 	/**
@@ -488,12 +488,12 @@ class WC_Admin_Api_Init {
 	/**
 	 * Increase per page limit for product categories
 	 *
-	 * @param array $query_params Rest query params.
+	 * @param array $prepared_args Prepared arguments for query.
 	 * @return array
 	 */
-	public static function increase_per_page_limit( $query_params ) {
-		$query_params['per_page']['maximum'] = PHP_INT_MAX;
-		return $query_params;
+	public static function increase_per_page_limit( $prepared_args ) {
+		$prepared_args['number'] = PHP_INT_MAX;
+		return $prepared_args;
 	}
 
 }

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -29,6 +29,8 @@ class WC_Admin_Api_Init {
 
 		// Initialize Orders data store class's static vars.
 		add_action( 'woocommerce_after_register_post_type', array( 'WC_Admin_Api_Init', 'orders_data_store_init' ), 20 );
+		// Add taxonomy support for product categories.
+		add_filter( 'woocommerce_taxonomy_args_product_cat', array( 'WC_Admin_Api_Init', 'show_product_categories_in_rest' ) );
 	}
 
 	/**
@@ -468,6 +470,17 @@ class WC_Admin_Api_Init {
 
 		// Initialize report tables.
 		add_action( 'woocommerce_after_register_post_type', array( 'WC_Admin_Api_Init', 'order_product_lookup_store_init' ), 20 );
+	}
+
+	/**
+	 * Enables the WP REST API for product categories
+	 *
+	 * @param array $args Default arguments for product_cat taxonomy.
+	 * @return array
+	 */
+	public static function show_product_categories_in_rest( $args ) {
+		$args['show_in_rest'] = true;
+		return $args;
 	}
 
 }

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -25,17 +25,21 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 * @var array
 	 */
 	protected $column_types = array(
-		'date_start'   => 'strval',
-		'date_end'     => 'strval',
-		'product_id'   => 'intval',
-		'items_sold'   => 'intval',
-		'net_revenue'  => 'floatval',
-		'orders_count' => 'intval',
+		'date_start'       => 'strval',
+		'date_end'         => 'strval',
+		'product_id'       => 'intval',
+		'items_sold'       => 'intval',
+		'net_revenue'      => 'floatval',
+		'orders_count'     => 'intval',
 		// Extended attributes.
-		'name'         => 'strval',
-		'price'        => 'floatval',
-		'image'        => 'strval',
-		'permalink'    => 'strval',
+		'name'             => 'strval',
+		'price'            => 'floatval',
+		'image'            => 'strval',
+		'permalink'        => 'strval',
+		'stock_status'     => 'strval',
+		'stock_quantity'   => 'intval',
+		'low_stock_amount' => 'intval',
+		'category_ids'     => 'array_values',
 	);
 
 	/**
@@ -63,6 +67,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'stock_status',
 		'stock_quantity',
 		'low_stock_amount',
+		'category_ids',
 	);
 
 	/**

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -214,7 +214,6 @@ function wc_admin_enqueue_script() {
 
 	wp_enqueue_script( WC_ADMIN_APP );
 	wp_enqueue_style( WC_ADMIN_APP );
-	wp_localize_script( WC_ADMIN_APP, 'server', array( 'php_int_max' => PHP_INT_MAX ) );
 }
 add_action( 'admin_enqueue_scripts', 'wc_admin_enqueue_script' );
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -214,6 +214,7 @@ function wc_admin_enqueue_script() {
 
 	wp_enqueue_script( WC_ADMIN_APP );
 	wp_enqueue_style( WC_ADMIN_APP );
+	wp_localize_script( WC_ADMIN_APP, 'server', array( 'php_int_max' => PHP_INT_MAX ) );
 }
 add_action( 'admin_enqueue_scripts', 'wc_admin_enqueue_script' );
 

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -199,6 +199,9 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 		$product->set_low_stock_amount( 5 );
 		$product->save();
 
+		$term = wp_insert_term( 'Test Category', 'product_cat' );
+		wp_set_object_terms( $product->get_id(), $term['term_id'], 'product_cat' );
+
 		$order = WC_Helper_Order::create_order( 1, $product );
 		$order->set_status( 'completed' );
 		$order->set_shipping_total( 10 );
@@ -217,7 +220,9 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 			'extended_info' => 1,
 		);
 		// Test retrieving the stats through the data store.
-		$data          = $data_store->get_data( $args );
+		$data = $data_store->get_data( $args );
+		// Get updated product data.
+		$product       = wc_get_product( $product->get_id() );
 		$expected_data = (object) array(
 			'total'   => 1,
 			'pages'   => 1,
@@ -234,8 +239,9 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 						'permalink'        => $product->get_permalink(),
 						'price'            => (float) $product->get_price(),
 						'stock_status'     => $product->get_stock_status(),
-						'stock_quantity'   => $product->get_stock_quantity() - 4, // subtract the ones purchased.
+						'stock_quantity'   => $product->get_stock_quantity(),
 						'low_stock_amount' => $product->get_low_stock_amount(),
+						'category_ids'     => array_values( $product->get_category_ids() ),
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #1045

Adds in an API to retrieve a full list of product categories to then refer to and build breadcrumbs on the front-end.

### Screenshots
<img width="440" alt="screen shot 2018-12-19 at 3 28 40 pm" src="https://user-images.githubusercontent.com/10561050/50209250-3fbc2b00-03ae-11e9-8ac7-ac82e3ee22d5.png">

### Detailed test instructions:

1.  Make sure you've added categories and nested categories (at least 4 levels to test this PR).
2.  Visit the categories report `/wp-admin/admin.php?page=wc-admin#/analytics/categories`.
3.  Check that categories and nested categories correctly generate breadcrumbs.
4.  Visit the products report `/wp-admin/admin.php?page=wc-admin#/analytics/products`.
5.  Check that product category names are listed and that if more than 1 category exists, a tab is displayed that shows the remaining category breadcrumbs when clicked.