### PR TITLE
Conditionally include Gutenberg plugin in test suite

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -168,8 +168,12 @@ install_deps() {
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 
-	# Install Gutenberg
-	php wp-cli.phar plugin install gutenberg --activate
+	# Install Gutenberg if WP < 5
+	if [[ $WP_VERSION =~ ^([0-9]+)[0-9\.]+\-? ]]; then
+		if [ "5" -gt "${BASH_REMATCH[1]}" ]; then
+			php wp-cli.phar plugin install gutenberg --activate
+		fi
+	fi
 
 	# Install WooCommerce
 	cd "wp-content/plugins/"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,7 +94,9 @@ function wc_test_includes() {
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( dirname( __FILE__ ) ) ) . '/gutenberg/gutenberg.php';
+	if ( version_compare( $GLOBALS['wp_version'], '4.9.9', '<=' ) ) { // < 5.0 fails for "5.0-alpha-12345-src
+		require dirname( dirname( dirname( __FILE__ ) ) ) . '/gutenberg/gutenberg.php';
+	}
 
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 	define( 'WC_USE_TRANSACTIONS', false );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -95,7 +95,13 @@ function wc_test_includes() {
  */
 function _manually_load_plugin() {
 	if ( version_compare( $GLOBALS['wp_version'], '4.9.9', '<=' ) ) { // < 5.0 fails for "5.0-alpha-12345-src
-		require dirname( dirname( dirname( __FILE__ ) ) ) . '/gutenberg/gutenberg.php';
+		$_tests_wp_core_dir = getenv( 'WP_CORE_DIR' );
+
+		if ( ! $_tests_wp_core_dir ) {
+			$_tests_wp_core_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress';
+		}
+
+		require $_tests_wp_core_dir . '/wp-content/plugins/gutenberg/gutenberg.php';
 	}
 
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );


### PR DESCRIPTION
Fixes #942.

Only install/activate Gutenberg plugin if WP version under test is earlier than 5.0.

### Detailed test instructions:

- Remove or rename Gutenberg plugin directory (that's adjacent to `wc-admin`)
- Verify that the php tests don't fatal error with a WP >= 5.0
- Run `bin/install-wp-tests.sh` with `latest` as WP_VERSION
- Verify that wp-cli does not try to install Gutenberg
- Run `bin/install-wp-tests.sh` with `5.0` as WP_VERSION
- Verify that wp-cli does not try to install Gutenberg
- Run `bin/install-wp-tests.sh` with `5.0-alpha-42970-src` as WP_VERSION
- Verify that wp-cli does not try to install Gutenberg
- Run `bin/install-wp-tests.sh` with `4.9.9` as WP_VERSION
- Verify that wp-cli **does** try to install Gutenberg
