### PR TITLE
Customers Report: fix order count filter

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -163,7 +163,7 @@ export const advancedFilters = {
 				} ) ),
 			},
 		},
-		order_count: {
+		orders_count: {
 			labels: {
 				add: __( 'No. of Orders', 'wc-admin' ),
 				remove: __( 'Remove order  filter', 'wc-admin' ),


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1386

No. Orders in Customers report had a misspelled query argument

### Detailed test instructions:

1. Customers Report > Advanced Filters > No. of Orders
2. Ensure the table and summary numbers respond to filtering
