### PR TITLE
Add single category filter to products report

### DIFF
--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
 
 /**
@@ -69,8 +70,9 @@ class CategoriesReportTable extends Component {
 	getRowsContent( categoryStats ) {
 		return map( categoryStats, categoryStat => {
 			const { category_id, items_sold, net_revenue, products_count, orders_count } = categoryStat;
-			const categories = this.props.categories;
+			const { categories, query } = this.props;
 			const category = categories[ category_id ];
+			const persistedQuery = getPersistedQuery( query );
 
 			return [
 				{
@@ -88,11 +90,11 @@ class CategoriesReportTable extends Component {
 				{
 					display: (
 						<Link
-							href={
-								'admin.php?page=wc-admin#/analytics/products?filter=single_category&categories=' +
-								category_id
-							}
-							type="wp-admin"
+							href={ getNewPath( persistedQuery, 'categories', {
+								filter: 'single_category',
+								categories: category.id,
+							} ) }
+							type="wc-admin"
 						>
 							{ numberFormat( products_count ) }
 						</Link>

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -88,7 +88,7 @@ class CategoriesReportTable extends Component {
 					value: getCurrencyFormatDecimal( net_revenue ),
 				},
 				{
-					display: (
+					display: category && (
 						<Link
 							href={ getNewPath( persistedQuery, 'categories', {
 								filter: 'single_category',

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -85,7 +86,17 @@ class CategoriesReportTable extends Component {
 					value: getCurrencyFormatDecimal( net_revenue ),
 				},
 				{
-					display: numberFormat( products_count ),
+					display: (
+						<Link
+							href={
+								'admin.php?page=wc-admin#/analytics/products?filter=single_category&categories=' +
+								category_id
+							}
+							type="wp-admin"
+						>
+							{ numberFormat( products_count ) }
+						</Link>
+					),
 					value: products_count,
 				},
 				{

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -61,6 +61,31 @@ const filterConfig = {
 			],
 		},
 		{
+			label: __( 'Single Product Category', 'wc-admin' ),
+			value: 'select_category',
+			chartMode: 'item-comparison',
+			subFilters: [
+				{
+					component: 'Search',
+					value: 'single_category',
+					chartMode: 'item-comparison',
+					path: [ 'select_category' ],
+					settings: {
+						type: 'categories',
+						param: 'categories',
+						getLabels: getRequestByIdString( NAMESPACE + 'products/categories', category => ( {
+							id: category.id,
+							label: category.name,
+						} ) ),
+						labels: {
+							placeholder: __( 'Type to search for a product category', 'wc-admin' ),
+							button: __( 'Single Product Category', 'wc-admin' ),
+						},
+					},
+				},
+			],
+		},
+		{
 			label: __( 'Product Comparison', 'wc-admin' ),
 			value: 'compare-products',
 			chartMode: 'item-comparison',

--- a/client/wc-api/categories/operations.js
+++ b/client/wc-api/categories/operations.js
@@ -14,13 +14,14 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { isResourcePrefix, getResourceIdentifier, getResourceName } from '../utils';
+import { NAMESPACE } from '../constants';
 
 function read( resourceNames, fetch = apiFetch ) {
 	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'category-query' ) );
 
 	return filteredNames.map( async resourceName => {
 		const query = getResourceIdentifier( resourceName );
-		const url = `/wc/v3/products/categories${ stringifyQuery( query ) }`;
+		const url = NAMESPACE + `/products/categories${ stringifyQuery( query ) }`;
 
 		try {
 			const categories = await fetch( {

--- a/includes/api/class-wc-admin-rest-product-categories-controller.php
+++ b/includes/api/class-wc-admin-rest-product-categories-controller.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * REST API Product Categories Controller
+ *
+ * Handles requests to /products/categories.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product categories controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Product_Categories_Controller
+ */
+class WC_Admin_REST_Product_Categories_Controller extends WC_REST_Product_Categories_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -161,6 +161,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-categories-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-system-status-tools-controller.php';
@@ -192,6 +193,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Data_Download_Ips_Controller',
 				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',
+				'WC_Admin_REST_Product_Categories_Controller',
 				'WC_Admin_REST_Product_Reviews_Controller',
 				'WC_Admin_REST_Reports_Controller',
 				'WC_Admin_REST_System_Status_Tools_Controller',
@@ -335,6 +337,17 @@ class WC_Admin_Api_Init {
 			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][0] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][3];
 			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][1] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][4];
 			$endpoints['/wc/v4/products/(?P<id>[\d]+)'][2] = $endpoints['/wc/v4/products/(?P<id>[\d]+)'][5];
+		}
+
+		// Override /wc/v4/products/categories.
+		if ( isset( $endpoints['/wc/v4/products/categories'] )
+			&& isset( $endpoints['/wc/v4/products/categories'][3] )
+			&& isset( $endpoints['/wc/v4/products/categories'][2] )
+			&& $endpoints['/wc/v4/products/categories'][2]['callback'][0] instanceof WC_Admin_REST_Product_categories_Controller
+			&& $endpoints['/wc/v4/products/categories'][3]['callback'][0] instanceof WC_Admin_REST_Product_categories_Controller
+		) {
+			$endpoints['/wc/v4/products/categories'][0] = $endpoints['/wc/v4/products/categories'][2];
+			$endpoints['/wc/v4/products/categories'][1] = $endpoints['/wc/v4/products/categories'][3];
 		}
 
 		// Override /wc/v4/products/reviews.

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -134,7 +134,9 @@ class FilterPicker extends Component {
 	renderButton( filter, onClose ) {
 		if ( filter.component ) {
 			const { type, labels } = filter.settings;
-			const { selectedTag } = this.state;
+			const persistedFilter = this.getFilter();
+			const selectedTag = persistedFilter.value === filter.value ? this.state.selectedTag : null;
+
 			return (
 				<Search
 					className="woocommerce-filters-filter__search"


### PR DESCRIPTION
Fixes #1046

Allows filtering by a single category on the products report.  Also links the product count on the categories table to the product report for a given category.

### Screenshots
<img width="388" alt="screen shot 2019-01-18 at 5 05 59 pm" src="https://user-images.githubusercontent.com/10561050/51376861-5c31bb80-1b44-11e9-97e3-7eeca7b4a22a.png">

### Detailed test instructions:

1.  Open the products report `/wp-admin/admin.php?page=wc-admin#/analytics/products`
2.  Filter by "Single Product Category" and search and select a category.
3.  Check that results are filtered by that category.
4.  Go to the categories report `/wp-admin/admin.php?page=wc-admin#/analytics/categories`.
5.  Click on the product count in a category row to make sure it takes you to the product report filtered by that category.