### PR TITLE
navigation: Lazy-create history

### DIFF
--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * WooCommerce dependencies
  */
 import { Card } from '@woocommerce/components';
-import { getAdminLink, history } from '@woocommerce/navigation';
+import { getAdminLink, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ class ChartBlock extends Component {
 			return null;
 		}
 
-		history.push( 'analytics/' + charts[ 0 ].endpoint + '?chart=' + charts[ 0 ].key );
+		getHistory().push( 'analytics/' + charts[ 0 ].endpoint + '?chart=' + charts[ 0 ].key );
 	};
 
 	render() {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -9,7 +9,7 @@ import { find, last, isEqual } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getNewPath, getPersistedQuery, history, stringifyQuery } from '@woocommerce/navigation';
+import { getNewPath, getPersistedQuery, getHistory, stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ class Controller extends Component {
 		const baseQuery = this.getBaseQuery( this.props.location.search );
 
 		if ( prevQuery.page > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
-			history.replace( getNewPath( { page: 1 } ) );
+			getHistory().replace( getNewPath( { page: 1 } ) );
 		}
 	}
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { history } from '@woocommerce/navigation';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -83,7 +83,7 @@ Layout.propTypes = {
 export class PageLayout extends Component {
 	render() {
 		return (
-			<Router history={ history }>
+			<Router history={ getHistory() }>
 				<Switch>
 					{ getPages().map( page => {
 						return <Route key={ page.path } path={ page.path } exact component={ Layout } />;

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0
+
+- Replace `history` export with `getHistory` (allows for lazy-create of history)
+
 # 1.1.0
 
 - Rename `getTimeRelatedQuery` to `getPersistedQuery`

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -12,16 +12,16 @@ npm install @woocommerce/navigation --save
 
 ## Usage
 
-### history
+### getHistory
 
 A single history object used to perform path changes. This needs to be passed into ReactRouter to use the other path functions from this library.
 
 ```jsx
-import { history } from '@woocommerce/navigation';
+import { getHistory } from '@woocommerce/navigation';
 
 render() {
 	return (
-		<Router history={ history }>
+		<Router history={ getHistory() }>
 			…
 		</Router>
 	);

--- a/packages/navigation/src/history.js
+++ b/packages/navigation/src/history.js
@@ -6,4 +6,13 @@ import { createHashHistory } from 'history';
 
 // See https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
 
-export default createHashHistory();
+let _history;
+
+function getHistory() {
+	if ( ! _history ) {
+		_history = createHashHistory();
+	}
+	return _history;
+}
+
+export { getHistory };

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -8,10 +8,10 @@ import { parse, stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import history from './history';
+import { getHistory } from './history';
 
 // Expose history so all uses get the same history object.
-export { history };
+export { getHistory };
 
 // Export all filter utilities
 export * from './filters';
@@ -35,7 +35,7 @@ export const getAdminLink = path => wcSettings.adminUrl + path;
  *
  * @return {String}  Current path.
  */
-export const getPath = () => history.location.pathname;
+export const getPath = () => getHistory().location.pathname;
 
 /**
  * Converts a query object to a query string.
@@ -89,7 +89,7 @@ export function getNewPath( query, path = getPath(), currentQuery = getQuery() )
  * @return {Object}  Current query object, defaults to empty object.
  */
 export function getQuery() {
-	const search = history.location.search;
+	const search = getHistory().location.search;
 	if ( search.length ) {
 		return parse( search.substring( 1 ) ) || {};
 	}
@@ -125,5 +125,5 @@ export function onQueryChange( param, path = getPath(), query = getQuery() ) {
  */
 export function updateQueryString( query, path = getPath(), currentQuery = getQuery() ) {
 	const newPath = getNewPath( query, path, currentQuery );
-	history.push( newPath );
+	getHistory().push( newPath );
 }


### PR DESCRIPTION
Fixes #1433

This will also address the blocks issue: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/327

`history.createHashHistory()` is being called whenever this package is
imported, which causes the URL to redirect to a hash. This is
unnecessary in cases where elements of wc-admin are used outside of a
completely controlled/routed page.

This lazy-creates the history object only when it's needed and therefore
avoids the URL redirection unless history features are in use.

**Compatibility note**
I've suggested a major version change for this to 2.0.0 because it breaks backward compatibility by replacing the `history` export from `@woocommerce/navigation` with a `getHistory()` export. I've updated all references to `history` within this repo, but code outside of this repo will need to adjust to update to this version.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:

- Navigate through analytics pages to ensure routing works correctly.
- Navigate to `/wp-admin/edit.php?post_type=shop_order` and ensure it is not redirected to `/wp-admin/edit.php?post_type=shop_order#/`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
