### PR TITLE
Make user column preferences refer to hidden columns

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -26,24 +26,26 @@ import { extendTableData } from './utils';
 const TABLE_FILTER = 'woocommerce_admin_report_table';
 
 class ReportTable extends Component {
-	onColumnsChange = columns => {
+	onColumnsChange = shownColumns => {
 		const { columnPrefsKey } = this.props;
+		const columns = this.props.getHeadersContent().map( header => header.key );
+		const hiddenColumns = columns.filter( column => ! shownColumns.includes( column ) );
 
 		if ( columnPrefsKey ) {
 			const userDataFields = {
-				[ columnPrefsKey ]: columns,
+				[ columnPrefsKey ]: hiddenColumns,
 			};
 			this.props.updateCurrentUserData( userDataFields );
 		}
 	};
 
-	filterShownHeaders = ( headers, shownKeys ) => {
-		if ( ! shownKeys ) {
+	filterShownHeaders = ( headers, hiddenKeys ) => {
+		if ( ! hiddenKeys ) {
 			return headers;
 		}
 
 		return headers.map( header => {
-			const hidden = ! shownKeys.includes( header.key );
+			const hidden = hiddenKeys.includes( header.key ) && ! header.required;
 			return { ...header, hiddenByDefault: hidden };
 		} );
 	};

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -27,8 +27,8 @@ const TABLE_FILTER = 'woocommerce_admin_report_table';
 
 class ReportTable extends Component {
 	onColumnsChange = shownColumns => {
-		const { columnPrefsKey } = this.props;
-		const columns = this.props.getHeadersContent().map( header => header.key );
+		const { columnPrefsKey, getHeadersContent } = this.props;
+		const columns = getHeadersContent().map( header => header.key );
 		const hiddenColumns = columns.filter( column => ! shownColumns.includes( column ) );
 
 		if ( columnPrefsKey ) {


### PR DESCRIPTION
Fixes #1136 

Changes column preferences to store hidden columns instead of shown so that new columns are shown by default.  Also prevents required columns from being saved to this array.

### Screenshots
<img width="384" alt="screen shot 2018-12-21 at 3 01 00 pm" src="https://user-images.githubusercontent.com/10561050/50329283-838b6d80-0531-11e9-9f20-41d21ff04ea3.png">

### Detailed test instructions:

1.  Open any report page.
2.  Turn on/off various columns.
3.  Check that columns continue to persist across browers/sessions.
4.  Note that new columns (e.g., Products-> Net Revenue) are now shown by default.