### PR TITLE
Allow sorting by title and other string fields in report tables

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -6,7 +6,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { get, orderBy } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -84,15 +84,13 @@ class ReportTable extends Component {
 		}
 
 		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
-		const orderedItems = orderBy( items.data, query.orderby, query.order );
 		const totals = get( primaryData, [ 'data', 'totals' ], null );
 		const totalResults = items.totalResults || 0;
 		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
 			endpoint: endpoint,
 			headers: getHeadersContent(),
-			orderedItems: orderedItems,
-			ids: itemIdField ? orderedItems.map( item => item[ itemIdField ] ) : null,
-			rows: getRowsContent( orderedItems ),
+			ids: itemIdField ? items.data.map( item => item[ itemIdField ] ) : null,
+			rows: getRowsContent( items.data ),
 			totals: totals,
 			summary: getSummary ? getSummary( totals, totalResults ) : null,
 		} );

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -33,6 +33,7 @@ class CategoriesReportTable extends Component {
 				label: __( 'Category', 'wc-admin' ),
 				key: 'category',
 				required: true,
+				isSortable: true,
 				isLeftAligned: true,
 			},
 			{

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -33,9 +33,10 @@ export default class CouponsReportTable extends Component {
 		return [
 			{
 				label: __( 'Coupon Code', 'wc-admin' ),
-				key: 'coupon_id',
+				key: 'code',
 				required: true,
 				isLeftAligned: true,
+				isSortable: true,
 			},
 			{
 				label: __( 'Orders', 'wc-admin' ),

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -42,7 +42,8 @@ export default class CouponsReportTable extends Component {
 			},
 			{
 				label: __( 'Product Title', 'wc-admin' ),
-				key: 'product_id',
+				key: 'product',
+				isSortable: true,
 				required: true,
 			},
 			{

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -36,14 +36,16 @@ class ProductsReportTable extends Component {
 		return [
 			{
 				label: __( 'Product Title', 'wc-admin' ),
-				key: 'name',
+				key: 'product_name',
 				required: true,
 				isLeftAligned: true,
+				isSortable: true,
 			},
 			{
 				label: __( 'SKU', 'wc-admin' ),
 				key: 'sku',
 				hiddenByDefault: true,
+				isSortable: true,
 			},
 			{
 				label: __( 'Items Sold', 'wc-admin' ),
@@ -118,9 +120,11 @@ class ProductsReportTable extends Component {
 				products: product_id,
 			} );
 			const categories = this.props.categories;
-			const productCategories = category_ids
-				.map( category_id => categories[ category_id ] )
-				.filter( Boolean );
+
+			const productCategories =
+				( category_ids &&
+					category_ids.map( category_id => categories[ category_id ] ).filter( Boolean ) ) ||
+				[];
 
 			return [
 				{

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -30,13 +30,15 @@ export default class StockReportTable extends Component {
 		return [
 			{
 				label: __( 'Product / Variation', 'wc-admin' ),
-				key: 'product_variation',
+				key: 'title',
 				required: true,
 				isLeftAligned: true,
+				isSortable: true,
 			},
 			{
 				label: __( 'SKU', 'wc-admin' ),
 				key: 'sku',
+				isSortable: true,
 			},
 			{
 				label: __( 'Status', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-coupons-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-coupons-controller.php
@@ -262,6 +262,7 @@ class WC_Admin_REST_Reports_Coupons_Controller extends WC_REST_Reports_Controlle
 			'default'           => 'coupon_id',
 			'enum'              => array(
 				'coupon_id',
+				'code',
 				'amount',
 				'orders_count',
 			),

--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -278,6 +278,7 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 			'default'           => 'date',
 			'enum'              => array(
 				'date',
+				'product',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -291,6 +291,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 				'orders_count',
 				'items_sold',
 				'product_name',
+				'sku',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -58,8 +58,9 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			$args['orderby'] = 'post__in';
 		} elseif ( 'id' === $args['orderby'] ) {
 			$args['orderby'] = 'ID'; // ID must be capitalized.
-		} elseif ( 'slug' === $args['orderby'] ) {
-			$args['orderby'] = 'name';
+		} elseif ( 'sku' === $args['orderby'] ) {
+			$args['meta_key'] = '_sku'; // WPCS: slow query ok.
+			$args['orderby']  = 'meta_value';
 		}
 
 		$args['post_type'] = array( 'product', 'product_variation' );
@@ -359,7 +360,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 				'id',
 				'include',
 				'title',
-				'slug',
+				'sku',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -94,6 +94,52 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 		return $sql_query_params;
 	}
 
+
+	/**
+	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return array
+	 */
+	protected function get_order_by_sql_params( $query_args ) {
+		global $wpdb;
+		$lookup_table                 = $wpdb->prefix . self::TABLE_NAME;
+		$sql_query                    = array();
+		$sql_query['from_clause']     = '';
+		$sql_query['order_by_clause'] = '';
+		if ( isset( $query_args['orderby'] ) ) {
+			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
+		}
+
+		if ( false !== strpos( $sql_query['order_by_clause'], '_coupons' ) ) {
+			$sql_query['from_clause'] .= " JOIN {$wpdb->prefix}posts AS _coupons ON {$lookup_table}.coupon_id = _coupons.ID";
+		}
+
+		if ( isset( $query_args['order'] ) ) {
+			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
+		} else {
+			$sql_query['order_by_clause'] .= ' DESC';
+		}
+
+		return $sql_query;
+	}
+
+	/**
+	 * Maps ordering specified by the user to columns in the database/fields in the data.
+	 *
+	 * @param string $order_by Sorting criterion.
+	 * @return string
+	 */
+	protected function normalize_order_by( $order_by ) {
+		if ( 'date' === $order_by ) {
+			return 'time_interval';
+		}
+		if ( 'code' === $order_by ) {
+			return '_coupons.post_title';
+		}
+		return $order_by;
+	}
+
 	/**
 	 * Enriches the coupon data with extra attributes.
 	 *

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -100,6 +100,10 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 			$sql_query['from_clause'] .= " JOIN {$wpdb->prefix}posts AS _products ON {$order_product_lookup_table}.product_id = _products.ID";
 		}
 
+		if ( 'postmeta.meta_value' === $sql_query['order_by_clause'] ) {
+			$sql_query['from_clause'] .= " JOIN {$wpdb->prefix}postmeta AS postmeta ON {$order_product_lookup_table}.product_id = postmeta.post_id AND postmeta.meta_key = '_sku'";
+		}
+
 		if ( isset( $query_args['order'] ) ) {
 			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
 		} else {
@@ -150,7 +154,9 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		if ( 'product_name' === $order_by ) {
 			return '_products.post_title';
 		}
-
+		if ( 'sku' === $order_by ) {
+			return 'postmeta.meta_value';
+		}
 		return $order_by;
 	}
 


### PR DESCRIPTION
Fixes #1111.

This PR adds the ability to sort by product name, category title, or SKU, where applicable on report tables.

The following are now sortable:
* Product Report: Product name, SKU.
* Categories Report: Category name.
* Coupons Report: Coupon code.
* Downloads report: Product name.
* Stock report: Product name, SKU.

### Screenshots

Example with category report:

<img width="872" alt="screen shot 2019-01-09 at 2 50 19 pm" src="https://user-images.githubusercontent.com/689165/50926337-c3ec5600-1422-11e9-8aca-e2df496660e2.png">

### Detailed test instructions:

* Run `phpunit` and make sure all tests pass.
* Test the above reports, and verify that you can sort both ascending and descending.
* Spot check sorting by a few existing numeric columns.