### PR TITLE
Increase default `wc-api` timeout.

### DIFF
--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -2,12 +2,12 @@
 /**
  * External dependencies
  */
-import { SECOND, MINUTE } from '@fresh-data/framework';
+import { MINUTE } from '@fresh-data/framework';
 
 export const NAMESPACE = '/wc/v4';
 
 export const DEFAULT_REQUIREMENT = {
-	timeout: 5 * SECOND,
+	timeout: 1 * MINUTE,
 	freshness: 5 * MINUTE,
 };
 


### PR DESCRIPTION
Fixes #1304.

Large datasets may cause responses to take longer than 5 seconds, which causes fresh-data to continually issue repeat requests until the first finally responds.

This PR increases the default timeout value to 30 seconds.

### Detailed test instructions:

- On `master` branch
- Open a report that will query a sufficiently large dataset and/or throttle network requests using your browser's development tools (the request must take longer than 5 seconds)
- Navigate to another table page
- Verify that duplicate requests are made every 5 seconds while the first hasn't responded
- Check out this branch, refresh report page
- Navigate to another table page
- Verify that only one request is made (provided it returns in less than 30 seconds)
