### PR TITLE
Variations Table: add product, variations query params

### DIFF
--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -176,6 +176,8 @@ export default class VariationsReportTable extends Component {
 					orderby: query.orderby || 'items_sold',
 					order: query.order || 'desc',
 					extended_info: true,
+					products: query.products,
+					variations: query.variations,
 				} }
 				title={ __( 'Variations', 'wc-admin' ) }
 				columnPrefsKey="variations_report_columns"


### PR DESCRIPTION
Add `variations` and `products` query parameters back to Variations Table query. They've somehow been removed.

### Test

1. Find a product with multiple variations. `Hoodie` comes with some if you're using sample data.
2. Go to Product Report and Show > Single Product > Hoodie.
3. See the table populate with those variations, not all variations across all products.

