### PR TITLE
Customers Report: REST API: Fix between argument handling

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -62,10 +62,10 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$normalized_numeric_params = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
 		$between_params_date       = array( 'last_active', 'registered' );
-		$normalized_date_params    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
-		$args                      = array_merge( $args, $normalized_numeric_params, $normalized_date_params );
+		$normalized_params_date    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
+		$args                      = array_merge( $args, $normalized_params_numeric, $normalized_params_date );
 
 		return $args;
 	}

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -63,9 +63,11 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value', 'last_active' );
-		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
-		$args           = array_merge( $args, $normalized );
+		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$date_between_params = array( 'last_active' );
+		$normalized     = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $numeric_between_params );
+		$normalized_dates     = WC_Admin_Reports_Interval::normalize_date_between_params( $request, $date_between_params );
+		$args           = array_merge( $args, $normalized, $normalized_dates );
 
 		return $args;
 	}

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -61,11 +61,11 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$between_params_numeric = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$between_params_date    = array( 'last_active', 'registered' );
-		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
-		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
-		$args                   = array_merge( $args, $normalized, $normalized_dates );
+		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$normalized_numeric_params = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$between_params_date       = array( 'last_active', 'registered' );
+		$normalized_date_params    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
+		$args                      = array_merge( $args, $normalized_numeric_params, $normalized_date_params );
 
 		return $args;
 	}
@@ -382,7 +382,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_between']     = array(
+		$params['registered_between']      = array(
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -52,6 +52,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['country']             = $request['country'];
 		$args['last_active_before']  = $request['last_active_before'];
 		$args['last_active_after']   = $request['last_active_after'];
+		$args['last_active_min']     = $request['last_active_min'];
+		$args['last_active_max']     = $request['last_active_max'];
 		$args['orders_count_min']    = $request['orders_count_min'];
 		$args['orders_count_max']    = $request['orders_count_max'];
 		$args['total_spend_min']     = $request['total_spend_min'];
@@ -61,7 +63,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value', 'last_active' );
 		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
 		$args           = array_merge( $args, $normalized );
 
@@ -296,14 +298,14 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']               = array(
+		$params['order']                   = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']             = array(
+		$params['orderby']                 = array(
 			'description'       => __( 'Sort collection by object attribute.', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'date_registered',
@@ -321,7 +323,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['match']               = array(
+		$params['match']                   = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'all',
@@ -331,7 +333,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']                = array(
+		$params['name']                    = array(
 			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -363,34 +365,39 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_before']  = array(
+		$params['last_active_between']     = array(
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),
+		);
+		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_after']   = array(
+		$params['registered_after']        = array(
 			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_min']    = array(
+		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_max']    = array(
+		$params['orders_count_max']        = array(
 			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_between']     = array(
+		$params['orders_count_between']    = array(
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
@@ -405,7 +412,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$params['total_spend_between']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
@@ -420,7 +427,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$params['avg_order_value_between'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['last_order_before']       = array(
 			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -52,8 +52,6 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['country']             = $request['country'];
 		$args['last_active_before']  = $request['last_active_before'];
 		$args['last_active_after']   = $request['last_active_after'];
-		$args['last_active_min']     = $request['last_active_min'];
-		$args['last_active_max']     = $request['last_active_max'];
 		$args['orders_count_min']    = $request['orders_count_min'];
 		$args['orders_count_max']    = $request['orders_count_max'];
 		$args['total_spend_min']     = $request['total_spend_min'];
@@ -64,10 +62,10 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$date_between_params = array( 'last_active' );
-		$normalized     = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $numeric_between_params );
-		$normalized_dates     = WC_Admin_Reports_Interval::normalize_date_between_params( $request, $date_between_params );
-		$args           = array_merge( $args, $normalized, $normalized_dates );
+		$date_between_params    = array( 'last_active' );
+		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
+		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
+		$args                   = array_merge( $args, $normalized, $normalized_dates );
 
 		return $args;
 	}

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -61,10 +61,10 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$date_between_params    = array( 'last_active', 'registered' );
-		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
-		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
+		$between_params_numeric = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$between_params_date    = array( 'last_active', 'registered' );
+		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
 		$args                   = array_merge( $args, $normalized, $normalized_dates );
 
 		return $args;

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -62,7 +62,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$date_between_params    = array( 'last_active' );
+		$date_between_params    = array( 'last_active', 'registered' );
 		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
 		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
 		$args                   = array_merge( $args, $normalized, $normalized_dates );
@@ -381,6 +381,11 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['registered_between']     = array(
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),
 		);
 		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -57,7 +57,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
+		$normalized     = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $between_params );
 		$args           = array_merge( $args, $normalized );
 
 		return $args;

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -119,7 +119,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 	public function get_item_schema() {
 		// TODO: should any of these be 'indicator's?
 		$totals = array(
-			'customers_count'    => array(
+			'customers_count'     => array(
 				'description' => __( 'Number of customers.', 'wc-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
@@ -131,7 +131,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'avg_total_spend' => array(
+			'avg_total_spend'     => array(
 				'description' => __( 'Average total spend per customer.', 'wc-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
@@ -234,7 +234,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['match']               = array(
+		$params['match']                   = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'wc-admin' ),
 			'type'              => 'string',
 			'default'           => 'all',
@@ -244,7 +244,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']                = array(
+		$params['name']                    = array(
 			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -276,34 +276,34 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_before']  = array(
+		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_after']   = array(
+		$params['registered_after']        = array(
 			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_min']    = array(
+		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_max']    = array(
+		$params['orders_count_max']        = array(
 			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'wc-admin' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orders_count_between']     = array(
+		$params['orders_count_between']    = array(
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'wc-admin' ),
@@ -318,7 +318,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$params['total_spend_between']     = array(
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'wc-admin' ),
@@ -333,7 +333,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$params['avg_order_value_between'] = array(
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'wc-admin' ),
 			'type'              => 'array',
-			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_arg' ),
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_numeric_arg' ),
 		);
 		$params['last_order_before']       = array(
 			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -57,10 +57,10 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$normalized_numeric_params = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
 		$between_params_date       = array( 'last_active', 'registered' );
-		$normalized_date_params    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
-		$args                      = array_merge( $args, $normalized_numeric_params, $normalized_date_params );
+		$normalized_params_date    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
+		$args                      = array_merge( $args, $normalized_params_numeric, $normalized_params_date );
 
 		return $args;
 	}

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -56,11 +56,11 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$between_params_numeric = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$between_params_date    = array( 'last_active', 'registered' );
-		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
-		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
-		$args                   = array_merge( $args, $normalized, $normalized_dates );
+		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$normalized_numeric_params = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$between_params_date       = array( 'last_active', 'registered' );
+		$normalized_date_params    = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
+		$args                      = array_merge( $args, $normalized_numeric_params, $normalized_date_params );
 
 		return $args;
 	}
@@ -295,7 +295,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['registered_between']     = array(
+		$params['registered_between']      = array(
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -57,7 +57,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$normalized     = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $between_params );
+		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
 		$args           = array_merge( $args, $normalized );
 
 		return $args;

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -56,10 +56,10 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$date_between_params    = array( 'last_active', 'registered' );
-		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
-		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
+		$between_params_numeric = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$between_params_date    = array( 'last_active', 'registered' );
+		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
+		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_date, true );
 		$args                   = array_merge( $args, $normalized, $normalized_dates );
 
 		return $args;

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -56,9 +56,11 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
 
-		$between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$normalized     = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params );
-		$args           = array_merge( $args, $normalized );
+		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
+		$date_between_params    = array( 'last_active' );
+		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
+		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
+		$args                   = array_merge( $args, $normalized, $normalized_dates );
 
 		return $args;
 	}
@@ -275,6 +277,11 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['last_active_between']     = array(
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),
 		);
 		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -57,7 +57,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['last_order_after']    = $request['last_order_after'];
 
 		$numeric_between_params = array( 'orders_count', 'total_spend', 'avg_order_value' );
-		$date_between_params    = array( 'last_active' );
+		$date_between_params    = array( 'last_active', 'registered' );
 		$normalized             = WC_Admin_Reports_Interval::normalize_between_params( $request, $numeric_between_params, false );
 		$normalized_dates       = WC_Admin_Reports_Interval::normalize_between_params( $request, $date_between_params, true );
 		$args                   = array_merge( $args, $normalized, $normalized_dates );
@@ -294,6 +294,11 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['registered_between']     = array(
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'wc-admin' ),
+			'type'              => 'array',
+			'validate_callback' => array( 'WC_Admin_Reports_Interval', 'rest_validate_between_date_arg' ),
 		);
 		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'wc-admin' ),

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -498,9 +498,10 @@ class WC_Admin_Reports_Interval {
 	 *
 	 * @param array        $request Query params from REST API request.
 	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.
+	 * @param bool         $is_date Boolean if the param is date is related.
 	 * @return array Normalized query values.
 	 */
-	public static function normalize_numeric_between_params( $request, $param_names ) {
+	public static function normalize_between_params( $request, $param_names, $is_date ) {
 		if ( ! is_array( $param_names ) ) {
 			$param_names = array( $param_names );
 		}
@@ -518,49 +519,15 @@ class WC_Admin_Reports_Interval {
 				continue;
 			}
 
-			if ( $range[0] < $range[1] ) {
-				$normalized[ $param_name . '_min' ] = $range[0];
-				$normalized[ $param_name . '_max' ] = $range[1];
-			} else {
-				$normalized[ $param_name . '_min' ] = $range[1];
-				$normalized[ $param_name . '_max' ] = $range[0];
-			}
-		}
-
-		return $normalized;
-	}
-
-	/**
-	 * Normalize "*_between" parameters to "*_after" and "*_before".
-	 *
-	 * @param array        $request Query params from REST API request.
-	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.
-	 * @return array Normalized query values.
-	 */
-	public static function normalize_date_between_params( $request, $param_names ) {
-		if ( ! is_array( $param_names ) ) {
-			$param_names = array( $param_names );
-		}
-
-		$normalized = array();
-
-		foreach ( $param_names as $param_name ) {
-			if ( ! is_array( $request[ $param_name . '_between' ] ) ) {
-				continue;
-			}
-
-			$range = $request[ $param_name . '_between' ];
-
-			if ( 2 !== count( $range ) ) {
-				continue;
-			}
+			$min = $is_date ? '_after' : '_min';
+			$max = $is_date ? '_before' : '_max';
 
 			if ( $range[0] < $range[1] ) {
-				$normalized[ $param_name . '_after' ] = $range[0];
-				$normalized[ $param_name . '_before' ] = $range[1];
+				$normalized[ $param_name . $min ] = $range[0];
+				$normalized[ $param_name . $max ] = $range[1];
 			} else {
-				$normalized[ $param_name . '_after' ] = $range[1];
-				$normalized[ $param_name . '_before' ] = $range[0];
+				$normalized[ $param_name . $min ] = $range[1];
+				$normalized[ $param_name . $max ] = $range[0];
 			}
 		}
 

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -500,7 +500,7 @@ class WC_Admin_Reports_Interval {
 	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.
 	 * @return array Normalized query values.
 	 */
-	public static function normalize_between_params( $request, $param_names ) {
+	public static function normalize_numeric_between_params( $request, $param_names ) {
 		if ( ! is_array( $param_names ) ) {
 			$param_names = array( $param_names );
 		}
@@ -524,6 +524,43 @@ class WC_Admin_Reports_Interval {
 			} else {
 				$normalized[ $param_name . '_min' ] = $range[1];
 				$normalized[ $param_name . '_max' ] = $range[0];
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize "*_between" parameters to "*_after" and "*_before".
+	 *
+	 * @param array        $request Query params from REST API request.
+	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.
+	 * @return array Normalized query values.
+	 */
+	public static function normalize_date_between_params( $request, $param_names ) {
+		if ( ! is_array( $param_names ) ) {
+			$param_names = array( $param_names );
+		}
+
+		$normalized = array();
+
+		foreach ( $param_names as $param_name ) {
+			if ( ! is_array( $request[ $param_name . '_between' ] ) ) {
+				continue;
+			}
+
+			$range = $request[ $param_name . '_between' ];
+
+			if ( 2 !== count( $range ) ) {
+				continue;
+			}
+
+			if ( $range[0] < $range[1] ) {
+				$normalized[ $param_name . '_after' ] = $range[0];
+				$normalized[ $param_name . '_before' ] = $range[1];
+			} else {
+				$normalized[ $param_name . '_after' ] = $range[1];
+				$normalized[ $param_name . '_before' ] = $range[0];
 			}
 		}
 

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -494,7 +494,8 @@ class WC_Admin_Reports_Interval {
 	}
 
 	/**
-	 * Normalize "*_between" parameters to "*_min" and "*_max".
+	 * Normalize "*_between" parameters to "*_min" and "*_max" for numeric values
+	 * and "*_after" and "*_before" for date values.
 	 *
 	 * @param array        $request Query params from REST API request.
 	 * @param string|array $param_names One or more param names to handle. Should not include "_between" suffix.

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -583,14 +583,15 @@ class WC_Admin_Reports_Interval {
 			);
 		}
 
-		// check for dates here.
 		if (
-			2 !== count( $value )
+			2 !== count( $value ) ||
+			! rest_parse_date( $value[0] ) ||
+			! rest_parse_date( $value[1] )
 		) {
 			return new WP_Error(
 				'rest_invalid_param',
 				/* translators: %s: parameter name */
-				sprintf( __( '%s must contain 2 dates.', 'wc-admin' ), $param )
+				sprintf( __( '%s must contain 2 valid dates.', 'wc-admin' ), $param )
 			);
 		}
 

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -538,7 +538,7 @@ class WC_Admin_Reports_Interval {
 	 * @param  string          $param Parameter name.
 	 * @return WP_Error|boolean
 	 */
-	public static function rest_validate_between_arg( $value, $request, $param ) {
+	public static function rest_validate_between_numeric_arg( $value, $request, $param ) {
 		if ( ! wp_is_numeric_array( $value ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
@@ -556,6 +556,37 @@ class WC_Admin_Reports_Interval {
 				'rest_invalid_param',
 				/* translators: %s: parameter name */
 				sprintf( __( '%s must contain 2 numbers.', 'wc-admin' ), $param )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a "*_between" range argument (an array with 2 date items).
+	 *
+	 * @param  mixed           $value Parameter value.
+	 * @param  WP_REST_Request $request REST Request.
+	 * @param  string          $param Parameter name.
+	 * @return WP_Error|boolean
+	 */
+	public static function rest_validate_between_date_arg( $value, $request, $param ) {
+		if ( ! wp_is_numeric_array( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				/* translators: 1: parameter name */
+				sprintf( __( '%1$s is not a numerically indexed array.', 'wc-admin' ), $param )
+			);
+		}
+
+		// check for dates here.
+		if (
+			2 !== count( $value )
+		) {
+			return new WP_Error(
+				'rest_invalid_param',
+				/* translators: %s: parameter name */
+				sprintf( __( '%s must contain 2 dates.', 'wc-admin' ), $param )
 			);
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -25,11 +25,11 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @var array
 	 */
 	protected $column_types = array(
-		'customer_id'      => 'intval',
-		'user_id'          => 'intval',
-		'orders_count'     => 'intval',
-		'total_spend'      => 'floatval',
-		'avg_order_value'  => 'floatval',
+		'customer_id'     => 'intval',
+		'user_id'         => 'intval',
+		'orders_count'    => 'intval',
+		'total_spend'     => 'floatval',
+		'avg_order_value' => 'floatval',
 	);
 
 	/**
@@ -60,7 +60,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		global $wpdb;
 
 		// Initialize some report columns that need disambiguation.
-		$this->report_columns['customer_id'] = $wpdb->prefix . self::TABLE_NAME . '.customer_id';
+		$this->report_columns['customer_id']     = $wpdb->prefix . self::TABLE_NAME . '.customer_id';
 		$this->report_columns['date_last_order'] = "MAX( {$wpdb->prefix}wc_order_stats.date_created ) as date_last_order";
 	}
 
@@ -274,7 +274,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		}
 
 		if ( $where_clauses ) {
-			$preceding_match = empty( $sql_query_params['where_time_clause'] ) ? ' AND ' : " {$match_operator} ";
+			$preceding_match                  = empty( $sql_query_params['where_time_clause'] ) ? ' AND ' : " {$match_operator} ";
 			$sql_query_params['where_clause'] = $preceding_match . implode( " {$match_operator} ", $where_clauses );
 		}
 
@@ -284,7 +284,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		}
 
 		if ( $having_clauses ) {
-			$preceding_match = empty( $sql_query_params['having_clause'] ) ? ' AND ' : " {$match_operator} ";
+			$preceding_match                    = empty( $sql_query_params['having_clause'] ) ? ' AND ' : " {$match_operator} ";
 			$sql_query_params['having_clause'] .= $preceding_match . implode( " {$match_operator} ", $having_clauses );
 		}
 
@@ -304,7 +304,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		$order_stats_table_name = $wpdb->prefix . 'wc_order_stats';
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
-		$defaults = array(
+		$defaults   = array(
 			'per_page' => get_option( 'posts_per_page' ),
 			'page'     => 1,
 			'order'    => 'DESC',
@@ -442,7 +442,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * Retrieve a guest (no user_id) customer row by email.
 	 *
 	 * @param string $email Email address.
-	 * @returns false|array Customer array if found, boolean false if not.
+	 * @return false|array Customer array if found, boolean false if not.
 	 */
 	public function get_guest_by_email( $email ) {
 		global $wpdb;
@@ -467,7 +467,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * Retrieve a registered customer row by user_id.
 	 *
 	 * @param string|int $user_id User ID.
-	 * @returns false|array Customer array if found, boolean false if not.
+	 * @return false|array Customer array if found, boolean false if not.
 	 */
 	public function get_customer_by_user_id( $user_id ) {
 		global $wpdb;
@@ -492,7 +492,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * Retrieve a registered customer row id by user_id.
 	 *
 	 * @param string|int $user_id User ID.
-	 * @returns false|int Customer ID if found, boolean false if not.
+	 * @return false|int Customer ID if found, boolean false if not.
 	 */
 	public static function get_customer_id_by_user_id( $user_id ) {
 		global $wpdb;
@@ -554,7 +554,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		if ( $customer_id ) {
 			// Preserve customer_id for existing user_id.
 			$data['customer_id'] = $customer_id;
-			$format[] = '%d';
+			$format[]            = '%d';
 		}
 
 		return $wpdb->replace( $wpdb->prefix . self::TABLE_NAME, $data, $format );

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -813,7 +813,7 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	/**
 	 * Test function that normalizes *_between query parameters to *_min & *_max.
 	 */
-	public function test_normalize_numeric_between_params() {
+	public function test_normalize_between_params() {
 		$request  = array(
 			'a_between' => 'malformed',     // won't be normalized (not an array).
 			'b_between' => array( 1, 5 ),   // results in min=1, max=5.
@@ -822,7 +822,7 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 			'f_between' => array( 10, 12 ), // not in params, skipped.
 		);
 		$params   = array( 'a', 'b', 'c', 'd' );
-		$result   = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $params );
+		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params );
 		$expected = array(
 			'b_min' => 1,
 			'b_max' => 5,

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -822,7 +822,7 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 			'f_between' => array( 10, 12 ), // not in params, skipped.
 		);
 		$params   = array( 'a', 'b', 'c', 'd' );
-		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params );
+		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params, false );
 		$expected = array(
 			'b_min' => 1,
 			'b_max' => 5,

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -813,7 +813,7 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	/**
 	 * Test function that normalizes *_between query parameters to *_min & *_max.
 	 */
-	public function test_normalize_between_params() {
+	public function test_normalize_numeric_between_params() {
 		$request  = array(
 			'a_between' => 'malformed',     // won't be normalized (not an array).
 			'b_between' => array( 1, 5 ),   // results in min=1, max=5.
@@ -822,7 +822,7 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 			'f_between' => array( 10, 12 ), // not in params, skipped.
 		);
 		$params   = array( 'a', 'b', 'c', 'd' );
-		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params );
+		$result   = WC_Admin_Reports_Interval::normalize_numeric_between_params( $request, $params );
 		$expected = array(
 			'b_min' => 1,
 			'b_max' => 5,

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -834,7 +834,30 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test function that validates *_between query parameters.
+	 * Test function that normalizes *_between query parameters for dates to *_after & *_before.
+	 */
+	public function test_normalize_between_date_params() {
+		$request  = array(
+			'a_between' => 'malformed',     // won't be normalized (not an array).
+			'b_between' => array( 1, 5 ),   // results in after=1, before=5.
+			'c_between' => array( 4, 2 ),   // results in after=2, before=4.
+			'd_between' => array( 7 ),      // won't be normalized (only 1 item).
+			'f_between' => array( 10, 12 ), // not in params, skipped.
+		);
+		$params   = array( 'a', 'b', 'c', 'd' );
+		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params, true );
+		$expected = array(
+			'b_after' => 1,
+			'b_before' => 5,
+			'c_after' => 2,
+			'c_before' => 4,
+		);
+
+		$this->assertEquals( $result, $expected );
+	}
+
+	/**
+	 * Test function that validates *_between query parameters for numeric values.
 	 */
 	public function test_rest_validate_between_numeric_arg() {
 		$this->assertIsWPError(
@@ -849,6 +872,30 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 
 		$this->assertTrue(
 			WC_Admin_Reports_Interval::rest_validate_between_numeric_arg( array( 1, 2 ), null, 'param' )
+		);
+	}
+
+	/**
+	 * Test function that validates *_between query parameters for date values.
+	 */
+	public function rest_validate_between_date_arg() {
+		$this->assertIsWPError(
+			WC_Admin_Reports_Interval::rest_validate_between_date_arg( 'not array', null, 'param' ),
+			'param is not a numerically indexed array.'
+		);
+
+		$this->assertIsWPError(
+			WC_Admin_Reports_Interval::rest_validate_between_date_arg( array( '2019-01-01T00:00:00' ), null, 'param' ),
+			'param must contain 2 valid dates.'
+		);
+
+		$this->assertIsWPError(
+			WC_Admin_Reports_Interval::rest_validate_between_date_arg( array( 'not a valid date' ), null, 'param' ),
+			'param must contain 2 valid dates.'
+		);
+
+		$this->assertTrue(
+			WC_Admin_Reports_Interval::rest_validate_between_date_arg( array( '2019-01-01T00:00:00', '2019-01-15T00:00:00' ), null, 'param' )
 		);
 	}
 }

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -836,19 +836,19 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	/**
 	 * Test function that validates *_between query parameters.
 	 */
-	public function test_rest_validate_between_arg() {
+	public function test_rest_validate_between_numeric_arg() {
 		$this->assertIsWPError(
-			WC_Admin_Reports_Interval::rest_validate_between_arg( 'not array', null, 'param' ),
+			WC_Admin_Reports_Interval::rest_validate_between_numeric_arg( 'not array', null, 'param' ),
 			'param is not a numerically indexed array.'
 		);
 
 		$this->assertIsWPError(
-			WC_Admin_Reports_Interval::rest_validate_between_arg( array( 1 ), null, 'param' ),
+			WC_Admin_Reports_Interval::rest_validate_between_numeric_arg( array( 1 ), null, 'param' ),
 			'param must contain 2 numbers.'
 		);
 
 		$this->assertTrue(
-			WC_Admin_Reports_Interval::rest_validate_between_arg( array( 1, 2 ), null, 'param' )
+			WC_Admin_Reports_Interval::rest_validate_between_numeric_arg( array( 1, 2 ), null, 'param' )
 		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1388

`between` parameters for Customer Report which accept date parameters (last_active and registered) were not being handled correctly. 

This PR normalizes the parameters to the accepted values which can be understood by the data store, eg:

`last_active_between = [ date1, date1 ]`  

becomes

`last_active_after = date1` and `last_active_before = date2`.

### Detailed test instructions:

1. Make sure PHP unit tests pass.
2. Customers Report > Show > Advanced Filters.
3. Play with Registered and Last active `between` filters and make sure tabular data reflects filter selection.
