### PR TITLE
Add showMenu prop to TableCard to hide ellipsis menu

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -57,6 +57,7 @@ export class Leaderboard extends Component {
 				isLoading={ isRequesting }
 				rows={ rows }
 				rowsPerPage={ totalRows }
+				showMenu={ false }
 				title={ title }
 				totalRows={ totalRows }
 			/>

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -443,7 +443,7 @@ TableCard.propTypes = {
 	 */
 	searchParam: PropTypes.string,
 	/**
-	 * Url query parameter search function operates on
+	 * Boolean to determine whether or not ellipsis menu is shown.
 	 */
 	showMenu: PropTypes.bool,
 	/**

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -237,6 +237,7 @@ class TableCard extends Component {
 			rowsPerPage,
 			searchBy,
 			searchParam,
+			showMenu,
 			summary,
 			title,
 			totalRows,
@@ -301,7 +302,7 @@ class TableCard extends Component {
 					),
 				] }
 				menu={
-					<EllipsisMenu label={ __( 'Choose which values to display', 'wc-admin' ) }>
+					showMenu && <EllipsisMenu label={ __( 'Choose which values to display', 'wc-admin' ) }>
 						<MenuTitle>{ __( 'Columns:', 'wc-admin' ) }</MenuTitle>
 						{ allHeaders.map( ( { key, label, required } ) => {
 							if ( required ) {
@@ -442,6 +443,10 @@ TableCard.propTypes = {
 	 */
 	searchParam: PropTypes.string,
 	/**
+	 * Url query parameter search function operates on
+	 */
+	showMenu: PropTypes.bool,
+	/**
 	 * An array of objects with `label` & `value` properties, which display in a line under the table.
 	 * Optional, can be left off to show no summary.
 	 */
@@ -470,6 +475,7 @@ TableCard.defaultProps = {
 	query: {},
 	rowHeader: 0,
 	rows: [],
+	showMenu: true,
 };
 
 export default TableCard;


### PR DESCRIPTION
Fixes #1280 

Adds a prop to enable/disable the ellipsis menu in the table card.

### Before
<img width="635" alt="screen shot 2019-01-14 at 2 42 29 pm" src="https://user-images.githubusercontent.com/10561050/51099264-aea06e80-180a-11e9-9638-4f7d116844a4.png">

### After
<img width="717" alt="screen shot 2019-01-14 at 2 39 44 pm" src="https://user-images.githubusercontent.com/10561050/51099271-bbbd5d80-180a-11e9-87a7-b4188cf72995.png">

### Detailed test instructions:

1. Open the dashboard page.
2. Check that the leaderboard charts do not have the ellipsis menu to toggle columns in the top right.
3. Check that all other reports (orders, products, categories, etc.) still have the ellipsis menu with column options.
