### PR TITLE
Add regex expression option to autocompleters

### DIFF
--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -193,7 +193,10 @@ export class Autocomplete extends Component {
 			}
 		}
 		// create a regular expression to filter the options
-		const search = new RegExp( escapeRegExp( query ), 'i' );
+		const expression = 'undefined' !== typeof completer.getSearchExpression
+			? completer.getSearchExpression( escapeRegExp( query ) )
+			: escapeRegExp( query );
+		const search = new RegExp( expression, 'i' );
 		// filter the options we already have
 		const filteredOptions = filterOptions( search, this.state.options, selected );
 		// update the state

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -23,6 +23,9 @@ export default {
 	options() {
 		return wcSettings.dataEndpoints.countries || [];
 	},
+	getSearchExpression( query ) {
+		return '^' + query;
+	},
 	getOptionKeywords( country ) {
 		return [ country.code, decodeEntities( country.name ) ];
 	},


### PR DESCRIPTION
Fixes #1348

Adds a regex search option to autocompleters so we can change how options are searched.

### Screenshots
<img width="606" alt="screen shot 2019-01-23 at 6 15 33 pm" src="https://user-images.githubusercontent.com/10561050/51599615-080b4a80-1f3b-11e9-9aba-b3b926f6770b.png">

### Detailed test instructions:

1.  Visit the Customers report.
2.  Filter by country.
3.  Make sure the search returns results that match country codes or searches that match the start of the country's name (not fuzzy matching).
4.  Check that other search autocompleters continue to work as expected.