### PR TITLE
Build: Create new number package

### DIFF
--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -22,7 +22,8 @@
   "react-native": "src/index",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.11",
+    "@woocommerce/number": "1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -6,9 +6,9 @@ import { get, isNaN } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
+ * WooCommerce dependencies
  */
-import { numberFormat } from 'lib/number';
+import { numberFormat } from '@woocommerce/number';
 
 /**
  * Formats money with a given currency code. Uses site's currency settings for formatting.

--- a/packages/number/.npmrc
+++ b/packages/number/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+- Initial release exports `numberFormat`, `formatValue`, and `calculateDelta`

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -1,0 +1,32 @@
+# Number
+
+A collection of utilities to propery localize numerical values in WooCommerce
+
+## Installation
+
+Install the module
+
+```bash
+npm install @woocommerce/number --save
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+## Usage
+
+```JS
+import { formatNumber, formatValue, calculateDelta } from '@woocommerce/number';
+
+// Formats a number using site's current locale.
+// Defaults to en-US localization
+const localizedNumber = formatNumber( 1337 ); // '1,377'
+
+// formatValue's first argument is a type: average, currency, or number
+// The second argument is the number/value to format
+const formattedAverage = formatValue( 'average', '10.5' ); // 11 just uses Math.round
+const formattedCurrency = formatValue( 'currency', '10.5' ); // $10.50 calls @woocommerce.formatCurrency
+const formattedNumber = formatValue( 'number', '1337' ); // 1,337 calls formatNumber ( see above )
+
+// Get a rounded percent change/delta between two numbers
+const delta = calculateDelta( 10, 8 ); // '25'
+```

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -21,10 +21,9 @@ import { formatNumber, formatValue, calculateDelta } from '@woocommerce/number';
 // Defaults to en-US localization
 const localizedNumber = formatNumber( 1337 ); // '1,377'
 
-// formatValue's first argument is a type: average, currency, or number
+// formatValue's first argument is a type: average, or number
 // The second argument is the number/value to format
 const formattedAverage = formatValue( 'average', '10.5' ); // 11 just uses Math.round
-const formattedCurrency = formatValue( 'currency', '10.5' ); // $10.50 calls @woocommerce.formatCurrency
 const formattedNumber = formatValue( 'number', '1337' ); // 1,337 calls formatNumber ( see above )
 
 // Get a rounded percent change/delta between two numbers

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@woocommerce/number",
+	"version": "1.0.0",
+	"description": "Number formatting utilities for WooCommerce.",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"woocommerce"
+	],
+	"homepage": "https://github.com/WooCommerce/wc-admin/tree/master/packages/number/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WooCommerce/wc-admin.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WooCommerce/wc-admin/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+        "@babel/runtime-corejs2": "7.1.5",
+        "locutus": "^2.0.10",
+        "lodash": "^4.17.11"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -1,0 +1,63 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get, isFinite } from 'lodash';
+const number_format = require( 'locutus/php/strings/number_format' );
+import { formatCurrency } from '@woocommerce/currency';
+
+/**
+ * Formats a number using site's current locale
+ *
+ * @see http://locutus.io/php/strings/number_format/
+ * @param {Number|String} number number to format
+ * @param {int|null} [precision=null] optional decimal precision
+ * @returns {?String} A formatted string.
+ */
+export function numberFormat( number, precision = null ) {
+	if ( 'number' !== typeof number ) {
+		number = parseFloat( number );
+	}
+
+	if ( isNaN( number ) ) {
+		return '';
+	}
+
+	const decimalSeparator = get( wcSettings, [ 'currency', 'decimal_separator' ], '.' );
+	const thousandSeparator = get( wcSettings, [ 'currency', 'thousand_separator' ], ',' );
+	precision = parseInt( precision );
+
+	if ( isNaN( precision ) ) {
+		const [ , decimals ] = number.toString().split( '.' );
+		precision = decimals ? decimals.length : 0;
+	}
+
+	return number_format( number, precision, decimalSeparator, thousandSeparator );
+}
+
+export function formatValue( type, value ) {
+	if ( ! isFinite( value ) ) {
+		return null;
+	}
+
+	switch ( type ) {
+		case 'average':
+			return Math.round( value );
+		case 'currency':
+			return formatCurrency( value );
+		case 'number':
+			return numberFormat( value );
+	}
+}
+
+export function calculateDelta( primaryValue, secondaryValue ) {
+	if ( ! isFinite( primaryValue ) || ! isFinite( secondaryValue ) ) {
+		return null;
+	}
+
+	if ( secondaryValue === 0 ) {
+		return 0;
+	}
+
+	return Math.round( ( primaryValue - secondaryValue ) / secondaryValue * 100 );
+}

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -4,7 +4,6 @@
  */
 import { get, isFinite } from 'lodash';
 const number_format = require( 'locutus/php/strings/number_format' );
-import { formatCurrency } from '@woocommerce/currency';
 
 /**
  * Formats a number using site's current locale
@@ -35,6 +34,13 @@ export function numberFormat( number, precision = null ) {
 	return number_format( number, precision, decimalSeparator, thousandSeparator );
 }
 
+/**
+ * Formats a number string based on type of `average` or `number`.
+ *
+ * @param {String} type of number to format, average or number
+ * @param {int} value to format.
+ * @returns {?String} A formatted string.
+ */
 export function formatValue( type, value ) {
 	if ( ! isFinite( value ) ) {
 		return null;
@@ -43,13 +49,18 @@ export function formatValue( type, value ) {
 	switch ( type ) {
 		case 'average':
 			return Math.round( value );
-		case 'currency':
-			return formatCurrency( value );
 		case 'number':
 			return numberFormat( value );
 	}
 }
 
+/**
+ * Calculates the delta/percentage change between two numbers.
+ *
+ * @param {int} primaryValue the value to calculate change for.
+ * @param {int} secondaryValue the baseline which to calculdate the change against.
+ * @returns {?int} Percent change between the primaryValue from the secondaryValue.
+ */
 export function calculateDelta( primaryValue, secondaryValue ) {
 	if ( ! isFinite( primaryValue ) || ! isFinite( secondaryValue ) ) {
 		return null;

--- a/packages/number/src/test/index.js
+++ b/packages/number/src/test/index.js
@@ -1,0 +1,35 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { numberFormat } from '../index';
+
+describe( 'numberFormat', () => {
+	it( 'should default to precision=null decimal=. thousands=,', () => {
+		expect( numberFormat( 1000 ) ).toBe( '1,000' );
+	} );
+
+	it( 'should return an empty string if no argument is passed', () => {
+		expect( numberFormat() ).toBe( '' );
+	} );
+
+	it( 'should accept a string', () => {
+		expect( numberFormat( '10000' ) ).toBe( '10,000' );
+	} );
+
+	it( 'maintains all decimals if no precision specified', () => {
+		expect( numberFormat( '10000.123456' ) ).toBe( '10,000.123456' );
+	} );
+
+	it( 'maintains all decimals if invalid precision specified', () => {
+		expect( numberFormat( '10000.123456', 'not a number' ) ).toBe( '10,000.123456' );
+	} );
+
+	it( 'uses store currency settings, not locale', () => {
+		global.wcSettings.siteLocale = 'en-US';
+		global.wcSettings.currency.decimal_separator = ',';
+		global.wcSettings.currency.thousand_separator = '.';
+
+		expect( numberFormat( '12345.6789', 3 ) ).toBe( '12.345,679' );
+	} );
+} );

--- a/packages/number/src/test/index.js
+++ b/packages/number/src/test/index.js
@@ -25,6 +25,10 @@ describe( 'numberFormat', () => {
 		expect( numberFormat( '10000.123456', 'not a number' ) ).toBe( '10,000.123456' );
 	} );
 
+	it( 'calculates the correct decimals based on precision passed in', () => {
+		expect( numberFormat( '1337.4498', 2 ) ).toBe( '1,337.45' );
+	} );
+
 	it( 'uses store currency settings, not locale', () => {
 		global.wcSettings.siteLocale = 'en-US';
 		global.wcSettings.currency.decimal_separator = ',';


### PR DESCRIPTION
Fixes #1390

Per feedback in the issue, this branch creates a new package for `@woocommerce/number` based upon the logic that currently exists in `lib/number`. The usage of `formatNumber` in `@woocommerce/currency` is also updated here to fix the broken build.

I followed the most excellent instructions for creating a new package that @ryelle created [here](https://github.com/woocommerce/wc-admin/tree/master/packages), but not entirely certain if I need to publish first with this branch prior to merging to master. 

In lieu of removing `lib/number` and updating all usage within the `/client` folder - I will do that in a follow up PR once this lands - otherwise there would be many many many more files modified in this pr.

### Accessibility

No visual changes.

### Detailed test instructions:

- Verify the tests pass

