### PR TITLE
Remove unused show_product_categories_in_rest function

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -491,17 +491,6 @@ class WC_Admin_Api_Init {
 		add_action( 'woocommerce_after_register_post_type', array( 'WC_Admin_Api_Init', 'order_product_lookup_store_init' ), 20 );
 	}
 
-	/**
-	 * Enables the WP REST API for product categories
-	 *
-	 * @param array $args Default arguments for product_cat taxonomy.
-	 * @return array
-	 */
-	public static function show_product_categories_in_rest( $args ) {
-		$args['show_in_rest'] = true;
-		return $args;
-	}
-
 }
 
 new WC_Admin_Api_Init();


### PR DESCRIPTION
Fixes #1232

Removes a function that was previously used when querying categories from the WP api which are now queried instead from the WC api.

### Detailed test instructions:

1.  Run phpunit tests and make sure all are passing.
2. Make sure categories still show correctly on category reports.
