### PR TITLE
Use stock_status sort order by default in Stock table

### DIFF
--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -43,12 +43,13 @@ export default class StockReportTable extends Component {
 			{
 				label: __( 'Status', 'wc-admin' ),
 				key: 'stock_status',
+				isSortable: true,
+				defaultSort: true,
 			},
 			{
 				label: __( 'Stock', 'wc-admin' ),
 				key: 'stock_quantity',
 				isSortable: true,
-				defaultSort: true,
 			},
 		];
 	}
@@ -136,8 +137,8 @@ export default class StockReportTable extends Component {
 				// getSummary={ this.getSummary }
 				query={ query }
 				tableQuery={ {
-					orderby: query.orderby || 'stock_quantity',
-					order: query.order || 'desc',
+					orderby: query.orderby || 'stock_status',
+					order: query.order || 'asc',
 					type: query.type || 'all',
 				} }
 				title={ __( 'Stock', 'wc-admin' ) }


### PR DESCRIPTION
Follow-up of #1335.

Make _Stock_ table to use `stock_status` as the default sort value instead of `stock_quantity`.

### Detailed test instructions:

- Go to the _Stock_ report.
- Verify it sorts stock items by `stock_status` by default.