### PR TITLE
Add table summary to Customers Report

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -25,6 +25,7 @@ export default class CustomersReportTable extends Component {
 
 		this.getHeadersContent = this.getHeadersContent.bind( this );
 		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getSummary = this.getSummary.bind( this );
 	}
 
 	getHeadersContent() {
@@ -187,6 +188,30 @@ export default class CustomersReportTable extends Component {
 		} );
 	}
 
+	getSummary( totals ) {
+		if ( ! totals ) {
+			return [];
+		}
+		return [
+			{
+				label: __( 'customers', 'wc-admin' ),
+				value: numberFormat( totals.customers_count ),
+			},
+			{
+				label: __( 'average orders', 'wc-admin' ),
+				value: numberFormat( totals.avg_orders_count ),
+			},
+			{
+				label: __( 'average lifetime spend', 'wc-admin' ),
+				value: formatCurrency( totals.avg_total_spend ),
+			},
+			{
+				label: __( 'average order value', 'wc-admin' ),
+				value: formatCurrency( totals.avg_avg_order_value ),
+			},
+		];
+	}
+
 	render() {
 		const { query } = this.props;
 
@@ -195,6 +220,7 @@ export default class CustomersReportTable extends Component {
 				endpoint="customers"
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
+				getSummary={ this.getSummary }
 				itemIdField="id"
 				query={ query }
 				labels={ { placeholder: __( 'Search by customer name', 'wc-admin' ) } }

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -16,7 +16,15 @@ import { getResourceIdentifier, getResourcePrefix } from '../../utils';
 import { NAMESPACE } from '../../constants';
 import { SWAGGERNAMESPACE } from 'store/constants';
 
-const statEndpoints = [ 'coupons', 'downloads', 'orders', 'products', 'revenue', 'taxes' ];
+const statEndpoints = [
+	'coupons',
+	'downloads',
+	'orders',
+	'products',
+	'revenue',
+	'taxes',
+	'customers',
+];
 // TODO: Remove once swagger endpoints are phased out.
 const swaggerEndpoints = [ 'categories' ];
 
@@ -28,6 +36,7 @@ const typeEndpointMap = {
 	'report-stats-query-downloads': 'downloads',
 	'report-stats-query-coupons': 'coupons',
 	'report-stats-query-taxes': 'taxes',
+	'report-stats-query-customers': 'customers',
 };
 
 function read( resourceNames, fetch = apiFetch ) {

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -75,7 +75,8 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$report_data     = $customers_query->get_data();
 		$out_data        = array(
 			'totals'    => $report_data,
-			'intervals' => array(), // TODO: is this needed?
+			// TODO: is this needed? the single element array tricks the isReportDataEmpty() selector.
+			'intervals' => array( (object) array() ),
 		);
 
 		return rest_ensure_response( $out_data );

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * REST API Reports customers stats controller
+ *
+ * Handles requests to the /reports/customers/stats endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Reports customers stats controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Reports_Controller
+ */
+class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'reports/customers/stats';
+
+	/**
+	 * Maps query arguments from the REST request.
+	 *
+	 * @param array $request Request array.
+	 * @return array
+	 */
+	protected function prepare_reports_query( $request ) {
+		$args                        = array();
+		$args['registered_before']   = $request['registered_before'];
+		$args['registered_after']    = $request['registered_after'];
+		$args['match']               = $request['match'];
+		$args['name']                = $request['name'];
+		$args['username']            = $request['username'];
+		$args['email']               = $request['email'];
+		$args['country']             = $request['country'];
+		$args['last_active_before']  = $request['last_active_before'];
+		$args['last_active_after']   = $request['last_active_after'];
+		$args['orders_count_min']    = $request['orders_count_min'];
+		$args['orders_count_max']    = $request['orders_count_max'];
+		$args['total_spend_min']     = $request['total_spend_min'];
+		$args['total_spend_max']     = $request['total_spend_max'];
+		$args['avg_order_value_min'] = $request['avg_order_value_min'];
+		$args['avg_order_value_max'] = $request['avg_order_value_max'];
+		$args['last_order_before']   = $request['last_order_before'];
+		$args['last_order_after']    = $request['last_order_after'];
+
+		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
+		$args           = array_merge( $args, $normalized );
+
+		return $args;
+	}
+
+	/**
+	 * Get all reports.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array|WP_Error
+	 */
+	public function get_items( $request ) {
+		$query_args      = $this->prepare_reports_query( $request );
+		$customers_query = new WC_Admin_Reports_Customers_Stats_Query( $query_args );
+		$report_data     = $customers_query->get_data();
+		$out_data        = array(
+			'totals'    => $report_data,
+			'intervals' => array(), // TODO: is this needed?
+		);
+
+		return rest_ensure_response( $out_data );
+	}
+
+	/**
+	 * Prepare a report object for serialization.
+	 *
+	 * @param Array           $report  Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $report, $request ) {
+		$data = $report;
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter a report returned from the API.
+		 *
+		 * Allows modification of the report data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param object           $report   The original report object.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_report_customers_stats', $response, $report, $request );
+	}
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		// TODO: should any of these be 'indicator's?
+		$totals = array(
+			'customers_count'    => array(
+				'description' => __( 'Number of customers.', 'wc-admin' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'avg_orders_count'    => array(
+				'description' => __( 'Average number of orders.', 'wc-admin' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'avg_total_spend' => array(
+				'description' => __( 'Average total spend per customer.', 'wc-admin' ),
+				'type'        => 'number',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'format'      => 'currency',
+			),
+			'avg_avg_order_value' => array(
+				'description' => __( 'Average AOV per customer.', 'wc-admin' ),
+				'type'        => 'number',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'format'      => 'currency',
+			),
+		);
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_customers_stats',
+			'type'       => 'object',
+			'properties' => array(
+				'totals'    => array(
+					'description' => __( 'Totals data.', 'wc-admin' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => $totals,
+				),
+				'intervals' => array( // TODO: remove this?
+					'description' => __( 'Reports data grouped by intervals.', 'wc-admin' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'interval'       => array(
+								'description' => __( 'Type of interval.', 'wc-admin' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'enum'        => array( 'day', 'week', 'month', 'year' ),
+							),
+							'date_start'     => array(
+								'description' => __( "The date the report start, in the site's timezone.", 'wc-admin' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_start_gmt' => array(
+								'description' => __( 'The date the report start, as GMT.', 'wc-admin' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end'       => array(
+								'description' => __( "The date the report end, in the site's timezone.", 'wc-admin' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end_gmt'   => array(
+								'description' => __( 'The date the report end, as GMT.', 'wc-admin' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'subtotals'      => array(
+								'description' => __( 'Interval subtotals.', 'wc-admin' ),
+								'type'        => 'object',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'properties'  => $totals,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                            = array();
+		$params['context']                 = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['registered_before']       = array(
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['registered_after']        = array(
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['match']               = array(
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'wc-admin' ),
+			'type'              => 'string',
+			'default'           => 'all',
+			'enum'              => array(
+				'all',
+				'any',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['name']                = array(
+			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['username']                = array(
+			'description'       => __( 'Limit response to objects with a specfic username.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['email']                   = array(
+			'description'       => __( 'Limit response to objects equal to an email.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['country']                 = array(
+			'description'       => __( 'Limit response to objects with a specfic country.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['last_active_before']      = array(
+			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['last_active_after']       = array(
+			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['registered_before']  = array(
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['registered_after']   = array(
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orders_count_min']    = array(
+			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orders_count_max']    = array(
+			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'wc-admin' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orders_count_between']     = array(
+			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+		);
+		$params['total_spend_min']         = array(
+			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
+			'type'              => 'number',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['total_spend_max']         = array(
+			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'wc-admin' ),
+			'type'              => 'number',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['total_spend_between']     = array(
+			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+		);
+		$params['avg_order_value_min']     = array(
+			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
+			'type'              => 'number',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['avg_order_value_max']     = array(
+			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'wc-admin' ),
+			'type'              => 'number',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['avg_order_value_between'] = array(
+			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+		);
+		$params['last_order_before']       = array(
+			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['last_order_after']        = array(
+			'description'       => __( 'Limit response to objects with last order after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -125,6 +125,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-downloads-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-downloads-stats-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-customers-query.php';
+		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-customers-stats-query.php';
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
@@ -141,6 +142,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-downloads-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-downloads-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-customers-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-customers-stats-data-store.php';
 
 		// Data triggers.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-notes-data-store.php';
@@ -169,6 +171,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-coupons-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-coupons-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-customers-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-customers-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-files-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-downloads-stats-controller.php';
@@ -212,6 +215,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Reports_Downloads_Controller',
 				'WC_Admin_REST_Reports_Downloads_Stats_Controller',
 				'WC_Admin_REST_Reports_Customers_Controller',
+				'WC_Admin_REST_Reports_Customers_Stats_Controller',
 			)
 		);
 
@@ -618,6 +622,7 @@ class WC_Admin_Api_Init {
 				'report-downloads-stats' => 'WC_Admin_Reports_Downloads_Stats_Data_Store',
 				'admin-note'             => 'WC_Admin_Notes_Data_Store',
 				'report-customers'       => 'WC_Admin_Reports_Customers_Data_Store',
+				'report-customers-stats' => 'WC_Admin_Reports_Customers_Stats_Data_Store',
 			)
 		);
 	}

--- a/includes/class-wc-admin-reports-customers-stats-query.php
+++ b/includes/class-wc-admin-reports-customers-stats-query.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Class for parameter-based Customers Report Stats querying
+ *
+ * Example usage:
+ * $args = array(
+ *          'registered_before'   => '2018-07-19 00:00:00',
+ *          'registered_after'    => '2018-07-05 00:00:00',
+ *          'page'                => 2,
+ *          'avg_order_value_min' => 100,
+ *          'country'             => 'GB',
+ *         );
+ * $report = new WC_Admin_Reports_Customers_Stats_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Customers_Stats_Query
+ */
+class WC_Admin_Reports_Customers_Stats_Query extends WC_Admin_Reports_Query {
+
+	/**
+	 * Valid fields for Customers report.
+	 *
+	 * @return array
+	 */
+	protected function get_default_query_vars() {
+		return array(
+			'per_page' => get_option( 'posts_per_page' ), // not sure if this should be the default.
+			'page'     => 1,
+			'order'    => 'DESC',
+			'orderby'  => 'date_registered',
+			'fields'   => '*', // TODO: needed?
+		);
+	}
+
+	/**
+	 * Get product data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args = apply_filters( 'woocommerce_reports_customers_stats_query_args', $this->get_query_vars() );
+
+		$data_store = WC_Data_Store::load( 'report-customers-stats' );
+		$results    = $data_store->get_data( $args );
+		return apply_filters( 'woocommerce_reports_customers_stats_select_query', $results, $args );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-customers-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-stats-data-store.php
@@ -80,7 +80,12 @@ class WC_Admin_Reports_Customers_Stats_Data_Store extends WC_Admin_Reports_Custo
 				"SELECT {$selections} FROM
 				(
 					SELECT
-						COUNT( order_id ) as orders_count, 
+						(
+							CASE WHEN COUNT( order_id ) = 0
+								THEN NULL
+								ELSE COUNT( order_id )
+							END
+						) as orders_count,
       					SUM( gross_total ) as total_spend, 
 						( SUM( gross_total ) / COUNT( order_id ) ) as avg_order_value
 					FROM

--- a/includes/data-stores/class-wc-admin-reports-customers-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-stats-data-store.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * WC_Admin_Reports_Customers_Stats_Data_Store class file.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Customers_Stats_Data_Store.
+ */
+class WC_Admin_Reports_Customers_Stats_Data_Store extends WC_Admin_Reports_Customers_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+	/**
+	 * Mapping columns to data type to return correct response types.
+	 *
+	 * @var array
+	 */
+	protected $column_types = array(
+		'customers_count'     => 'intval',
+		'avg_orders_count'    => 'floatval',
+		'avg_total_spend'     => 'floatval',
+		'avg_avg_order_value' => 'floatval',
+	);
+
+	/**
+	 * SQL columns to select in the db query and their mapping to SQL code.
+	 *
+	 * @var array
+	 */
+	protected $report_columns = array(
+		'customers_count'     => 'COUNT( * ) as customers_count',
+		'avg_orders_count'    => 'AVG( orders_count ) as avg_orders_count',
+		'avg_total_spend'     => 'AVG( total_spend ) as avg_total_spend',
+		'avg_avg_order_value' => 'AVG( avg_order_value ) as avg_avg_order_value',
+	);
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// This space intentionally left blank (to avoid parent constructor).
+	}
+
+	/**
+	 * Returns the report data based on parameters supplied by the user.
+	 *
+	 * @param array $query_args  Query parameters.
+	 * @return stdClass|WP_Error Data.
+	 */
+	public function get_data( $query_args ) {
+		global $wpdb;
+
+		$customers_table_name = $wpdb->prefix . self::TABLE_NAME;
+
+		// These defaults are only partially applied when used via REST API, as that has its own defaults.
+		$defaults   = array(
+			'per_page' => get_option( 'posts_per_page' ),
+			'page'     => 1,
+			'order'    => 'DESC',
+			'orderby'  => 'date_registered',
+			'fields'   => '*',
+		);
+		$query_args = wp_parse_args( $query_args, $defaults );
+		$cache_key  = $this->get_cache_key( $query_args );
+		$data       = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $data ) {
+			$data = (object) array(
+				'customers_count'     => 0,
+				'avg_orders_count'    => 0,
+				'avg_total_spend'     => 0.0,
+				'avg_avg_order_value' => 0.0,
+			);
+
+			$selections       = $this->selected_columns( $query_args );
+			$sql_query_params = $this->get_sql_query_params( $query_args );
+
+			$report_data = $wpdb->get_results(
+				"SELECT {$selections} FROM
+				(
+					SELECT
+						COUNT( order_id ) as orders_count, 
+      					SUM( gross_total ) as total_spend, 
+						( SUM( gross_total ) / COUNT( order_id ) ) as avg_order_value
+					FROM
+						{$customers_table_name}
+						{$sql_query_params['from_clause']}
+					WHERE
+						1=1
+						{$sql_query_params['where_time_clause']}
+						{$sql_query_params['where_clause']}
+					GROUP BY
+						{$customers_table_name}.customer_id
+					HAVING
+						1=1
+						{$sql_query_params['having_clause']}
+				) as tt",
+				ARRAY_A
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			if ( null === $report_data ) {
+				return $data;
+			}
+
+			$data = (object) $this->cast_numbers( $report_data[0] );
+
+			wp_cache_set( $cache_key, $data, $this->cache_group );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
+	}
+}

--- a/tests/api/reports-customers-stats.php
+++ b/tests/api/reports-customers-stats.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Reports Customers Stats REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+
+/**
+ * Reports Customers Stats REST API Test Class
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v4/reports/customers/stats';
+
+	/**
+	 * Setup test reports products data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function _test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 2, $properties );
+		$this->assertArrayHasKey( 'totals', $properties );
+		$this->assertArrayHasKey( 'intervals', $properties );
+		$this->assertCount( 4, $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'customers_count', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'avg_orders_count', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'avg_total_spend', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'avg_avg_order_value', $properties['totals']['properties'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$test_customers = array();
+
+		// Create 10 test customers.
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$test_customers[] = WC_Helper_Customer::create_customer( "customer{$i}", 'password', "customer{$i}@example.com" );
+		}
+		// One differing name.
+		$test_customers[2]->set_first_name( 'Jeff' );
+		$test_customers[2]->save();
+
+		// Create a test product for use in an order.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		// Place some test orders.
+		$order = WC_Helper_Order::create_order( $test_customers[0]->get_id(), $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		$order = WC_Helper_Order::create_order( $test_customers[0]->get_id(), $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 234 );
+		$order->save();
+
+		$order = WC_Helper_Order::create_order( $test_customers[1]->get_id(), $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 55 );
+		$order->save();
+
+		$order = WC_Helper_Order::create_order( $test_customers[2]->get_id(), $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 9.12 );
+		$order->save();
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 10, $reports['totals']->customers_count );
+		$this->assertEquals( 1.333, round( $reports['totals']->avg_orders_count, 3 ) );
+		$this->assertEquals( 132.707, round( $reports['totals']->avg_total_spend, 3 ) );
+		$this->assertEquals( 77.04, $reports['totals']->avg_avg_order_value );
+
+		// Test name parameter (case with no matches).
+		$request->set_query_params(
+			array(
+				'name' => 'Nota Customername',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, $reports['totals']->customers_count );
+		$this->assertEquals( 0, $reports['totals']->avg_orders_count );
+		$this->assertEquals( 0, $reports['totals']->avg_total_spend );
+		$this->assertEquals( 0, $reports['totals']->avg_avg_order_value );
+
+		// Test name and last_order parameters.
+		$request->set_query_params(
+			array(
+				'name'             => 'Jeff',
+				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $reports['totals']->customers_count );
+		$this->assertEquals( 1, $reports['totals']->avg_orders_count );
+		$this->assertEquals( 9.12, $reports['totals']->avg_total_spend );
+		$this->assertEquals( 9.12, $reports['totals']->avg_avg_order_value );
+	}
+}


### PR DESCRIPTION
Fixes #918.

This PR seeks to add a table summary to the customers report, powered by a new `/reports/customers/stats` endpoint.

### Screenshots

Design:
![screen shot 2019-01-23 at 6 08 59 pm](https://user-images.githubusercontent.com/63922/51647445-160c9b80-1f3a-11e9-92fa-2fc229202c2e.png)

As implemented:
![screen shot 2019-01-23 at 6 11 25 pm](https://user-images.githubusercontent.com/63922/51647502-5409bf80-1f3a-11e9-8197-483c731efc5c.png)

### Detailed test instructions:

- Open Customers Report
- Verify that the summary displays
- Verify that the totals change (and are correct) when adding filters to the report

**Note:** the aggregate values are calculated only for customers that have placed orders. If your report contains 10 customers, but only 4 have placed orders, the summary totals will be based on those 4 customers, not all 10.
