### PR TITLE
Show today charts up to the current hour

### DIFF
--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -327,7 +327,7 @@ describe( 'getSummaryNumbers()', () => {
 		} );
 
 		setGetReportStats( ( endpoint, _query ) => {
-			if ( '2018-10-10T00:00:00+00:00' === _query.after ) {
+			if ( '2018-10-10T00:00:00' === _query.after ) {
 				return {
 					data: {
 						totals: totals.primary,

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -119,15 +119,15 @@ export function isReportDataEmpty( report ) {
  * @returns {Object} data request query parameters.
  */
 function getRequestQuery( endpoint, dataType, query ) {
-	const datesFromQuery = getCurrentDates( query );
+	const datesFromQuery = getCurrentDates( query, 'YYYY-MM-DDTHH:00:00' );
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( endpoint, query );
 	return {
 		order: 'asc',
 		interval,
 		per_page: MAX_PER_PAGE,
-		after: appendTimestamp( datesFromQuery[ dataType ].after, 'start' ),
-		before: appendTimestamp( datesFromQuery[ dataType ].before, 'end' ),
+		after: datesFromQuery[ dataType ].after,
+		before: datesFromQuery[ dataType ].before,
 		...filterQuery,
 	};
 }

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -274,11 +274,11 @@ export const getDateParamsFromQuery = ( { period, compare, after, before } ) => 
  * Get Date Value Objects for a primary and secondary date range
  *
  * @param {Object} query - date parameters derived from query parameters
- * @param {String} dateFormat - format of the dates to return
  * @property {string} [period] - period value, ie `last_week`
  * @property {string} [compare] - compare valuer, ie previous_year
  * @property {string} [after] - date in iso date format, ie 2018-07-03
  * @property {string} [before] - date in iso date format, ie 2018-07-03
+ * @param {String} dateFormat - format of the dates to return
  * @return {{primary: DateValue, secondary: DateValue}} - Primary and secondary DateValue objects
  */
 export const getCurrentDates = ( query, dateFormat = isoDateFormat ) => {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -172,14 +172,14 @@ export function getLastPeriod( period, compare ) {
  */
 export function getCurrentPeriod( period, compare ) {
 	const primaryStart = moment().startOf( period );
-	const primaryEnd = moment();
-	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
+	const primaryEnd = moment().add( 1, 'hour' );
+	const hoursSoFar = primaryEnd.diff( primaryStart, 'hours' );
 	let secondaryStart;
 	let secondaryEnd;
 
 	if ( 'previous_period' === compare ) {
 		secondaryStart = primaryStart.clone().subtract( 1, period );
-		secondaryEnd = primaryEnd.clone().subtract( 1, period );
+		secondaryEnd = primaryEnd.clone().subtract( 1, period ).add( 1, 'hour' );
 	} else {
 		secondaryStart =
 			'week' === period
@@ -189,7 +189,7 @@ export function getCurrentPeriod( period, compare ) {
 						.week( primaryStart.week() )
 						.startOf( 'week' )
 				: primaryStart.clone().subtract( 1, 'years' );
-		secondaryEnd = secondaryStart.clone().add( daysSoFar, 'days' );
+		secondaryEnd = secondaryStart.clone().add( hoursSoFar + 1, 'hours' );
 	}
 	return {
 		primaryStart,
@@ -274,13 +274,14 @@ export const getDateParamsFromQuery = ( { period, compare, after, before } ) => 
  * Get Date Value Objects for a primary and secondary date range
  *
  * @param {Object} query - date parameters derived from query parameters
+ * @param {String} dateFormat - format of the dates to return
  * @property {string} [period] - period value, ie `last_week`
  * @property {string} [compare] - compare valuer, ie previous_year
  * @property {string} [after] - date in iso date format, ie 2018-07-03
  * @property {string} [before] - date in iso date format, ie 2018-07-03
  * @return {{primary: DateValue, secondary: DateValue}} - Primary and secondary DateValue objects
  */
-export const getCurrentDates = query => {
+export const getCurrentDates = ( query, dateFormat = isoDateFormat ) => {
 	const { period, compare, after, before } = getDateParamsFromQuery( query );
 	const { primaryStart, primaryEnd, secondaryStart, secondaryEnd } = getDateValue(
 		period,
@@ -293,14 +294,14 @@ export const getCurrentDates = query => {
 		primary: {
 			label: find( presetValues, item => item.value === period ).label,
 			range: getRangeLabel( primaryStart, primaryEnd ),
-			after: primaryStart.format( isoDateFormat ),
-			before: primaryEnd.format( isoDateFormat ),
+			after: primaryStart.format( dateFormat ),
+			before: primaryEnd.format( dateFormat ),
 		},
 		secondary: {
 			label: find( periods, item => item.value === compare ).label,
 			range: getRangeLabel( secondaryStart, secondaryEnd ),
-			after: secondaryStart.format( isoDateFormat ),
-			before: secondaryEnd.format( isoDateFormat ),
+			after: secondaryStart.format( dateFormat ),
+			before: secondaryEnd.format( dateFormat ),
 		},
 	};
 };


### PR DESCRIPTION
Fixes the third point and closes #1156.

When displaying a chart with the date range set to _Today_, it will display the dates until the current hour instead of the entire day. To accomplish that, this PR changes the `before` param sent to retrieve chart data to the current hour +1 instead of `23:59:59` until now.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50512639-728fae80-0a93-11e9-9aac-f9405e3f433f.png)

### Detailed test instructions:
- Go to any report, for example _Orders_.
- In the _Date Range_ dropdown, select _Today_.
- Verify the chart shows data until your current hour +1.
- Verify there are no regressions in other charts.