### PR TITLE
Check for product categories before loading value

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -166,7 +166,8 @@ class ProductsReportTable extends Component {
 							) }
 						</div>
 					),
-					value: productCategories.map( category => category.name ).join( ', ' ),
+					value:
+						productCategories && productCategories.map( category => category.name ).join( ', ' ),
 				},
 				{
 					display: numberFormat( variations.length ),

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -112,7 +112,9 @@ class ProductsReportTable extends Component {
 				products: product_id,
 			} );
 			const categories = this.props.categories;
-			const productCategories = category_ids.map( category_id => categories[ category_id ] );
+			const productCategories = category_ids
+				.map( category_id => categories[ category_id ] )
+				.filter( Boolean );
 
 			return [
 				{

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -168,8 +168,7 @@ class ProductsReportTable extends Component {
 							) }
 						</div>
 					),
-					value:
-						productCategories && productCategories.map( category => category.name ).join( ', ' ),
+					value: productCategories.map( category => category.name ).join( ', ' ),
 				},
 				{
 					display: numberFormat( variations.length ),


### PR DESCRIPTION
Fixes #1163 

Checks if product categories exist before attempting to map them to column value.

### Detailed test instructions:

1.  Add a lot of product categories (~200).
2.  Open the products report.
3.  Note that the page loads as expected and no console warnings exist.