### PR TITLE
Add product SKU to products report

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -95,14 +95,20 @@ class ProductsReportTable extends Component {
 		return map( data, row => {
 			const {
 				product_id,
-				sku = '', // @TODO
 				extended_info,
 				items_sold,
 				net_revenue,
 				orders_count,
 				variations = [], // @TODO
 			} = row;
-			const { category_ids, low_stock_amount, name, stock_status, stock_quantity } = extended_info;
+			const {
+				category_ids,
+				low_stock_amount,
+				name,
+				sku,
+				stock_status,
+				stock_quantity,
+			} = extended_info;
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',
 				product_includes: product_id,

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -224,6 +224,12 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Product inventory threshold for low stock.', 'wc-admin' ),
 					),
+					'sku'              => array(
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product SKU.', 'wc-admin' ),
+					),
 				),
 			),
 		);

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -40,6 +40,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'stock_quantity'   => 'intval',
 		'low_stock_amount' => 'intval',
 		'category_ids'     => 'array_values',
+		'sku'              => 'strval',
 	);
 
 	/**
@@ -68,6 +69,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'stock_quantity',
 		'low_stock_amount',
 		'category_ids',
+		'sku',
 	);
 
 	/**

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -242,6 +242,7 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 						'stock_quantity'   => $product->get_stock_quantity(),
 						'low_stock_amount' => $product->get_low_stock_amount(),
 						'category_ids'     => array_values( $product->get_category_ids() ),
+						'sku'              => $product->get_sku(),
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #1154 

Adds the SKU to the API extended info data and adds in the missing SKU to products report.

### Screenshots
<img width="721" alt="screen shot 2018-12-24 at 10 36 05 am" src="https://user-images.githubusercontent.com/10561050/50389657-bd45b980-0767-11e9-8792-4b57a7b707e1.png">


### Detailed test instructions:
1.  Visit the products report `wp-admin/admin.php?page=wc-admin#/analytics/products`.
2.  SKU showing?