### PR TITLE
Add dashboard chart links to reports

### DIFF
--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -42,13 +42,9 @@ class ChartBlock extends Component {
 				className="woocommerce-dashboard__chart-block-wrapper"
 				onClick={ this.handleChartClick }
 			>
-				<Card
-					className="woocommerce-dashboard__chart-block"
-					title={ charts[ 0 ].label }
-					onClick={ this.handleChartClick }
-				>
+				<Card className="woocommerce-dashboard__chart-block" title={ charts[ 0 ].label }>
 					<a
-						className="woocommerce-dashboard__chart-block screen-reader-text"
+						className="screen-reader-text"
 						href={ getAdminLink(
 							'admin.php?page=wc-admin#/analytics/' +
 								charts[ 0 ].endpoint +

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -16,7 +16,7 @@ import { getAdminLink, history } from '@woocommerce/navigation';
  */
 import ReportChart from 'analytics/components/report-chart';
 import './block.scss';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 class ChartBlock extends Component {
 	handleChartClick = () => {
@@ -52,8 +52,8 @@ class ChartBlock extends Component {
 								charts[ 0 ].key
 						) }
 					>
-						{ /* translators: appended to end of chart type for report link */
-						charts[ 0 ].label + __( ' Report', 'wc-admin' ) }
+						{ /* translators: %s is the chart type */
+						sprintf( __( '%s Report', 'wc-admin' ), charts[ 0 ].label ) }
 					</a>
 					<ReportChart
 						charts={ charts }

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -4,6 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -16,7 +17,6 @@ import { getAdminLink, history } from '@woocommerce/navigation';
  */
 import ReportChart from 'analytics/components/report-chart';
 import './block.scss';
-import { __, sprintf } from '@wordpress/i18n';
 
 class ChartBlock extends Component {
 	handleChartClick = () => {

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -2,21 +2,33 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
  * WooCommerce dependencies
  */
 import { Card } from '@woocommerce/components';
+import { getAdminLink, history } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import ReportChart from 'analytics/components/report-chart';
 import './block.scss';
+import { __ } from '@wordpress/i18n';
 
 class ChartBlock extends Component {
+	handleChartClick = () => {
+		const { charts } = this.props;
+
+		if ( ! charts || ! charts.length ) {
+			return null;
+		}
+
+		history.push( 'analytics/' + charts[ 0 ].endpoint + '?chart=' + charts[ 0 ].key );
+	};
+
 	render() {
 		const { charts, endpoint, path, query } = this.props;
 
@@ -25,8 +37,28 @@ class ChartBlock extends Component {
 		}
 
 		return (
-			<Fragment>
-				<Card className="woocommerce-dashboard__chart-block" title={ charts[ 0 ].label }>
+			<div
+				role="presentation"
+				className="woocommerce-dashboard__chart-block-wrapper"
+				onClick={ this.handleChartClick }
+			>
+				<Card
+					className="woocommerce-dashboard__chart-block"
+					title={ charts[ 0 ].label }
+					onClick={ this.handleChartClick }
+				>
+					<a
+						className="woocommerce-dashboard__chart-block screen-reader-text"
+						href={ getAdminLink(
+							'admin.php?page=wc-admin#/analytics/' +
+								charts[ 0 ].endpoint +
+								'?chart=' +
+								charts[ 0 ].key
+						) }
+					>
+						{ /* translators: appended to end of chart type for report link */
+						charts[ 0 ].label + __( ' Report', 'wc-admin' ) }
+					</a>
 					<ReportChart
 						charts={ charts }
 						endpoint={ endpoint }
@@ -36,7 +68,7 @@ class ChartBlock extends Component {
 						selectedChart={ charts[ 0 ] }
 					/>
 				</Card>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -1,5 +1,9 @@
 /** @format */
 
+.woocommerce-dashboard__chart-block-wrapper {
+	cursor: pointer;
+}
+
 .woocommerce-dashboard__chart-block {
 	.woocommerce-card__body {
 		padding: 0;
@@ -33,5 +37,24 @@
 
 	&:hover {
 		background: $core-grey-light-100;
+	}
+
+	.screen-reader-text:focus {
+		background: #fff;
+		clip: auto;
+		clip-path: none;
+		z-index: 1;
+		left: 6px;
+		top: 7px;
+		height: auto;
+		width: auto;
+		display: block;
+		@include font-size( 14 );
+		font-weight: 600;
+		padding: 15px 23px 14px;
+		background: #f1f1f1;
+		color: #0073aa;
+		text-decoration: none;
+		box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	}
 }

--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -7,6 +7,9 @@
 		.woocommerce-card__header {
 			background: #f8f9f9;
 		}
+		.woocommerce-legend__item button {
+			background: transparent;
+		}
 	}
 	.woocommerce-chart__footer {
 		position: relative;

--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -40,7 +40,6 @@
 	}
 
 	.screen-reader-text:focus {
-		background: #fff;
 		clip: auto;
 		clip-path: none;
 		z-index: 1;

--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -2,6 +2,25 @@
 
 .woocommerce-dashboard__chart-block-wrapper {
 	cursor: pointer;
+	&:hover {
+		.woocommerce-chart,
+		.woocommerce-card__header {
+			background: #f8f9f9;
+		}
+	}
+	.woocommerce-chart__footer {
+		position: relative;
+		&:after {
+			content: '';
+			position: absolute;
+			width: 100%;
+			height: 100%;
+			left: 0;
+			top: 0;
+			cursor: pointer;
+			z-index: 1;
+		}
+	}
 }
 
 .woocommerce-dashboard__chart-block {


### PR DESCRIPTION
Fixes #1191 

Makes the charts link directly to the reports on click and adds screen reader links for accessibility.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
<img width="756" alt="screen shot 2019-01-04 at 6 16 23 pm" src="https://user-images.githubusercontent.com/10561050/50683449-10afe580-104d-11e9-850c-02e3df23d76c.png">

### Detailed test instructions:

1.  Open the dashboards page.
2.  Enable each chart under the "Charts" section and click on each checking to make sure it goes to the correct report when clicked.
3.  Using your keyboard, tab through the page to make sure the screen reader link for each report is accessible.
4.  Using a screen reader, verify that you are still able to read through the charts in addition to being able to access the link to the report.

### Questions
* @ryelle I was able to tab through and access the links via screen reader, but this is somewhat unfamiliar territory for me so I appreciate any guidance you can give.
>Sighted keyboard users will tab through the page, and when they land on the link, it will appear above the graph, then they can move to the next block (because none of the graph will be interactive/tab-able content - unless we want to give focus to the blue boxes too, but if they don't have an action, is that useful?)

Does this mean we want to skip over the chart entirely when tabbing through so these users cannot access the information in (hovered) chart points?
* @LevinMedia I've made the screen reader label visible on tabbing through the page, as seen in the above screenshot "Items Sold Report", on tabbing and styled the same as the WordPress dashboard.  Does this look okay or do we have other styles in place for wc-admin?