### PR TITLE
Update all wc-admin endpoints to v4

### DIFF
--- a/client/analytics/components/leaderboard/__mocks__/top-selling-products-mock-data.js
+++ b/client/analytics/components/leaderboard/__mocks__/top-selling-products-mock-data.js
@@ -14,7 +14,7 @@ And as such will require data layer logic for products to fully build the table
     "_links": {
       "product": [
         {
-          "href": "https://example.com/wp-json/wc/v3/products/20"
+          "href": "https://example.com/wp-json/wc/v4/products/20"
         }
       ]
     }
@@ -32,7 +32,7 @@ export default [
 		_links: {
 			product: [
 				{
-					href: 'https://example.com/wp-json/wc/v3/products/20',
+					href: 'https://example.com/wp-json/wc/v4/products/20',
 				},
 			],
 		},
@@ -46,7 +46,7 @@ export default [
 		_links: {
 			product: [
 				{
-					href: 'https://example.com/wp-json/wc/v3/products/22',
+					href: 'https://example.com/wp-json/wc/v4/products/22',
 				},
 			],
 		},
@@ -60,7 +60,7 @@ export default [
 		_links: {
 			product: [
 				{
-					href: 'https://example.com/wp-json/wc/v3/products/23',
+					href: 'https://example.com/wp-json/wc/v4/products/23',
 				},
 			],
 		},
@@ -74,7 +74,7 @@ export default [
 		_links: {
 			product: [
 				{
-					href: 'https://example.com/wp-json/wc/v3/products/24',
+					href: 'https://example.com/wp-json/wc/v4/products/24',
 				},
 			],
 		},
@@ -88,7 +88,7 @@ export default [
 		_links: {
 			product: [
 				{
-					href: 'https://example.com/wp-json/wc/v3/products/25',
+					href: 'https://example.com/wp-json/wc/v4/products/25',
 				},
 			],
 		},

--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -69,7 +69,7 @@ Leaderboard.propTypes = {
 	/**
 	 * The endpoint to use in API calls to populate the table rows and summary.
 	 * For example, if `taxes` is provided, data will be fetched from the report
-	 * `taxes` endpoint (ie: `/wc/v3/reports/taxes` and `/wc/v3/reports/taxes/stats`).
+	 * `taxes` endpoint (ie: `/wc/v4/reports/taxes` and `/wc/v4/reports/taxes/stats`).
 	 * If the provided endpoint doesn't exist, an error will be shown to the user
 	 * with `ReportError`.
 	 */

--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -102,7 +102,7 @@ describe( 'Leaderboard', () => {
 		);
 		const leaderboard = leaderboardWrapper.root.findByType( Leaderboard );
 
-		const endpoint = '/wc/v3/reports/products';
+		const endpoint = '/wc/v4/reports/products';
 		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );

--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -17,6 +17,7 @@ import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency'
  * Internal dependencies
  */
 import LeaderboardWithSelect, { Leaderboard } from '../';
+import { NAMESPACE } from 'store/constants';
 import { numberFormat } from 'lib/number';
 import mockData from '../__mocks__/top-selling-products-mock-data';
 
@@ -102,7 +103,7 @@ describe( 'Leaderboard', () => {
 		);
 		const leaderboard = leaderboardWrapper.root.findByType( Leaderboard );
 
-		const endpoint = '/wc/v4/reports/products';
+		const endpoint = NAMESPACE + 'reports/products';
 		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -80,7 +80,7 @@ ReportSummary.propTypes = {
 	/**
 	 * The endpoint to use in API calls to populate the Summary Numbers.
 	 * For example, if `taxes` is provided, data will be fetched from the report
-	 * `taxes` endpoint (ie: `/wc/v3/reports/taxes/stats`). If the provided endpoint
+	 * `taxes` endpoint (ie: `/wc/v4/reports/taxes/stats`). If the provided endpoint
 	 * doesn't exist, an error will be shown to the user with `ReportError`.
 	 */
 	endpoint: PropTypes.string.isRequired,

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -124,7 +124,7 @@ ReportTable.propTypes = {
 	/**
 	 * The endpoint to use in API calls to populate the table rows and summary.
 	 * For example, if `taxes` is provided, data will be fetched from the report
-	 * `taxes` endpoint (ie: `/wc/v3/reports/taxes` and `/wc/v3/reports/taxes/stats`).
+	 * `taxes` endpoint (ie: `/wc/v4/reports/taxes` and `/wc/v4/reports/taxes/stats`).
 	 * If the provided endpoint doesn't exist, an error will be shown to the user
 	 * with `ReportError`.
 	 */

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getRequestByIdString } from 'lib/async-requests';
-import { NAMESPACE } from 'store/constants';
 
 export const charts = [
 	{
@@ -43,7 +42,7 @@ export const filters = [
 				settings: {
 					type: 'categories',
 					param: 'categories',
-					getLabels: getRequestByIdString( NAMESPACE + 'products/categories', cat => ( {
+					getLabels: getRequestByIdString( '/wc/v4/products/categories', cat => ( {
 						id: cat.id,
 						label: cat.name,
 					} ) ),

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getRequestByIdString } from 'lib/async-requests';
+import { NAMESPACE } from 'store/constants';
 
 export const charts = [
 	{
@@ -42,7 +43,7 @@ export const filters = [
 				settings: {
 					type: 'categories',
 					param: 'categories',
-					getLabels: getRequestByIdString( '/wc/v4/products/categories', cat => ( {
+					getLabels: getRequestByIdString( NAMESPACE + 'products/categories', cat => ( {
 						id: cat.id,
 						label: cat.name,
 					} ) ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -2,30 +2,25 @@
 /**
  * External dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
 import { map } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
+import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency } from '@woocommerce/currency';
 
 /**
  * Internal dependencies
  */
-import { QUERY_DEFAULTS } from 'store/constants';
-import { getFilterQuery } from 'store/reports/utils';
 import { numberFormat } from 'lib/number';
-import withSelect from 'wc-api/with-select';
 import ReportTable from 'analytics/components/report-table';
-import { formatTableOrders } from './utils';
 import './style.scss';
 
-class OrdersReportTable extends Component {
+export default class OrdersReportTable extends Component {
 	constructor() {
 		super();
 
@@ -98,26 +93,26 @@ class OrdersReportTable extends Component {
 	getRowsContent( tableData ) {
 		return map( tableData, row => {
 			const {
-				date,
-				id,
+				currency,
+				customer_type,
+				date_created,
+				extended_info,
+				net_total,
+				num_items_sold,
+				order_id,
 				status,
-				customer_id,
-				line_items,
-				items_sold,
-				coupon_lines,
-				currency_symbol,
-				net_revenue,
 			} = row;
+			const { coupons, products } = extended_info;
 
-			const products = line_items
+			const formattedProducts = products
 				.sort( ( itemA, itemB ) => itemB.quantity - itemA.quantity )
 				.map( item => ( {
 					label: item.name,
-					href: 'post.php?post=' + item.product_id + '&action=edit',
+					href: 'post.php?post=' + item.id + '&action=edit',
 					quantity: item.quantity,
 				} ) );
 
-			const coupons = coupon_lines.map( coupon => ( {
+			const formattedCoupons = coupons.map( coupon => ( {
 				label: coupon.code,
 				// @TODO It should link to the coupons report
 				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
@@ -125,16 +120,16 @@ class OrdersReportTable extends Component {
 
 			return [
 				{
-					display: <Date date={ date } visibleFormat={ defaultTableDateFormat } />,
-					value: date,
+					display: <Date date={ date_created } visibleFormat={ defaultTableDateFormat } />,
+					value: date_created,
 				},
 				{
 					display: (
-						<Link href={ 'post.php?post=' + id + '&action=edit' } type="wp-admin">
-							{ id }
+						<Link href={ 'post.php?post=' + order_id + '&action=edit' } type="wp-admin">
+							{ order_id }
 						</Link>
 					),
-					value: id,
+					value: order_id,
 				},
 				{
 					display: (
@@ -143,32 +138,36 @@ class OrdersReportTable extends Component {
 					value: status,
 				},
 				{
-					// @TODO This should display customer type (new/returning) once it's
-					// implemented in the API.
-					display: customer_id,
-					value: customer_id,
+					display:
+						customer_type === 'new'
+							? _x( 'New', 'customer type', 'wc-admin' )
+							: _x( 'Returning', 'customer type', 'wc-admin' ),
+					value: customer_type,
 				},
 				{
 					display: this.renderList(
-						products.length ? [ products[ 0 ] ] : [],
-						products.map( product => ( {
+						formattedProducts.length ? [ formattedProducts[ 0 ] ] : [],
+						formattedProducts.map( product => ( {
 							label: sprintf( __( '%s× %s', 'wc-admin' ), product.quantity, product.label ),
 							href: product.href,
 						} ) )
 					),
-					value: products.map( product => product.label ).join( ' ' ),
+					value: formattedProducts.map( product => product.label ).join( ' ' ),
 				},
 				{
-					display: numberFormat( items_sold ),
-					value: items_sold,
+					display: numberFormat( num_items_sold ),
+					value: num_items_sold,
 				},
 				{
-					display: this.renderList( coupons.length ? [ coupons[ 0 ] ] : [], coupons ),
-					value: coupons.map( item => item.code ).join( ' ' ),
+					display: this.renderList(
+						formattedCoupons.length ? [ formattedCoupons[ 0 ] ] : [],
+						formattedCoupons
+					),
+					value: formattedCoupons.map( item => item.code ).join( ' ' ),
 				},
 				{
-					display: formatCurrency( net_revenue, currency_symbol ),
-					value: net_revenue,
+					display: formatCurrency( net_total, currency ),
+					value: net_total,
 				},
 			];
 		} );
@@ -233,7 +232,7 @@ class OrdersReportTable extends Component {
 	}
 
 	render() {
-		const { query, tableData } = this.props;
+		const { query } = this.props;
 
 		return (
 			<ReportTable
@@ -242,49 +241,12 @@ class OrdersReportTable extends Component {
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
 				query={ query }
-				tableData={ tableData }
+				tableQuery={ {
+					extended_info: true,
+				} }
 				title={ __( 'Orders', 'wc-admin' ) }
 				columnPrefsKey="orders_report_columns"
 			/>
 		);
 	}
 }
-
-export default compose(
-	withSelect( ( select, props ) => {
-		const { query } = props;
-		const datesFromQuery = getCurrentDates( query );
-		const filterQuery = getFilterQuery( 'orders', query );
-
-		const { getOrders, getOrdersTotalCount, getOrdersError, isGetOrdersRequesting } = select(
-			'wc-api'
-		);
-
-		const tableQuery = {
-			orderby: query.orderby || 'date',
-			order: query.order || 'desc',
-			page: query.page || 1,
-			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
-			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
-			before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
-			status: [ 'processing', 'on-hold', 'completed' ],
-			...filterQuery,
-		};
-		const orders = getOrders( tableQuery );
-		const ordersTotalCount = getOrdersTotalCount( tableQuery );
-		const isError = Boolean( getOrdersError( tableQuery ) );
-		const isRequesting = isGetOrdersRequesting( tableQuery );
-
-		return {
-			tableData: {
-				items: {
-					data: formatTableOrders( orders ),
-					totalResults: ordersTotalCount,
-				},
-				isError,
-				isRequesting,
-				query: tableQuery,
-			},
-		};
-	} )
-)( OrdersReportTable );

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -108,7 +108,8 @@ export default class OrdersReportTable extends Component {
 				.sort( ( itemA, itemB ) => itemB.quantity - itemA.quantity )
 				.map( item => ( {
 					label: item.name,
-					href: 'post.php?post=' + item.id + '&action=edit',
+					href:
+						'admin.php?page=wc-admin#/analytics/products?filter=single_product&products=' + item.id,
 					quantity: item.quantity,
 				} ) );
 

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -86,7 +86,7 @@ const filterConfig = {
 			settings: {
 				type: 'categories',
 				param: 'categories',
-				getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
+				getLabels: getRequestByIdString( '/wc/v4/products/categories', category => ( {
 					id: category.id,
 					label: category.name,
 				} ) ),

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -86,7 +86,7 @@ const filterConfig = {
 			settings: {
 				type: 'categories',
 				param: 'categories',
-				getLabels: getRequestByIdString( '/wc/v4/products/categories', category => ( {
+				getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
 					id: category.id,
 					label: category.name,
 				} ) ),

--- a/client/store/constants.js
+++ b/client/store/constants.js
@@ -2,7 +2,7 @@
  * @format
  */
 
-export const NAMESPACE = '/wc/v3/';
+export const NAMESPACE = '/wc/v4/';
 export const SWAGGERNAMESPACE = 'https://virtserver.swaggerhub.com/peterfabian/wc-v3-api/1.0.0/';
 export const ERROR = 'ERROR';
 

--- a/client/store/notes/test/resolvers.js
+++ b/client/store/notes/test/resolvers.js
@@ -29,10 +29,10 @@ describe( 'getNotes', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v3/admin/notes' ) {
+			if ( options.path === '/wc/v4/admin/notes' ) {
 				return Promise.resolve( NOTES_1 );
 			}
-			if ( options.path === '/wc/v3/admin/notes?page=2' ) {
+			if ( options.path === '/wc/v4/admin/notes?page=2' ) {
 				return Promise.resolve( NOTES_2 );
 			}
 		} );

--- a/client/store/notes/test/resolvers.js
+++ b/client/store/notes/test/resolvers.js
@@ -11,6 +11,7 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from 'store/constants';
 import resolvers from '../resolvers';
 
 const { getNotes } = resolvers;
@@ -29,10 +30,10 @@ describe( 'getNotes', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v4/admin/notes' ) {
+			if ( options.path === NAMESPACE + 'admin/notes' ) {
 				return Promise.resolve( NOTES_1 );
 			}
-			if ( options.path === '/wc/v4/admin/notes?page=2' ) {
+			if ( options.path === NAMESPACE + 'admin/notes?page=2' ) {
 				return Promise.resolve( NOTES_2 );
 			}
 		} );

--- a/client/store/orders/test/resolvers.js
+++ b/client/store/orders/test/resolvers.js
@@ -29,10 +29,10 @@ describe( 'getOrders', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v3/orders' ) {
+			if ( options.path === '/wc/v4/orders' ) {
 				return Promise.resolve( ORDERS_1 );
 			}
-			if ( options.path === '/wc/v3/orders?orderby=id' ) {
+			if ( options.path === '/wc/v4/orders?orderby=id' ) {
 				return Promise.resolve( ORDERS_2 );
 			}
 		} );

--- a/client/store/orders/test/resolvers.js
+++ b/client/store/orders/test/resolvers.js
@@ -11,6 +11,7 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from 'store/constants';
 import resolvers from '../resolvers';
 
 const { getOrders } = resolvers;
@@ -29,10 +30,10 @@ describe( 'getOrders', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v4/orders' ) {
+			if ( options.path === NAMESPACE + 'orders' ) {
 				return Promise.resolve( ORDERS_1 );
 			}
-			if ( options.path === '/wc/v4/orders?orderby=id' ) {
+			if ( options.path === NAMESPACE + 'orders?orderby=id' ) {
 				return Promise.resolve( ORDERS_2 );
 			}
 		} );

--- a/client/store/reports/items/test/resolvers.js
+++ b/client/store/reports/items/test/resolvers.js
@@ -31,7 +31,7 @@ describe( 'getReportItems', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === `/wc/v3/reports/${ endpoint }` ) {
+			if ( options.path === `/wc/v4/reports/${ endpoint }` ) {
 				return Promise.resolve( {
 					headers: {
 						get: () => ITEMS_1_COUNT,
@@ -39,7 +39,7 @@ describe( 'getReportItems', () => {
 					json: () => Promise.resolve( ITEMS_1 ),
 				} );
 			}
-			if ( options.path === `/wc/v3/reports/${ endpoint }?orderby=id` ) {
+			if ( options.path === `/wc/v4/reports/${ endpoint }?orderby=id` ) {
 				return Promise.resolve( {
 					headers: {
 						get: () => ITEMS_2_COUNT,

--- a/client/store/reports/stats/test/resolvers.js
+++ b/client/store/reports/stats/test/resolvers.js
@@ -55,7 +55,7 @@ describe( 'getReportStats', () => {
 
 	beforeAll( () => {
 		apiFetch.mockImplementation( options => {
-			if ( options.path === '/wc/v3/reports/revenue/stats' ) {
+			if ( options.path === '/wc/v4/reports/revenue/stats' ) {
 				return Promise.resolve( {
 					headers: {
 						get: header => REPORT_1_TOTALS[ header ],
@@ -63,7 +63,7 @@ describe( 'getReportStats', () => {
 					json: () => Promise.resolve( REPORT_1 ),
 				} );
 			}
-			if ( options.path === '/wc/v3/reports/products/stats?interval=week' ) {
+			if ( options.path === '/wc/v4/reports/products/stats?interval=week' ) {
 				return Promise.resolve( {
 					headers: {
 						get: header => REPORT_2_TOTALS[ header ],

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -4,7 +4,7 @@
  */
 import { SECOND, MINUTE } from '@fresh-data/framework';
 
-export const NAMESPACE = '/wc/v3';
+export const NAMESPACE = '/wc/v4';
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 5 * SECOND,

--- a/docs/components/analytics/report-summary.md
+++ b/docs/components/analytics/report-summary.md
@@ -22,7 +22,7 @@ Properties of all the charts available for that report.
 
 The endpoint to use in API calls to populate the Summary Numbers.
 For example, if `taxes` is provided, data will be fetched from the report
-`taxes` endpoint (ie: `/wc/v3/reports/taxes/stats`). If the provided endpoint
+`taxes` endpoint (ie: `/wc/v4/reports/taxes/stats`). If the provided endpoint
 doesn't exist, an error will be shown to the user with `ReportError`.
 
 ### `query`

--- a/docs/components/analytics/report-table.md
+++ b/docs/components/analytics/report-table.md
@@ -20,7 +20,7 @@ The key for user preferences settings for column visibility.
 
 The endpoint to use in API calls to populate the table rows and summary.
 For example, if `taxes` is provided, data will be fetched from the report
-`taxes` endpoint (ie: `/wc/v3/reports/taxes` and `/wc/v3/reports/taxes/stats`).
+`taxes` endpoint (ie: `/wc/v4/reports/taxes` and `/wc/v4/reports/taxes/stats`).
 If the provided endpoint doesn't exist, an error will be shown to the user
 with `ReportError`.
 

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-coupons-controller.php
+++ b/includes/api/class-wc-admin-rest-coupons-controller.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * REST API Coupons Controller
+ *
+ * Handles requests to /coupons/*
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Coupons controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Coupons_Controller
+ */
+class WC_Admin_REST_Coupons_Controller extends WC_REST_Coupons_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+}

--- a/includes/api/class-wc-admin-rest-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-customers-controller.php
@@ -20,6 +20,13 @@ class WC_Admin_REST_Customers_Controller extends WC_REST_Customers_Controller {
 	// TODO Add support for guests here. See https://wp.me/p7bje6-1dM.
 
 	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
 	 * Searches emails by partial search instead of a strict match.
 	 * See "search parameters" under https://codex.wordpress.org/Class_Reference/WP_User_Query.
 	 *

--- a/includes/api/class-wc-admin-rest-data-controller.php
+++ b/includes/api/class-wc-admin-rest-data-controller.php
@@ -18,6 +18,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Admin_REST_Data_Controller extends WC_REST_Data_Controller {
 
 	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
 	 * Return the list of data resources.
 	 *
 	 * @param  WP_REST_Request $request Request data.

--- a/includes/api/class-wc-admin-rest-data-download-ips-controller.php
+++ b/includes/api/class-wc-admin-rest-data-download-ips-controller.php
@@ -21,7 +21,7 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -15,7 +15,14 @@ defined( 'ABSPATH' ) || exit;
  * @package WooCommerce Admin/API
  * @extends WC_REST_Orders_Controller
  */
-class WC_Admin_REST_Orders_Stats_Controller extends WC_REST_Orders_Controller {
+class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
 	/**
 	 * Get the query params for collections.
 	 *

--- a/includes/api/class-wc-admin-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-admin-rest-product-reviews-controller.php
@@ -16,6 +16,12 @@ defined( 'ABSPATH' ) || exit;
  * @extends WC_REST_Product_Reviews_Controller
  */
 class WC_Admin_REST_Product_Reviews_Controller extends WC_REST_Product_Reviews_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Prepare links for the request.

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -18,6 +18,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 
 	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
 	 * Adds properties that can be embed via ?_embed=1.
 	 *
 	 * @return array

--- a/includes/api/class-wc-admin-rest-reports-categories-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-categories-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-coupons-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-coupons-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Coupons_Controller extends WC_REST_Reports_Controlle
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-coupons-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-coupons-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Coupons_Stats_Controller extends WC_REST_Reports_Con
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-downloads-files-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-files-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Downloads_Files_Controller extends WC_REST_Reports_C
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_Admin_REST_Report
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.
@@ -53,7 +53,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 	public function get_allowed_stats() {
 		global $wp_rest_server;
 
-		$request       = new WP_REST_Request( 'GET', '/wc/v3/reports' );
+		$request       = new WP_REST_Request( 'GET', '/wc/v4/reports' );
 		$response      = rest_do_request( $request );
 		$endpoints     = $response->get_data();
 		$allowed_stats = array();
@@ -63,7 +63,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 
 		foreach ( $endpoints as $endpoint ) {
 			if ( '/stats' === substr( $endpoint['slug'], -6 ) ) {
-				$request  = new WP_REST_Request( 'OPTIONS', '/wc/v3/reports/' . $endpoint['slug'] );
+				$request  = new WP_REST_Request( 'OPTIONS', '/wc/v4/reports/' . $endpoint['slug'] );
 				$response = rest_do_request( $request );
 				$data     = $response->get_data();
 				$prefix   = substr( $endpoint['slug'], 0, -6 );
@@ -126,7 +126,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 			if ( ! empty( $stats_endpoints [ $endpoint ] ) ) {
 				$request_url = $stats_endpoints [ $endpoint ];
 			} else {
-				$request_url = '/wc/v3/reports/' . $endpoint . '/stats';
+				$request_url = '/wc/v4/reports/' . $endpoint . '/stats';
 			}
 
 			$request = new WP_REST_Request( 'GET', $request_url );

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Revenue_Stats_Controller extends WC_REST_Reports_Con
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-reports-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-variations-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_Reports_Variations_Controller extends WC_REST_Reports_Contro
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-admin-rest-system-status-tools-controller.php
@@ -22,7 +22,7 @@ class WC_Admin_REST_System_Status_Tools_Controller extends WC_REST_System_Status
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/v4';
 
 	/**
 	 * A list of available tools for use in the system status section.

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -227,112 +227,112 @@ class WC_Admin_Api_Init {
 	 * @return array
 	 */
 	public static function filter_rest_endpoints( $endpoints ) {
-		// Override GET /wc/v3/system_status/tools.
-		if ( isset( $endpoints['/wc/v3/system_status/tools'] )
-			&& isset( $endpoints['/wc/v3/system_status/tools'][1] )
-			&& isset( $endpoints['/wc/v3/system_status/tools'][0] )
-			&& $endpoints['/wc/v3/system_status/tools'][1]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
+		// Override GET /wc/v4/system_status/tools.
+		if ( isset( $endpoints['/wc/v4/system_status/tools'] )
+			&& isset( $endpoints['/wc/v4/system_status/tools'][1] )
+			&& isset( $endpoints['/wc/v4/system_status/tools'][0] )
+			&& $endpoints['/wc/v4/system_status/tools'][1]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
 		) {
-			$endpoints['/wc/v3/system_status/tools'][0] = $endpoints['/wc/v3/system_status/tools'][1];
+			$endpoints['/wc/v4/system_status/tools'][0] = $endpoints['/wc/v4/system_status/tools'][1];
 		}
-		// // Override GET & PUT for /wc/v3/system_status/tools.
-		if ( isset( $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'] )
-			&& isset( $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][3] )
-			&& isset( $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][2] )
-			&& $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][2]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
-			&& $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][3]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
+		// // Override GET & PUT for /wc/v4/system_status/tools.
+		if ( isset( $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'] )
+			&& isset( $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][3] )
+			&& isset( $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][2] )
+			&& $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][2]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
+			&& $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][3]['callback'][0] instanceof WC_Admin_REST_System_Status_Tools_Controller
 		) {
-			$endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][0] = $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][2];
-			$endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][1] = $endpoints['/wc/v3/system_status/tools/(?P<id>[\w-]+)'][3];
-		}
-
-		// Override GET /wc/v3/reports.
-		if ( isset( $endpoints['/wc/v3/reports'] )
-			&& isset( $endpoints['/wc/v3/reports'][1] )
-			&& isset( $endpoints['/wc/v3/reports'][0] )
-			&& $endpoints['/wc/v3/reports'][1]['callback'][0] instanceof WC_Admin_REST_Reports_Controller
-		) {
-			$endpoints['/wc/v3/reports'][0] = $endpoints['/wc/v3/reports'][1];
+			$endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][0] = $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][2];
+			$endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][1] = $endpoints['/wc/v4/system_status/tools/(?P<id>[\w-]+)'][3];
 		}
 
-		// Override /wc/v3/customers.
-		if ( isset( $endpoints['/wc/v3/customers'] )
-			&& isset( $endpoints['/wc/v3/customers'][3] )
-			&& isset( $endpoints['/wc/v3/customers'][2] )
-			&& $endpoints['/wc/v3/customers'][2]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
-			&& $endpoints['/wc/v3/customers'][3]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
+		// Override GET /wc/v4/reports.
+		if ( isset( $endpoints['/wc/v4/reports'] )
+			&& isset( $endpoints['/wc/v4/reports'][1] )
+			&& isset( $endpoints['/wc/v4/reports'][0] )
+			&& $endpoints['/wc/v4/reports'][1]['callback'][0] instanceof WC_Admin_REST_Reports_Controller
 		) {
-			$endpoints['/wc/v3/customers'][0] = $endpoints['/wc/v3/customers'][2];
-			$endpoints['/wc/v3/customers'][1] = $endpoints['/wc/v3/customers'][3];
+			$endpoints['/wc/v4/reports'][0] = $endpoints['/wc/v4/reports'][1];
 		}
 
-		// Override /wc/v3/orders/$id.
-		if ( isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'] )
-			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5] )
-			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4] )
-			&& isset( $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3] )
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
-			&& $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
+		// Override /wc/v4/customers.
+		if ( isset( $endpoints['/wc/v4/customers'] )
+			&& isset( $endpoints['/wc/v4/customers'][3] )
+			&& isset( $endpoints['/wc/v4/customers'][2] )
+			&& $endpoints['/wc/v4/customers'][2]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
+			&& $endpoints['/wc/v4/customers'][3]['callback'][0] instanceof WC_Admin_REST_Customers_Controller
 		) {
-			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][0] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][3];
-			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][1] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][4];
-			$endpoints['/wc/v3/orders/(?P<id>[\d]+)'][2] = $endpoints['/wc/v3/orders/(?P<id>[\d]+)'][5];
+			$endpoints['/wc/v4/customers'][0] = $endpoints['/wc/v4/customers'][2];
+			$endpoints['/wc/v4/customers'][1] = $endpoints['/wc/v4/customers'][3];
 		}
 
-		// Override /wc/v3orders.
-		if ( isset( $endpoints['/wc/v3/orders'] )
-			&& isset( $endpoints['/wc/v3/orders'][3] )
-			&& isset( $endpoints['/wc/v3/orders'][2] )
-			&& $endpoints['/wc/v3/orders'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
-			&& $endpoints['/wc/v3/orders'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Stats_Controller
+		// Override /wc/v4/orders/$id.
+		if ( isset( $endpoints['/wc/v4/orders/(?P<id>[\d]+)'] )
+			&& isset( $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][5] )
+			&& isset( $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][4] )
+			&& isset( $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][3] )
+			&& $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
 		) {
-			$endpoints['/wc/v3/orders'][0] = $endpoints['/wc/v3/orders'][2];
-			$endpoints['/wc/v3/orders'][1] = $endpoints['/wc/v3/orders'][3];
+			$endpoints['/wc/v4/orders/(?P<id>[\d]+)'][0] = $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][3];
+			$endpoints['/wc/v4/orders/(?P<id>[\d]+)'][1] = $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][4];
+			$endpoints['/wc/v4/orders/(?P<id>[\d]+)'][2] = $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][5];
 		}
 
-		// Override /wc/v3/data.
-		if ( isset( $endpoints['/wc/v3/data'] )
-			&& isset( $endpoints['/wc/v3/data'][1] )
-			&& $endpoints['/wc/v3/data'][1]['callback'][0] instanceof WC_Admin_REST_Data_Controller
+		// Override /wc/v4orders.
+		if ( isset( $endpoints['/wc/v4/orders'] )
+			&& isset( $endpoints['/wc/v4/orders'][3] )
+			&& isset( $endpoints['/wc/v4/orders'][2] )
+			&& $endpoints['/wc/v4/orders'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v4/orders'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
 		) {
-			$endpoints['/wc/v3/data'][0] = $endpoints['/wc/v3/data'][1];
+			$endpoints['/wc/v4/orders'][0] = $endpoints['/wc/v4/orders'][2];
+			$endpoints['/wc/v4/orders'][1] = $endpoints['/wc/v4/orders'][3];
 		}
 
-		// Override /wc/v3/products.
-		if ( isset( $endpoints['/wc/v3/products'] )
-			&& isset( $endpoints['/wc/v3/products'][3] )
-			&& isset( $endpoints['/wc/v3/products'][2] )
-			&& $endpoints['/wc/v3/products'][2]['callback'][0] instanceof WC_Admin_REST_Products_Controller
-			&& $endpoints['/wc/v3/products'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+		// Override /wc/v4/data.
+		if ( isset( $endpoints['/wc/v4/data'] )
+			&& isset( $endpoints['/wc/v4/data'][1] )
+			&& $endpoints['/wc/v4/data'][1]['callback'][0] instanceof WC_Admin_REST_Data_Controller
 		) {
-			$endpoints['/wc/v3/products'][0] = $endpoints['/wc/v3/products'][2];
-			$endpoints['/wc/v3/products'][1] = $endpoints['/wc/v3/products'][3];
+			$endpoints['/wc/v4/data'][0] = $endpoints['/wc/v4/data'][1];
 		}
 
-		// Override /wc/v3/products/$id.
-		if ( isset( $endpoints['/wc/v3/products/(?P<id>[\d]+)'] )
-			&& isset( $endpoints['/wc/v3/products/(?P<id>[\d]+)'][5] )
-			&& isset( $endpoints['/wc/v3/products/(?P<id>[\d]+)'][4] )
-			&& isset( $endpoints['/wc/v3/products/(?P<id>[\d]+)'][3] )
-			&& $endpoints['/wc/v3/products/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
-			&& $endpoints['/wc/v3/products/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Products_Controller
-			&& $endpoints['/wc/v3/products/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+		// Override /wc/v4/products.
+		if ( isset( $endpoints['/wc/v4/products'] )
+			&& isset( $endpoints['/wc/v4/products'][3] )
+			&& isset( $endpoints['/wc/v4/products'][2] )
+			&& $endpoints['/wc/v4/products'][2]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+			&& $endpoints['/wc/v4/products'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
 		) {
-			$endpoints['/wc/v3/products/(?P<id>[\d]+)'][0] = $endpoints['/wc/v3/products/(?P<id>[\d]+)'][3];
-			$endpoints['/wc/v3/products/(?P<id>[\d]+)'][1] = $endpoints['/wc/v3/products/(?P<id>[\d]+)'][4];
-			$endpoints['/wc/v3/products/(?P<id>[\d]+)'][2] = $endpoints['/wc/v3/products/(?P<id>[\d]+)'][5];
+			$endpoints['/wc/v4/products'][0] = $endpoints['/wc/v4/products'][2];
+			$endpoints['/wc/v4/products'][1] = $endpoints['/wc/v4/products'][3];
 		}
 
-		// Override /wc/v3/products/reviews.
-		if ( isset( $endpoints['/wc/v3/products/reviews'] )
-			&& isset( $endpoints['/wc/v3/products/reviews'][3] )
-			&& isset( $endpoints['/wc/v3/products/reviews'][2] )
-			&& $endpoints['/wc/v3/products/reviews'][2]['callback'][0] instanceof WC_Admin_REST_Product_Reviews_Controller
-			&& $endpoints['/wc/v3/products/reviews'][3]['callback'][0] instanceof WC_Admin_REST_Product_Reviews_Controller
+		// Override /wc/v4/products/$id.
+		if ( isset( $endpoints['/wc/v4/products/(?P<id>[\d]+)'] )
+			&& isset( $endpoints['/wc/v4/products/(?P<id>[\d]+)'][5] )
+			&& isset( $endpoints['/wc/v4/products/(?P<id>[\d]+)'][4] )
+			&& isset( $endpoints['/wc/v4/products/(?P<id>[\d]+)'][3] )
+			&& $endpoints['/wc/v4/products/(?P<id>[\d]+)'][3]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+			&& $endpoints['/wc/v4/products/(?P<id>[\d]+)'][4]['callback'][0] instanceof WC_Admin_REST_Products_Controller
+			&& $endpoints['/wc/v4/products/(?P<id>[\d]+)'][5]['callback'][0] instanceof WC_Admin_REST_Products_Controller
 		) {
-			$endpoints['/wc/v3/products/reviews'][0] = $endpoints['/wc/v3/products/reviews'][2];
-			$endpoints['/wc/v3/products/reviews'][1] = $endpoints['/wc/v3/products/reviews'][3];
+			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][0] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][3];
+			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][1] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][4];
+			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][2] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][5];
+		}
+
+		// Override /wc/v4/products/reviews.
+		if ( isset( $endpoints['/wc/v4/products/reviews'] )
+			&& isset( $endpoints['/wc/v4/products/reviews'][3] )
+			&& isset( $endpoints['/wc/v4/products/reviews'][2] )
+			&& $endpoints['/wc/v4/products/reviews'][2]['callback'][0] instanceof WC_Admin_REST_Product_Reviews_Controller
+			&& $endpoints['/wc/v4/products/reviews'][3]['callback'][0] instanceof WC_Admin_REST_Product_Reviews_Controller
+		) {
+			$endpoints['/wc/v4/products/reviews'][0] = $endpoints['/wc/v4/products/reviews'][2];
+			$endpoints['/wc/v4/products/reviews'][1] = $endpoints['/wc/v4/products/reviews'][3];
 		}
 
 		return $endpoints;

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -158,7 +158,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
-		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-stats-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
@@ -188,7 +188,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Customers_Controller',
 				'WC_Admin_REST_Data_Controller',
 				'WC_Admin_REST_Data_Download_Ips_Controller',
-				'WC_Admin_REST_Orders_Stats_Controller',
+				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Reviews_Controller',
 				'WC_Admin_REST_Reports_Controller',

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -155,6 +155,7 @@ class WC_Admin_Api_Init {
 	 */
 	public function rest_api_init() {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-admin-notes-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-coupons-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
@@ -185,6 +186,7 @@ class WC_Admin_Api_Init {
 			'woocommerce_admin_rest_controllers',
 			array(
 				'WC_Admin_REST_Admin_Notes_Controller',
+				'WC_Admin_REST_Coupons_Controller',
 				'WC_Admin_REST_Customers_Controller',
 				'WC_Admin_REST_Data_Controller',
 				'WC_Admin_REST_Data_Download_Ips_Controller',
@@ -255,6 +257,17 @@ class WC_Admin_Api_Init {
 			$endpoints['/wc/v4/reports'][0] = $endpoints['/wc/v4/reports'][1];
 		}
 
+		// Override /wc/v4/coupons.
+		if ( isset( $endpoints['/wc/v4/coupons'] )
+			&& isset( $endpoints['/wc/v4/coupons'][3] )
+			&& isset( $endpoints['/wc/v4/coupons'][2] )
+			&& $endpoints['/wc/v4/coupons'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v4/coupons'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+		) {
+			$endpoints['/wc/v4/coupons'][0] = $endpoints['/wc/v4/coupons'][2];
+			$endpoints['/wc/v4/coupons'][1] = $endpoints['/wc/v4/coupons'][3];
+		}
+
 		// Override /wc/v4/customers.
 		if ( isset( $endpoints['/wc/v4/customers'] )
 			&& isset( $endpoints['/wc/v4/customers'][3] )
@@ -280,7 +293,7 @@ class WC_Admin_Api_Init {
 			$endpoints['/wc/v4/orders/(?P<id>[\d]+)'][2] = $endpoints['/wc/v4/orders/(?P<id>[\d]+)'][5];
 		}
 
-		// Override /wc/v4orders.
+		// Override /wc/v4/orders.
 		if ( isset( $endpoints['/wc/v4/orders'] )
 			&& isset( $endpoints['/wc/v4/orders'][3] )
 			&& isset( $endpoints['/wc/v4/orders'][2] )

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -250,8 +250,9 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			}
 
 			$mapped_data[ $product['order_id'] ]['products'][] = array(
-				'id'   => $product['product_id'],
-				'name' => $product['product_name'],
+				'id'       => $product['product_id'],
+				'name'     => $product['product_name'],
+				'quantity' => $product['product_quantity'],
 			);
 			$mapped_data[ $product['order_id'] ]['categories'] = array_unique(
 				array_merge(
@@ -262,7 +263,14 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		foreach ( $orders_data as $key => $order_data ) {
-			$orders_data[ $key ]['extended_info'] = $mapped_data[ $order_data['order_id'] ];
+			if ( isset( $mapped_data[ $order_data['order_id'] ] ) ) {
+				$orders_data[ $key ]['extended_info'] = $mapped_data[ $order_data['order_id'] ];
+			} else {
+				$orders_data[ $key ]['extended_info'] = array(
+					'products'   => array(),
+					'categories' => array(),
+				);
+			}
 		}
 	}
 
@@ -293,7 +301,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		$included_order_ids         = implode( ',', $order_ids );
 
 		$products = $wpdb->get_results(
-			"SELECT order_id, ID as product_id, post_title as product_name
+			"SELECT order_id, ID as product_id, post_title as product_name, product_qty as product_quantity
 				FROM {$wpdb->prefix}posts
 				JOIN {$order_product_lookup_table} ON {$order_product_lookup_table}.product_id = {$wpdb->prefix}posts.ID
 				WHERE 

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -42,7 +42,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	protected $report_columns = array(
 		'order_id'       => 'order_id',
 		'date_created'   => 'date_created',
-		'status'         => 'status',
+		'status'         => 'REPLACE(status, "wc-", "") as status',
 		'customer_id'    => 'customer_id',
 		'net_total'      => 'net_total',
 		'num_items_sold' => 'num_items_sold',

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -270,7 +270,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 			$mapped_data[ $coupon['order_id'] ]['coupons'][] = array(
 				'id'   => $coupon['coupon_id'],
-				'code' => $coupon['coupon_code'],
+				'code' => wc_format_coupon_code( $coupon['coupon_code'] ),
 			);
 		}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -153,7 +153,7 @@ function wc_admin_print_script_settings() {
 	}
 
 	$preload_data_endpoints = array(
-		'countries' => '/wc/v3/data/countries',
+		'countries' => '/wc/v4/data/countries',
 	);
 
 	if ( function_exists( 'gutenberg_preload_api_request' ) ) {

--- a/packages/components/src/search/autocompleters/coupons.js
+++ b/packages/components/src/search/autocompleters/coupons.js
@@ -32,7 +32,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/coupons${ payload }` } );
+		return apiFetch( { path: `/wc/v4/coupons${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( coupon ) {

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -34,7 +34,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/customers${ payload }` } );
+		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/download-ips.js
+++ b/packages/components/src/search/autocompleters/download-ips.js
@@ -30,7 +30,7 @@ export default {
 				match,
 			};
 			payload = stringifyQuery( query );
-			return apiFetch( { path: `/wc/v3/data/download-ips${ payload }` } );
+			return apiFetch( { path: `/wc/v4/data/download-ips${ payload }` } );
 		}
 	},
 	isDebounced: true,

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -32,7 +32,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/customers${ payload }` } );
+		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -38,7 +38,7 @@ export default {
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );
-			return apiFetch( { path: `/wc/v3/orders${ payload }` } );
+			return apiFetch( { path: `/wc/v4/orders${ payload }` } );
 		}
 	},
 	isDebounced: true,

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -34,7 +34,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/products${ payload }` } );
+		return apiFetch( { path: `/wc/v4/products${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( product ) {

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -32,7 +32,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/taxes${ payload }` } );
+		return apiFetch( { path: `/wc/v4/taxes${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( tax ) {

--- a/packages/components/src/search/autocompleters/usernames.js
+++ b/packages/components/src/search/autocompleters/usernames.js
@@ -29,7 +29,7 @@ export default {
 			};
 			payload = stringifyQuery( query );
 		}
-		return apiFetch( { path: `/wc/v3/customers${ payload }` } );
+		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -52,7 +52,7 @@ export default {
 		if ( ! product || product.includes( ',' ) ) {
 			console.warn( 'Invalid product id supplied to Variations autocompleter' );
 		}
-		return apiFetch( { path: `/wc/v3/products/${ product }/variations${ payload }` } );
+		return apiFetch( { path: `/wc/v4/products/${ product }/variations${ payload }` } );
 	},
 	isDebounced: true,
 	getOptionKeywords( variation ) {

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/admin/notes';
+	protected $endpoint = '/wc/v4/admin/notes';
 
 	/**
 	 * Setup test admin notes data. Called before every test.

--- a/tests/api/data.php
+++ b/tests/api/data.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Data extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/data';
+	protected $endpoint = '/wc/v4/data';
 
 	/**
 	 * Setup test data. Called before every test.

--- a/tests/api/orders.php
+++ b/tests/api/orders.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/orders';
+	protected $endpoint = '/wc/v4/orders';
 
 	/**
 	 * Setup test data. Called before every test.

--- a/tests/api/product-reviews.php
+++ b/tests/api/product-reviews.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/products/reviews';
+	protected $endpoint = '/wc/v4/products/reviews';
 
 	/**
 	 * Setup test data. Called before every test.
@@ -38,7 +38,7 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 		$product    = WC_Helper_Product::create_simple_product();
 		WC_Helper_Product::create_product_review( $product->get_id() );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/products/reviews' );
+		$request = new WP_REST_Request( 'GET', '/wc/v4/products/reviews' );
 
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();

--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/products';
+	protected $endpoint = '/wc/v4/products';
 
 	/**
 	 * Setup test data. Called before every test.
@@ -36,7 +36,7 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 	public function test_product_schema() {
 		wp_set_current_user( $this->user );
 		$product    = WC_Helper_Product::create_simple_product();
-		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/products/' . $product->get_id() );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v4/products/' . $product->get_id() );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];

--- a/tests/api/reports-categories.php
+++ b/tests/api/reports-categories.php
@@ -16,7 +16,7 @@ class WC_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/categories';
+	protected $endpoint = '/wc/v4/reports/categories';
 
 	/**
 	 * Setup test reports categories data.

--- a/tests/api/reports-coupons-stats.php
+++ b/tests/api/reports-coupons-stats.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Reports_Coupons_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/coupons/stats';
+	protected $endpoint = '/wc/v4/reports/coupons/stats';
 
 	/**
 	 * Setup test reports products stats data.

--- a/tests/api/reports-coupons.php
+++ b/tests/api/reports-coupons.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Reports_Coupons extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/coupons';
+	protected $endpoint = '/wc/v4/reports/coupons';
 
 	/**
 	 * Setup test reports products data.

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -18,7 +18,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/customers';
+	protected $endpoint = '/wc/v4/reports/customers';
 
 	/**
 	 * Setup test reports products data.

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/downloads/stats';
+	protected $endpoint = '/wc/v4/reports/downloads/stats';
 
 	/**
 	 * Setup test reports downloads data.

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/downloads';
+	protected $endpoint = '/wc/v4/reports/downloads';
 
 	/**
 	 * Setup test reports downloads data.

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Class WC_Tests_API_Reports_Orders_Stats
+ */
 class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -12,7 +16,7 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/orders/stats';
+	protected $endpoint = '/wc/v4/reports/orders/stats';
 
 	/**
 	 * Setup test reports orders data.

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/performance-indicators';
+	protected $endpoint = '/wc/v4/reports/performance-indicators';
 
 	/**
 	 * Setup tests.

--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -16,7 +16,7 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/products/stats';
+	protected $endpoint = '/wc/v4/reports/products/stats';
 
 	/**
 	 * Setup test reports products stats data.

--- a/tests/api/reports-products.php
+++ b/tests/api/reports-products.php
@@ -19,7 +19,7 @@ class WC_Tests_API_Reports_Products extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/products';
+	protected $endpoint = '/wc/v4/reports/products';
 
 	/**
 	 * Setup test reports products data.

--- a/tests/api/reports-revenue-stats.php
+++ b/tests/api/reports-revenue-stats.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Class WC_Tests_API_Reports_Revenue_Stats
+ */
 class WC_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -12,8 +16,13 @@ class WC_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/revenue/stats';
+	protected $endpoint = '/wc/v4/reports/revenue/stats';
 
+	/**
+	 * Orders
+	 *
+	 * @var array
+	 */
 	protected $orders = array();
 
 	/**
@@ -56,7 +65,7 @@ class WC_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $data ) ); // @todo update results after implement report interface.
-		//$this->assertEquals( array(), $reports ); // @todo update results after implement report interface.
+		// $this->assertEquals( array(), $reports ); // @todo update results after implement report interface.
 	}
 
 	/**

--- a/tests/api/reports-stock.php
+++ b/tests/api/reports-stock.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Class WC_Tests_API_Reports_Stock
+ */
 class WC_Tests_API_Reports_Stock extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -12,7 +16,7 @@ class WC_Tests_API_Reports_Stock extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/stock';
+	protected $endpoint = '/wc/v4/reports/stock';
 
 	/**
 	 * Setup test reports stock data.

--- a/tests/api/reports-taxes-stats.php
+++ b/tests/api/reports-taxes-stats.php
@@ -16,7 +16,7 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/taxes/stats';
+	protected $endpoint = '/wc/v4/reports/taxes/stats';
 
 	/**
 	 * Setup test reports taxes data.

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -16,7 +16,7 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/taxes';
+	protected $endpoint = '/wc/v4/reports/taxes';
 
 	/**
 	 * Setup test reports taxes data.

--- a/tests/api/reports-variations.php
+++ b/tests/api/reports-variations.php
@@ -16,7 +16,7 @@ class WC_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v3/reports/variations';
+	protected $endpoint = '/wc/v4/reports/variations';
 
 	/**
 	 * Setup test reports products data.


### PR DESCRIPTION
Fixes #1264 

Bumps all wc-admin endpoints to v4 and hooks up the orders page.

### Screenshots
<img width="1111" alt="screen shot 2019-01-16 at 5 39 38 pm" src="https://user-images.githubusercontent.com/10561050/51239977-b81a0a00-19b5-11e9-8050-b0bf5d170fe2.png">

### Detailed test instructions:

1.  Go through each wc-admin page. 
2.  Make sure pages are loading without any API 404 errors and data still loads correctly.
3.  Check that the Orders report loads the correct data with the new orders endpoint hooked up.
4.  Check that orders report contains the correct coupon data.
5.  Make sure all tests are passing.