### PR TITLE
Update packages docs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.0 ( unreleased )
+# 1.4.0
 - Add download log ip address autocompleter to search component
 - Add order number autocompleter to search component
 - Add order number, username, and IP address filters to the downloads report.

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.5 Not Released
+# 1.0.5
 
 - Fixed bug in getAllowedIntervalsForQuery() to not return `hour` for default intervals
 


### PR DESCRIPTION
Removing (unreleased) tags from package changelogs to prep for an npm publish.