### PR TITLE
Add manage_stock to stock controller response

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -106,6 +106,7 @@ class ProductsReportTable extends Component {
 			const {
 				category_ids,
 				low_stock_amount,
+				manage_stock,
 				name,
 				sku,
 				stock_status,
@@ -125,6 +126,14 @@ class ProductsReportTable extends Component {
 				( category_ids &&
 					category_ids.map( category_id => categories.get( category_id ) ).filter( Boolean ) ) ||
 				[];
+
+			const stockStatus = isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
+				<Link href={ 'post.php?action=edit&post=' + product_id } type="wp-admin">
+					{ _x( 'Low', 'Indication of a low quantity', 'wc-admin' ) }
+				</Link>
+			) : (
+				stockStatuses[ stock_status ]
+			);
 
 			return [
 				{
@@ -186,17 +195,11 @@ class ProductsReportTable extends Component {
 					value: variations.length,
 				},
 				{
-					display: isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
-						<Link href={ 'post.php?action=edit&post=' + product_id } type="wp-admin">
-							{ _x( 'Low', 'Indication of a low quantity', 'wc-admin' ) }
-						</Link>
-					) : (
-						stockStatuses[ stock_status ]
-					),
-					value: stockStatuses[ stock_status ],
+					display: manage_stock ? stockStatus : __( 'N/A', 'wc-admin' ),
+					value: manage_stock ? stockStatuses[ stock_status ] : null,
 				},
 				{
-					display: numberFormat( stock_quantity ),
+					display: manage_stock ? numberFormat( stock_quantity ) : __( 'N/A', 'wc-admin' ),
 					value: stock_quantity,
 				},
 			];

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -60,7 +60,7 @@ export default class StockReportTable extends Component {
 		const { stockStatuses } = wcSettings;
 
 		return products.map( product => {
-			const { id, name, parent_id, sku, stock_quantity, stock_status } = product;
+			const { id, manage_stock, name, parent_id, sku, stock_quantity, stock_status } = product;
 
 			const productDetailLink = getNewPath( persistedQuery, 'products', {
 				filter: 'single_product',
@@ -95,7 +95,7 @@ export default class StockReportTable extends Component {
 					value: stock_status,
 				},
 				{
-					display: numberFormat( stock_quantity ),
+					display: manage_stock ? numberFormat( stock_quantity ) : __( 'N/A', 'wc-admin' ),
 					value: stock_quantity,
 				},
 			];

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -198,7 +198,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			'name'           => $product->get_name(),
 			'sku'            => $product->get_sku(),
 			'stock_status'   => $product->get_stock_status(),
-			'stock_quantity' => (int) $product->get_stock_quantity(),
+			'stock_quantity' => (float) $product->get_stock_quantity(),
 			'manage_stock'   => $product->get_manage_stock(),
 		);
 

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -198,7 +198,8 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			'name'           => $product->get_name(),
 			'sku'            => $product->get_sku(),
 			'stock_status'   => $product->get_stock_status(),
-			'stock_quantity' => (float) $product->get_stock_quantity(),
+			'stock_quantity' => (int) $product->get_stock_quantity(),
+			'manage_stock'   => $product->get_manage_stock(),
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -302,6 +303,12 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 				'stock_quantity' => array(
 					'description' => __( 'Stock quantity.', 'wc-admin' ),
 					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'manage_stock'   => array(
+					'description' => __( 'Manage stock.', 'wc-admin' ),
+					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -67,6 +67,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		'permalink',
 		'stock_status',
 		'stock_quantity',
+		'manage_stock',
 		'low_stock_amount',
 		'category_ids',
 		'sku',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Number of selectable chart elements is now limited to 5.
 - Color scale logic for charts with lots of items has been fixed.
 - Update `@woocommerce/navigation` to v2.0.0
+- Bug fix for `<StockReportTable />` returning N/A instead of zero.
 
 # 1.4.2
 - Add emoji-flags dependency

--- a/tests/api/reports-stock.php
+++ b/tests/api/reports-stock.php
@@ -107,12 +107,13 @@ class WC_Tests_API_Reports_Stock extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 6, count( $properties ) );
+		$this->assertEquals( 7, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'parent_id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'sku', $properties );
 		$this->assertArrayHasKey( 'stock_status', $properties );
 		$this->assertArrayHasKey( 'stock_quantity', $properties );
+		$this->assertArrayHasKey( 'manage_stock', $properties );
 	}
 }

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -247,6 +247,7 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 						'price'            => (float) $product->get_price(),
 						'stock_status'     => $product->get_stock_status(),
 						'stock_quantity'   => $product->get_stock_quantity(),
+						'manage_stock'     => $product->get_manage_stock(),
 						'low_stock_amount' => $product->get_low_stock_amount(),
 						'category_ids'     => array_values( $product->get_category_ids() ),
 						'sku'              => $product->get_sku(),


### PR DESCRIPTION
Fixes #1395 

Adds `manage_stock` to the API response so that we can display "N/A" on the stock page if stock isn't being managed.

### Screenshots
<img width="757" alt="screen shot 2019-02-05 at 2 53 29 pm" src="https://user-images.githubusercontent.com/10561050/52257445-d3918880-2955-11e9-80b8-1a7ec7eab0e9.png">

### Detailed test instructions:

1.  Enable stock management for some of your products and disable for others.
2.  Go the stock report `/wp-admin/admin.php?page=wc-admin#/analytics/stock`.
3.  Check that "N/A" is shown if the product is not using stock management and that the stock quantity is shown if management is enabled.