### PR TITLE
Add new props to chart component

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -68,7 +68,18 @@ export class ReportChart extends Component {
 	}
 
 	render() {
-		const { query, itemsLabel, mode, path, primaryData, secondaryData, selectedChart } = this.props;
+		const {
+			interactiveLegend,
+			itemsLabel,
+			legendPosition,
+			mode,
+			path,
+			primaryData,
+			query,
+			secondaryData,
+			selectedChart,
+			showHeaderControls,
+		} = this.props;
 
 		if ( primaryData.isError || secondaryData.isError ) {
 			return <ReportError isError />;
@@ -106,23 +117,26 @@ export class ReportChart extends Component {
 
 		return (
 			<Chart
+				allowedIntervals={ allowedIntervals }
+				data={ chartData }
+				dateParser={ '%Y-%m-%dT%H:%M:%S' }
+				interactiveLegend={ interactiveLegend }
+				interval={ currentInterval }
+				isRequesting={ primaryData.isRequesting || secondaryData.isRequesting }
+				itemsLabel={ itemsLabel }
+				legendPosition={ legendPosition }
+				mode={ mode || this.getChartMode() }
 				path={ path }
 				query={ query }
-				data={ chartData }
+				showHeaderControls={ showHeaderControls }
 				title={ selectedChart.label }
-				interval={ currentInterval }
-				type={ getChartTypeForQuery( query ) }
-				allowedIntervals={ allowedIntervals }
-				itemsLabel={ itemsLabel }
-				mode={ mode || this.getChartMode() }
 				tooltipLabelFormat={ formats.tooltipLabelFormat }
-				tooltipValueFormat={ getTooltipValueFormat( selectedChart.type ) }
 				tooltipTitle={ selectedChart.label }
+				tooltipValueFormat={ getTooltipValueFormat( selectedChart.type ) }
+				type={ getChartTypeForQuery( query ) }
+				valueType={ selectedChart.type }
 				xFormat={ formats.xFormat }
 				x2Format={ formats.x2Format }
-				dateParser={ '%Y-%m-%dT%H:%M:%S' }
-				valueType={ selectedChart.type }
-				isRequesting={ primaryData.isRequesting || secondaryData.isRequesting }
 			/>
 		);
 	}

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -30,10 +30,12 @@ class ChartBlock extends Component {
 					<ReportChart
 						charts={ charts }
 						endpoint={ endpoint }
-						mode="block"
-						path={ path }
 						query={ query }
+						interactiveLegend={ false }
+						legendPosition="bottom"
+						path={ path }
 						selectedChart={ charts[ 0 ] }
+						showHeaderControls={ false }
 					/>
 				</Card>
 			</Fragment>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,11 @@
 - Add order number autocompleter to search component
 - Add order number, username, and IP address filters to the downloads report.
 - Added `interactive` prop for `d3chart/legend` to signal if legend items are clickable or not.
-- Fix for undefined ref in `d3chart/legend`
+- Fix for undefined ref in `d3chart/legend`.
+- Added three news props to `<Chart>`:
+  - `interactiveLegend`: whether legend items are clickable or not. Defaults to true.
+  - `legendPosition`: can be `top`, `side` or `bottom`. If not specified, it's calculated based on `mode` and viewport width.
+  - `showHeaderControls`: whether the header controls must be visible. Defaults to true.
 
 # 1.3.0
 


### PR DESCRIPTION
Coming from the discussion here: https://github.com/woocommerce/wc-admin/pull/1213#issuecomment-450838602

This PR removes the option `block` from the `mode` prop in charts. `mode` should be used to specify whether the chart is comparing time periods or different items, so screen readers can read the values properly. Using it for other purposes might be problematic.

Instead, this PR adds three new props to the chart component:
- `interactiveLegend`
- `legendPosition`
- `showHeaderControls`

### Accessibility

- [x] I've tested using a screen reader

### Screenshots
_(this PR shouldn't produce any visual change)_


### Detailed test instructions:
- Go to the Dashboard.
- With the devtools, search for `.bargroup` and verify it has an `aria-label` value (that means it's a `mode=time-comparison` chart).
_Before:_
![image](https://user-images.githubusercontent.com/3616980/50777656-73e38700-129c-11e9-9e31-97e0497d9972.png)
_After:_
![image](https://user-images.githubusercontent.com/3616980/50777675-81990c80-129c-11e9-9560-fa8470ea97d0.png)
- Verify there are no regressions in charts.