### PR TITLE
Set minimum content height to prevent cutoff of absolute content

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -11,7 +11,7 @@
 	height: 80px;
 	position: fixed;
 	width: 100%;
-	top: 32px;
+	top: $adminbar-height;
 	z-index: 99991; /* higher than component-popover (99990), lower than notification dropdown at 99999 */
 
 	&.is-scrolled {
@@ -19,7 +19,7 @@
 	}
 
 	@include breakpoint( '<782px' ) {
-		top: 46px;
+		top: $adminbar-height-mobile;
 		height: 50px;
 		flex-flow: row wrap;
 	}

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -23,3 +23,7 @@ $light-gray-500: $core-grey-light-500;
 $dark-gray-300: $core-grey-dark-300;
 $dark-gray-900: $core-grey-dark-900;
 $alert-red: $error-red;
+
+// WordPress defaults
+$adminbar-height: 32px;
+$adminbar-height-mobile: 46px;

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -9,12 +9,17 @@
 	#wpbody-content {
 		padding: 0;
 		overflow-x: hidden !important;
+		min-height: calc(100vh - 32px);
 	}
 
 	@include breakpoint( '<782px' ) {
 		// WP breakpoint for mobile menu
 		.wp-responsive-open #wpbody {
 			right: -14.5em;
+		}
+		#wpcontent,
+		#wpbody-content {
+			min-height: calc(100vh - 46px);
 		}
 	}
 

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -9,7 +9,7 @@
 	#wpbody-content {
 		padding: 0;
 		overflow-x: hidden !important;
-		min-height: calc(100vh - 32px);
+		min-height: calc(100vh - #{$adminbar-height});
 	}
 
 	@include breakpoint( '<782px' ) {
@@ -19,7 +19,7 @@
 		}
 		#wpcontent,
 		#wpbody-content {
-			min-height: calc(100vh - 46px);
+			min-height: calc(100vh - #{$adminbar-height-mobile});
 		}
 	}
 


### PR DESCRIPTION
Fixes #1107 

Sets a minimum height on the content body so that long search results do not get cut off.

### Before
<img width="720" alt="screen shot 2018-12-24 at 2 27 39 pm" src="https://user-images.githubusercontent.com/10561050/50392295-158cb380-0788-11e9-8209-f48653bd96d6.png">

### After
<img width="718" alt="screen shot 2018-12-24 at 2 04 58 pm" src="https://user-images.githubusercontent.com/10561050/50392287-f7bf4e80-0787-11e9-8ad0-274d5ac9ec42.png">

### Detailed test instructions:

1.  Open any report with a search.
2.  Make sure only 1 row is visible to limit content height.
3.  Search using a term that will return at least 10 items.
4.  Note that all items are visible and not cut off.