### PR TITLE
Advanced Filters: append time stamp to dates for API query

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -281,6 +281,36 @@ export const advancedFilters = {
 				component: 'Date',
 			},
 		},
+		last_active: {
+			labels: {
+				add: __( 'Last active', 'wc-admin' ),
+				remove: __( 'Remove last active filter', 'wc-admin' ),
+				rule: __( 'Select a last active filter match', 'wc-admin' ),
+				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+				title: __( 'Last active {{rule /}} {{filter /}}', 'wc-admin' ),
+				filter: __( 'Select registered date', 'wc-admin' ),
+			},
+			rules: [
+				{
+					value: 'before',
+					/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Before', 'date', 'wc-admin' ),
+				},
+				{
+					value: 'after',
+					/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'After', 'date', 'wc-admin' ),
+				},
+				{
+					value: 'between',
+					/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+					label: _x( 'Between', 'date', 'wc-admin' ),
+				},
+			],
+			input: {
+				component: 'Date',
+			},
+		},
 	},
 };
 /*eslint-enable max-len*/

--- a/client/store/reports/test/utils.js
+++ b/client/store/reports/test/utils.js
@@ -555,12 +555,12 @@ describe( 'timeStampFilterDates', () => {
 	it( 'should append timestamps to activeFilters using the Date component', () => {
 		const activeFilter = {
 			key: 'my_date',
-			rule: 'before',
+			rule: 'after',
 			value: '2018-04-04',
 		};
 		const timeStampedActiveFilter = timeStampFilterDates( advancedFilters, activeFilter );
 
-		expect( timeStampedActiveFilter.value ).toHaveLength( 25 );
+		expect( timeStampedActiveFilter.value ).toBe( '2018-04-04T00:00:00+00:00' );
 	} );
 
 	it( 'should append start of day for "after" rule', () => {
@@ -570,7 +570,7 @@ describe( 'timeStampFilterDates', () => {
 			value: '2018-04-04',
 		};
 		const timeStampedActiveFilter = timeStampFilterDates( advancedFilters, activeFilter );
-		expect( timeStampedActiveFilter.value ).toContain( 'T00:00:00+00:00' );
+		expect( timeStampedActiveFilter.value ).toBe( '2018-04-04T00:00:00+00:00' );
 	} );
 
 	it( 'should append end of day for "before" rule', () => {
@@ -580,7 +580,7 @@ describe( 'timeStampFilterDates', () => {
 			value: '2018-04-04',
 		};
 		const timeStampedActiveFilter = timeStampFilterDates( advancedFilters, activeFilter );
-		expect( timeStampedActiveFilter.value ).toContain( 'T23:59:59+00:00' );
+		expect( timeStampedActiveFilter.value ).toBe( '2018-04-04T23:59:59+00:00' );
 	} );
 
 	it( 'should handle "between" values', () => {

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -56,29 +56,30 @@ export function getFilterQuery( endpoint, query ) {
  */
 export function timeStampFilterDates( config, activeFilter ) {
 	const advancedFilterConfig = config.filters[ activeFilter.key ];
-	if ( 'Date' === get( advancedFilterConfig, [ 'input', 'component' ] ) ) {
-		const { rule, value } = activeFilter;
-		const timeOfDayMap = {
-			after: 'start',
-			before: 'end',
-		};
-		// If the value is an array, it signifies "between" values which must have a timestamp
-		// appended to each value.
-		if ( Array.isArray( value ) ) {
-			const [ after, before ] = value;
-			return Object.assign( {}, activeFilter, {
-				value: [
-					appendTimestamp( moment( after ), timeOfDayMap.after ),
-					appendTimestamp( moment( before ), timeOfDayMap.before ),
-				],
-			} );
-		}
+	if ( 'Date' !== get( advancedFilterConfig, [ 'input', 'component' ] ) ) {
+		return activeFilter;
+	}
 
+	const { rule, value } = activeFilter;
+	const timeOfDayMap = {
+		after: 'start',
+		before: 'end',
+	};
+	// If the value is an array, it signifies "between" values which must have a timestamp
+	// appended to each value.
+	if ( Array.isArray( value ) ) {
+		const [ after, before ] = value;
 		return Object.assign( {}, activeFilter, {
-			value: appendTimestamp( moment( value ), timeOfDayMap[ rule ] ),
+			value: [
+				appendTimestamp( moment( after ), timeOfDayMap.after ),
+				appendTimestamp( moment( before ), timeOfDayMap.before ),
+			],
 		} );
 	}
-	return activeFilter;
+
+	return Object.assign( {}, activeFilter, {
+		value: appendTimestamp( moment( value ), timeOfDayMap[ rule ] ),
+	} );
 }
 
 export function getQueryFromConfig( config, advancedFilters, query ) {

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -46,9 +46,27 @@ export function getFilterQuery( endpoint, query ) {
 	return {};
 }
 
-// export function timeStampFilterDates() {
-//
-// }
+export function timeStampFilterDates( config, activeFilter ) {
+	if ( 'Date' === config.filters[ activeFilter.key ].input.component ) {
+		const { rule, value } = activeFilter;
+		const timeOfDayMap = {
+			after: 'start',
+			before: 'end',
+		};
+		let appendedValue;
+		if ( Array.isArray( value ) ) {
+			const [ after, before ] = value;
+			appendedValue = [
+				appendTimestamp( moment( after ), timeOfDayMap.after ),
+				appendTimestamp( moment( before ), timeOfDayMap.before ),
+			];
+		} else {
+			appendedValue = appendTimestamp( moment( value ), timeOfDayMap[ rule ] );
+		}
+		return Object.assign( {}, activeFilter, { value: appendedValue } );
+	}
+	return activeFilter;
+}
 
 export function getQueryFromConfig( config, advancedFilters, query ) {
 	const queryValue = query[ config.param ];
@@ -64,7 +82,7 @@ export function getQueryFromConfig( config, advancedFilters, query ) {
 			return {};
 		}
 
-		return activeFilters.reduce(
+		return activeFilters.map( filter => timeStampFilterDates( advancedFilters, filter ) ).reduce(
 			( result, activeFilter ) => {
 				const { key, rule, value } = activeFilter;
 				result[ getUrlKey( key, rule ) ] = value;

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -46,6 +46,10 @@ export function getFilterQuery( endpoint, query ) {
 	return {};
 }
 
+// export function timeStampFilterDates() {
+//
+// }
+
 export function getQueryFromConfig( config, advancedFilters, query ) {
 	const queryValue = query[ config.param ];
 

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -62,17 +62,21 @@ export function timeStampFilterDates( config, activeFilter ) {
 			after: 'start',
 			before: 'end',
 		};
-		let appendedValue;
+		// If the value is an array, it signifies "between" values which must have a timestamp
+		// appended to each value.
 		if ( Array.isArray( value ) ) {
 			const [ after, before ] = value;
-			appendedValue = [
-				appendTimestamp( moment( after ), timeOfDayMap.after ),
-				appendTimestamp( moment( before ), timeOfDayMap.before ),
-			];
-		} else {
-			appendedValue = appendTimestamp( moment( value ), timeOfDayMap[ rule ] );
+			return Object.assign( {}, activeFilter, {
+				value: [
+					appendTimestamp( moment( after ), timeOfDayMap.after ),
+					appendTimestamp( moment( before ), timeOfDayMap.before ),
+				],
+			} );
 		}
-		return Object.assign( {}, activeFilter, { value: appendedValue } );
+
+		return Object.assign( {}, activeFilter, {
+			value: appendTimestamp( moment( value ), timeOfDayMap[ rule ] ),
+		} );
 	}
 	return activeFilter;
 }

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { find, forEach, isNull } from 'lodash';
+import { find, forEach, isNull, get } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -46,8 +46,17 @@ export function getFilterQuery( endpoint, query ) {
 	return {};
 }
 
+/**
+ * Add timestamp to advanced filter parameters involving date. The api
+ * expects a timestamp for these values similar to `before` and `after`.
+ *
+ * @param {object} config - advancedFilters config object.
+ * @param {object} activeFilter - an active filter.
+ * @returns {object} - an active filter with timestamp added to date values.
+ */
 export function timeStampFilterDates( config, activeFilter ) {
-	if ( 'Date' === config.filters[ activeFilter.key ].input.component ) {
+	const advancedFilterConfig = config.filters[ activeFilter.key ];
+	if ( 'Date' === get( advancedFilterConfig, [ 'input', 'component' ] ) ) {
 		const { rule, value } = activeFilter;
 		const timeOfDayMap = {
 			after: 'start',

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -172,10 +172,10 @@ class DateFilter extends Component {
 	}
 
 	onRuleChange( value ) {
-		const { onFilterChange, filter, replaceFilter } = this.props;
+		const { onFilterChange, filter, updateFilter } = this.props;
 		const { before } = this.state;
 		if ( 'between' === filter.rule && 'between' !== value ) {
-			replaceFilter( {
+			updateFilter( {
 				key: filter.key,
 				rule: value,
 				value: before ? before.format( isoDateFormat ) : undefined,

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -42,6 +42,7 @@ class DateFilter extends Component {
 
 		this.onSingleDateChange = this.onSingleDateChange.bind( this );
 		this.onRangeDateChange = this.onRangeDateChange.bind( this );
+		this.onRuleChange = this.onRuleChange.bind( this );
 	}
 
 	getBetweenString() {
@@ -170,21 +171,23 @@ class DateFilter extends Component {
 		);
 	}
 
-	// onRuleChange( value ) {
-	// 	const { onFilterChange, filter } = this.props;
-	// 	if ( 'between' === filter.rule && 'between' !== value ) {
-	// 		this.setState( {
-	// 			after: null,
-	// 			afterText: '',
-	// 			afterError: null,
-	// 		} );
-	// 	}
-	// 	onFilterChange( filter.key, 'rule', value );
-	// }
+	onRuleChange( value ) {
+		const { onFilterChange, filter, replaceFilter } = this.props;
+		const { before } = this.state;
+		if ( 'between' === filter.rule && 'between' !== value ) {
+			replaceFilter( {
+				key: filter.key,
+				rule: value,
+				value: before ? before.format( isoDateFormat ) : undefined,
+			} );
+		} else {
+			onFilterChange( filter.key, 'rule', value );
+		}
+	}
 
 	render() {
-		const { config, filter, onFilterChange, isEnglish } = this.props;
-		const { key, rule } = filter;
+		const { config, filter, isEnglish } = this.props;
+		const { rule } = filter;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
 		const children = interpolateComponents( {
@@ -195,7 +198,7 @@ class DateFilter extends Component {
 						className="woocommerce-filters-advanced__rule"
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, key, 'rule' ) }
+						onChange={ this.onRuleChange }
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -27,7 +27,7 @@ class DateFilter extends Component {
 	constructor( { filter } ) {
 		super( ...arguments );
 
-		const [ isoAfter, isoBefore ] = Array.isArray( filter.value ) ? filter.value : [ filter.value ];
+		const [ isoAfter, isoBefore ] = Array.isArray( filter.value ) ? filter.value : [ null, filter.value ];
 		const after = isoAfter ? toMoment( isoDateFormat, isoAfter ) : null;
 		const before = isoBefore ? toMoment( isoDateFormat, isoBefore ) : null;
 

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -27,7 +27,7 @@ class DateFilter extends Component {
 	constructor( { filter } ) {
 		super( ...arguments );
 
-		const [ isoAfter, isoBefore ] = ( filter.value || '' ).split( ',' );
+		const [ isoAfter, isoBefore ] = Array.isArray( filter.value ) ? filter.value : [ filter.value ];
 		const after = isoAfter ? toMoment( isoDateFormat, isoAfter ) : null;
 		const before = isoBefore ? toMoment( isoDateFormat, isoBefore ) : null;
 
@@ -58,7 +58,7 @@ class DateFilter extends Component {
 		const { before, after } = this.state;
 
 		// Return nothing if we're missing input(s)
-		if ( ! before || 'between' === rule.value && ! after ) {
+		if ( ! before || ( 'between' === rule.value && ! after ) ) {
 			return '';
 		}
 
@@ -75,13 +75,15 @@ class DateFilter extends Component {
 			} );
 		}
 
-		return textContent( interpolateComponents( {
-			mixedString: config.labels.title,
-			components: {
-				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
-			},
-		} ) );
+		return textContent(
+			interpolateComponents( {
+				mixedString: config.labels.title,
+				components: {
+					filter: <Fragment>{ filterStr }</Fragment>,
+					rule: <Fragment>{ rule.label }</Fragment>,
+				},
+			} )
+		);
 	}
 
 	onSingleDateChange( { date, text, error } ) {
@@ -118,7 +120,7 @@ class DateFilter extends Component {
 			}
 
 			if ( nextAfter && nextBefore ) {
-				onFilterChange( filter.key, 'value', [ nextAfter, nextBefore ].join( ',' ) );
+				onFilterChange( filter.key, 'value', [ nextAfter, nextBefore ] );
 			}
 		}
 	}
@@ -168,6 +170,18 @@ class DateFilter extends Component {
 		);
 	}
 
+	// onRuleChange( value ) {
+	// 	const { onFilterChange, filter } = this.props;
+	// 	if ( 'between' === filter.rule && 'between' !== value ) {
+	// 		this.setState( {
+	// 			after: null,
+	// 			afterText: '',
+	// 			afterError: null,
+	// 		} );
+	// 	}
+	// 	onFilterChange( filter.key, 'rule', value );
+	// }
+
 	render() {
 		const { config, filter, onFilterChange, isEnglish } = this.props;
 		const { key, rule } = filter;
@@ -199,9 +213,7 @@ class DateFilter extends Component {
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset tabIndex="0">
-				<legend className="screen-reader-text">
-					{ labels.add || '' }
-				</legend>
+				<legend className="screen-reader-text">{ labels.add || '' }</legend>
 				<div
 					className={ classnames( 'woocommerce-filters-advanced__fieldset', {
 						'is-english': isEnglish,
@@ -209,11 +221,7 @@ class DateFilter extends Component {
 				>
 					{ children }
 				</div>
-				{ screenReaderText && (
-					<span className="screen-reader-text">
-						{ screenReaderText }
-					</span>
-				) }
+				{ screenReaderText && <span className="screen-reader-text">{ screenReaderText }</span> }
 			</fieldset>
 		);
 		/*eslint-enable jsx-a11y/no-noninteractive-tabindex*/

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -55,6 +55,7 @@ class AdvancedFilters extends Component {
 		this.removeFilter = this.removeFilter.bind( this );
 		this.clearFilters = this.clearFilters.bind( this );
 		this.getUpdateHref = this.getUpdateHref.bind( this );
+		this.replaceFilter = this.replaceFilter.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -78,6 +79,17 @@ class AdvancedFilters extends Component {
 		const activeFilters = this.state.activeFilters.map( activeFilter => {
 			if ( key === activeFilter.key ) {
 				return Object.assign( {}, activeFilter, { [ property ]: value } );
+			}
+			return activeFilter;
+		} );
+
+		this.setState( { activeFilters } );
+	}
+
+	replaceFilter( filter ) {
+		const activeFilters = this.state.activeFilters.map( activeFilter => {
+			if ( filter.key === activeFilter.key ) {
+				return filter;
 			}
 			return activeFilter;
 		} );
@@ -218,6 +230,7 @@ class AdvancedFilters extends Component {
 										onFilterChange={ this.onFilterChange }
 										isEnglish={ isEnglish }
 										query={ query }
+										replaceFilter={ this.replaceFilter }
 									/>
 								) }
 								<IconButton

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -55,7 +55,7 @@ class AdvancedFilters extends Component {
 		this.removeFilter = this.removeFilter.bind( this );
 		this.clearFilters = this.clearFilters.bind( this );
 		this.getUpdateHref = this.getUpdateHref.bind( this );
-		this.replaceFilter = this.replaceFilter.bind( this );
+		this.updateFilter = this.updateFilter.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -86,7 +86,7 @@ class AdvancedFilters extends Component {
 		this.setState( { activeFilters } );
 	}
 
-	replaceFilter( filter ) {
+	updateFilter( filter ) {
 		const activeFilters = this.state.activeFilters.map( activeFilter => {
 			if ( filter.key === activeFilter.key ) {
 				return filter;
@@ -230,7 +230,7 @@ class AdvancedFilters extends Component {
 										onFilterChange={ this.onFilterChange }
 										isEnglish={ isEnglish }
 										query={ query }
-										replaceFilter={ this.replaceFilter }
+										updateFilter={ this.updateFilter }
 									/>
 								) }
 								<IconButton


### PR DESCRIPTION
API expects timestamped values for advanced filter parameters such as `registered_before` or `last_active_between`. This PR adds timestamps for applicable filters.

https://github.com/woocommerce/wc-admin/pull/1267 set a pattern of using a true array for the `between` rule, so changes reflect this direction.

Lastly, `updateFilter` is introduced to `AdvancedFilters` methods due to oddities of using `onFilterChange` multiple times to amend different properties of the same filter. 

### Testing

1. Customers Report > Show > Advanced Filters.
2. Add either _Registered_ or _Last active_ filters.
3. Using values for before, after, and between ensure the resulting API query parameters reflect timestamps.
4. Check that tabular results reflect the filters you've set.