### PR TITLE
Fix/search css tags

### DIFF
--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -107,11 +107,6 @@
 			display: block;
 		}
 	}
-
-	.woocommerce-tag {
-		margin-top: 1px;
-		margin-bottom: 1px;
-	}
 }
 
 .woocommerce-filters-advanced__rule {

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -158,7 +158,9 @@ class Search extends Component {
 		const shouldRenderTags = this.shouldRenderTags();
 
 		return (
-			<div className={ classnames( 'woocommerce-search', className ) }>
+			<div className={ classnames( 'woocommerce-search', className, {
+				'has-inline-tags': inlineTags,
+			} ) }>
 				<Gridicon className="woocommerce-search__icon" icon="search" size={ 18 } />
 				<Autocomplete
 					completer={ autocompleter }

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -5,10 +5,24 @@
 
 	.woocommerce-search__icon {
 		position: absolute;
-		top: 50%;
+		top: 10px;
 		left: 10px;
 		fill: $core-grey-light-900;
-		transform: translateY(-50%);
+	}
+
+	.woocommerce-tag {
+		margin: 8px 6px 0 0;
+	}
+
+	&.has-inline-tags {
+		.woocommerce-search__icon {
+			top: 50%;
+			transform: translateY(-50%);
+		}
+
+		.woocommerce-tag {
+			margin: initial;
+		}
 	}
 
 	.woocommerce-search__inline-container {

--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -2,7 +2,7 @@
 
 .woocommerce-tag {
 	display: inline-flex;
-	margin: 0 4px 0 0;
+	margin: 1px 4px 1px 0;
 	overflow: hidden;
 	vertical-align: middle;
 


### PR DESCRIPTION
Search tags that were not `inlineTags` had incorrect styles applied to them.

**Designs:** p6riRB-3lz-p2

### Before

![screen shot 2019-01-02 at 2 41 44 pm](https://user-images.githubusercontent.com/1922453/50578475-ae65b200-0e9f-11e9-90d3-045e2546b629.png)

### After

![screen shot 2019-01-02 at 2 55 28 pm](https://user-images.githubusercontent.com/1922453/50578479-b6255680-0e9f-11e9-8cae-30bdd7deea92.png)

### Detailed test instructions:

1. Go to Products Report > Show > Product Comparison.
2. Add a few products to Search and see that styles are correctly applied.
3. Go to Orders > Show > Advanced Filters > Add a Filter > Products.
4. Add a few products to Search and see that styles are correctly applied for inline rendered tags.