### PR TITLE
Fix date issues introduced in #1203

### DIFF
--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -5,7 +5,7 @@
 import classnames from 'classnames';
 import { cloneElement, Component } from '@wordpress/element';
 import Gridicon from 'gridicons';
-import { moment } from '@wordpress/date';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 
 /**

--- a/client/header/activity-panel/activity-card/test/index.js
+++ b/client/header/activity-panel/activity-card/test/index.js
@@ -5,6 +5,7 @@
 import { Button } from '@wordpress/components';
 import Gridicon from 'gridicons';
 import { shallow } from 'enzyme';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -54,8 +55,7 @@ describe( 'ActivityCard', () => {
 
 	test( 'should render a timestamp on a card', () => {
 		// We're generating this via moment to ensure it's always "3 days ago".
-		const threeDaysAgo = wp.date
-			.moment()
+		const threeDaysAgo = moment()
 			.subtract( 3, 'days' )
 			.format();
 		const card = shallow(

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -327,7 +327,7 @@ describe( 'getSummaryNumbers()', () => {
 		} );
 
 		setGetReportStats( ( endpoint, _query ) => {
-			if ( '2018-10-10T00:00:00' === _query.after ) {
+			if ( '2018-10-10T00:00:00+00:00' === _query.after ) {
 				return {
 					data: {
 						totals: totals.primary,

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -111,6 +111,24 @@ export function isReportDataEmpty( report ) {
 }
 
 /**
+ * Returns true if `date` is today.
+ *
+ * @param  {String|Object} date Date string or object in a format that can be
+ * understood by the Date JS object. For example `yyyy-mm-dd`.
+ * @returns {Boolean} Whether `date` is today.
+ */
+function isToday( date ) {
+	const d = new Date( date );
+	const today = new Date();
+
+	return (
+		d.getFullYear() === today.getFullYear() &&
+		d.getMonth() === today.getMonth() &&
+		d.getDate() === today.getDate()
+	);
+}
+
+/**
  * Constructs and returns a query associated with a Report data request.
  *
  * @param  {String} endpoint Report API Endpoint
@@ -122,12 +140,13 @@ function getRequestQuery( endpoint, dataType, query ) {
 	const datesFromQuery = getCurrentDates( query );
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( endpoint, query );
+	const endingTimeOfDay = isToday( datesFromQuery[ dataType ].before ) ? 'now' : 'end';
 	return {
 		order: 'asc',
 		interval,
 		per_page: MAX_PER_PAGE,
 		after: appendTimestamp( datesFromQuery[ dataType ].after, 'start' ),
-		before: appendTimestamp( datesFromQuery[ dataType ].before, 'end' ),
+		before: appendTimestamp( datesFromQuery[ dataType ].before, endingTimeOfDay ),
 		...filterQuery,
 	};
 }

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -119,15 +119,15 @@ export function isReportDataEmpty( report ) {
  * @returns {Object} data request query parameters.
  */
 function getRequestQuery( endpoint, dataType, query ) {
-	const datesFromQuery = getCurrentDates( query, 'YYYY-MM-DDTHH:00:00' );
+	const datesFromQuery = getCurrentDates( query );
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( endpoint, query );
 	return {
 		order: 'asc',
 		interval,
 		per_page: MAX_PER_PAGE,
-		after: datesFromQuery[ dataType ].after,
-		before: datesFromQuery[ dataType ].before,
+		after: appendTimestamp( datesFromQuery[ dataType ].after, 'start' ),
+		before: appendTimestamp( datesFromQuery[ dataType ].before, 'end' ),
 		...filterQuery,
 	};
 }

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { find, forEach, isNull } from 'lodash';
+import moment from 'moment';
 
 /**
  * WooCommerce dependencies
@@ -111,24 +112,6 @@ export function isReportDataEmpty( report ) {
 }
 
 /**
- * Returns true if `date` is today.
- *
- * @param  {String|Object} date Date string or object in a format that can be
- * understood by the Date JS object. For example `yyyy-mm-dd`.
- * @returns {Boolean} Whether `date` is today.
- */
-function isToday( date ) {
-	const d = new Date( date );
-	const today = new Date();
-
-	return (
-		d.getFullYear() === today.getFullYear() &&
-		d.getMonth() === today.getMonth() &&
-		d.getDate() === today.getDate()
-	);
-}
-
-/**
  * Constructs and returns a query associated with a Report data request.
  *
  * @param  {String} endpoint Report API Endpoint
@@ -140,13 +123,15 @@ function getRequestQuery( endpoint, dataType, query ) {
 	const datesFromQuery = getCurrentDates( query );
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( endpoint, query );
-	const endingTimeOfDay = isToday( datesFromQuery[ dataType ].before ) ? 'now' : 'end';
+	const end = datesFromQuery[ dataType ].before;
+	const endingTimeOfDay = end.isSame( moment(), 'day' ) ? 'now' : 'end';
+
 	return {
 		order: 'asc',
 		interval,
 		per_page: MAX_PER_PAGE,
 		after: appendTimestamp( datesFromQuery[ dataType ].after, 'start' ),
-		before: appendTimestamp( datesFromQuery[ dataType ].before, endingTimeOfDay ),
+		before: appendTimestamp( end, endingTimeOfDay ),
 		...filterQuery,
 	};
 }

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -172,14 +172,14 @@ export function getLastPeriod( period, compare ) {
  */
 export function getCurrentPeriod( period, compare ) {
 	const primaryStart = moment().startOf( period );
-	const primaryEnd = moment().add( 1, 'hour' );
-	const hoursSoFar = primaryEnd.diff( primaryStart, 'hours' );
+	const primaryEnd = moment();
+	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;
 	let secondaryEnd;
 
 	if ( 'previous_period' === compare ) {
 		secondaryStart = primaryStart.clone().subtract( 1, period );
-		secondaryEnd = primaryEnd.clone().subtract( 1, period ).add( 1, 'hour' );
+		secondaryEnd = primaryEnd.clone().subtract( 1, period );
 	} else {
 		secondaryStart =
 			'week' === period
@@ -189,7 +189,7 @@ export function getCurrentPeriod( period, compare ) {
 						.week( primaryStart.week() )
 						.startOf( 'week' )
 				: primaryStart.clone().subtract( 1, 'years' );
-		secondaryEnd = secondaryStart.clone().add( hoursSoFar + 1, 'hours' );
+		secondaryEnd = secondaryStart.clone().add( daysSoFar, 'days' );
 	}
 	return {
 		primaryStart,
@@ -278,10 +278,9 @@ export const getDateParamsFromQuery = ( { period, compare, after, before } ) => 
  * @property {string} [compare] - compare valuer, ie previous_year
  * @property {string} [after] - date in iso date format, ie 2018-07-03
  * @property {string} [before] - date in iso date format, ie 2018-07-03
- * @param {String} dateFormat - format of the dates to return
  * @return {{primary: DateValue, secondary: DateValue}} - Primary and secondary DateValue objects
  */
-export const getCurrentDates = ( query, dateFormat = isoDateFormat ) => {
+export const getCurrentDates = query => {
 	const { period, compare, after, before } = getDateParamsFromQuery( query );
 	const { primaryStart, primaryEnd, secondaryStart, secondaryEnd } = getDateValue(
 		period,
@@ -294,14 +293,14 @@ export const getCurrentDates = ( query, dateFormat = isoDateFormat ) => {
 		primary: {
 			label: find( presetValues, item => item.value === period ).label,
 			range: getRangeLabel( primaryStart, primaryEnd ),
-			after: primaryStart.format( dateFormat ),
-			before: primaryEnd.format( dateFormat ),
+			after: primaryStart.format( isoDateFormat ),
+			before: primaryEnd.format( isoDateFormat ),
 		},
 		secondary: {
 			label: find( periods, item => item.value === compare ).label,
 			range: getRangeLabel( secondaryStart, secondaryEnd ),
-			after: secondaryStart.format( dateFormat ),
-			before: secondaryEnd.format( dateFormat ),
+			after: secondaryStart.format( isoDateFormat ),
+			before: secondaryEnd.format( isoDateFormat ),
 		},
 	};
 };

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -56,14 +56,12 @@ export const periods = [
 /**
  * Adds timestamp to a string date.
  *
- * @param {string|moment.Moment} date - Date as a string or a moment object.
+ * @param {moment.Moment} date - Date as a moment object.
  * @param {string} timeOfDay - Either `start`, `now` or `end` of the day.
  * @return {string} - String date with timestamp attached.
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
-	if ( moment.isMoment( date ) ) {
-		date = date.format( isoDateFormat );
-	}
+	date = date.format( isoDateFormat );
 	if ( timeOfDay === 'start' ) {
 		return date + 'T00:00:00+00:00';
 	}

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -68,7 +68,9 @@ export const appendTimestamp = ( date, timeOfDay ) => {
 		return date + 'T00:00:00+00:00';
 	}
 	if ( timeOfDay === 'now' ) {
-		return date + 'T' + moment().format( 'HH:mm:ss' ) + '+00:00';
+		// Set seconds to 00 to avoid consecutives calls happening before the previous
+		// one finished.
+		return date + 'T' + moment().format( 'HH:mm:00' ) + '+00:00';
 	}
 	if ( timeOfDay === 'end' ) {
 		return date + 'T23:59:59+00:00';

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -57,17 +57,20 @@ export const periods = [
  * Adds timestamp to a string date.
  *
  * @param {string} date - Date as a string.
- * @param {string} timeOfDay - Either `start` or `end` of the day.
+ * @param {string} timeOfDay - Either `start`, `now` or `end` of the day.
  * @return {string} - String date with timestamp attached.
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
 	if ( timeOfDay === 'start' ) {
 		return date + 'T00:00:00+00:00';
 	}
+	if ( timeOfDay === 'now' ) {
+		return date + 'T' + moment().format( 'HH:mm:ss' ) + '+00:00';
+	}
 	if ( timeOfDay === 'end' ) {
 		return date + 'T23:59:59+00:00';
 	}
-	throw new Error( 'appendTimestamp requires second parameter to be either `start` or `end`' );
+	throw new Error( 'appendTimestamp requires second parameter to be either `start`, `now` or `end`' );
 };
 
 /**

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -56,11 +56,14 @@ export const periods = [
 /**
  * Adds timestamp to a string date.
  *
- * @param {string} date - Date as a string.
+ * @param {string|moment.Moment} date - Date as a string or a moment object.
  * @param {string} timeOfDay - Either `start`, `now` or `end` of the day.
  * @return {string} - String date with timestamp attached.
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
+	if ( moment.isMoment( date ) ) {
+		date = date.format( isoDateFormat );
+	}
 	if ( timeOfDay === 'start' ) {
 		return date + 'T00:00:00+00:00';
 	}
@@ -296,14 +299,14 @@ export const getCurrentDates = query => {
 		primary: {
 			label: find( presetValues, item => item.value === period ).label,
 			range: getRangeLabel( primaryStart, primaryEnd ),
-			after: primaryStart.format( isoDateFormat ),
-			before: primaryEnd.format( isoDateFormat ),
+			after: primaryStart,
+			before: primaryEnd,
 		},
 		secondary: {
 			label: find( periods, item => item.value === compare ).label,
 			range: getRangeLabel( secondaryStart, secondaryEnd ),
-			after: secondaryStart.format( isoDateFormat ),
-			before: secondaryEnd.format( isoDateFormat ),
+			after: secondaryStart,
+			before: secondaryEnd,
 		},
 	};
 };
@@ -325,11 +328,11 @@ export const getDateDifferenceInDays = ( date, date2 ) => {
  * Get the previous date for either the previous period of year.
  *
  * @param {String} date - Base date
- * @param {String} date1 - primary start
- * @param {String} date2 - secondary start
+ * @param {String|Moment.moment} date1 - primary start
+ * @param {String|Moment.moment} date2 - secondary start
  * @param {String} compare - `previous_period`  or `previous_year`
  * @param {String} interval - interval
- * @return {String}  - Calculated date
+ * @return {Moment.moment}  - Calculated date
  */
 export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
 	const dateMoment = moment( date );

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -25,20 +25,20 @@ import {
 
 describe( 'appendTimestamp', () => {
 	it( 'should append `start` timestamp', () => {
-		expect( appendTimestamp( '2018-01-01', 'start' ) ).toEqual( '2018-01-01T00:00:00+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'start' ) ).toEqual( '2018-01-01T00:00:00+00:00' );
 	} );
 
 	it( 'should append `now` timestamp', () => {
 		const nowTimestamp = moment().format( 'HH:mm:00' );
-		expect( appendTimestamp( '2018-01-01', 'now' ) ).toEqual( '2018-01-01T' + nowTimestamp + '+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'now' ) ).toEqual( '2018-01-01T' + nowTimestamp + '+00:00' );
 	} );
 
 	it( 'should append `end` timestamp', () => {
-		expect( appendTimestamp( '2018-01-01', 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
 	} );
 
 	it( 'should throw and error if `timeOfDay` is not valid', () => {
-		expect( () => appendTimestamp( '2018-01-01' ) ).toThrow( Error );
+		expect( () => appendTimestamp( moment( '2018-01-01' ) ) ).toThrow( Error );
 	} );
 } );
 

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -28,6 +28,11 @@ describe( 'appendTimestamp', () => {
 		expect( appendTimestamp( '2018-01-01', 'start' ) ).toEqual( '2018-01-01T00:00:00+00:00' );
 	} );
 
+	it( 'should append `now` timestamp', () => {
+		const nowTimestamp = moment().format( 'HH:mm:00' );
+		expect( appendTimestamp( '2018-01-01', 'now' ) ).toEqual( '2018-01-01T' + nowTimestamp + '+00:00' );
+	} );
+
 	it( 'should append `end` timestamp', () => {
 		expect( appendTimestamp( '2018-01-01', 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
 	} );

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -486,16 +486,16 @@ describe( 'getCurrentDates', () => {
 		const currentDates = getCurrentDates( query );
 
 		expect( currentDates.primary ).toBeDefined();
-		expect( 'string' === typeof currentDates.primary.label ).toBe( true );
-		expect( 'string' === typeof currentDates.primary.range ).toBe( true );
-		expect( 'string' === typeof currentDates.primary.after ).toBe( true );
-		expect( 'string' === typeof currentDates.primary.before ).toBe( true );
+		expect( typeof currentDates.primary.label ).toBe( 'string' );
+		expect( typeof currentDates.primary.range ).toBe( 'string' );
+		expect( moment.isMoment( currentDates.primary.after ) ).toBe( true );
+		expect( moment.isMoment( currentDates.primary.before ) ).toBe( true );
 
 		expect( currentDates.secondary ).toBeDefined();
-		expect( 'string' === typeof currentDates.secondary.label ).toBe( true );
-		expect( 'string' === typeof currentDates.secondary.range ).toBe( true );
-		expect( 'string' === typeof currentDates.secondary.after ).toBe( true );
-		expect( 'string' === typeof currentDates.secondary.before ).toBe( true );
+		expect( typeof currentDates.secondary.label ).toBe( 'string' );
+		expect( typeof currentDates.secondary.range ).toBe( 'string' );
+		expect( moment.isMoment( currentDates.secondary.after ) ).toBe( true );
+		expect( moment.isMoment( currentDates.secondary.before ) ).toBe( true );
 	} );
 
 	it( 'should correctly apply default values', () => {
@@ -514,12 +514,12 @@ describe( 'getCurrentDates', () => {
 		const currentDates = getCurrentDates( query );
 
 		// Ensure default period is 'month'
-		expect( currentDates.primary.after ).toBe( startOfMonth );
-		expect( currentDates.primary.before ).toBe( today );
+		expect( currentDates.primary.after.format( isoDateFormat ) ).toBe( startOfMonth );
+		expect( currentDates.primary.before.format( isoDateFormat ) ).toBe( today );
 
 		// Ensure default compare is `previous_period`
-		expect( currentDates.secondary.after ).toBe( startOfMonthYearAgo );
-		expect( currentDates.secondary.before ).toBe( todayLastYear );
+		expect( currentDates.secondary.after.format( isoDateFormat ) ).toBe( startOfMonthYearAgo );
+		expect( currentDates.secondary.before.format( isoDateFormat ) ).toBe( todayLastYear );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #1218 and some other issues introduced in #1203.

This PR undo's the changes introduced in #1203 and tries a simpler approach to display _Today_ charts until the current time.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50608833-17641e80-0ece-11e9-9ef1-3108c742a758.png)

### Detailed test instructions:
- Go to any report, for example _Revenue_.
- In the _Date Range_ dropdown, select _Today_.
- Verify the chart shows data until your current hour.
- Verify there are no regressions in other charts.

---

- Go to any report, for example _Revenue_.
- In the _Date Range_ dropdown, select a custom date, for example `2018/01/02`.
- Verify data is loaded properly.