### PR TITLE
Handle *_between params in Reports controllers

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -389,8 +389,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['orders_count_between']     = array(
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
 		);
 		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
@@ -404,8 +404,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['total_spend_between']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
 		);
 		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
@@ -419,8 +419,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['avg_order_value_between'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
 		);
 		$params['last_order_before']       = array(
 			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -38,31 +38,33 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                            = array();
-		$args['registered_before']       = $request['registered_before'];
-		$args['registered_after']        = $request['registered_after'];
-		$args['page']                    = $request['page'];
-		$args['per_page']                = $request['per_page'];
-		$args['order']                   = $request['order'];
-		$args['orderby']                 = $request['orderby'];
-		$args['match']                   = $request['match'];
-		$args['name']                    = $request['name'];
-		$args['username']                = $request['username'];
-		$args['email']                   = $request['email'];
-		$args['country']                 = $request['country'];
-		$args['last_active_before']      = $request['last_active_before'];
-		$args['last_active_after']       = $request['last_active_after'];
-		$args['orders_count_min']        = $request['orders_count_min'];
-		$args['orders_count_max']        = $request['orders_count_max'];
-		$args['orders_count_between']    = $request['orders_count_between'];
-		$args['total_spend_min']         = $request['total_spend_min'];
-		$args['total_spend_max']         = $request['total_spend_max'];
-		$args['total_spend_between']     = $request['total_spend_between'];
-		$args['avg_order_value_min']     = $request['avg_order_value_min'];
-		$args['avg_order_value_max']     = $request['avg_order_value_max'];
-		$args['avg_order_value_between'] = $request['avg_order_value_between'];
-		$args['last_order_before']       = $request['last_order_before'];
-		$args['last_order_after']        = $request['last_order_after'];
+		$args                        = array();
+		$args['registered_before']   = $request['registered_before'];
+		$args['registered_after']    = $request['registered_after'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['order']               = $request['order'];
+		$args['orderby']             = $request['orderby'];
+		$args['match']               = $request['match'];
+		$args['name']                = $request['name'];
+		$args['username']            = $request['username'];
+		$args['email']               = $request['email'];
+		$args['country']             = $request['country'];
+		$args['last_active_before']  = $request['last_active_before'];
+		$args['last_active_after']   = $request['last_active_after'];
+		$args['orders_count_min']    = $request['orders_count_min'];
+		$args['orders_count_max']    = $request['orders_count_max'];
+		$args['total_spend_min']     = $request['total_spend_min'];
+		$args['total_spend_max']     = $request['total_spend_max'];
+		$args['avg_order_value_min'] = $request['avg_order_value_min'];
+		$args['avg_order_value_max'] = $request['avg_order_value_max'];
+		$args['last_order_before']   = $request['last_order_before'];
+		$args['last_order_after']    = $request['last_order_after'];
+
+		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
+		$args           = array_merge( $args, $normalized );
+
 		return $args;
 	}
 
@@ -387,7 +389,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['orders_count_between']     = array(
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
-			'type'              => 'array',
+			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['total_spend_min']         = array(
@@ -402,7 +404,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['total_spend_between']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
-			'type'              => 'array',
+			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['avg_order_value_min']     = array(
@@ -417,7 +419,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['avg_order_value_between'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
-			'type'              => 'array',
+			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_order_before']       = array(

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class for time interval handling for reports
+ * Class for time interval and numeric range handling for reports.
  *
  * @package  WooCommerce Admin/Classes
  */
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Date & time interval handling class for Reporting API.
+ * Date & time interval and numeric range handling class for Reporting API.
  */
 class WC_Admin_Reports_Interval {
 
@@ -474,4 +474,38 @@ class WC_Admin_Reports_Interval {
 		}
 	}
 
+	/**
+	 * Normalize "*_between" parameters to "*_min" and "*_max".
+	 *
+	 * @param array        $request Query params from REST API request.
+	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.
+	 * @return array Normalized query values.
+	 */
+	public static function normalize_between_params( $request, $param_names ) {
+		if ( ! is_array( $param_names ) ) {
+			$param_names = array( $param_names );
+		}
+
+		$normalized = array();
+
+		foreach ( $param_names as $param_name ) {
+			if ( empty( $request[ $param_name . '_between' ] ) ) {
+				continue;
+			}
+
+			$min_param = $param_name . '_min';
+			$max_param = $param_name . '_max';
+			$range     = explode( ',', $request[ $param_name . '_between' ] );
+
+			if ( isset( $range[0] ) && is_numeric( $range[0] ) ) {
+				$normalized[ $min_param ] = $range[0];
+			}
+
+			if ( isset( $range[1] ) && is_numeric( $range[1] ) ) {
+				$normalized[ $max_param ] = $range[1];
+			}
+		}
+
+		return $normalized;
+	}
 }

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -796,4 +796,30 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 		}
 	}
 
+	/**
+	 * Test function that normalizes *_between query parameters to *_min & *_max.
+	 */
+	public function test_normalize_between_params() {
+		$request  = array(
+			'a_between' => 'malformed', // won't be normalized.
+			'b_between' => '1,5',       // results in min=1, max=5.
+			'c_between' => ',6',        // results in max=6.
+			'd_between' => '7',         // results in min=7.
+			'e_between' => '8,',        // results in min=8.
+			'f_between' => '10,12',     // not in params, skipped.
+			'g_between' => '-1,a',       // results in min=-1.
+		);
+		$params   = array( 'a', 'b', 'c', 'd', 'e', 'g' );
+		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params );
+		$expected = array(
+			'b_min' => '1',
+			'b_max' => '5',
+			'c_max' => '6',
+			'd_min' => '7',
+			'e_min' => '8',
+			'g_min' => '-1',
+		);
+
+		$this->assertEquals( $result, $expected );
+	}
 }

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -801,25 +801,40 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	 */
 	public function test_normalize_between_params() {
 		$request  = array(
-			'a_between' => 'malformed', // won't be normalized.
-			'b_between' => '1,5',       // results in min=1, max=5.
-			'c_between' => ',6',        // results in max=6.
-			'd_between' => '7',         // results in min=7.
-			'e_between' => '8,',        // results in min=8.
-			'f_between' => '10,12',     // not in params, skipped.
-			'g_between' => '-1,a',       // results in min=-1.
+			'a_between' => 'malformed',     // won't be normalized (not an array).
+			'b_between' => array( 1, 5 ),   // results in min=1, max=5.
+			'c_between' => array( 4, 2 ),   // results in min=2, max=4.
+			'd_between' => array( 7 ),      // won't be normalized (only 1 item).
+			'f_between' => array( 10, 12 ), // not in params, skipped.
 		);
-		$params   = array( 'a', 'b', 'c', 'd', 'e', 'g' );
+		$params   = array( 'a', 'b', 'c', 'd' );
 		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params );
 		$expected = array(
-			'b_min' => '1',
-			'b_max' => '5',
-			'c_max' => '6',
-			'd_min' => '7',
-			'e_min' => '8',
-			'g_min' => '-1',
+			'b_min' => 1,
+			'b_max' => 5,
+			'c_min' => 2,
+			'c_max' => 4,
 		);
 
 		$this->assertEquals( $result, $expected );
+	}
+
+	/**
+	 * Test function that validates *_between query parameters.
+	 */
+	public function test_rest_validate_between_arg() {
+		$this->assertIsWPError(
+			WC_Admin_Reports_Interval::rest_validate_between_arg( 'not array', null, 'param' ),
+			'param is not a numerically indexed array.'
+		);
+
+		$this->assertIsWPError(
+			WC_Admin_Reports_Interval::rest_validate_between_arg( array( 1 ), null, 'param' ),
+			'param must contain 2 numbers.'
+		);
+
+		$this->assertTrue(
+			WC_Admin_Reports_Interval::rest_validate_between_arg( array( 1, 2 ), null, 'param' )
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1239

Adds a utility method to `WC_Admin_Reports_Interval` to normalize numeric range`_between` parameters into `_min` and `_max`. It's only used by the Customers Report endpoint now, but can be used for all reports that make use of the advanced numeric filter.

### Accessibility

N/A - this is purely in the REST API.

### Detailed test instructions:

- Verify that the `phpunit` tests pass
- Use Postman or another tool to make some test requests to `/wc/v3/reports/customers`
- Test these params: `orders_count_between`, `total_spend_between`, `avg_order_value_between`
