### PR TITLE
Format todo comments to match WC Core format

### DIFF
--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -82,7 +82,7 @@ describe( 'Leaderboard', () => {
 		expect( firstRow[ 3 ].value ).toBe( getCurrencyFormatDecimal( mockData[ 0 ].net_revenue ) );
 	} );
 
-	// TODO: Since this now uses fresh-data / wc-api, the API testing needs to be revisted.
+	// @todo Since this now uses fresh-data / wc-api, the API testing needs to be revisted.
 	xtest( 'should load report stats from API', () => {
 		const getReportStatsMock = jest.fn().mockReturnValue( { data: mockData } );
 		const isReportStatsRequestingMock = jest.fn().mockReturnValue( false );

--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -25,7 +25,7 @@ class ReportError extends Component {
 			title = __( 'There was an error getting your stats. Please try again.', 'wc-admin' );
 			actionLabel = __( 'Reload', 'wc-admin' );
 			actionCallback = () => {
-				// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
+				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 				window.location.reload();
 			};
 		} else if ( isEmpty ) {

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -101,7 +101,7 @@ class ProductsReportTable extends Component {
 				items_sold,
 				net_revenue,
 				orders_count,
-				variations = [], // @todo
+				variations = [],
 			} = row;
 			const {
 				category_ids,

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -101,7 +101,7 @@ class ProductsReportTable extends Component {
 				items_sold,
 				net_revenue,
 				orders_count,
-				variations = [], // @TODO
+				variations = [], // @todo
 			} = row;
 			const {
 				category_ids,

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -106,7 +106,7 @@ class RevenueReportTable extends Component {
 				taxes,
 			} = row.subtotals;
 
-			// @TODO How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
+			// @todo How to create this per-report? Can use `w`, `year`, `m` to build time-specific order links
 			// we need to know which kind of report this is, and parse the `label` to get this row's date
 			const orderLink = (
 				<Link
@@ -223,7 +223,7 @@ export default compose(
 		const datesFromQuery = getCurrentDates( query );
 		const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 
-		// TODO Support hour here when viewing a single day
+		// @todo Support hour here when viewing a single day
 		const tableQuery = {
 			interval: 'day',
 			orderby: query.orderby || 'date',

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -32,7 +32,7 @@ export default class TaxesReportTable extends Component {
 		return [
 			{
 				label: __( 'Tax Code', 'wc-admin' ),
-				// @TODO it should be the tax code, not the ID
+				// @todo It should be the tax code, not the ID
 				key: 'tax_rate_id',
 				required: true,
 				isLeftAligned: true,
@@ -74,7 +74,7 @@ export default class TaxesReportTable extends Component {
 		return map( taxes, tax => {
 			const { order_tax, orders_count, tax_rate, tax_rate_id, total_tax, shipping_tax } = tax;
 
-			// @TODO must link to the tax detail report
+			// @todo Must link to the tax detail report
 			const taxLink = (
 				<Link href="" type="wc-admin">
 					{ getTaxCode( tax ) }

--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -59,7 +59,7 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 			),
 			components: {
 				strong: <strong />,
-				moreLink: <Link href="#" type="external" />, // @TODO: this needs to be replaced with a real link.
+				moreLink: <Link href="#" type="external" />, // @todo This needs to be replaced with a real link.
 			},
 		} ),
 		initialValue: wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses || [],

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -61,7 +61,7 @@ class Settings extends Component {
 
 	saveChanges = () => {
 		this.props.updateSettings( this.state.settings );
-		// @TODO: Need a confirmation on successful update.
+		// @todo Need a confirmation on successful update.
 	};
 
 	handleInputChange( e ) {

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -89,7 +89,7 @@ class ActivityPanel extends Component {
 		} );
 	}
 
-	// TODO Pull in dynamic unread status/count
+	// @todo Pull in dynamic unread status/count
 	getTabs() {
 		return [
 			{

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -26,7 +26,7 @@ class InboxPanel extends Component {
 			const title = __( 'There was an error getting your inbox. Please try again.', 'wc-admin' );
 			const actionLabel = __( 'Reload', 'wc-admin' );
 			const actionCallback = () => {
-				// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
+				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 				window.location.reload();
 			};
 

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -41,7 +41,7 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 		const title = __( 'There was an error getting your orders. Please try again.', 'wc-admin' );
 		const actionLabel = __( 'Reload', 'wc-admin' );
 		const actionCallback = () => {
-			// TODO Add tracking for how often an error is displayed, and the reload action is clicked.
+			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 			window.location.reload();
 		};
 
@@ -83,7 +83,7 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 					),
 					components: {
 						orderLink: <Link href={ 'post.php?action=edit&post=' + order.id } type="wp-admin" />,
-						// @TODO: Hook up customer name link
+						// @todo Hook up customer name link
 						customerLink: <Link href={ '#' } type="wp-admin" />,
 						destinationFlag: <Flag order={ order } round={ false } />,
 					},

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -12,8 +12,8 @@ export function recordEvent( eventName, eventProperties ) {
 		return false;
 	}
 
-	// TODO - should we add validation/whitelist of tracks
-	// TODO - Don't send tracks in dev envs maybe based off WP_DEBUG?
+	// @todo Should we add validation/whitelist of tracks
+	// @todo Don't send tracks in dev envs maybe based off WP_DEBUG?
 	const event = `wca_${ eventName }`;
 
 	// Should already be initialized via inline ./lib/clicent-assets.php

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -13,7 +13,7 @@ $gap-small: 12px;
 $gap-smaller: 8px;
 $gap-smallest: 4px;
 
-// @todo remove this spacing variable
+// @todo Remove this spacing variable
 $spacing: 16px;
 
 // Gutenberg Button variables. These are temporary until Gutenberg's variables are exposed.

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -6,7 +6,7 @@ import { MINUTE } from '@fresh-data/framework';
 
 export const NAMESPACE = '/wc/v4';
 
-// TODO: Remove once swagger endpoints are phased out.
+// @todo Remove once swagger endpoints are phased out.
 export const SWAGGERNAMESPACE = 'https://virtserver.swaggerhub.com/peterfabian/wc-v3-api/1.0.0/';
 
 export const DEFAULT_REQUIREMENT = {

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -24,7 +24,7 @@ const statEndpoints = [
 	'taxes',
 	'customers',
 ];
-// TODO: Remove once swagger endpoints are phased out.
+// @todo Remove once swagger endpoints are phased out.
 const swaggerEndpoints = [ 'categories' ];
 
 const typeEndpointMap = {

--- a/client/wc-api/with-select.js
+++ b/client/wc-api/with-select.js
@@ -2,7 +2,7 @@
  * NOTE: This is temporary code. It exists only until a version of `@wordpress/data`
  * is released which supports this functionality.
  *
- * TODO: Remove this and use `@wordpress/data` `withSelect` instead after
+ * @todo Remove this and use `@wordpress/data` `withSelect` instead after
  * this PR is merged: https://github.com/WordPress/gutenberg/pull/11460
  *
  * @format

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -31,7 +31,7 @@ function createWcApiStore() {
 	return {
 		// The wrapped function for getSelectors is temporary code.
 		//
-		// TODO: Remove the `() =>` after the `@wordpress/data` PR is merged:
+		// @todo Remove the `() =>` after the `@wordpress/data` PR is merged:
 		// https://github.com/WordPress/gutenberg/pull/11460
 		//
 		getSelectors: () => context => {

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -77,7 +77,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$report_data     = $customers_query->get_data();
 		$out_data        = array(
 			'totals'    => $report_data,
-			// @todo: is this needed? the single element array tricks the isReportDataEmpty() selector.
+			// @todo Is this needed? the single element array tricks the isReportDataEmpty() selector.
 			'intervals' => array( (object) array() ),
 		);
 
@@ -119,7 +119,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 	 * @return array
 	 */
 	public function get_item_schema() {
-		// @todo: should any of these be 'indicator's?
+		// @todo Should any of these be 'indicator's?
 		$totals = array(
 			'customers_count'     => array(
 				'description' => __( 'Number of customers.', 'wc-admin' ),
@@ -161,7 +161,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
-				'intervals' => array( // @todo: remove this?
+				'intervals' => array( // @todo Remove this?
 					'description' => __( 'Reports data grouped by intervals.', 'wc-admin' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -729,7 +729,7 @@ class WC_Admin_Api_Init {
 		$customer_ids = $customer_query->get_results();
 
 		foreach ( $customer_ids as $customer_id ) {
-			// @todo: schedule single customer update if this fails?
+			// @todo Schedule single customer update if this fails?
 			WC_Admin_Reports_Customers_Data_Store::update_registered_customer( $customer_id );
 		}
 	}
@@ -776,7 +776,7 @@ class WC_Admin_Api_Init {
 		return array_merge(
 			$wc_tables,
 			array(
-				// @todo: will this work on multisite?
+				// @todo Will this work on multisite?
 				"{$wpdb->prefix}wc_order_stats",
 				"{$wpdb->prefix}wc_order_product_lookup",
 				"{$wpdb->prefix}wc_order_tax_lookup",

--- a/includes/class-wc-admin-order.php
+++ b/includes/class-wc-admin-order.php
@@ -139,7 +139,7 @@ class WC_Admin_Order extends WC_Order {
 	 *
 	 * Loosely based on code in includes/admin/meta-boxes/views/html-order-item(s).php.
 	 *
-	 * @todo: if WC is currently not tax enabled, but it was before (or vice versa), would this work correctly?
+	 * @todo If WC is currently not tax enabled, but it was before (or vice versa), would this work correctly?
 	 *
 	 * @param WC_Order_Item $item Line item from order.
 	 *

--- a/includes/class-wc-admin-reports-customers-stats-query.php
+++ b/includes/class-wc-admin-reports-customers-stats-query.php
@@ -34,7 +34,7 @@ class WC_Admin_Reports_Customers_Stats_Query extends WC_Admin_Reports_Query {
 			'page'     => 1,
 			'order'    => 'DESC',
 			'orderby'  => 'date_registered',
-			'fields'   => '*', // @todo: needed?
+			'fields'   => '*', // @todo Needed?
 		);
 	}
 

--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -194,7 +194,7 @@ class WC_Admin_Reports_Interval {
 
 				return (int) floor( ( (int) $diff_timestamp ) / DAY_IN_SECONDS ) + 1 + $addendum;
 			case 'week':
-				// @todo: optimize? approximately day count / 7, but year end is tricky, a week can have fewer days.
+				// @todo Optimize? approximately day count / 7, but year end is tricky, a week can have fewer days.
 				$week_count = 0;
 				do {
 					$start_datetime = self::next_week_start( $start_datetime );

--- a/includes/class-wc-admin-reports-orders-stats-segmenting.php
+++ b/includes/class-wc-admin-reports-orders-stats-segmenting.php
@@ -27,7 +27,7 @@ class WC_Admin_Reports_Orders_Stats_Segmenting extends WC_Admin_Reports_Segmenti
 			'refunds'        => "SUM($products_table.refund_amount) AS refunds",
 			'taxes'          => "SUM($products_table.tax_amount) AS taxes",
 			'shipping'       => "SUM($products_table.shipping_amount) AS shipping",
-			// @todo: product_net_revenue should already have refunds subtracted, so it should not be here. Pls check.
+			// @todo product_net_revenue should already have refunds subtracted, so it should not be here. Pls check.
 			'net_revenue'    => "SUM($products_table.product_net_revenue) AS net_revenue",
 		);
 
@@ -354,7 +354,7 @@ class WC_Admin_Reports_Orders_Stats_Segmenting extends WC_Admin_Reports_Segmenti
 		// while coupon and customer are bound to order, so we don't need the extra JOIN for those.
 		// This also means that segment selections need to be calculated differently.
 		if ( 'product' === $this->query_args['segmentby'] ) {
-			// @todo: how to handle shipping taxes when grouped by product?
+			// @todo How to handle shipping taxes when grouped by product?
 			$segmenting_selections     = array(
 				'product_level' => $this->get_segment_selections_product_level( $product_segmenting_table ),
 				'order_level'   => $this->get_segment_selections_order_level( $unique_orders_table ),

--- a/includes/class-wc-admin-reports-segmenting.php
+++ b/includes/class-wc-admin-reports-segmenting.php
@@ -322,7 +322,7 @@ class WC_Admin_Reports_Segmenting {
 				$segment_labels[ $id ] = $segment->get_name();
 			}
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
-			// @todo: assuming that this will only be used for one product, check assumption.
+			// @todo Assuming that this will only be used for one product, check assumption.
 			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
 				$this->all_segment_ids = array();
 				return;
@@ -354,8 +354,8 @@ class WC_Admin_Reports_Segmenting {
 			);
 			$segments   = wp_list_pluck( $categories, 'cat_ID' );
 		} elseif ( 'coupon' === $this->query_args['segmentby'] ) {
-			// @todo: switch to a non-direct-SQL way to get all coupons?
-			// @todo: These are only currently existing coupons, but we should add also deleted ones, if they have been used at least once.
+			// @todo Switch to a non-direct-SQL way to get all coupons?
+			// @todo These are only currently existing coupons, but we should add also deleted ones, if they have been used at least once.
 			$coupon_ids = $wpdb->get_results( "SELECT ID FROM {$wpdb->prefix}posts WHERE post_type='shop_coupon' AND post_status='publish'", ARRAY_A ); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 			$segments   = wp_list_pluck( $coupon_ids, 'ID' );
 		} elseif ( 'customer_type' === $this->query_args['segmentby'] ) {
@@ -363,7 +363,7 @@ class WC_Admin_Reports_Segmenting {
 			// 1 -- returning customer
 			$segments = array( 0, 1 );
 		} elseif ( 'tax_rate_id' === $this->query_args['segmentby'] ) {
-			// @todo: do we need to include tax rates that existed in the past, but have never been used? I guess there are other, more pressing problems...
+			// @todo Do we need to include tax rates that existed in the past, but have never been used? I guess there are other, more pressing problems...
 			// Current tax rates UNION previously used tax rates.
 			$tax_rate_ids = $wpdb->get_results(
 				"SELECT tax_rate_id FROM {$wpdb->prefix}woocommerce_tax_rates

--- a/includes/data-stores/class-wc-admin-reports-categories-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-categories-data-store.php
@@ -82,7 +82,7 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 		$sql_query_params = $this->get_time_period_sql_params( $query_args, $order_product_lookup_table );
 
 		// join wp_order_product_lookup_table with relationships and taxonomies
-		// @TODO: How to handle custom product tables?
+		// @todo How to handle custom product tables?
 		$sql_query_params['from_clause'] .= " LEFT JOIN {$wpdb->prefix}term_relationships ON {$order_product_lookup_table}.product_id = {$wpdb->prefix}term_relationships.object_id";
 		$sql_query_params['from_clause'] .= " LEFT JOIN {$wpdb->prefix}term_taxonomy ON {$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}term_taxonomy.term_taxonomy_id";
 
@@ -95,7 +95,7 @@ class WC_Admin_Reports_Categories_Data_Store extends WC_Admin_Reports_Data_Store
 			$sql_query_params['where_clause'] .= " AND {$wpdb->prefix}term_taxonomy.term_id IN ({$included_categories})";
 		}
 
-		// @todo: only products in the category C or orders with products from category C (and, possibly others?).
+		// @todo Only products in the category C or orders with products from category C (and, possibly others?).
 		$included_products = $this->get_included_products( $query_args );
 		if ( $included_products ) {
 			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -41,7 +41,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		'customer_id'      => 'customer_id',
 		'user_id'          => 'user_id',
 		'username'         => 'username',
-		'name'             => "CONCAT_WS( ' ', first_name, last_name ) as name", // @todo: what does this mean for RTL?
+		'name'             => "CONCAT_WS( ' ', first_name, last_name ) as name", // @todo What does this mean for RTL?
 		'email'            => 'email',
 		'country'          => 'country',
 		'city'             => 'city',

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -49,7 +49,7 @@ class WC_Admin_Reports_Data_Store {
 	 */
 	protected $report_columns = array();
 
-	// @todo: this does not really belong here, maybe factor out the comparison as separate class?
+	// @todo This does not really belong here, maybe factor out the comparison as separate class?
 	/**
 	 * Order by property, used in the cmp function.
 	 *
@@ -73,7 +73,7 @@ class WC_Admin_Reports_Data_Store {
 	private function interval_cmp( $a, $b ) {
 		if ( '' === $this->order_by || '' === $this->order ) {
 			return 0;
-			// @todo: should return WP_Error here perhaps?
+			// @todo Should return WP_Error here perhaps?
 		}
 		if ( $a[ $this->order_by ] === $b[ $this->order_by ] ) {
 			// As relative order is undefined in case of equality in usort, second-level sorting by date needs to be enforced
@@ -129,7 +129,7 @@ class WC_Admin_Reports_Data_Store {
 	 * @return stdClass
 	 */
 	protected function fill_in_missing_intervals( $db_intervals, $datetime_start, $datetime_end, $time_interval, &$data ) {
-		// @todo: this is ugly and messy.
+		// @todo This is ugly and messy.
 		// At this point, we don't know when we can stop iterating, as the ordering can be based on any value.
 		$end_datetime = new DateTime( $datetime_end );
 		$time_ids     = array_flip( wp_list_pluck( $data->intervals, 'time_interval' ) );
@@ -140,7 +140,7 @@ class WC_Admin_Reports_Data_Store {
 		foreach ( $totals_arr as $key => $val ) {
 			$totals_arr[ $key ] = 0;
 		}
-		// @todo: should 'products' be in intervals?
+		// @todo Should 'products' be in intervals?
 		unset( $totals_arr['products'] );
 		while ( $datetime <= $end_datetime ) {
 			$next_start = WC_Admin_Reports_Interval::iterate( $datetime, $time_interval );
@@ -349,7 +349,7 @@ class WC_Admin_Reports_Data_Store {
 					$start_iteration = 0;
 				}
 				if ( $start_iteration ) {
-					// @todo: is this correct? should it only be added if iterate runs? other two iterate instances, too?
+					// @todo Is this correct? should it only be added if iterate runs? other two iterate instances, too?
 					$new_start_date_timestamp = (int) $new_start_date->format( 'U' ) + 1;
 					$new_start_date->setTimestamp( $new_start_date_timestamp );
 				}
@@ -475,7 +475,7 @@ class WC_Admin_Reports_Data_Store {
 			$datetime = new DateTime( $interval['datetime_anchor'] );
 
 			$prev_start = WC_Admin_Reports_Interval::iterate( $datetime, $time_interval, true );
-			// @todo: not sure if the +1/-1 here are correct, especially as they are applied before the ?: below.
+			// @todo Not sure if the +1/-1 here are correct, especially as they are applied before the ?: below.
 			$prev_start_timestamp = (int) $prev_start->format( 'U' ) + 1;
 			$prev_start->setTimestamp( $prev_start_timestamp );
 			if ( $datetime_start ) {

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -85,7 +85,7 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 	 * @param array $intervals_query Array of options for intervals db query.
 	 */
 	protected function orders_stats_sql_filter( $query_args, &$totals_query, &$intervals_query ) {
-		// @todo: performance of all of this?
+		// @todo Performance of all of this?
 		global $wpdb;
 
 		$from_clause        = '';
@@ -94,7 +94,7 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 
 		$where_filters = array();
 
-		// @todo: maybe move the sql inside the get_included/excluded functions?
+		// @todo Maybe move the sql inside the get_included/excluded functions?
 		// Products filters.
 		$included_products = $this->get_included_products( $query_args );
 		$excluded_products = $this->get_excluded_products( $query_args );

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -347,7 +347,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 			$coupon_amount       = $order->get_item_coupon_amount( $order_item );
 
 			// Tax amount.
-			// @todo: check if this calculates tax correctly with refunds.
+			// @todo Check if this calculates tax correctly with refunds.
 			$tax_amount = 0;
 
 			$order_taxes = $order->get_taxes();
@@ -357,7 +357,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
 			}
 
-			// @todo: should net revenue be affected by refunds, as refunds are tracked separately?
+			// @todo Should net revenue be affected by refunds, as refunds are tracked separately?
 			$net_revenue = $order_item->get_subtotal( 'edit' ) - $amount_refunded;
 
 			if ( $quantity_refunded >= $order_item->get_quantity( 'edit' ) ) {
@@ -390,7 +390,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 						'tax_amount'            => $tax_amount,
 						'shipping_amount'       => $shipping_amount,
 						'shipping_tax_amount'   => $shipping_tax_amount,
-						// @todo: can this be incorrect if modified by filters?
+						// @todo Can this be incorrect if modified by filters?
 						'product_gross_revenue' => $net_revenue + $tax_amount + $shipping_amount + $shipping_tax_amount,
 						'refund_amount'         => $amount_refunded,
 					),

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -283,9 +283,8 @@ add_action( 'admin_notices', 'wc_admin_admin_after_notices', PHP_INT_MAX );
 /**
  * Edits Admin title based on section of wc-admin.
  *
- * @TODO Can we do some URL rewriting so we can figure out which page they are on server side?
- *
  * @param string $admin_title Modifies admin title.
+ * @todo Can we do some URL rewriting so we can figure out which page they are on server side?
  */
 function wc_admin_admin_title( $admin_title ) {
 	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
@@ -344,8 +343,8 @@ function wc_admin_output_breadcrumb( $section ) {
 /**
  * Set up a div for the header embed to render into.
  * The initial contents here are meant as a place loader for when the PHP page initialy loads.
-
- * TODO Icon Placeholders for the ActivityPanel, when we implement the new designs.
+ *
+ * @todo Icon Placeholders for the ActivityPanel, when we implement the new designs.
  */
 function woocommerce_embed_page_header() {
 	if ( ! wc_admin_is_embed_enabled_wc_page() ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -153,7 +153,7 @@ function wc_admin_print_script_settings() {
 	$tracking_script  = '';
 	if ( $tracking_enabled && defined( 'JETPACK__VERSION' ) ) {
 		$tracking_script  = "var wc_tracking_script = document.createElement( 'script' );\n";
-		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; // TODO Version/cache buster.
+		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; // @todo Version/cache buster.
 		$tracking_script .= "wc_tracking_script.type = 'text/javascript';\n";
 		$tracking_script .= "wc_tracking_script.async = true;\n";
 		$tracking_script .= "wc_tracking_script.defer = true;\n";
@@ -183,11 +183,11 @@ function wc_admin_print_script_settings() {
 	}
 
 	/**
-	 * TODO: On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and
+	 * Settings and variables can be passed here for access in the app.
+	 *
+	 * @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired, and
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
 	 */
-
-	// Settings and variables can be passed here for access in the app.
 	$settings = array(
 		'adminUrl'              => admin_url(),
 		'wcAssetUrl'            => plugins_url( 'assets/', WC_PLUGIN_FILE ),

--- a/lib/common.php
+++ b/lib/common.php
@@ -54,7 +54,7 @@ function wc_admin_get_current_screen_id() {
 /**
  * Returns breadcrumbs for the current page.
  *
- * TODO When merging to core, we should explore a better API for defining breadcrumbs, instead of just defining an array.
+ * @todo When merging to core, we should explore a better API for defining breadcrumbs, instead of just defining an array.
  */
 function wc_admin_get_embed_breadcrumbs() {
 	$current_screen_id = wc_admin_get_current_screen_id();
@@ -210,7 +210,8 @@ function wc_admin_get_embed_breadcrumbs() {
  * `wc_admin_get_embed_enabled_screen_ids`,  `wc_admin_get_embed_enabled_plugin_screen_ids`,
  * `wc_admin_get_embed_enabled_screen_ids` should be considered temporary functions for the feature plugin.
  *  This is separate from WC's screen_id functions so that extensions explictly have to opt-in to the feature plugin.
- *  TODO When merging to core, we should explore a better API for opting into the new header for extensions.
+ *
+ *  @todo When merging to core, we should explore a better API for opting into the new header for extensions.
  */
 function wc_admin_get_embed_enabled_core_screen_ids() {
 	$screens = array(

--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -65,7 +65,7 @@ class DatePicker extends Component {
 
 	render() {
 		const { date, text, dateFormat, error } = this.props;
-		// @TODO: make upstream Gutenberg change to invalidate certain days.
+		// @todo Make upstream Gutenberg change to invalidate certain days.
 		// const isOutsideRange = getOutsideRange( invalidDays );
 		return (
 			<Dropdown

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -160,7 +160,7 @@ class D3Chart extends Component {
 	render() {
 		const { className, data, height, type } = this.props;
 		if ( isEmpty( data ) ) {
-			return null; // TODO: improve messaging
+			return null; // @todo Improve messaging
 		}
 		const computedWidth = this.getWidth();
 		return (

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -143,7 +143,7 @@ class Pagination extends Component {
 	}
 
 	renderPerPagePicker() {
-		// TODO Replace this with a styleized Select drop-down/control?
+		// @todo Replace this with a styleized Select drop-down/control?
 		const pickerOptions = PER_PAGE_OPTIONS.map( option => {
 			return { value: option, label: option };
 		} );

--- a/packages/components/src/search/autocompleters/categories.js
+++ b/packages/components/src/search/autocompleters/categories.js
@@ -62,7 +62,7 @@ export default {
 	},
 	getOptionLabel( cat, query ) {
 		const match = computeSuggestionMatch( cat.name, query ) || {};
-		// @todo bring back ProductImage, but allow for product category image
+		// @todo Bring back ProductImage, but allow for product category image
 		return [
 			<span key="name" className="woocommerce-search__result-name" aria-label={ cat.name }>
 				{ match.suggestionBeforeMatch }

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -129,7 +129,7 @@ class TableCard extends Component {
 	onClickDownload() {
 		const { query, onClickDownload, title } = this.props;
 
-		// @TODO The current implementation only downloads the contents displayed in the table.
+		// @todo The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).
 		downloadCSVFile(
 			generateCSVFileName( title, query ),

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	plugins: [
 		require( './node_modules/@wordpress/postcss-themes' )( {
-			// @TODO: A default is required for now. Fix postcss-themes to allow no default
+			// @todo A default is required for now. Fix postcss-themes to allow no default
 			defaults: {
 				primary: '#0085ba',
 				secondary: '#11a0d2',

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -55,13 +55,13 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 	public function test_get_reports() {
 		wp_set_current_user( $this->user );
 
-		// @todo update after report interface is done.
+		// @todo Update after report interface is done.
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $reports ) ); // totals and intervals.
-		// $this->assertEquals( array(), $reports ); // @todo update results after implement report interface.
+		// $this->assertEquals( array(), $reports ); // @todo Update results after implement report interface.
 	}
 
 	/**

--- a/tests/api/reports-revenue-stats.php
+++ b/tests/api/reports-revenue-stats.php
@@ -64,8 +64,8 @@ class WC_Tests_API_Reports_Revenue_Stats extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 2, count( $data ) ); // @todo update results after implement report interface.
-		// $this->assertEquals( array(), $reports ); // @todo update results after implement report interface.
+		$this->assertEquals( 2, count( $data ) ); // @todo Update results after implement report interface.
+		// $this->assertEquals( array(), $reports ); // @todo Update results after implement report interface.
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1427 

Updates all the `@todo` comments to be consistent with WC core formatting and make them more searchable.

### Detailed test instructions:

Nothing to test, but todo comments should all be formatted correctly.