### PR TITLE
Reports: Reduce Margins on Small Viewports

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -11,6 +11,10 @@
 	@include breakpoint( '>960px' ) {
 		margin-top: 100px;
 	}
+
+	@include breakpoint( '<782px' ) {
+		margin-top: 60px;
+	}
 }
 
 .woocommerce-layout .woocommerce-layout__main {

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	@include breakpoint( '<400px' ) {
-		margin: $gap-smaller 0;
+		margin: $gap-small 0;
 	}
 }
 
@@ -210,6 +210,6 @@
 	}
 
 	.separator {
-		padding: 0 8px;
+		text-align: center;
 	}
 }

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -20,6 +20,11 @@
 	.components-base-control__field {
 		margin-bottom: 0;
 	}
+
+	@include breakpoint( '<782px' ) {
+		margin: $gap 0;
+		border: 1px solid $core-grey-light-700;
+	}
 }
 
 .woocommerce-filters-advanced__title-select {
@@ -85,10 +90,13 @@
 		padding: 0 $gap-smallest;
 
 		@include breakpoint( '<782px' ) {
-			display: block;
-			margin: 0;
 			width: 100%;
 			padding: $gap-smallest 0;
+		}
+
+		@include breakpoint( '<400px' ) {
+			display: block;
+			margin: 0;
 		}
 	}
 
@@ -187,9 +195,5 @@
 
 	.separator {
 		padding: 0 8px;
-
-		@include breakpoint( '<782px' ) {
-			padding: 0;
-		}
 	}
 }

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -25,6 +25,10 @@
 		margin: $gap 0;
 		border: 1px solid $core-grey-light-700;
 	}
+
+	@include breakpoint( '<400px' ) {
+		margin: $gap-smaller 0;
+	}
 }
 
 .woocommerce-filters-advanced__title-select {
@@ -57,10 +61,22 @@
 		width: 40px;
 		height: 38px;
 		align-self: center;
+
+		@include breakpoint( '<400px' ) {
+			position: absolute;
+			top: 0;
+			right: $gap-smallest;
+		}
 	}
 
 	.components-form-token-field {
 		border-radius: 4px;
+	}
+
+	@include breakpoint( '<400px' ) {
+		display: block;
+		position: relative;
+		padding: $gap-smaller $gap-smaller 0 0;
 	}
 }
 
@@ -95,8 +111,8 @@
 		}
 
 		@include breakpoint( '<400px' ) {
-			display: block;
-			margin: 0;
+			//display: block;
+			//margin: 0;
 		}
 	}
 

--- a/packages/components/src/filters/style.scss
+++ b/packages/components/src/filters/style.scss
@@ -13,6 +13,10 @@
 	@include breakpoint( '<1280px' ) {
 		flex-direction: column;
 	}
+
+	@include breakpoint( '<782px' ) {
+		margin-bottom: $gap;
+	}
 }
 
 .woocommerce-filters-filter {

--- a/packages/components/src/filters/style.scss
+++ b/packages/components/src/filters/style.scss
@@ -4,6 +4,11 @@
 	.components-base-control__field {
 		margin-bottom: 0;
 	}
+
+	@include breakpoint( '<400px' ) {
+		margin-left: -8px;
+		margin-right: -8px;
+	}
 }
 
 .woocommerce-filters__basic-filters {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1295

Reduce margin bottom on `.woocommerce-filters__basic-filters` for small viewports

### Screenshots

![screen shot 2019-01-17 at 1 10 20 pm](https://user-images.githubusercontent.com/1922453/51286782-4e533c00-1a59-11e9-80ed-9093eb2c8a3a.png)

### Detailed test instructions:

1. Go any report
2. See the margin between the last filter and the rest of the report get smaller for `<782px`
