### PR TITLE
Added primary key to tax lookup table to prevent duplicate entries.

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -744,7 +744,7 @@ class WC_Admin_Api_Init {
 		  	shipping_tax double DEFAULT 0 NOT NULL,
 		  	order_tax double DEFAULT 0 NOT NULL,
 		  	total_tax double DEFAULT 0 NOT NULL,
-		  	KEY order_id (order_id),
+		  	PRIMARY KEY (order_id, tax_rate_id),
 		  	KEY tax_rate_id (tax_rate_id),
 		  	KEY date_created (date_created)
 		  ) $collate;


### PR DESCRIPTION
Fixes #1445 

This PR adds a primary key to table `wc_order_tax_lookup` to prevent duplicates being created when orders are updated.

### Detailed test instructions:

- Please see #1445.

