### PR TITLE
Update 5.0.0 version check and add basic readme.txt

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -79,6 +79,6 @@ zip -r wc-admin.zip \
 	$build_files \
 	languages/wc-admin.pot \
 	languages/wc-admin.php \
-	README.md
+	readme.txt
 
 success "Done. You've built WooCommerce Admin! 🎉 "

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,15 @@
+=== WooCommerce Admin ===
+Contributors: automattic
+Tags: ecommerce, e-commerce, store, sales, reports, analytics, stats, woo commerce, woocommerce
+Requires at least: 5.0.0
+Tested up to: 5.0
+Stable tag: 1.0.0
+License: GPLv2
+License URI: https://github.com/woocommerce/wc-admin/blob/master/LICENSE.md
+
+A feature plugin for a modern, javascript-driven WooCommerce admin experience.
+
+== Description ==
+
+
+== Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce Admin ===
 Contributors: automattic
-Tags: ecommerce, e-commerce, store, sales, reports, analytics, stats, woo commerce, woocommerce
+Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activity, notices, insights, stats, woo commerce, woocommerce
 Requires at least: 5.0.0
 Tested up to: 5.0.3
 Stable tag: 1.0.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic
 Tags: ecommerce, e-commerce, store, sales, reports, analytics, stats, woo commerce, woocommerce
 Requires at least: 5.0.0
-Tested up to: 5.0
+Tested up to: 5.0.3
 Stable tag: 1.0.0
 License: GPLv2
 License URI: https://github.com/woocommerce/wc-admin/blob/master/LICENSE.md

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,12 +46,8 @@ function wc_admin_install() {
 	}
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
-	if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
-		$GLOBALS['wp_roles']->reinit();
-	} else {
-		$GLOBALS['wp_roles'] = null; // WPCS: override ok.
-		wp_roles();
-	}
+	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
+	wp_roles();
 
 	echo esc_html( 'Installing wc-admin...' . PHP_EOL );
 }
@@ -94,16 +90,6 @@ function wc_test_includes() {
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	if ( version_compare( $GLOBALS['wp_version'], '4.9.9', '<=' ) ) { // < 5.0 fails for "5.0-alpha-12345-src
-		$_tests_wp_core_dir = getenv( 'WP_CORE_DIR' );
-
-		if ( ! $_tests_wp_core_dir ) {
-			$_tests_wp_core_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress';
-		}
-
-		require $_tests_wp_core_dir . '/wp-content/plugins/gutenberg/gutenberg.php';
-	}
-
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 	define( 'WC_USE_TRANSACTIONS', false );
 	require_once wc_dir() . '/woocommerce.php';

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -25,7 +25,7 @@ if ( ! defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {
 }
 
 /**
- * Notify users of the plugin requirements
+ * Notify users of the plugin requirements.
  */
 function wc_admin_plugins_notice() {
 	// The notice varies by WordPress version.
@@ -40,9 +40,9 @@ function wc_admin_plugins_notice() {
 		);
 	} else {
 		$message = sprintf(
-			/* translators: 1: URL of Gutenberg plugin, 2: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">Gutenberg</a> and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
-			'https://wordpress.org/plugins/gutenberg/',
+			/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
+			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> (>=5.0) and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
+			'https://wordpress.org/',
 			'https://wordpress.org/plugins/woocommerce/'
 		);
 	}
@@ -50,7 +50,7 @@ function wc_admin_plugins_notice() {
 }
 
 /**
- * Notify users that the plugin needs to be built
+ * Notify users that the plugin needs to be built.
  */
 function wc_admin_build_notice() {
 	$message_one = __( 'You have installed a development version of WooCommerce Admin which requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files.', 'wc-admin' );
@@ -73,11 +73,8 @@ function dependencies_satisfied() {
 		return false;
 	}
 
-	$wordpress_version            = get_bloginfo( 'version' );
-	$wordpress_includes_gutenberg = version_compare( $wordpress_version, '4.9.9', '>' );
-	$gutenberg_plugin_active      = defined( 'GUTENBERG_DEVELOPMENT_MODE' ) || defined( 'GUTENBERG_VERSION' );
-
-	return $wordpress_includes_gutenberg || $gutenberg_plugin_active;
+	$wordpress_version = get_bloginfo( 'version' );
+	return version_compare( $wordpress_version, '4.9.9', '>' );
 }
 
 /**

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -41,7 +41,7 @@ function wc_admin_plugins_notice() {
 	} else {
 		$message = sprintf(
 			/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> (>=5.0) and <a href="%2$s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> 5.0 or greater and <a href="%2$s">WooCommerce</a> 3.5 or greater to be installed and active.', 'wc-admin' ),
 			'https://wordpress.org/',
 			'https://wordpress.org/plugins/woocommerce/'
 		);


### PR DESCRIPTION
Fixes #1355.

This PR adds a WordPress.org `readme.txt` file, containing a "Requires at least" header which the plugin repository uses for showing compatible plugins. I've added a few keywords and such for now, but we can continue filling this out in future PRs before release.

It also updates the notice, requiring 5.0.0.

<img width="1502" alt="screen shot 2019-02-11 at 3 20 43 pm" src="https://user-images.githubusercontent.com/689165/52591863-fbc82e00-2e12-11e9-9bac-368329fcbd6f.png">

### Detailed test instructions:

* Run `phpunit` and make sure all tests pass.
* Test this branch on 4.9.9 or build a zip using `pm run-script build:release` and install it. Verify that you see the version check message.
* Test on 5.0.0 and see everything displays correctly.
