### PR TITLE
Customer report: Update lifetime spend label and re-order columns + default sorting

### DIFF
--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -20,7 +20,7 @@ export default class CustomersReport extends Component {
 	render() {
 		const { query, path } = this.props;
 		const tableQuery = {
-			orderby: 'date_registered',
+			orderby: 'date_last_active',
 			order: 'desc',
 			...query,
 		};

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -42,9 +42,14 @@ export default class CustomersReportTable extends Component {
 				hiddenByDefault: true,
 			},
 			{
+				label: __( 'Last Active', 'wc-admin' ),
+				key: 'date_last_active',
+				defaultSort: true,
+				isSortable: true,
+			},
+			{
 				label: __( 'Sign Up', 'wc-admin' ),
 				key: 'date_registered',
-				defaultSort: true,
 				isSortable: true,
 			},
 			{
@@ -58,7 +63,7 @@ export default class CustomersReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Lifetime Spend', 'wc-admin' ),
+				label: __( 'Total Spend', 'wc-admin' ),
 				key: 'total_spend',
 				isSortable: true,
 				isNumeric: true,
@@ -68,11 +73,6 @@ export default class CustomersReportTable extends Component {
 				screenReaderLabel: __( 'Average Order Value', 'wc-admin' ),
 				key: 'avg_order_value',
 				isNumeric: true,
-			},
-			{
-				label: __( 'Last Active', 'wc-admin' ),
-				key: 'date_last_active',
-				isSortable: true,
 			},
 			{
 				label: __( 'Country', 'wc-admin' ),
@@ -148,6 +148,10 @@ export default class CustomersReportTable extends Component {
 					value: username,
 				},
 				{
+					display: <Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />,
+					value: date_last_active,
+				},
+				{
 					display: dateRegistered,
 					value: date_registered,
 				},
@@ -166,10 +170,6 @@ export default class CustomersReportTable extends Component {
 				{
 					display: formatCurrency( avg_order_value ),
 					value: getCurrencyFormatDecimal( avg_order_value ),
-				},
-				{
-					display: <Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />,
-					value: date_last_active,
 				},
 				{
 					display: countryDisplay,


### PR DESCRIPTION
This PR updates the "Lifetime Spend" column label, to "Total Spend" so that it matches the label in the advanced filter. 

It also re-orders the table columns, making "Last Active" the second column, and the default sorting column as well. 

**Before:**

<img width="2182" alt="screen shot 2019-01-23 at 10 09 58 am" src="https://user-images.githubusercontent.com/4500952/51627577-61518a80-1ef7-11e9-81c6-fdce2cd327e1.png">

**After:**

<img width="2182" alt="screen shot 2019-01-23 at 10 09 22 am" src="https://user-images.githubusercontent.com/4500952/51627590-6b738900-1ef7-11e9-84b5-c9a73ed3b1c6.png">
