### PR TITLE
Add remaining filters to the downloads report

### DIFF
--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -70,6 +70,104 @@ export const advancedFilters = {
 				} ) ),
 			},
 		},
+		username: {
+			labels: {
+				add: __( 'Username', 'wc-admin' ),
+				placeholder: __( 'Search customer username', 'wc-admin' ),
+				remove: __( 'Remove customer username filter', 'wc-admin' ),
+				rule: __( 'Select a customer username filter match', 'wc-admin' ),
+				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
+				title: __( 'Username {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select customer username', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to customer usernames including a given username(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Includes', 'customer usernames', 'wc-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to customer usernames excluding a given username(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Excludes', 'customer usernames', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'usernames',
+				getLabels: getRequestByIdString( NAMESPACE + 'customers', customer => ( {
+					id: customer.id,
+					label: customer.username,
+				} ) ),
+			},
+		},
+		order: {
+			labels: {
+				add: __( 'Order number', 'wc-admin' ),
+				placeholder: __( 'Search order number', 'wc-admin' ),
+				remove: __( 'Remove order number filter', 'wc-admin' ),
+				rule: __( 'Select a order number filter match', 'wc-admin' ),
+				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
+				title: __( 'Order number {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select order number', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to order numbers including a given order(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Includes', 'order numbers', 'wc-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to order numbers excluding a given order(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Excludes', 'order numbers', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'orders',
+				getLabels: getRequestByIdString( NAMESPACE + 'orders', order => ( {
+					id: order.id,
+					label: '#' + order.id,
+				} ) ),
+			},
+		},
+		downloadIp: {
+			labels: {
+				add: __( 'IP Address', 'wc-admin' ),
+				placeholder: __( 'Search IP address', 'wc-admin' ),
+				remove: __( 'Remove IP address filter', 'wc-admin' ),
+				rule: __( 'Select an IP address filter match', 'wc-admin' ),
+				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
+				title: __( 'IP Address {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select IP address', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to IP addresses including a given address(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Includes', 'IP addresses', 'wc-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to IP addresses excluding a given address(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
+					label: _x( 'Excludes', 'IP addresses', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'downloadIps',
+				getLabels: async value => {
+					const ips = value.split( ',' );
+					return await ips.map( ip => {
+						return {
+							id: ip,
+							label: ip,
+						};
+					} );
+				},
+			},
+		},
 	},
 };
 /*eslint-enable max-len*/

--- a/includes/api/class-wc-admin-rest-data-controller.php
+++ b/includes/api/class-wc-admin-rest-data-controller.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * REST API Data Controller
+ *
+ * Handles requests to /data
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Data controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class WC_Admin_REST_Data_Controller extends WC_REST_Data_Controller {
+
+	/**
+	 * Return the list of data resources.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$response = parent::get_items( $request );
+		$response->data[] = $this->prepare_response_for_collection(
+			$this->prepare_item_for_response(
+				(object) array(
+					'slug'        => 'download-ips',
+					'description' => __( 'An endpoint used for searching download logs for a specific IP address.', 'wc-admin' ),
+				),
+				$request
+			)
+		);
+		return $response;
+	}
+
+}

--- a/includes/api/class-wc-admin-rest-data-download-ips-controller.php
+++ b/includes/api/class-wc-admin-rest-data-download-ips-controller.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * REST API Data Download IP Controller
+ *
+ * Handles requests to /data/download-ips
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Data Download IP controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/download-ips';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Return the download IPs matching the passed parameters.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		global $wpdb;
+
+		if ( isset( $request['match'] ) ) {
+			$downloads = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT DISTINCT( user_ip_address ) FROM `wp_wc_download_log`
+					WHERE user_ip_address LIKE %s',
+					$request['match'] . '%'
+				)
+			);
+		} else {
+			return new WP_Error( 'woocommerce_rest_data_download_ips_invalid_request', __( 'Invalid request. Please pass the match parameter.', 'wc-admin' ), array( 'status' => 400 ) );
+		}
+
+		$data = array();
+
+		if ( ! empty( $downloads ) ) {
+			foreach ( $downloads as $download ) {
+				$response  = $this->prepare_item_for_response( $download, $request );
+				$data[]    = $this->prepare_response_for_collection( $response );
+			}
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @since  3.5.0
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter the ist returned from the API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original item.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_download_ip', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given object.
+	 */
+	protected function prepare_links( $item ) {
+		$links = array(
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+		return $links;
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                     = array();
+		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['match']            = array(
+			'description'       => __( 'A partial IP address can be passed and matching results will be returned.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+
+	/**
+	 * Get the schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_download_ips',
+			'type'       => 'object',
+			'properties' => array(
+				'user_ip_address'      => array(
+					'type'        => 'string',
+					'description' => __( 'IP address.', 'wc-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-admin-rest-data-download-ips-controller.php
+++ b/includes/api/class-wc-admin-rest-data-download-ips-controller.php
@@ -63,8 +63,9 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 		if ( isset( $request['match'] ) ) {
 			$downloads = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT DISTINCT( user_ip_address ) FROM `wp_wc_download_log`
-					WHERE user_ip_address LIKE %s',
+					"SELECT DISTINCT( user_ip_address ) FROM {$wpdb->prefix}wc_download_log
+					WHERE user_ip_address LIKE %s
+					LIMIT 10",
 					$request['match'] . '%'
 				)
 			);

--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * REST API Orders Controller
+ *
+ * Handles requests to /orders/*
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Orders controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Orders_Controller
+ */
+class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['number'] = array(
+			'description'       => __( 'Limit result set to orders matching part of an order number.', 'wc-admin' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+	/**
+	 * Prepare objects query.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		global $wpdb;
+		$args = parent::prepare_objects_query( $request );
+
+		// Search by partial order number.
+		if ( ! empty( $request['number'] ) ) {
+			$order_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM wp_posts WHERE post_type = 'shop_order' AND ID LIKE %s",
+					intval( $request['number'] ) . '%'
+				)
+			);
+
+			// Force WP_Query return empty if don't found any order.
+			$order_ids = ! empty( $order_ids ) ? $order_ids : array( 0 );
+			$args['post__in'] = $order_ids;
+		}
+
+		return $args;
+	}
+}

--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -46,7 +46,7 @@ class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
 		if ( ! empty( $request['number'] ) ) {
 			$order_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT ID FROM wp_posts WHERE post_type = 'shop_order' AND ID LIKE %s",
+					"SELECT ID FROM {$wpdb->prefix}posts WHERE post_type = 'shop_order' AND ID LIKE %s",
 					intval( $request['number'] ) . '%'
 				)
 			);

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -87,6 +87,9 @@ class WC_Admin_Api_Init {
 	public function rest_api_init() {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-admin-notes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
@@ -111,6 +114,9 @@ class WC_Admin_Api_Init {
 		$controllers = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
 			'WC_Admin_REST_Customers_Controller',
+			'WC_Admin_REST_Data_Controller',
+			'WC_Admin_REST_Data_Download_Ips_Controller',
+			'WC_Admin_REST_Orders_Controller',
 			'WC_Admin_REST_Products_Controller',
 			'WC_Admin_REST_Product_Reviews_Controller',
 			'WC_Admin_REST_Reports_Controller',
@@ -170,17 +176,6 @@ class WC_Admin_Api_Init {
 			$endpoints['/wc/v3/reports'][0] = $endpoints['/wc/v3/reports'][1];
 		}
 
-		// Override /wc/v3/products.
-		if ( isset( $endpoints['/wc/v3/products'] )
-			&& isset( $endpoints['/wc/v3/products'][3] )
-			&& isset( $endpoints['/wc/v3/products'][2] )
-			&& $endpoints['/wc/v3/products'][2]['callback'][0] instanceof WC_Admin_REST_Products_Controller
-			&& $endpoints['/wc/v3/products'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
-		) {
-			$endpoints['/wc/v3/products'][0] = $endpoints['/wc/v3/products'][2];
-			$endpoints['/wc/v3/products'][1] = $endpoints['/wc/v3/products'][3];
-		}
-
 		// Override /wc/v3/customers.
 		if ( isset( $endpoints['/wc/v3/customers'] )
 			&& isset( $endpoints['/wc/v3/customers'][3] )
@@ -190,6 +185,50 @@ class WC_Admin_Api_Init {
 		) {
 			$endpoints['/wc/v3/customers'][0] = $endpoints['/wc/v3/customers'][2];
 			$endpoints['/wc/v3/customers'][1] = $endpoints['/wc/v3/customers'][3];
+		}
+
+		// Override /wc/v3/orders/$id.
+		if ( isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'] )
+			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5] )
+			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4] )
+			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3] )
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+		) {
+			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][0] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3];
+			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][1] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4];
+			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][2] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5];
+		}
+
+		// Override /wc/v3orders.
+		if ( isset( $endpoints['/wc/v3/orders'] )
+			&& isset( $endpoints['/wc/v3/orders'][3] )
+			&& isset( $endpoints['/wc/v3/orders'][2] )
+			&& $endpoints['/wc/v3/orders'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v3/orders'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+		) {
+			$endpoints['/wc/v3/orders'][0] = $endpoints['/wc/v3/orders'][2];
+			$endpoints['/wc/v3/orders'][1] = $endpoints['/wc/v3/orders'][3];
+		}
+
+		// Override /wc/v3/data.
+		if ( isset( $endpoints['/wc/v3/data'] )
+			&& isset( $endpoints['/wc/v3/data'][1] )
+			&& $endpoints['/wc/v3/data'][1]['callback'][0] instanceof WC_Admin_REST_Data_Controller
+		) {
+			$endpoints['/wc/v3/data'][0] = $endpoints['/wc/v3/data'][1];
+		}
+
+		// Override /wc/v3/products.
+		if ( isset( $endpoints['/wc/v3/products'] )
+			&& isset( $endpoints['/wc/v3/products'][3] )
+			&& isset( $endpoints['/wc/v3/products'][2] )
+			&& $endpoints['/wc/v3/products'][2]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+			&& $endpoints['/wc/v3/products'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+		) {
+			$endpoints['/wc/v3/products'][0] = $endpoints['/wc/v3/products'][2];
+			$endpoints['/wc/v3/products'][1] = $endpoints['/wc/v3/products'][3];
 		}
 
 		// Override /wc/v3/products/$id.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 1.3.1
-
+# 1.4.0 ( unreleased )
+- Add download log ip address autocompleter to search component
+- Add order number autocompleter to search component
+- Add order number, username, and IP address filters to the downloads report.
 - Added `interactive` prop for `d3chart/legend` to signal if legend items are clickable or not.
 
 # 1.3.0

--- a/packages/components/src/search/autocompleters/download-ips.js
+++ b/packages/components/src/search/autocompleters/download-ips.js
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+
+/**
+ * A download IP address autocompleter.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'download-ips',
+	className: 'woocommerce-search__download-ip-result',
+	options( match ) {
+		let payload = '';
+		if ( match ) {
+			const query = {
+				match,
+			};
+			payload = stringifyQuery( query );
+			return apiFetch( { path: `/wc/v3/data/download-ips${ payload }` } );
+		}
+	},
+	isDebounced: true,
+	getOptionKeywords( download ) {
+		return [ download.user_ip_address ];
+	},
+	getOptionLabel( download, query ) {
+		const match = computeSuggestionMatch( download.user_ip_address, query ) || {};
+		return [
+			<span key="name" className="woocommerce-search__result-name" aria-label={ download.user_ip_address }>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	getOptionCompletion( download ) {
+		return {
+			id: download.user_ip_address,
+			label: download.user_ip_address,
+		};
+	},
+};

--- a/packages/components/src/search/autocompleters/index.js
+++ b/packages/components/src/search/autocompleters/index.js
@@ -5,7 +5,9 @@
 export { default as countries } from './countries';
 export { default as coupons } from './coupons';
 export { default as customers } from './customers';
+export { default as downloadIps } from './download-ips';
 export { default as emails } from './emails';
+export { default as orders } from './orders';
 export { default as product } from './product';
 export { default as productCategory } from './product-cat';
 export { default as taxes } from './taxes';

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+
+/**
+ * A orders autocompleter.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'orders',
+	className: 'woocommerce-search__order-result',
+	options( number ) {
+		let payload = '';
+		if ( number ) {
+			const query = {
+				number,
+				per_page: 10,
+			};
+			payload = stringifyQuery( query );
+		}
+		return apiFetch( { path: `/wc/v3/orders${ payload }` } );
+	},
+	isDebounced: true,
+	getOptionKeywords( order ) {
+		return [ '#' + order.number ];
+	},
+	getOptionLabel( order, query ) {
+		const match = computeSuggestionMatch( '#' + order.number, query ) || {};
+		return [
+			<span key="name" className="woocommerce-search__result-name" aria-label={ '#' + order.number }>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>,
+		];
+	},
+	getOptionCompletion( order ) {
+		return {
+			id: order.id,
+			label: '#' + order.number,
+		};
+	},
+};

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { isNaN } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -23,16 +24,22 @@ import { computeSuggestionMatch } from './utils';
 export default {
 	name: 'orders',
 	className: 'woocommerce-search__order-result',
-	options( number ) {
+	options( search ) {
 		let payload = '';
-		if ( number ) {
+		if ( search ) {
+			const number = parseInt( search );
+
+			if ( isNaN( number ) ) {
+				return;
+			}
+
 			const query = {
 				number,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );
+			return apiFetch( { path: `/wc/v3/orders${ payload }` } );
 		}
-		return apiFetch( { path: `/wc/v3/orders${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( order ) {

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -14,7 +14,19 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { countries, coupons, customers, emails, product, productCategory, taxes, usernames, variations } from './autocompleters';
+import {
+	countries,
+	coupons,
+	customers,
+	downloadIps,
+	emails,
+	orders,
+	product,
+	productCategory,
+	taxes,
+	usernames,
+	variations,
+} from './autocompleters';
 import Tag from '../tag';
 
 /**
@@ -72,8 +84,12 @@ class Search extends Component {
 				return coupons;
 			case 'customers':
 				return customers;
+			case 'downloadIps':
+				return downloadIps;
 			case 'emails':
 				return emails;
+			case 'orders':
+				return orders;
 			case 'products':
 				return product;
 			case 'product_cats':
@@ -228,6 +244,7 @@ Search.propTypes = {
 		'countries',
 		'coupons',
 		'customers',
+		'downloadIps',
 		'emails',
 		'orders',
 		'products',

--- a/tests/api/data.php
+++ b/tests/api/data.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Data REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Data
+ */
+class WC_Tests_API_Data extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/data';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that the list of data endpoints includes download-ips.
+	 */
+	public function test_get_items_contains_download_ips() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 4, count( $data ) );
+		$this->assertEquals( 'download-ips', $data[3]['slug'] );
+	}
+
+	/**
+	 * Test download-ips match searching.
+	 */
+	public function test_download_ips() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$prod_download = new WC_Product_Download();
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_id( 1 );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_downloadable( 'yes' );
+		$product->set_downloads( array( $prod_download ) );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $this->user );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( $prod_download->get_id() );
+		$download->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$id = $object->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '54.2.1.3' );
+		$id = $object->save();
+
+		// Save a second log for the same IP -- only one result for this IP should be returned.
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '54.2.1.3' );
+		$id = $object->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '54.5.1.7' );
+		$id = $object->save();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/download-ips' );
+		$request->set_query_params(
+			array(
+				'match' => '54',
+			)
+		);
+
+		$response  = $this->server->dispatch( $request );
+		$addresses = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $addresses ) );
+
+		$this->assertEquals( '54.2.1.3', $addresses[0]['user_ip_address'] );
+		$this->assertEquals( '54.5.1.7', $addresses[1]['user_ip_address'] );
+	}
+}

--- a/tests/api/orders.php
+++ b/tests/api/orders.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Orders REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Orders
+ */
+class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/orders';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test order number param.
+	 */
+	public function test_get_items_number_param() {
+		wp_set_current_user( $this->user );
+
+		$orders = array();
+		for ( $i = 0; $i < 10; $i++ ) {
+			$orders[] = WC_Helper_Order::create_order( $this->user );
+		}
+
+		$order = $orders[9];
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'number' => $order->get_id(),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$orders   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $order->get_id(), $orders[0]['id'] );
+	}
+}


### PR DESCRIPTION
Fixes #263.

This PR adds the remaining missing autocomplete filters for the downloads report:
* Order number
* IP Address
* Username

The username autocompleter already existed, but orders and ip address did not, so they are added in this PR.

Some REST API changes are made to power them:
* You can now search for partial order ID number on the REST API endpoint.
* A new data endpoint is added so we can provide lookup for IP addresses in the download log.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

I did not test with a screen reader, however the filter text is being worked in #1099.

### Screenshots

<img width="1361" alt="screen shot 2018-12-20 at 1 38 50 pm" src="https://user-images.githubusercontent.com/689165/50303935-9d0eb580-045c-11e9-84cd-d91cc8d47b07.png">

### Detailed test instructions:

* Run `phpunit` and make sure all tests pass.
* Create a downloadable product, place an order for it, and make sure that order is marked as completed. Then go to "My Account > Downloads" on the front end, and download the file a few times.
* Go to the downloads report and test the username, order number, and IP filter.
* After selecting some options and filtering, try refreshing and make sure the tags stay present.