### PR TITLE
Exclude trashed orders from reports

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -417,8 +417,8 @@ class WC_Admin_Reports_Data_Store {
 	 * @return array
 	 */
 	protected static function get_excluded_report_order_statuses() {
-		$excluded_statuses   = WC_Admin_Settings::get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
-		$excluded_statuses[] = 'refunded';
+		$excluded_statuses = WC_Admin_Settings::get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
+		$excluded_statuses = array_merge( array( 'refunded', 'trash' ), $excluded_statuses );
 		return apply_filters( 'woocommerce_reports_excluded_order_statuses', $excluded_statuses );
 	}
 


### PR DESCRIPTION
Fixes #1463

Excludes orders with a trashed status from reports.

### Before
<img width="852" alt="screen shot 2019-02-04 at 4 28 03 pm" src="https://user-images.githubusercontent.com/10561050/52197272-e34b9700-2899-11e9-8628-18b48016126a.png">

### After
<img width="809" alt="screen shot 2019-02-04 at 4 27 20 pm" src="https://user-images.githubusercontent.com/10561050/52197275-e47cc400-2899-11e9-87b9-46dbca34f04e.png">

### Detailed test instructions:

1.  Check the orders report.
2.  Trash an order within that period.
3.  Check that the order is no longer reflected in report stats.