### PR TITLE
Filters: make 1/4 width for wiiiiiiide screens

### DIFF
--- a/packages/components/src/filters/style.scss
+++ b/packages/components/src/filters/style.scss
@@ -16,7 +16,7 @@
 }
 
 .woocommerce-filters-filter {
-	width: 33.3%;
+	width: 25%;
 	padding: 0 $gap-small;
 	min-height: 82px;
 	display: flex;
@@ -29,6 +29,10 @@
 
 	&:last-child {
 		padding-right: 0;
+	}
+
+	@include breakpoint( '<1440px' ) {
+		width: 33.3%;
 	}
 
 	@include breakpoint( '<1280px' ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1294

For wide screens (>1440px) make the filters occupy 25% of the available width, otherwise keep everything else the same.

### Screenshots

![screen shot 2019-01-17 at 12 23 33 pm](https://user-images.githubusercontent.com/1922453/51285128-beaa8f00-1a52-11e9-9dda-19b23c511ad4.png)

### Detailed test instructions:

1. Products Report 
2. Make screen larger then 1440px and shrink to see how media queries respond.