### PR TITLE
Date: Remove hour from default interval in getAllowedIntervalsForQuery

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5 Not Released
+
+- Fixed bug in getAllowedIntervalsForQuery() to not return `hour` for default intervals
+
 # 1.0.4
 
 - Remove deprecated @wordpress/date::getSettings() usage.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -395,7 +395,7 @@ export function getAllowedIntervalsForQuery( query ) {
 				allowed = [ 'day', 'week', 'month', 'quarter' ];
 				break;
 			default:
-				allowed = [ 'hour', 'day' ];
+				allowed = [ 'day' ];
 				break;
 		}
 	}

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -21,6 +21,7 @@ import {
 	getDateDifferenceInDays,
 	getPreviousDate,
 	getChartTypeForQuery,
+	getAllowedIntervalsForQuery,
 } from '../src';
 
 describe( 'appendTimestamp', () => {
@@ -79,6 +80,53 @@ describe( 'toMoment', () => {
 	it( 'shoud return null on invalid date', () => {
 		const invalidDate = toMoment( 'YYYY', '2018-00-00' );
 		expect( invalidDate ).toBe( null );
+	} );
+} );
+
+describe( 'getAllowedIntervalsForQuery', () => {
+	it( 'should return days when query period is defined but empty', () => {
+		const allowedIntervals = getAllowedIntervalsForQuery( { period: '' } );
+		expect( allowedIntervals ).toEqual( [ 'day' ] );
+	} );
+
+	it( 'should return days and hours for today and yesterday periods', () => {
+		const allowedIntervalsToday = getAllowedIntervalsForQuery( { period: 'today' } );
+		expect( allowedIntervalsToday ).toEqual( [ 'hour', 'day' ] );
+
+		const allowedIntervalsYesterday = getAllowedIntervalsForQuery( { period: 'yesterday' } );
+		expect( allowedIntervalsYesterday ).toEqual( [ 'hour', 'day' ] );
+	} );
+
+	it( 'should return day for week and last_week periods', () => {
+		const allowedIntervalsWeek = getAllowedIntervalsForQuery( { period: 'week' } );
+		expect( allowedIntervalsWeek ).toEqual( [ 'day' ] );
+
+		const allowedIntervalsLastWeek = getAllowedIntervalsForQuery( { period: 'last_week' } );
+		expect( allowedIntervalsLastWeek ).toEqual( [ 'day' ] );
+	} );
+
+	it( 'should return day, week for month and last_month periods', () => {
+		const allowedIntervalsMonth = getAllowedIntervalsForQuery( { period: 'month' } );
+		expect( allowedIntervalsMonth ).toEqual( [ 'day', 'week' ] );
+
+		const allowedIntervalsLastMonth = getAllowedIntervalsForQuery( { period: 'last_month' } );
+		expect( allowedIntervalsLastMonth ).toEqual( [ 'day', 'week' ] );
+	} );
+
+	it( 'should return day, week, month for quarter and last_quarter periods', () => {
+		const allowedIntervalsQuarter = getAllowedIntervalsForQuery( { period: 'quarter' } );
+		expect( allowedIntervalsQuarter ).toEqual( [ 'day', 'week', 'month' ] );
+
+		const allowedIntervalsLastQuarter = getAllowedIntervalsForQuery( { period: 'last_quarter' } );
+		expect( allowedIntervalsLastQuarter ).toEqual( [ 'day', 'week', 'month' ] );
+	} );
+
+	it( 'should return day, week, month, quarter for year and last_year periods', () => {
+		const allowedIntervalsYear = getAllowedIntervalsForQuery( { period: 'year' } );
+		expect( allowedIntervalsYear ).toEqual( [ 'day', 'week', 'month', 'quarter' ] );
+
+		const allowedIntervalsLastYear = getAllowedIntervalsForQuery( { period: 'last_year' } );
+		expect( allowedIntervalsLastYear ).toEqual( [ 'day', 'week', 'month', 'quarter' ] );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #1278

Currently when loading the dashboard, or a chart without any date picker parameters set `getAllowedIntervalsForQuery()` is returning `[ 'hour', 'day' ]` as valid intervals for the time selection, resulting in `hour` being selected by default. The desired behavior is to default to `day`, and this also saves a ton of extra queries to render the charts in the dashbaord.

### Accessibility
No interaction changes

### Detailed test instructions:

- Open the dashboard, verify the interval selection in the charts area only shows 'days' as an option
- Open any report and verify the same
- Change the date range in the date picker to verify other date range options present the expected interval options.