### PR TITLE
Fix Tag misalignment inside Search in Firefox

### DIFF
--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -15,6 +15,8 @@
 		padding: 2px 2px 2px 36px;
 		border: 1px solid $core-grey-light-700;
 		background-color: $white;
+		display: flex;
+		align-items: center;
 
 		&.is-active {
 			border-color: $input-active-border;

--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -2,8 +2,9 @@
 
 .woocommerce-tag {
 	display: inline-flex;
-	margin: 2px 4px 2px 0;
+	margin: 0 4px 0 0;
 	overflow: hidden;
+	vertical-align: middle;
 
 	.woocommerce-tag__text,
 	.woocommerce-tag__remove.components-icon-button {


### PR DESCRIPTION
Fixes a visual glitch that was affecting the Search box in Firefox (see screenshots below).

### Screenshots
_Before:_
![before](https://user-images.githubusercontent.com/3616980/50212829-4f228080-037c-11e9-81fa-565bbd6e2f52.gif)

_After:_
![after](https://user-images.githubusercontent.com/3616980/50212828-4d58bd00-037c-11e9-8553-710c8ad614be.gif)

### Detailed test instructions:
- Go to the _Customers_ report with Firefox.
- Try applying an advanced filter.
- Verify the search box doesn't change its size when adding a `Tag` and they are vertically aligned.
- Verify it didn't cause regressions with other browsers.