### PR TITLE
Remove on hover color from disabled button

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -56,11 +56,13 @@
 
 	.components-button.is-button.is-primary {
 		color: $white;
-	}
 
-	.components-button.is-button.is-primary:hover,
-	.components-button.is-button.is-primary:active,
-	.components-button.is-button.is-primary:focus {
-		color: $white;
+		&:not(:disabled) {
+			&:hover,
+			&:active,
+			&:focus {
+				color: $white;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1339

When hovering the disabled filter button, the text color should not change.

### Screenshots

![button-disabled](https://user-images.githubusercontent.com/1177726/52564726-c9abd180-2dfc-11e9-8b58-552a73023083.gif)

### Detailed test instructions:

* Go to the _Downloads_ report and select _Advanced Filters_ under the _Show_ dropdown (or directly go to `wc-admin#/analytics/downloads?filter=advanced`).
* Notice the _Filter_ button is disabled.
* Hover it.
* The text color shouldn't change.