### PR TITLE
Add single category filter to categories report

### DIFF
--- a/client/analytics/report/categories/breadcrumbs.js
+++ b/client/analytics/report/categories/breadcrumbs.js
@@ -54,7 +54,10 @@ export default class CategoryBreadcrumbs extends Component {
 			<div className="woocommerce-table__breadcrumbs">
 				{ this.getCategoryAncestors( category, categories ) }
 				<Link
-					href={ 'term.php?taxonomy=product_cat&post_type=product&tag_ID=' + category.id }
+					href={
+						'admin.php?page=wc-admin#/analytics/categories?filter=single_category&categories=' +
+						category.id
+					}
 					type="wp-admin"
 				>
 					{ category.name }

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -37,6 +37,31 @@ export const filters = [
 		filters: [
 			{ label: __( 'All Categories', 'wc-admin' ), value: 'all' },
 			{
+				label: __( 'Single Category', 'wc-admin' ),
+				value: 'select_category',
+				chartMode: 'item-comparison',
+				subFilters: [
+					{
+						component: 'Search',
+						value: 'single_category',
+						chartMode: 'item-comparison',
+						path: [ 'select_category' ],
+						settings: {
+							type: 'categories',
+							param: 'categories',
+							getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
+								id: category.id,
+								label: category.name,
+							} ) ),
+							labels: {
+								placeholder: __( 'Type to search for a category', 'wc-admin' ),
+								button: __( 'Single Category', 'wc-admin' ),
+							},
+						},
+					},
+				],
+			},
+			{
 				label: __( 'Comparison', 'wc-admin' ),
 				value: 'compare-categories',
 				chartMode: 'item-comparison',

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -59,7 +59,6 @@ export class TopSellingCategories extends Component {
 		return map( data, row => {
 			const { category_id, items_sold, net_revenue, extended_info } = row;
 			const name = get( extended_info, [ 'name' ] );
-			// TODO Update this to use a single_category filter, once it exists.
 			const categoryUrl = getNewPath( persistedQuery, 'analytics/categories', {
 				filter: 'single_category',
 				categories: category_id,

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -61,7 +61,7 @@ export class TopSellingCategories extends Component {
 			const name = get( extended_info, [ 'name' ] );
 			// TODO Update this to use a single_category filter, once it exists.
 			const categoryUrl = getNewPath( persistedQuery, 'analytics/categories', {
-				filter: 'compare-categories',
+				filter: 'single_category',
 				categories: category_id,
 			} );
 			const categoryLink = (


### PR DESCRIPTION
Fixes #1277 

Adds in a single category filter so we can link directly to categories from other reports.  Also links the dashboard categories leaderboard to specific category reports.

### Screenshots
<img width="522" alt="screen shot 2019-01-17 at 2 56 00 pm" src="https://user-images.githubusercontent.com/10561050/51300890-5797d500-1a68-11e9-91f3-db193cae52ef.png">
<img width="430" alt="screen shot 2019-01-17 at 2 55 46 pm" src="https://user-images.githubusercontent.com/10561050/51300891-5797d500-1a68-11e9-91b2-059bcf206d7a.png">


### Detailed test instructions:
1.  Open the categories report `wp-admin/admin.php?page=wc-admin#/analytics/categories`.
2.  Select "Single Category" under the filter.
3.  Search for a single category name and select it.
4.  Check that the table reflects the single category previously selected.
5.  Visit the dashboard `wp-admin/admin.php?page=wc-admin#/`.
6.  Check that links to individual categories under "Top Categories" open the filtered categories report.