### PR TITLE
Download Report API: Add path to response, fix ordering, and fix schema typo

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -107,8 +107,10 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 		$product_id                  = intval( $data['product_id'] );
 		$_product                    = wc_get_product( $product_id );
 		$file_path                   = $_product->get_file_download_path( $data['download_id'] );
+
 		$filename                    = basename( $file_path );
 		$response->data['file_name'] = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
+		$response->data['file_path'] = $file_path;
 
 		/**
 		 * Filter a report returned from the API.
@@ -189,6 +191,12 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'File name.', 'wc-admin' ),
+				),
+				'file_path' => array(
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'File URL.', 'wc-admin' ),
 				),
 				'product_id' => array(
 					'type'        => 'integer',

--- a/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
@@ -138,7 +138,7 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 	 */
 	public function get_item_schema() {
 		$totals = array(
-			'downloads_count' => array(
+			'download_count' => array(
 				'description' => __( 'Number of downloads.', 'wc-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
@@ -263,7 +263,7 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 			'default'           => 'date',
 			'enum'              => array(
 				'date',
-				'downloads_count',
+				'download_count',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/data-stores/class-wc-admin-reports-downloads-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-downloads-stats-data-store.php
@@ -199,7 +199,12 @@ class WC_Admin_Reports_Downloads_Stats_Data_Store extends WC_Admin_Reports_Downl
 	 * @param string   $direction DESC/ASC.
 	 */
 	protected function sort_intervals( &$data, $sort_by, $direction ) {
-		$this->order_by = 'time_interval';
+		if ( 'date' === $sort_by ) {
+			$this->order_by = 'time_interval';
+		} else {
+			$this->order_by = $sort_by;
+		}
+
 		$this->order    = $direction;
 		usort( $data->intervals, array( $this, 'interval_cmp' ) );
 	}

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -138,7 +138,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		$totals = $properties['totals']['properties'];
 		$this->assertEquals( 1, count( $totals ) );
-		$this->assertArrayHasKey( 'downloads_count', $totals );
+		$this->assertArrayHasKey( 'download_count', $totals );
 
 		$intervals = $properties['intervals']['items']['properties'];
 		$this->assertEquals( 6, count( $intervals ) );
@@ -151,6 +151,6 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		$subtotals = $properties['intervals']['items']['properties']['subtotals']['properties'];
 		$this->assertEquals( 1, count( $subtotals ) );
-		$this->assertArrayHasKey( 'downloads_count', $subtotals );
+		$this->assertArrayHasKey( 'download_count', $subtotals );
 	}
 }

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -110,6 +110,121 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 8, count( $reports['intervals'] ) );
 		$this->assertEquals( 0, $reports['intervals'][1]['subtotals']->download_count );
+
+		// Test sorting by download_count.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
+				'interval' => 'day',
+				'orderby'  => 'download_count',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+	}
+
+	/**
+	 * Test getting report ordering.
+	 */
+	public function test_get_report_orderby() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$prod_download = new WC_Product_Download();
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_id( 1 );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_downloadable( 'yes' );
+		$product->set_downloads( array( $prod_download ) );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $this->user );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( $prod_download->get_id() );
+		$download->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->save();
+
+		$three_days_from_now = current_time( 'timestamp', true ) - ( 3 * DAY_IN_SECONDS );
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->set_timestamp( $three_days_from_now );
+		$object->save();
+
+		$time           = time();
+		$seven_days_ago = $time - ( 7 * DAY_IN_SECONDS );
+
+		// Test sorting by download_count.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d H:00:00', $seven_days_ago ),
+				'interval' => 'day',
+				'orderby'  => 'download_count',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 3, $reports['intervals'][0]['subtotals']->download_count );
+		$this->assertEquals( date( 'Y-m-d', $time ), $reports['intervals'][0]['interval'] );
+
+		$this->assertEquals( 1, $reports['intervals'][1]['subtotals']->download_count );
+		$this->assertEquals( date( 'Y-m-d', $three_days_from_now ), $reports['intervals'][1]['interval'] );
+
+		// Test sorting by date.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d H:00:00', $seven_days_ago ),
+				'interval' => 'day',
+				'orderby'  => 'date',
+				'order'    => 'asc',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 0, $reports['intervals'][0]['subtotals']->download_count );
+		$this->assertEquals( date( 'Y-m-d', $seven_days_ago ), $reports['intervals'][0]['interval'] );
+
+		$this->assertEquals( 3, $reports['intervals'][7]['subtotals']->download_count );
+		$this->assertEquals( date( 'Y-m-d', $time ), $reports['intervals'][7]['interval'] );
 	}
 
 	/**

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -91,6 +91,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $this->user, $download_report['user_id'] );
 		$this->assertEquals( '1.2.3.4', $download_report['ip_address'] );
 		$this->assertEquals( 'help.png', $download_report['file_name'] );
+		$this->assertEquals( plugin_dir_url( __FILE__ ) . '/assets/images/help.png', $download_report['file_path'] );
 	}
 
 	/**

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -387,13 +387,14 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 9, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
 		$this->assertArrayHasKey( 'date_gmt', $properties );
 		$this->assertArrayHasKey( 'download_id', $properties );
 		$this->assertArrayHasKey( 'file_name', $properties );
+		$this->assertArrayHasKey( 'file_path', $properties );
 		$this->assertArrayHasKey( 'order_id', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
 		$this->assertArrayHasKey( 'ip_address', $properties );


### PR DESCRIPTION
Fixes #1245.

This PR fixes a few issues with the download report endpoints.

* It adds a `download_path` to the response which contains a URL to the download of the file. 
* It fixes a typo between `download_count` and `downloads_count` in the schema.
* It fixes the ?orderby option so it actually sorts. Tests included.

Note on `download_path`:
This links to the file path that is stored in the product data. This can link externally or to the media library. It is different from a WC download link. Download links are tied to orders/users, so to use that we would need to generate permissions for each admin and link here otherwise.

### Detailed test instructions:

- Running `phpunit` should be enough to test the changes here, though you can make manual requests or test the report page as well.