### PR TITLE
Fix javascript conflict with Gutenberg Products block plugin.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
 	"globals": {
 		"wp": true,
 		"wpApiSettings": true,
-		"wcSettings": true,
+		"wcAdminSettings": true,
 	},
 	"rules": {
 		"camelcase": 0,

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -90,7 +90,7 @@ export const advancedFilters = {
 				type: 'countries',
 				getLabels: async value => {
 					const countries =
-						( wcSettings.dataEndpoints && wcSettings.dataEndpoints.countries ) || [];
+						( wcAdminSettings.dataEndpoints && wcAdminSettings.dataEndpoints.countries ) || [];
 
 					const allLabels = countries.map( country => ( {
 						id: country.code,

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -10,7 +10,7 @@ import { __, _x } from '@wordpress/i18n';
 import { getRequestByIdString } from 'lib/async-requests';
 import { NAMESPACE } from 'store/constants';
 
-const { orderStatuses } = wcSettings;
+const { orderStatuses } = wcAdminSettings;
 
 export const charts = [
 	{

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -71,7 +71,7 @@ export default class VariationsReportTable extends Component {
 	}
 
 	getRowsContent( data = [] ) {
-		const { stockStatuses } = wcSettings;
+		const { stockStatuses } = wcAdminSettings;
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -90,7 +90,7 @@ class ProductsReportTable extends Component {
 	}
 
 	getRowsContent( data = [] ) {
-		const { stockStatuses } = wcSettings;
+		const { stockStatuses } = wcAdminSettings;
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -56,7 +56,7 @@ export default class StockReportTable extends Component {
 	getRowsContent( products ) {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
-		const { stockStatuses } = wcSettings;
+		const { stockStatuses } = wcAdminSettings;
 
 		return products.map( product => {
 			const { id, name, parent_id, sku, stock_quantity, stock_status } = product;

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -72,7 +72,7 @@ class Header extends Component {
 			sprintf(
 				__( '%1$s &lsaquo; %2$s &#8212; WooCommerce', 'wc-admin' ),
 				documentTitle,
-				wcSettings.siteTitle
+				wcAdminSettings.siteTitle
 			)
 		);
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -99,7 +99,7 @@ export class EmbedLayout extends Component {
 	render() {
 		return (
 			<Fragment>
-				<Header sections={ wcSettings.embedBreadcrumbs } isEmbedded />
+				<Header sections={ wcAdminSettings.embedBreadcrumbs } isEmbedded />
 				<Layout isEmbeded />
 			</Fragment>
 		);

--- a/client/lib/number/index.js
+++ b/client/lib/number/index.js
@@ -8,7 +8,7 @@
  */
 
 export function numberFormat( number ) {
-	const locale = wcSettings.siteLocale || 'en-US'; // Default so we don't break.
+	const locale = wcAdminSettings.siteLocale || 'en-US'; // Default so we don't break.
 
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -8,7 +8,7 @@
  */
 
 export function recordEvent( eventName, eventProperties ) {
-	if ( ! wcSettings.trackingEnabled || 'development' === process.env.NODE_ENV ) {
+	if ( ! wcAdminSettings.trackingEnabled || 'development' === process.env.NODE_ENV ) {
 		return false;
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -134,7 +134,7 @@ function format_order_statuses( $statuses ) {
 }
 
 /**
- * Output the wcSettings global before printing any script tags.
+ * Output the wcAdminSettings global before printing any script tags.
  */
 function wc_admin_print_script_settings() {
 	global $wp_locale;
@@ -199,7 +199,7 @@ function wc_admin_print_script_settings() {
 		<?php
 		echo $tracking_script; // WPCS: XSS ok.
 		?>
-		var wcSettings = <?php echo wp_json_encode( $settings ); ?>;
+		var wcAdminSettings = <?php echo wp_json_encode( $settings ); ?>;
 	</script>
 	<?php
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8995,13 +8995,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9014,18 +9012,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9128,8 +9123,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9139,7 +9133,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9152,20 +9145,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9182,7 +9172,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9255,8 +9244,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9266,7 +9254,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9372,7 +9359,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -30,7 +30,7 @@ d3FormatDefaultLocale( {
 	decimal: '.',
 	thousands: ',',
 	grouping: [ 3 ],
-	currency: [ decodeEntities( get( wcSettings, 'currency.symbol', '' ) ), '' ],
+	currency: [ decodeEntities( get( wcAdminSettings, 'currency.symbol', '' ) ), '' ],
 } );
 
 function getOrderedKeys( props, previousOrderedKeys = [] ) {

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -157,7 +157,7 @@ class AdvancedFilters extends Component {
 	}
 
 	isEnglish() {
-		const { siteLocale } = wcSettings;
+		const { siteLocale } = wcAdminSettings;
 		return /en-/.test( siteLocale );
 	}
 

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -71,8 +71,8 @@ class NumberFilter extends Component {
 
 	getFormControl( { type, value, label, onChange } ) {
 		if ( 'currency' === type ) {
-			const currencySymbol = get( wcSettings, [ 'currency', 'symbol' ] );
-			const symbolPosition = get( wcSettings, [ 'currency', 'position' ] );
+			const currencySymbol = get( wcAdminSettings, [ 'currency', 'symbol' ] );
+			const symbolPosition = get( wcAdminSettings, [ 'currency', 'position' ] );
 
 			return (
 				0 === symbolPosition.indexOf( 'right' )

--- a/packages/components/src/filters/example.md
+++ b/packages/components/src/filters/example.md
@@ -1,6 +1,6 @@
 ```jsx
 import { ReportFilters } from '@woocommerce/components';
-const { orderStatuses } = wcSettings;
+const { orderStatuses } = wcAdminSettings;
 
 const path = '';
 const query = {};

--- a/packages/components/src/image-asset/index.js
+++ b/packages/components/src/image-asset/index.js
@@ -16,7 +16,7 @@ class ImageAsset extends Component {
 
 		if ( illustrationSrc.indexOf( '/' ) === 0 ) {
 			illustrationSrc = illustrationSrc.substring( 1 );
-			illustrationSrc = wcSettings.wcAdminAssetUrl + illustrationSrc;
+			illustrationSrc = wcAdminSettings.wcAdminAssetUrl + illustrationSrc;
 		}
 
 		return <img src={ illustrationSrc } alt={ alt || '' } { ...restOfProps } />;

--- a/packages/components/src/order-status/index.js
+++ b/packages/components/src/order-status/index.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
  */
 const OrderStatus = ( { order, className } ) => {
 	const { status } = order;
-	const { orderStatuses } = wcSettings;
+	const { orderStatuses } = wcAdminSettings;
 	const classes = classnames( 'woocommerce-order-status', className );
 	const indicatorClasses = classnames( 'woocommerce-order-status__indicator', {
 		[ 'is-' + status ]: true,

--- a/packages/components/src/product-image/index.js
+++ b/packages/components/src/product-image/index.js
@@ -26,7 +26,7 @@ const ProductImage = ( { product, alt, width, height, className, ...props } ) =>
 	return (
 		<img
 			className={ classes }
-			src={ src || wcSettings.wcAssetUrl + 'images/placeholder.png' }
+			src={ src || wcAdminSettings.wcAssetUrl + 'images/placeholder.png' }
 			width={ width }
 			height={ height }
 			alt={ altText }

--- a/packages/components/src/product-image/test/index.js
+++ b/packages/components/src/product-image/test/index.js
@@ -73,7 +73,7 @@ describe( 'ProductImage', () => {
 	} );
 
 	test( 'should render a placeholder image if no product images are found', () => {
-		global.wcSettings.wcAssetUrl = 'https://woocommerce.com/wp-content/plugins/woocommerce/assets/';
+		global.wcAdminSettings.wcAssetUrl = 'https://woocommerce.com/wp-content/plugins/woocommerce/assets/';
 		const product = {
 			name: 'Test Product',
 		};

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -21,7 +21,7 @@ export default {
 	name: 'countries',
 	className: 'woocommerce-search__country-result',
 	options() {
-		return wcSettings.dataEndpoints.countries || [];
+		return wcAdminSettings.dataEndpoints.countries || [];
 	},
 	getOptionKeywords( country ) {
 		return [ decodeEntities( country.name ) ];

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -18,12 +18,12 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 import { formatCurrency, getCurrencyFormatDecimal, getCurrencyFormatString } from '@woocommerce/currency';
 
 // Formats money with a given currency code. Uses site's current locale for symbol formatting,
-// from the wcSettings global. Defaults to `en-US`. If no currency provided, this is also
-// pulled from wcSettings, and defaults to USD.
+// from the wcAdminSettings global. Defaults to `en-US`. If no currency provided, this is also
+// pulled from wcAdminSettings, and defaults to USD.
 const total = formatCurrency( 20.923, 'USD' ); // '$20.92'
 
 // Get the rounded decimal value of a number at the precision used for the current currency,
-// from the wcSettings global. Defaults to 2.
+// from the wcAdminSettings global. Defaults to 2.
 const total = getCurrencyFormatDecimal( '6.2892' ); // 6.29 https://google.com/?q=test
 
 // Get the string representation of a floating point number to the precision used by the current

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -13,10 +13,10 @@ import { get, isNaN } from 'lodash';
  * @returns {?String}                  A formatted string.
  */
 export function formatCurrency( number, currency ) {
-	const locale = wcSettings.siteLocale || 'en-US'; // Default so we don't break.
-	// default to wcSettings if currency is not passed in
+	const locale = wcAdminSettings.siteLocale || 'en-US'; // Default so we don't break.
+	// default to wcAdminSettings if currency is not passed in
 	if ( ! currency ) {
-		currency = get( wcSettings, 'currency.code', 'USD' );
+		currency = get( wcAdminSettings, 'currency.code', 'USD' );
 	}
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
@@ -35,7 +35,7 @@ export function formatCurrency( number, currency ) {
  * @return {Number} The original number rounded to a decimal point
  */
 export function getCurrencyFormatDecimal( number ) {
-	const { precision = 2 } = wcSettings.currency;
+	const { precision = 2 } = wcAdminSettings.currency;
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}
@@ -53,7 +53,7 @@ export function getCurrencyFormatDecimal( number ) {
  * @return {String}               The original number rounded to a decimal point
  */
 export function getCurrencyFormatString( number ) {
-	const { precision = 2 } = wcSettings.currency;
+	const { precision = 2 } = wcAdminSettings.currency;
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}

--- a/packages/currency/test/index.js
+++ b/packages/currency/test/index.js
@@ -5,7 +5,7 @@
 import { formatCurrency, getCurrencyFormatDecimal, getCurrencyFormatString } from '../src';
 
 describe( 'formatCurrency', () => {
-	it( 'should default to wcSettings or USD when currency not passed in', () => {
+	it( 'should default to wcAdminSettings or USD when currency not passed in', () => {
 		expect( formatCurrency( 9.99 ) ).toBe( '$9.99' );
 		expect( formatCurrency( 30 ) ).toBe( '$30.00' );
 	} );
@@ -41,31 +41,31 @@ describe( 'formatCurrency', () => {
 
 describe( 'getCurrencyFormatDecimal', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatDecimal( 9.49258 ) ).toBe( 9.49 );
 		expect( getCurrencyFormatDecimal( 30 ) ).toBe( 30 );
 		expect( getCurrencyFormatDecimal( 3.0002 ) ).toBe( 3 );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		global.wcSettings.currency.precision = 0;
+		global.wcAdminSettings.currency.precision = 0;
 		expect( getCurrencyFormatDecimal( 1239.88 ) ).toBe( 1240 );
 		expect( getCurrencyFormatDecimal( 1500 ) ).toBe( 1500 );
 		expect( getCurrencyFormatDecimal( 33715.02 ) ).toBe( 33715 );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatDecimal( '19.80' ) ).toBe( 19.8 );
 	} );
 
 	it( 'should default to a precision of 2 if none set', () => {
-		delete global.wcSettings.currency.precision;
+		delete global.wcAdminSettings.currency.precision;
 		expect( getCurrencyFormatDecimal( 59.282 ) ).toBe( 59.28 );
 	} );
 
 	it( "should return 0 when given an input that isn't a number", () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatDecimal( 'abc' ) ).toBe( 0 );
 		expect( getCurrencyFormatDecimal( false ) ).toBe( 0 );
 		expect( getCurrencyFormatDecimal( null ) ).toBe( 0 );
@@ -74,31 +74,31 @@ describe( 'getCurrencyFormatDecimal', () => {
 
 describe( 'getCurrencyFormatString', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatString( 9.49258 ) ).toBe( '9.49' );
 		expect( getCurrencyFormatString( 30 ) ).toBe( '30.00' );
 		expect( getCurrencyFormatString( 3.0002 ) ).toBe( '3.00' );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		global.wcSettings.currency.precision = 0;
+		global.wcAdminSettings.currency.precision = 0;
 		expect( getCurrencyFormatString( 1239.88 ) ).toBe( '1240' );
 		expect( getCurrencyFormatString( 1500 ) ).toBe( '1500' );
 		expect( getCurrencyFormatString( 33715.02 ) ).toBe( '33715' );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatString( '19.80' ) ).toBe( '19.80' );
 	} );
 
 	it( 'should default to a precision of 2 if none set', () => {
-		delete global.wcSettings.currency.precision;
+		delete global.wcAdminSettings.currency.precision;
 		expect( getCurrencyFormatString( '59.282' ) ).toBe( '59.28' );
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
-		global.wcSettings.currency.precision = 2;
+		global.wcAdminSettings.currency.precision = 2;
 		expect( getCurrencyFormatString( 'abc' ) ).toBe( '' );
 		expect( getCurrencyFormatString( false ) ).toBe( '' );
 		expect( getCurrencyFormatString( null ) ).toBe( '' );

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -501,7 +501,7 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
  * of moment style js formats.
  */
 export function loadLocaleData() {
-	const { userLocale, weekdaysShort } = wcSettings.l10n;
+	const { userLocale, weekdaysShort } = wcAdminSettings.l10n;
 	// Don't update if the wp locale hasn't been set yet, like in unit tests, for instance.
 	if ( 'en' !== moment.locale() ) {
 		moment.updateLocale( userLocale, {

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -508,14 +508,14 @@ describe( 'getRangeLabel', () => {
 describe( 'loadLocaleData', () => {
 	beforeEach( () => {
 		// Reset to default settings
-		wcSettings.l10n = {
+		wcAdminSettings.l10n = {
 			userLocale: 'en_US',
 			weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
 		};
 	} );
 
 	it( 'should load locale data on user locale', () => {
-		wcSettings.l10n = {
+		wcAdminSettings.l10n = {
 			userLocale: 'fr_FR',
 			weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
 		};
@@ -524,7 +524,7 @@ describe( 'loadLocaleData', () => {
 		moment.locale( 'fr_FR', {} );
 
 		loadLocaleData();
-		expect( moment.localeData().weekdaysMin() ).toEqual( wcSettings.l10n.weekdaysShort );
+		expect( moment.localeData().weekdaysMin() ).toEqual( wcAdminSettings.l10n.weekdaysShort );
 	} );
 } );
 

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -29,7 +29,7 @@ render() {
 ```
 
 ### getAdminLink(path) ⇒ <code>String</code>
-Returns a string with the site's wp-admin URL appended. JS version of `admin_url`. This relies on a global object `wcSettings` with a property `adminUrl` set.
+Returns a string with the site's wp-admin URL appended. JS version of `admin_url`. This relies on a global object `wcAdminSettings` with a property `adminUrl` set.
 
 **Returns**: <code>String</code> - Full admin URL.
 

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -28,7 +28,7 @@ import * as navUtils from './index';
  * @param {String} path Relative path.
  * @return {String} Full admin URL.
  */
-export const getAdminLink = path => wcSettings.adminUrl + path;
+export const getAdminLink = path => wcAdminSettings.adminUrl + path;
 
 /**
  * Get the current path from history.

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -41,7 +41,7 @@ wooCommercePackages.forEach( lib => {
 	} );
 } );
 
-global.wcSettings = {
+global.wcAdminSettings = {
 	adminUrl: 'https://vagrant.local/wp/wp-admin/',
 	locale: 'en-US',
 	currency: { code: 'USD', precision: 2, symbol: '&#36;' },


### PR DESCRIPTION
Rename `wcSettings` object to avoid collisions with the [WooCommerce Gutenberg Products block plugin](https://github.com/woocommerce/woocommerce-gutenberg-products-block).

### Detailed test instructions:

- On `master`
- Install + Activate the products block plugin
- Verify that wc-admin screens do not render
- Checkout this branch
- Verify that wc-admin screens do render