### PR TITLE
Added zero-filling for intervals for taxes/stats endpoint

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -132,6 +132,14 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 		$data      = wp_cache_get( $cache_key, $this->cache_group );
 
 		if ( false === $data ) {
+			$data = (object) array(
+				'totals'    => (object) array(),
+				'intervals' => (object) array(),
+				'total'     => 0,
+				'pages'     => 0,
+				'page_no'   => 0,
+			);
+
 			$selections      = $this->selected_columns( $query_args );
 			$totals_query    = array();
 			$intervals_query = array();
@@ -155,7 +163,7 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 
 			$total_pages = (int) ceil( $db_records_count / $intervals_query['per_page'] );
 			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
-				return array();
+				return $data;
 			}
 
 			$totals = $wpdb->get_results(

--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -209,7 +209,7 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'wc-admin' ) );
+				return new WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching tax data failed.', 'wc-admin' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );


### PR DESCRIPTION
Fixes #1393 

For some reason, this endpoint didn't have 0-filling for empty intervals. 
To make the behaviour consistent with other endpoints, this PR is adding this functionality.

### Detailed test instructions:

- Create orders with some gaps (e.g. some months/days/hours, there will be no taxes charged)
- Request data from `/taxes/stats`, e.g. ` http://local.wordpress.test/wp-json/wc/v4/reports/taxes/stats?after=2018-01-23T10:59:58&interval=month&before=2019-01-25T19:59:59` and check that the no-tax-charged intervals are present in the response and contain 0.
