### PR TITLE
Fix variation search autocompleter invalid route

### DIFF
--- a/includes/api/class-wc-admin-rest-product-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-product-variations-controller.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * REST API Product Variations Controller
+ *
+ * Handles requests to /products/variations.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product variations controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Product_Variations_Controller
+ */
+class WC_Admin_REST_Product_Variations_Controller extends WC_REST_Product_Variations_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -166,6 +166,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-products-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-categories-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-reviews-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-product-variations-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-setting-options-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-system-status-tools-controller.php';
@@ -202,6 +203,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Categories_Controller',
 				'WC_Admin_REST_Product_Reviews_Controller',
+				'WC_Admin_REST_Product_Variations_Controller',
 				'WC_Admin_REST_Reports_Controller',
 				'WC_Admin_REST_Setting_Options_Controller',
 				'WC_Admin_REST_System_Status_Tools_Controller',
@@ -369,6 +371,17 @@ class WC_Admin_Api_Init {
 		) {
 			$endpoints['/wc/v4/products/reviews'][0] = $endpoints['/wc/v4/products/reviews'][2];
 			$endpoints['/wc/v4/products/reviews'][1] = $endpoints['/wc/v4/products/reviews'][3];
+		}
+
+		// Override /wc/v4/products/$product_id/variations.
+		if ( isset( $endpoints['products/(?P<product_id>[\d]+)/variations'] )
+			&& isset( $endpoints['products/(?P<product_id>[\d]+)/variations'][3] )
+			&& isset( $endpoints['products/(?P<product_id>[\d]+)/variations'][2] )
+			&& $endpoints['products/(?P<product_id>[\d]+)/variations'][2]['callback'][0] instanceof WC_Admin_REST_Product_Variations_Controller
+			&& $endpoints['products/(?P<product_id>[\d]+)/variations'][3]['callback'][0] instanceof WC_Admin_REST_Product_Variations_Controller
+		) {
+			$endpoints['products/(?P<product_id>[\d]+)/variations'][0] = $endpoints['products/(?P<product_id>[\d]+)/variations'][2];
+			$endpoints['products/(?P<product_id>[\d]+)/variations'][1] = $endpoints['products/(?P<product_id>[\d]+)/variations'][3];
 		}
 
 		// Override /wc/v4/taxes.


### PR DESCRIPTION
Fixes #1421 

Adds a v4 controller for product variations to fix missing routes.

### Screenshots
<img width="518" alt="screen shot 2019-02-01 at 6 02 16 pm" src="https://user-images.githubusercontent.com/10561050/52116929-688e3c00-264d-11e9-8470-debf674f094f.png">

### Detailed test instructions:

1.  Go to the products report.
2.  Select a product variation with variation data inside the table.
3.  Use the search at the top of the table and make sure the search returns respective variations on typing.