### PR TITLE
Fix chart legend checkboxes not reacting to clicks

### DIFF
--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -114,7 +114,7 @@ class Chart extends Component {
 
 	handleLegendToggle( event ) {
 		const { data, mode } = this.props;
-		if ( mode ) {
+		if ( mode === 'block' ) {
 			return;
 		}
 		const orderedKeys = this.state.orderedKeys.map( d => ( {


### PR DESCRIPTION
This PR fixes a regression that made it impossible to enable/disable chart legend items in report charts.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
![legend](https://user-images.githubusercontent.com/3616980/50575074-ff20d080-0df5-11e9-80e7-69c3c3f0ae37.gif)

### Detailed test instructions:
- Go to the _Revenue_ report (or any other).
- Try deactivating and activating again legend items clicking on their name or checkbox.
- Verify the chart updates to hide/show them accordingly.
- Go to the _Dashboard_ and look for a chart.
- Try deactivating legend items and verify they can't be disabled.