### PR TITLE
Fix initial order sync stalling

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -319,7 +319,7 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 		global $wpdb;
 
 		$order = wc_get_order( $order_id );
-		if ( ! $order ) {
+		if ( ! $order || 'shop_order' !== $order->get_type() ) {
 			return -1;
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -319,6 +319,8 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 		global $wpdb;
 
 		$order = wc_get_order( $order_id );
+
+		// Skip `shop_order_refunds` when factoring stats on coupon usage.
 		if ( ! $order || 'shop_order' !== $order->get_type() ) {
 			return -1;
 		}

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -367,6 +367,9 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 					array( '%d' )
 				); // WPCS: cache ok, DB call ok.
 
+				// Deleting 0 items here isn't a problem, and we should force a successful return.
+				$result = ( 0 === $result ) ? 1 : $result;
+
 				/**
 				 * Fires when product's reports are deleted.
 				 *

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -258,6 +258,8 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	public static function sync_order_taxes( $order_id ) {
 		global $wpdb;
 		$order = wc_get_order( $order_id );
+
+		// Skip `shop_order_refunds` when factoring stats on order tax.
 		if ( ! $order || 'shop_order' !== $order->get_type() ) {
 			return -1;
 		}

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -258,7 +258,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	public static function sync_order_taxes( $order_id ) {
 		global $wpdb;
 		$order = wc_get_order( $order_id );
-		if ( ! $order ) {
+		if ( ! $order || 'shop_order' !== $order->get_type() ) {
 			return -1;
 		}
 


### PR DESCRIPTION
_Warning: 🐇🕳_

This issue was introduced (in part) by #1426.

### The Problem(s)

The logic introduced in #1426 to determine order processing success (and whether or not a retry should be attempted) relies on a success indicator returned from each sync class/method. This proved to be problematic:

* `shop_order_refund`-type posts were skipped by the order stats and product sync methods, but not the coupon and tax sync methods (causing a non +/- 4 result)
* The success logic in `WC_Admin_Reports_Products_Data_Store::sync_order_products()` was faulty - on initial syncs, refunded products were attempted to be deleted from the lookup table but since they hadn't been inserted yet, 0 rows were affected by the query and a non-success code was returned

Additionally:

* Occasionally the "next run" of a job considered to be blocking a "dependent action" was NULL (https://github.com/woocommerce/wc-admin/pull/1426#issuecomment-459696449)
* The blocking job could be a false positive where the scheduled hook was actually "queue dependent action" and not "queue batch action"

### Detailed test instructions:

The best test data is the WCCOM development environment. Start it fresh and rebuild reports - make sure that all scheduled actions complete. (My environment stalled at 197 pending jobs on two separate attempts before this fix)
