### PR TITLE
Add missing intervals to product reports

### DIFF
--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -74,8 +74,8 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'before'   => date( 'Y-m-d H:00:00', $time + DAY_IN_SECONDS ),
-				'after'    => date( 'Y-m-d H:00:00', $time - DAY_IN_SECONDS ),
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d 00:00:00', $time ),
 				'interval' => 'day',
 			)
 		);


### PR DESCRIPTION
Fixes #957 

Adds missing intervals to product reports to fix truncated dates when not enough data exists.

### Before
<img width="1027" alt="screen shot 2018-12-28 at 5 23 19 pm" src="https://user-images.githubusercontent.com/10561050/50510606-5442a680-0ac5-11e9-86e3-106aaf71b71f.png">

### After
<img width="1029" alt="screen shot 2018-12-28 at 5 23 04 pm" src="https://user-images.githubusercontent.com/10561050/50510603-51e04c80-0ac5-11e9-8ab5-510328cc62e6.png">

### Detailed test instructions:

1. Add/remove data to create a week's worth of missing data on either side (e.g., Add data to mid-December and remove all orders from the last week).
2. Visit the products report.
3. Select the month of data you created in step 1 (e.g., Dec 1-31).
4.  Note that the days with no data still appear as intervals on the chart.
