### PR TITLE
Remove decimals from Y-axis

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `showHeaderControls`: whether the header controls must be visible. Defaults to true.
 - `getColor()` method in chart utils now requires `keys` and `colorScheme` to be passed as separate params.
 - Fix to avoid duplicated Y-axis ticks when the Y max value was 0.
+- Remove decimals from Y-axis when displaying currencies.
 
 # 1.3.0
 

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -275,7 +275,7 @@ class Chart extends Component {
 				yFormat = '.0f';
 				break;
 			case 'currency':
-				yFormat = '$.3s';
+				yFormat = '$.3~s';
 				break;
 			case 'number':
 				yFormat = '.0f';


### PR DESCRIPTION
Fixes #1268

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51039458-a69bc100-15b5-11e9-9d3f-09b7d7239f18.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51040226-2f672c80-15b7-11e9-9ec7-dfc8165147f8.png)

### Detailed test instructions:
- Go to a chart that displays currency values (_Revenue_ for example).
- Verify there are no decimals.