### PR TITLE
Add autocompleter input type and fix load options

### DIFF
--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -146,6 +146,9 @@ export class Autocomplete extends Component {
 		const promise = ( this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( optionsData => {
+			if ( ! optionsData ) {
+				return;
+			}
 			const { selected } = this.props;
 			if ( promise !== this.activePromise ) {
 				// Another promise has become active since this one was asked to resolve, so do nothing,

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -24,6 +24,7 @@ import { computeSuggestionMatch } from './utils';
 export default {
 	name: 'orders',
 	className: 'woocommerce-search__order-result',
+	inputType: 'number',
 	options( search ) {
 		let payload = '';
 		if ( search ) {

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -156,6 +156,7 @@ class Search extends Component {
 			'aria-label': this.props[ 'aria-label' ],
 		};
 		const shouldRenderTags = this.shouldRenderTags();
+		const inputType = autocompleter.inputType ? autocompleter.inputType : 'text';
 
 		return (
 			<div className={ classnames( 'woocommerce-search', className, {
@@ -188,7 +189,7 @@ class Search extends Component {
 									{ this.renderTags() }
 									<input
 										ref={ this.input }
-										type="text"
+										type={ inputType }
 										size={
 											( ( value.length === 0 && placeholder && placeholder.length ) ||
 												value.length ) + 1

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -52,6 +52,12 @@
 		min-width: 70px;
 		font-size: inherit;
 		vertical-align: middle;
+
+		&[type="number"]::-webkit-outer-spin-button,
+		&[type="number"]::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
 	}
 
 	.woocommerce-search__input {


### PR DESCRIPTION
Fixes #1331 

Adds an `inputType` option to autocompleters to allow `number` as a type for the input and restrict input.  Also fixes a console mapping error when data returned from the API is undefined.

### Screenshots
<img width="605" alt="screen shot 2019-01-17 at 1 03 08 pm" src="https://user-images.githubusercontent.com/10561050/51296755-6f675d00-1a58-11e9-859f-c9468b169b1b.png">

### Detailed test instructions:

1.  Visit the downloads report with advanced filters. `wp-admin/admin.php?page=wc-admin#/analytics/downloads?filter=advanced`
2.  Add the Order Number filter.
3.  Make sure the input type is number and only allows numeric entry.
4.  Check that no error is thrown when deleting text entirely from the input box.
5.  Make sure other autocompleter fields are still working as expected.