### PR TITLE
Fix margin on dashboard block charts

### DIFF
--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -7,8 +7,7 @@
 
 		.woocommerce-chart {
 			border: none;
-			margin-bottom: 0;
-			margin-top: 0;
+			margin: 0;
 
 			.woocommerce-legend__item > button {
 				cursor: default;


### PR DESCRIPTION
Fixes #1152 

Fixes the margin needed for mobile styling in the dashboard blocks.

### Before
<img width="527" alt="screen shot 2018-12-24 at 1 43 48 pm" src="https://user-images.githubusercontent.com/10561050/50391603-fb4fd700-0781-11e9-9c89-869744ebb8d9.png">

### After
<img width="524" alt="screen shot 2018-12-24 at 1 42 48 pm" src="https://user-images.githubusercontent.com/10561050/50391602-fa1eaa00-0781-11e9-906c-fdb334559529.png">

### Detailed test instructions:

1.  Visit `wp-admin/admin.php?page=wc-admin`.
2.  Narrow your viewport to under 782px.
3.  Note the margin between viewport and chart text.
