### PR TITLE
 Fill full plot area in bar charts 

### DIFF
--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -33,7 +33,7 @@ export const getYMax = lineData => {
 export const getXScale = ( uniqueDates, width, compact = false ) =>
 	d3ScaleBand()
 		.domain( uniqueDates )
-		.rangeRound( [ 0, width ] )
+		.range( [ 0, width ] )
 		.paddingInner( compact ? 0 : 0.1 );
 
 /**

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -12,17 +12,6 @@ import {
 import moment from 'moment';
 
 /**
- * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
- * @param {array} lineData - from `getLineData`
- * @returns {number} the maximum value in the timeseries multiplied by 4/3
- */
-export const getYMax = lineData => {
-	const yMax = 4 / 3 * d3Max( lineData, d => d3Max( d.values.map( date => date.value ) ) );
-	const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
-	return Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y );
-};
-
-/**
  * Describes getXScale
  * @param {array} uniqueDates - from `getUniqueDates`
  * @param {number} width - calculated width of the charting space
@@ -63,6 +52,17 @@ export const getXLineScale = ( uniqueDates, width ) =>
 			moment( uniqueDates[ uniqueDates.length - 1 ], 'YYYY-MM-DD HH:mm' ).toDate(),
 		] )
 		.rangeRound( [ 0, width ] );
+
+/**
+ * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
+ * @param {array} lineData - from `getLineData`
+ * @returns {number} the maximum value in the timeseries multiplied by 4/3
+ */
+export const getYMax = lineData => {
+	const yMax = 4 / 3 * d3Max( lineData, d => d3Max( d.values.map( date => date.value ) ) );
+	const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
+	return Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y );
+};
 
 /**
  * Describes getYScale


### PR DESCRIPTION
Fixes #1269.

- Change bar chart scale to use [`range`](https://github.com/d3/d3-scale#band_range) instead of [`rangeRound`](https://github.com/d3/d3-scale#band_rangeRound), so it better adapts to the available width. It has the drawback that bars might look a bit blurry because they might take decimal widths, but I tested in a non-HiDPI screen and it looks good-enough.
- Refactor scale tests, so they only test the params we pass to d3 functions, instead of values returned by those functions.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/51476504-03e9fc00-1d86-11e9-8c12-cc0d863883e6.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/51476522-0ea49100-1d86-11e9-95dd-927cc1030ca2.png)

### Detailed test instructions:
- Go to the _Revenue_ report, for example.
- Select _Last Year_ as the date range.
- Switch to bar chart.
- Verify it fills all the available space (similar to the line chart).