### PR TITLE
Use a date instead of hour for single dates in report tables

### DIFF
--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -68,7 +68,7 @@ export default class CouponsReportTable extends Component {
 
 	getRowsContent( coupons ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 
 		return map( coupons, coupon => {

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { Link } from '@woocommerce/components';
+import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 
 /**
@@ -100,11 +101,13 @@ export default class CouponsReportTable extends Component {
 					value: getCurrencyFormatDecimal( amount ),
 				},
 				{
-					display: formatDate( 'm/d/Y', date_created ),
+					display: formatDate( defaultTableDateFormat, date_created ),
 					value: date_created,
 				},
 				{
-					display: date_expires ? formatDate( 'm/d/Y', date_expires ) : __( 'N/A', 'wc-admin' ),
+					display: date_expires
+						? formatDate( defaultTableDateFormat, date_expires )
+						: __( 'N/A', 'wc-admin' ),
 					value: date_expires,
 				},
 				{

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -10,7 +10,6 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getIntervalForQuery, getDateFormatsForInterval } from '@woocommerce/date';
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 
@@ -67,10 +66,6 @@ export default class CouponsReportTable extends Component {
 	}
 
 	getRowsContent( coupons ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
-		const { tableFormat } = getDateFormatsForInterval( currentInterval );
-
 		return map( coupons, coupon => {
 			const { amount, coupon_id, extended_info, orders_count } = coupon;
 			const { code, date_created, date_expires, discount_type } = extended_info;
@@ -105,11 +100,11 @@ export default class CouponsReportTable extends Component {
 					value: getCurrencyFormatDecimal( amount ),
 				},
 				{
-					display: formatDate( tableFormat, date_created ),
+					display: formatDate( 'm/d/Y', date_created ),
 					value: date_created,
 				},
 				{
-					display: date_expires ? formatDate( tableFormat, date_expires ) : __( 'N/A', 'wc-admin' ),
+					display: date_expires ? formatDate( 'm/d/Y', date_expires ) : __( 'N/A', 'wc-admin' ),
 					value: date_expires,
 				},
 				{

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -93,7 +93,7 @@ export default class CustomersReportTable extends Component {
 
 	getRowsContent( customers ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
 		const formats = getDateFormatsForInterval( currentInterval );
 
 		return customers.map( customer => {

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -9,6 +9,7 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * WooCommerce dependencies
  */
+import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 import { Link } from '@woocommerce/components';
 
@@ -124,7 +125,7 @@ export default class CustomersReportTable extends Component {
 					value: username,
 				},
 				{
-					display: formatDate( 'm/d/Y', date_sign_up ),
+					display: formatDate( defaultTableDateFormat, date_sign_up ),
 					value: date_sign_up,
 				},
 				{
@@ -144,7 +145,7 @@ export default class CustomersReportTable extends Component {
 					value: getCurrencyFormatDecimal( avg_order_value ),
 				},
 				{
-					display: formatDate( 'm/d/Y', date_last_active ),
+					display: formatDate( defaultTableDateFormat, date_last_active ),
 					value: date_last_active,
 				},
 				{

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -9,7 +9,6 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * WooCommerce dependencies
  */
-import { getDateFormatsForInterval, getIntervalForQuery } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 import { Link } from '@woocommerce/components';
 
@@ -92,10 +91,6 @@ export default class CustomersReportTable extends Component {
 	}
 
 	getRowsContent( customers ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
-		const formats = getDateFormatsForInterval( currentInterval );
-
 		return customers.map( customer => {
 			const {
 				avg_order_value,
@@ -129,7 +124,7 @@ export default class CustomersReportTable extends Component {
 					value: username,
 				},
 				{
-					display: formatDate( formats.tableFormat, date_sign_up ),
+					display: formatDate( 'm/d/Y', date_sign_up ),
 					value: date_sign_up,
 				},
 				{
@@ -149,7 +144,7 @@ export default class CustomersReportTable extends Component {
 					value: getCurrencyFormatDecimal( avg_order_value ),
 				},
 				{
-					display: formatDate( formats.tableFormat, date_last_active ),
+					display: formatDate( 'm/d/Y', date_last_active ),
 					value: date_last_active,
 				},
 				{

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -11,7 +11,7 @@ import moment from 'moment';
 /**
  * WooCommerce dependencies
  */
-import { getCurrentDates } from '@woocommerce/date';
+import { defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 
@@ -81,7 +81,7 @@ export default class CouponsReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( 'm/d/Y', date ),
+					display: formatDate( defaultTableDateFormat, date ),
 					value: date,
 				},
 				{

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -11,7 +11,7 @@ import moment from 'moment';
 /**
  * WooCommerce dependencies
  */
-import { getIntervalForQuery, getCurrentDates, getDateFormatsForInterval } from '@woocommerce/date';
+import { getCurrentDates } from '@woocommerce/date';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 
@@ -67,8 +67,6 @@ export default class CouponsReportTable extends Component {
 
 	getRowsContent( downloads ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
-		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( downloads, download => {
@@ -83,7 +81,7 @@ export default class CouponsReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( tableFormat, date ),
+					display: formatDate( 'm/d/Y', date ),
 					value: date,
 				},
 				{

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -67,7 +67,7 @@ export default class CouponsReportTable extends Component {
 
 	getRowsContent( downloads ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 		const persistedQuery = getPersistedQuery( query );
 

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -103,7 +103,7 @@ class OrdersReportTable extends Component {
 
 	getRowsContent( tableData ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
 		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 		return map( tableData, row => {
 			const {

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -11,7 +11,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
+import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
 
@@ -126,7 +126,7 @@ class OrdersReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( 'm/d/Y', date ),
+					display: formatDate( defaultTableDateFormat, date ),
 					value: date,
 				},
 				{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -11,12 +11,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import {
-	appendTimestamp,
-	getCurrentDates,
-	getIntervalForQuery,
-	getDateFormatsForInterval,
-} from '@woocommerce/date';
+import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
 import { Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
 
@@ -102,9 +97,6 @@ class OrdersReportTable extends Component {
 	}
 
 	getRowsContent( tableData ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
-		const { tableFormat } = getDateFormatsForInterval( currentInterval );
 		return map( tableData, row => {
 			const {
 				date,
@@ -134,7 +126,7 @@ class OrdersReportTable extends Component {
 
 			return [
 				{
-					display: formatDate( tableFormat, date ),
+					display: formatDate( 'm/d/Y', date ),
 					value: date,
 				},
 				{

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -11,12 +11,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import {
-	appendTimestamp,
-	getCurrentDates,
-	getDateFormatsForInterval,
-	getIntervalForQuery,
-} from '@woocommerce/date';
+import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 
@@ -100,10 +95,6 @@ class RevenueReportTable extends Component {
 	}
 
 	getRowsContent( data = [] ) {
-		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
-		const formats = getDateFormatsForInterval( currentInterval );
-
 		return data.map( row => {
 			const {
 				coupons,
@@ -127,7 +118,7 @@ class RevenueReportTable extends Component {
 			);
 			return [
 				{
-					display: formatDate( formats.tableFormat, row.date_start ),
+					display: formatDate( 'm/d/Y', row.date_start ),
 					value: row.date_start,
 				},
 				{

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
+import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 
@@ -118,7 +118,7 @@ class RevenueReportTable extends Component {
 			);
 			return [
 				{
-					display: formatDate( 'm/d/Y', row.date_start ),
+					display: formatDate( defaultTableDateFormat, row.date_start ),
 					value: row.date_start,
 				},
 				{

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -101,7 +101,7 @@ class RevenueReportTable extends Component {
 
 	getRowsContent( data = [] ) {
 		const { query } = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( { interval: 'day', ...query } );
 		const formats = getDateFormatsForInterval( currentInterval );
 
 		return data.map( row => {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -376,7 +376,7 @@ export function getAllowedIntervalsForQuery( query ) {
 		switch ( query.period ) {
 			case 'today':
 			case 'yesterday':
-				allowed = [ 'hour' ];
+				allowed = [ 'day' ];
 				break;
 			case 'week':
 			case 'last_week':

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -367,10 +367,10 @@ export function getAllowedIntervalsForQuery( query ) {
 			allowed = [ 'day', 'week', 'month' ];
 		} else if ( differenceInDays >= 7 ) {
 			allowed = [ 'day', 'week' ];
-		} else if ( differenceInDays > 1 && differenceInDays < 7 ) {
-			allowed = [ 'day' ];
+		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
+			allowed = [ 'day', 'hour' ];
 		} else {
-			allowed = [ 'hour', 'day' ];
+			allowed = [ 'day', 'hour' ];
 		}
 	} else {
 		switch ( query.period ) {
@@ -395,7 +395,7 @@ export function getAllowedIntervalsForQuery( query ) {
 				allowed = [ 'day', 'week', 'month', 'quarter' ];
 				break;
 			default:
-				allowed = [ 'day' ];
+				allowed = [ 'day', 'hour' ];
 				break;
 		}
 	}

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -367,8 +367,8 @@ export function getAllowedIntervalsForQuery( query ) {
 			allowed = [ 'day', 'week', 'month' ];
 		} else if ( differenceInDays >= 7 ) {
 			allowed = [ 'day', 'week' ];
-		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
-			allowed = [ 'day', 'hour' ];
+		} else if ( differenceInDays > 1 && differenceInDays < 7 ) {
+			allowed = [ 'day' ];
 		} else {
 			allowed = [ 'hour', 'day' ];
 		}

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -370,13 +370,13 @@ export function getAllowedIntervalsForQuery( query ) {
 		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
 			allowed = [ 'day', 'hour' ];
 		} else {
-			allowed = [ 'day', 'hour' ];
+			allowed = [ 'hour', 'day' ];
 		}
 	} else {
 		switch ( query.period ) {
 			case 'today':
 			case 'yesterday':
-				allowed = [ 'day' ];
+				allowed = [ 'hour', 'day' ];
 				break;
 			case 'week':
 			case 'last_week':
@@ -395,7 +395,7 @@ export function getAllowedIntervalsForQuery( query ) {
 				allowed = [ 'day', 'week', 'month', 'quarter' ];
 				break;
 			default:
-				allowed = [ 'day', 'hour' ];
+				allowed = [ 'hour', 'day' ];
 				break;
 		}
 	}

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -434,6 +434,7 @@ export function getChartTypeForQuery( { type } ) {
 
 export const dayTicksThreshold = 63;
 export const weekTicksThreshold = 9;
+export const defaultTableDateFormat = 'm/d/Y';
 
 /**
  * Returns date formats for the current interval.
@@ -447,7 +448,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 	let tooltipLabelFormat = '%B %d, %Y';
 	let xFormat = '%Y-%m-%d';
 	let x2Format = '%b %Y';
-	let tableFormat = 'm/d/Y';
+	let tableFormat = defaultTableDateFormat;
 
 	switch ( interval ) {
 		case 'hour':


### PR DESCRIPTION
Fixes #1205 

Adds `day` to the allowed list of intervals for periods less than a day so that the date format will parse as a date instead of an hour for single days.

### Before
<img width="301" alt="screen shot 2018-12-31 at 1 25 40 pm" src="https://user-images.githubusercontent.com/10561050/50554956-95be9600-0cff-11e9-8133-04865c87cabd.png">

### After
<img width="300" alt="screen shot 2018-12-31 at 1 25 27 pm" src="https://user-images.githubusercontent.com/10561050/50554955-93f4d280-0cff-11e9-8a74-dff75dc3a376.png">

### Detailed test instructions:

1.  Open any reports page with a page (e.g. Revenue).
2.  Select different date ranges with single day periods (Yesterday, Today, and Custom: Same day to same day).
3.  Check that the date in the table shows the date selected and not 12am.