### PR TITLE
Move search icon inside input wrapper

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -157,12 +157,12 @@ class Search extends Component {
 		};
 		const shouldRenderTags = this.shouldRenderTags();
 		const inputType = autocompleter.inputType ? autocompleter.inputType : 'text';
+		const searchIcon = <Gridicon className="woocommerce-search__icon" icon="search" size={ 18 } />;
 
 		return (
 			<div className={ classnames( 'woocommerce-search', className, {
 				'has-inline-tags': inlineTags,
 			} ) }>
-				<Gridicon className="woocommerce-search__icon" icon="search" size={ 18 } />
 				<Autocomplete
 					completer={ autocompleter }
 					onSelect={ this.selectResult }
@@ -185,6 +185,7 @@ class Search extends Component {
 									this.input.current.focus();
 								} }
 							>
+								{ searchIcon }
 								<div className="woocommerce-search__token-list">
 									{ this.renderTags() }
 									<input
@@ -213,16 +214,19 @@ class Search extends Component {
 								</div>
 							</div>
 						) : (
-							<input
-								type="search"
-								value={ value }
-								placeholder={ placeholder }
-								className="woocommerce-search__input"
-								onChange={ this.updateSearch( onChange ) }
-								aria-owns={ listBoxId }
-								aria-activedescendant={ activeId }
-								{ ...aria }
-							/>
+							<Fragment>
+								{ searchIcon }
+								<input
+									type="search"
+									value={ value }
+									placeholder={ placeholder }
+									className="woocommerce-search__input"
+									onChange={ this.updateSearch( onChange ) }
+									aria-owns={ listBoxId }
+									aria-activedescendant={ activeId }
+									{ ...aria }
+								/>
+							</Fragment>
 						)
 					}
 				</Autocomplete>

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -30,6 +30,7 @@
 		background-color: $white;
 		display: flex;
 		align-items: center;
+		position: relative;
 
 		&.is-active {
 			border-color: $input-active-border;


### PR DESCRIPTION
Fixes #1349 

Moves search icon inside input wrapper so we can set it's position relative to input and not the results.

### Before
<img width="384" alt="screen shot 2019-01-18 at 5 34 11 pm" src="https://user-images.githubusercontent.com/10561050/51378126-8173f900-1b47-11e9-846e-7c97e8fbfbd7.png">

### After
<img width="384" alt="screen shot 2019-01-18 at 5 34 54 pm" src="https://user-images.githubusercontent.com/10561050/51378129-833dbc80-1b47-11e9-9e50-6581a7a1bc53.png">

### Detailed test instructions:

1.  Open the products report and filter by "Single Product."
2.  Type in a search query with results and check that the search icon stays in the correct place.
3.  Check other search inputs to make sure the search icon remains in the correct place.
