### PR TITLE
Fix performance-indicators/allowed schema.

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -458,7 +458,7 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 		$schema = $this->get_public_item_schema();
 		unset( $schema['properties']['value'] );
 		unset( $schema['properties']['format'] );
-		return $sceham;
+		return $schema;
 	}
 
 	/**

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -161,4 +161,21 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		$this->assertArrayHasKey( 'format', $properties );
 		$this->assertArrayHasKey( 'value', $properties );
 	}
+
+	/**
+	 * Test schema for /allowed indicators endpoint.
+	 */
+	public function test_indicators_schema_allowed() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint . '/allowed' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 3, count( $properties ) );
+		$this->assertArrayHasKey( 'stat', $properties );
+		$this->assertArrayHasKey( 'chart', $properties );
+		$this->assertArrayHasKey( 'label', $properties );
+	}
 }


### PR DESCRIPTION
This tiny PR fixes a typo with the schema of the `/wc/v4/reports/performance-indicators/allowed` endpoint.

`PHP Notice:  Undefined variable: sceham in includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php on line 461`.

To test:
* Run `phpunit` and make sure all tests pass.