### PR TITLE
Fix watch package files in Linux

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -5,6 +5,7 @@ const fs = require( 'fs' );
 const { execSync } = require( 'child_process' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
+const watch = require( 'node-watch' );
 
 /**
  * Internal dependencies
@@ -33,14 +34,14 @@ getPackages().forEach( ( p ) => {
 	const srcDir = path.resolve( p, 'src' );
 	try {
 		fs.accessSync( srcDir, fs.F_OK );
-		fs.watch( path.resolve( p, 'src' ), { recursive: true }, ( event, filename ) => {
+		watch( path.resolve( p, 'src' ), { recursive: true }, ( event, filename ) => {
 			const filePath = path.resolve( srcDir, filename );
 
 			if ( ! isSourceFile( filename ) ) {
 				return;
 			}
 
-			if ( ( event === 'change' || event === 'rename' ) && exists( filePath ) ) {
+			if ( ( [ 'update', 'change', 'rename' ].includes( event ) ) && exists( filePath ) ) {
 				// eslint-disable-next-line no-console
 				console.log( chalk.green( '->' ), `${ event }: ${ filename }` );
 				rebuild( filePath );

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "husky": "1.3.1",
     "lerna": "3.10.5",
     "node-sass": "4.11.0",
+    "node-watch": "^0.6.0",
     "postcss-color-function": "4.0.1",
     "postcss-loader": "3.0.0",
     "prettier": "github:automattic/calypso-prettier#c56b4251",


### PR DESCRIPTION
`fs.watch()` [doesn't work recursively in Linux](https://nodejs.org/api/fs.html#fs_caveats), that made modifying `packages` files a nightmare, because you had to call `npm start` or `npm build:packages` everytime you modified a file.

There is a NPM package that seems to work the same as `fs.watch` and fixes that and other issues:

https://github.com/yuanchuan/node-watch

### Detailed test instructions:
It would be great to verify this PR doesn't cause any regression in Mac OS/Windows:
- Run `npm start`.
- Make a change in a file inside `packages` folder.
- Refresh the browser and verify the change has been applied.