### PR TITLE
Charts: fix weird Y-axis ticks when max Y value is a small number

### DIFF
--- a/packages/components/src/chart/d3chart/utils.js
+++ b/packages/components/src/chart/d3chart/utils.js
@@ -176,14 +176,14 @@ export const getXLineScale = ( uniqueDates, width ) =>
 		.rangeRound( [ 0, width ] );
 
 /**
- * Describes and rounds the maximum y value to the nearest thousadn, ten-thousand, million etc.
+ * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
  * @param {array} lineData - from `getLineData`
  * @returns {number} the maximum value in the timeseries multiplied by 4/3
  */
 export const getYMax = lineData => {
 	const yMax = 4 / 3 * d3Max( lineData, d => d3Max( d.values.map( date => date.value ) ) );
 	const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
-	return Math.ceil( yMax / pow3Y ) * pow3Y;
+	return Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y );
 };
 
 /**
@@ -395,7 +395,14 @@ export const drawAxis = ( node, params ) => {
 
 	const yGrids = [];
 	for ( let i = 0; i < 4; i++ ) {
-		yGrids.push( i / 3 * params.yMax );
+		if ( params.yMax > 1 ) {
+			const roundedValue = Math.round( i / 3 * params.yMax );
+			if ( yGrids[ yGrids.length - 1 ] !== roundedValue ) {
+				yGrids.push( roundedValue );
+			}
+		} else {
+			yGrids.push( i / 3 * params.yMax );
+		}
 	}
 
 	const ticks = params.xTicks.map( d => ( params.type === 'line' ? new Date( d ) : d ) );


### PR DESCRIPTION
Fixes #1155.

When the max Y value was a small number, Y-axis ticks could be a decimal number, which was later rounded. That made that some times different Y-axis ticks displayed the same number (see screenshot below: there are two `1` ticks).

This PR forces the max Y value to be an integer and all Y-axis ticks to be integers too and not to be repeated.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/50403291-b174ea00-079d-11e9-99fe-0c9645f8de15.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/50403277-9904cf80-079d-11e9-900c-ad9e478dac7d.png)


### Detailed test instructions:
- Go to a report and select the filters/date range so the maximum Y value in the chart is 1.
- Verify Y-axis ticks are not repeated.