### PR TITLE
Add v4 orders endpoint

### DIFF
--- a/includes/api/class-wc-admin-rest-orders-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-stats-controller.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @package WooCommerce Admin/API
  * @extends WC_REST_Orders_Controller
  */
-class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
+class WC_Admin_REST_Orders_Stats_Controller extends WC_REST_Orders_Controller {
 	/**
 	 * Get the query params for collections.
 	 *

--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -224,4 +224,19 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 		);
 	}
+
+	/**
+	 * Get order statuses without prefixes.
+	 *
+	 * @return array
+	 */
+	public function get_order_statuses() {
+		$order_statuses = array();
+
+		foreach ( array_keys( wc_get_order_statuses() ) as $status ) {
+			$order_statuses[] = str_replace( 'wc-', '', $status );
+		}
+
+		return $order_statuses;
+	}
 }

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -161,6 +161,12 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'date_created'       => array(
+					'description' => __( 'Date the order was created.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'status'             => array(
 					'description' => __( 'Order status.', 'wc-admin' ),
 					'type'        => 'string',
@@ -185,9 +191,9 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'returning_customer' => array(
-					'description' => __( 'Returning customer.', 'wc-admin' ),
-					'type'        => 'bool',
+				'customer_type' => array(
+					'description' => __( 'Returning or new customer.', 'wc-admin' ),
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -46,9 +46,9 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 		$args['orderby']          = $request['orderby'];
 		$args['order']            = $request['order'];
 		$args['product_includes'] = (array) $request['product_includes'];
-		$args['product_exlcudes'] = (array) $request['product_exlcudes'];
+		$args['product_excludes'] = (array) $request['product_excludes'];
 		$args['coupon_includes']  = (array) $request['coupon_includes'];
-		$args['coupon_exlcudes']  = (array) $request['coupon_exlcudes'];
+		$args['coupon_excludes']  = (array) $request['coupon_excludes'];
 		$args['status_is']        = (array) $request['status_is'];
 		$args['status_is_not']    = (array) $request['status_is_not'];
 		$args['customer_type']    = $request['customer_type'];

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -52,6 +52,7 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 		$args['status_is']        = (array) $request['status_is'];
 		$args['status_is_not']    = (array) $request['status_is_not'];
 		$args['customer_type']    = $request['customer_type'];
+		$args['extended_info']    = $request['extended_info'];
 		return $args;
 	}
 
@@ -190,6 +191,20 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'extended_info'      => array(
+					'products'   => array(
+						'type'        => 'array',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'List of product IDs and names.', 'wc-admin' ),
+					),
+					'categories' => array(
+						'type'        => 'array',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Category IDs.', 'wc-admin' ),
+					),
+				),
 			),
 		);
 
@@ -320,6 +335,13 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 				'returning',
 				'new',
 			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['extended_info']    = array(
+			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'wc-admin' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * REST API Reports categories controller
+ * REST API Reports orders controller
  *
- * Handles requests to the /reports/categories endpoint.
+ * Handles requests to the /reports/orders endpoint.
  *
  * @package WooCommerce Admin/API
  */
@@ -10,12 +10,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST API Reports categories controller class.
+ * REST API Reports orders controller class.
  *
  * @package WooCommerce/API
  * @extends WC_Admin_REST_Reports_Controller
  */
-class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_Controller {
+class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -29,7 +29,7 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'reports/categories';
+	protected $rest_base = 'reports/orders';
 
 	/**
 	 * Maps query arguments from the REST request.
@@ -38,19 +38,20 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                  = array();
-		$args['before']        = $request['before'];
-		$args['after']         = $request['after'];
-		$args['interval']      = $request['interval'];
-		$args['page']          = $request['page'];
-		$args['per_page']      = $request['per_page'];
-		$args['orderby']       = $request['orderby'];
-		$args['order']         = $request['order'];
-		$args['extended_info'] = $request['extended_info'];
-		$args['categories']    = (array) $request['categories'];
-		$args['status_is']     = (array) $request['status_is'];
-		$args['status_is_not'] = (array) $request['status_is_not'];
-
+		$args                     = array();
+		$args['before']           = $request['before'];
+		$args['after']            = $request['after'];
+		$args['page']             = $request['page'];
+		$args['per_page']         = $request['per_page'];
+		$args['orderby']          = $request['orderby'];
+		$args['order']            = $request['order'];
+		$args['product_includes'] = (array) $request['product_includes'];
+		$args['product_exlcudes'] = (array) $request['product_exlcudes'];
+		$args['coupon_includes']  = (array) $request['coupon_includes'];
+		$args['coupon_exlcudes']  = (array) $request['coupon_exlcudes'];
+		$args['status_is']        = (array) $request['status_is'];
+		$args['status_is_not']    = (array) $request['status_is_not'];
+		$args['customer_type']    = $request['customer_type'];
 		return $args;
 	}
 
@@ -61,26 +62,18 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args       = $this->prepare_reports_query( $request );
-		$categories_query = new WC_Admin_Reports_Categories_Query( $query_args );
-		$report_data      = $categories_query->get_data();
+		$query_args   = $this->prepare_reports_query( $request );
+		$orders_query = new WC_Admin_Reports_Orders_Query( $query_args );
+		$report_data  = $orders_query->get_data();
 
-		if ( is_wp_error( $report_data ) ) {
-			return $report_data;
+		$data = array();
+
+		foreach ( $report_data->data as $orders_data ) {
+			$item   = $this->prepare_item_for_response( $orders_data, $request );
+			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		if ( ! isset( $report_data->data ) || ! isset( $report_data->page_no ) || ! isset( $report_data->pages ) ) {
-			return new WP_Error( 'woocommerce_rest_reports_categories_invalid_response', __( 'Invalid response from data store.', 'wc-admin' ), array( 'status' => 500 ) );
-		}
-
-		$out_data = array();
-
-		foreach ( $report_data->data as $datum ) {
-			$item       = $this->prepare_item_for_response( $datum, $request );
-			$out_data[] = $this->prepare_response_for_collection( $item );
-		}
-
-		$response = rest_ensure_response( $out_data );
+		$response = rest_ensure_response( $data );
 		$response->header( 'X-WP-Total', (int) $report_data->total );
 		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
 
@@ -131,19 +124,19 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 		 * @param object           $report   The original report object.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_report_categories', $response, $report, $request );
+		return apply_filters( 'woocommerce_rest_prepare_report_orders', $response, $report, $request );
 	}
 
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @param WC_Admin_Reports_Query $object Object data.
+	 * @param WC_Reports_Query $object Object data.
 	 * @return array
 	 */
 	protected function prepare_links( $object ) {
 		$links = array(
-			'category' => array(
-				'href' => rest_url( sprintf( '/%s/products/categories/%d', $this->namespace, $object['category_id'] ) ),
+			'order' => array(
+				'href' => rest_url( sprintf( '/%s/orders/%d', $this->namespace, $object['order_id'] ) ),
 			),
 		);
 
@@ -158,46 +151,44 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_categories',
+			'title'      => 'report_orders',
 			'type'       => 'object',
 			'properties' => array(
-				'category_id'    => array(
-					'description' => __( 'Category ID.', 'wc-admin' ),
+				'order_id'           => array(
+					'description' => __( 'Order ID.', 'wc-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'items_sold'     => array(
-					'description' => __( 'Amount of items sold.', 'wc-admin' ),
+				'status'             => array(
+					'description' => __( 'Order status.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'customer_id'        => array(
+					'description' => __( 'Customer ID.', 'wc-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'net_revenue'  => array(
-					'description' => __( 'Gross revenue.', 'wc-admin' ),
-					'type'        => 'number',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'orders_count'   => array(
-					'description' => __( 'Amount of orders.', 'wc-admin' ),
+				'num_items_sold'     => array(
+					'description' => __( 'Number of items sold.', 'wc-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'products_count' => array(
-					'description' => __( 'Amount of products.', 'wc-admin' ),
-					'type'        => 'integer',
+				'net_total'          => array(
+					'description' => __( 'Net total revenue.', 'wc-admin' ),
+					'type'        => 'float',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'extended_info' => array(
-					'name'       => array(
-						'type'        => 'string',
-						'readonly'    => true,
-						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Category name.', 'wc-admin' ),
-					),
+				'returning_customer' => array(
+					'description' => __( 'Returning customer.', 'wc-admin' ),
+					'type'        => 'bool',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);
@@ -211,9 +202,9 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                  = array();
-		$params['context']       = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']          = array(
+		$params                     = array();
+		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']             = array(
 			'description'       => __( 'Current page of the collection.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -221,7 +212,7 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']      = array(
+		$params['per_page']         = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'wc-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -230,54 +221,77 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']         = array(
+		$params['after']            = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']        = array(
+		$params['before']           = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']         = array(
+		$params['order']            = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']       = array(
+		$params['orderby']          = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
-			'default'           => 'category_id',
+			'default'           => 'date',
 			'enum'              => array(
-				'category_id',
-				'items_sold',
-				'net_revenue',
-				'orders_count',
-				'products_count',
-				'category',
+				'date',
+				'num_items_sold',
+				'net_total',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['interval']      = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'wc-admin' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
+		$params['product_includes'] = array(
+			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'wc-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
 			),
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['status_is']     = array(
+		$params['product_excludes'] = array(
+			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'wc-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+		$params['coupon_includes']  = array(
+			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'wc-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['coupon_excludes']  = array(
+			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'wc-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+		$params['status_is']        = array(
 			'description'       => __( 'Limit result set to items that have the specified order status.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -287,7 +301,7 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 				'type' => 'string',
 			),
 		);
-		$params['status_is_not'] = array(
+		$params['status_is_not']    = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -297,24 +311,18 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 				'type' => 'string',
 			),
 		);
-		$params['categories']    = array(
-			'description'       => __( 'Limit result set to all items that have the specified term assigned in the categories taxonomy.', 'wc-admin' ),
-			'type'              => 'array',
-			'sanitize_callback' => 'wp_parse_id_list',
-			'validate_callback' => 'rest_validate_request_arg',
-			'items'             => array(
-				'type' => 'integer',
+		$params['customer_type']    = array(
+			'description'       => __( 'Limit result set to returning or new customers.', 'wc-admin' ),
+			'type'              => 'string',
+			'default'           => '',
+			'enum'              => array(
+				'',
+				'returning',
+				'new',
 			),
-		);
-		$params['extended_info'] = array(
-			'description'       => __( 'Add additional piece of info about each category to the report.', 'wc-admin' ),
-			'type'              => 'boolean',
-			'default'           => false,
-			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;
 	}
-
 }

--- a/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
@@ -13,9 +13,9 @@ defined( 'ABSPATH' ) || exit;
  * REST API Reports orders stats controller class.
  *
  * @package WooCommerce/API
- * @extends WC_REST_Reports_Controller
+ * @extends WC_Admin_REST_Reports_Controller
  */
-class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller {
+class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_Admin_REST_Reports_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -384,18 +384,4 @@ class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Cont
 		return $params;
 	}
 
-	/**
-	 * Get order statuses without prefixes.
-	 *
-	 * @return array
-	 */
-	protected function get_order_statuses() {
-		$order_statuses = array();
-
-		foreach ( array_keys( wc_get_order_statuses() ) as $status ) {
-			$order_statuses[] = str_replace( 'wc-', '', $status );
-		}
-
-		return $order_statuses;
-	}
 }

--- a/includes/api/class-wc-admin-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-admin-rest-system-status-tools-controller.php
@@ -55,7 +55,7 @@ class WC_Admin_REST_System_Status_Tools_Controller extends WC_REST_System_Status
 
 		switch ( $tool ) {
 			case 'rebuild_stats':
-				WC_Admin_Reports_Orders_Data_Store::queue_order_stats_repopulate_database();
+				WC_Admin_Reports_Orders_Stats_Data_Store::queue_order_stats_repopulate_database();
 				$message = __( 'Rebuilding reports data in the background . . .', 'wc-admin' );
 				break;
 			default:

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -48,6 +48,7 @@ class WC_Admin_Api_Init {
 
 		// Query classes for reports.
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-revenue-query.php';
+		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-orders-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-orders-stats-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-products-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-variations-query.php';
@@ -63,6 +64,7 @@ class WC_Admin_Api_Init {
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-orders-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-orders-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-products-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-variations-data-store.php';
@@ -104,6 +106,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-files-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-stats-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-orders-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-variations-controller.php';
@@ -130,6 +133,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Reports_Variations_Controller',
 				'WC_Admin_REST_Reports_Products_Stats_Controller',
 				'WC_Admin_REST_Reports_Revenue_Stats_Controller',
+				'WC_Admin_REST_Reports_Orders_Controller',
 				'WC_Admin_REST_Reports_Orders_Stats_Controller',
 				'WC_Admin_REST_Reports_Categories_Controller',
 				'WC_Admin_REST_Reports_Taxes_Controller',
@@ -411,6 +415,7 @@ class WC_Admin_Api_Init {
 			$data_stores,
 			array(
 				'report-revenue-stats'  => 'WC_Admin_Reports_Orders_Stats_Data_Store',
+				'report-orders'         => 'WC_Admin_Reports_Orders_Data_Store',
 				'report-orders-stats'   => 'WC_Admin_Reports_Orders_Stats_Data_Store',
 				'report-products'       => 'WC_Admin_Reports_Products_Data_Store',
 				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -63,7 +63,7 @@ class WC_Admin_Api_Init {
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
-		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-orders-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-orders-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-products-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-variations-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-products-stats-data-store.php';
@@ -92,7 +92,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
-		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
@@ -121,7 +121,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Customers_Controller',
 				'WC_Admin_REST_Data_Controller',
 				'WC_Admin_REST_Data_Download_Ips_Controller',
-				'WC_Admin_REST_Orders_Controller',
+				'WC_Admin_REST_Orders_Stats_Controller',
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Reviews_Controller',
 				'WC_Admin_REST_Reports_Controller',
@@ -203,9 +203,9 @@ class WC_Admin_Api_Init {
 			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5] )
 			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4] )
 			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3] )
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
+			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
 		) {
 			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][0] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3];
 			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][1] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4];
@@ -216,8 +216,8 @@ class WC_Admin_Api_Init {
 		if ( isset( $endpoints['/wc/v3/orders'] )
 			&& isset( $endpoints['/wc/v3/orders'][3] )
 			&& isset( $endpoints['/wc/v3/orders'][2] )
-			&& $endpoints['/wc/v3/orders'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
-			&& $endpoints['/wc/v3/orders'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v3/orders'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
+			&& $endpoints['/wc/v3/orders'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
 		) {
 			$endpoints['/wc/v3/orders'][0] = $endpoints['/wc/v3/orders'][2];
 			$endpoints['/wc/v3/orders'][1] = $endpoints['/wc/v3/orders'][3];
@@ -277,7 +277,7 @@ class WC_Admin_Api_Init {
 		// Add registered customers to the lookup table before updating order stats
 		// so that the orders can be associated with the `customer_id` column.
 		self::customer_lookup_store_init();
-		WC_Admin_Reports_Orders_Data_Store::queue_order_stats_repopulate_database();
+		WC_Admin_Reports_Orders_Stats_Data_Store::queue_order_stats_repopulate_database();
 		self::order_product_lookup_store_init();
 	}
 
@@ -305,7 +305,7 @@ class WC_Admin_Api_Init {
 	 * Init orders data store.
 	 */
 	public static function orders_data_store_init() {
-		WC_Admin_Reports_Orders_Data_Store::init();
+		WC_Admin_Reports_Orders_Stats_Data_Store::init();
 		WC_Admin_Reports_Products_Data_Store::init();
 		WC_Admin_Reports_Taxes_Data_Store::init();
 		WC_Admin_Reports_Coupons_Data_Store::init();
@@ -410,17 +410,17 @@ class WC_Admin_Api_Init {
 		return array_merge(
 			$data_stores,
 			array(
-				'report-revenue-stats'   => 'WC_Admin_Reports_Orders_Data_Store',
-				'report-orders-stats'    => 'WC_Admin_Reports_Orders_Data_Store',
-				'report-products'        => 'WC_Admin_Reports_Products_Data_Store',
-				'report-variations'      => 'WC_Admin_Reports_Variations_Data_Store',
-				'report-products-stats'  => 'WC_Admin_Reports_Products_Stats_Data_Store',
-				'report-categories'      => 'WC_Admin_Reports_Categories_Data_Store',
-				'report-taxes'           => 'WC_Admin_Reports_Taxes_Data_Store',
-				'report-taxes-stats'     => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
-				'report-coupons'         => 'WC_Admin_Reports_Coupons_Data_Store',
-				'report-coupons-stats'   => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
-				'report-downloads'       => 'WC_Admin_Reports_Downloads_Data_Store',
+				'report-revenue-stats'  => 'WC_Admin_Reports_Orders_Stats_Data_Store',
+				'report-orders-stats'   => 'WC_Admin_Reports_Orders_Stats_Data_Store',
+				'report-products'       => 'WC_Admin_Reports_Products_Data_Store',
+				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',
+				'report-products-stats' => 'WC_Admin_Reports_Products_Stats_Data_Store',
+				'report-categories'     => 'WC_Admin_Reports_Categories_Data_Store',
+				'report-taxes'          => 'WC_Admin_Reports_Taxes_Data_Store',
+				'report-taxes-stats'    => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
+				'report-coupons'        => 'WC_Admin_Reports_Coupons_Data_Store',
+				'report-coupons-stats'  => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
+				'report-downloads'      => 'WC_Admin_Reports_Downloads_Data_Store',
 				'report-downloads-stats' => 'WC_Admin_Reports_Downloads_Stats_Data_Store',
 				'admin-note'             => 'WC_Admin_Notes_Data_Store',
 				'report-customers'       => 'WC_Admin_Reports_Customers_Data_Store',

--- a/includes/class-wc-admin-order-stats-background-process.php
+++ b/includes/class-wc-admin-order-stats-background-process.php
@@ -71,7 +71,7 @@ class WC_Admin_Order_Stats_Background_Process extends WC_Background_Process {
 			return false;
 		}
 
-		WC_Admin_Reports_Orders_Data_Store::update( $order );
+		WC_Admin_Reports_Orders_Stats_Data_Store::update( $order );
 		return false;
 	}
 }

--- a/includes/class-wc-admin-reports-orders-query.php
+++ b/includes/class-wc-admin-reports-orders-query.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Class for parameter-based Orders Reports querying
+ *
+ * Example usage:
+ * $args = array(
+ *          'before'        => '2018-07-19 00:00:00',
+ *          'after'         => '2018-07-05 00:00:00',
+ *          'interval'      => 'week',
+ *          'products'      => array(15, 18),
+ *          'coupons'       => array(138),
+ *          'status_is'     => array('completed'),
+ *          'status_is_not' => array('failed'),
+ *          'new_customers' => false,
+ *         );
+ * $report = new WC_Admin_Reports_Orders_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Orders_Query
+ */
+class WC_Admin_Reports_Orders_Query extends WC_Admin_Reports_Query {
+
+	/**
+	 * Get order data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args = apply_filters( 'woocommerce_reports_orders_query_args', $this->get_query_vars() );
+
+		$data_store = WC_Data_Store::load( 'report-orders' );
+		$results    = $data_store->get_data( $args );
+		return apply_filters( 'woocommerce_reports_orders_select_query', $results, $args );
+	}
+
+}

--- a/includes/class-wc-admin-reports-orders-stats-query.php
+++ b/includes/class-wc-admin-reports-orders-stats-query.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class for parameter-based Orders Reports querying
+ * Class for parameter-based Order Stats Reports querying
  *
  * Example usage:
  * $args = array(

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WC_Admin_Reports_Copons_Data_Store class file.
+ * WC_Admin_Reports_Coupons_Data_Store class file.
  *
  * @package WooCommerce Admin/Classes
  */

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -138,7 +138,9 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			'product_excludes' => array(),
 			'coupon_includes'  => array(),
 			'coupon_excludes'  => array(),
+			'customer_type'    => null,
 			'status_is'        => parent::get_report_order_statuses(),
+			'extended_info'    => false,
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
 

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -88,24 +88,26 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		$included_coupons          = $this->get_included_coupons( $query_args );
 		$excluded_coupons          = $this->get_excluded_coupons( $query_args );
 		$order_coupon_lookup_table = $wpdb->prefix . 'wc_order_coupon_lookup';
+		if ( $included_coupons || $excluded_coupons ) {
+			$sql_query_params['from_clause'] .= " JOIN {$order_coupon_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_coupon_lookup_table}.order_id";
+		}
 		if ( $included_coupons ) {
-			$sql_query_params['from_clause']  .= " JOIN {$order_coupon_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_coupon_lookup_table}.order_id";
 			$sql_query_params['where_clause'] .= " AND {$order_coupon_lookup_table}.coupon_id IN ({$included_coupons})";
 		}
 		if ( $excluded_coupons ) {
-			$sql_query_params['from_clause']  .= " JOIN {$order_coupon_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_coupon_lookup_table}.order_id";
 			$sql_query_params['where_clause'] .= " AND {$order_coupon_lookup_table}.coupon_id NOT IN ({$excluded_coupons})";
 		}
 
 		$included_products          = $this->get_included_products( $query_args );
 		$excluded_products          = $this->get_excluded_products( $query_args );
 		$order_product_lookup_table = $wpdb->prefix . 'wc_order_product_lookup';
+		if ( $included_products || $excluded_products ) {
+			$sql_query_params['from_clause'] .= " JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id";
+		}
 		if ( $included_products ) {
-			$sql_query_params['from_clause']  .= " JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id";
 			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";
 		}
 		if ( $excluded_products ) {
-			$sql_query_params['from_clause']  .= " JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id";
 			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id NOT IN ({$excluded_products})";
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -80,6 +80,11 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			$sql_query_params['where_clause'] .= " AND {$status_subquery}";
 		}
 
+		if ( $query_args['customer_type'] ) {
+			$returning_customer                = 'returning' === $query_args['customer_type'] ? 1 : 0;
+			$sql_query_params['where_clause'] .= " AND returning_customer = ${returning_customer}";
+		}
+
 		$included_coupons          = $this->get_included_coupons( $query_args );
 		$excluded_coupons          = $this->get_excluded_coupons( $query_args );
 		$order_coupon_lookup_table = $wpdb->prefix . 'wc_order_coupon_lookup';

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * WC_Admin_Reports_Orders_Data_Store class file.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Orders_Data_Store.
+ */
+class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+
+	/**
+	 * Table used to get the data.
+	 *
+	 * @var string
+	 */
+	const TABLE_NAME = 'wc_order_stats';
+
+	/**
+	 * Mapping columns to data type to return correct response types.
+	 *
+	 * @var array
+	 */
+	protected $column_types = array(
+		'order_id'       => 'intval',
+		'date_created'   => 'strval',
+		'status'         => 'strval',
+		'customer_id'    => 'intval',
+		'net_total'      => 'floatval',
+		'num_items_sold' => 'intval',
+		'customer_type'  => 'strval',
+	);
+
+	/**
+	 * SQL columns to select in the db query and their mapping to SQL code.
+	 *
+	 * @var array
+	 */
+	protected $report_columns = array(
+		'order_id'       => 'order_id',
+		'date_created'   => 'date_created',
+		'status'         => 'status',
+		'customer_id'    => 'customer_id',
+		'net_total'      => 'net_total',
+		'num_items_sold' => 'num_items_sold',
+		'customer_type'  => '(CASE WHEN returning_customer <> 0 THEN "returning" ELSE "new" END) as customer_type',
+	);
+
+	/**
+	 * Returns comma separated ids of included coupons, based on query arguments from the user.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return string
+	 */
+	protected function get_included_coupons( $query_args ) {
+		$included_coupons_str = '';
+
+		if ( isset( $query_args['coupons'] ) && is_array( $query_args['coupons'] ) && count( $query_args['coupons'] ) > 0 ) {
+			$included_coupons_str = implode( ',', $query_args['coupons'] );
+		}
+		return $included_coupons_str;
+	}
+
+	/**
+	 * Updates the database query with parameters used for orders report: coupons and products filters.
+	 *
+	 * @param array $query_args Query arguments supplied by the user.
+	 * @return array            Array of parameters used for SQL query.
+	 */
+	protected function get_sql_query_params( $query_args ) {
+		global $wpdb;
+		$order_stats_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+
+		$sql_query_params = $this->get_time_period_sql_params( $query_args, $order_stats_lookup_table );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_limit_sql_params( $query_args ) );
+		$sql_query_params = array_merge( $sql_query_params, $this->get_order_by_sql_params( $query_args ) );
+
+		$included_coupons = $this->get_included_coupons( $query_args );
+		if ( $included_coupons ) {
+			$sql_query_params['where_clause'] .= " AND {$order_stats_lookup_table}.coupon_id IN ({$included_coupons})";
+		}
+
+		return $sql_query_params;
+	}
+
+	/**
+	 * Returns the report data based on parameters supplied by the user.
+	 *
+	 * @param array $query_args  Query parameters.
+	 * @return stdClass|WP_Error Data.
+	 */
+	public function get_data( $query_args ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . self::TABLE_NAME;
+		$now        = time();
+		$week_back  = $now - WEEK_IN_SECONDS;
+
+		// These defaults are only partially applied when used via REST API, as that has its own defaults.
+		$defaults   = array(
+			'per_page'         => get_option( 'posts_per_page' ),
+			'page'             => 1,
+			'order'            => 'DESC',
+			'orderby'          => 'date_created',
+			'before'           => date( WC_Admin_Reports_Interval::$iso_datetime_format, $now ),
+			'after'            => date( WC_Admin_Reports_Interval::$iso_datetime_format, $week_back ),
+			'fields'           => '*',
+			'product_includes' => array(),
+			'product_excludes' => array(),
+			'coupon_includes'  => array(),
+			'coupon_excludes'  => array(),
+			'status_is'        => parent::get_report_order_statuses(),
+		);
+		$query_args = wp_parse_args( $query_args, $defaults );
+
+		$cache_key = $this->get_cache_key( $query_args );
+		$data      = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $data ) {
+			$data = (object) array(
+				'data'    => array(),
+				'total'   => 0,
+				'pages'   => 0,
+				'page_no' => 0,
+			);
+
+			$selections       = $this->selected_columns( $query_args );
+			$sql_query_params = $this->get_sql_query_params( $query_args );
+
+			$db_records_count = (int) $wpdb->get_var(
+				"SELECT COUNT(*) FROM (
+							SELECT
+								order_id
+							FROM
+								{$table_name}
+								{$sql_query_params['from_clause']}
+							WHERE
+								1=1
+								{$sql_query_params['where_time_clause']}
+								{$sql_query_params['where_clause']}
+					  		) AS tt"
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			$total_pages = (int) ceil( $db_records_count / $sql_query_params['per_page'] );
+			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
+				return $data;
+			}
+
+			$order_data = $wpdb->get_results(
+				"SELECT
+						{$selections}
+					FROM
+						{$table_name}
+						{$sql_query_params['from_clause']}
+					WHERE
+						1=1
+						{$sql_query_params['where_time_clause']}
+						{$sql_query_params['where_clause']}
+					ORDER BY
+						{$sql_query_params['order_by_clause']}
+					{$sql_query_params['limit']}
+					",
+				ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			if ( null === $order_data ) {
+				return $data;
+			}
+
+			$order_data = array_map( array( $this, 'cast_numbers' ), $order_data );
+			$data       = (object) array(
+				'data'    => $order_data,
+				'total'   => $db_records_count,
+				'pages'   => $total_pages,
+				'page_no' => (int) $query_args['page'],
+			);
+
+			wp_cache_set( $cache_key, $data, $this->cache_group );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Normalizes order_by clause to match to SQL query.
+	 *
+	 * @param string $order_by Order by option requeste by user.
+	 * @return string
+	 */
+	protected function normalize_order_by( $order_by ) {
+		if ( 'date' === $order_by ) {
+			return 'date_created';
+		}
+
+		return $order_by;
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WC_Admin_Reports_Orders_Data_Store class file.
+ * WC_Admin_Reports_Orders_Stats_Data_Store class file.
  *
  * @package WooCommerce Admin/Classes
  */
@@ -12,11 +12,11 @@ if ( ! class_exists( 'WC_Admin_Order_Stats_Background_Process', false ) ) {
 }
 
 /**
- * WC_Admin_Reports_Orders_Data_Store.
+ * WC_Admin_Reports_Orders_Stats_Data_Store.
  *
  * @version  3.5.0
  */
-class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
 
 	/**
 	 * Table used to get the data.
@@ -556,6 +556,6 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	 * @return string
 	 */
 	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
+		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Reports Orders REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+
+/**
+ * Reports Orders REST API Test Class
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v4/reports/orders';
+
+	/**
+	 * Setup test reports orders data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $reports ) );
+
+		$order_report = reset( $reports );
+
+		$this->assertEquals( $order->get_id(), $order_report['order_id'] );
+		$this->assertEquals( date( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ), $order_report['date_created'] );
+		$this->assertEquals( 0, $order_report['customer_id'] ); // @TODO: This should be 1, but customer_id is returning 0 in lookup table.
+		$this->assertEquals( 4, $order_report['num_items_sold'] );
+		$this->assertEquals( 90.0, $order_report['net_total'] ); // 25 x 4 - 10 (shipping)
+		$this->assertEquals( 'new', $order_report['customer_type'] );
+		$this->assertArrayHasKey( '_links', $order_report );
+		$this->assertArrayHasKey( 'order', $order_report['_links'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 8, count( $properties ) );
+		$this->assertArrayHasKey( 'order_id', $properties );
+		$this->assertArrayHasKey( 'date_created', $properties );
+		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertArrayHasKey( 'customer_id', $properties );
+		$this->assertArrayHasKey( 'net_total', $properties );
+		$this->assertArrayHasKey( 'num_items_sold', $properties );
+		$this->assertArrayHasKey( 'customer_type', $properties );
+		$this->assertArrayHasKey( 'extended_info', $properties );
+	}
+}

--- a/tests/framework/helpers/class-wc-helper-reports.php
+++ b/tests/framework/helpers/class-wc-helper-reports.php
@@ -17,7 +17,7 @@ class WC_Helper_Reports {
 	 */
 	public static function reset_stats_dbs() {
 		global $wpdb;
-		$wpdb->query( "DELETE FROM $wpdb->prefix" . WC_Admin_Reports_Orders_Data_Store::TABLE_NAME ); // @codingStandardsIgnoreLine.
+		$wpdb->query( "DELETE FROM $wpdb->prefix" . WC_Admin_Reports_Orders_Stats_Data_Store::TABLE_NAME ); // @codingStandardsIgnoreLine.
 		$wpdb->query( "DELETE FROM $wpdb->prefix" . WC_Admin_Reports_Products_Data_Store::TABLE_NAME ); // @codingStandardsIgnoreLine.
 		$wpdb->query( "DELETE FROM $wpdb->prefix" . WC_Admin_Reports_Coupons_Data_Store::TABLE_NAME ); // @codingStandardsIgnoreLine.
 		$wpdb->query( "DELETE FROM $wpdb->prefix" . WC_Admin_Reports_Customers_Data_Store::TABLE_NAME ); // @codingStandardsIgnoreLine.

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -6,9 +6,9 @@
  */
 
 /**
- * Class WC_Tests_Reports_Orders
+ * Class WC_Tests_Reports_Orders_Stats
  */
-class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
+class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 	/**
 	 * Test the calculations and querying works correctly for the base case of 1 order.
@@ -41,7 +41,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			)
 		);
 
-		$data_store = new WC_Admin_Reports_Orders_Data_Store();
+		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
 
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );
@@ -321,7 +321,7 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			}
 		}
 
-		$data_store = new WC_Admin_Reports_Orders_Data_Store();
+		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
 
 		// Tests for before & after set to current hour.
 		$current_hour = new DateTime();

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -38,7 +38,7 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		$order->save();
 
 		// /reports/revenue/stats is mapped to Orders_Data_Store.
-		$data_store = new WC_Admin_Reports_Orders_Data_Store();
+		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
 
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
 		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );


### PR DESCRIPTION
Fixes #950 

Adds the new endpoint so we can use new filters and return data from lookup tables.

### Screenshots
<img width="563" alt="screen shot 2019-01-09 at 2 32 29 pm" src="https://user-images.githubusercontent.com/10561050/50881066-728c9880-141b-11e9-891b-96af6018282a.png">

### Detailed test instructions:

1.  Make sure you have coupons and products associated with orders in your lookup tables.
2.  Rebuild your reports to ensure statuses are in the lookup tables.
3.  Send a request to `wp-json/wc/v4/reports/orders` and test the following params **(note the v4 namespace)**:
`before (date)`
`after (date)`
`page (int)`
`per_page (int)`
`orderby (date, num_items_sold, or net_total)`
`order (asc or desc)`
`status_is (string - status type without 'wc-' prefix)`
`status_is_not (string - status type without 'wc-' prefix)`
`product_includes (int or array)`
`product_excludes (int or array)`
`coupon_includes (int or array)`
`coupon_excludes (int or array)`
`customer_type (string 'returning' or 'new')`
`extended_info (bool)`
4.  Run phpunit tests to make sure everything is ✅ 