### PR TITLE
Add store performance indicator endpoint

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -74,6 +74,10 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 		$data    = array();
 		$reports = array(
 			array(
+				'slug'        => 'store-performance',
+				'description' => __( 'Batch endpoint for getting specific performance indicators from `stats` endpoints.', 'wc-admin' ),
+			),
+			array(
 				'slug'        => 'revenue/stats',
 				'description' => __( 'Stats about revenue.', 'wc-admin' ),
 			),

--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -74,7 +74,7 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 		$data    = array();
 		$reports = array(
 			array(
-				'slug'        => 'store-performance',
+				'slug'        => 'performance-indicators',
 				'description' => __( 'Batch endpoint for getting specific performance indicators from `stats` endpoints.', 'wc-admin' ),
 			),
 			array(

--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API Performance indiciators controller
+ * REST API Performance indicators controller
  *
  * Handles requests to the /reports/store-performance endpoint.
  *
@@ -44,10 +44,10 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 		$args['stats']  = $request['stats'];
 		return $args;
 	}
-	
 
 	/**
 	 * Get all allowed stats that can be returned from this endpoint.
+	 *
 	 * @return array
 	 */
 	public function get_allowed_stats() {
@@ -72,7 +72,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 					continue;
 				}
 
-				foreach( $data['schema']['properties']['totals']['properties'] as $property_key => $schema_info ) {
+				foreach ( $data['schema']['properties']['totals']['properties'] as $property_key => $schema_info ) {
 					$allowed_stats[] = $prefix . '/' . $property_key;
 				}
 			}
@@ -94,7 +94,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 		}
 
 		$query_args = $this->prepare_reports_query( $request );
-		if ( empty ( $query_args['stats'] ) ) {
+		if ( empty( $query_args['stats'] ) ) {
 			return new WP_Error( 'woocommerce_reports_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'wc-admin' ), 400 );
 		}
 
@@ -149,7 +149,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param stdClass        $data    Report data.
+	 * @param stdClass        $stat_data    Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
@@ -241,6 +241,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['stats']   = array(
 			'description'       => sprintf(
+				/* translators: Allowed values is a list of stat endpoints. */
 				__( 'Limit response to specific report stats. Allowed values: %s.', 'wc-admin' ),
 				$allowed_stats
 			),

--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -78,6 +78,11 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 			}
 		}
 
+		/**
+		 * Filter the list of allowed stats that can be returned via the performance indiciator endpoint.
+		 *
+		 * @param array $allowed_stats The list of allowed stats.
+		 */
 		return apply_filters( 'woocommerce_admin_performance_indicators_allowed_stats', $allowed_stats );
 	}
 
@@ -111,7 +116,12 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 				continue;
 			}
 
-			// Allow custom endpoints to be loaded here.
+			/**
+			 * Filter the list of allowed endpoints, so that data can be loaded from extensions rather than core.
+			 * These should be in the format of slug => path. Example: `bookings` => `/wc-bookings/v1/reports/bookings/stats`.
+			 *
+			 * @param array $endpoints The list of allowed endpoints.
+			 */
 			$stats_endpoints = apply_filters( 'woocommerce_admin_performance_indicators_stats_endpoints', array() );
 			if ( ! empty( $stats_endpoints [ $endpoint ] ) ) {
 				$request_url = $stats_endpoints [ $endpoint ];

--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -77,7 +77,8 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 				}
 			}
 		}
-		return $allowed_stats;
+
+		return apply_filters( 'woocommerce_admin_performance_indicators_allowed_stats', $allowed_stats );
 	}
 
 	/**
@@ -110,7 +111,15 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 				continue;
 			}
 
-			$request = new WP_REST_Request( 'GET', '/wc/v3/reports/' . $endpoint . '/stats' );
+			// Allow custom endpoints to be loaded here.
+			$stats_endpoints = apply_filters( 'woocommerce_admin_performance_indicators_stats_endpoints', array() );
+			if ( ! empty( $stats_endpoints [ $endpoint ] ) ) {
+				$request_url = $stats_endpoints [ $endpoint ];
+			} else {
+				$request_url = '/wc/v3/reports/' . $endpoint . '/stats';
+			}
+
+			$request = new WP_REST_Request( 'GET', $request_url );
 			$request->set_param( 'before', $query_args['before'] );
 			$request->set_param( 'after', $query_args['after'] );
 

--- a/includes/api/class-wc-admin-rest-reports-store-performance-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-store-performance-controller.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * REST API Store Performance controller
+ *
+ * Handles requests to the /reports/store-performance endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Reports Store Performance controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Reports_Controller
+ */
+class WC_Admin_REST_Reports_Store_Performance_Controller extends WC_REST_Reports_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'reports/store-performance';
+
+	/**
+	 * Maps query arguments from the REST request.
+	 *
+	 * @param array $request Request array.
+	 * @return array
+	 */
+	protected function prepare_reports_query( $request ) {
+		$args           = array();
+		$args['before'] = $request['before'];
+		$args['after']  = $request['after'];
+		$args['stats']  = $request['stats'];
+		return $args;
+	}
+
+	/**
+	 * Get all reports.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return array|WP_Error
+	 */
+	public function get_items( $request ) {
+		$query_args    = $this->prepare_reports_query( $request );
+		$stats         = array();
+		foreach ( $query_args['stats'] as $stat_request ) {
+			$is_error = false;
+
+			$pieces   = explode( '/', $stat_request );
+			$endpoint = $pieces[0];
+			$stat     = $pieces[1];
+
+			// Validate the stat is a proper path format.
+			if ( ! preg_match( '/^[0-9a-zA-Z\/\_-]+$/', $stat_request ) ) {
+				$stats[] = (object) array(
+					'stat'  => $stat_request,
+					'value' => null,
+				);
+				continue;
+			}
+
+			$request = new WP_REST_Request( 'GET', '/wc/v3/reports/' . $endpoint . '/stats' );
+			$request->set_param( 'before', $query_args['before'] );
+			$request->set_param( 'after', $query_args['after'] );
+
+			$response = rest_do_request( $request );
+			$data     = $response->get_data();
+
+			if ( 200 !== $response->get_status() || empty( $data['totals'][ $stat ] ) ) {
+				$stats[] = (object) array(
+					'stat'  => $stat_request,
+					'value' => null,
+				);
+				continue;
+			}
+
+			$stats[] = (object) array(
+				'stat'  => $stat_request,
+				'value' => $data['totals'][ $stat ],
+			);
+		}
+
+		$objects = array();
+		foreach ( $stats as $stat ) {
+			$data      = $this->prepare_item_for_response( $stat, $request );
+			$objects[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$response = rest_ensure_response( $objects );
+		$response->header( 'X-WP-Total', count( $stats ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare a report object for serialization.
+	 *
+	 * @param stdClass        $data    Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $data, $request ) {
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $data ) );
+
+		/**
+		 * Filter a report returned from the API.
+		 *
+		 * Allows modification of the report data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param object           $report   The original report object.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_report_store_performance', $response, $report, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param WC_Admin_Reports_Query $object Object data.
+	 * @return array
+	 */
+	protected function prepare_links( $object ) {
+		$pieces   = explode( '/', $object->stat );
+		$endpoint = $pieces[0];
+		$stat     = $pieces[1];
+
+		$links = array(
+			'report' => array(
+				'href' => rest_url( sprintf( '/%s/reports/%s/stats', $this->namespace, $endpoint ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_store_performance',
+			'type'       => 'array',
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'stat'             => array(
+						'description' => __( 'Unique identifier for the resource.', 'wc-admin' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'value'      => array(
+						'description' => __( 'Value of the stat. Returns null if the stat does not exist or cannot be loaded.', 'wc-admin' ),
+						'type'        => 'number',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params            = array();
+		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['stats']   = array(
+			'description'       => __( 'Limit response to specific report stats.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type'   => 'string',
+			),
+		);
+		$params['after']   = array(
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['before'] = array(
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -143,7 +143,7 @@ class WC_Admin_Api_Init {
 			)
 		);
 
-		// The performance indiciators controller must be registered last, after other /stats endpoints have been registered.
+		// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
 		$controllers[] = 'WC_Admin_REST_Reports_Performance_Indicators_Controller';
 
 		foreach ( $controllers as $controller ) {

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -108,6 +108,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-variations-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-products-stats-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-store-performance-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-revenue-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
@@ -123,6 +124,7 @@ class WC_Admin_Api_Init {
 			'WC_Admin_REST_Product_Reviews_Controller',
 			'WC_Admin_REST_Reports_Controller',
 			'WC_Admin_REST_System_Status_Tools_Controller',
+			'WC_Admin_REST_Reports_Store_Performance_Controller',
 			'WC_Admin_REST_Reports_Products_Controller',
 			'WC_Admin_REST_Reports_Variations_Controller',
 			'WC_Admin_REST_Reports_Products_Stats_Controller',
@@ -403,20 +405,20 @@ class WC_Admin_Api_Init {
 		return array_merge(
 			$data_stores,
 			array(
-				'report-revenue-stats'  => 'WC_Admin_Reports_Orders_Data_Store',
-				'report-orders-stats'   => 'WC_Admin_Reports_Orders_Data_Store',
-				'report-products'       => 'WC_Admin_Reports_Products_Data_Store',
-				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',
-				'report-products-stats' => 'WC_Admin_Reports_Products_Stats_Data_Store',
-				'report-categories'     => 'WC_Admin_Reports_Categories_Data_Store',
-				'report-taxes'          => 'WC_Admin_Reports_Taxes_Data_Store',
-				'report-taxes-stats'    => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
-				'report-coupons'        => 'WC_Admin_Reports_Coupons_Data_Store',
-				'report-coupons-stats'  => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
-				'report-downloads'      => 'WC_Admin_Reports_Downloads_Data_Store',
+				'report-revenue-stats'   => 'WC_Admin_Reports_Orders_Data_Store',
+				'report-orders-stats'    => 'WC_Admin_Reports_Orders_Data_Store',
+				'report-products'        => 'WC_Admin_Reports_Products_Data_Store',
+				'report-variations'      => 'WC_Admin_Reports_Variations_Data_Store',
+				'report-products-stats'  => 'WC_Admin_Reports_Products_Stats_Data_Store',
+				'report-categories'      => 'WC_Admin_Reports_Categories_Data_Store',
+				'report-taxes'           => 'WC_Admin_Reports_Taxes_Data_Store',
+				'report-taxes-stats'     => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
+				'report-coupons'         => 'WC_Admin_Reports_Coupons_Data_Store',
+				'report-coupons-stats'   => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
+				'report-downloads'       => 'WC_Admin_Reports_Downloads_Data_Store',
 				'report-downloads-stats' => 'WC_Admin_Reports_Downloads_Stats_Data_Store',
-				'admin-note'            => 'WC_Admin_Notes_Data_Store',
-				'report-customers'      => 'WC_Admin_Reports_Customers_Data_Store',
+				'admin-note'             => 'WC_Admin_Notes_Data_Store',
+				'report-customers'       => 'WC_Admin_Reports_Customers_Data_Store',
 			)
 		);
 	}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -108,38 +108,43 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-variations-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-products-stats-controller.php';
-		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-store-performance-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-performance-indicators-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-revenue-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-stock-controller.php';
 
-		$controllers = array(
-			'WC_Admin_REST_Admin_Notes_Controller',
-			'WC_Admin_REST_Customers_Controller',
-			'WC_Admin_REST_Data_Controller',
-			'WC_Admin_REST_Data_Download_Ips_Controller',
-			'WC_Admin_REST_Orders_Controller',
-			'WC_Admin_REST_Products_Controller',
-			'WC_Admin_REST_Product_Reviews_Controller',
-			'WC_Admin_REST_Reports_Controller',
-			'WC_Admin_REST_System_Status_Tools_Controller',
-			'WC_Admin_REST_Reports_Store_Performance_Controller',
-			'WC_Admin_REST_Reports_Products_Controller',
-			'WC_Admin_REST_Reports_Variations_Controller',
-			'WC_Admin_REST_Reports_Products_Stats_Controller',
-			'WC_Admin_REST_Reports_Revenue_Stats_Controller',
-			'WC_Admin_REST_Reports_Orders_Stats_Controller',
-			'WC_Admin_REST_Reports_Categories_Controller',
-			'WC_Admin_REST_Reports_Taxes_Controller',
-			'WC_Admin_REST_Reports_Taxes_Stats_Controller',
-			'WC_Admin_REST_Reports_Coupons_Controller',
-			'WC_Admin_REST_Reports_Coupons_Stats_Controller',
-			'WC_Admin_REST_Reports_Stock_Controller',
-			'WC_Admin_REST_Reports_Downloads_Controller',
-			'WC_Admin_REST_Reports_Downloads_Stats_Controller',
-			'WC_Admin_REST_Reports_Customers_Controller',
+		$controllers = apply_filters(
+			'woocommerce_admin_rest_controllers',
+			array(
+				'WC_Admin_REST_Admin_Notes_Controller',
+				'WC_Admin_REST_Customers_Controller',
+				'WC_Admin_REST_Data_Controller',
+				'WC_Admin_REST_Data_Download_Ips_Controller',
+				'WC_Admin_REST_Orders_Controller',
+				'WC_Admin_REST_Products_Controller',
+				'WC_Admin_REST_Product_Reviews_Controller',
+				'WC_Admin_REST_Reports_Controller',
+				'WC_Admin_REST_System_Status_Tools_Controller',
+				'WC_Admin_REST_Reports_Products_Controller',
+				'WC_Admin_REST_Reports_Variations_Controller',
+				'WC_Admin_REST_Reports_Products_Stats_Controller',
+				'WC_Admin_REST_Reports_Revenue_Stats_Controller',
+				'WC_Admin_REST_Reports_Orders_Stats_Controller',
+				'WC_Admin_REST_Reports_Categories_Controller',
+				'WC_Admin_REST_Reports_Taxes_Controller',
+				'WC_Admin_REST_Reports_Taxes_Stats_Controller',
+				'WC_Admin_REST_Reports_Coupons_Controller',
+				'WC_Admin_REST_Reports_Coupons_Stats_Controller',
+				'WC_Admin_REST_Reports_Stock_Controller',
+				'WC_Admin_REST_Reports_Downloads_Controller',
+				'WC_Admin_REST_Reports_Downloads_Stats_Controller',
+				'WC_Admin_REST_Reports_Customers_Controller',
+			)
 		);
+
+		// The performance indiciators controller must be registered last, after other /stats endpoints have been registered.
+		$controllers[] = 'WC_Admin_REST_Reports_Performance_Indicators_Controller';
 
 		foreach ( $controllers as $controller ) {
 			$this->$controller = new $controller();

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Reports Performance indicators REST API Tests
+ *
+ * @package WooCommerce Admin\Tests\API.
+ */
+
+/**
+ * WC_Tests_API_Reports_Performance_Indicators
+ */
+class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/reports/performance-indicators';
+
+	/**
+	 * Setup tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting indicators.
+	 */
+	public function test_get_indicators() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data. We'll create an order and a download.
+		$prod_download = new WC_Product_Download();
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_id( 1 );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_downloadable( 'yes' );
+		$product->set_downloads( array( $prod_download ) );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 25 );
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $this->user );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( $prod_download->get_id() );
+		$download->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $this->user );
+		$object->set_user_ip_address( '1.2.3.4' );
+		$object->save();
+
+		$time = time();
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
+				'stats' => 'orders/orders_count,downloads/download_count,test/bogus_stat',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( 2, count( $reports ) );
+
+		$this->assertEquals( 'orders/orders_count', $reports[0]['stat'] );
+		$this->assertEquals( 1, $reports[0]['value'] );
+
+		$this->assertEquals( 'downloads/download_count', $reports[1]['stat'] );
+		$this->assertEquals( 2, $reports[1]['value'] );
+	}
+
+	/**
+	 * Test getting indicators with an empty request.
+	 */
+	public function test_get_indicators_empty_request() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$time = time();
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'before'   => date( 'Y-m-d 23:59:59', $time ),
+				'after'    => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	/**
+	 * Test getting without valid permissions.
+	 */
+	public function test_get_indicators_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test schema.
+	 */
+	public function test_indicators_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 2, count( $properties ) );
+		$this->assertArrayHasKey( 'stat', $properties );
+		$this->assertArrayHasKey( 'value', $properties );
+	}
+}


### PR DESCRIPTION
Fixes #912.

This PR adds a new `/wc/v3/reports/performance-indicators` endpoint, that allows for receiving multiple totals numbers from stat report endpoints.

You pass a `before` and `after` date, as well as a list of stats from a whitelisted list. You can see the list by making an OPTIONS request to `/wc/v3/reports/performance-indicators`. The list of allowed stats is automatically generated by any endpoint that is named `/reports/$endpoint/stats` and contains `totals` in the response.

### Detailed test instructions:

* Run `phpunit` and make sure all tests pass.
* Use Postman or another tool to make requests. Example request: `http://binarydev.org/wp-json/wc/v3/reports/performance-indicators?after=2018-01-01T00%3A00%3A00%2B00%3A00&before=2019-01-01T14%3A51%3A00%2B00%3A00&stats=orders/avg_order_value`. Spot check values.
* Use Postman or another tool to make a request to `OPTIONS /wc/v3/reports/performance-indicators`. Make sure that a list of allowed values is displayed.