### PR TITLE
Add the order status column to lookup table

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -401,6 +401,7 @@ class WC_Admin_Api_Init {
 			shipping_total double DEFAULT 0 NOT NULL,
 			net_total double DEFAULT 0 NOT NULL,
 			returning_customer boolean DEFAULT 0 NOT NULL,
+			status varchar(200) NOT NULL,
 			PRIMARY KEY (order_id),
 			KEY date_created (date_created)
 		  ) $collate;

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -708,14 +708,14 @@ class WC_Admin_Reports_Data_Store {
 		if ( isset( $query_args['status_is'] ) && is_array( $query_args['status_is'] ) && count( $query_args['status_is'] ) > 0 ) {
 			$allowed_statuses = array_map( array( $this, 'normalize_order_status' ), $query_args['status_is'] );
 			if ( $allowed_statuses ) {
-				$subqueries[] = "{$wpdb->prefix}posts.post_status IN ( '" . implode( "','", $allowed_statuses ) . "' )";
+				$subqueries[] = "{$wpdb->prefix}wc_order_stats.status IN ( '" . implode( "','", $allowed_statuses ) . "' )";
 			}
 		}
 
 		if ( isset( $query_args['status_is_not'] ) && is_array( $query_args['status_is_not'] ) && count( $query_args['status_is_not'] ) > 0 ) {
 			$forbidden_statuses = array_map( array( $this, 'normalize_order_status' ), $query_args['status_is_not'] );
 			if ( $forbidden_statuses ) {
-				$subqueries[] = "{$wpdb->prefix}posts.post_status NOT IN ( '" . implode( "','", $forbidden_statuses ) . "' )";
+				$subqueries[] = "{$wpdb->prefix}wc_order_stats.status NOT IN ( '" . implode( "','", $forbidden_statuses ) . "' )";
 			}
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -345,7 +345,7 @@ class WC_Admin_Reports_Data_Store {
 	 * @param string $status Order status.
 	 * @return string
 	 */
-	protected function normalize_order_status( $status ) {
+	protected static function normalize_order_status( $status ) {
 		$status = trim( $status );
 		return 'wc-' . $status;
 	}

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -460,6 +460,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			'shipping_total'     => $order->get_shipping_total(),
 			'net_total'          => (float) $order->get_total() - (float) $order->get_total_tax() - (float) $order->get_shipping_total(),
 			'returning_customer' => self::is_returning_customer( $order ),
+			'status'             => $order->get_status(),
 		);
 
 		// Update or add the information to the DB.
@@ -476,6 +477,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				'%f',
 				'%f',
 				'%f',
+				'%d',
+				'%s',
 			)
 		);
 	}

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -458,7 +458,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			'shipping_total'     => $order->get_shipping_total(),
 			'net_total'          => (float) $order->get_total() - (float) $order->get_total_tax() - (float) $order->get_shipping_total(),
 			'returning_customer' => self::is_returning_customer( $order ),
-			'status'             => normalize_order_status( $order->get_status() ),
+			'status'             => self::normalize_order_status( $order->get_status() ),
 		);
 
 		// Update or add the information to the DB.

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -170,10 +170,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				)";
 		}
 
-		// TODO: move order status to wc_order_stats so that JOIN is not necessary.
 		$order_status_filter = $this->get_status_subquery( $query_args, $operator );
 		if ( $order_status_filter ) {
-			$from_clause    .= " JOIN {$wpdb->prefix}posts ON {$orders_stats_table}.order_id = {$wpdb->prefix}posts.ID";
 			$where_filters[] = $order_status_filter;
 		}
 
@@ -460,7 +458,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			'shipping_total'     => $order->get_shipping_total(),
 			'net_total'          => (float) $order->get_total() - (float) $order->get_total_tax() - (float) $order->get_shipping_total(),
 			'returning_customer' => self::is_returning_customer( $order ),
-			'status'             => $order->get_status(),
+			'status'             => normalize_order_status( $order->get_status() ),
 		);
 
 		// Update or add the information to the DB.


### PR DESCRIPTION
Fixes #475 

Adds the `status` column to the `wc_order_stats` lookup table.  And changes filtering to reflect this in the order stats endpoint.

### Detailed test instructions:

1.  Rebuild order reports so that the `status` column is populated with data `/wp-admin/admin.php?page=wc-status&tab=tools`.
2.  Visit the Order report page `/wp-admin/admin.php?page=wc-admin#/analytics/orders`.
3.  Under Advanced Filters, test the Order Status option using both `Is` and `Is not` options.
4.  Check that the stats (**not the orders table**), update with the correct order stats.  

Note that the existing order data store will need to be updated in order to work with status filters ( #950  ) and that only a select few statuses are currently recorded in the orders table ( `completed`, `processing`, `on-hold` ).