### PR TITLE
DateRange: change focusInput prop on input focus

### DIFF
--- a/packages/components/src/calendar/date-range.js
+++ b/packages/components/src/calendar/date-range.js
@@ -118,6 +118,7 @@ class DateRange extends Component {
 							),
 							shortDateFormat
 						) }
+						onFocus={ () => this.onFocusChange( 'startDate' ) }
 					/>
 					<div className="woocommerce-calendar__inputs-to">{ __( 'to', 'wc-admin' ) }</div>
 					<DateInput
@@ -133,6 +134,7 @@ class DateRange extends Component {
 							),
 							shortDateFormat
 						) }
+						onFocus={ () => this.onFocusChange( 'endDate' ) }
 					/>
 				</div>
 				<div className="woocommerce-calendar__react-dates">


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1097

Explicitly tell the react-dates calendar that focus has changed when inputs receive focus. This way, a mix of keyboard and mouse interactions still retain the concept of which date is being modified when an input has focus.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots

### Detailed test instructions:

1. To reproduce, navigate to a report from anywhere else in WP-admin
2. Select the date range picker, the select the custom tab
3. using the manual inputs, select the first input and type `01/01/2016` or something else in the distant past that isn't visible on the current calendar) When you've entered the date TAB to the next field. (end date)
4. Note the focus is applied to the end date. 
5. using the calendar, select todays date. 
6. note the date selected in the calendar gets placed in the "end date".
