### PR TITLE
Advanced Filters: Ranges: Allow update only on complete selection

### DIFF
--- a/packages/navigation/src/filters.js
+++ b/packages/navigation/src/filters.js
@@ -109,6 +109,13 @@ export function getQueryFromActiveFilters( activeFilters, query, config ) {
 		return data;
 	}, {} );
 	const nextData = activeFilters.reduce( ( data, filter ) => {
+		if (
+			'between' === filter.rule &&
+			( ! Array.isArray( filter.value ) || filter.value.some( value => ! value ) )
+		) {
+			return data;
+		}
+
 		if ( filter.value ) {
 			data[ getUrlKey( filter.key, filter.rule ) ] = filter.value;
 		}

--- a/packages/navigation/src/test/filters.js
+++ b/packages/navigation/src/test/filters.js
@@ -126,6 +126,20 @@ describe( 'getQueryFromActiveFilters', () => {
 		expect( nextQuery.with_select_is ).toBeUndefined();
 		expect( nextQuery.with_search_includes ).toBeUndefined();
 	} );
+
+	it( 'should only reflect complete filters with multiple values', () => {
+		const activeFilters = [
+			{ key: 'valid_date', rule: 'between', value: [ '2018-04-04', '2018-04-10' ] },
+			{ key: 'invalid_date_1', rule: 'between', value: [ '2018-04-04', undefined ] },
+			{ key: 'invalid_date_2', rule: 'between', value: '2018-04-04' },
+		];
+		const query = {};
+		const nextQuery = getQueryFromActiveFilters( activeFilters, query, config );
+
+		expect( nextQuery.valid_date_between ).toBeDefined();
+		expect( nextQuery.invalid_date_1_between ).toBeUndefined();
+		expect( nextQuery.invalid_date_2_between ).toBeUndefined();
+	} );
 } );
 
 describe( 'getDefaultOptionValue', () => {


### PR DESCRIPTION
Fixes #

Advanced Filters enables the "Filter" button when a filter has all values defined AND it will produce a new url that is different than the current one.

This PR updates the logic for "between" values (Numerical or Date. Although testing with Date ranges won't work until #1305 gets merged). You can only update the filters if both max and min (or before/after) values are set.

### Screenshots

![screen shot 2019-01-17 at 12 50 26 pm](https://user-images.githubusercontent.com/1922453/51286155-a0df2900-1a56-11e9-916b-a687599aacdd.png)

### Detailed test instructions:

1. Customers Report > Show > Advanced Filters > Add a filter > No. of Orders.
2. See the "Filter" button disabled.
3. Add a minimum value.
4. See the "Filter" button disabled.
5. Add a maximum value.
6. See the "Filter" button enabled.



