### PR TITLE
Set default order to 'desc' in time tables

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -262,7 +262,7 @@ export default compose(
 
 		const tableQuery = {
 			orderby: query.orderby || 'date',
-			order: query.order || 'asc',
+			order: query.order || 'desc',
 			page: query.page || 1,
 			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -222,7 +222,7 @@ export default compose(
 		const tableQuery = {
 			interval: 'day',
 			orderby: query.orderby || 'date',
-			order: query.order || 'asc',
+			order: query.order || 'desc',
 			page: query.page || 1,
 			per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),

--- a/client/store/reports/utils.js
+++ b/client/store/reports/utils.js
@@ -284,7 +284,7 @@ export function getReportTableQuery( endpoint, urlQuery, query ) {
 
 	return {
 		orderby: urlQuery.orderby || 'date',
-		order: urlQuery.order || 'asc',
+		order: urlQuery.order || 'desc',
 		after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 		before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		page: urlQuery.page || 1,


### PR DESCRIPTION
Makes time-ordered tables to display most recent rows first by default.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51317014-b81e1680-1a56-11e9-9c97-a4e1a2bb95c2.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51316996-a472b000-1a56-11e9-9f32-6e25ee917dcc.png)

### Detailed test instructions:
- Go to the _Revenue_ report.
- Verify most recent dates are the first ones displayed in the table.
- Repeat the same in the _Orders_, the _Downloads_ nd the _Customers_ report.