### PR TITLE
Add top categories block

### DIFF
--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -82,11 +82,11 @@ class Leaderboards extends Component {
 		const allLeaderboards = [
 			{
 				key: 'top-products',
-				label: __( 'Top Products', 'wc-admin' ),
+				label: __( 'Top Products - Items Sold', 'wc-admin' ),
 			},
 			{
 				key: 'top-categories',
-				label: __( 'Top Categories', 'wc-admin' ),
+				label: __( 'Top Categories - Items Sold', 'wc-admin' ),
 			},
 			{
 				key: 'top-coupons',
@@ -125,17 +125,18 @@ class Leaderboards extends Component {
 
 	render() {
 		const { hiddenLeaderboardKeys, rowsPerTable } = this.state;
+		const { query } = this.props;
 		return (
 			<Fragment>
 				<div className="woocommerce-dashboard__dashboard-leaderboards">
 					<SectionHeader title={ __( 'Leaderboards', 'wc-admin' ) } menu={ this.renderMenu() } />
 					<div className="woocommerce-dashboard__columns">
 						{ ! hiddenLeaderboardKeys.includes( 'top-products' ) && (
-							<TopSellingProducts query={ this.props.query } totalRows={ rowsPerTable } />
+							<TopSellingProducts query={ query } totalRows={ rowsPerTable } />
 						) }
 
 						{ ! hiddenLeaderboardKeys.includes( 'top-categories' ) && (
-							<TopSellingCategories query={ this.props.query } totalRows={ rowsPerTable } />
+							<TopSellingCategories query={ query } totalRows={ rowsPerTable } />
 						) }
 					</div>
 				</div>

--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -19,6 +19,7 @@ import { EllipsisMenu, MenuItem, MenuTitle, SectionHeader } from '@woocommerce/c
  * Internal dependencies
  */
 import withSelect from 'wc-api/with-select';
+import TopSellingCategories from './top-selling-categories';
 import TopSellingProducts from './top-selling-products';
 import './style.scss';
 
@@ -129,11 +130,13 @@ class Leaderboards extends Component {
 				<div className="woocommerce-dashboard__dashboard-leaderboards">
 					<SectionHeader title={ __( 'Leaderboards', 'wc-admin' ) } menu={ this.renderMenu() } />
 					<div className="woocommerce-dashboard__columns">
-						<div>
-							{ ! hiddenLeaderboardKeys.includes( 'top-products' ) && (
-								<TopSellingProducts query={ this.props.query } totalRows={ rowsPerTable } />
-							) }
-						</div>
+						{ ! hiddenLeaderboardKeys.includes( 'top-products' ) && (
+							<TopSellingProducts query={ this.props.query } totalRows={ rowsPerTable } />
+						) }
+
+						{ ! hiddenLeaderboardKeys.includes( 'top-categories' ) && (
+							<TopSellingCategories query={ this.props.query } totalRows={ rowsPerTable } />
+						) }
 					</div>
 				</div>
 			</Fragment>

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -10,7 +10,8 @@ import { get, map } from 'lodash';
  * WooCommerce dependencies
  */
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -53,13 +54,24 @@ export class TopSellingCategories extends Component {
 	}
 
 	getRowsContent( data ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
 		return map( data, row => {
-			const { items_sold, net_revenue, extended_info } = row;
+			const { category_id, items_sold, net_revenue, extended_info } = row;
 			const name = get( extended_info, [ 'name' ] );
-			const productLink = <a href={ getAdminLink( '/post.php?post=' ) }>{ name }</a>;
+			// TODO Update this to use a single_category filter, once it exists.
+			const categoryUrl = getNewPath( persistedQuery, 'analytics/categories', {
+				filter: 'compare-categories',
+				categories: category_id,
+			} );
+			const categoryLink = (
+				<Link href={ categoryUrl } type="wc-admin">
+					{ name }
+				</Link>
+			);
 			return [
 				{
-					display: productLink,
+					display: categoryLink,
 					value: name,
 				},
 				{
@@ -90,7 +102,7 @@ export class TopSellingCategories extends Component {
 				getRowsContent={ this.getRowsContent }
 				query={ query }
 				tableQuery={ tableQuery }
-				title={ __( 'Top Selling Categories', 'wc-admin' ) }
+				title={ __( 'Top Selling Categories - Items Sold', 'wc-admin' ) }
 			/>
 		);
 	}

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -102,7 +102,7 @@ export class TopSellingCategories extends Component {
 				getRowsContent={ this.getRowsContent }
 				query={ query }
 				tableQuery={ tableQuery }
-				title={ __( 'Top Selling Categories - Items Sold', 'wc-admin' ) }
+				title={ __( 'Top Categories - Items Sold', 'wc-admin' ) }
 			/>
 		);
 	}

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -1,0 +1,99 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { get, map } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getAdminLink } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { numberFormat } from 'lib/number';
+import Leaderboard from 'analytics/components/leaderboard';
+
+export class TopSellingCategories extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Category', 'wc-admin' ),
+				key: 'category',
+				required: true,
+				isLeftAligned: true,
+				isSortable: false,
+			},
+			{
+				label: __( 'Items Sold', 'wc-admin' ),
+				key: 'items_sold',
+				required: false,
+				isSortable: false,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Net Revenue', 'wc-admin' ),
+				key: 'net_revenue',
+				required: true,
+				isSortable: false,
+				isNumeric: true,
+			},
+		];
+	}
+
+	getRowsContent( data ) {
+		return map( data, row => {
+			const { items_sold, net_revenue, extended_info } = row;
+			const name = get( extended_info, [ 'name' ] );
+			const productLink = <a href={ getAdminLink( '/post.php?post=' ) }>{ name }</a>;
+			return [
+				{
+					display: productLink,
+					value: name,
+				},
+				{
+					display: numberFormat( items_sold ),
+					value: items_sold,
+				},
+				{
+					display: formatCurrency( net_revenue ),
+					value: getCurrencyFormatDecimal( net_revenue ),
+				},
+			];
+		} );
+	}
+
+	render() {
+		const { query, totalRows } = this.props;
+		const tableQuery = {
+			orderby: 'items_sold',
+			order: 'desc',
+			per_page: totalRows,
+			extended_info: true,
+		};
+
+		return (
+			<Leaderboard
+				endpoint="categories"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				query={ query }
+				tableQuery={ tableQuery }
+				title={ __( 'Top Selling Categories', 'wc-admin' ) }
+			/>
+		);
+	}
+}
+
+export default TopSellingCategories;

--- a/client/dashboard/leaderboards/top-selling-products.js
+++ b/client/dashboard/leaderboards/top-selling-products.js
@@ -44,13 +44,6 @@ export class TopSellingProducts extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Orders', 'wc-admin' ),
-				key: 'orders_count',
-				required: false,
-				isSortable: false,
-				isNumeric: true,
-			},
-			{
 				label: __( 'Net Revenue', 'wc-admin' ),
 				key: 'net_revenue',
 				required: true,
@@ -64,7 +57,7 @@ export class TopSellingProducts extends Component {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		return map( data, row => {
-			const { product_id, items_sold, net_revenue, orders_count, extended_info } = row;
+			const { product_id, items_sold, net_revenue, extended_info } = row;
 			const name = get( extended_info, [ 'name' ] );
 
 			const productUrl = getNewPath( persistedQuery, 'analytics/products', {
@@ -85,10 +78,6 @@ export class TopSellingProducts extends Component {
 				{
 					display: numberFormat( items_sold ),
 					value: items_sold,
-				},
-				{
-					display: numberFormat( orders_count ),
-					value: orders_count,
 				},
 				{
 					display: formatCurrency( net_revenue ),
@@ -114,7 +103,7 @@ export class TopSellingProducts extends Component {
 				getRowsContent={ this.getRowsContent }
 				query={ query }
 				tableQuery={ tableQuery }
-				title={ __( 'Top Selling Products - Items Sold', 'wc-admin' ) }
+				title={ __( 'Top Products - Items Sold', 'wc-admin' ) }
 			/>
 		);
 	}

--- a/client/dashboard/leaderboards/top-selling-products.js
+++ b/client/dashboard/leaderboards/top-selling-products.js
@@ -10,7 +10,8 @@ import { get, map } from 'lodash';
  * WooCommerce dependencies
  */
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -60,12 +61,22 @@ export class TopSellingProducts extends Component {
 	}
 
 	getRowsContent( data ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
 		return map( data, row => {
 			const { product_id, items_sold, net_revenue, orders_count, extended_info } = row;
 			const name = get( extended_info, [ 'name' ] );
+
+			const productUrl = getNewPath( persistedQuery, 'analytics/products', {
+				filter: 'single_product',
+				products: product_id,
+			} );
 			const productLink = (
-				<a href={ getAdminLink( `/post.php?post=${ product_id }&action=edit` ) }>{ name }</a>
+				<Link href={ productUrl } type="wc-admin">
+					{ name }
+				</Link>
 			);
+
 			return [
 				{
 					display: productLink,
@@ -103,7 +114,7 @@ export class TopSellingProducts extends Component {
 				getRowsContent={ this.getRowsContent }
 				query={ query }
 				tableQuery={ tableQuery }
-				title={ __( 'Top Selling Products', 'wc-admin' ) }
+				title={ __( 'Top Selling Products - Items Sold', 'wc-admin' ) }
 			/>
 		);
 	}


### PR DESCRIPTION
Fixes #1192. Fixes #1182. Fixes #696.

This PR adds a top selling categories block to the dashboard. It also updates the top selling products block to correctly link to the products report.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

<img width="1179" alt="screen shot 2019-01-10 at 3 14 08 pm" src="https://user-images.githubusercontent.com/689165/50995048-ea29f880-14eb-11e9-9291-4487762bfc14.png">

<img width="616" alt="screen shot 2019-01-10 at 3 37 03 pm" src="https://user-images.githubusercontent.com/689165/50995620-991b0400-14ed-11e9-8459-a42b49618428.png">

### Detailed test instructions:

* View the dashboard and verify you see your top selling categories.
* Click through to the reports on both the top products and top categories blocks. The dashboard date should be persisted on the report, and the report should be filtered by the single object.

--

Note: Right now the top category block is linking to `compare-categories`. This should actually be a single category filter like the top products block -- but this filter doesn't exist yet so I've added a TODO and opened an issue. #1277.
