### PR TITLE
Fix CSS Lint warning

### DIFF
--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -131,7 +131,7 @@
 .woocommerce-search__clear {
 	position: absolute;
 	right: 10px;
-	top: calc( 50% - 10px );
+	top: calc(50% - 10px);
 
 	& > .dashicon {
 		color: #c9c9c9;


### PR DESCRIPTION
Fix a CSS Lint error that was appearing in Travis.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52202197-1e37d580-286e-11e9-8b49-a42550532ed7.png)

### Detailed test instructions:
- Check the Travis build logs of this PR ([#](https://travis-ci.org/woocommerce/wc-admin/builds/488426966)).
- Verify there are no CSS warnings/errors.
