### PR TITLE
Added indices for faster joins with customer table and filtering by order status.

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -720,7 +720,9 @@ class WC_Admin_Api_Init {
 			status varchar(200) NOT NULL,
 			customer_id BIGINT UNSIGNED NOT NULL,
 			PRIMARY KEY (order_id),
-			KEY date_created (date_created)
+			KEY date_created (date_created),
+			KEY customer_id (customer_id),
+			KEY status (status)
 		  ) $collate;
 		  CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 			order_item_id BIGINT UNSIGNED NOT NULL,


### PR DESCRIPTION
Should help with #1372.

As order_stats table is getting joined with customer lookup table on `customer_id`, we need an index on `customer_id` in order_stats table. 
In addition, this table will be filtered on order status all the time, so added index for that as well. 