### PR TITLE
Add Taxes REST controller override

### DIFF
--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * REST API Taxes Controller
+ *
+ * Handles requests to /taxes/*
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Taxes controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Taxes_Controller
+ */
+class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -186,6 +186,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-stock-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-taxes-controller.php';
 
 		$controllers = apply_filters(
 			'woocommerce_admin_rest_controllers',
@@ -218,6 +219,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Reports_Downloads_Stats_Controller',
 				'WC_Admin_REST_Reports_Customers_Controller',
 				'WC_Admin_REST_Reports_Customers_Stats_Controller',
+				'WC_Admin_REST_Taxes_Controller',
 			)
 		);
 
@@ -365,6 +367,17 @@ class WC_Admin_Api_Init {
 		) {
 			$endpoints['/wc/v4/products/reviews'][0] = $endpoints['/wc/v4/products/reviews'][2];
 			$endpoints['/wc/v4/products/reviews'][1] = $endpoints['/wc/v4/products/reviews'][3];
+		}
+
+		// Override /wc/v4/taxes.
+		if ( isset( $endpoints['/wc/v4/taxes'] )
+			&& isset( $endpoints['/wc/v4/taxes'][3] )
+			&& isset( $endpoints['/wc/v4/taxes'][2] )
+			&& $endpoints['/wc/v4/taxes'][2]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+			&& $endpoints['/wc/v4/taxes'][3]['callback'][0] instanceof WC_Admin_REST_Orders_Controller
+		) {
+			$endpoints['/wc/v4/taxes'][0] = $endpoints['/wc/v4/taxes'][2];
+			$endpoints['/wc/v4/taxes'][1] = $endpoints['/wc/v4/taxes'][3];
 		}
 
 		return $endpoints;


### PR DESCRIPTION
This PR adds an override to make the taxes API work with `v4`, like all other endpoints.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/51900921-c1907280-23b6-11e9-8056-c9d8ec90cb72.png)

### Detailed test instructions:
- Go to the _Taxes_ report.
- Try searching in the table input box and verify the autocompleter works.