### PR TITLE
Update page query to 1 when base query is changed

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -9,7 +9,7 @@ import { find, last, isEqual } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getPersistedQuery, stringifyQuery, updateQueryString } from '@woocommerce/navigation';
+import { getNewPath, getPersistedQuery, history, stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ class Controller extends Component {
 		const baseQuery = this.getBaseQuery( this.props.location.search );
 
 		if ( prevQuery.page > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
-			updateQueryString( { page: 1 } );
+			history.replace( getNewPath( { page: 1 } ) );
 		}
 	}
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -4,12 +4,12 @@
  */
 import { Component, createElement } from '@wordpress/element';
 import { parse } from 'qs';
-import { find, last } from 'lodash';
+import { find, last, isEqual } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { getPersistedQuery, stringifyQuery } from '@woocommerce/navigation';
+import { getPersistedQuery, stringifyQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -64,11 +64,35 @@ const getPages = () => {
 };
 
 class Controller extends Component {
+	componentDidUpdate( prevProps ) {
+		const prevQuery = this.getQuery( prevProps.location.search );
+		const prevBaseQuery = this.getBaseQuery( prevProps.location.search );
+		const baseQuery = this.getBaseQuery( this.props.location.search );
+
+		if ( prevQuery.page > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
+			updateQueryString( { page: 1 } );
+		}
+	}
+
+	getQuery( searchString ) {
+		if ( ! searchString ) {
+			return {};
+		}
+
+		const search = searchString.substring( 1 );
+		return parse( search );
+	}
+
+	getBaseQuery( searchString ) {
+		const query = this.getQuery( searchString );
+		delete query.page;
+		return query;
+	}
+
 	render() {
 		// Pass URL parameters (example :report -> params.report) and query string parameters
 		const { path, url, params } = this.props.match;
-		const search = this.props.location.search.substring( 1 );
-		const query = parse( search );
+		const query = this.getQuery( this.props.location.search );
 		const page = find( getPages(), { path } );
 		window.wpNavMenuUrlUpdate( page, query );
 		window.wpNavMenuClassChange( page );


### PR DESCRIPTION
Fixes #1405 

Switches back to the first page whenever the query is modified by changing filters or sorting.

### Screenshots
![feb-01-2019 17-08-22](https://user-images.githubusercontent.com/10561050/52113388-21e81400-2644-11e9-88cf-8e4b972829cc.gif)

### Detailed test instructions:

1. Go to any report page that has multiple pages.
2. Use the pagination to navigate to any page after page 1 on the report table.
3.  Remain on the same page and change the filter or sorting.
4.  Note that the report has returned to the first page.