### PR TITLE
Update order of summary numbers on taxes report

### DIFF
--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -13,13 +13,13 @@ import { NAMESPACE } from 'store/constants';
 
 export const charts = [
 	{
-		key: 'order_tax',
-		label: __( 'Order Tax', 'wc-admin' ),
+		key: 'total_tax',
+		label: __( 'Total Tax', 'wc-admin' ),
 		type: 'currency',
 	},
 	{
-		key: 'total_tax',
-		label: __( 'Total Tax', 'wc-admin' ),
+		key: 'order_tax',
+		label: __( 'Order Tax', 'wc-admin' ),
 		type: 'currency',
 	},
 	{


### PR DESCRIPTION
Re-orders the summary numbers in the taxes report. Total tax should be first. 

**Before**

<img width="1238" alt="screen shot 2019-01-18 at 10 52 03 am" src="https://user-images.githubusercontent.com/4500952/51406877-363df400-1b0f-11e9-9840-9d805f40d9e9.png">

**After**

<img width="1229" alt="screen shot 2019-01-18 at 10 50 39 am" src="https://user-images.githubusercontent.com/4500952/51406886-405ff280-1b0f-11e9-8dbb-3507ace5c78d.png">

