### PR TITLE
Components: Fix SummaryNumber example

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.4.1 (unreleased)
 - Chart component: format numbers and prices using store currency settings.
 - Make `href`/linking optional in SummaryNumber.
+- Fix SummaryNumber example code.
 
 # 1.4.0
 - Add download log ip address autocompleter to search component

--- a/packages/components/src/summary/example.md
+++ b/packages/components/src/summary/example.md
@@ -3,24 +3,31 @@ import { SummaryList, SummaryNumber } from '@woocommerce/components';
 
 const MySummaryList = () => (
 	<SummaryList>
-		<SummaryNumber
-			value={ '$829.40' }
-			label="Gross Revenue"
-			delta={ 29 }
-			href="/analytics/report"
-		/>
-		<SummaryNumber
-			value={ '$24.00' }
-			label="Refunds"
-			delta={ -10 }
-			href="/analytics/report"
-			selected
-		/>
-		<SummaryNumber
-			value={ '$49.90' }
-			label="Coupons"
-			href="/analytics/report"
-		/>
+		{ () => {
+			return [
+				<SummaryNumber
+					key="revenue"
+					value={ '$829.40' }
+					label="Gross Revenue"
+					delta={ 29 }
+					href="/analytics/report"
+				/>,
+				<SummaryNumber
+					key="refunds"
+					value={ '$24.00' }
+					label="Refunds"
+					delta={ -10 }
+					href="/analytics/report"
+					selected
+				/>,
+				<SummaryNumber
+					key="coupons"
+					value={ '$49.90' }
+					label="Coupons"
+					href="/analytics/report"
+				/>
+			];
+		} }
 	</SummaryList>
 );
 ```


### PR DESCRIPTION
While testing some code today, I noticed the following warning being thrown in devdocs:

![devdocs-warning](https://user-images.githubusercontent.com/22080/51718457-1ec4a680-1ffa-11e9-84d3-d56123935692.png)

This PR fixes the warning, and makes the SummaryNumber example work again

### Accessibility

No a11y changes in this PR.

### Detailed test instructions:

- Open the Devdocs page
- Verify no warnings are shown in the console, and the SummaryNumber demo works
