### PR TITLE
Sort default category response by category ID

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-categories-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-categories-controller.php
@@ -252,9 +252,9 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_REST_Reports_Contro
 		$params['orderby']       = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
-			'default'           => 'date',
+			'default'           => 'category_id',
 			'enum'              => array(
-				'date',
+				'category_id',
 				'items_sold',
 				'net_revenue',
 				'orders_count',

--- a/includes/data-stores/class-wc-admin-reports-categories-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-categories-data-store.php
@@ -116,20 +116,6 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 	}
 
 	/**
-	 * Maps ordering specified by the user to columns in the database/fields in the data.
-	 *
-	 * @param string $order_by Sorting criterion.
-	 * @return string
-	 */
-	protected function normalize_order_by( $order_by ) {
-		if ( 'date' === $order_by ) {
-			return 'date_created';
-		}
-
-		return $order_by;
-	}
-
-	/**
 	 * Compares values in 2 arrays based on criterion specified when called via sort_records.
 	 *
 	 * @param array $a Array 1 to compare.


### PR DESCRIPTION
Fixes #1137 

Fixes the warning for no `date_created` field and sets the default sorting to use the category ID if orderby is set to the default value of date.

### Before
<img width="542" alt="screen shot 2018-12-28 at 5 54 52 pm" src="https://user-images.githubusercontent.com/10561050/50511714-b2718880-0ac9-11e9-9a03-73bb4445a514.png">

### After
<img width="537" alt="screen shot 2018-12-28 at 5 51 57 pm" src="https://user-images.githubusercontent.com/10561050/50511618-4abb3d80-0ac9-11e9-8773-c43f3767dd71.png">

### Detailed test instructions:

1.  Make a request to the categories endpoint without any orderby param `wp-json/wc/v3/reports/categories`.
2.  Check that no notices/errors are given.
3.  Make a request to the categories endpoint with the orderby param set to `date_created`.
4.  Note the error that this is not a valid field.