### PR TITLE
Add initial state hydration for user data

### DIFF
--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -28,7 +28,7 @@ class Leaderboards extends Component {
 		super( ...arguments );
 		this.state = {
 			hiddenLeaderboardKeys: props.userPrefLeaderboards || [],
-			rowsPerTable: props.userPrefLeaderboardRows || 5,
+			rowsPerTable: parseInt( props.userPrefLeaderboardRows ) || 5,
 		};
 
 		this.toggle = this.toggle.bind( this );

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -8,7 +8,8 @@ import { DEFAULT_REQUIREMENT } from '../constants';
 const getCurrentUserData = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	return requireResource( requirement, 'current-user-data' ).data || {};
+	const initalState = wcAdminServer.currentUserData; // eslint-disable-line
+	return requireResource( requirement, 'current-user-data' ).data || initalState;
 };
 
 export default {

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -8,7 +8,7 @@ import { DEFAULT_REQUIREMENT } from '../constants';
 const getCurrentUserData = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const initalState = wcAdminServer.currentUserData; // eslint-disable-line no-undef
+	const initalState = wcSettings.currentUserData;
 	return requireResource( requirement, 'current-user-data' ).data || initalState;
 };
 

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -8,7 +8,7 @@ import { DEFAULT_REQUIREMENT } from '../constants';
 const getCurrentUserData = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const initalState = wcAdminServer.currentUserData; // eslint-disable-line
+	const initalState = wcAdminServer.currentUserData; // eslint-disable-line no-undef
 	return requireResource( requirement, 'current-user-data' ).data || initalState;
 };
 

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -228,23 +228,6 @@ function wc_admin_enqueue_script() {
 add_action( 'admin_enqueue_scripts', 'wc_admin_enqueue_script' );
 
 /**
- * Hydrates the initial state.
- */
-function wc_admin_hydrate_state() {
-	$current_user_data = array();
-	foreach ( wc_admin_get_user_data_fields() as $user_field ) {
-		$current_user_data[ $user_field ] = get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true );
-	}
-
-	wp_localize_script(
-		WC_ADMIN_APP,
-		'wcAdminServer',
-		array( 'currentUserData' => $current_user_data )
-	);
-}
-add_action( 'admin_enqueue_scripts', 'wc_admin_hydrate_state' );
-
-/**
  * Adds an admin body class.
  *
  * @param string $admin_body_class Body class to add.

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -228,6 +228,23 @@ function wc_admin_enqueue_script() {
 add_action( 'admin_enqueue_scripts', 'wc_admin_enqueue_script' );
 
 /**
+ * Hydrates the initial state.
+ */
+function wc_admin_hydrate_state() {
+	$current_user_data = array();
+	foreach ( wc_admin_get_user_data_fields() as $user_field ) {
+		$current_user_data[ $user_field ] = get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true );
+	}
+
+	wp_localize_script(
+		WC_ADMIN_APP,
+		'wcAdminServer',
+		array( 'currentUserData' => $current_user_data )
+	);
+}
+add_action( 'admin_enqueue_scripts', 'wc_admin_hydrate_state' );
+
+/**
  * Adds an admin body class.
  *
  * @param string $admin_body_class Body class to add.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -167,6 +167,11 @@ function wc_admin_print_script_settings() {
 		$preload_function
 	);
 
+	$current_user_data = array();
+	foreach ( wc_admin_get_user_data_fields() as $user_field ) {
+		$current_user_data[ $user_field ] = get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true );
+	}
+
 	/**
 	 * TODO: On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
@@ -189,6 +194,7 @@ function wc_admin_print_script_settings() {
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
+		'currentUserData'  => $current_user_data,
 	);
 
 	foreach ( $preload_data_endpoints as $key => $endpoint ) {


### PR DESCRIPTION
Fixes #1250 

Adds in the user data from the server prior to fetching in the state.  This allows us to load initial user preferences without the secondary flash after user data is fetched.

### Detailed test instructions:

1.  Visit the following places that contain user preferences:
* Dashboard: Rows per leaderboard
* Dashboard: Shown leaderboards
* Dashboard: Shown charts
* Reports: Shown user columns
2. Note that the user preferences are reflected on initial load and a subsequent flash and API request is not made after user preferences are loaded asynchronously  🚤 
3. Toggle user preferences and make sure they load correctly on refresh.