### PR TITLE
Improve display of 0-value charts

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.5.0 (unreleased)
+- Improves display of charts where all values are 0.
+
 # 1.4.2
 - Add emoji-flags dependency
 

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -197,7 +197,7 @@ export const drawAxis = ( node, params, xOffset ) => {
 			: compareStrings( formatter( prevMonth ), formatter( monthDate ) ).join( ' ' );
 	};
 
-	const yGrids = getYGrids( params.yMax );
+	const yGrids = getYGrids( params.yMax === 0 ? 1 : params.yMax );
 
 	const ticks = params.xTicks.map( d => ( params.type === 'line' ? moment( d ).toDate() : d ) );
 
@@ -257,7 +257,7 @@ export const drawAxis = ( node, params, xOffset ) => {
 		.attr( 'text-anchor', 'start' )
 		.call(
 			d3AxisLeft( params.yTickOffset )
-				.tickValues( yGrids )
+				.tickValues( params.yMax === 0 ? [ yGrids[ 0 ] ] : yGrids )
 				.tickFormat( d => params.yFormat( d !== 0 ? d : 0 ) )
 		);
 

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -72,7 +72,7 @@ export const getYMax = lineData => {
  */
 export const getYScale = ( height, yMax ) =>
 	d3ScaleLinear()
-		.domain( [ 0, yMax ] )
+		.domain( [ 0, yMax === 0 ? 1 : yMax ] )
 		.rangeRound( [ height, 0 ] );
 
 /**
@@ -83,5 +83,5 @@ export const getYScale = ( height, yMax ) =>
  */
 export const getYTickOffset = ( height, yMax ) =>
 	d3ScaleLinear()
-		.domain( [ 0, yMax ] )
+		.domain( [ 0, yMax === 0 ? 1 : yMax ] )
 		.rangeRound( [ height + 12, 12 ] );

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -107,6 +107,14 @@ describe( 'Y scales', () => {
 			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
 			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 100, 0 ] );
 		} );
+
+		it( 'avoids the domain starting and ending at the same point when yMax is 0', () => {
+			getYScale( 100, 0 );
+
+			const args = scaleLinear().domain.mock.calls;
+			const lastArgs = args[ args.length - 1 ][ 0 ];
+			expect( lastArgs[ 0 ] ).toBeLessThan( lastArgs[ 1 ] );
+		} );
 	} );
 
 	describe( 'getYTickOffset', () => {
@@ -115,6 +123,14 @@ describe( 'Y scales', () => {
 
 			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
 			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 112, 12 ] );
+		} );
+
+		it( 'avoids the domain starting and ending at the same point when yMax is 0', () => {
+			getYTickOffset( 100, 0 );
+
+			const args = scaleLinear().domain.mock.calls;
+			const lastArgs = args[ args.length - 1 ][ 0 ];
+			expect( lastArgs[ 0 ] ).toBeLessThan( lastArgs[ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #1467 and implements part of https://github.com/woocommerce/wc-admin/issues/582#issuecomment-459209125.

When all values of a chart are 0:
- Make the 0 Y-axis to be aligned to the bottom.
- Display Y-axis lines to keep it consistent with other charts, but do not display Y-axis labels other than 0.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/52205730-517f6200-2878-11e9-85a8-f16baa3a34f4.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/52205709-40365580-2878-11e9-9676-a6535e663763.png)

### Detailed test instructions:
- Go to the _Orders_ report (for example), and select a day with no orders.
- Verify the chart:
  - Displays the 0 Y-axis aligned to the bottom.
  - Displays Y-axis lines.
  - Doesn't display Y-axis labels.