### PR TITLE
Update chart interval thresholds

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -354,18 +354,18 @@ export function getAllowedIntervalsForQuery( query ) {
 	if ( 'custom' === query.period ) {
 		const { primary } = getCurrentDates( query );
 		const differenceInDays = getDateDifferenceInDays( primary.before, primary.after );
-		if ( differenceInDays > 728 ) {
+		if ( differenceInDays >= 365 ) {
 			allowed = [ 'day', 'week', 'month', 'quarter', 'year' ];
-		} else if ( differenceInDays > 364 ) {
+		} else if ( differenceInDays >= 90 ) {
 			allowed = [ 'day', 'week', 'month', 'quarter' ];
-		} else if ( differenceInDays > 90 ) {
+		} else if ( differenceInDays >= 28 ) {
 			allowed = [ 'day', 'week', 'month' ];
-		} else if ( differenceInDays > 7 ) {
+		} else if ( differenceInDays >= 7 ) {
 			allowed = [ 'day', 'week' ];
-		} else if ( differenceInDays > 1 && differenceInDays <= 7 ) {
-			allowed = [ 'day', 'hour' ];
+		} else if ( differenceInDays > 1 && differenceInDays < 7 ) {
+			allowed = [ 'day' ];
 		} else {
-			allowed = [ 'hour' ];
+			allowed = [ 'hour', 'day' ];
 		}
 	} else {
 		switch ( query.period ) {


### PR DESCRIPTION
Fixes #1187.

Updates the thresholds used to decide which intervals are available for each different date range.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50575187-3f358280-0df9-11e9-93bb-0af3f18c84b2.png)

### Detailed test instructions:
- Go to the _Revenue_ report (or any other).
- Select a _Custom date range_ from _02/01/2017_ to _02/01/2018_, for example.
- Verify one of the suggested intervals is _By year_.
- You can repeat the previous process with other intervals and verify it matches the description in #1187.