### PR TITLE
Use tableQuery sorting when url query is not present

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -193,6 +193,7 @@ export default compose(
 		const selectProps = {
 			primaryData,
 			tableData: extendedTableData,
+			query: { ...tableQuery, ...query },
 		};
 
 		if ( columnPrefsKey ) {


### PR DESCRIPTION
Fixes #1363

Applies default `tableQuery` to the sorting table when url params aren't set so that initial sorting (arrow) is properly set.

### Before
<img width="827" alt="screen shot 2019-01-23 at 5 22 16 pm" src="https://user-images.githubusercontent.com/10561050/51596269-882db200-1f33-11e9-9fde-a4928d8a1601.png">

### After
<img width="818" alt="screen shot 2019-01-23 at 5 20 45 pm" src="https://user-images.githubusercontent.com/10561050/51596228-6a604d00-1f33-11e9-9164-57cb32f84994.png">

### Detailed test instructions:

1.  Visit the Stock report `wp-admin/admin.php?page=wc-admin#/analytics/stock`.
2.  Check that the arrow is a chevron-up (ascending).
3.  Check that other reports show the correct icon.
