### PR TITLE
Add country code as keyword for countries search

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import { Tooltip } from '@wordpress/components';
 
 /**
  * WooCommerce dependencies
@@ -90,6 +91,12 @@ export default class CustomersReportTable extends Component {
 		];
 	}
 
+	getCountryName( code ) {
+		const countries = ( wcSettings.dataEndpoints && wcSettings.dataEndpoints.countries ) || [];
+		const country = countries.find( c => c.code === code );
+		return country ? country.name : null;
+	}
+
 	getRowsContent( customers ) {
 		return customers.map( customer => {
 			const {
@@ -106,6 +113,7 @@ export default class CustomersReportTable extends Component {
 				city,
 				country,
 			} = customer;
+			const countryName = this.getCountryName( country );
 
 			const customerNameLink = user_id ? (
 				<Link href={ 'user-edit.php?user_id=' + user_id } type="wp-admin">
@@ -119,6 +127,15 @@ export default class CustomersReportTable extends Component {
 				<Date date={ date_registered } visibleFormat={ defaultTableDateFormat } />
 			) : (
 				'—'
+			);
+
+			const countryDisplay = (
+				<Fragment>
+					<Tooltip text={ countryName }>
+						<span aria-hidden="true">{ country }</span>
+					</Tooltip>
+					<span className="screen-reader-text">{ countryName }</span>
+				</Fragment>
 			);
 
 			return [
@@ -155,7 +172,7 @@ export default class CustomersReportTable extends Component {
 					value: date_last_active,
 				},
 				{
-					display: country,
+					display: countryDisplay,
 					value: country,
 				},
 				{

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -24,7 +24,7 @@ export default {
 		return wcSettings.dataEndpoints.countries || [];
 	},
 	getOptionKeywords( country ) {
-		return [ decodeEntities( country.name ) ];
+		return [ country.code, decodeEntities( country.name ) ];
 	},
 	getOptionLabel( country, query ) {
 		const name = decodeEntities( country.name );


### PR DESCRIPTION
Fixes #1272 

Adds the country code to the list of searched keywords and adds a tooltip with the country name to the table.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
<img width="495" alt="screen shot 2019-01-17 at 4 18 04 pm" src="https://user-images.githubusercontent.com/10561050/51304637-a6973780-1a73-11e9-942f-5eecc06508be.png">
<img width="214" alt="screen shot 2019-01-17 at 4 17 42 pm" src="https://user-images.githubusercontent.com/10561050/51304638-a72fce00-1a73-11e9-837a-8d01d9e8d497.png">


### Detailed test instructions:

1. Visit the customers report page and add the advanced filter `wp-admin/admin.php?page=wc-admin#/analytics/customers?filter=advanced`.
2.  Select "Country" as a filter option.
3.  Type a country code that contains letters not in its actual name (e.g., GQ for Equatorial Guinea).
4.  Note the country is shown in the dropdown list.
5.  Hover over the country code in the customers table and note the tooltip with the country name.
6.  Using a screen reader, check that the country name is read when navigating through the country column.

### Questions
* When typing something like `ES` (the country code for Spain), there are enough other matches that Spain is still never shown since results are alphabetical and the maximum shown is 10.  Should we:
  * Allow more than 10 results.
  * Sort by best match (probably best in a follow-up PR).
  * Leave as is.
* Should we include the country code in the label of the search dropdown?  (e.g., Spain (ES) ).

