### PR TITLE
Add Top Coupons Block

### DIFF
--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -75,12 +75,12 @@ export default class CouponsReportTable extends Component {
 			const { amount, coupon_id, extended_info, orders_count } = coupon;
 			const { code, date_created, date_expires, discount_type } = extended_info;
 
-			const productUrl = getNewPath( persistedQuery, '/analytics/coupons', {
+			const couponUrl = getNewPath( persistedQuery, '/analytics/coupons', {
 				filter: 'single_coupon',
 				coupons: coupon_id,
 			} );
 			const couponLink = (
-				<Link href={ productUrl } type="wc-admin">
+				<Link href={ couponUrl } type="wc-admin">
 					{ code }
 				</Link>
 			);

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -12,6 +12,7 @@ import { map } from 'lodash';
 import { Date, Link } from '@woocommerce/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -67,22 +68,29 @@ export default class CouponsReportTable extends Component {
 	}
 
 	getRowsContent( coupons ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
+
 		return map( coupons, coupon => {
 			const { amount, coupon_id, extended_info, orders_count } = coupon;
 			const { code, date_created, date_expires, discount_type } = extended_info;
 
-			// @TODO must link to the coupon detail report
+			const productUrl = getNewPath( persistedQuery, '/analytics/coupons', {
+				filter: 'single_coupon',
+				coupons: coupon_id,
+			} );
 			const couponLink = (
-				<Link href="" type="wc-admin">
+				<Link href={ productUrl } type="wc-admin">
 					{ code }
 				</Link>
 			);
 
+			const ordersUrl = getNewPath( persistedQuery, '/analytics/orders', {
+				filter: 'advanced',
+				coupon_includes: coupon_id,
+			} );
 			const ordersLink = (
-				<Link
-					href={ '/analytics/orders?filter=advanced&code_includes=' + coupon_id }
-					type="wc-admin"
-				>
+				<Link href={ ordersUrl } type="wc-admin">
 					{ numberFormat( orders_count ) }
 				</Link>
 			);

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -170,8 +170,8 @@ export default class CouponsReportTable extends Component {
 				itemIdField="coupon_id"
 				query={ query }
 				tableQuery={ {
-					orderby: query.orderby || 'coupon_id',
-					order: query.order || 'asc',
+					orderby: query.orderby || 'orders_count',
+					order: query.order || 'desc',
 					extended_info: true,
 				} }
 				title={ __( 'Coupons', 'wc-admin' ) }

--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -21,6 +21,7 @@ import { EllipsisMenu, MenuItem, MenuTitle, SectionHeader } from '@woocommerce/c
 import withSelect from 'wc-api/with-select';
 import TopSellingCategories from './top-selling-categories';
 import TopSellingProducts from './top-selling-products';
+import TopCoupons from './top-coupons';
 import './style.scss';
 
 class Leaderboards extends Component {
@@ -134,9 +135,11 @@ class Leaderboards extends Component {
 						{ ! hiddenLeaderboardKeys.includes( 'top-products' ) && (
 							<TopSellingProducts query={ query } totalRows={ rowsPerTable } />
 						) }
-
 						{ ! hiddenLeaderboardKeys.includes( 'top-categories' ) && (
 							<TopSellingCategories query={ query } totalRows={ rowsPerTable } />
+						) }
+						{ ! hiddenLeaderboardKeys.includes( 'top-coupons' ) && (
+							<TopCoupons query={ query } totalRows={ rowsPerTable } />
 						) }
 					</div>
 				</div>

--- a/client/dashboard/leaderboards/top-coupons.js
+++ b/client/dashboard/leaderboards/top-coupons.js
@@ -1,0 +1,122 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { map } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { numberFormat } from 'lib/number';
+import Leaderboard from 'analytics/components/leaderboard';
+
+export class TopCoupons extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.getRowsContent = this.getRowsContent.bind( this );
+		this.getHeadersContent = this.getHeadersContent.bind( this );
+	}
+
+	getHeadersContent() {
+		return [
+			{
+				label: __( 'Coupon Code', 'wc-admin' ),
+				key: 'code',
+				required: true,
+				isLeftAligned: true,
+				isSortable: false,
+			},
+			{
+				label: __( 'Orders', 'wc-admin' ),
+				key: 'orders_count',
+				required: true,
+				defaultSort: true,
+				isSortable: false,
+				isNumeric: true,
+			},
+			{
+				label: __( 'Amount Discounted', 'wc-admin' ),
+				key: 'amount',
+				isSortable: false,
+				isNumeric: true,
+			},
+		];
+	}
+
+	getRowsContent( data ) {
+		const { query } = this.props;
+		const persistedQuery = getPersistedQuery( query );
+		return map( data, row => {
+			const { amount, coupon_id, extended_info, orders_count } = row;
+			const { code } = extended_info;
+
+			const couponUrl = getNewPath( persistedQuery, 'analytics/coupons', {
+				filter: 'single_coupon',
+				coupons: coupon_id,
+			} );
+			const couponLink = (
+				<Link href={ couponUrl } type="wc-admin">
+					{ code }
+				</Link>
+			);
+
+			const ordersUrl = getNewPath( persistedQuery, 'analytics/orders', {
+				filter: 'advanced',
+				coupon_includes: coupon_id,
+			} );
+			const ordersLink = (
+				<Link href={ ordersUrl } type="wc-admin">
+					{ numberFormat( orders_count ) }
+				</Link>
+			);
+
+			return [
+				{
+					display: couponLink,
+					value: code,
+				},
+				{
+					display: ordersLink,
+					value: orders_count,
+				},
+				{
+					display: formatCurrency( amount ),
+					value: getCurrencyFormatDecimal( amount ),
+				},
+			];
+		} );
+	}
+
+	render() {
+		const { query, totalRows } = this.props;
+		const tableQuery = {
+			orderby: 'coupon_id',
+			order: 'asc',
+			per_page: totalRows,
+			extended_info: true,
+		};
+
+		return (
+			<Leaderboard
+				endpoint="coupons"
+				getHeadersContent={ this.getHeadersContent }
+				getRowsContent={ this.getRowsContent }
+				query={ query }
+				tableQuery={ tableQuery }
+				title={ __( 'Top Coupons', 'wc-admin' ) }
+			/>
+		);
+	}
+}
+
+export default TopCoupons;

--- a/client/dashboard/leaderboards/top-coupons.js
+++ b/client/dashboard/leaderboards/top-coupons.js
@@ -100,8 +100,8 @@ export class TopCoupons extends Component {
 	render() {
 		const { query, totalRows } = this.props;
 		const tableQuery = {
-			orderby: 'coupon_id',
-			order: 'asc',
+			orderby: 'orders_count',
+			order: 'desc',
 			per_page: totalRows,
 			extended_info: true,
 		};


### PR DESCRIPTION
Fixes #1359.

This PR:
- adds the Top Coupons leaderboard block to the _Dashboard_
- fixes the links in the _Coupons_ table
- change the default order of the _Coupons_ table so coupons are sorted by `orders_count`

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/51761234-dd50fb80-20cc-11e9-9198-1bdef257e2f3.png)

### Detailed test instructions:
- Go to the _Dashboard_.
- Verify the _Top Coupons_ block can be activated/deactivated.
- Verify coupons are sorted by _Orders_ in descending order.
- Click on the _Coupon Code_ of one coupon and verify it links to the _Coupons report_ filtered by that coupon.
- Go back and click on the _Orders_ of one coupon, and verify it links to the _Orders report_ filtered by that coupon.
- Go to the _Coupons report_ and repeat the last three steps (test that the _Coupon Code_ and _Orders_ links work and coupons are sorted by _Orders_).