### PR TITLE
Report Tables: Update links and add persistedQuery

### DIFF
--- a/client/analytics/report/categories/breadcrumbs.js
+++ b/client/analytics/report/categories/breadcrumbs.js
@@ -10,6 +10,7 @@ import { Spinner } from '@wordpress/components';
  * WooCommerce dependencies
  */
 import { Link } from '@woocommerce/components';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 
 export default class CategoryBreadcrumbs extends Component {
 	getCategoryAncestorIds( category, categories ) {
@@ -48,17 +49,18 @@ export default class CategoryBreadcrumbs extends Component {
 	}
 
 	render() {
-		const { categories, category } = this.props;
+		const { categories, category, query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
 
 		return category ? (
 			<div className="woocommerce-table__breadcrumbs">
 				{ this.getCategoryAncestors( category, categories ) }
 				<Link
-					href={
-						'admin.php?page=wc-admin#/analytics/categories?filter=single_category&categories=' +
-						category.id
-					}
-					type="wp-admin"
+					href={ getNewPath( persistedQuery, 'categories', {
+						filter: 'single_category',
+						categories: category.id,
+					} ) }
+					type="wc-admin"
 				>
 					{ category.name }
 				</Link>

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -68,6 +68,7 @@ class CategoriesReportTable extends Component {
 	}
 
 	getRowsContent( categoryStats ) {
+		const { query } = this.props;
 		return map( categoryStats, categoryStat => {
 			const { category_id, items_sold, net_revenue, products_count, orders_count } = categoryStat;
 			const { categories, query } = this.props;
@@ -76,7 +77,9 @@ class CategoriesReportTable extends Component {
 
 			return [
 				{
-					display: <CategoryBreacrumbs category={ category } categories={ categories } />,
+					display: (
+						<CategoryBreacrumbs query={ query } category={ category } categories={ categories } />
+					),
 					value: category && category.name,
 				},
 				{

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -32,6 +32,31 @@ export const filters = [
 		filters: [
 			{ label: __( 'All Coupons', 'wc-admin' ), value: 'all' },
 			{
+				label: __( 'Single Coupon', 'wc-admin' ),
+				value: 'select_coupon',
+				chartMode: 'item-comparison',
+				subFilters: [
+					{
+						component: 'Search',
+						value: 'single_coupon',
+						chartMode: 'item-comparison',
+						path: [ 'select_coupon' ],
+						settings: {
+							type: 'coupons',
+							param: 'coupons',
+							getLabels: getRequestByIdString( NAMESPACE + 'coupons', coupon => ( {
+								id: coupon.id,
+								label: coupon.code,
+							} ) ),
+							labels: {
+								placeholder: __( 'Type to search for a coupon', 'wc-admin' ),
+								button: __( 'Single Coupon', 'wc-admin' ),
+							},
+						},
+					},
+				],
+			},
+			{
 				label: __( 'Comparison', 'wc-admin' ),
 				value: 'compare-coupons',
 				settings: {

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -18,6 +18,7 @@ import { formatCurrency } from '@woocommerce/currency';
  */
 import { numberFormat } from 'lib/number';
 import ReportTable from 'analytics/components/report-table';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import './style.scss';
 
 export default class OrdersReportTable extends Component {
@@ -91,6 +92,8 @@ export default class OrdersReportTable extends Component {
 	}
 
 	getRowsContent( tableData ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
 		return map( tableData, row => {
 			const {
 				currency,
@@ -108,15 +111,19 @@ export default class OrdersReportTable extends Component {
 				.sort( ( itemA, itemB ) => itemB.quantity - itemA.quantity )
 				.map( item => ( {
 					label: item.name,
-					href:
-						'admin.php?page=wc-admin#/analytics/products?filter=single_product&products=' + item.id,
 					quantity: item.quantity,
+					href: getNewPath( persistedQuery, 'products', {
+						filter: 'single_product',
+						products: item.id,
+					} ),
 				} ) );
 
 			const formattedCoupons = coupons.map( coupon => ( {
 				label: coupon.code,
-				// @TODO It should link to the coupons report
-				href: 'edit.php?s=' + coupon.code + '&post_type=shop_coupon',
+				href: getNewPath( persistedQuery, 'coupons', {
+					filter: 'single_coupon',
+					coupons: coupon.id,
+				} ),
 			} ) );
 
 			return [
@@ -217,7 +224,7 @@ export default class OrdersReportTable extends Component {
 
 	renderLinks( items = [] ) {
 		return items.map( ( item, i ) => (
-			<Link href={ item.href } key={ i } type="wp-admin">
+			<Link href={ item.href } key={ i } type="wc-admin">
 				{ item.label }
 			</Link>
 		) );

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -172,6 +172,7 @@ class ProductsReportTable extends Component {
 											category={ category }
 											categories={ categories }
 											key={ category.id }
+											query={ query }
 										/>
 									) ) }
 								/>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1347

Use `persistedQuery` in Orders Report to pass along date related query parameters to links in the table. 

Since we now have a Coupons Report, we can link directly to that report when a coupon was used in an order. This required the addition of a "Single Coupon" search filter, which I went ahead and added cc @LevinMedia.

![screen shot 2019-01-21 at 11 36 52 am](https://user-images.githubusercontent.com/1922453/51446020-e5c5d100-1d70-11e9-9292-31ef4ec81b50.png)

Category Breadcrumbs have also been updated.

### Detailed test instructions:

1. Orders Report.
2. Change the date range.
3. Click on Products and Coupons in the table.
4. Ensure the resulting report has all the correct elements (date, filters, data).
5. Repeat for Categories links in the Categories Report and Products Report.

#### Known Issue

 * Single Category filter isn't working to populate the category name. Its being fixed in https://github.com/woocommerce/wc-admin/pull/1350