### PR TITLE
Add missing thousands separator in charts Y-axis

### DIFF
--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -272,13 +272,13 @@ class Chart extends Component {
 
 		switch ( valueType ) {
 			case 'average':
-				yFormat = '.0f';
+				yFormat = ',.0f';
 				break;
 			case 'currency':
 				yFormat = '$.3~s';
 				break;
 			case 'number':
-				yFormat = '.0f';
+				yFormat = ',.0f';
 				break;
 		}
 		return (


### PR DESCRIPTION
Fixes #1303.

Adds the missing thousands' separator in Y-axis percentage and number labels.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51180255-4021e600-18c8-11e9-87d9-8b23c3274bf4.png)


_After:_
![image](https://user-images.githubusercontent.com/3616980/51180194-0355ef00-18c8-11e9-948d-00ab61d694bb.png)

### Detailed test instructions:
Quoting #1303:
> 1. I imported sales data from wc.com to get the above chart, or you could smooth generate a large number of data, or create a test order with a thousand items or something.
> 2. Open a report with a chart
- Verify the thousands' separator is displayed.
