### PR TITLE
Center points in single-date charts

### DIFF
--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -121,13 +121,16 @@ class D3Chart extends Component {
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth, compact );
 		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
+		const xOffset = type === 'line' && uniqueDates.length <= 1
+			? adjWidth / 2
+			: 0;
 		return {
 			adjHeight,
 			adjWidth,
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
 			interval,
-			line: getLine( xLineScale, yScale ),
+			line: getLine( xLineScale, yScale, xOffset ),
 			lineData,
 			margin,
 			mode,
@@ -140,17 +143,18 @@ class D3Chart extends Component {
 			type,
 			uniqueDates,
 			uniqueKeys,
+			valueType,
 			xFormat: getFormatter( xFormat, d3TimeFormat ),
 			x2Format: getFormatter( x2Format, d3TimeFormat ),
 			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
 			xLineScale,
+			xOffset,
 			xTicks,
 			xScale,
 			yMax,
 			yScale,
 			yTickOffset: getYTickOffset( adjHeight, yMax ),
 			yFormat: getFormatter( yFormat ),
-			valueType,
 		};
 	}
 

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -60,8 +60,11 @@ class D3Chart extends Component {
 			.append( 'g' )
 			.attr( 'transform', `translate(${ margin.left },${ margin.top })` );
 
-		drawAxis( g, adjParams );
-		type === 'line' && drawLines( g, data, adjParams );
+		const xOffset = type === 'line' && adjParams.uniqueDates.length <= 1
+			? adjParams.width / 2
+			: 0;
+		drawAxis( g, adjParams, xOffset );
+		type === 'line' && drawLines( g, data, adjParams, xOffset );
 		type === 'bar' && drawBars( g, data, adjParams );
 	}
 
@@ -121,9 +124,6 @@ class D3Chart extends Component {
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth, compact );
 		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
-		const xOffset = type === 'line' && uniqueDates.length <= 1
-			? adjWidth / 2
-			: 0;
 		return {
 			adjHeight,
 			adjWidth,
@@ -148,7 +148,6 @@ class D3Chart extends Component {
 			x2Format: getFormatter( x2Format, d3TimeFormat ),
 			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
 			xLineScale,
-			xOffset,
 			xTicks,
 			xScale,
 			yMax,

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -130,7 +130,7 @@ class D3Chart extends Component {
 			colorScheme,
 			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
 			interval,
-			line: getLine( xLineScale, yScale, xOffset ),
+			line: getLine( xLineScale, yScale ),
 			lineData,
 			margin,
 			mode,

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -186,7 +186,7 @@ export const getYGrids = ( yMax ) => {
 	return yGrids;
 };
 
-export const drawAxis = ( node, params ) => {
+export const drawAxis = ( node, params, xOffset ) => {
 	const xScale = params.type === 'line' ? params.xLineScale : params.xScale;
 	const removeDuplicateDates = ( d, i, ticks, formatter ) => {
 		const monthDate = moment( d ).toDate();
@@ -205,7 +205,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height })` )
+		.attr( 'transform', `translate(${ xOffset }, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -218,7 +218,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis axis-month' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height + 20 })` )
+		.attr( 'transform', `translate(${ xOffset }, ${ params.height + 20 })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -229,7 +229,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'pipes' )
-		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height })` )
+		.attr( 'transform', `translate(${ xOffset }, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -205,7 +205,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(0, ${ params.height })` )
+		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -218,7 +218,7 @@ export const drawAxis = ( node, params ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis axis-month' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(0, ${ params.height + 20 })` )
+		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height + 20 })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -229,7 +229,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'pipes' )
-		.attr( 'transform', `translate(0, ${ params.height })` )
+		.attr( 'transform', `translate(${ params.xOffset }, ${ params.height })` )
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
@@ -240,7 +240,7 @@ export const drawAxis = ( node, params ) => {
 	node
 		.append( 'g' )
 		.attr( 'class', 'grid' )
-		.attr( 'transform', `translate(-${ params.margin.left },0)` )
+		.attr( 'transform', `translate(-${ params.margin.left }, 0)` )
 		.call(
 			d3AxisLeft( params.yScale )
 				.tickValues( yGrids )

--- a/packages/components/src/chart/d3chart/utils/index.js
+++ b/packages/components/src/chart/d3chart/utils/index.js
@@ -90,12 +90,14 @@ export const getUniqueDates = ( lineData, parseDate ) => {
  * Describes getLine
  * @param {function} xLineScale - from `getXLineScale`.
  * @param {function} yScale - from `getYScale`.
+ * @param {number} xOffset - Offset to use to draw the line in the X axis.
  * @returns {function} the D3 line function for plotting all category values
  */
-export const getLine = ( xLineScale, yScale ) =>
-	d3Line()
-		.x( d => xLineScale( moment( d.date ).toDate() ) )
+export const getLine = ( xLineScale, yScale, xOffset ) => {
+	return d3Line()
+		.x( d => xLineScale( moment( d.date ).toDate() ) + xOffset )
 		.y( d => yScale( d.value ) );
+};
 
 /**
  * Describes getDateSpaces

--- a/packages/components/src/chart/d3chart/utils/index.js
+++ b/packages/components/src/chart/d3chart/utils/index.js
@@ -90,14 +90,12 @@ export const getUniqueDates = ( lineData, parseDate ) => {
  * Describes getLine
  * @param {function} xLineScale - from `getXLineScale`.
  * @param {function} yScale - from `getYScale`.
- * @param {number} xOffset - Offset to use to draw the line in the X axis.
  * @returns {function} the D3 line function for plotting all category values
  */
-export const getLine = ( xLineScale, yScale, xOffset ) => {
-	return d3Line()
-		.x( d => xLineScale( moment( d.date ).toDate() ) + xOffset )
+export const getLine = ( xLineScale, yScale ) =>
+	d3Line()
+		.x( d => xLineScale( moment( d.date ).toDate() ) )
 		.y( d => yScale( d.value ) );
-};
 
 /**
  * Describes getDateSpaces

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -20,7 +20,7 @@ const handleMouseOverLineChart = ( date, parentNode, node, data, params, positio
 	showTooltip( params, data.find( e => e.date === date ), position );
 };
 
-export const drawLines = ( node, data, params ) => {
+export const drawLines = ( node, data, params, xOffset ) => {
 	const series = node
 		.append( 'g' )
 		.attr( 'class', 'lines' )
@@ -66,7 +66,7 @@ export const drawLines = ( node, data, params ) => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
 			} )
-			.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
+			.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
 			.attr( 'cy', d => params.yScale( d.value ) )
 			.attr( 'tabindex', '0' )
 			.attr( 'aria-label', d => {
@@ -101,9 +101,9 @@ export const drawLines = ( node, data, params ) => {
 
 	focusGrid
 		.append( 'line' )
-		.attr( 'x1', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
+		.attr( 'x1', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
 		.attr( 'y1', 0 )
-		.attr( 'x2', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
+		.attr( 'x2', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
 		.attr( 'y2', params.height );
 
 	focusGrid
@@ -115,7 +115,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'fill', d => getColor( d.key, params.orderedKeys, params.colorScheme ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', lineStroke + 2 )
-		.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
+		.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
 		.attr( 'cy', d => params.yScale( d.value ) );
 
 	focus

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -127,8 +127,8 @@ export const drawLines = ( node, data, params, xOffset ) => {
 		.attr( 'height', params.height )
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) => {
-			const tooltipAlignedToTheLeft = ( i === 0 || i === params.dateSpaces.length - 1 ) && params.uniqueDates.length > 1;
-			const elementWidthRatio = tooltipAlignedToTheLeft ? 0 : 0.5;
+			const isTooltipLeftAligned = ( i === 0 || i === params.dateSpaces.length - 1 ) && params.uniqueDates.length > 1;
+			const elementWidthRatio = isTooltipLeftAligned ? 0 : 0.5;
 			const position = calculateTooltipPosition(
 				d3Event.target,
 				node.node(),

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -65,7 +65,7 @@ export const drawLines = ( node, data, params ) => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
 			} )
-			.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) )
+			.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
 			.attr( 'cy', d => params.yScale( d.value ) )
 			.attr( 'tabindex', '0' )
 			.attr( 'aria-label', d => {
@@ -100,9 +100,9 @@ export const drawLines = ( node, data, params ) => {
 
 	focusGrid
 		.append( 'line' )
-		.attr( 'x1', d => params.xLineScale( moment( d.date ).toDate() ) )
+		.attr( 'x1', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
 		.attr( 'y1', 0 )
-		.attr( 'x2', d => params.xLineScale( moment( d.date ).toDate() ) )
+		.attr( 'x2', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
 		.attr( 'y2', params.height );
 
 	focusGrid
@@ -114,7 +114,7 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'fill', d => getColor( d.key, params.orderedKeys, params.colorScheme ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', lineStroke + 2 )
-		.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) )
+		.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + params.xOffset )
 		.attr( 'cy', d => params.yScale( d.value ) );
 
 	focus
@@ -126,7 +126,8 @@ export const drawLines = ( node, data, params ) => {
 		.attr( 'height', params.height )
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) => {
-			const elementWidthRatio = i === 0 || i === params.dateSpaces.length - 1 ? 0 : 0.5;
+			const tooltipAlignedToTheLeft = ( i === 0 || i === params.dateSpaces.length - 1 ) && params.uniqueDates.length > 1;
+			const elementWidthRatio = tooltipAlignedToTheLeft ? 0 : 0.5;
 			const position = calculateTooltipPosition(
 				d3Event.target,
 				node.node(),

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -36,18 +36,19 @@ export const drawLines = ( node, data, params ) => {
 	lineStroke = params.width <= smallBreak ? 1.25 : lineStroke;
 	const dotRadius = params.width <= wideBreak ? 4 : 6;
 
-	series
-		.append( 'path' )
-		.attr( 'fill', 'none' )
-		.attr( 'stroke-width', lineStroke )
-		.attr( 'stroke-linejoin', 'round' )
-		.attr( 'stroke-linecap', 'round' )
-		.attr( 'stroke', d => getColor( d.key, params.orderedKeys, params.colorScheme ) )
-		.style( 'opacity', d => {
-			const opacity = d.focus ? 1 : 0.1;
-			return d.visible ? opacity : 0;
-		} )
-		.attr( 'd', d => params.line( d.values ) );
+	params.uniqueDates.length > 1 &&
+		series
+			.append( 'path' )
+			.attr( 'fill', 'none' )
+			.attr( 'stroke-width', lineStroke )
+			.attr( 'stroke-linejoin', 'round' )
+			.attr( 'stroke-linecap', 'round' )
+			.attr( 'stroke', d => getColor( d.key, params.orderedKeys, params.colorScheme ) )
+			.style( 'opacity', d => {
+				const opacity = d.focus ? 1 : 0.1;
+				return d.visible ? opacity : 0;
+			} )
+			.attr( 'd', d => params.line( d.values ) );
 
 	const minDataPointSpacing = 36;
 


### PR DESCRIPTION
Fixes #1270.

Centers points in single-date charts

It also avoids creating the `<path>` element (_aka_ the line) when there is only one single date.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51443487-c6379580-1ce9-11e9-8b6b-65162ba52f0f.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51443306-28db6200-1ce7-11e9-8fd2-8f3691b8e83b.png)

### Detailed test instructions:
- Go to the _Revenue_ report (or any other).
- Select _Year to Date_ as the date range and _By quarter_ as the interval, for example. So only one point appears in the line chart.
- Verify it's centered in the middle of the chart.
