### PR TITLE
Add dashboard chart user preferences

### DIFF
--- a/client/dashboard/dashboard-charts/config.js
+++ b/client/dashboard/dashboard-charts/config.js
@@ -21,19 +21,11 @@ const allCharts = ordersCharts
 	);
 
 // Need to remove duplicate charts, by key, from the configs
-const uniqCharts = allCharts.reduce( ( a, b ) => {
+export const uniqCharts = allCharts.reduce( ( a, b ) => {
 	if ( a.findIndex( d => d.key === b.key ) < 0 ) {
 		a.push( b );
 	}
 	return a;
 }, [] );
 
-// Default charts.
-// TODO: Implement user-based toggling/persistence.
-const defaultCharts = [ 'items_sold', 'gross_revenue' ];
-
-export const showCharts = uniqCharts.map( d => ( {
-	...d,
-	show: defaultCharts.indexOf( d.key ) >= 0,
-} ) );
 export const getChartFromKey = key => allCharts.filter( d => d.key === key );

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -42,14 +42,14 @@ class DashboardCharts extends Component {
 		userPrefChartType: prevUserPrefChartType,
 	} ) {
 		const { userPrefCharts, userPrefChartType } = this.props;
-		if ( ! isEqual( userPrefCharts, prevUserPrefCharts ) ) {
+		if ( userPrefCharts && ! isEqual( userPrefCharts, prevUserPrefCharts ) ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( {
 				hiddenChartKeys: userPrefCharts,
 			} );
 			/* eslint-enable react/no-did-update-set-state */
 		}
-		if ( userPrefChartType !== prevUserPrefChartType ) {
+		if ( userPrefChartType && userPrefChartType !== prevUserPrefChartType ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( {
 				chartType: userPrefChartType,

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -4,10 +4,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
-import { ToggleControl, IconButton, NavigableMenu } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import Gridicon from 'gridicons';
+import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
+import { ToggleControl, IconButton, NavigableMenu } from '@wordpress/components';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -18,27 +21,52 @@ import { EllipsisMenu, MenuItem, SectionHeader } from '@woocommerce/components';
  * Internal dependencies
  */
 import ChartBlock from './block';
-import { getChartFromKey, showCharts } from './config';
+import { getChartFromKey, uniqCharts } from './config';
+import withSelect from 'wc-api/with-select';
 import './style.scss';
 
 class DashboardCharts extends Component {
-	constructor() {
+	constructor( props ) {
 		super( ...arguments );
 		this.state = {
 			chartType: 'line', // @TODO: Remove this and use from props containing persisted user preferences.
-			showCharts,
+			hiddenChartKeys: props.userPrefCharts || [],
+			query: props.query,
 		};
 
 		this.toggle = this.toggle.bind( this );
 	}
 
+	componentDidUpdate( { userPrefCharts: prevUserPrefCharts } ) {
+		const { userPrefCharts } = this.props;
+		if ( ! isEqual( userPrefCharts, prevUserPrefCharts ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( {
+				hiddenChartKeys: userPrefCharts,
+			} );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+	}
+
 	toggle( key ) {
 		return () => {
-			this.setState( state => {
-				const foundIndex = state.showCharts.findIndex( x => x.key === key );
-				state.showCharts[ foundIndex ].show = ! state.showCharts[ foundIndex ].show;
-				return state;
-			} );
+			this.setState(
+				prevState => {
+					const hidden = prevState.hiddenChartKeys.includes( key );
+					const hiddenChartKeys = prevState.hiddenChartKeys.filter( chartKey => chartKey !== key );
+
+					if ( ! hidden ) {
+						hiddenChartKeys.push( key );
+					}
+					return { hiddenChartKeys };
+				},
+				() => {
+					const userDataFields = {
+						[ 'dashboard_charts' ]: this.state.hiddenChartKeys,
+					};
+					this.props.updateCurrentUserData( userDataFields );
+				}
+			);
 		};
 	}
 
@@ -53,12 +81,12 @@ class DashboardCharts extends Component {
 	renderMenu() {
 		return (
 			<EllipsisMenu label={ __( 'Choose which charts to display', 'wc-admin' ) }>
-				{ this.state.showCharts.map( chart => {
+				{ uniqCharts.map( chart => {
 					return (
 						<MenuItem onInvoke={ this.toggle( chart.key ) } key={ chart.key }>
 							<ToggleControl
 								label={ __( `${ chart.label }`, 'wc-admin' ) }
-								checked={ chart.show }
+								checked={ ! this.state.hiddenChartKeys.includes( chart.key ) }
 								onChange={ this.toggle( chart.key ) }
 							/>
 						</MenuItem>
@@ -70,7 +98,8 @@ class DashboardCharts extends Component {
 
 	render() {
 		const { path } = this.props;
-		const query = { ...this.props.query, type: this.state.chartType };
+		const { hiddenChartKeys, chartType } = this.state;
+		const query = { ...this.props.query, type: chartType };
 		return (
 			<Fragment>
 				<div className="woocommerce-dashboard__dashboard-charts">
@@ -105,8 +134,8 @@ class DashboardCharts extends Component {
 						</NavigableMenu>
 					</SectionHeader>
 					<div className="woocommerce-dashboard__columns">
-						{ this.state.showCharts.map( chart => {
-							return ! chart.show ? null : (
+						{ uniqCharts.map( chart => {
+							return hiddenChartKeys.includes( chart.key ) ? null : (
 								<div key={ chart.key }>
 									<ChartBlock
 										charts={ getChartFromKey( chart.key ) }
@@ -129,4 +158,20 @@ DashboardCharts.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default DashboardCharts;
+export default compose(
+	withSelect( select => {
+		const { getCurrentUserData } = select( 'wc-api' );
+		const userData = getCurrentUserData();
+
+		return {
+			userPrefCharts: userData.dashboard_charts,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { updateCurrentUserData } = dispatch( 'wc-api' );
+
+		return {
+			updateCurrentUserData,
+		};
+	} )
+)( DashboardCharts );

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
-import { isEqual } from 'lodash';
+import { isEqual, xor } from 'lodash';
 import PropTypes from 'prop-types';
 import { ToggleControl, IconButton, NavigableMenu } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
@@ -60,34 +60,22 @@ class DashboardCharts extends Component {
 
 	toggle( key ) {
 		return () => {
-			this.setState(
-				prevState => {
-					const hidden = prevState.hiddenChartKeys.includes( key );
-					const hiddenChartKeys = prevState.hiddenChartKeys.filter( chartKey => chartKey !== key );
-
-					if ( ! hidden ) {
-						hiddenChartKeys.push( key );
-					}
-					return { hiddenChartKeys };
-				},
-				() => {
-					const userDataFields = {
-						[ 'dashboard_charts' ]: this.state.hiddenChartKeys,
-					};
-					this.props.updateCurrentUserData( userDataFields );
-				}
-			);
+			const hiddenChartKeys = xor( this.state.hiddenChartKeys, [ key ] );
+			this.setState( { hiddenChartKeys } );
+			const userDataFields = {
+				[ 'dashboard_charts' ]: hiddenChartKeys,
+			};
+			this.props.updateCurrentUserData( userDataFields );
 		};
 	}
 
 	handleTypeToggle( type ) {
 		return () => {
-			this.setState( { chartType: type }, () => {
-				const userDataFields = {
-					[ 'dashboard_chart_type' ]: this.state.chartType,
-				};
-				this.props.updateCurrentUserData( userDataFields );
-			} );
+			this.setState( { chartType: type } );
+			const userDataFields = {
+				[ 'dashboard_chart_type' ]: type,
+			};
+			this.props.updateCurrentUserData( userDataFields );
 		};
 	}
 

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -29,7 +29,7 @@ class DashboardCharts extends Component {
 	constructor( props ) {
 		super( ...arguments );
 		this.state = {
-			chartType: 'line', // @TODO: Remove this and use from props containing persisted user preferences.
+			chartType: props.userPrefChartType || 'line',
 			hiddenChartKeys: props.userPrefCharts || [],
 			query: props.query,
 		};
@@ -37,12 +37,22 @@ class DashboardCharts extends Component {
 		this.toggle = this.toggle.bind( this );
 	}
 
-	componentDidUpdate( { userPrefCharts: prevUserPrefCharts } ) {
-		const { userPrefCharts } = this.props;
+	componentDidUpdate( {
+		userPrefCharts: prevUserPrefCharts,
+		userPrefChartType: prevUserPrefChartType,
+	} ) {
+		const { userPrefCharts, userPrefChartType } = this.props;
 		if ( ! isEqual( userPrefCharts, prevUserPrefCharts ) ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( {
 				hiddenChartKeys: userPrefCharts,
+			} );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+		if ( userPrefChartType !== prevUserPrefChartType ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( {
+				chartType: userPrefChartType,
 			} );
 			/* eslint-enable react/no-did-update-set-state */
 		}
@@ -72,8 +82,11 @@ class DashboardCharts extends Component {
 
 	handleTypeToggle( type ) {
 		return () => {
-			this.setState( {
-				chartType: type,
+			this.setState( { chartType: type }, () => {
+				const userDataFields = {
+					[ 'dashboard_chart_type' ]: this.state.chartType,
+				};
+				this.props.updateCurrentUserData( userDataFields );
 			} );
 		};
 	}
@@ -98,7 +111,7 @@ class DashboardCharts extends Component {
 
 	render() {
 		const { path } = this.props;
-		const { hiddenChartKeys, chartType } = this.state;
+		const { chartType, hiddenChartKeys } = this.state;
 		const query = { ...this.props.query, type: chartType };
 		return (
 			<Fragment>
@@ -165,6 +178,7 @@ export default compose(
 
 		return {
 			userPrefCharts: userData.dashboard_charts,
+			userPrefChartType: userData.dashboard_chart_type,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -41,6 +41,7 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 		'taxes_report_columns',
 		'variations_report_columns',
 		'dashboard_charts',
+		'dashboard_chart_type',
 	];
 
 	if ( resourceNames.includes( resourceName ) ) {

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -40,6 +40,7 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 		'revenue_report_columns',
 		'taxes_report_columns',
 		'variations_report_columns',
+		'dashboard_charts',
 	];
 
 	if ( resourceNames.includes( resourceName ) ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -399,6 +399,7 @@ function wc_admin_get_user_data_fields() {
 		'revenue_report_columns',
 		'taxes_report_columns',
 		'variations_report_columns',
+		'dashboard_charts',
 	);
 
 	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -400,6 +400,7 @@ function wc_admin_get_user_data_fields() {
 		'taxes_report_columns',
 		'variations_report_columns',
 		'dashboard_charts',
+		'dashboard_chart_type',
 	);
 
 	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );


### PR DESCRIPTION
Fixes #1184 

Persists shown dashboard charts and chart type for users.  We store hidden charts much like we store hidden columns in report tables as opposed to the shown charts to avoid always hiding newly introduced charts.

### Screenshots
<img width="996" alt="screen shot 2019-01-02 at 5 48 48 pm" src="https://user-images.githubusercontent.com/10561050/50586942-b250fe80-0eb6-11e9-9e12-04c630114348.png">

### Detailed test instructions:
1.  Visit the dashboard `wp-admin/admin.php?page=wc-admin`.
2.  Turn on/off some charts.
3.  Refresh the page and make sure that previously hidden charts remain hidden.
4.  Change to a bar chart by clicking the bar chart icon to the right of the section header.
5.  Refresh the page and make sure that the bar chart is still shown.