### PR TITLE
Set eslint React version to 'detect'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,11 @@
 		"wpApiSettings": true,
 		"wcSettings": true,
 	},
+	"settings": {
+		"react": {
+			"version": "detect",
+		},
+	},
 	"rules": {
 		"camelcase": 0,
 		"indent": 0,


### PR DESCRIPTION
A warning was appearing in every commit after a change in `eslint-plugin-react` that required the React version to be specified in the eslint config:

```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```

More info can be found here: https://github.com/yannickcr/eslint-plugin-react/issues/1955.

This PR adds the React version to `.eslintrc`.

### Detailed test instructions:
- Make any dumb change in a file, `git add` it and run `git commit -m "123"`.
- Verify the warning does not appear.