### PR TITLE
Try: Fix failing returning customer test

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -525,9 +525,10 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 
 		$customer_orders = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM ${orders_stats_table} WHERE customer_id = %d AND date_created < %s",
+				"SELECT COUNT(*) FROM ${orders_stats_table} WHERE customer_id = %d AND date_created < %s AND order_id != %d",
 				$customer_id,
-				date( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() )
+				date( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ),
+				$order->get_id()
 			)
 		);
 

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -4732,6 +4732,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			) as $order_time
 		) {
 			// Order with 1 product.
+			sleep( 1 );
 			$order = WC_Helper_Order::create_order( $customer->get_id(), $product );
 			$order->set_date_created( $order_time );
 			$order->set_status( $order_status );

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -180,7 +180,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$order->save();
 
 			// Wait one second to avoid potentially ambiguous new/returning customer.
-			sleep( 1 );
+			sleep( 1 ); // @todo Remove this after p90Yrv-XN-p2 is resolved.
 		}
 
 		WC_Helper_Queue::run_all_pending();
@@ -4732,7 +4732,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			) as $order_time
 		) {
 			// Order with 1 product.
-			sleep( 1 );
+			sleep( 1 ); // @todo Remove this after p90Yrv-XN-p2 is resolved.
 			$order = WC_Helper_Order::create_order( $customer->get_id(), $product );
 			$order->set_date_created( $order_time );
 			$order->set_status( $order_status );


### PR DESCRIPTION
Fixes #1490 

Doesn't check against against the same order in `is_returning_customer()` if the order was previously created and the date is being updated.

### Detailed test instructions:

Make sure all phpunit tests are passing.