### PR TITLE
Add chart loading spinner while data is being requested

### DIFF
--- a/packages/components/src/chart/placeholder.js
+++ b/packages/components/src/chart/placeholder.js
@@ -4,6 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { Spinner } from '@wordpress/components';
 
 /**
  * `ChartPlaceholder` displays a large loading indiciator for use in place of a `Chart` while data is loading.
@@ -13,7 +14,9 @@ class ChartPlaceholder extends Component {
 		const { height } = this.props;
 
 		return (
-			<div aria-hidden="true" className="woocommerce-chart-placeholder" style={ { height } } />
+			<div aria-hidden="true" className="woocommerce-chart-placeholder" style={ { height } }>
+				<Spinner />
+			</div>
 		);
 	}
 }

--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -56,6 +56,12 @@
 	@include placeholder();
 	padding: 0;
 	width: 100%;
+	display: flex;
+    align-items: center;
+	justify-content: center;
+	.components-spinner {
+		margin: 0;
+	}
 }
 
 .woocommerce-chart__interval-select {


### PR DESCRIPTION
Fixes #1189 

Adds a spinner while chart data is being loaded.

### Screenshots
<img width="1298" alt="screen shot 2018-12-31 at 4 50 20 pm" src="https://user-images.githubusercontent.com/10561050/50557077-9154a600-0d1c-11e9-83bf-1d48c7f9acf1.png">

### Detailed test instructions:

1.  Open any report with a chart.
2.  Reload the page and check that a spinner is shown while data is loading.
3.  Throttle your connection if things load too quickly to view.
