### PR TITLE
IE11: Enable Autoprefixer 'grid' in packages

### DIFF
--- a/bin/packages/post-css-config.js
+++ b/bin/packages/post-css-config.js
@@ -17,6 +17,6 @@ module.exports = [
 			},
 		},
 	} ),
-	require( 'autoprefixer' ),
+	require( 'autoprefixer' )( { grid: true } ),
 	require( 'postcss-color-function' ),
 ];


### PR DESCRIPTION
While reviewing #1199 I noticed packages' CSS was not generating Autprofixer 'grid' rules that we have enabled in other parts of the project. That caused many issues in IE11.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/50514834-25b2d480-0aa1-11e9-9f46-b9a0cfd47950.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/50514845-2ea3a600-0aa1-11e9-9a98-fa984f4e0cc2.png)

### Detailed test instructions:
- Go to any report in IE11.
- Verify the Summary Numbers are displayed horizontally.