### PR TITLE
 Improve Charts X-axis when displaying a single date 

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -83,7 +83,7 @@ export class ReportChart extends Component {
 
 		const chartData = primaryData.data.intervals.map( function( interval, index ) {
 			const secondaryDate = getPreviousDate(
-				formatDate( 'Y-m-d', interval.date_start ),
+				interval.date_start,
 				primary.after,
 				secondary.after,
 				query.compare,

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -127,6 +127,7 @@ class D3Chart extends Component {
 			adjWidth,
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
+			interval,
 			line: getLine( xLineScale, yScale ),
 			lineData,
 			margin,

--- a/packages/components/src/chart/d3chart/test/utils.js
+++ b/packages/components/src/chart/d3chart/test/utils.js
@@ -401,7 +401,7 @@ describe( 'getYTickOffset', () => {
 	} );
 } );
 
-describe( 'getdateSpaces', () => {
+describe( 'getDateSpaces', () => {
 	it( 'return an array used to space out the mouseover rectangles, used for tooltips', () => {
 		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, 100, testXLineScale );
 		expect( testDateSpaces[ 0 ].date ).toEqual( '2018-05-30T00:00:00' );

--- a/packages/components/src/chart/d3chart/test/utils.js
+++ b/packages/components/src/chart/d3chart/test/utils.js
@@ -421,5 +421,6 @@ describe( 'compareStrings', () => {
 		expect( compareStrings( 'Jul 2018', 'Aug 2018' ).join( ' ' ) ).toEqual( 'Aug' );
 		expect( compareStrings( 'Jul 2017', 'Aug 2018' ).join( ' ' ) ).toEqual( 'Aug 2018' );
 		expect( compareStrings( 'Jul 2017', 'Jul 2018' ).join( ' ' ) ).toEqual( '2018' );
+		expect( compareStrings( 'Jul, 2018', 'Aug, 2018' ).join( ' ' ) ).toEqual( 'Aug' );
 	} );
 } );

--- a/packages/components/src/chart/d3chart/test/utils.js
+++ b/packages/components/src/chart/d3chart/test/utils.js
@@ -20,6 +20,7 @@ import {
 	getXScale,
 	getXGroupScale,
 	getXLineScale,
+	getXTicks,
 	getYMax,
 	getYScale,
 	getYTickOffset,
@@ -154,6 +155,228 @@ describe( 'getXLineScale', () => {
 		expect( testXLineScale( new Date( orderedDates[ 0 ] ) ) ).toEqual( 0 );
 		expect( testXLineScale( new Date( orderedDates[ 2 ] ) ) ).toEqual( 40 );
 		expect( testXLineScale( new Date( orderedDates[ orderedDates.length - 1 ] ) ) ).toEqual( 100 );
+	} );
+} );
+
+describe( 'getXTicks', () => {
+	describe( 'interval=day', () => {
+		const uniqueDates = [
+			'2018-01-01T00:00:00',
+			'2018-01-02T00:00:00',
+			'2018-01-03T00:00:00',
+			'2018-01-04T00:00:00',
+			'2018-01-05T00:00:00',
+			'2018-01-06T00:00:00',
+			'2018-01-07T00:00:00',
+			'2018-01-08T00:00:00',
+			'2018-01-09T00:00:00',
+			'2018-01-10T00:00:00',
+			'2018-01-11T00:00:00',
+			'2018-01-12T00:00:00',
+			'2018-01-13T00:00:00',
+			'2018-01-14T00:00:00',
+			'2018-01-15T00:00:00',
+			'2018-01-16T00:00:00',
+			'2018-01-17T00:00:00',
+			'2018-01-18T00:00:00',
+			'2018-01-19T00:00:00',
+			'2018-01-20T00:00:00',
+			'2018-01-21T00:00:00',
+			'2018-01-22T00:00:00',
+			'2018-01-23T00:00:00',
+			'2018-01-24T00:00:00',
+			'2018-01-25T00:00:00',
+			'2018-01-26T00:00:00',
+			'2018-01-27T00:00:00',
+			'2018-01-28T00:00:00',
+			'2018-01-29T00:00:00',
+			'2018-01-30T00:00:00',
+			'2018-01-31T00:00:00',
+		];
+
+		it( 'returns a subset of the uniqueDates as ticks depending on the width', () => {
+			const width = 0;
+			const mode = 'item-comparison';
+			const interval = 'day';
+			const expectedXTicks = [
+				'2018-01-01T00:00:00',
+				'2018-01-06T00:00:00',
+				'2018-01-11T00:00:00',
+				'2018-01-16T00:00:00',
+				'2018-01-21T00:00:00',
+				'2018-01-26T00:00:00',
+				'2018-01-31T00:00:00',
+			];
+
+			const xTicks = getXTicks( uniqueDates, width, mode, interval );
+
+			expect( xTicks ).toEqual( expectedXTicks );
+		} );
+
+		it( 'returns a tick for the first date of each month when the list of uniqueDates exceeds the threshold', () => {
+			const width = 0;
+			const mode = 'item-comparison';
+			const interval = 'day';
+			const extendedUniqueDates = [
+				'2018-02-01T00:00:00',
+				'2018-02-02T00:00:00',
+				'2018-02-03T00:00:00',
+				'2018-02-04T00:00:00',
+				'2018-02-05T00:00:00',
+				'2018-02-06T00:00:00',
+				'2018-02-07T00:00:00',
+				'2018-02-08T00:00:00',
+				'2018-02-09T00:00:00',
+				'2018-02-10T00:00:00',
+				'2018-02-11T00:00:00',
+				'2018-02-12T00:00:00',
+				'2018-02-13T00:00:00',
+				'2018-02-14T00:00:00',
+				'2018-02-15T00:00:00',
+				'2018-02-16T00:00:00',
+				'2018-02-17T00:00:00',
+				'2018-02-18T00:00:00',
+				'2018-02-19T00:00:00',
+				'2018-02-20T00:00:00',
+				'2018-02-21T00:00:00',
+				'2018-02-22T00:00:00',
+				'2018-02-23T00:00:00',
+				'2018-02-24T00:00:00',
+				'2018-02-25T00:00:00',
+				'2018-02-26T00:00:00',
+				'2018-02-27T00:00:00',
+				'2018-02-28T00:00:00',
+				'2018-03-01T00:00:00',
+				'2018-03-02T00:00:00',
+				'2018-03-03T00:00:00',
+				'2018-03-04T00:00:00',
+				'2018-03-05T00:00:00',
+				'2018-03-06T00:00:00',
+				'2018-03-07T00:00:00',
+				'2018-03-08T00:00:00',
+				'2018-03-09T00:00:00',
+				'2018-03-10T00:00:00',
+				'2018-03-11T00:00:00',
+				'2018-03-12T00:00:00',
+				'2018-03-13T00:00:00',
+				'2018-03-14T00:00:00',
+				'2018-03-15T00:00:00',
+				'2018-03-16T00:00:00',
+				'2018-03-17T00:00:00',
+				'2018-03-18T00:00:00',
+				'2018-03-19T00:00:00',
+				'2018-03-20T00:00:00',
+				'2018-03-21T00:00:00',
+				'2018-03-22T00:00:00',
+				'2018-03-23T00:00:00',
+				'2018-03-24T00:00:00',
+				'2018-03-25T00:00:00',
+				'2018-03-26T00:00:00',
+				'2018-03-27T00:00:00',
+				'2018-03-28T00:00:00',
+				'2018-03-29T00:00:00',
+				'2018-03-30T00:00:00',
+				'2018-03-31T00:00:00',
+				'2018-04-01T00:00:00',
+				'2018-04-02T00:00:00',
+				'2018-04-03T00:00:00',
+				'2018-04-04T00:00:00',
+				'2018-04-05T00:00:00',
+				'2018-04-06T00:00:00',
+				'2018-04-07T00:00:00',
+				'2018-04-08T00:00:00',
+			];
+			const expectedXTicks = [
+				'2018-01-01T00:00:00',
+				'2018-02-01T00:00:00',
+				'2018-03-01T00:00:00',
+				'2018-04-01T00:00:00',
+			];
+
+			const xTicks = getXTicks( uniqueDates.concat( extendedUniqueDates ), width, mode, interval );
+
+			expect( xTicks ).toEqual( expectedXTicks );
+		} );
+	} );
+
+	describe( 'interval=hour', () => {
+		const uniqueDates = [
+			'2018-01-02T00:00:00',
+			'2018-01-02T01:00:00',
+			'2018-01-02T02:00:00',
+			'2018-01-02T03:00:00',
+			'2018-01-02T04:00:00',
+			'2018-01-02T05:00:00',
+			'2018-01-02T06:00:00',
+			'2018-01-02T07:00:00',
+			'2018-01-02T08:00:00',
+			'2018-01-02T09:00:00',
+			'2018-01-02T10:00:00',
+			'2018-01-02T11:00:00',
+			'2018-01-02T12:00:00',
+			'2018-01-02T13:00:00',
+			'2018-01-02T14:00:00',
+			'2018-01-02T15:00:00',
+			'2018-01-02T16:00:00',
+			'2018-01-02T17:00:00',
+			'2018-01-02T18:00:00',
+			'2018-01-02T19:00:00',
+			'2018-01-02T20:00:00',
+			'2018-01-02T21:00:00',
+			'2018-01-02T22:00:00',
+			'2018-01-02T23:00:00',
+		];
+
+		it( 'doesn\'t return a tick for each unique date when width is not big enough', () => {
+			const width = 0;
+			const mode = 'item-comparison';
+			const interval = 'hour';
+			const expectedXTicks = [
+				'2018-01-02T00:00:00',
+				'2018-01-02T11:00:00',
+				'2018-01-02T22:00:00',
+			];
+
+			const xTicks = getXTicks( uniqueDates, width, mode, interval );
+
+			expect( xTicks ).toEqual( expectedXTicks );
+		} );
+
+		it( 'doesn\'t return a tick for each unique date when all dates don\'t belong to the same day', () => {
+			const width = 9999;
+			const mode = 'item-comparison';
+			const interval = 'hour';
+			const expectedXTicks = [
+				'2018-01-01T23:00:00',
+				'2018-01-02T01:00:00',
+				'2018-01-02T03:00:00',
+				'2018-01-02T05:00:00',
+				'2018-01-02T07:00:00',
+				'2018-01-02T09:00:00',
+				'2018-01-02T11:00:00',
+				'2018-01-02T13:00:00',
+				'2018-01-02T15:00:00',
+				'2018-01-02T17:00:00',
+				'2018-01-02T19:00:00',
+				'2018-01-02T21:00:00',
+				'2018-01-02T23:00:00',
+			];
+
+			const xTicks = getXTicks( [ '2018-01-01T23:00:00' ].concat( uniqueDates ), width, mode, interval );
+
+			expect( xTicks ).toEqual( expectedXTicks );
+		} );
+
+		it( 'returns a tick for each unique date when all dates are from the same day and width is big enough', () => {
+			const width = 9999;
+			const mode = 'item-comparison';
+			const interval = 'hour';
+			const expectedXTicks = uniqueDates;
+
+			const xTicks = getXTicks( uniqueDates, width, mode, interval );
+
+			expect( xTicks ).toEqual( expectedXTicks );
+		} );
 	} );
 } );
 

--- a/packages/components/src/chart/d3chart/utils.js
+++ b/packages/components/src/chart/d3chart/utils.js
@@ -305,12 +305,12 @@ export const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
  * @returns {boolean} whether the first and last date are different hours from the same date.
  */
 const areDatesInTheSameDay = dates => {
-	const firstDate = new Date( dates [ 0 ] + 'Z' );
-	const lastDate = new Date( dates [ dates.length - 1 ] + 'Z' );
+	const firstDate = new Date( dates [ 0 ] );
+	const lastDate = new Date( dates [ dates.length - 1 ] );
 	return (
-		firstDate.getUTCDate() === lastDate.getUTCDate() &&
-		firstDate.getUTCMonth() === lastDate.getUTCMonth() &&
-		firstDate.getUTCFullYear() === lastDate.getUTCFullYear()
+		firstDate.getDate() === lastDate.getDate() &&
+		firstDate.getMonth() === lastDate.getMonth() &&
+		firstDate.getFullYear() === lastDate.getFullYear()
 	);
 };
 

--- a/packages/components/src/chart/d3chart/utils.js
+++ b/packages/components/src/chart/d3chart/utils.js
@@ -300,6 +300,21 @@ export const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 };
 
 /**
+ * Given an array of dates, returns true if the first and last one belong to the same day.
+ * @param {array} dates - an array of dates
+ * @returns {boolean} whether the first and last date are different hours from the same date.
+ */
+const areDatesInTheSameDay = dates => {
+	const firstDate = new Date( dates [ 0 ] + 'Z' );
+	const lastDate = new Date( dates [ dates.length - 1 ] + 'Z' );
+	return (
+		firstDate.getUTCDate() === lastDate.getUTCDate() &&
+		firstDate.getUTCMonth() === lastDate.getUTCMonth() &&
+		firstDate.getUTCFullYear() === lastDate.getUTCFullYear()
+	);
+};
+
+/**
  * Returns ticks for the x-axis.
  * @param {array} uniqueDates - all the unique dates from the input data for the chart
  * @param {integer} width - calculated page width
@@ -316,7 +331,8 @@ export const getXTicks = ( uniqueDates, width, mode, interval ) => {
 	) {
 		uniqueDates = getFirstDatePerMonth( uniqueDates );
 	}
-	if ( uniqueDates.length <= maxTicks ) {
+	if ( uniqueDates.length <= maxTicks ||
+			( interval === 'hour' && areDatesInTheSameDay( uniqueDates ) && width > smallBreak ) ) {
 		return uniqueDates;
 	}
 
@@ -368,10 +384,10 @@ export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
  * Compares 2 strings and returns a list of words that are unique from s2
  * @param {string} s1 - base string to compare against
  * @param {string} s2 - string to compare against the base string
- * @param {string} splitChar - character to use to deliminate words
+ * @param {string|Object} splitChar - character or RegExp to use to deliminate words
  * @returns {array} of unique words that appear in s2 but not in s1, the base string
  */
-export const compareStrings = ( s1, s2, splitChar = ' ' ) => {
+export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' ) ) => {
 	const string1 = s1.split( splitChar );
 	const string2 = s2.split( splitChar );
 	const diff = new Array();
@@ -415,7 +431,9 @@ export const drawAxis = ( node, params ) => {
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
-				.tickFormat( ( d, i ) => removeDuplicateDates( d, i, ticks, params.xFormat ) )
+				.tickFormat( ( d, i ) => params.interval === 'hour'
+					? params.xFormat( d )
+					: removeDuplicateDates( d, i, ticks, params.xFormat ) )
 		);
 
 	node

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -365,10 +365,14 @@ export function getAllowedIntervalsForQuery( query ) {
 		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
 			allowed = [ 'day', 'hour' ];
 		} else {
-			allowed = [ 'hour', 'day' ];
+			allowed = [ 'hour' ];
 		}
 	} else {
 		switch ( query.period ) {
+			case 'today':
+			case 'yesterday':
+				allowed = [ 'hour' ];
+				break;
 			case 'week':
 			case 'last_week':
 				allowed = [ 'day' ];
@@ -386,7 +390,7 @@ export function getAllowedIntervalsForQuery( query ) {
 				allowed = [ 'day', 'week', 'month', 'quarter' ];
 				break;
 			default:
-				allowed = [ 'hour', 'day' ];
+				allowed = [ 'day' ];
 				break;
 		}
 	}

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -345,8 +345,6 @@ export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
 
 /**
  * Returns the allowed selectable intervals for a specific query.
- * TODO Add support for hours. `` if ( differenceInDays <= 1 ) { allowed = [ 'hour' ]; }
- * Today/yesterday/default: allowed = [ 'hour' ];
  *
  * @param  {Object} query Current query
  * @return {Array} Array containing allowed intervals.
@@ -365,9 +363,9 @@ export function getAllowedIntervalsForQuery( query ) {
 		} else if ( differenceInDays > 7 ) {
 			allowed = [ 'day', 'week' ];
 		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
-			allowed = [ 'day' ];
+			allowed = [ 'day', 'hour' ];
 		} else {
-			allowed = [ 'day' ];
+			allowed = [ 'hour', 'day' ];
 		}
 	} else {
 		switch ( query.period ) {
@@ -388,7 +386,7 @@ export function getAllowedIntervalsForQuery( query ) {
 				allowed = [ 'day', 'week', 'month', 'quarter' ];
 				break;
 			default:
-				allowed = [ 'day' ];
+				allowed = [ 'hour', 'day' ];
 				break;
 		}
 	}
@@ -444,8 +442,9 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 
 	switch ( interval ) {
 		case 'hour':
-			tooltipLabelFormat = '%I %p';
-			xFormat = '%I %p';
+			tooltipLabelFormat = '%_I%p';
+			xFormat = '%_I%p';
+			x2Format = '%b %d, %Y';
 			tableFormat = 'h A';
 			break;
 		case 'day':

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,7 +5,6 @@
 import moment from 'moment';
 import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { format as formatDate } from '@wordpress/date';
 
 const QUERY_DEFAULTS = {
 	pageSize: 25,
@@ -314,8 +313,8 @@ export const getCurrentDates = query => {
  * @return {Int}  - Difference in days.
  */
 export const getDateDifferenceInDays = ( date, date2 ) => {
-	const _date = toMoment( isoDateFormat, formatDate( 'Y-m-d', date ) );
-	const _date2 = toMoment( isoDateFormat, formatDate( 'Y-m-d', date2 ) );
+	const _date = moment( date );
+	const _date2 = moment( date2 );
 	return _date.diff( _date2, 'days' );
 };
 
@@ -330,14 +329,14 @@ export const getDateDifferenceInDays = ( date, date2 ) => {
  * @return {String}  - Calculated date
  */
 export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
-	const dateMoment = toMoment( isoDateFormat, formatDate( 'Y-m-d', date ) );
+	const dateMoment = moment( date );
 
 	if ( 'previous_year' === compare ) {
 		return dateMoment.clone().subtract( 1, 'years' );
 	}
 
-	const _date1 = toMoment( isoDateFormat, formatDate( 'Y-m-d', date1 ) );
-	const _date2 = toMoment( isoDateFormat, formatDate( 'Y-m-d', date2 ) );
+	const _date1 = moment( date1 );
+	const _date2 = moment( date2 );
 	const difference = _date1.diff( _date2, interval );
 
 	return dateMoment.clone().subtract( difference, interval );


### PR DESCRIPTION
Fixes part 1, 2 and 4 from #1156.

Implements several improvements to charts when displaying single dates.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50478397-25e39f00-09d1-11e9-9d63-5ddc26cad215.png)

### Detailed test instructions:
- Go to any report and select _Today_ or _Yesterday_ in the date picker.
- Verify the interval changes to _By hour_.
- Verify all hours between 12AM and 23PM appear in the X-axis.
- Make the screen smaller and verify some ticks disappear, so they don't overlap.
- Hover the chart dots and verify the green line shows the hours correctly (before, it was always showing 12PM, as you can see in the screenshot above taken before fixing this).
- Verify the date shown in the first tick is in the format _Dec 12, 2018_.