### PR TITLE
REST API: Allow sorting by stock_status in stocks endpoint

### DIFF
--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -43,12 +43,13 @@ export default class StockReportTable extends Component {
 			{
 				label: __( 'Status', 'wc-admin' ),
 				key: 'stock_status',
+				isSortable: true,
+				defaultSort: true,
 			},
 			{
 				label: __( 'Stock', 'wc-admin' ),
 				key: 'stock_quantity',
 				isSortable: true,
-				defaultSort: true,
 			},
 		];
 	}
@@ -136,8 +137,8 @@ export default class StockReportTable extends Component {
 				// getSummary={ this.getSummary }
 				query={ query }
 				tableQuery={ {
-					orderby: query.orderby || 'stock_quantity',
-					order: query.order || 'desc',
+					orderby: query.orderby || 'stock_status',
+					order: query.order || 'asc',
 					type: query.type || 'all',
 				} }
 				title={ __( 'Stock', 'wc-admin' ) }

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -51,6 +51,9 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date ID';
+		} elseif ( 'stock_status' === $args['orderby'] ) {
+			$args['meta_key'] = '_stock_status'; // WPCS: slow query ok.
+			$args['orderby']  = 'meta_value';
 		} elseif ( 'stock_quantity' === $args['orderby'] ) {
 			$args['meta_key'] = '_stock'; // WPCS: slow query ok.
 			$args['orderby']  = 'meta_value_num';
@@ -355,6 +358,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			'type'              => 'string',
 			'default'           => 'stock_quantity',
 			'enum'              => array(
+				'stock_status',
 				'stock_quantity',
 				'date',
 				'id',

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -356,7 +356,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 		$params['orderby']        = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
-			'default'           => 'stock_quantity',
+			'default'           => 'stock_status',
 			'enum'              => array(
 				'stock_status',
 				'stock_quantity',

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -52,8 +52,22 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date ID';
 		} elseif ( 'stock_status' === $args['orderby'] ) {
-			$args['meta_key'] = '_stock_status'; // WPCS: slow query ok.
-			$args['orderby']  = 'meta_value';
+			$args['meta_query'] = array( // WPCS: slow query ok.
+				'relation'      => 'AND',
+				'_stock_status' => array(
+					'key'     => '_stock_status',
+					'compare' => 'EXISTS',
+				),
+				'_stock' => array(
+					'key'     => '_stock',
+					'compare' => 'EXISTS',
+					'type'    => 'NUMERIC',
+				),
+			);
+			$args['orderby']    = array(
+				'_stock_status' => $args['order'],
+				'_stock'        => $args['order'],
+			);
 		} elseif ( 'stock_quantity' === $args['orderby'] ) {
 			$args['meta_key'] = '_stock'; // WPCS: slow query ok.
 			$args['orderby']  = 'meta_value_num';

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -66,7 +66,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			);
 			$args['orderby']    = array(
 				'_stock_status' => $args['order'],
-				'_stock'        => $args['order'],
+				'_stock'        => 'desc' === $args['order'] ? 'asc' : 'desc',
 			);
 		} elseif ( 'stock_quantity' === $args['orderby'] ) {
 			$args['meta_key'] = '_stock'; // WPCS: slow query ok.


### PR DESCRIPTION
Fixes #966 

Allows sorting by `stock_status` on stocks endpoint.

### Detailed test instructions:

1.  Make a request to `/wp-json/wc/v3/reports/stock`
2.  Pass `stock_status` as the `orderby` param.
3.  Check that sorting returns by status.
4.  Change the `order` param to `desc` and check that sorting by status is reversed.
