### PR TITLE
Filter by categories query param in categories data store

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-categories-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-categories-data-store.php
@@ -78,6 +78,11 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 		$sql_query_params['from_clause'] .= " LEFT JOIN {$wpdb->prefix}term_relationships ON {$order_product_lookup_table}.product_id = {$wpdb->prefix}term_relationships.object_id";
 		$sql_query_params['from_clause'] .= " LEFT JOIN {$wpdb->prefix}term_taxonomy ON {$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}term_taxonomy.term_taxonomy_id";
 
+		$included_categories = $this->get_included_categories( $query_args );
+		if ( $included_categories ) {
+			$sql_query_params['where_clause'] .= " AND {$wpdb->prefix}term_taxonomy.term_id IN ({$included_categories})";
+		}
+
 		// TODO: only products in the category C or orders with products from category C (and, possibly others?).
 		$included_products = $this->get_included_products( $query_args );
 		if ( $included_products ) {
@@ -93,6 +98,21 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 		$sql_query_params['where_clause'] .= " AND taxonomy = 'product_cat' ";
 
 		return $sql_query_params;
+	}
+
+	/**
+	 * Returns comma separated ids of included categories, based on query arguments from the user.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return string
+	 */
+	protected function get_included_categories( $query_args ) {
+		$included_categories_str = '';
+
+		if ( isset( $query_args['categories'] ) && is_array( $query_args['categories'] ) && count( $query_args['categories'] ) > 0 ) {
+			$included_categories_str = implode( ',', $query_args['categories'] );
+		}
+		return $included_categories_str;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1159 

Fixes the `categories` param in API requests to the category data store. 

### Before
<img width="679" alt="screen shot 2018-12-26 at 3 56 54 pm" src="https://user-images.githubusercontent.com/10561050/50437967-e9f3ff80-0926-11e9-96f0-cc7dab082996.png">

### After
<img width="753" alt="screen shot 2018-12-26 at 3 57 03 pm" src="https://user-images.githubusercontent.com/10561050/50437971-eb252c80-0926-11e9-8204-c969717f111a.png">

### Detailed test instructions:

1.  Make a request to `/wp-json/wc/v3/reports/categories`.
2.  Add the categories param with a category ID or list of comma separated category IDs.
3.  Note the correct categories returned in the response.