### PR TITLE
Change category gross stats to net

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -18,7 +18,7 @@ export const charts = [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Gross Revenue', 'wc-admin' ),
+		label: __( 'Net Revenue', 'wc-admin' ),
 		type: 'currency',
 	},
 	{

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -111,7 +111,7 @@ class CategoriesReportTable extends Component {
 				value: numberFormat( totals.items_sold ),
 			},
 			{
-				label: __( 'gross revenue', 'wc-admin' ),
+				label: __( 'net revenue', 'wc-admin' ),
 				value: formatCurrency( totals.net_revenue ),
 			},
 			{


### PR DESCRIPTION
Fixes #1254 

The category stats should be returning `net_total` and not `gross_total` since that's the correct measure for category totals.

Testing is blocked for the numbers until the SwaggerHub endpoint is updated.  This PR only updates the labels from `gross` to `net`.

### Screenshots
<img width="516" alt="screen shot 2019-01-11 at 3 30 51 pm" src="https://user-images.githubusercontent.com/10561050/51019438-e95d9900-15b5-11e9-84a6-2c5fe9846004.png">
<img width="1443" alt="screen shot 2019-01-11 at 3 30 45 pm" src="https://user-images.githubusercontent.com/10561050/51019439-e95d9900-15b5-11e9-8986-a87205b58eb5.png">

### Detailed test instructions:

1.  Visit the categories report `/wp-admin/admin.php?page=wc-admin#/analytics/categories`.
2.  Verify that there are no references to `gross` but instead to `net`.
3.  Check that the`net_total` is showing correctly once the SwaggerHub endpoint is updated.