### PR TITLE
SummaryNumbers: close on click for mobile

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -42,33 +42,35 @@ export class ReportSummary extends Component {
 		const secondaryTotals = totals.secondary || {};
 		const { compare } = getDateParamsFromQuery( query );
 
-		const summaryNumbers = charts.map( chart => {
-			const { key, label, type } = chart;
-			const delta = calculateDelta( primaryTotals[ key ], secondaryTotals[ key ] );
-			const href = getNewPath( { chart: key } );
-			const prevValue = formatValue( type, secondaryTotals[ key ] );
-			const isSelected = selectedChart.key === key;
-			const value = formatValue( type, primaryTotals[ key ] );
+		const renderSummaryNumbers = ( { onToggle } ) =>
+			charts.map( chart => {
+				const { key, label, type } = chart;
+				const delta = calculateDelta( primaryTotals[ key ], secondaryTotals[ key ] );
+				const href = getNewPath( { chart: key } );
+				const prevValue = formatValue( type, secondaryTotals[ key ] );
+				const isSelected = selectedChart.key === key;
+				const value = formatValue( type, primaryTotals[ key ] );
 
-			return (
-				<SummaryNumber
-					key={ key }
-					delta={ delta }
-					href={ href }
-					label={ label }
-					prevLabel={
-						'previous_period' === compare
-							? __( 'Previous Period:', 'wc-admin' )
-							: __( 'Previous Year:', 'wc-admin' )
-					}
-					prevValue={ prevValue }
-					selected={ isSelected }
-					value={ value }
-				/>
-			);
-		} );
+				return (
+					<SummaryNumber
+						key={ key }
+						delta={ delta }
+						href={ href }
+						label={ label }
+						prevLabel={
+							'previous_period' === compare
+								? __( 'Previous Period:', 'wc-admin' )
+								: __( 'Previous Year:', 'wc-admin' )
+						}
+						prevValue={ prevValue }
+						selected={ isSelected }
+						value={ value }
+						onLinkClickCallback={ onToggle }
+					/>
+				);
+			} );
 
-		return <SummaryList>{ summaryNumbers }</SummaryList>;
+		return <SummaryList>{ renderSummaryNumbers }</SummaryList>;
 	}
 }
 

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -112,37 +112,39 @@ class StorePerformance extends Component {
 				: __( 'Previous Year:', 'wc-admin' );
 		return (
 			<SummaryList>
-				{ userIndicators.map( ( indicator, i ) => {
-					const primaryItem = find( primaryData.data, data => data.stat === indicator.stat );
-					const secondaryItem = find( secondaryData.data, data => data.stat === indicator.stat );
+				{ () =>
+					userIndicators.map( ( indicator, i ) => {
+						const primaryItem = find( primaryData.data, data => data.stat === indicator.stat );
+						const secondaryItem = find( secondaryData.data, data => data.stat === indicator.stat );
 
-					if ( ! primaryItem || ! secondaryItem ) {
-						return null;
-					}
+						if ( ! primaryItem || ! secondaryItem ) {
+							return null;
+						}
 
-					const href =
-						( primaryItem._links &&
-							primaryItem._links.report[ 0 ] &&
-							primaryItem._links.report[ 0 ].href ) ||
-						'';
-					const reportUrl =
-						( href && getNewPath( persistedQuery, href, { chart: primaryItem.chart } ) ) || '';
-					const delta = calculateDelta( primaryItem.value, secondaryItem.value );
-					const primaryValue = formatValue( primaryItem.format, primaryItem.value );
-					const secondaryValue = formatValue( secondaryItem.format, secondaryItem.value );
+						const href =
+							( primaryItem._links &&
+								primaryItem._links.report[ 0 ] &&
+								primaryItem._links.report[ 0 ].href ) ||
+							'';
+						const reportUrl =
+							( href && getNewPath( persistedQuery, href, { chart: primaryItem.chart } ) ) || '';
+						const delta = calculateDelta( primaryItem.value, secondaryItem.value );
+						const primaryValue = formatValue( primaryItem.format, primaryItem.value );
+						const secondaryValue = formatValue( secondaryItem.format, secondaryItem.value );
 
-					return (
-						<SummaryNumber
-							key={ i }
-							href={ reportUrl }
-							label={ indicator.label }
-							value={ primaryValue }
-							prevLabel={ prevLabel }
-							prevValue={ secondaryValue }
-							delta={ delta }
-						/>
-					);
-				} ) }
+						return (
+							<SummaryNumber
+								key={ i }
+								href={ reportUrl }
+								label={ indicator.label }
+								value={ primaryValue }
+								prevLabel={ prevLabel }
+								prevValue={ secondaryValue }
+								delta={ delta }
+							/>
+						);
+					} )
+				}
 			</SummaryList>
 		);
 	}

--- a/packages/components/src/summary/menu.js
+++ b/packages/components/src/summary/menu.js
@@ -1,0 +1,63 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { NavigableMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { uniqueId } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getHasItemsClass } from './utils';
+
+const Menu = ( { label, orientation, itemCount, items } ) => {
+	const instanceId = uniqueId( 'woocommerce-summary-helptext-' );
+	const hasItemsClass = getHasItemsClass( itemCount );
+	const classes = classnames( 'woocommerce-summary', {
+		[ hasItemsClass ]: orientation === 'horizontal',
+	} );
+
+	return (
+		<NavigableMenu
+			aria-label={ label }
+			aria-describedby={ instanceId }
+			orientation={ orientation }
+			stopNavigationEvents
+		>
+			<p id={ instanceId } className="screen-reader-text">
+				{ __(
+					'List of data points available for filtering. Use arrow keys to cycle through ' +
+						'the list. Click a data point for a detailed report.',
+					'wc-admin'
+				) }
+			</p>
+			<ul className={ classes }>
+				{ items }
+			</ul>
+		</NavigableMenu>
+	);
+};
+
+Menu.propTypes = {
+	/**
+	 * An optional label of this group, read to screen reader users.
+	 */
+	label: PropTypes.string,
+	/**
+	 * Item layout orientation.
+	 */
+	orientation: PropTypes.oneOf( [ 'vertical', 'horizontal' ] ).isRequired,
+	/**
+	 * A list of `<SummaryNumber />`s.
+	 */
+	items: PropTypes.node.isRequired,
+	/**
+	 * Number of items.
+	 */
+	itemCount: PropTypes.number.isRequired,
+};
+
+export default Menu;

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
-import { isNil } from 'lodash';
+import { isNil, noop } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -30,6 +30,7 @@ const SummaryNumber = ( {
 	reverseTrend,
 	selected,
 	value,
+	onLinkClickCallback,
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
 		'is-dropdown-button': onToggle,
@@ -59,13 +60,15 @@ const SummaryNumber = ( {
 	};
 
 	if ( onToggle || href ) {
-		Container = onToggle ? Button : Link;
-		if ( ! onToggle ) {
-			containerProps.href = href;
-			containerProps.role = 'menuitem';
-		} else {
+		const isButton = !! onToggle;
+		Container = isButton ? Button : Link;
+		if ( isButton ) {
 			containerProps.onClick = onToggle;
 			containerProps[ 'aria-expanded' ] = isOpen;
+		} else {
+			containerProps.href = href;
+			containerProps.role = 'menuitem';
+			containerProps.onClick = onLinkClickCallback;
 		}
 	} else {
 		Container = 'div';
@@ -150,6 +153,10 @@ SummaryNumber.propTypes = {
 	 * A string or number value to display - a string is allowed so we can accept currency formatting.
 	 */
 	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+	/**
+	 * A function to be called after a SummaryNumber, rendered as a link, is clicked.
+	 */
+	onLinkClickCallback: PropTypes.func,
 };
 
 SummaryNumber.defaultProps = {
@@ -158,6 +165,7 @@ SummaryNumber.defaultProps = {
 	prevLabel: __( 'Previous Period:', 'wc-admin' ),
 	reverseTrend: false,
 	selected: false,
+	onLinkClickCallback: noop,
 };
 
 export default SummaryNumber;

--- a/packages/components/src/summary/placeholder.js
+++ b/packages/components/src/summary/placeholder.js
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import { withViewportMatch } from '@wordpress/viewport';
 
 /**
+ * Internal dependencies
+ */
+import { getHasItemsClass } from './utils';
+
+/**
  * `SummaryListPlaceholder` behaves like `SummaryList` but displays placeholder summary items instead of data.
  * This can be used while loading data.
  */
@@ -17,7 +22,7 @@ class SummaryListPlaceholder extends Component {
 		const { isDropdownBreakpoint } = this.props;
 		const numberOfItems = isDropdownBreakpoint ? 1 : this.props.numberOfItems;
 
-		const hasItemsClass = numberOfItems < 10 ? `has-${ numberOfItems }-items` : 'has-10-items';
+		const hasItemsClass = getHasItemsClass( numberOfItems );
 		const classes = classnames( 'woocommerce-summary', {
 			[ hasItemsClass ]: ! isDropdownBreakpoint,
 			'is-placeholder': true,

--- a/packages/components/src/summary/utils.js
+++ b/packages/components/src/summary/utils.js
@@ -1,0 +1,9 @@
+/**
+ * Get a class name depending on item count.
+ *
+ * @param {number} count - Item count.
+ * @returns {string} - class name.
+ */
+export function getHasItemsClass( count ) {
+	return count < 10 ? `has-${ count }-items` : 'has-10-items';
+}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1096

Close Summary Numbers menu when selecting a summary number on smaller viewports.

SummaryList now accepts a function as children instead of an array of Summary Numbers. The function allows the passage of the `onToggle` parameter provided by Gutenberg's `<Dropdown />`.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Detailed test instructions:

1. Dashboard > Store Performance.
2. Ensure Summary Numbers render correctly.
3. Revenue Report Ensure Summary Numbers render correctly at large viewports.
4. Check again on smaller viewports.
5. When selecting a chart type (Net Revenue, for example) the dropdown should close automatically.
