### PR TITLE
Allow customer date_last_active to be null

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -148,7 +148,9 @@ export default class CustomersReportTable extends Component {
 					value: username,
 				},
 				{
-					display: <Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />,
+					display: date_last_active && (
+						<Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />
+					),
 					value: date_last_active,
 				},
 				{

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -754,7 +754,7 @@ class WC_Admin_Api_Init {
 				first_name varchar(255) NOT NULL,
 				last_name varchar(255) NOT NULL,
 				email varchar(100) NOT NULL,
-				date_last_active timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
+				date_last_active timestamp NULL default null,
 				date_registered timestamp NULL default null,
 				country char(2) DEFAULT '' NOT NULL,
 				postcode varchar(20) DEFAULT '' NOT NULL,

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -534,7 +534,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			'postcode'         => $customer->get_billing_postcode( 'edit' ),
 			'country'          => $customer->get_billing_country( 'edit' ),
 			'date_registered'  => date( 'Y-m-d H:i:s', $customer->get_date_created( 'edit' )->getTimestamp() ),
-			'date_last_active' => $last_active ? date( 'Y-m-d H:i:s', $last_active ) : '',
+			'date_last_active' => $last_active ? date( 'Y-m-d H:i:s', $last_active ) : null,
 		);
 		$format      = array(
 			'%d',


### PR DESCRIPTION
Fixes #1368 

Allows `date_last_active` to be null since sometimes customers/users are created without having made orders.

We set `date_last_active` to null since we don't know if the user has actually been active since an admin could have created and updated this user.

### Screenshots
<img width="1446" alt="screen shot 2019-01-23 at 3 48 56 pm" src="https://user-images.githubusercontent.com/10561050/51590862-68dc5800-1f26-11e9-9a9f-5d1b8faaed28.png">

### Detailed test instructions:

1.  Deactivate/reactivate the plugin and make sure the `date_last_active` column in `wc_customer_lookup` has been made nullable.  You may need to delete this table and rebuild data for this to work.
2.  Create a user through the admin panel.
3.  Update that user.
4.  Note that the user is in the customers table and `date_last_active` is null.
5.  Note that no date is shown and "Invalid date" is not shown in the customers report for this user `wp-admin/admin.php?page=wc-admin#/analytics/customers`.
