### PR TITLE
Add SKU to product variations table

### DIFF
--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -37,6 +37,12 @@ export default class VariationsReportTable extends Component {
 				isLeftAligned: true,
 			},
 			{
+				label: __( 'SKU', 'wc-admin' ),
+				key: 'sku',
+				hiddenByDefault: true,
+				isSortable: true,
+			},
+			{
 				label: __( 'Items Sold', 'wc-admin' ),
 				key: 'items_sold',
 				required: true,
@@ -77,7 +83,7 @@ export default class VariationsReportTable extends Component {
 
 		return map( data, row => {
 			const { items_sold, net_revenue, orders_count, extended_info, product_id } = row;
-			const { stock_status, stock_quantity, low_stock_amount } = extended_info;
+			const { stock_status, stock_quantity, low_stock_amount, sku } = extended_info;
 			const name = get( row, [ 'extended_info', 'name' ], '' ).replace( ' - ', ' / ' );
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',
@@ -93,6 +99,10 @@ export default class VariationsReportTable extends Component {
 						</Link>
 					),
 					value: name,
+				},
+				{
+					display: sku,
+					value: sku,
 				},
 				{
 					display: items_sold,

--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -25,17 +25,18 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 	 * @var array
 	 */
 	protected $column_types = array(
-		'date_start'    => 'strval',
-		'date_end'      => 'strval',
-		'product_id'    => 'intval',
-		'variation_id'  => 'intval',
-		'items_sold'    => 'intval',
-		'net_revenue'   => 'floatval',
-		'orders_count'  => 'intval',
-		'name'          => 'strval',
-		'price'         => 'floatval',
-		'image'         => 'strval',
-		'permalink'     => 'strval',
+		'date_start'   => 'strval',
+		'date_end'     => 'strval',
+		'product_id'   => 'intval',
+		'variation_id' => 'intval',
+		'items_sold'   => 'intval',
+		'net_revenue'  => 'floatval',
+		'orders_count' => 'intval',
+		'name'         => 'strval',
+		'price'        => 'floatval',
+		'image'        => 'strval',
+		'permalink'    => 'strval',
+		'sku'          => 'strval',
 	);
 
 	/**
@@ -64,6 +65,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 		'stock_status',
 		'stock_quantity',
 		'low_stock_amount',
+		'sku',
 	);
 
 	/**

--- a/tests/reports/class-wc-tests-reports-variations.php
+++ b/tests/reports/class-wc-tests-reports-variations.php
@@ -32,6 +32,7 @@ class WC_Tests_Reports_Variations extends WC_Unit_Test_Case {
 		$variation->set_parent_id( $product->get_id() );
 		$variation->set_regular_price( 10 );
 		$variation->set_attributes( array( 'pa_color' => 'green' ) );
+		$variation->set_sku( 'test-sku' );
 		$variation->save();
 
 		$order = WC_Helper_Order::create_order( 1, $variation );
@@ -142,6 +143,7 @@ class WC_Tests_Reports_Variations extends WC_Unit_Test_Case {
 								'option' => 'green',
 							),
 						),
+						'sku'              => $variation->get_sku(),
 					),
 				),
 			),


### PR DESCRIPTION
Fixes #1396

Adds SKU to the API response and displays the SKU in the variation table.

### Screenshots
<img width="807" alt="screen shot 2019-01-30 at 12 19 33 pm" src="https://user-images.githubusercontent.com/10561050/51958165-9fb3f000-2489-11e9-8732-d8e800858595.png">

### Detailed test instructions:

1.  Make sure your product and/or variation have a SKU.
2.  Create an order with a product variation.
3.  Click on the product with a variation from the products report `wp-admin/admin.php?page=wc-admin#/analytics/products`.
4.  Enable this column under the column toggle preferences since it's hidden by default.
5.  Note the SKU column and correct SKU for the variation.