### PR TITLE
Add Product Detail Report & Finish Comparison Chart Mode Functionality

### DIFF
--- a/client/analytics/components/report-chart/test/index.js
+++ b/client/analytics/components/report-chart/test/index.js
@@ -8,6 +8,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { ReportChart } from '../';
+import { getChartMode } from '../utils';
 
 jest.mock( '@woocommerce/components', () => ( {
 	...require.requireActual( '@woocommerce/components' ),
@@ -30,7 +31,7 @@ const selectedChart = {
 };
 
 describe( 'ReportChart', () => {
-	test( 'should not set the mode prop by default', () => {
+	test( 'should set the time-comparison mode prop by default', () => {
 		const reportChart = shallow(
 			<ReportChart
 				path={ path }
@@ -42,7 +43,7 @@ describe( 'ReportChart', () => {
 		);
 		const chart = reportChart.find( 'Chart' );
 
-		expect( chart.props().mode ).toBeUndefined();
+		expect( chart.props().mode ).toEqual( 'time-comparison' );
 	} );
 
 	test( 'should set the mode prop depending on the active filter', () => {
@@ -62,19 +63,7 @@ describe( 'ReportChart', () => {
 			},
 		];
 		const query = { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' };
-		const reportChart = shallow(
-			<ReportChart
-				filters={ filters }
-				path={ path }
-				primaryData={ data }
-				query={ query }
-				secondaryData={ data }
-				selectedChart={ selectedChart }
-			/>
-		);
-
-		const chart = reportChart.find( 'Chart' );
-
-		expect( chart.props().mode ).toEqual( 'item-comparison' );
+		const mode = getChartMode( filters, query );
+		expect( mode ).toEqual( 'item-comparison' );
 	} );
 } );

--- a/client/analytics/components/report-chart/utils.js
+++ b/client/analytics/components/report-chart/utils.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { find, get } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { flattenFilters } from '@woocommerce/navigation';
+
+export const DEFAULT_FILTER = 'all';
+
+export function getSelectedFilter( filters, query, selectedFilterArgs = {} ) {
+	if ( filters.length === 0 ) {
+		return null;
+	}
+
+	const filterConfig = filters.pop();
+
+	if ( filterConfig.showFilters( query, selectedFilterArgs ) ) {
+		const allFilters = flattenFilters( filterConfig.filters );
+		const value = query[ filterConfig.param ] || DEFAULT_FILTER;
+		const selectedFilter = find( allFilters, { value } );
+		const selectedFilterParam = get( selectedFilter, [ 'settings', 'param' ] );
+
+		if ( ! selectedFilterParam || Object.keys( query ).includes( selectedFilterParam ) ) {
+			return selectedFilter;
+		}
+	}
+
+	return getSelectedFilter( filters, query, selectedFilterArgs );
+}
+
+export function getChartMode( filters, query, selectedFilterArgs ) {
+	if ( ! filters ) {
+		return;
+	}
+	const clonedFilters = filters.slice( 0 );
+	const selectedFilter = getSelectedFilter( clonedFilters, query, selectedFilterArgs );
+
+	return get( selectedFilter, [ 'chartMode' ] );
+}

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -29,7 +29,7 @@ export const charts = [
 
 const filterConfig = {
 	label: __( 'Show', 'wc-admin' ),
-	staticParams: [ 'chart' ],
+	staticParams: [],
 	param: 'filter',
 	showFilters: () => true,
 	filters: [
@@ -114,19 +114,20 @@ const filterConfig = {
 			label: __( 'Top Products by Items Sold', 'wc-admin' ),
 			value: 'top_items',
 			chartMode: 'item-comparison',
-			query: { orderby: 'items_sold', order: 'desc' },
+			query: { orderby: 'items_sold', order: 'desc', chart: 'items_sold' },
 		},
 		{
 			label: __( 'Top Products by Net Revenue', 'wc-admin' ),
 			value: 'top_sales',
 			chartMode: 'item-comparison',
-			query: { orderby: 'net_revenue', order: 'desc' },
+			query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
 		},
 	],
 };
 
 const variationsConfig = {
-	showFilters: query => 'single_product' === query.filter && !! query.products,
+	showFilters: query =>
+		'single_product' === query.filter && !! query.products && query[ 'is-variable' ],
 	staticParams: [ 'filter', 'products' ],
 	param: 'filter-variations',
 	filters: [
@@ -151,13 +152,13 @@ const variationsConfig = {
 			label: __( 'Top Variations by Items Sold', 'wc-admin' ),
 			chartMode: 'item-comparison',
 			value: 'top_items',
-			query: { orderby: 'items_sold', order: 'desc' },
+			query: { orderby: 'items_sold', order: 'desc', chart: 'item_sold' },
 		},
 		{
 			label: __( 'Top Variations by Net Revenue', 'wc-admin' ),
 			chartMode: 'item-comparison',
 			value: 'top_sales',
-			query: { orderby: 'net_revenue', order: 'desc' },
+			query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
 		},
 	],
 };

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -4,12 +4,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
 /**
  * WooCommerce dependencies
  */
-import { ReportFilters } from '@woocommerce/components';
+import { ReportFilters, SummaryListPlaceholder, ChartPlaceholder } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -18,37 +19,99 @@ import { charts, filters } from './config';
 import getSelectedChart from 'lib/get-selected-chart';
 import ProductsReportTable from './table';
 import ReportChart from 'analytics/components/report-chart';
+import ReportError from 'analytics/components/report-error';
 import ReportSummary from 'analytics/components/report-summary';
 import VariationsReportTable from './table-variations';
+import withSelect from 'wc-api/with-select';
 
-export default class ProductsReport extends Component {
+class ProductsReport extends Component {
+	getChartMeta() {
+		const { query, isSingleProductView, isSingleProductVariable } = this.props;
+
+		const isProductDetailsView =
+			'top_items' === query.filter ||
+			'top_sales' === query.filter ||
+			'single_product' === query.filter;
+
+		const mode =
+			isProductDetailsView || ( isSingleProductView && isSingleProductVariable )
+				? 'item-comparison'
+				: 'time-comparison';
+		const compareObject =
+			isSingleProductView && isSingleProductVariable ? 'variations' : 'products';
+		const label =
+			isSingleProductView && isSingleProductVariable
+				? __( '%s variations', 'wc-admin' )
+				: __( '%s products', 'wc-admin' );
+
+		return {
+			compareObject,
+			itemsLabel: label,
+			mode,
+		};
+	}
+
 	render() {
-		const { path, query } = this.props;
-		const isProductDetailsView = query.filter === 'single_product';
+		const { compareObject, itemsLabel, mode } = this.getChartMeta();
+		const {
+			path,
+			query,
+			isProductsError,
+			isProductsRequesting,
+			isSingleProductVariable,
+		} = this.props;
 
-		const itemsLabel = isProductDetailsView
-			? __( '%s variations', 'wc-admin' )
-			: __( '%s products', 'wc-admin' );
+		if ( isProductsError ) {
+			return <ReportError isError />;
+		}
+
+		if ( isProductsRequesting ) {
+			return (
+				<Fragment>
+					<ReportFilters query={ query } path={ path } filters={ filters } />
+					<SummaryListPlaceholder numberOfItems={ charts.length } />
+					<span className="screen-reader-text">
+						{ __( 'Your requested data is loading', 'wc-admin' ) }
+					</span>
+					<div className="woocommerce-chart">
+						<div className="woocommerce-chart__body">
+							<ChartPlaceholder height={ 220 } />
+						</div>
+					</div>
+					<ProductsReportTable query={ query } />
+				</Fragment>
+			);
+		}
+
+		const chartQuery = {
+			...query,
+		};
+
+		if ( 'item-comparison' === mode ) {
+			chartQuery.segmentby = 'products' === compareObject ? 'product' : 'variation';
+		}
 
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
+					mode={ mode }
 					charts={ charts }
 					endpoint="products"
-					query={ query }
+					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
+					mode={ mode }
 					filters={ filters }
 					charts={ charts }
 					endpoint="products"
 					itemsLabel={ itemsLabel }
 					path={ path }
-					query={ query }
-					selectedChart={ getSelectedChart( query.chart, charts ) }
+					query={ chartQuery }
+					selectedChart={ getSelectedChart( chartQuery.chart, charts ) }
 				/>
-				{ isProductDetailsView ? (
+				{ isSingleProductVariable ? (
 					<VariationsReportTable query={ query } />
 				) : (
 					<ProductsReportTable query={ query } />
@@ -62,3 +125,34 @@ ProductsReport.propTypes = {
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
+
+export default compose(
+	withSelect( ( select, props ) => {
+		const { query } = props;
+		const { getProducts, isGetProductsRequesting, getProductsError } = select( 'wc-api' );
+		const isSingleProductView = query.products && 1 === query.products.split( ',' ).length;
+		if ( isSingleProductView ) {
+			const includeArgs = { include: query.products };
+			// TODO Look at similar usage to populate tags in the Search component.
+			const products = getProducts( includeArgs );
+			const isVariable = products[ 0 ] && 'variable' === products[ 0 ].type;
+			const isProductsRequesting = isGetProductsRequesting( includeArgs );
+			const isProductsError = getProductsError( includeArgs );
+			return {
+				query: {
+					...query,
+					'is-variable': isVariable,
+				},
+				isSingleProductView,
+				isSingleProductVariable: isVariable,
+				isProductsRequesting,
+				isProductsError,
+			};
+		}
+
+		return {
+			query,
+			isSingleProductView,
+		};
+	} )
+)( ProductsReport );

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -139,12 +139,11 @@ export default class VariationsReportTable extends Component {
 	}
 
 	getSummary( totals ) {
-		const { products_count = 0, items_sold = 0, net_revenue = 0, orders_count = 0 } = totals;
+		const { variations_count = 0, items_sold = 0, net_revenue = 0, orders_count = 0 } = totals;
 		return [
 			{
-				// @TODO: When primaryData is segmented, fix this to reflect variations, not products.
-				label: _n( 'variation sold', 'variations sold', products_count, 'wc-admin' ),
-				value: numberFormat( products_count ),
+				label: _n( 'variation sold', 'variations sold', variations_count, 'wc-admin' ),
+				value: numberFormat( variations_count ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', items_sold, 'wc-admin' ),
@@ -176,7 +175,7 @@ export default class VariationsReportTable extends Component {
 				endpoint="variations"
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
-				itemIdField="product_id"
+				itemIdField="variation_id"
 				labels={ labels }
 				query={ query }
 				getSummary={ this.getSummary }

--- a/client/wc-api/products/index.js
+++ b/client/wc-api/products/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+
+export default {
+	operations,
+	selectors,
+};

--- a/client/wc-api/products/operations.js
+++ b/client/wc-api/products/operations.js
@@ -1,0 +1,51 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { isResourcePrefix, getResourceIdentifier, getResourceName } from '../utils';
+
+function read( resourceNames, fetch = apiFetch ) {
+	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'product-query' ) );
+
+	return filteredNames.map( async resourceName => {
+		const query = getResourceIdentifier( resourceName );
+		const url = `/wc/v3/products${ stringifyQuery( query ) }`;
+
+		try {
+			const products = await fetch( {
+				path: url,
+			} );
+
+			const ids = products.map( product => product.id );
+			const productResources = products.reduce( ( resources, product ) => {
+				resources[ getResourceName( 'product', product.id ) ] = { data: product };
+				return resources;
+			}, {} );
+
+			return {
+				[ resourceName ]: {
+					data: ids,
+					totalCount: ids.length,
+				},
+				...productResources,
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	read,
+};

--- a/client/wc-api/products/selectors.js
+++ b/client/wc-api/products/selectors.js
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+import { DEFAULT_REQUIREMENT } from '../constants';
+
+const getProducts = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'product-query', query );
+	const ids = requireResource( requirement, resourceName ).data || [];
+	const products = ids.map( id => getResource( getResourceName( 'product', id ) ).data || {} );
+	return products;
+};
+
+const getProductsError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'product-query', query );
+	return getResource( resourceName ).error;
+};
+
+const isGetProductsRequesting = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'product-query', query );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+export default {
+	getProducts,
+	getProductsError,
+	isGetProductsRequesting,
+};

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -168,14 +168,13 @@ function getRequestQuery( endpoint, dataType, query ) {
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( endpoint, query );
 	const end = datesFromQuery[ dataType ].before;
-	const endingTimeOfDay = end.isSame( moment(), 'day' ) ? 'now' : 'end';
-
 	return {
 		order: 'asc',
 		interval,
 		per_page: MAX_PER_PAGE,
 		after: appendTimestamp( datesFromQuery[ dataType ].after, 'start' ),
-		before: appendTimestamp( end, endingTimeOfDay ),
+		before: appendTimestamp( end, 'end' ),
+		segmentby: query.segmentby,
 		...filterQuery,
 	};
 }

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -5,6 +5,7 @@
  */
 import items from './items';
 import notes from './notes';
+import products from './products';
 import reportItems from './reports/items';
 import reportStats from './reports/stats';
 import reviews from './reviews';
@@ -20,6 +21,7 @@ function createWcApiSpec() {
 		selectors: {
 			...items.selectors,
 			...notes.selectors,
+			...products.selectors,
 			...reportItems.selectors,
 			...reportStats.selectors,
 			...reviews.selectors,
@@ -31,6 +33,7 @@ function createWcApiSpec() {
 				return [
 					...items.operations.read( resourceNames ),
 					...notes.operations.read( resourceNames ),
+					...products.operations.read( resourceNames ),
 					...reportItems.operations.read( resourceNames ),
 					...reportStats.operations.read( resourceNames ),
 					...reviews.operations.read( resourceNames ),

--- a/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-stats-controller.php
@@ -60,6 +60,7 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 				'net_revenue',
 				'orders_count',
 				'products_count',
+				'variations_count',
 			),
 		);
 
@@ -187,6 +188,13 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
+						),
+						'segment_label' => array(
+							'description' => __( 'Human readable segment label, either product or variation name.', 'wc-admin' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'enum'        => array( 'day', 'week', 'month', 'year' ),
 						),
 						'subtotals'  => array(
 							'description' => __( 'Interval subtotals.', 'wc-admin' ),
@@ -376,6 +384,15 @@ class WC_Admin_REST_Reports_Products_Stats_Controller extends WC_REST_Reports_Co
 		);
 		$params['products']   = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'wc-admin' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'integer',
+			),
+		);
+		$params['variations']   = array(
+			'description'       => __( 'Limit result to items with specified variation ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-variations-controller.php
@@ -290,7 +290,7 @@ class WC_Admin_REST_Reports_Variations_Controller extends WC_REST_Reports_Contro
 			'default'           => 'date',
 			'enum'              => array(
 				'date',
-				'gross_revenue',
+				'net_revenue',
 				'orders_count',
 				'items_sold',
 			),

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -180,6 +180,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-orders-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-categories-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-variations-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-variations-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
@@ -217,6 +218,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Categories_Controller',
+				'WC_Admin_REST_Product_Variations_Controller',
 				'WC_Admin_REST_Product_Reviews_Controller',
 				'WC_Admin_REST_Product_Variations_Controller',
 				'WC_Admin_REST_Reports_Controller',

--- a/includes/class-wc-admin-reports-products-stats-segmenting.php
+++ b/includes/class-wc-admin-reports-products-stats-segmenting.php
@@ -21,10 +21,11 @@ class WC_Admin_Reports_Products_Stats_Segmenting extends WC_Admin_Reports_Segmen
 	 */
 	protected function get_segment_selections_product_level( $products_table ) {
 		$columns_mapping = array(
-			'items_sold'     => "SUM($products_table.product_qty) as items_sold",
-			'net_revenue'    => "SUM($products_table.product_net_revenue ) AS net_revenue",
-			'orders_count'   => "COUNT( DISTINCT $products_table.order_id ) AS orders_count",
-			'products_count' => "COUNT( DISTINCT $products_table.product_id ) AS products_count",
+			'items_sold'       => "SUM($products_table.product_qty) as items_sold",
+			'net_revenue'      => "SUM($products_table.product_net_revenue ) AS net_revenue",
+			'orders_count'     => "COUNT( DISTINCT $products_table.order_id ) AS orders_count",
+			'products_count'   => "COUNT( DISTINCT $products_table.product_id ) AS products_count",
+			'variations_count' => "COUNT( DISTINCT $products_table.variation_id ) AS variations_count",
 		);
 
 		return $this->prepare_selections( $columns_mapping );

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -673,6 +673,24 @@ class WC_Admin_Reports_Data_Store {
 	}
 
 	/**
+	 * Returns comma separated ids of allowed variations, based on query arguments from the user.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return string
+	 */
+	protected function get_included_variations( $query_args ) {
+		$included_variations = array();
+		$operator            = $this->get_match_operator( $query_args );
+
+		if ( isset( $query_args['variations'] ) && is_array( $query_args['variations'] ) && count( $query_args['variations'] ) > 0 ) {
+			$included_variations = array_filter( array_map( 'intval', $query_args['variations'] ) );
+		}
+
+		$included_variations_str = implode( ',', $included_variations );
+		return $included_variations_str;
+	}
+
+	/**
 	 * Returns comma separated ids of excluded products, based on query arguments from the user.
 	 *
 	 * @param array $query_args Parameters supplied by the user.

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -133,6 +133,11 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";
 		}
 
+		$included_variations = $this->get_included_variations( $query_args );
+		if ( $included_variations ) {
+			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.variation_id IN ({$included_variations})";
+		}
+
 		$order_status_filter = $this->get_status_subquery( $query_args );
 		if ( $order_status_filter ) {
 			$sql_query_params['from_clause']  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";

--- a/includes/data-stores/class-wc-admin-reports-products-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-stats-data-store.php
@@ -19,13 +19,14 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 	 * @var array
 	 */
 	protected $column_types = array(
-		'date_start'     => 'strval',
-		'date_end'       => 'strval',
-		'product_id'     => 'intval',
-		'items_sold'     => 'intval',
-		'net_revenue'    => 'floatval',
-		'orders_count'   => 'intval',
-		'products_count' => 'intval',
+		'date_start'       => 'strval',
+		'date_end'         => 'strval',
+		'product_id'       => 'intval',
+		'items_sold'       => 'intval',
+		'net_revenue'      => 'floatval',
+		'orders_count'     => 'intval',
+		'products_count'   => 'intval',
+		'variations_count' => 'intval',
 	);
 
 	/**
@@ -34,10 +35,11 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 	 * @var array
 	 */
 	protected $report_columns = array(
-		'items_sold'     => 'SUM(product_qty) as items_sold',
-		'net_revenue'    => 'SUM(product_net_revenue) AS net_revenue',
-		'orders_count'   => 'COUNT(DISTINCT order_id) as orders_count',
-		'products_count' => 'COUNT(DISTINCT product_id) as products_count',
+		'items_sold'       => 'SUM(product_qty) as items_sold',
+		'net_revenue'      => 'SUM(product_net_revenue) AS net_revenue',
+		'orders_count'     => 'COUNT(DISTINCT order_id) as orders_count',
+		'products_count'   => 'COUNT(DISTINCT product_id) as products_count',
+		'variations_count' => 'COUNT(DISTINCT variation_id) as variations_count',
 	);
 
 	/**
@@ -68,6 +70,11 @@ class WC_Admin_Reports_Products_Stats_Data_Store extends WC_Admin_Reports_Produc
 		$included_products = $this->get_included_products( $query_args );
 		if ( $included_products ) {
 			$products_where_clause .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";
+		}
+
+		$included_variations = $this->get_included_variations( $query_args );
+		if ( $included_variations ) {
+			$products_where_clause .= " AND {$order_product_lookup_table}.variation_id IN ({$included_variations})";
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );

--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -229,6 +229,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 								{$sql_query_params['from_clause']}
 							WHERE
 								1=1
+								{$sql_query_params['where_time_clause']}
 								{$sql_query_params['where_clause']}
 							GROUP BY
 								variation_id
@@ -248,6 +249,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 						{$sql_query_params['from_clause']}
 					WHERE
 						1=1
+						{$sql_query_params['where_time_clause']}
 						{$sql_query_params['where_clause']}
 					GROUP BY
 						variation_id

--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
 import PropTypes from 'prop-types';
@@ -36,7 +37,7 @@ class D3Legend extends Component {
 	}
 
 	updateListScroll() {
-		if ( ! this.listRef ) {
+		if ( ! this || ! this.listRef ) {
 			return;
 		}
 		const list = this.listRef.current;
@@ -93,7 +94,12 @@ class D3Legend extends Component {
 							<button
 								onClick={ handleLegendToggle }
 								id={ row.key }
-								disabled={ ( row.visible && numberOfRowsVisible <= 1 ) || ! interactive }
+								disabled={
+									( row.visible && numberOfRowsVisible <= 1 ) ||
+									( ! row.visible && numberOfRowsVisible >= 5 ) ||
+									! interactive
+								}
+								title={ numberOfRowsVisible >= 5 ? __( 'You may select up to 5 items.', 'wc-admin' ) : '' }
 							>
 								<div className="woocommerce-legend__item-container" id={ row.key }>
 									<span

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -4,9 +4,12 @@
  */
 @import './legend.scss';
 
+.woocommerce-chart__body-row .d3-chart__container {
+	width: calc( 100% - 320px );
+}
+
 .d3-chart__container {
 	position: relative;
-	width: 100%;
 
 	svg {
 		overflow: visible;

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -176,6 +176,11 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 export const getYGrids = ( yMax ) => {
 	const yGrids = [];
 
+	// If all values are 0, yMax can become NaN.
+	if ( isNaN( yMax ) ) {
+		return null;
+	}
+
 	for ( let i = 0; i < 4; i++ ) {
 		const value = yMax > 1 ? Math.round( i / 3 * yMax ) : i / 3 * yMax;
 		if ( yGrids[ yGrids.length - 1 ] !== value ) {
@@ -237,29 +242,31 @@ export const drawAxis = ( node, params, xOffset ) => {
 				.tickFormat( '' )
 		);
 
-	node
-		.append( 'g' )
-		.attr( 'class', 'grid' )
-		.attr( 'transform', `translate(-${ params.margin.left }, 0)` )
-		.call(
-			d3AxisLeft( params.yScale )
-				.tickValues( yGrids )
-				.tickSize( -params.width - params.margin.left - params.margin.right )
-				.tickFormat( '' )
-		)
-		.call( g => g.select( '.domain' ).remove() );
+	if ( yGrids ) {
+		node
+			.append( 'g' )
+			.attr( 'class', 'grid' )
+			.attr( 'transform', `translate(-${ params.margin.left }, 0)` )
+			.call(
+				d3AxisLeft( params.yScale )
+					.tickValues( yGrids )
+					.tickSize( -params.width - params.margin.left - params.margin.right )
+					.tickFormat( '' )
+			)
+			.call( g => g.select( '.domain' ).remove() );
 
-	node
-		.append( 'g' )
-		.attr( 'class', 'axis y-axis' )
-		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', 'translate(-50, 0)' )
-		.attr( 'text-anchor', 'start' )
-		.call(
-			d3AxisLeft( params.yTickOffset )
-				.tickValues( params.yMax === 0 ? [ yGrids[ 0 ] ] : yGrids )
-				.tickFormat( d => params.yFormat( d !== 0 ? d : 0 ) )
-		);
+		node
+			.append( 'g' )
+			.attr( 'class', 'axis y-axis' )
+			.attr( 'aria-hidden', 'true' )
+			.attr( 'transform', 'translate(-50, 0)' )
+			.attr( 'text-anchor', 'start' )
+			.call(
+				d3AxisLeft( params.yTickOffset )
+					.tickValues( params.yMax === 0 ? [ yGrids[ 0 ] ] : yGrids )
+					.tickFormat( d => params.yFormat( d !== 0 ? d : 0 ) )
+			);
+	}
 
 	node.selectAll( '.domain' ).remove();
 	node

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -45,8 +45,7 @@ import TableSummary from './summary';
 class TableCard extends Component {
 	constructor( props ) {
 		super( props );
-		const { compareBy, query } = props;
-
+		const { query, compareBy } = this.props;
 		const showCols = props.headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean );
 		const selectedRows = query.filter ? getIdsFromQuery( query[ compareBy ] ) : [];
 
@@ -143,11 +142,10 @@ class TableCard extends Component {
 	}
 
 	onCompare() {
-		const { compareBy, compareParam, onQueryChange } = this.props;
-		const { selectedRows } = this.state;
-		if ( compareBy ) {
-			onQueryChange( 'compare' )( compareBy, compareParam, selectedRows.join( ',' ) );
-		}
+		// Reset selected rows so the user can start a comparison again.
+		this.setState( {
+			selectedRows: [],
+		} );
 	}
 
 	onSearch( values ) {

--- a/tests/api/reports-products-stats.php
+++ b/tests/api/reports-products-stats.php
@@ -87,11 +87,12 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 
 		$expected_reports = array(
 			'totals'    => array(
-				'items_sold'     => 4,
-				'net_revenue'    => 100.0,
-				'orders_count'   => 1,
-				'products_count' => 1,
-				'segments'       => array(),
+				'items_sold'       => 4,
+				'net_revenue'      => 100.0,
+				'orders_count'     => 1,
+				'products_count'   => 1,
+				'variations_count' => 1,
+				'segments'         => array(),
 			),
 			'intervals' => array(
 				array(
@@ -101,11 +102,12 @@ class WC_Tests_API_Reports_Products_Stats extends WC_REST_Unit_Test_Case {
 					'date_end'       => date( 'Y-m-d 23:59:59', $time ),
 					'date_end_gmt'   => date( 'Y-m-d 23:59:59', $time ),
 					'subtotals'      => (object) array(
-						'items_sold'     => 4,
-						'net_revenue'    => 100.0,
-						'orders_count'   => 1,
-						'products_count' => 1,
-						'segments'       => array(),
+						'items_sold'       => 4,
+						'net_revenue'      => 100.0,
+						'orders_count'     => 1,
+						'products_count'   => 1,
+						'variations_count' => 1,
+						'segments'         => array(),
 					),
 				),
 			),

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -3465,7 +3465,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 				'products'                => 2,
 				'segments'                => array(
 					array(
-						'segment_id' => $product_1->get_id(),
+						'segment_id'    => $product_1->get_id(),
+						'segment_label' => $product_1->get_name(),
 						'subtotals'  => array(
 							'orders_count'            => $p1_orders_count,
 							'num_items_sold'          => $p1_num_items_sold,
@@ -3482,7 +3483,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						),
 					),
 					array(
-						'segment_id' => $product_2->get_id(),
+						'segment_id'    => $product_2->get_id(),
+						'segment_label' => $product_2->get_name(),
 						'subtotals'  => array(
 							'orders_count'            => $p2_orders_count,
 							'num_items_sold'          => $p2_num_items_sold,
@@ -3499,7 +3501,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						),
 					),
 					array(
-						'segment_id' => $product_3->get_id(),
+						'segment_id'    => $product_3->get_id(),
+						'segment_label' => $product_3->get_name(),
 						'subtotals'  => array(
 							'orders_count'            => 0,
 							'num_items_sold'          => 0,
@@ -3539,7 +3542,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'num_new_customers'       => $i3_tot_new_customers,
 						'segments'                => array(
 							array(
-								'segment_id' => $product_1->get_id(),
+								'segment_id'    => $product_1->get_id(),
+								'segment_label' => $product_1->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => $i3_p1_orders_count,
 									'num_items_sold'      => $i3_p1_num_items_sold,
@@ -3556,7 +3560,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_2->get_id(),
+								'segment_id'     => $product_2->get_id(),
+								'segment_label'  => $product_2->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => $i3_p2_orders_count,
 									'num_items_sold'      => $i3_p2_num_items_sold,
@@ -3573,7 +3578,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_3->get_id(),
+								'segment_id'     => $product_3->get_id(),
+								'segment_label'  => $product_3->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
@@ -3613,7 +3619,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'num_new_customers'       => $i2_tot_new_customers,
 						'segments'                => array(
 							array(
-								'segment_id' => $product_1->get_id(),
+								'segment_id'     => $product_1->get_id(),
+								'segment_label'  => $product_1->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => $i2_p1_orders_count,
 									'num_items_sold'      => $i2_p1_num_items_sold,
@@ -3630,7 +3637,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_2->get_id(),
+								'segment_id'     => $product_2->get_id(),
+								'segment_label'  => $product_2->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => $i2_p2_orders_count,
 									'num_items_sold'      => $i2_p2_num_items_sold,
@@ -3647,7 +3655,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_3->get_id(),
+								'segment_id'     => $product_3->get_id(),
+								'segment_label'  => $product_3->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
@@ -3687,7 +3696,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'num_new_customers'       => 0,
 						'segments'                => array(
 							array(
-								'segment_id' => $product_1->get_id(),
+								'segment_id'     => $product_1->get_id(),
+								'segment_label'  => $product_1->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
@@ -3704,7 +3714,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_2->get_id(),
+								'segment_id'     => $product_2->get_id(),
+								'segment_label'  => $product_2->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
@@ -3721,7 +3732,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id' => $product_3->get_id(),
+								'segment_id'     => $product_3->get_id(),
+								'segment_label'  => $product_3->get_name(),
 								'subtotals'  => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,


### PR DESCRIPTION
Fixes #564, Fixes #695. Dependent on #1286.

This PR wires up the product comparison, single product view, variation view, and variation comparison to the new segmentation API functionality. It allows you to compare many different products and variations over a set time-line. It does contain some API tweaks to make this all possible.

It also completes #695 by fully implementing the 'item-comparison' mode. Some code for this already existed and just needed finished/wired up.

Some notes/known issues for the future:
* Sometimes colors are not always different enough in graph values to tell them apart, sometimes they are. I want to log this so we can investigate further why this happens.
* The product category filters do not work yet. We should be able to pattern off of this PR to make it work though in a separate issue/PR.
*  Smooth Generator doesn’t seem to generate valid variations data, so data for those don't display properly. I added some handling around this, but it works fine with real orders. We should open up an issue in the smooth generator repo, but otherwise I don't think we need to do anything here.
* You can select up to 5 products to compare at a time on the chart. We can adjust this as needed.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

![screen shot 2019-01-24 at 2 40 58 pm](https://user-images.githubusercontent.com/689165/51707546-81fd0b80-1fef-11e9-9aeb-1bf8a6c1eda4.png)

![screen shot 2019-01-24 at 2 41 07 pm](https://user-images.githubusercontent.com/689165/51707590-a35df780-1fef-11e9-8b73-931670312971.png)

![screen shot 2019-01-24 at 2 42 01 pm](https://user-images.githubusercontent.com/689165/51707607-ab1d9c00-1fef-11e9-9442-0d28c297f375.png)

![screen shot 2019-01-24 at 2 44 55 pm](https://user-images.githubusercontent.com/689165/51707627-b244aa00-1fef-11e9-85e6-c1580d7baebf.png)

![screen shot 2019-01-24 at 2 50 06 pm](https://user-images.githubusercontent.com/689165/51707641-bb357b80-1fef-11e9-9cb2-d080b25432aa.png)

### Detailed test instructions:

* Run `npm test` and make sure all tests pass.
* Run `phpunit` and make sure all tests pass.
* Test the various different product detail modes on the product report. Single product, product comparison, variable product, variable comparison, Top Products filters, and Top variations filters. Check chart data is what you would expect. Check table and summary numbers as well.
* Spot check existing time based graphs.