### PR TITLE
Avoid duplicated Y-axis values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `legendPosition`: can be `top`, `side` or `bottom`. If not specified, it's calculated based on `mode` and viewport width.
   - `showHeaderControls`: whether the header controls must be visible. Defaults to true.
 - `getColor()` method in chart utils now requires `keys` and `colorScheme` to be passed as separate params.
+- Fix to avoid duplicated Y-axis ticks when the Y max value was 0.
 
 # 1.3.0
 

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -176,9 +176,9 @@ export const getYGrids = ( yMax ) => {
 	const yGrids = [];
 
 	for ( let i = 0; i < 4; i++ ) {
-		const roundedValue = yMax > 1 ? Math.round( i / 3 * yMax ) : i / 3 * yMax;
-		if ( yGrids[ yGrids.length - 1 ] !== roundedValue ) {
-			yGrids.push( roundedValue );
+		const value = yMax > 1 ? Math.round( i / 3 * yMax ) : i / 3 * yMax;
+		if ( yGrids[ yGrids.length - 1 ] !== value ) {
+			yGrids.push( value );
 		}
 	}
 

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -172,7 +172,7 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 	return diff;
 };
 
-const getYGrids = ( yMax ) => {
+export const getYGrids = ( yMax ) => {
 	const yGrids = [];
 
 	for ( let i = 0; i < 4; i++ ) {

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -172,6 +172,19 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 	return diff;
 };
 
+const getYGrids = ( yMax ) => {
+	const yGrids = [];
+
+	for ( let i = 0; i < 4; i++ ) {
+		const roundedValue = yMax > 1 ? Math.round( i / 3 * yMax ) : i / 3 * yMax;
+		if ( yGrids[ yGrids.length - 1 ] !== roundedValue ) {
+			yGrids.push( roundedValue );
+		}
+	}
+
+	return yGrids;
+};
+
 export const drawAxis = ( node, params ) => {
 	const xScale = params.type === 'line' ? params.xLineScale : params.xScale;
 	const removeDuplicateDates = ( d, i, ticks, formatter ) => {
@@ -183,17 +196,7 @@ export const drawAxis = ( node, params ) => {
 			: compareStrings( formatter( prevMonth ), formatter( monthDate ) ).join( ' ' );
 	};
 
-	const yGrids = [];
-	for ( let i = 0; i < 4; i++ ) {
-		if ( params.yMax > 1 ) {
-			const roundedValue = Math.round( i / 3 * params.yMax );
-			if ( yGrids[ yGrids.length - 1 ] !== roundedValue ) {
-				yGrids.push( roundedValue );
-			}
-		} else {
-			yGrids.push( i / 3 * params.yMax );
-		}
-	}
+	const yGrids = getYGrids( params.yMax );
 
 	const ticks = params.xTicks.map( d => ( params.type === 'line' ? new Date( d ) : d ) );
 

--- a/packages/components/src/chart/d3chart/utils/test/axis.js
+++ b/packages/components/src/chart/d3chart/utils/test/axis.js
@@ -6,7 +6,7 @@
 /**
 * Internal dependencies
 */
-import { compareStrings, getXTicks } from '../axis';
+import { compareStrings, getXTicks, getYGrids } from '../axis';
 
 describe( 'getXTicks', () => {
 	describe( 'interval=day', () => {
@@ -236,5 +236,23 @@ describe( 'compareStrings', () => {
 		expect( compareStrings( 'Jul 2017', 'Aug 2018' ).join( ' ' ) ).toEqual( 'Aug 2018' );
 		expect( compareStrings( 'Jul 2017', 'Jul 2018' ).join( ' ' ) ).toEqual( '2018' );
 		expect( compareStrings( 'Jul, 2018', 'Aug, 2018' ).join( ' ' ) ).toEqual( 'Aug' );
+	} );
+} );
+
+describe( 'getYGrids', () => {
+	it( 'returns a single 0 when yMax is 0', () => {
+		expect( getYGrids( 0 ) ).toEqual( [ 0 ] );
+	} );
+
+	it( 'returns decimal values when yMax is <= 1', () => {
+		expect( getYGrids( 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
+	} );
+
+	it( 'doesn\'t return decimal values when yMax is >1', () => {
+		expect( getYGrids( 2 ) ).toEqual( [ 0, 1, 2 ] );
+	} );
+
+	it( 'returns up to four values when yMax is a big number', () => {
+		expect( getYGrids( 10000 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
 	} );
 } );


### PR DESCRIPTION
When the max Y value of a chart was 0, the axis was displaying several 0's one on top of the other, making it look blurry. This PR fixes that.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51039323-5cb2db00-15b5-11e9-9075-97c14d69504d.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51039337-65a3ac80-15b5-11e9-8516-2363100874d2.png)

### Detailed test instructions:
- Go to a chart whose max value is 0, for example, the _Orders_ report with the date range set to a day you know there wasn't any order.
- Verify 0 is rendered smoothly.