### PR TITLE
Customers Report: remove extended data call

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -115,9 +115,11 @@ export default class CustomersReportTable extends Component {
 				name
 			);
 
-			const dateRegistered = date_registered
-				? <Date date={ date_registered } visibleFormat={ defaultTableDateFormat } />
-				: '—';
+			const dateRegistered = date_registered ? (
+				<Date date={ date_registered } visibleFormat={ defaultTableDateFormat } />
+			) : (
+				'—'
+			);
 
 			return [
 				{
@@ -174,11 +176,6 @@ export default class CustomersReportTable extends Component {
 		return (
 			<ReportTable
 				endpoint="customers"
-				extendItemsMethodNames={ {
-					load: 'getCustomers',
-					getError: 'getCustomersError',
-					isRequesting: 'isGetCustomersRequesting',
-				} }
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				itemIdField="id"


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1306

Remove `extendItemsMethodNames` from Customers Report Table. Recent API work removes the requirement for the second call for more information.

This is the only instance of `extendTableData` but I think we should keep it the repo because it can be useful for extension developers. cc @Aljullu 

### Detailed test instructions:

1. Customers Report
2. Using the Network tab, see only one request for `customers` keyword instead of two.
