### PR TITLE
Components package: Add emoji-flags dependency

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 1.4.1 (unreleased)
+# 1.4.2 (unreleased)
+- Add emoji-flags dependency
+
+# 1.4.1
 - Chart component: format numbers and prices using store currency settings.
 - Make `href`/linking optional in SummaryNumber.
 - Fix SummaryNumber example code.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,7 @@
     "d3-selection": "^1.3.2",
     "d3-shape": "^1.2.2",
     "d3-time-format": "^2.1.3",
+    "emoji-flags": "^1.2.0",
     "gridicons": "3.1.1",
     "interpolate-components": "1.1.1",
     "lodash": "^4.17.11",
@@ -52,8 +53,7 @@
     "qs": "^6.5.2",
     "react-dates": "^18.0.4",
     "react-router-dom": "4.3.1",
-    "react-transition-group": "^2.4.0",
-    "react-world-flags": "1.2.4"
+    "react-transition-group": "^2.4.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/373 - In #1384, the emoji-flags package was added, but it wasn't swapped out in the component's package.json. This caused an issue when I went to run tests in the product blocks plugin:

`Cannot find module 'emoji-flags' from 'wc-admin/packages/components/src/flag/index.js'`

- In the components directly, run `npm link`
- In `woocommerce-gutenberg-products-block`, run `npm link @woocommerce/components`
- In `woocommerce-gutenberg-products-block`, run `npm test`
- Expect: the tests should pass
- In `woocommerce-gutenberg-products-block`, run `npm run build`
- Expect: the files should build, no errors in the output
