### PR TITLE
Remove leading zero from chart dates

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -445,7 +445,7 @@ export const defaultTableDateFormat = 'm/d/Y';
  * @return {String} Current interval.
  */
 export function getDateFormatsForInterval( interval, ticks = 0 ) {
-	let tooltipLabelFormat = '%B %d, %Y';
+	let tooltipLabelFormat = '%B %-d, %Y';
 	let xFormat = '%Y-%m-%d';
 	let x2Format = '%b %Y';
 	let tableFormat = defaultTableDateFormat;
@@ -454,12 +454,12 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 		case 'hour':
 			tooltipLabelFormat = '%_I%p';
 			xFormat = '%_I%p';
-			x2Format = '%b %d, %Y';
+			x2Format = '%b %-d, %Y';
 			tableFormat = 'h A';
 			break;
 		case 'day':
 			if ( ticks < dayTicksThreshold ) {
-				xFormat = '%d';
+				xFormat = '%-d';
 			} else {
 				xFormat = '%b';
 				x2Format = '%Y';
@@ -467,13 +467,13 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 			break;
 		case 'week':
 			if ( ticks < weekTicksThreshold ) {
-				xFormat = '%d';
+				xFormat = '%-d';
 				x2Format = '%b %Y';
 			} else {
 				xFormat = '%b';
 				x2Format = '%Y';
 			}
-			tooltipLabelFormat = __( 'Week of %B %d, %Y', 'wc-admin' );
+			tooltipLabelFormat = __( 'Week of %B %-d, %Y', 'wc-admin' );
 			break;
 		case 'quarter':
 		case 'month':


### PR DESCRIPTION
Removes leading zeros from dates displayed in charts.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51387000-ba4ea680-1b24-11e9-8ae3-382167e45588.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51386990-b1f66b80-1b24-11e9-8c7c-38acce74536e.png)

### Detailed test instructions:
- Go to any report with a chart.
- Verify dates are displayed without a leading zero.
- Test different periods and intervals (day, week, etc.).