### PR TITLE
Fix chart blocks not being responsive

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -137,14 +137,13 @@ class DashboardCharts extends Component {
 					<div className="woocommerce-dashboard__columns">
 						{ uniqCharts.map( chart => {
 							return hiddenChartKeys.includes( chart.key ) ? null : (
-								<div key={ chart.key }>
-									<ChartBlock
-										charts={ getChartFromKey( chart.key ) }
-										endpoint={ chart.endpoint }
-										path={ path }
-										query={ query }
-									/>
-								</div>
+								<ChartBlock
+									charts={ getChartFromKey( chart.key ) }
+									endpoint={ chart.endpoint }
+									key={ chart.key }
+									path={ path }
+									query={ query }
+								/>
 							);
 						} ) }
 					</div>

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -2,11 +2,11 @@
 
 .woocommerce-dashboard__columns {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});
 	grid-column-gap: $gap-large;
 
 	@include breakpoint( '<960px' ) {
-		grid-template-columns: 1fr;
+		grid-template-columns: 100%;
 	}
 }
 


### PR DESCRIPTION
Fixes #1249.

This PR makes chart blocks in the Dashboard responsive so they are resized when the viewport width changes.

### Screenshots
![charts](https://user-images.githubusercontent.com/3616980/50907549-f482be80-1427-11e9-961f-7f80a57275f9.gif)

### Detailed test instructions:
- Go to the _Dashboard_.
- Make the window wider and narrower.
- Verify the charts react to the size change.

