### PR TITLE
Fixed WordPress database error in unit tests

### DIFF
--- a/tests/api-init.php
+++ b/tests/api-init.php
@@ -35,12 +35,14 @@ class WC_Tests_API_Init extends WC_REST_Unit_Test_Case {
 	 * @return string
 	 */
 	public function filter_order_query( $query ) {
+		global $wpdb;
+
 		if (
 			0 === strpos( $query, 'REPLACE INTO' ) &&
 			false !== strpos( $query, WC_Admin_Reports_Orders_Stats_Data_Store::TABLE_NAME )
 		) {
 			remove_filter( 'query', array( $this, 'filter_order_query' ) );
-			return 'THIS WONT MATCH';
+			return "DESCRIBE $wpdb->posts"; // Execute any random query.
 		}
 
 		return $query;


### PR DESCRIPTION
Fixes the follow error:

```
WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'THIS WONT MATCH' at line 1]
```

Fixes #1489