### PR TITLE
Fix hourly labels in bar charts X-axis

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0 (unreleased)
+- Fix X-axis labels in hourly bar charts.
+- New `<Search>` prop named `showClearButton`, that will display a 'Clear' button when the search box contains one or more tags.
+
 # 1.4.2
 - Add emoji-flags dependency
 
@@ -5,7 +9,6 @@
 - Chart component: format numbers and prices using store currency settings.
 - Make `href`/linking optional in SummaryNumber.
 - Fix SummaryNumber example code.
-- New `<Search>` prop named `showClearButton`, that will display a 'Clear' button when the search box contains one or more tags.
 
 # 1.4.0
 - Add download log ip address autocompleter to search component

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -210,7 +210,7 @@ export const drawAxis = ( node, params, xOffset ) => {
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => params.interval === 'hour'
-					? params.xFormat( d )
+					? params.xFormat( d instanceof Date ? new Date( d ) : moment( d ).toDate() )
 					: removeDuplicateDates( d, i, ticks, params.xFormat ) )
 		);
 

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -210,7 +210,7 @@ export const drawAxis = ( node, params, xOffset ) => {
 			d3AxisBottom( xScale )
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => params.interval === 'hour'
-					? params.xFormat( d instanceof Date ? new Date( d ) : moment( d ).toDate() )
+					? params.xFormat( d instanceof Date ? d : moment( d ).toDate() )
 					: removeDuplicateDates( d, i, ticks, params.xFormat ) )
 		);
 


### PR DESCRIPTION
Fixes #1413.

Fixes the X-axis labels in bar charts when the interval is set to _hours_.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/52200662-af587d80-2869-11e9-9edd-c2bda19e75f3.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/52200599-82a46600-2869-11e9-8799-91ac8a015595.png)

### Detailed test instructions:
- Go to the _Orders_ report.
- Select _Today_ in the date picker and set _Hours_ as the interval.
- Verify the correct hour is displayed below each chart.