### PR TITLE
Use unbounded per_page limit in apiFetch for categories

### DIFF
--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -149,10 +149,13 @@ class CategoriesReportTable extends Component {
 export default compose(
 	withSelect( select => {
 		const { getCategories, getCategoriesError, isGetCategoriesRequesting } = select( 'wc-api' );
+		const tableQuery = {
+			per_page: -1,
+		};
 
-		const categories = getCategories();
-		const isError = Boolean( getCategoriesError() );
-		const isRequesting = isGetCategoriesRequesting();
+		const categories = getCategories( tableQuery );
+		const isError = Boolean( getCategoriesError( tableQuery ) );
+		const isRequesting = isGetCategoriesRequesting( tableQuery );
 
 		return { categories, isError, isRequesting };
 	} )

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -112,7 +112,9 @@ class ProductsReportTable extends Component {
 				products: product_id,
 			} );
 			const categories = this.props.categories;
-			const productCategories = category_ids.map( category_id => categories[ category_id ] );
+			const productCategories = category_ids
+				.map( category_id => categories[ category_id ] )
+				.filter( Boolean );
 
 			return [
 				{
@@ -247,10 +249,13 @@ class ProductsReportTable extends Component {
 export default compose(
 	withSelect( select => {
 		const { getCategories, getCategoriesError, isGetCategoriesRequesting } = select( 'wc-api' );
+		const tableQuery = {
+			per_page: -1,
+		};
 
-		const categories = getCategories();
-		const isError = Boolean( getCategoriesError() );
-		const isRequesting = isGetCategoriesRequesting();
+		const categories = getCategories( tableQuery );
+		const isError = Boolean( getCategoriesError( tableQuery ) );
+		const isRequesting = isGetCategoriesRequesting( tableQuery );
 
 		return { categories, isError, isRequesting };
 	} )

--- a/client/wc-api/categories/operations.js
+++ b/client/wc-api/categories/operations.js
@@ -23,13 +23,10 @@ function read( resourceNames, fetch = apiFetch ) {
 		const url = `/wc/v3/products/categories${ stringifyQuery( query ) }`;
 
 		try {
-			const response = await fetch( {
-				parse: false,
+			const categories = await fetch( {
 				path: url,
 			} );
 
-			const categories = await response.json();
-			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
 			const ids = categories.map( category => category.id );
 			const categoryResources = categories.reduce( ( resources, category ) => {
 				resources[ getResourceName( 'category', category.id ) ] = { data: category };
@@ -39,7 +36,7 @@ function read( resourceNames, fetch = apiFetch ) {
 			return {
 				[ resourceName ]: {
 					data: ids,
-					totalCount,
+					totalCount: ids.length,
 				},
 				...categoryResources,
 			};

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -29,10 +29,6 @@ class WC_Admin_Api_Init {
 
 		// Initialize Orders data store class's static vars.
 		add_action( 'woocommerce_after_register_post_type', array( 'WC_Admin_Api_Init', 'orders_data_store_init' ), 20 );
-		// Add taxonomy support for product categories.
-		add_filter( 'woocommerce_taxonomy_args_product_cat', array( 'WC_Admin_Api_Init', 'show_product_categories_in_rest' ) );
-		// Increase per_page limit in REST response.
-		add_filter( 'woocommerce_rest_product_cat_query', array( 'WC_Admin_Api_Init', 'increase_per_page_limit' ) );
 	}
 
 	/**
@@ -483,17 +479,6 @@ class WC_Admin_Api_Init {
 	public static function show_product_categories_in_rest( $args ) {
 		$args['show_in_rest'] = true;
 		return $args;
-	}
-
-	/**
-	 * Increase per page limit for product categories
-	 *
-	 * @param array $prepared_args Prepared arguments for query.
-	 * @return array
-	 */
-	public static function increase_per_page_limit( $prepared_args ) {
-		$prepared_args['number'] = PHP_INT_MAX;
-		return $prepared_args;
 	}
 
 }


### PR DESCRIPTION
Fixes #1148 

Removes the forced `per_page` limit and uses a `-1` value for `per_page` to retrieve categories in batches.

### Screenshots
<img width="393" alt="screen shot 2018-12-21 at 2 21 12 pm" src="https://user-images.githubusercontent.com/10561050/50327875-c5b1b080-052b-11e9-9fc1-796827c4bc68.png">
<img width="318" alt="screen shot 2018-12-21 at 2 21 02 pm" src="https://user-images.githubusercontent.com/10561050/50327876-c5b1b080-052b-11e9-940c-279309e8e878.png">

### Detailed test instructions:

1.  Open Products and Category reports.
2.  Add at least 10 categories (but preferably over 100) to test the upper limit of the api fetch.
3.  Check that categories for both reports still show correctly with breadcrumbs.
