### PR TITLE
Add 404 response to REST response for invalid note ID

### DIFF
--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -76,6 +76,15 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 */
 	public function get_item( $request ) {
 		$note = WC_Admin_Notes::get_note( $request->get_param( 'id' ) );
+
+		if ( ! $note ) {
+			return new WP_Error(
+				'woocommerce_admin_notes_invalid_id',
+				__( 'Sorry, there is no resouce with that ID.', 'wc-admin' ),
+				array( 'status' => 404 )
+			);
+		}
+
 		if ( is_wp_error( $note ) ) {
 			return $note;
 		}


### PR DESCRIPTION
Fixes #849 

Returns a 404 response when an invalid ID is used for the notes REST API.

### Before
<img width="629" alt="screen shot 2018-12-27 at 6 15 07 pm" src="https://user-images.githubusercontent.com/10561050/50476505-5c3a1200-0a03-11e9-9d4a-1dc7475663fb.png">

### After
<img width="605" alt="screen shot 2018-12-27 at 6 12 20 pm" src="https://user-images.githubusercontent.com/10561050/50476446-2137de80-0a03-11e9-9776-8d58bd24274c.png">

### Detailed test instructions:
1.  Make a request to `wp-json/wc/v3/admin/notes/{ID}`.
2.  Ensure that a valid ID fetches a note.
3.  Ensure that an invalid ID gets a WP error with a 404 response.
