### PR TITLE
Add Accessibility section to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,15 @@ Fixes #
 
 _Replace this with a good description of your changes & reasoning._
 
+### Accessibility
+
+<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->
+
+- [ ] I've tested using only a keyboard (no mouse)
+- [ ] I've tested using a screen reader
+- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
+
 ### Screenshots
 
 ### Detailed test instructions:


### PR DESCRIPTION
This PR adds a new section to the PR template for accessibility, adding some checkboxes to remind everyone to test the a11y of new features. These can be deleted if they don't apply to the PR.

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

See an example on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/266 – I don't need all the items because this PR has no animations or new colors, but I can verify that I tested with a screen reader & keyboard.