### PR TITLE
Chart legend alignment in IE11

### DIFF
--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -69,7 +69,6 @@
 			display: flex;
 			flex-direction: row;
 			flex-wrap: nowrap;
-			justify-content: space-between;
 			position: relative;
 			padding: 3px 0 3px 24px;
 			cursor: pointer;
@@ -118,6 +117,7 @@
 			}
 
 			.woocommerce-legend__item-total {
+				margin-left: auto;
 				font-weight: bold;
 			}
 		}


### PR DESCRIPTION
Fixes #1513.

Fixes the chart legend alignment in IE11 from centered to left aligned so all browsers should be consistent now.

Changes tested in IE11, Chrome, Firefox and Safari.

### How to test

* Open any report with a chart in IE11
* Note the chart legend text is now aligned to the left

### Screenshots

Before:

<img width="862" alt="screenshot 2019-02-12 at 12 44 14" src="https://user-images.githubusercontent.com/1177726/52636671-34c0db00-2ec5-11e9-982e-69115f328488.png">

After:

<img width="863" alt="screenshot 2019-02-12 at 12 42 58" src="https://user-images.githubusercontent.com/1177726/52636672-35597180-2ec5-11e9-883a-289776ef182e.png">