### PR TITLE
Remove `barfocus` elements from charts

### DIFF
--- a/packages/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/components/src/chart/d3chart/utils/bar-chart.js
@@ -14,7 +14,7 @@ import { calculateTooltipPosition, hideTooltip, showTooltip } from './tooltip';
 
 const handleMouseOverBarChart = ( date, parentNode, node, data, params, position ) => {
 	d3Select( parentNode )
-		.select( '.barfocus' )
+		.select( '.barmouse' )
 		.attr( 'opacity', '0.1' );
 	showTooltip( params, data.find( e => e.date === date ), position );
 };
@@ -37,15 +37,6 @@ export const drawBars = ( node, data, params ) => {
 					? params.tooltipLabelFormat( d.date instanceof Date ? d.date : new Date( d.date ) )
 					: null
 		);
-
-	barGroup
-		.append( 'rect' )
-		.attr( 'class', 'barfocus' )
-		.attr( 'x', 0 )
-		.attr( 'y', 0 )
-		.attr( 'width', params.xGroupScale.range()[ 1 ] )
-		.attr( 'height', params.height )
-		.attr( 'opacity', '0' );
 
 	barGroup
 		.selectAll( '.bar' )

--- a/packages/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/components/src/chart/d3chart/utils/bar-chart.js
@@ -14,7 +14,7 @@ import { calculateTooltipPosition, hideTooltip, showTooltip } from './tooltip';
 
 const handleMouseOverBarChart = ( date, parentNode, node, data, params, position ) => {
 	d3Select( parentNode )
-		.select( '.barmouse' )
+		.select( '.barfocus' )
 		.attr( 'opacity', '0.1' );
 	showTooltip( params, data.find( e => e.date === date ), position );
 };
@@ -40,7 +40,7 @@ export const drawBars = ( node, data, params ) => {
 
 	barGroup
 		.append( 'rect' )
-		.attr( 'class', 'barmouse' )
+		.attr( 'class', 'barfocus' )
 		.attr( 'x', 0 )
 		.attr( 'y', 0 )
 		.attr( 'width', params.xGroupScale.range()[ 1 ] )

--- a/packages/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/components/src/chart/d3chart/utils/bar-chart.js
@@ -39,6 +39,24 @@ export const drawBars = ( node, data, params ) => {
 		);
 
 	barGroup
+		.append( 'rect' )
+		.attr( 'class', 'barmouse' )
+		.attr( 'x', 0 )
+		.attr( 'y', 0 )
+		.attr( 'width', params.xGroupScale.range()[ 1 ] )
+		.attr( 'height', params.height )
+		.attr( 'opacity', '0' )
+		.on( 'mouseover', ( d, i, nodes ) => {
+			const position = calculateTooltipPosition(
+				d3Event.target,
+				node.node(),
+				params.tooltipPosition
+			);
+			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
+		} )
+		.on( 'mouseout', ( d, i, nodes ) => hideTooltip( nodes[ i ].parentNode, params.tooltip ) );
+
+	barGroup
 		.selectAll( '.bar' )
 		.data( d =>
 			params.orderedKeys.filter( row => row.visible ).map( row => ( {
@@ -58,6 +76,7 @@ export const drawBars = ( node, data, params ) => {
 		.attr( 'width', params.xGroupScale.bandwidth() )
 		.attr( 'height', d => params.height - params.yScale( d.value ) )
 		.attr( 'fill', d => getColor( d.key, params.orderedKeys, params.colorScheme ) )
+		.attr( 'pointer-events', 'none' )
 		.attr( 'tabindex', '0' )
 		.attr( 'aria-label', d => {
 			const label = params.mode === 'time-comparison' && d.label ? d.label : d.key;
@@ -73,22 +92,4 @@ export const drawBars = ( node, data, params ) => {
 			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
 		} )
 		.on( 'blur', ( d, i, nodes ) => hideTooltip( nodes[ i ].parentNode, params.tooltip ) );
-
-	barGroup
-		.append( 'rect' )
-		.attr( 'class', 'barmouse' )
-		.attr( 'x', 0 )
-		.attr( 'y', 0 )
-		.attr( 'width', params.xGroupScale.range()[ 1 ] )
-		.attr( 'height', params.height )
-		.attr( 'opacity', '0' )
-		.on( 'mouseover', ( d, i, nodes ) => {
-			const position = calculateTooltipPosition(
-				d3Event.target,
-				node.node(),
-				params.tooltipPosition
-			);
-			handleMouseOverBarChart( d.date, nodes[ i ].parentNode, node, data, params, position );
-		} )
-		.on( 'mouseout', ( d, i, nodes ) => hideTooltip( nodes[ i ].parentNode, params.tooltip ) );
 };

--- a/packages/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/components/src/chart/d3chart/utils/tooltip.js
@@ -12,7 +12,7 @@ import { getColor } from './color';
 
 export const hideTooltip = ( parentNode, tooltipNode ) => {
 	d3Select( parentNode )
-		.selectAll( '.barfocus, .focus-grid' )
+		.selectAll( '.barmouse, .focus-grid' )
 		.attr( 'opacity', '0' );
 	d3Select( tooltipNode )
 		.style( 'visibility', 'hidden' );

--- a/packages/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/components/src/chart/d3chart/utils/tooltip.js
@@ -12,7 +12,7 @@ import { getColor } from './color';
 
 export const hideTooltip = ( parentNode, tooltipNode ) => {
 	d3Select( parentNode )
-		.selectAll( '.barmouse, .focus-grid' )
+		.selectAll( '.barfocus, .focus-grid' )
 		.attr( 'opacity', '0' );
 	d3Select( tooltipNode )
 		.style( 'visibility', 'hidden' );


### PR DESCRIPTION
Bar charts were rendering a `.barfocus` element for each day, it was used to show the background color when the day was hovered/focused.

There was another element, named `.barmouse`, that was used to detect `hover` events.

This PR merges both of them.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
_(This PR shouldn't produce any visible change)_
![image](https://user-images.githubusercontent.com/3616980/51179216-2d59e200-18c5-11e9-8f35-ab4dd5c1753b.png)

### Detailed test instructions:
- Go to any report page and change the chart type to _Bar chart_.
- Hover it and navigate it with the keyboard.
- Verify there are no regressions: bars are still hoverable/focusable and the background color changes when they are hovered/focused.
- In your browser devtools search for `.barmouse` and verify there are 0.