### PR TITLE
Update chart button active state for dashboard charts

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -80,7 +80,7 @@ class DashboardCharts extends Component {
 						>
 							<IconButton
 								className={ classNames( 'woocommerce-chart__type-button', {
-									'woocommerce-chart__type-button-selected': query.type === 'line',
+									'woocommerce-chart__type-button-selected': ! query.type || query.type === 'line',
 								} ) }
 								icon={ <Gridicon icon="line-graph" /> }
 								title={ __( 'Line chart', 'wc-admin' ) }

--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -33,18 +33,6 @@
 			margin-left: $gap;
 			margin-right: $gap;
 		}
-
-		.woocommerce-chart__type-button {
-			&.components-icon-button {
-				color: $core-grey-light-700;
-				&.woocommerce-chart__type-button-selected {
-					color: $core-grey-dark-500;
-				}
-				&:hover {
-					box-shadow: none;
-				}
-			}
-		}
 	}
 
 	.woocommerce-chart__body {
@@ -111,4 +99,17 @@
 
 .woocommerce-chart__types {
 	padding: 0 8px;
+}
+
+.woocommerce-chart__type-button {
+	background: transparent !important;
+	&.components-icon-button {
+		color: $core-grey-light-700;
+		&.woocommerce-chart__type-button-selected {
+			color: $core-grey-dark-500;
+		}
+		&:hover {
+			box-shadow: none !important;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #1185 

Applies chart button styling to the dashboard charts.

### Before
<img width="220" alt="screen shot 2018-12-28 at 6 10 24 pm" src="https://user-images.githubusercontent.com/10561050/50512244-16954c00-0acc-11e9-844d-14f9369fef00.png">

### After
<img width="300" alt="screen shot 2018-12-28 at 6 10 09 pm" src="https://user-images.githubusercontent.com/10561050/50512243-15641f00-0acc-11e9-8ac4-edd6fa97f0c9.png">

### Detailed test instructions:

1. Visit the dashboard charts `/wp-admin/admin.php?page=wc-admin#/`.
2. Click on a chart type.
3. Check that the active chart type is highlighted correctly.