### PR TITLE
Fix incorrect label async request paths

### DIFF
--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -39,30 +39,30 @@ export function getRequestByIdString( path, handleData = identity ) {
 }
 
 export const getCategoryLabels = getRequestByIdString(
-	NAMESPACE + 'products/categories',
+	NAMESPACE + '/products/categories',
 	category => ( {
 		id: category.id,
 		label: category.name,
 	} )
 );
 
-export const getCouponLabels = getRequestByIdString( NAMESPACE + 'coupons', coupon => ( {
+export const getCouponLabels = getRequestByIdString( NAMESPACE + '/coupons', coupon => ( {
 	id: coupon.id,
 	label: coupon.code,
 } ) );
 
-export const getCustomerLabels = getRequestByIdString( NAMESPACE + 'customers', customer => ( {
+export const getCustomerLabels = getRequestByIdString( NAMESPACE + '/customers', customer => ( {
 	id: customer.id,
 	label: customer.username,
 } ) );
 
-export const getProductLabels = getRequestByIdString( NAMESPACE + 'products', product => ( {
+export const getProductLabels = getRequestByIdString( NAMESPACE + '/products', product => ( {
 	id: product.id,
 	label: product.name,
 } ) );
 
 export const getVariationLabels = getRequestByIdString(
-	query => NAMESPACE + `products/${ query.products }/variations`,
+	query => NAMESPACE + `/products/${ query.products }/variations`,
 	variation => {
 		return {
 			id: variation.id,


### PR DESCRIPTION
Fixes #1424 fixes #1425 

Fixes the request paths for getting labels to prevent the 404 and also show persisted comparison labels on page reload.

### Screenshots
<img width="706" alt="screen shot 2019-02-01 at 5 40 38 pm" src="https://user-images.githubusercontent.com/10561050/52115061-9cb32e00-2648-11e9-9cdf-9f83430692ca.png">

### Detailed test instructions:

1. Go to the products report.
2. Select 2 product using the product comparison filter and click "Compare."
3. Make sure no 404s are shown under network requests.
4. Refresh the page.
5.  Make sure that the comparison tags persist after reloading.
6.  Make sure that coupons, customers, and product variation comparison filters continue to work as expected.
