### PR TITLE
Clear filter query on removing all items

### DIFF
--- a/packages/components/src/filters/compare/index.js
+++ b/packages/components/src/filters/compare/index.js
@@ -39,13 +39,11 @@ class CompareFilter extends Component {
 		}
 	}
 
-	componentDidUpdate( { param: prevParam, query: prevQuery } ) {
-		const { getLabels, param, path, query } = this.props;
-		if ( prevParam !== param ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { selected: [] } );
-			/* eslint-enable react/no-did-update-set-state */
-			updateQueryString( { [ param ]: undefined }, path, query );
+	componentDidUpdate( { param: prevParam, query: prevQuery }, { selected: prevSelected } ) {
+		const { getLabels, param, query } = this.props;
+		const { selected } = this.state;
+		if ( prevParam !== param || ( prevSelected.length > 0 && selected.length === 0 ) ) {
+			this.clearQuery();
 			return;
 		}
 


### PR DESCRIPTION
Fixes #998 

Clears the filter query from the URL when removing all tags/items from a filter.

### Screenshots
<img width="476" alt="screen shot 2018-12-24 at 12 35 32 pm" src="https://user-images.githubusercontent.com/10561050/50390927-6bf1f600-0778-11e9-9bf8-783646a665f1.png">

### Detailed test instructions:

1.  Visit any reports page (e.g. Products report).
2.  Add a comparison filter.
3.  Add items by typing/searching for items and click on the item.
4.  After adding at least 2 items, click "Compare."
5.  Note the query params for this filter in the URL.
6.  Use the "x" next to the tag to remove each item.
7.  On the last item removal, note the removal in the query params from the URL.