### PR TITLE
Packages: Release @woocommerce/components 1.4.2

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.2 (unreleased)
+# 1.4.2
 - Add emoji-flags dependency
 
 # 1.4.1

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "UI components for WooCommerce.",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
[1.4.2 has already been released,](https://www.npmjs.com/package/@woocommerce/components) this PR just updates the changelog & bumps the version.

I think the package release docs need to be updated, but I'm not entirely sure I did this correctly – I manually changed the version number in package.json, so it only released the components package.