### PR TITLE
Update dashboard charts on query change

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -5,7 +5,6 @@
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { isEqual } from 'lodash';
 import { ToggleControl, IconButton, NavigableMenu } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
@@ -23,24 +22,14 @@ import { getChartFromKey, showCharts } from './config';
 import './style.scss';
 
 class DashboardCharts extends Component {
-	constructor( props ) {
+	constructor() {
 		super( ...arguments );
 		this.state = {
+			chartType: 'line', // @TODO: Remove this and use from props containing persisted user preferences.
 			showCharts,
-			query: props.query,
 		};
 
 		this.toggle = this.toggle.bind( this );
-	}
-
-	static getDerivedStateFromProps( props, state ) {
-		const { query } = props;
-		if ( ! isEqual( { ...query, ...state.type }, state.query ) ) {
-			return {
-				query: { ...query, ...state.type },
-			};
-		}
-		return null;
 	}
 
 	toggle( key ) {
@@ -55,7 +44,9 @@ class DashboardCharts extends Component {
 
 	handleTypeToggle( type ) {
 		return () => {
-			this.setState( state => ( { query: { ...state.query, type } } ) );
+			this.setState( {
+				chartType: type,
+			} );
 		};
 	}
 
@@ -79,7 +70,7 @@ class DashboardCharts extends Component {
 
 	render() {
 		const { path } = this.props;
-		const { query } = this.state;
+		const query = { ...this.props.query, type: this.state.chartType };
 		return (
 			<Fragment>
 				<div className="woocommerce-dashboard__dashboard-charts">

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -5,6 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { isEqual } from 'lodash';
 import { ToggleControl, IconButton, NavigableMenu } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
@@ -30,6 +31,16 @@ class DashboardCharts extends Component {
 		};
 
 		this.toggle = this.toggle.bind( this );
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		const { query } = props;
+		if ( ! isEqual( { ...query, ...state.type }, state.query ) ) {
+			return {
+				query: { ...query, ...state.type },
+			};
+		}
+		return null;
 	}
 
 	toggle( key ) {


### PR DESCRIPTION
Fixes #1188 

Assigns the query from props to the state query when updated.

### Detailed test instructions:

1.  Open the dashboard reports `/wp-admin/admin.php?page=wc-admin`.
2.  Change the query params using the date range picker.
3.  Check that the charts are updated when the date range is changed.
