### PR TITLE
Add order status tests and refund tests

### DIFF
--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -154,12 +154,12 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		$order_types = array(
 			array(
-				'status' => 'completed',
-				'total'  => 100,
-			),
-			array(
 				'status' => 'refunded',
 				'total'  => 50,
+			),
+			array(
+				'status' => 'completed',
+				'total'  => 100,
 			),
 			array(
 				'status' => 'failed',
@@ -167,13 +167,15 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			),
 		);
 
-		foreach ( $order_types as $n => $order_type ) {
-			$order = WC_Helper_Order::create_order( $n + 1, $product );
+		foreach ( $order_types as $order_type ) {
+			$order = WC_Helper_Order::create_order( 1, $product );
 			$order->set_status( $order_type['status'] );
 			$order->set_total( $order_type['total'] );
 			$order->set_shipping_total( 0 );
 			$order->set_cart_tax( 0 );
 			$order->save();
+			// Wait one second to avoid potentially ambiguous new/returning customer.
+			sleep( 1 );
 		}
 
 		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
@@ -223,6 +225,59 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'avg_order_value'         => 100,
 						'num_returning_customers' => 0,
 						'num_new_customers'       => 1,
+					),
+				),
+			),
+			'total'     => 1,
+			'pages'     => 1,
+			'page_no'   => 1,
+		);
+
+		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
+
+		// Query an excluded status which should still return orders with the queried status.
+		$args           = array(
+			'interval'  => 'hour',
+			'after'     => $start_time,
+			'before'    => $end_time,
+			'status_is' => array( 'failed' ),
+		);
+		$expected_stats = array(
+			'totals'    => array(
+				'orders_count'            => 1,
+				'num_items_sold'          => 4,
+				'avg_items_per_order'     => 4,
+				'avg_order_value'         => 75,
+				'gross_revenue'           => 75,
+				'coupons'                 => 0,
+				'refunds'                 => 0,
+				'taxes'                   => 0,
+				'shipping'                => 0,
+				'net_revenue'             => 75,
+				'num_returning_customers' => 1,
+				'num_new_customers'       => 0,
+				'products'                => 1,
+			),
+			'intervals' => array(
+				array(
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getOffsetTimestamp() ),
+					'date_start'     => $start_time,
+					'date_start_gmt' => $start_time,
+					'date_end'       => $end_time,
+					'date_end_gmt'   => $end_time,
+					'subtotals'      => array(
+						'gross_revenue'           => 75,
+						'net_revenue'             => 75,
+						'coupons'                 => 0,
+						'shipping'                => 0,
+						'taxes'                   => 0,
+						'refunds'                 => 0,
+						'orders_count'            => 1,
+						'num_items_sold'          => 4,
+						'avg_items_per_order'     => 4,
+						'avg_order_value'         => 75,
+						'num_returning_customers' => 1,
+						'num_new_customers'       => 0,
 					),
 				),
 			),

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -36,8 +36,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		$refund = wc_create_refund(
 			array(
-				'amount'         => 12,
-				'order_id'       => $order->get_id(),
+				'amount'   => 12,
+				'order_id' => $order->get_id(),
 			)
 		);
 
@@ -136,6 +136,102 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$this->assertEquals( $expected_stats, json_decode( json_encode( $query->get_data() ), true ) );
+	}
+
+	/**
+	 * Test the calculations and querying works correctly for the base case of 1 order.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_populate_and_query_statuses() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order_types = array(
+			array(
+				'status' => 'completed',
+				'total'  => 100,
+			),
+			array(
+				'status' => 'refunded',
+				'total'  => 50,
+			),
+			array(
+				'status' => 'failed',
+				'total'  => 75,
+			),
+		);
+
+		foreach ( $order_types as $n => $order_type ) {
+			$order = WC_Helper_Order::create_order( $n + 1, $product );
+			$order->set_status( $order_type['status'] );
+			$order->set_total( $order_type['total'] );
+			$order->set_shipping_total( 0 );
+			$order->set_cart_tax( 0 );
+			$order->save();
+		}
+
+		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
+
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:59:59', $order->get_date_created()->getOffsetTimestamp() );
+
+		// Query default statuses that should not include excluded or refunded order statuses.
+		$args           = array(
+			'interval' => 'hour',
+			'after'    => $start_time,
+			'before'   => $end_time,
+		);
+		$expected_stats = array(
+			'totals'    => array(
+				'orders_count'            => 1,
+				'num_items_sold'          => 4,
+				'avg_items_per_order'     => 4,
+				'avg_order_value'         => 100,
+				'gross_revenue'           => 100,
+				'coupons'                 => 0,
+				'refunds'                 => 0,
+				'taxes'                   => 0,
+				'shipping'                => 0,
+				'net_revenue'             => 100,
+				'num_returning_customers' => 0,
+				'num_new_customers'       => 1,
+				'products'                => 1,
+			),
+			'intervals' => array(
+				array(
+					'interval'       => date( 'Y-m-d H', $order->get_date_created()->getOffsetTimestamp() ),
+					'date_start'     => $start_time,
+					'date_start_gmt' => $start_time,
+					'date_end'       => $end_time,
+					'date_end_gmt'   => $end_time,
+					'subtotals'      => array(
+						'gross_revenue'           => 100,
+						'net_revenue'             => 100,
+						'coupons'                 => 0,
+						'shipping'                => 0,
+						'taxes'                   => 0,
+						'refunds'                 => 0,
+						'orders_count'            => 1,
+						'num_items_sold'          => 4,
+						'avg_items_per_order'     => 4,
+						'avg_order_value'         => 100,
+						'num_returning_customers' => 0,
+						'num_new_customers'       => 1,
+					),
+				),
+			),
+			'total'     => 1,
+			'pages'     => 1,
+			'page_no'   => 1,
+		);
+
+		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
 	}
 
 	/**

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -140,8 +140,6 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 	/**
 	 * Test that querying statuses includes the default or query-specific statuses.
-	 *
-	 * @since 3.5.0
 	 */
 	public function test_populate_and_query_statuses() {
 		WC_Helper_Reports::reset_stats_dbs();

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -139,7 +139,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the calculations and querying works correctly for the base case of 1 order.
+	 * Test that querying statuses includes the default or query-specific statuses.
 	 *
 	 * @since 3.5.0
 	 */

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -249,4 +249,76 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected_data, $data );
 	}
+
+	/**
+	 * Tests that line item refunds are reflected in product stats.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_populate_and_refund() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_shipping_total( 10 );
+		$order->set_discount_total( 20 );
+		$order->set_discount_tax( 0 );
+		$order->set_cart_tax( 5 );
+		$order->set_shipping_tax( 2 );
+		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
+		$order->save();
+
+		foreach ( $order->get_items() as  $item_key => $item_values ) {
+			$item_data = $item_values->get_data();
+			$refund    = wc_create_refund(
+				array(
+					'amount'     => 12,
+					'order_id'   => $order->get_id(),
+					'line_items' => array(
+						$item_data['id'] => array(
+							'qty'          => 1,
+							'refund_total' => 10,
+						),
+					),
+				)
+			);
+			break;
+		}
+
+		$data_store = new WC_Admin_Reports_Products_Data_Store();
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() + HOUR_IN_SECONDS );
+		$args       = array(
+			'after'  => $start_time,
+			'before' => $end_time,
+		);
+
+		// Test retrieving the stats through the data store.
+		$data          = $data_store->get_data( $args );
+		$expected_data = (object) array(
+			'total'   => 1,
+			'pages'   => 1,
+			'page_no' => 1,
+			'data'    => array(
+				0 => array(
+					'product_id'    => $product->get_id(),
+					'items_sold'    => 3,
+					'net_revenue'   => 90.0, // $25 * 4 - $10 refund.
+					'orders_count'  => 1,
+					'extended_info' => new ArrayObject(),
+				),
+			),
+		);
+		$this->assertEquals( $expected_data, $data );
+
+		// Test retrieving the stats through the query class.
+		$query = new WC_Admin_Reports_Products_Query( $args );
+		$this->assertEquals( $expected_data, $query->get_data() );
+	}
 }

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -252,8 +252,6 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests that line item refunds are reflected in product stats.
-	 *
-	 * @since 3.5.0
 	 */
 	public function test_populate_and_refund() {
 		WC_Helper_Reports::reset_stats_dbs();


### PR DESCRIPTION
Fixes #1193 

Adds in tests for excluded and default refund statuses as well as line item refunds.

### Detailed test instructions:

1.  Run phpunit tests.
2.  Check that all tests are passing.