### PR TITLE
Fix country filter by adding v4 of data/countries API

### DIFF
--- a/includes/api/class-wc-admin-rest-data-countries-controller.php
+++ b/includes/api/class-wc-admin-rest-data-countries-controller.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * REST API Data countries controller.
+ *
+ * Handles requests to the /data/countries endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Data countries controller class.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Countries_Controller
+ */
+class WC_Admin_REST_Data_Countries_Controller extends WC_REST_Data_Countries_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -158,6 +158,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-coupons-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-countries-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
@@ -189,6 +190,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Coupons_Controller',
 				'WC_Admin_REST_Customers_Controller',
 				'WC_Admin_REST_Data_Controller',
+				'WC_Admin_REST_Data_Countries_Controller',
 				'WC_Admin_REST_Data_Download_Ips_Controller',
 				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',


### PR DESCRIPTION
In https://github.com/woocommerce/wc-admin/pull/1298, endpoints were bumped to use v4.

The code that loads country data into wcSettings was calling v4 of `/data/countries` which doesn't exist, so a notice was showing:

`PHP Notice:  Undefined index: /wc/v4/data/countries in wc-admin/lib/client-assets.php on line 201`, which stopped the autocompleter from showing any results.

To Test:
* Run this branch and make sure the notice is gone.
* Make sure the country autocompleter works under the customer report.

