### PR TITLE
Chart: Fix/current of undefined

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add order number autocompleter to search component
 - Add order number, username, and IP address filters to the downloads report.
 - Added `interactive` prop for `d3chart/legend` to signal if legend items are clickable or not.
+- Fix for undefined ref in `d3chart/legend`
 
 # 1.3.0
 

--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -35,6 +35,9 @@ class D3Legend extends Component {
 	}
 
 	updateListScroll() {
+		if ( ! this.listRef ) {
+			return;
+		}
 		const list = this.listRef.current;
 		const scrolledToEnd = list.scrollHeight - list.scrollTop <= list.offsetHeight;
 		this.setState( {


### PR DESCRIPTION
While testing PRs lately, I would periodically see the following error:

<img width="768" alt="dashboard woo test woocommerce 2018-12-21 16-44-23" src="https://user-images.githubusercontent.com/22080/50368665-1df2ad80-0540-11e9-875d-ffbb5f2956b9.png">

I could never track down exact steps to reproduce the bug, but it seems to be thrown potentially when a chart component is re-rendering or unmounting. I figured adding in a simple undefined check for the ref would be easy enough to add, so here it is.

__To Test__
Verify charts and chart legends are still working properly.