### PR TITLE
Add products stats endpoint to categories

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -194,7 +194,9 @@ export default compose(
 		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
 			return {};
 		}
-		const chartEndpoint = 'variations' === endpoint ? 'products' : endpoint;
+		const chartEndpoint = [ 'variations', 'categories' ].includes( endpoint )
+			? 'products'
+			: endpoint;
 		const primaryData = getSummary
 			? getReportChartData( chartEndpoint, 'primary', query, select )
 			: {};

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -4,6 +4,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -20,23 +21,53 @@ import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 
 export default class CategoriesReport extends Component {
+	getChartMeta() {
+		const { query } = this.props;
+		const isCategoryDetailsView =
+			'top_items' === query.filter ||
+			'top_revenue' === query.filter ||
+			'compare-categories' === query.filter;
+
+		const isSingleCategoryView = query.categories && 1 === query.categories.split( ',' ).length;
+		const mode =
+			isCategoryDetailsView || isSingleCategoryView ? 'item-comparison' : 'time-comparison';
+		const itemsLabel = __( '%d categories', 'wc-admin' );
+
+		return {
+			itemsLabel,
+			mode,
+		};
+	}
+
 	render() {
 		const { query, path } = this.props;
+		const { mode, itemsLabel } = this.getChartMeta();
+
+		const chartQuery = {
+			...query,
+		};
+
+		if ( 'item-comparison' === mode ) {
+			chartQuery.segmentby = 'category';
+		}
 
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
 					charts={ charts }
-					endpoint="categories"
-					query={ query }
+					endpoint="products"
+					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
+					filters={ filters }
 					charts={ charts }
-					endpoint="categories"
+					mode={ mode }
+					endpoint="products"
 					path={ path }
-					query={ query }
+					query={ chartQuery }
+					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<CategoriesReportTable query={ query } />
@@ -47,4 +78,5 @@ export default class CategoriesReport extends Component {
 
 CategoriesReport.propTypes = {
 	query: PropTypes.object.isRequired,
+	path: PropTypes.string.isRequired,
 };

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -41,8 +41,8 @@ class ProductsReport extends Component {
 			isSingleProductView && isSingleProductVariable ? 'variations' : 'products';
 		const label =
 			isSingleProductView && isSingleProductVariable
-				? __( '%s variations', 'wc-admin' )
-				: __( '%s products', 'wc-admin' );
+				? __( '%d variations', 'wc-admin' )
+				: __( '%d products', 'wc-admin' );
 
 		return {
 			compareObject,

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -6,9 +6,6 @@ import { MINUTE } from '@fresh-data/framework';
 
 export const NAMESPACE = '/wc/v4';
 
-// @todo Remove once swagger endpoints are phased out.
-export const SWAGGERNAMESPACE = 'https://virtserver.swaggerhub.com/peterfabian/wc-v3-api/1.0.0/';
-
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,
 	freshness: 30 * MINUTE,

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -13,7 +13,7 @@ import { stringifyQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { getResourceIdentifier, getResourcePrefix } from 'wc-api/utils';
-import { NAMESPACE, SWAGGERNAMESPACE } from 'wc-api/constants';
+import { NAMESPACE } from 'wc-api/constants';
 
 const statEndpoints = [
 	'coupons',
@@ -25,8 +25,6 @@ const statEndpoints = [
 	'taxes',
 	'customers',
 ];
-// @todo Remove once swagger endpoints are phased out.
-const swaggerEndpoints = [ 'categories' ];
 
 const typeEndpointMap = {
 	'report-stats-query-orders': 'orders',
@@ -55,9 +53,7 @@ function read( resourceNames, fetch = apiFetch ) {
 			parse: false,
 		};
 
-		if ( swaggerEndpoints.indexOf( endpoint ) >= 0 ) {
-			fetchArgs.url = SWAGGERNAMESPACE + 'reports/' + endpoint + '/stats' + stringifyQuery( query );
-		} else if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
+		if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
 			fetchArgs.path = NAMESPACE + '/reports/' + endpoint + '/stats' + stringifyQuery( query );
 		} else {
 			fetchArgs.path = endpoint + stringifyQuery( query );

--- a/includes/class-wc-admin-reports-segmenting.php
+++ b/includes/class-wc-admin-reports-segmenting.php
@@ -94,8 +94,8 @@ class WC_Admin_Reports_Segmenting {
 		}
 
 		foreach ( $segments_db_result as $segment_data ) {
-			$segment_id = $segment_data[ $segment_dimension ];
-			$segment_labels  = $this->get_segment_labels();
+			$segment_id     = $segment_data[ $segment_dimension ];
+			$segment_labels = $this->get_segment_labels();
 			unset( $segment_data[ $segment_dimension ] );
 			$segment_datum                 = array(
 				'segment_id'    => $segment_id,
@@ -208,7 +208,7 @@ class WC_Admin_Reports_Segmenting {
 	 */
 	protected function merge_segment_intervals_results( $segment_dimension, $result1, $result2 ) {
 		$result_segments = array();
-		$segment_labels = $this->get_segment_labels();
+		$segment_labels  = $this->get_segment_labels();
 
 		foreach ( $result1 as $segment_data ) {
 			$time_interval = $segment_data['time_interval'];
@@ -317,8 +317,8 @@ class WC_Admin_Reports_Segmenting {
 
 			$segment_objects = wc_get_products( $args );
 			foreach ( $segment_objects as $segment ) {
-				$id = $segment->get_id();
-				$segments[] = $id;
+				$id                    = $segment->get_id();
+				$segments[]            = $id;
 				$segment_labels[ $id ] = $segment->get_name();
 			}
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
@@ -342,17 +342,24 @@ class WC_Admin_Reports_Segmenting {
 			$segment_objects = wc_get_products( $args );
 
 			foreach ( $segment_objects as $segment ) {
-				$id = $segment->get_id();
-				$segments[] = $id;
+				$id                    = $segment->get_id();
+				$segments[]            = $id;
 				$segment_labels[ $id ] = $segment->get_name();
 			}
 		} elseif ( 'category' === $this->query_args['segmentby'] ) {
-			$categories = get_categories(
-				array(
-					'taxonomy' => 'product_cat',
-				)
+			$args = array(
+				'taxonomy' => 'product_cat',
 			);
-			$segments   = wp_list_pluck( $categories, 'cat_ID' );
+
+			if ( isset( $this->query_args['categories'] ) ) {
+				$args['include'] = $this->query_args['categories'];
+			}
+
+			$categories = get_categories( $args );
+
+			$segments       = wp_list_pluck( $categories, 'cat_ID' );
+			$segment_labels = wp_list_pluck( $categories, 'name', 'cat_ID' );
+
 		} elseif ( 'coupon' === $this->query_args['segmentby'] ) {
 			// @todo Switch to a non-direct-SQL way to get all coupons?
 			// @todo These are only currently existing coupons, but we should add also deleted ones, if they have been used at least once.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1284

### Changes

* Remove SwaggerHub endpoint from Categories Report in favor of using `/reports/products/stats`.
* Enable item comparison mode the chart.
* Add label data and filter according category segmentation, eg `?segmentby=category&categories=19,33`.

### Detailed test instructions:

1. Categories Report
2. See a request made to `/reports/products/stats` instead of SwaggerHub.
3. Show > Comparison and see the chart change to `item-comparison` mode.
4. Select a few categories to compare and see segments get filtered appropriately.
