### PR TITLE
Add link to file in Downloads table

### DIFF
--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -132,7 +132,7 @@ export const advancedFilters = {
 				} ) ),
 			},
 		},
-		downloadIp: {
+		ip_address: {
 			labels: {
 				add: __( 'IP Address', 'wc-admin' ),
 				placeholder: __( 'Search IP address', 'wc-admin' ),

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -72,7 +72,7 @@ export default class CouponsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( downloads, download => {
-			const { _embedded, date, file_name, ip_address, order_id, product_id } = download;
+			const { _embedded, date, file_name, file_path, ip_address, order_id, product_id } = download;
 			const { name: productName } = _embedded.product[ 0 ];
 			const { name: userName } = _embedded.user[ 0 ];
 
@@ -95,7 +95,11 @@ export default class CouponsReportTable extends Component {
 					value: productName,
 				},
 				{
-					display: file_name,
+					display: (
+						<Link href={ file_path } type="external">
+							{ file_name }
+						</Link>
+					),
 					value: file_name,
 				},
 				{


### PR DESCRIPTION
Adds a link to the file in the _Downloads_ table and fixes the param name for `ip_address`.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/50828137-cc6c6000-1340-11e9-9bb3-de1906d97e4e.png)

### Detailed test instructions:
- Go to the _Downloads_ report.
- See #1142 test instructions if you need to create downloads.
- Verify the file name is a link to the file.
- Filter by IP address and verify the URL param is `ip_address` and downloads are properly filtered.
