### PR TITLE
Fixed database prefixes for admin notes tables

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -686,8 +686,8 @@ class WC_Admin_Api_Init {
 				"{$wpdb->prefix}wc_order_product_lookup",
 				"{$wpdb->prefix}wc_order_tax_lookup",
 				"{$wpdb->prefix}wc_order_coupon_lookup",
-				"{$wpdb->prefix}woocommerce_admin_notes",
-				"{$wpdb->prefix}woocommerce_admin_note_actions",
+				"{$wpdb->prefix}wc_admin_notes",
+				"{$wpdb->prefix}wc_admin_note_actions",
 				"{$wpdb->prefix}wc_customer_lookup",
 			)
 		);
@@ -759,7 +759,7 @@ class WC_Admin_Api_Init {
 			KEY coupon_id (coupon_id),
 			KEY date_created (date_created)
 		  ) $collate;
-			CREATE TABLE {$wpdb->prefix}woocommerce_admin_notes (
+			CREATE TABLE {$wpdb->prefix}wc_admin_notes (
 				note_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 				name varchar(255) NOT NULL,
 				type varchar(20) NOT NULL,
@@ -774,7 +774,7 @@ class WC_Admin_Api_Init {
 				date_reminder datetime NULL default null,
 				PRIMARY KEY (note_id)
 				) $collate;
-			CREATE TABLE {$wpdb->prefix}woocommerce_admin_note_actions (
+			CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (
 				action_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 				note_id BIGINT UNSIGNED NOT NULL,
 				name varchar(255) NOT NULL,

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -37,7 +37,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$note_to_be_inserted['date_created']  = gmdate( 'Y-m-d H:i:s', $date_created );
 		$note_to_be_inserted['date_reminder'] = null;
 
-		$wpdb->insert( $wpdb->prefix . 'woocommerce_admin_notes', $note_to_be_inserted );
+		$wpdb->insert( $wpdb->prefix . 'wc_admin_notes', $note_to_be_inserted );
 		$note_id = $wpdb->insert_id;
 		$note->set_id( $note_id );
 		$note->save_meta_data();
@@ -63,7 +63,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		if ( 0 !== $note_id || '0' !== $note_id ) {
 			$note_row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT name, type, locale, title, content, icon, content_data, status, source, date_created, date_reminder FROM {$wpdb->prefix}woocommerce_admin_notes WHERE note_id = %d LIMIT 1",
+					"SELECT name, type, locale, title, content, icon, content_data, status, source, date_created, date_reminder FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
 					$note->get_id()
 				)
 			);
@@ -117,7 +117,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 			}
 
 			$wpdb->update(
-				$wpdb->prefix . 'woocommerce_admin_notes',
+				$wpdb->prefix . 'wc_admin_notes',
 				array(
 					'name'          => $note->get_name(),
 					'type'          => $note->get_type(),
@@ -151,8 +151,8 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$note_id = $note->get_id();
 		if ( $note_id ) {
 			global $wpdb;
-			$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_notes', array( 'note_id' => $note_id ) );
-			$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_note_actions', array( 'note_id' => $note_id ) );
+			$wpdb->delete( $wpdb->prefix . 'wc_admin_notes', array( 'note_id' => $note_id ) );
+			$wpdb->delete( $wpdb->prefix . 'wc_admin_note_actions', array( 'note_id' => $note_id ) );
 			$note->set_id( null );
 		}
 		do_action( 'woocommerce_trash_note', $note_id );
@@ -168,7 +168,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		$actions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT name, label, query FROM {$wpdb->prefix}woocommerce_admin_note_actions WHERE note_id = %d",
+				"SELECT name, label, query FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id = %d",
 				$note->get_id()
 			)
 		);
@@ -194,10 +194,10 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		global $wpdb;
-		$wpdb->delete( $wpdb->prefix . 'woocommerce_admin_note_actions', array( 'note_id' => $note->get_id() ) );
+		$wpdb->delete( $wpdb->prefix . 'wc_admin_note_actions', array( 'note_id' => $note->get_id() ) );
 		foreach ( $note->get_actions( 'edit' ) as $action ) {
 			$wpdb->insert(
-				$wpdb->prefix . 'woocommerce_admin_note_actions',
+				$wpdb->prefix . 'wc_admin_note_actions',
 				array(
 					'note_id' => $note->get_id(),
 					'name'    => $action->name,
@@ -244,14 +244,14 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		if ( empty( $escaped_where_types ) ) {
 			$query = $wpdb->prepare(
-				"SELECT note_id, title, content FROM {$wpdb->prefix}woocommerce_admin_notes ORDER BY note_id DESC LIMIT %d, %d",
+				"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes ORDER BY note_id DESC LIMIT %d, %d",
 				$offset,
 				$per_page
 			);
 		} else {
 			$query = $wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				"SELECT note_id, title, content FROM {$wpdb->prefix}woocommerce_admin_notes WHERE type IN ($escaped_where_types) ORDER BY note_id DESC LIMIT %d, %d",
+				"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE type IN ($escaped_where_types) ORDER BY note_id DESC LIMIT %d, %d",
 				$offset,
 				$per_page
 			);
@@ -267,7 +267,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function get_notes_count() {
 		global $wpdb;
-		return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_admin_notes" );
+		return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes" );
 	}
 
 	/**
@@ -280,7 +280,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		global $wpdb;
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT note_id FROM {$wpdb->prefix}woocommerce_admin_notes WHERE name = %s ORDER BY note_id ASC",
+				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE name = %s ORDER BY note_id ASC",
 				$name
 			)
 		);

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Admin notes helper for wc-admin unit tests.
+ *
+ * @package WooCommerce\Tests\Framework\Helpers
+ */
 
 /**
  * Class WC_Helper_Admin_Notes.
@@ -12,8 +17,8 @@ class WC_Helper_Admin_Notes {
 	 */
 	public static function reset_notes_dbs() {
 		global $wpdb;
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_admin_notes" ); // @codingStandardsIgnoreLine.
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_admin_note_actions" ); // @codingStandardsIgnoreLine.
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_admin_notes" ); // @codingStandardsIgnoreLine.
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_admin_note_actions" ); // @codingStandardsIgnoreLine.
 	}
 
 	/**


### PR DESCRIPTION
WooCommerce is moving database prefix from `woocommerce_` to `wc_` in order to avoid problems with long database names. Almost all tables on this project already uses the new prefix, only not for admin notes.

Fixes #1460 