### PR TITLE
Empty chart message

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -218,10 +218,13 @@ ReportChart.defaultProps = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const { query, endpoint, filters } = props;
-		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
-			return {};
-		}
 		const chartMode = props.mode || getChartMode( filters, query ) || 'time-comparison';
+
+		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
+			return {
+				mode: chartMode,
+			};
+		}
 
 		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
 			return {

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
@@ -89,6 +90,7 @@ export class ReportChart extends Component {
 
 	renderChart( mode, isRequesting, chartData ) {
 		const {
+			emptySearch,
 			interactiveLegend,
 			itemsLabel,
 			legendPosition,
@@ -101,11 +103,15 @@ export class ReportChart extends Component {
 		const currentInterval = getIntervalForQuery( query );
 		const allowedIntervals = getAllowedIntervalsForQuery( query );
 		const formats = getDateFormatsForInterval( currentInterval, primaryData.data.intervals.length );
+		const emptyMessage = emptySearch
+			? __( 'No data for the current search', 'wc-admin' )
+			: __( 'No data for the selected date range', 'wc-admin' );
 		return (
 			<Chart
 				allowedIntervals={ allowedIntervals }
 				data={ chartData }
 				dateParser={ '%Y-%m-%dT%H:%M:%S' }
+				emptyMessage={ emptyMessage }
 				interactiveLegend={ interactiveLegend }
 				interval={ currentInterval }
 				isRequesting={ isRequesting }
@@ -222,6 +228,7 @@ export default compose(
 
 		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
 			return {
+				emptySearch: true,
 				mode: chartMode,
 			};
 		}

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -218,6 +218,9 @@ ReportChart.defaultProps = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const { query, endpoint, filters } = props;
+		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
+			return {};
+		}
 		const chartMode = props.mode || getChartMode( filters, query ) || 'time-comparison';
 
 		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -90,7 +90,7 @@ export class ReportChart extends Component {
 
 	renderChart( mode, isRequesting, chartData ) {
 		const {
-			emptySearch,
+			emptySearchResults,
 			interactiveLegend,
 			itemsLabel,
 			legendPosition,
@@ -103,7 +103,7 @@ export class ReportChart extends Component {
 		const currentInterval = getIntervalForQuery( query );
 		const allowedIntervals = getAllowedIntervalsForQuery( query );
 		const formats = getDateFormatsForInterval( currentInterval, primaryData.data.intervals.length );
-		const emptyMessage = emptySearch
+		const emptyMessage = emptySearchResults
 			? __( 'No data for the current search', 'wc-admin' )
 			: __( 'No data for the selected date range', 'wc-admin' );
 		return (
@@ -228,7 +228,7 @@ export default compose(
 
 		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
 			return {
-				emptySearch: true,
+				emptySearchResults: true,
 				mode: chartMode,
 			};
 		}

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -233,12 +233,6 @@ export default compose(
 			};
 		}
 
-		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
-			return {
-				mode: chartMode,
-			};
-		}
-
 		if ( 'item-comparison' === chartMode ) {
 			const primaryData = getReportChartData( endpoint, 'primary', query, select );
 			return {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.5.0 (unreleased)
-- Chart component: new prop `emptyMessage`. When a message is provided, it will be displayed on top of the chart if there are no values higher than 0.
+- Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.
 - Chart component: remove d3-array dependency.
 - Chart component: fix display when there is no data.
 - Improves display of charts where all values are 0.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 1.5.0 (unreleased)
+- Chart component: new prop `emptyMessage`. When a message is provided, it will be displayed on top of the chart if there are no values over 0.
 - Chart component: remove d3-array dependency.
 - Chart component: fix display when there is no data.
 - Improves display of charts where all values are 0.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.5.0 (unreleased)
-- Chart component: new prop `emptyMessage`. When a message is provided, it will be displayed on top of the chart if there are no values over 0.
+- Chart component: new prop `emptyMessage`. When a message is provided, it will be displayed on top of the chart if there are no values higher than 0.
 - Chart component: remove d3-array dependency.
 - Chart component: fix display when there is no data.
 - Improves display of charts where all values are 0.

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -122,15 +122,17 @@ class D3Chart extends Component {
 		const visibleKeys = newOrderedKeys.filter( key => key.visible );
 		const lineData = getLineData( data, newOrderedKeys );
 		const yMax = getYMax( lineData );
-		this.setState( {
-			isEmpty: yMax === 0,
-		} );
 		const yScale = getYScale( adjHeight, yMax );
 		const parseDate = d3UTCParse( dateParser );
 		const uniqueDates = getUniqueDates( lineData, parseDate );
 		const xLineScale = getXLineScale( uniqueDates, adjWidth );
 		const xScale = getXScale( uniqueDates, adjWidth, compact );
 		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
+
+		this.setState( {
+			isEmpty: yMax === 0,
+		} );
+
 		return {
 			adjHeight,
 			adjWidth,

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -42,6 +42,9 @@ class D3Chart extends Component {
 		this.drawChart = this.drawChart.bind( this );
 		this.getParams = this.getParams.bind( this );
 		this.tooltipRef = createRef();
+		this.state = {
+			isEmpty: false,
+		};
 	}
 
 	drawChart( node ) {
@@ -62,6 +65,7 @@ class D3Chart extends Component {
 		const xOffset = type === 'line' && adjParams.uniqueDates.length <= 1
 			? adjParams.width / 2
 			: 0;
+
 		drawAxis( g, adjParams, xOffset );
 		type === 'line' && drawLines( g, data, adjParams, xOffset );
 		type === 'bar' && drawBars( g, data, adjParams );
@@ -118,6 +122,9 @@ class D3Chart extends Component {
 		const visibleKeys = newOrderedKeys.filter( key => key.visible );
 		const lineData = getLineData( data, newOrderedKeys );
 		const yMax = getYMax( lineData );
+		this.setState( {
+			isEmpty: yMax === 0,
+		} );
 		const yScale = getYScale( adjHeight, yMax );
 		const parseDate = d3UTCParse( dateParser );
 		const uniqueDates = getUniqueDates( lineData, parseDate );
@@ -158,6 +165,17 @@ class D3Chart extends Component {
 		};
 	}
 
+	getEmptyMessage() {
+		const { isEmpty } = this.state;
+		const { emptyMessage } = this.props;
+
+		if ( isEmpty && emptyMessage ) {
+			return (
+				<div className="d3-chart__empty-message">{ emptyMessage }</div>
+			);
+		}
+	}
+
 	render() {
 		const { className, data, height, type } = this.props;
 		const computedWidth = this.getWidth();
@@ -166,6 +184,7 @@ class D3Chart extends Component {
 				className={ classNames( 'd3-chart__container', className ) }
 				style={ { height } }
 			>
+				{ this.getEmptyMessage() }
 				<div className="d3-chart__tooltip" ref={ this.tooltipRef } />
 				<D3Base
 					className={ classNames( this.props.className ) }
@@ -199,6 +218,10 @@ D3Chart.propTypes = {
 	 * Format to parse dates into d3 time format
 	 */
 	dateParser: PropTypes.string.isRequired,
+	/**
+	 * The message to be displayed if there is no data to render.
+	 */
+	emptyMessage: PropTypes.string,
 	/**
 	 * Height of the `svg`.
 	 */

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -221,7 +221,8 @@ D3Chart.propTypes = {
 	 */
 	dateParser: PropTypes.string.isRequired,
 	/**
-	 * The message to be displayed if there is no data to render.
+	 * The message to be displayed if there is no data to render. If no message is provided,
+	 * nothing will be displayed.
 	 */
 	emptyMessage: PropTypes.string,
 	/**

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -20,6 +20,7 @@ import {
 	getUniqueKeys,
 	getUniqueDates,
 	getFormatter,
+	isDataEmpty,
 } from './utils/index';
 import {
 	getXScale,
@@ -42,9 +43,6 @@ class D3Chart extends Component {
 		this.drawChart = this.drawChart.bind( this );
 		this.getParams = this.getParams.bind( this );
 		this.tooltipRef = createRef();
-		this.state = {
-			isEmpty: false,
-		};
 	}
 
 	drawChart( node ) {
@@ -129,10 +127,6 @@ class D3Chart extends Component {
 		const xScale = getXScale( uniqueDates, adjWidth, compact );
 		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
 
-		this.setState( {
-			isEmpty: yMax === 0,
-		} );
-
 		return {
 			adjHeight,
 			adjWidth,
@@ -168,10 +162,9 @@ class D3Chart extends Component {
 	}
 
 	getEmptyMessage() {
-		const { isEmpty } = this.state;
-		const { emptyMessage } = this.props;
+		const { baseValue, data, emptyMessage } = this.props;
 
-		if ( isEmpty && emptyMessage ) {
+		if ( emptyMessage && isDataEmpty( data, baseValue ) ) {
 			return (
 				<div className="d3-chart__empty-message">{ emptyMessage }</div>
 			);
@@ -204,6 +197,11 @@ class D3Chart extends Component {
 }
 
 D3Chart.propTypes = {
+	/**
+	 * Base chart value. If no data value is different than the baseValue, the
+	 * `emptyMessage` will be displayed if provided.
+	 */
+	baseValue: PropTypes.number,
 	/**
 	 * Additional CSS classes.
 	 */
@@ -290,6 +288,7 @@ D3Chart.propTypes = {
 };
 
 D3Chart.defaultProps = {
+	baseValue: 0,
 	data: [],
 	dateParser: '%Y-%m-%dT%H:%M:%S',
 	height: 200,

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -15,6 +15,29 @@
 		overflow: visible;
 	}
 
+	.d3-chart__empty-message {
+		align-items: center;
+		bottom: 0;
+		color: $core-grey-dark-300;
+		display: flex;
+		@include font-size( 18 );
+		font-weight: bold;
+		justify-content: center;
+		left: 0;
+		line-height: 1.5;
+		margin: 0 auto;
+		max-width: 50%;
+		padding-bottom: 48px;
+		position: absolute;
+		right: 0;
+		top: 0;
+		text-align: center;
+
+		@include breakpoint( '<782px' ) {
+			@include font-size( 13 );
+		}
+	}
+
 	.d3-chart__tooltip {
 		border: 1px solid $core-grey-light-700;
 		position: absolute;

--- a/packages/components/src/chart/d3chart/utils/index.js
+++ b/packages/components/src/chart/d3chart/utils/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { find, get, isNil } from 'lodash';
 import { format as d3Format } from 'd3-format';
 import { line as d3Line } from 'd3-shape';
 import moment from 'moment';
@@ -135,3 +135,22 @@ export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
 				} ),
 		};
 	} );
+
+/**
+ * Check whether data is empty.
+ * @param {array} data - the chart component's `data` prop.
+ * @param {number} baseValue - base value to test data values against.
+ * @returns {boolean} `false` if there was at least one data value different than
+ * the baseValue.
+ */
+export const isDataEmpty = ( data, baseValue = 0 ) => {
+	for ( let i = 0; i < data.length; i++ ) {
+		for ( const [ key, item ] of Object.entries( data[ i ] ) ) {
+			if ( key !== 'date' && ! isNil( item.value ) && item.value !== baseValue ) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+};

--- a/packages/components/src/chart/d3chart/utils/test/index.js
+++ b/packages/components/src/chart/d3chart/utils/test/index.js
@@ -16,6 +16,7 @@ import {
 	getLineData,
 	getUniqueKeys,
 	getUniqueDates,
+	isDataEmpty,
 } from '../index';
 import { getXLineScale } from '../scales';
 
@@ -92,5 +93,65 @@ describe( 'getDateSpaces', () => {
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].date ).toEqual( '2018-06-04T00:00:00' );
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].start ).toEqual( 90 );
 		expect( testDateSpaces[ testDateSpaces.length - 1 ].width ).toEqual( 10 );
+	} );
+} );
+
+describe( 'isDataEmpty', () => {
+	it( 'should return true when all data values are 0 and no baseValue is provided', () => {
+		const data = [
+			{
+				lorem: {
+					value: 0,
+				},
+				ipsum: {
+					value: 0,
+				},
+			},
+		];
+		expect( isDataEmpty( data ) ).toBeTruthy();
+	} );
+
+	it( 'should return true when all data values match the base value', () => {
+		const data = [
+			{
+				lorem: {
+					value: 100,
+				},
+				ipsum: {
+					value: 100,
+				},
+			},
+		];
+		expect( isDataEmpty( data, 100 ) ).toBeTruthy();
+	} );
+
+	it( 'should return false if at least one data values doesn\'t match the base value', () => {
+		const data = [
+			{
+				lorem: {
+					value: 100,
+				},
+				ipsum: {
+					value: 0,
+				},
+			},
+		];
+		expect( isDataEmpty( data, 100 ) ).toBeFalsy();
+	} );
+
+	it( 'should return true when all data values match the base value or are null/undefined', () => {
+		const data = [
+			{
+				lorem: {
+					value: 100,
+				},
+				ipsum: {
+					value: null,
+				},
+				dolor: {
+				},
+			},
+		];
+		expect( isDataEmpty( data, 100 ) ).toBeTruthy();
 	} );
 } );

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -267,6 +267,7 @@ class Chart extends Component {
 		const { interactiveLegend, orderedKeys, visibleData, width } = this.state;
 		const {
 			dateParser,
+			emptyMessage,
 			interval,
 			isRequesting,
 			isViewportLarge,
@@ -380,6 +381,7 @@ class Chart extends Component {
 									data={ visibleData }
 									dateParser={ dateParser }
 									height={ chartHeight }
+									emptyMessage={ emptyMessage }
 									interval={ interval }
 									margin={ margin }
 									mode={ mode }
@@ -419,6 +421,10 @@ Chart.propTypes = {
 	 * Format to parse dates into d3 time format
 	 */
 	dateParser: PropTypes.string.isRequired,
+	/**
+	 * The message to be displayed if there is no data to render.
+	 */
+	emptyMessage: PropTypes.string,
 	/**
 	 * Label describing the legend items.
 	 */

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -422,7 +422,8 @@ Chart.propTypes = {
 	 */
 	dateParser: PropTypes.string.isRequired,
 	/**
-	 * The message to be displayed if there is no data to render.
+	 * The message to be displayed if there is no data to render. If no message is provided,
+	 * nothing will be displayed.
 	 */
 	emptyMessage: PropTypes.string,
 	/**

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -266,6 +266,7 @@ class Chart extends Component {
 	render() {
 		const { interactiveLegend, orderedKeys, visibleData, width } = this.state;
 		const {
+			baseValue,
 			dateParser,
 			emptyMessage,
 			interval,
@@ -377,6 +378,7 @@ class Chart extends Component {
 						{ ! isRequesting &&
 							width > 0 && (
 								<D3Chart
+									baseValue={ baseValue }
 									colorScheme={ d3InterpolateViridis }
 									data={ visibleData }
 									dateParser={ dateParser }
@@ -413,6 +415,11 @@ Chart.propTypes = {
 	 * Allowed intervals to show in a dropdown.
 	 */
 	allowedIntervals: PropTypes.array,
+	/**
+	 * Base chart value. If no data value is different than the baseValue, the
+	 * `emptyMessage` will be displayed if provided.
+	 */
+	baseValue: PropTypes.number,
 	/**
 	 * An array of data.
 	 */
@@ -507,6 +514,7 @@ Chart.propTypes = {
 };
 
 Chart.defaultProps = {
+	baseValue: 0,
 	data: [],
 	dateParser: '%Y-%m-%dT%H:%M:%S',
 	interactiveLegend: true,


### PR DESCRIPTION
Fixes #582.

Updates the design of empty charts according to https://github.com/woocommerce/wc-admin/issues/582#issuecomment-459209125.

A couple of notes:
- I changed the color from `light-grey-700` to `grey-dark-300` in order to comply with the minimum contrast ratio.
- In narrow viewports (mobile) I reduced the font size of the message, otherwise it was overlapping the chart y-axis lines.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52403867-06f42480-2ac8-11e9-828c-b6e8ea64a2a6.png)
![image](https://user-images.githubusercontent.com/3616980/52403921-212e0280-2ac8-11e9-85c8-025748c5c1ba.png)

### Detailed test instructions:
- Go to the _Products_ report and select a day with no orders in the day picker.
- Verify a message `No data for the selected date range` appears in the chart.
- Reset the date selection to include some results and verify the message disappears.
- In the table, search for a product that doesn't exist, for example introduce `adfads` in the table search input.
- Verify the chart displays a message `No data for the current search`.