### PR TITLE
Add margin to inline search tags

### DIFF
--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -10,18 +10,16 @@
 		fill: $core-grey-light-900;
 	}
 
-	.woocommerce-tag {
-		margin: 8px 6px 0 0;
+	&:not(.has-inline-tags) {
+		.woocommerce-tag {
+			margin: 8px 6px 0 0;
+		}
 	}
 
 	&.has-inline-tags {
 		.woocommerce-search__icon {
 			top: 50%;
 			transform: translateY(-50%);
-		}
-
-		.woocommerce-tag {
-			margin: initial;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a regression that removed the margins between inline search tags.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/50605352-61470780-0ec2-11e9-83dd-be8dbb794ce5.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/50605286-352b8680-0ec2-11e9-8b6d-259728966f64.png)

### Detailed test instructions:
- Go to the _Customers_ report, select _Advanced filters_ and add a _Name_ filter.
- Add enough names to make them break in several lines.
- Verify there is a margin between tags.
- Go to the _Products_ report, select _Product Comparison_ and add a couple of products.
- Verify there is a margin between tags (= there is no regression).