### PR TITLE
Fix/dev docs file path

### DIFF
--- a/client/devdocs/docs.js
+++ b/client/devdocs/docs.js
@@ -18,7 +18,8 @@ class Docs extends Component {
 	}
 
 	getReadme() {
-		const readme = require( `../../docs/components/${ this.props.filePath }.md` );
+		const { filePath, docPath } = this.props;
+		const readme = require( `../../docs/components/${ docPath }/${ filePath }.md` );
 		if ( ! readme ) {
 			return;
 		}
@@ -36,5 +37,9 @@ class Docs extends Component {
 		return <div className="woocommerce-devdocs__docs">{ readme }</div>;
 	}
 }
+
+Docs.defaultProps = {
+	docPath: 'packages',
+};
 
 export default Docs;

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -52,7 +52,7 @@ export default class extends Component {
 			<div className={ className }>
 				<Header sections={ breadcrumbs } />
 				{ exampleList.map( example => {
-					const { componentName, filePath, render } = getExampleData( example );
+					const { componentName, filePath, render, docPath } = getExampleData( example );
 					const cardClasses = classnames(
 						'woocommerce-devdocs__card',
 						`woocommerce-devdocs__card--${ filePath }`
@@ -78,7 +78,11 @@ export default class extends Component {
 							/>
 
 							{ component && (
-								<ComponentDocs componentName={ componentName } filePath={ filePath } />
+								<ComponentDocs
+									componentName={ componentName }
+									filePath={ filePath }
+									docPath={ docPath }
+								/>
 							) }
 						</Card>
 					);

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -18,6 +18,6 @@ You can use [`card/example.md`](https://raw.githubusercontent.com/woocommerce/wc
 
 ## 4. Add your example to `client/devdocs/examples.json`
 
-Keep these alphabetized. Optional properties here are `render` and `filePath`. `render` defaults to `My{ComponentName}`, and `filePath` defaults to `/docs/component/{component-name-as-slug}`.
+Keep these alphabetized. Optional properties here are `render`, `filePath`, and `docPath`. `render` defaults to `My{ComponentName}`, and `filePath` defaults to `/docs/component/packages/{component-name-as-slug}`. `docPath` designates the origin of the component and efaults to `packages` for components from `/packages/components`.
 
 Now you can visit `/wp-admin/admin.php?page=wc-admin#/devdocs` to see your component in action.


### PR DESCRIPTION
Individual devDocs pages aren't working (`/wp-admin/admin.php?page=wc-admin#/devdocs/*`) due to an incorrect path. This PR updates the path to the correct `docs/componenents/[packages|analytics]` folder.

I added an accepted property `isAnalyticsComponent` in the `examples.json` config, but am open to a more elegant solution.