### PR TITLE
Fix autocompleters in customers and taxes report

### DIFF
--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -103,7 +103,7 @@ describe( 'Leaderboard', () => {
 		);
 		const leaderboard = leaderboardWrapper.root.findByType( Leaderboard );
 
-		const endpoint = NAMESPACE + 'reports/products';
+		const endpoint = NAMESPACE + '/reports/products';
 		const query = { orderby: 'items_sold', per_page: 5, extended_info: 1 };
 
 		expect( getReportStatsMock.mock.calls[ 0 ][ 1 ] ).toBe( endpoint );

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -57,7 +57,7 @@ export const advancedFilters = {
 			input: {
 				component: 'Search',
 				type: 'customers',
-				getLabels: getRequestByIdString( NAMESPACE + 'customers', customer => ( {
+				getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
 					id: customer.id,
 					label: [ customer.first_name, customer.last_name ].filter( Boolean ).join( ' ' ),
 				} ) ),
@@ -157,7 +157,7 @@ export const advancedFilters = {
 			input: {
 				component: 'Search',
 				type: 'emails',
-				getLabels: getRequestByIdString( NAMESPACE + 'customers', customer => ( {
+				getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
 					id: customer.id,
 					label: customer.email,
 				} ) ),

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -49,7 +49,7 @@ export const filters = [
 				settings: {
 					type: 'taxes',
 					param: 'taxes',
-					getLabels: getRequestByIdString( NAMESPACE + 'taxes', tax => ( {
+					getLabels: getRequestByIdString( NAMESPACE + '/taxes', tax => ( {
 						id: tax.id,
 						label: getTaxCode( tax ),
 					} ) ),


### PR DESCRIPTION
Fixes some incorrect paths when getting item labels.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52133969-cbc6a100-2642-11e9-9016-8fb0a8eccc3a.png)

### Detailed test instructions:
_Customers_ report:
- Add _Advanced filters_.
- Add a _name_ filter.
- Add an _email_ filter.
- Click on _Filter_.
- Verify there are no 404 responses in the _Network_ tab of your browser devtools.

_Taxes_ report:
- Add a _Comparison_.
- Select two tax codes and click 'Compare'.
- Verify there are no 404 responses in the _Network_ tab of your browser devtools.
- Reload the page and verify the filter is preserved.
