### PR TITLE
Add helpText to coupon compare button

### DIFF
--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -44,6 +44,7 @@ export const filters = [
 					labels: {
 						title: __( 'Compare Coupon Codes', 'wc-admin' ),
 						update: __( 'Compare', 'wc-admin' ),
+						helpText: __( 'Select at least two coupon codes to compare', 'wc-admin' ),
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #1330 

Adds the coupon compare button help text and gets rid of the console error for a missing prop.

### Screenshots
<img width="399" alt="screen shot 2019-01-17 at 12 29 37 pm" src="https://user-images.githubusercontent.com/10561050/51295654-9f603180-1a53-11e9-9ffd-7978263f769d.png">

### Detailed test instructions:

1.  Open the Coupons report and add the comparison filter `wp-admin/admin.php?page=wc-admin#/analytics/coupons?filter=compare-coupons`.
2.  Without any coupons added, hover the "Compare" button and make sure the help text is shown.
3.  Check that no console errors exist on this page.