### PR TITLE
Add 'variations' attribute in products 'extended_info'

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -75,7 +75,8 @@ class ProductsReportTable extends Component {
 			},
 			{
 				label: __( 'Variations', 'wc-admin' ),
-				key: 'variation',
+				key: 'variations',
+				isSortable: true,
 			},
 			{
 				label: __( 'Status', 'wc-admin' ),
@@ -95,14 +96,7 @@ class ProductsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( data, row => {
-			const {
-				product_id,
-				extended_info,
-				items_sold,
-				net_revenue,
-				orders_count,
-				variations = [],
-			} = row;
+			const { product_id, extended_info, items_sold, net_revenue, orders_count } = row;
 			const {
 				category_ids,
 				low_stock_amount,
@@ -110,6 +104,7 @@ class ProductsReportTable extends Component {
 				sku,
 				stock_status,
 				stock_quantity,
+				variations = [],
 			} = extended_info;
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',

--- a/includes/api/class-wc-admin-rest-reports-products-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-products-controller.php
@@ -224,6 +224,12 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 						'context'     => array( 'view', 'edit' ),
 						'description' => __( 'Product inventory threshold for low stock.', 'wc-admin' ),
 					),
+					'variations'      => array(
+						'type'        => 'array',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit' ),
+						'description' => __( 'Product variations IDs.', 'wc-admin' ),
+					),
 					'sku'              => array(
 						'type'        => 'string',
 						'readonly'    => true,
@@ -291,6 +297,7 @@ class WC_Admin_REST_Reports_Products_Controller extends WC_REST_Reports_Controll
 				'orders_count',
 				'items_sold',
 				'product_name',
+				'variations',
 				'sku',
 			),
 			'validate_callback' => 'rest_validate_request_arg',


### PR DESCRIPTION
Fixes #1477.

This PR adds a `variations` attribute in products' `extended_info`, so we can display the number of variations each product has.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52275216-2d428480-294f-11e9-872c-cc651fa7bf2b.png)

### Detailed test instructions:
- Go to the _Products_ report.
- Verify variable products display the number of variations in the _Variations_ column.
- Try sorting it and verify it doesn't break.