### PR TITLE
Refactor D3Chart

### DIFF
--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -6,18 +6,14 @@
 import { Component, createRef } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { timeFormat as d3TimeFormat, utcParse as d3UTCParse } from 'd3-time-format';
+import { timeFormat as d3TimeFormat } from 'd3-time-format';
 
 /**
  * Internal dependencies
  */
 import D3Base from './d3base';
 import {
-	getDateSpaces,
 	getOrderedKeys,
-	getLine,
-	getLineData,
-	getUniqueKeys,
 	getUniqueDates,
 	getFormatter,
 	isDataEmpty,
@@ -28,11 +24,11 @@ import {
 	getXLineScale,
 	getYMax,
 	getYScale,
-	getYTickOffset,
 } from './utils/scales';
-import { drawAxis, getXTicks } from './utils/axis';
+import { drawAxis } from './utils/axis';
 import { drawBars } from './utils/bar-chart';
 import { drawLines } from './utils/line-chart';
+import ChartTooltip from './utils/tooltip';
 
 /**
  * A simple D3 line and bar chart component for timeseries data in React.
@@ -45,28 +41,89 @@ class D3Chart extends Component {
 		this.tooltipRef = createRef();
 	}
 
+	getFormatParams() {
+		const { xFormat, x2Format, yFormat } = this.props;
+
+		return {
+			xFormat: getFormatter( xFormat, d3TimeFormat ),
+			x2Format: getFormatter( x2Format, d3TimeFormat ),
+			yFormat: getFormatter( yFormat ),
+		};
+	}
+
+	getScaleParams( uniqueDates ) {
+		const { data, height, margin, orderedKeys, type } = this.props;
+
+		const adjHeight = height - margin.top - margin.bottom;
+		const adjWidth = this.getWidth() - margin.left - margin.right;
+		const yMax = getYMax( data );
+		const yScale = getYScale( adjHeight, yMax );
+
+		if ( type === 'line' ) {
+			return {
+				xScale: getXLineScale( uniqueDates, adjWidth ),
+				yMax,
+				yScale,
+			};
+		}
+
+		const compact = this.shouldBeCompact();
+		const xScale = getXScale( uniqueDates, adjWidth, compact );
+
+		return {
+			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
+			xScale,
+			yMax,
+			yScale,
+		};
+	}
+
+	getParams( uniqueDates ) {
+		const { colorScheme, data, interval, mode, orderedKeys, type } = this.props;
+		const newOrderedKeys = orderedKeys || getOrderedKeys( data );
+
+		return {
+			colorScheme,
+			interval,
+			mode,
+			type,
+			uniqueDates,
+			visibleKeys: newOrderedKeys.filter( key => key.visible ),
+		};
+	}
+
+	createTooltip( chart, visibleKeys ) {
+		const { colorScheme, tooltipLabelFormat, tooltipPosition, tooltipTitle, tooltipValueFormat } = this.props;
+
+		const tooltip = new ChartTooltip();
+		tooltip.ref = this.tooltipRef.current;
+		tooltip.chart = chart;
+		tooltip.position = tooltipPosition;
+		tooltip.title = tooltipTitle;
+		tooltip.labelFormat = getFormatter( tooltipLabelFormat, d3TimeFormat );
+		tooltip.valueFormat = getFormatter( tooltipValueFormat );
+		tooltip.visibleKeys = visibleKeys;
+		tooltip.colorScheme = colorScheme;
+		this.tooltip = tooltip;
+	}
+
 	drawChart( node ) {
-		const { data, margin, type } = this.props;
-		const params = this.getParams();
-		const adjParams = Object.assign( {}, params, {
-			height: params.adjHeight,
-			width: params.adjWidth,
-			tooltip: this.tooltipRef.current,
-			valueType: params.valueType,
-		} );
+		const { data, dateParser, margin, type } = this.props;
+		const uniqueDates = getUniqueDates( data, dateParser );
+		const formats = this.getFormatParams();
+		const params = this.getParams( uniqueDates );
+		const scales = this.getScaleParams( uniqueDates );
 
 		const g = node
 			.attr( 'id', 'chart' )
 			.append( 'g' )
-			.attr( 'transform', `translate(${ margin.left },${ margin.top })` );
+			.attr( 'transform', `translate(${ margin.left }, ${ margin.top })` );
 
-		const xOffset = type === 'line' && adjParams.uniqueDates.length <= 1
-			? adjParams.width / 2
-			: 0;
+		this.createTooltip( g.node(), params.visibleKeys );
 
-		drawAxis( g, adjParams, xOffset );
-		type === 'line' && drawLines( g, data, adjParams, xOffset );
-		type === 'bar' && drawBars( g, data, adjParams );
+		drawAxis( g, params, scales, formats, margin );
+		type === 'line' && drawLines( g, data, params, scales, formats, this.tooltip );
+		type === 'bar' && drawBars( g, data, params, scales, formats, this.tooltip );
 	}
 
 	shouldBeCompact() {
@@ -92,75 +149,6 @@ class D3Chart extends Component {
 		return Math.max( width, minimumWidth + margin.left + margin.right );
 	}
 
-	getParams() {
-		const {
-			colorScheme,
-			data,
-			dateParser,
-			height,
-			interval,
-			margin,
-			mode,
-			orderedKeys,
-			tooltipPosition,
-			tooltipLabelFormat,
-			tooltipValueFormat,
-			tooltipTitle,
-			type,
-			xFormat,
-			x2Format,
-			yFormat,
-			valueType,
-		} = this.props;
-		const adjHeight = height - margin.top - margin.bottom;
-		const adjWidth = this.getWidth() - margin.left - margin.right;
-		const compact = this.shouldBeCompact();
-		const uniqueKeys = getUniqueKeys( data );
-		const newOrderedKeys = orderedKeys || getOrderedKeys( data, uniqueKeys );
-		const visibleKeys = newOrderedKeys.filter( key => key.visible );
-		const lineData = getLineData( data, newOrderedKeys );
-		const yMax = getYMax( lineData );
-		const yScale = getYScale( adjHeight, yMax );
-		const parseDate = d3UTCParse( dateParser );
-		const uniqueDates = getUniqueDates( lineData, parseDate );
-		const xLineScale = getXLineScale( uniqueDates, adjWidth );
-		const xScale = getXScale( uniqueDates, adjWidth, compact );
-		const xTicks = getXTicks( uniqueDates, adjWidth, mode, interval );
-
-		return {
-			adjHeight,
-			adjWidth,
-			colorScheme,
-			dateSpaces: getDateSpaces( data, uniqueDates, adjWidth, xLineScale ),
-			interval,
-			line: getLine( xLineScale, yScale ),
-			lineData,
-			margin,
-			mode,
-			orderedKeys: newOrderedKeys,
-			visibleKeys,
-			parseDate,
-			tooltipPosition,
-			tooltipLabelFormat: getFormatter( tooltipLabelFormat, d3TimeFormat ),
-			tooltipValueFormat: getFormatter( tooltipValueFormat ),
-			tooltipTitle,
-			type,
-			uniqueDates,
-			uniqueKeys,
-			valueType,
-			xFormat: getFormatter( xFormat, d3TimeFormat ),
-			x2Format: getFormatter( x2Format, d3TimeFormat ),
-			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
-			xLineScale,
-			xTicks,
-			xScale,
-			yMax,
-			yScale,
-			yTickOffset: getYTickOffset( adjHeight, yMax ),
-			yFormat: getFormatter( yFormat ),
-		};
-	}
-
 	getEmptyMessage() {
 		const { baseValue, data, emptyMessage } = this.props;
 
@@ -172,7 +160,7 @@ class D3Chart extends Component {
 	}
 
 	render() {
-		const { className, data, height, type } = this.props;
+		const { className, data, height, orderedKeys, type } = this.props;
 		const computedWidth = this.getWidth();
 		return (
 			<div
@@ -182,12 +170,12 @@ class D3Chart extends Component {
 				{ this.getEmptyMessage() }
 				<div className="d3-chart__tooltip" ref={ this.tooltipRef } />
 				<D3Base
-					className={ classNames( this.props.className ) }
+					className={ classNames( className ) }
 					data={ data }
 					drawChart={ this.drawChart }
 					height={ height }
-					orderedKeys={ this.props.orderedKeys }
-					tooltipRef={ this.tooltipRef }
+					orderedKeys={ orderedKeys }
+					tooltip={ this.tooltip }
 					type={ type }
 					width={ computedWidth }
 				/>

--- a/packages/components/src/chart/d3chart/d3base/index.js
+++ b/packages/components/src/chart/d3chart/d3base/index.js
@@ -54,7 +54,7 @@ export default class D3Base extends Component {
 	delayedScroll() {
 		const { tooltip } = this.props;
 		return throttle( () => {
-			tooltip.hide();
+			tooltip && tooltip.hide();
 		}, 300 );
 	}
 
@@ -104,5 +104,6 @@ D3Base.propTypes = {
 	className: PropTypes.string,
 	data: PropTypes.array,
 	orderedKeys: PropTypes.array, // required to detect changes in data
+	tooltip: PropTypes.object,
 	type: PropTypes.string,
 };

--- a/packages/components/src/chart/d3chart/d3base/index.js
+++ b/packages/components/src/chart/d3chart/d3base/index.js
@@ -10,11 +10,6 @@ import { isEqual, throttle } from 'lodash';
 import { select as d3Select } from 'd3-selection';
 
 /**
- * Internal dependencies
- */
-import { hideTooltip } from '../utils/tooltip';
-
-/**
  * Provides foundation to use D3 within React.
  *
  * React is responsible for determining when a chart should be updated (e.g. whenever data changes or the browser is
@@ -30,10 +25,6 @@ export default class D3Base extends Component {
 		super( props );
 
 		this.chartRef = createRef();
-
-		this.delayedScroll = throttle( () => {
-			hideTooltip( this.chartRef.current, props.tooltipRef.current );
-		}, 300 );
 	}
 
 	componentDidMount() {
@@ -58,6 +49,13 @@ export default class D3Base extends Component {
 
 	componentWillUnmount() {
 		this.deleteChart();
+	}
+
+	delayedScroll() {
+		const { tooltip } = this.props;
+		return throttle( () => {
+			tooltip.hide();
+		}, 300 );
 	}
 
 	deleteChart() {
@@ -95,8 +93,9 @@ export default class D3Base extends Component {
 	}
 
 	render() {
+		const { className } = this.props;
 		return (
-			<div className={ classNames( 'd3-base', this.props.className ) } ref={ this.chartRef } onScroll={ this.delayedScroll } />
+			<div className={ classNames( 'd3-base', className ) } ref={ this.chartRef } onScroll={ this.delayedScroll() } />
 		);
 	}
 }

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -10,6 +10,7 @@
 
 .d3-chart__container {
 	position: relative;
+	width: 100%;
 
 	svg {
 		overflow: visible;
@@ -157,8 +158,12 @@
 
 	.focus-grid {
 		line {
-			stroke: $core-grey-light-700;
+			stroke: rgba( 0, 0, 0, 0.1 );
 			stroke-width: 1px;
 		}
+	}
+
+	.barfocus {
+		fill: rgba( 0, 0, 0, 0.1 );
 	}
 }

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -22,7 +22,7 @@ const mostPoints = 31;
 */
 const getFactors = inputNum => {
 	const numFactors = [];
-	for ( let i = 1; i <= Math.floor( Math.sqrt( inputNum ) ); i += 1 ) {
+	for ( let i = 1; i <= Math.floor( Math.sqrt( inputNum ) ); i++ ) {
 		if ( inputNum % i === 0 ) {
 			numFactors.push( i );
 			inputNum / i !== i && numFactors.push( inputNum / i );
@@ -176,11 +176,6 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 export const getYGrids = ( yMax ) => {
 	const yGrids = [];
 
-	// If all values are 0, yMax can become NaN.
-	if ( isNaN( yMax ) ) {
-		return null;
-	}
-
 	for ( let i = 0; i < 4; i++ ) {
 		const value = yMax > 1 ? Math.round( i / 3 * yMax ) : i / 3 * yMax;
 		if ( yGrids[ yGrids.length - 1 ] !== value ) {
@@ -191,87 +186,90 @@ export const getYGrids = ( yMax ) => {
 	return yGrids;
 };
 
-export const drawAxis = ( node, params, xOffset ) => {
-	const xScale = params.type === 'line' ? params.xLineScale : params.xScale;
-	const removeDuplicateDates = ( d, i, ticks, formatter ) => {
-		const monthDate = moment( d ).toDate();
-		let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
-		prevMonth = prevMonth instanceof Date ? prevMonth : moment( prevMonth ).toDate();
-		return i === 0
-			? formatter( monthDate )
-			: compareStrings( formatter( prevMonth ), formatter( monthDate ) ).join( ' ' );
-	};
+const removeDuplicateDates = ( d, i, ticks, formatter ) => {
+	const monthDate = moment( d ).toDate();
+	let prevMonth = i !== 0 ? ticks[ i - 1 ] : ticks[ i ];
+	prevMonth = prevMonth instanceof Date ? prevMonth : moment( prevMonth ).toDate();
+	return i === 0
+		? formatter( monthDate )
+		: compareStrings( formatter( prevMonth ), formatter( monthDate ) ).join( ' ' );
+};
 
-	const yGrids = getYGrids( params.yMax === 0 ? 1 : params.yMax );
-
-	const ticks = params.xTicks.map( d => ( params.type === 'line' ? moment( d ).toDate() : d ) );
+const drawXAxis = ( node, params, scales, formats ) => {
+	const height = scales.yScale.range()[ 0 ];
+	let ticks = getXTicks( params.uniqueDates, scales.xScale.range()[ 1 ], params.mode, params.interval );
+	if ( params.type === 'line' ) {
+		ticks = ticks.map( d => moment( d ).toDate() );
+	}
 
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(${ xOffset }, ${ params.height })` )
+		.attr( 'transform', `translate(0, ${ height })` )
 		.call(
-			d3AxisBottom( xScale )
+			d3AxisBottom( scales.xScale )
 				.tickValues( ticks )
 				.tickFormat( ( d, i ) => params.interval === 'hour'
-					? params.xFormat( d instanceof Date ? d : moment( d ).toDate() )
-					: removeDuplicateDates( d, i, ticks, params.xFormat ) )
+					? formats.xFormat( d instanceof Date ? d : moment( d ).toDate() )
+					: removeDuplicateDates( d, i, ticks, formats.xFormat ) )
 		);
 
 	node
 		.append( 'g' )
 		.attr( 'class', 'axis axis-month' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', `translate(${ xOffset }, ${ params.height + 20 })` )
+		.attr( 'transform', `translate(0, ${ height + 14 })` )
 		.call(
-			d3AxisBottom( xScale )
+			d3AxisBottom( scales.xScale )
 				.tickValues( ticks )
-				.tickFormat( ( d, i ) => removeDuplicateDates( d, i, ticks, params.x2Format ) )
-		)
-		.call( g => g.select( '.domain' ).remove() );
+				.tickFormat( ( d, i ) => removeDuplicateDates( d, i, ticks, formats.x2Format ) )
+		);
 
 	node
 		.append( 'g' )
 		.attr( 'class', 'pipes' )
-		.attr( 'transform', `translate(${ xOffset }, ${ params.height })` )
+		.attr( 'transform', `translate(0, ${ height })` )
 		.call(
-			d3AxisBottom( xScale )
+			d3AxisBottom( scales.xScale )
 				.tickValues( ticks )
 				.tickSize( 5 )
 				.tickFormat( '' )
 		);
+};
 
-	if ( yGrids ) {
-		node
-			.append( 'g' )
-			.attr( 'class', 'grid' )
-			.attr( 'transform', `translate(-${ params.margin.left }, 0)` )
-			.call(
-				d3AxisLeft( params.yScale )
-					.tickValues( yGrids )
-					.tickSize( -params.width - params.margin.left - params.margin.right )
-					.tickFormat( '' )
-			)
-			.call( g => g.select( '.domain' ).remove() );
+const drawYAxis = ( node, scales, formats, margin ) => {
+	const yGrids = getYGrids( scales.yScale.domain()[ 1 ] );
+	const width = scales.xScale.range()[ 1 ];
 
-		node
-			.append( 'g' )
-			.attr( 'class', 'axis y-axis' )
-			.attr( 'aria-hidden', 'true' )
-			.attr( 'transform', 'translate(-50, 0)' )
-			.attr( 'text-anchor', 'start' )
-			.call(
-				d3AxisLeft( params.yTickOffset )
-					.tickValues( params.yMax === 0 ? [ yGrids[ 0 ] ] : yGrids )
-					.tickFormat( d => params.yFormat( d !== 0 ? d : 0 ) )
-			);
-	}
+	node
+		.append( 'g' )
+		.attr( 'class', 'grid' )
+		.attr( 'transform', `translate(-${ margin.left }, 0)` )
+		.call(
+			d3AxisLeft( scales.yScale )
+				.tickValues( yGrids )
+				.tickSize( -width - margin.left - margin.right )
+				.tickFormat( '' )
+		);
+
+	node
+		.append( 'g' )
+		.attr( 'class', 'axis y-axis' )
+		.attr( 'aria-hidden', 'true' )
+		.attr( 'transform', 'translate(-50, 12)' )
+		.attr( 'text-anchor', 'start' )
+		.call(
+			d3AxisLeft( scales.yScale )
+				.tickValues( scales.yMax === 0 ? [ yGrids[ 0 ] ] : yGrids )
+				.tickFormat( d => formats.yFormat( d !== 0 ? d : 0 ) )
+		);
+};
+
+export const drawAxis = ( node, params, scales, formats, margin ) => {
+	drawXAxis( node, params, scales, formats );
+	drawYAxis( node, scales, formats, margin );
 
 	node.selectAll( '.domain' ).remove();
-	node
-		.selectAll( '.axis' )
-		.selectAll( '.tick' )
-		.select( 'line' )
-		.remove();
+	node.selectAll( '.axis .tick line' ).remove();
 };

--- a/packages/components/src/chart/d3chart/utils/index.js
+++ b/packages/components/src/chart/d3chart/utils/index.js
@@ -3,10 +3,9 @@
 /**
  * External dependencies
  */
-import { find, get, isNil } from 'lodash';
+import { isNil } from 'lodash';
 import { format as d3Format } from 'd3-format';
-import { line as d3Line } from 'd3-shape';
-import moment from 'moment';
+import { utcParse as d3UTCParse } from 'd3-time-format';
 
 /**
  * Allows an overriding formatter or defaults to d3Format or d3TimeFormat
@@ -18,29 +17,17 @@ export const getFormatter = ( format, formatter = d3Format ) =>
 	typeof format === 'function' ? format : formatter( format );
 
 /**
- * Describes `getUniqueKeys`
- * @param {array} data - The chart component's `data` prop.
- * @returns {array} of unique category keys
- */
-export const getUniqueKeys = data => {
-	return [
-		...new Set(
-			data.reduce( ( accum, curr ) => {
-				Object.keys( curr ).forEach( key => key !== 'date' && accum.push( key ) );
-				return accum;
-			}, [] )
-		),
-	];
-};
-
-/**
  * Describes `getOrderedKeys`
  * @param {array} data - The chart component's `data` prop.
- * @param {array} uniqueKeys - from `getUniqueKeys`.
  * @returns {array} of unique category keys ordered by cumulative total value
  */
-export const getOrderedKeys = ( data, uniqueKeys ) =>
-	uniqueKeys
+export const getOrderedKeys = ( data ) => {
+	const keys = new Set(
+		data.reduce( ( acc, curr ) => acc.concat( Object.keys( curr ) ), [] )
+	);
+
+	return [ ...keys ]
+		.filter( key => key !== 'date' )
 		.map( key => ( {
 			key,
 			focus: true,
@@ -48,93 +35,21 @@ export const getOrderedKeys = ( data, uniqueKeys ) =>
 			visible: true,
 		} ) )
 		.sort( ( a, b ) => b.total - a.total );
-
-/**
- * Describes `getLineData`
- * @param {array} data - The chart component's `data` prop.
- * @param {array} orderedKeys - from `getOrderedKeys`.
- * @returns {array} an array objects with a category `key` and an array of `values` with `date` and `value` properties
- */
-export const getLineData = ( data, orderedKeys ) =>
-	orderedKeys.map( row => ( {
-		key: row.key,
-		focus: row.focus,
-		visible: row.visible,
-		values: data.map( d => ( {
-			date: d.date,
-			focus: row.focus,
-			label: get( d, [ row.key, 'label' ], '' ),
-			value: get( d, [ row.key, 'value' ], 0 ),
-			visible: row.visible,
-		} ) ),
-	} ) );
-
-/**
- * Describes `getUniqueDates`
- * @param {array} lineData - from `GetLineData`
- * @param {function} parseDate - D3 time format parser
- * @returns {array} an array of unique date values sorted from earliest to latest
- */
-export const getUniqueDates = ( lineData, parseDate ) => {
-	return [
-		...new Set(
-			lineData.reduce( ( accum, { values } ) => {
-				values.forEach( ( { date } ) => accum.push( date ) );
-				return accum;
-			}, [] )
-		),
-	].sort( ( a, b ) => parseDate( a ) - parseDate( b ) );
 };
 
 /**
- * Describes getLine
- * @param {function} xLineScale - from `getXLineScale`.
- * @param {function} yScale - from `getYScale`.
- * @returns {function} the D3 line function for plotting all category values
+ * Describes `getUniqueDates`
+ * @param {array} data - the chart component's `data` prop.
+ * @param {string} dateParser - D3 time format
+ * @returns {array} an array of unique date values sorted from earliest to latest
  */
-export const getLine = ( xLineScale, yScale ) =>
-	d3Line()
-		.x( d => xLineScale( moment( d.date ).toDate() ) )
-		.y( d => yScale( d.value ) );
-
-/**
- * Describes getDateSpaces
- * @param {array} data - The chart component's `data` prop.
- * @param {array} uniqueDates - from `getUniqueDates`
- * @param {number} width - calculated width of the charting space
- * @param {function} xLineScale - from `getXLineScale`
- * @returns {array} that icnludes the date, start (x position) and width to mode the mouseover rectangles
- */
-export const getDateSpaces = ( data, uniqueDates, width, xLineScale ) =>
-	uniqueDates.map( ( d, i ) => {
-		const datapoints = find( data, { date: d } );
-		const xNow = xLineScale( moment( d ).toDate() );
-		const xPrev =
-			i >= 1
-				? xLineScale( moment( uniqueDates[ i - 1 ] ).toDate() )
-				: xLineScale( moment( uniqueDates[ 0 ] ).toDate() );
-		const xNext =
-			i < uniqueDates.length - 1
-				? xLineScale( moment( uniqueDates[ i + 1 ] ).toDate() )
-				: xLineScale( moment( uniqueDates[ uniqueDates.length - 1 ] ).toDate() );
-		let xWidth = i === 0 ? xNext - xNow : xNow - xPrev;
-		const xStart = i === 0 ? 0 : xNow - xWidth / 2;
-		xWidth = i === 0 || i === uniqueDates.length - 1 ? xWidth / 2 : xWidth;
-		return {
-			date: d,
-			start: uniqueDates.length > 1 ? xStart : 0,
-			width: uniqueDates.length > 1 ? xWidth : width,
-			values: Object.keys( datapoints )
-				.filter( key => key !== 'date' )
-				.map( key => {
-					return {
-						key,
-						value: datapoints[ key ].value,
-						date: d,
-					};
-				} ),
-		};
-	} );
+export const getUniqueDates = ( data, dateParser ) => {
+	const parseDate = d3UTCParse( dateParser );
+	const dates = new Set(
+		data.map( d => d.date )
+	);
+	return [ ...dates ].sort( ( a, b ) => parseDate( a ) - parseDate( b ) );
+};
 
 /**
  * Check whether data is empty.

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -3,38 +3,107 @@
 /**
  * External dependencies
  */
-import { event as d3Event, select as d3Select } from 'd3-selection';
-import { smallBreak, wideBreak } from './breakpoints';
+import { event as d3Event } from 'd3-selection';
+import { line as d3Line } from 'd3-shape';
 import moment from 'moment';
+import { first, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getColor } from './color';
-import { calculateTooltipPosition, hideTooltip, showTooltip } from './tooltip';
+import { smallBreak, wideBreak } from './breakpoints';
 
-const handleMouseOverLineChart = ( date, parentNode, node, data, params, position ) => {
-	d3Select( parentNode )
-		.select( '.focus-grid' )
-		.attr( 'opacity', '1' );
-	showTooltip( params, data.find( e => e.date === date ), position );
-};
+/**
+ * Describes getDateSpaces
+ * @param {array} data - The chart component's `data` prop.
+ * @param {array} uniqueDates - from `getUniqueDates`
+ * @param {number} width - calculated width of the charting space
+ * @param {function} xScale - from `getXLineScale`
+ * @returns {array} that includes the date, start (x position) and width to mode the mouseover rectangles
+ */
+export const getDateSpaces = ( data, uniqueDates, width, xScale ) =>
+	uniqueDates.map( ( d, i ) => {
+		const datapoints = first( data.filter( item => item.date === d ) );
+		const xNow = xScale( moment( d ).toDate() );
+		const xPrev =
+			i >= 1
+				? xScale( moment( uniqueDates[ i - 1 ] ).toDate() )
+				: xScale( moment( uniqueDates[ 0 ] ).toDate() );
+		const xNext =
+			i < uniqueDates.length - 1
+				? xScale( moment( uniqueDates[ i + 1 ] ).toDate() )
+				: xScale( moment( uniqueDates[ uniqueDates.length - 1 ] ).toDate() );
+		let xWidth = i === 0 ? xNext - xNow : xNow - xPrev;
+		const xStart = i === 0 ? 0 : xNow - xWidth / 2;
+		xWidth = i === 0 || i === uniqueDates.length - 1 ? xWidth / 2 : xWidth;
+		return {
+			date: d,
+			start: uniqueDates.length > 1 ? xStart : 0,
+			width: uniqueDates.length > 1 ? xWidth : width,
+			values: Object.keys( datapoints )
+				.filter( key => key !== 'date' )
+				.map( key => {
+					return {
+						key,
+						value: datapoints[ key ].value,
+						date: d,
+					};
+				} ),
+		};
+	} );
 
-export const drawLines = ( node, data, params, xOffset ) => {
+/**
+ * Describes getLine
+ * @param {function} xScale - from `getXLineScale`.
+ * @param {function} yScale - from `getYScale`.
+ * @returns {function} the D3 line function for plotting all category values
+ */
+export const getLine = ( xScale, yScale ) =>
+	d3Line()
+		.x( d => xScale( moment( d.date ).toDate() ) )
+		.y( d => yScale( d.value ) );
+
+/**
+ * Describes `getLineData`
+ * @param {array} data - The chart component's `data` prop.
+ * @param {array} orderedKeys - from `getOrderedKeys`.
+ * @returns {array} an array objects with a category `key` and an array of `values` with `date` and `value` properties
+ */
+export const getLineData = ( data, orderedKeys ) =>
+	orderedKeys.map( row => ( {
+		key: row.key,
+		focus: row.focus,
+		visible: row.visible,
+		values: data.map( d => ( {
+			date: d.date,
+			focus: row.focus,
+			label: get( d, [ row.key, 'label' ], '' ),
+			value: get( d, [ row.key, 'value' ], 0 ),
+			visible: row.visible,
+		} ) ),
+	} ) );
+
+export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
+	const height = scales.yScale.range()[ 0 ];
+	const width = scales.xScale.range()[ 1 ];
+	const line = getLine( scales.xScale, scales.yScale );
+	const lineData = getLineData( data, params.visibleKeys );
 	const series = node
 		.append( 'g' )
 		.attr( 'class', 'lines' )
 		.selectAll( '.line-g' )
-		.data( params.lineData.filter( d => d.visible ).reverse() )
+		.data( lineData.filter( d => d.visible ).reverse() )
 		.enter()
 		.append( 'g' )
 		.attr( 'class', 'line-g' )
 		.attr( 'role', 'region' )
 		.attr( 'aria-label', d => d.key );
+	const dateSpaces = getDateSpaces( data, params.uniqueDates, width, scales.xScale );
 
-	let lineStroke = params.width <= wideBreak || params.uniqueDates.length > 50 ? 2 : 3;
-	lineStroke = params.width <= smallBreak ? 1.25 : lineStroke;
-	const dotRadius = params.width <= wideBreak ? 4 : 6;
+	let lineStroke = width <= wideBreak || params.uniqueDates.length > 50 ? 2 : 3;
+	lineStroke = width <= smallBreak ? 1.25 : lineStroke;
+	const dotRadius = width <= wideBreak ? 4 : 6;
 
 	params.uniqueDates.length > 1 &&
 		series
@@ -48,11 +117,11 @@ export const drawLines = ( node, data, params, xOffset ) => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
 			} )
-			.attr( 'd', d => params.line( d.values ) );
+			.attr( 'd', d => line( d.values ) );
 
 	const minDataPointSpacing = 36;
 
-	params.width / params.uniqueDates.length > minDataPointSpacing &&
+	width / params.uniqueDates.length > minDataPointSpacing &&
 		series
 			.selectAll( 'circle' )
 			.data( ( d, i ) => d.values.map( row => ( { ...row, i, visible: d.visible, key: d.key } ) ) )
@@ -66,30 +135,25 @@ export const drawLines = ( node, data, params, xOffset ) => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
 			} )
-			.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
-			.attr( 'cy', d => params.yScale( d.value ) )
+			.attr( 'cx', d => scales.xScale( moment( d.date ).toDate() ) )
+			.attr( 'cy', d => scales.yScale( d.value ) )
 			.attr( 'tabindex', '0' )
 			.attr( 'aria-label', d => {
 				const label = d.label
 					? d.label
-					: params.tooltipLabelFormat( d.date instanceof Date ? d.date : moment( d.date ).toDate() );
-				return `${ label } ${ params.tooltipValueFormat( d.value ) }`;
+					: tooltip.labelFormat( d.date instanceof Date ? d.date : moment( d.date ).toDate() );
+				return `${ label } ${ tooltip.valueFormat( d.value ) }`;
 			} )
 			.on( 'focus', ( d, i, nodes ) => {
-				const position = calculateTooltipPosition(
-					d3Event.target,
-					node.node(),
-					params.tooltipPosition
-				);
-				handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
+				tooltip.show( data.find( e => e.date === d.date ), nodes[ i ].parentNode, d3Event.target );
 			} )
-			.on( 'blur', ( d, i, nodes ) => hideTooltip( nodes[ i ].parentNode, params.tooltip ) );
+			.on( 'blur', () => tooltip.hide() );
 
 	const focus = node
 		.append( 'g' )
 		.attr( 'class', 'focusspaces' )
 		.selectAll( '.focus' )
-		.data( params.dateSpaces )
+		.data( dateSpaces )
 		.enter()
 		.append( 'g' )
 		.attr( 'class', 'focus' );
@@ -101,10 +165,10 @@ export const drawLines = ( node, data, params, xOffset ) => {
 
 	focusGrid
 		.append( 'line' )
-		.attr( 'x1', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
+		.attr( 'x1', d => scales.xScale( moment( d.date ).toDate() ) )
 		.attr( 'y1', 0 )
-		.attr( 'x2', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
-		.attr( 'y2', params.height );
+		.attr( 'x2', d => scales.xScale( moment( d.date ).toDate() ) )
+		.attr( 'y2', height );
 
 	focusGrid
 		.selectAll( 'circle' )
@@ -115,8 +179,8 @@ export const drawLines = ( node, data, params, xOffset ) => {
 		.attr( 'fill', d => getColor( d.key, params.visibleKeys, params.colorScheme ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', lineStroke + 2 )
-		.attr( 'cx', d => params.xLineScale( moment( d.date ).toDate() ) + xOffset )
-		.attr( 'cy', d => params.yScale( d.value ) );
+		.attr( 'cx', d => scales.xScale( moment( d.date ).toDate() ) )
+		.attr( 'cy', d => scales.yScale( d.value ) );
 
 	focus
 		.append( 'rect' )
@@ -124,18 +188,12 @@ export const drawLines = ( node, data, params, xOffset ) => {
 		.attr( 'x', d => d.start )
 		.attr( 'y', 0 )
 		.attr( 'width', d => d.width )
-		.attr( 'height', params.height )
+		.attr( 'height', height )
 		.attr( 'opacity', 0 )
 		.on( 'mouseover', ( d, i, nodes ) => {
-			const isTooltipLeftAligned = ( i === 0 || i === params.dateSpaces.length - 1 ) && params.uniqueDates.length > 1;
+			const isTooltipLeftAligned = ( i === 0 || i === dateSpaces.length - 1 ) && params.uniqueDates.length > 1;
 			const elementWidthRatio = isTooltipLeftAligned ? 0 : 0.5;
-			const position = calculateTooltipPosition(
-				d3Event.target,
-				node.node(),
-				params.tooltipPosition,
-				elementWidthRatio
-			);
-			handleMouseOverLineChart( d.date, nodes[ i ].parentNode, node, data, params, position );
+			tooltip.show( data.find( e => e.date === d.date ), d3Event.target, nodes[ i ].parentNode, elementWidthRatio );
 		} )
-		.on( 'mouseout', ( d, i, nodes ) => hideTooltip( nodes[ i ].parentNode, params.tooltip ) );
+		.on( 'mouseout', () => tooltip.hide() );
 };

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -52,13 +52,26 @@ export const getXLineScale = ( uniqueDates, width ) =>
 		] )
 		.rangeRound( [ 0, width ] );
 
+const getMaxYValue = data => {
+	let maxYValue = Number.NEGATIVE_INFINITY;
+	data.map( d => {
+		for ( const [ key, item ] of Object.entries( d ) ) {
+			if ( key !== 'date' && Number.isFinite( item.value ) && item.value > maxYValue ) {
+				maxYValue = item.value;
+			}
+		}
+	} );
+
+	return maxYValue;
+};
+
 /**
  * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
- * @param {array} lineData - from `getLineData`
+ * @param {array} data - The chart component's `data` prop.
  * @returns {number} the maximum value in the timeseries multiplied by 4/3
  */
-export const getYMax = lineData => {
-	const maxValue = Math.max( ...lineData.map( d => Math.max( ...d.values.map( date => date.value ) ) ) );
+export const getYMax = data => {
+	const maxValue = getMaxYValue( data );
 	if ( ! Number.isFinite( maxValue ) || maxValue <= 0 ) {
 		return 0;
 	}
@@ -70,21 +83,10 @@ export const getYMax = lineData => {
 /**
  * Describes getYScale
  * @param {number} height - calculated height of the charting space
- * @param {number} yMax - from `getYMax`
+ * @param {number} yMax - maximum y value
  * @returns {function} the D3 linear scale from 0 to the value from `getYMax`
  */
 export const getYScale = ( height, yMax ) =>
 	d3ScaleLinear()
 		.domain( [ 0, yMax === 0 ? 1 : yMax ] )
 		.rangeRound( [ height, 0 ] );
-
-/**
- * Describes getyTickOffset
- * @param {number} height - calculated height of the charting space
- * @param {number} yMax - from `getYMax`
- * @returns {function} the D3 linear scale from 0 to the value from `getYMax`, offset by 12 pixels down
- */
-export const getYTickOffset = ( height, yMax ) =>
-	d3ScaleLinear()
-		.domain( [ 0, yMax === 0 ? 1 : yMax ] )
-		.rangeRound( [ height + 12, 12 ] );

--- a/packages/components/src/chart/d3chart/utils/test/index.js
+++ b/packages/components/src/chart/d3chart/utils/test/index.js
@@ -8,24 +8,14 @@ import { utcParse as d3UTCParse } from 'd3-time-format';
  * Internal dependencies
  */
 import dummyOrders from './fixtures/dummy-orders';
-import orderedDates from './fixtures/dummy-ordered-dates';
 import orderedKeys from './fixtures/dummy-ordered-keys';
 import {
-	getDateSpaces,
 	getOrderedKeys,
-	getLineData,
-	getUniqueKeys,
-	getUniqueDates,
 	isDataEmpty,
 } from '../index';
-import { getXLineScale } from '../scales';
 
 const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
-const testUniqueKeys = getUniqueKeys( dummyOrders );
-const testOrderedKeys = getOrderedKeys( dummyOrders, testUniqueKeys );
-const testLineData = getLineData( dummyOrders, testOrderedKeys );
-const testUniqueDates = getUniqueDates( testLineData, parseDate );
-const testXLineScale = getXLineScale( testUniqueDates, 100 );
+const testOrderedKeys = getOrderedKeys( dummyOrders );
 
 describe( 'parseDate', () => {
 	it( 'correctly parse date in the expected format', () => {
@@ -35,64 +25,9 @@ describe( 'parseDate', () => {
 	} );
 } );
 
-describe( 'getUniqueKeys', () => {
-	it( 'returns an array of keys excluding date', () => {
-		// sort is a mutating action so we need a copy
-		const testUniqueKeysClone = testUniqueKeys.slice();
-		const sortedAZKeys = orderedKeys.map( d => d.key ).slice();
-		expect( testUniqueKeysClone.sort() ).toEqual( sortedAZKeys.sort() );
-	} );
-} );
-
 describe( 'getOrderedKeys', () => {
 	it( 'returns an array of keys order by value from largest to smallest', () => {
 		expect( testOrderedKeys ).toEqual( orderedKeys );
-	} );
-} );
-
-describe( 'getLineData', () => {
-	it( 'returns a sorted array of objects with category key', () => {
-		expect( testLineData ).toBeInstanceOf( Array );
-		expect( testLineData ).toHaveLength( 5 );
-		expect( testLineData.map( d => d.key ) ).toEqual( orderedKeys.map( d => d.key ) );
-	} );
-
-	testLineData.forEach( d => {
-		it( 'ensure a key and that the values property is an array', () => {
-			expect( d ).toHaveProperty( 'key' );
-			expect( d ).toHaveProperty( 'values' );
-			expect( d.values ).toBeInstanceOf( Array );
-		} );
-
-		it( 'ensure all unique dates exist in values array', () => {
-			const rowDates = d.values.map( row => row.date );
-			expect( rowDates ).toEqual( orderedDates );
-		} );
-
-		d.values.forEach( row => {
-			it( 'ensure a date property and that the values property is an array with date (parseable) and value properties', () => {
-				expect( row ).toHaveProperty( 'date' );
-				expect( row ).toHaveProperty( 'value' );
-				expect( parseDate( row.date ) ).not.toBeNull();
-				expect( typeof row.date ).toBe( 'string' );
-				expect( typeof row.value ).toBe( 'number' );
-			} );
-		} );
-	} );
-} );
-
-describe( 'getDateSpaces', () => {
-	it( 'return an array used to space out the mouseover rectangles, used for tooltips', () => {
-		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, 100, testXLineScale );
-		expect( testDateSpaces[ 0 ].date ).toEqual( '2018-05-30T00:00:00' );
-		expect( testDateSpaces[ 0 ].start ).toEqual( 0 );
-		expect( testDateSpaces[ 0 ].width ).toEqual( 10 );
-		expect( testDateSpaces[ 3 ].date ).toEqual( '2018-06-02T00:00:00' );
-		expect( testDateSpaces[ 3 ].start ).toEqual( 50 );
-		expect( testDateSpaces[ 3 ].width ).toEqual( 20 );
-		expect( testDateSpaces[ testDateSpaces.length - 1 ].date ).toEqual( '2018-06-04T00:00:00' );
-		expect( testDateSpaces[ testDateSpaces.length - 1 ].start ).toEqual( 90 );
-		expect( testDateSpaces[ testDateSpaces.length - 1 ].width ).toEqual( 10 );
 	} );
 } );
 

--- a/packages/components/src/chart/d3chart/utils/test/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/test/line-chart.js
@@ -1,0 +1,73 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { utcParse as d3UTCParse } from 'd3-time-format';
+
+/**
+ * Internal dependencies
+ */
+import dummyOrders from './fixtures/dummy-orders';
+import orderedDates from './fixtures/dummy-ordered-dates';
+import orderedKeys from './fixtures/dummy-ordered-keys';
+import {
+	getOrderedKeys,
+	getUniqueDates,
+} from '../index';
+import {
+	getDateSpaces,
+	getLineData,
+} from '../line-chart';
+import { getXLineScale } from '../scales';
+
+const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
+const testOrderedKeys = getOrderedKeys( dummyOrders );
+const testLineData = getLineData( dummyOrders, testOrderedKeys );
+const testUniqueDates = getUniqueDates( dummyOrders, '%Y-%m-%dT%H:%M:%S' );
+const testXLineScale = getXLineScale( testUniqueDates, 100 );
+
+describe( 'getDateSpaces', () => {
+	it( 'return an array used to space out the mouseover rectangles, used for tooltips', () => {
+		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, 100, testXLineScale );
+		expect( testDateSpaces[ 0 ].date ).toEqual( '2018-05-30T00:00:00' );
+		expect( testDateSpaces[ 0 ].start ).toEqual( 0 );
+		expect( testDateSpaces[ 0 ].width ).toEqual( 10 );
+		expect( testDateSpaces[ 3 ].date ).toEqual( '2018-06-02T00:00:00' );
+		expect( testDateSpaces[ 3 ].start ).toEqual( 50 );
+		expect( testDateSpaces[ 3 ].width ).toEqual( 20 );
+		expect( testDateSpaces[ testDateSpaces.length - 1 ].date ).toEqual( '2018-06-04T00:00:00' );
+		expect( testDateSpaces[ testDateSpaces.length - 1 ].start ).toEqual( 90 );
+		expect( testDateSpaces[ testDateSpaces.length - 1 ].width ).toEqual( 10 );
+	} );
+} );
+
+describe( 'getLineData', () => {
+	it( 'returns a sorted array of objects with category key', () => {
+		expect( testLineData ).toBeInstanceOf( Array );
+		expect( testLineData ).toHaveLength( 5 );
+		expect( testLineData.map( d => d.key ) ).toEqual( orderedKeys.map( d => d.key ) );
+	} );
+
+	testLineData.forEach( d => {
+		it( 'ensure a key and that the values property is an array', () => {
+			expect( d ).toHaveProperty( 'key' );
+			expect( d ).toHaveProperty( 'values' );
+			expect( d.values ).toBeInstanceOf( Array );
+		} );
+
+		it( 'ensure all unique dates exist in values array', () => {
+			const rowDates = d.values.map( row => row.date );
+			expect( rowDates ).toEqual( orderedDates );
+		} );
+
+		d.values.forEach( row => {
+			it( 'ensure a date property and that the values property is an array with date (parseable) and value properties', () => {
+				expect( row ).toHaveProperty( 'date' );
+				expect( row ).toHaveProperty( 'value' );
+				expect( parseDate( row.date ) ).not.toBeNull();
+				expect( typeof row.date ).toBe( 'string' );
+				expect( typeof row.value ).toBe( 'number' );
+			} );
+		} );
+	} );
+} );

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { utcParse as d3UTCParse } from 'd3-time-format';
 import { scaleBand, scaleLinear, scaleTime } from 'd3-scale';
 
 /**
@@ -11,11 +10,9 @@ import { scaleBand, scaleLinear, scaleTime } from 'd3-scale';
 import dummyOrders from './fixtures/dummy-orders';
 import {
 	getOrderedKeys,
-	getLineData,
-	getUniqueKeys,
 	getUniqueDates,
 } from '../index';
-import { getXGroupScale, getXScale, getXLineScale, getYMax, getYScale, getYTickOffset } from '../scales';
+import { getXGroupScale, getXScale, getXLineScale, getYMax, getYScale } from '../scales';
 
 jest.mock( 'd3-scale', () => ( {
 	...require.requireActual( 'd3-scale' ),
@@ -37,13 +34,10 @@ jest.mock( 'd3-scale', () => ( {
 	} ),
 } ) );
 
-const testUniqueKeys = getUniqueKeys( dummyOrders );
-const testOrderedKeys = getOrderedKeys( dummyOrders, testUniqueKeys );
-const testLineData = getLineData( dummyOrders, testOrderedKeys );
+const testOrderedKeys = getOrderedKeys( dummyOrders );
 
 describe( 'X scales', () => {
-	const parseDate = d3UTCParse( '%Y-%m-%dT%H:%M:%S' );
-	const testUniqueDates = getUniqueDates( testLineData, parseDate );
+	const testUniqueDates = getUniqueDates( dummyOrders, '%Y-%m-%dT%H:%M:%S' );
 
 	describe( 'getXScale', () => {
 		it( 'creates band scale with correct parameters', () => {
@@ -96,7 +90,7 @@ describe( 'X scales', () => {
 describe( 'Y scales', () => {
 	describe( 'getYMax', () => {
 		it( 'calculate the correct maximum y value', () => {
-			expect( getYMax( testLineData ) ).toEqual( 15000000 );
+			expect( getYMax( dummyOrders ) ).toEqual( 15000000 );
 		} );
 
 		it( 'return 0 if there is no line data', () => {
@@ -114,23 +108,6 @@ describe( 'Y scales', () => {
 
 		it( 'avoids the domain starting and ending at the same point when yMax is 0', () => {
 			getYScale( 100, 0 );
-
-			const args = scaleLinear().domain.mock.calls;
-			const lastArgs = args[ args.length - 1 ][ 0 ];
-			expect( lastArgs[ 0 ] ).toBeLessThan( lastArgs[ 1 ] );
-		} );
-	} );
-
-	describe( 'getYTickOffset', () => {
-		it( 'creates linear scale with correct parameters', () => {
-			getYTickOffset( 100, 15000000 );
-
-			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
-			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 112, 12 ] );
-		} );
-
-		it( 'avoids the domain starting and ending at the same point when yMax is 0', () => {
-			getYTickOffset( 100, 0 );
 
 			const args = scaleLinear().domain.mock.calls;
 			const lastArgs = args[ args.length - 1 ][ 0 ];

--- a/packages/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/components/src/chart/d3chart/utils/tooltip.js
@@ -11,138 +11,148 @@ import moment from 'moment';
  */
 import { getColor } from './color';
 
-export const hideTooltip = ( parentNode, tooltipNode ) => {
-	d3Select( parentNode )
-		.selectAll( '.barfocus, .focus-grid' )
-		.attr( 'opacity', '0' );
-	d3Select( tooltipNode )
-		.style( 'visibility', 'hidden' );
-};
+class ChartTooltip {
+	constructor() {
+		this.ref = null;
+		this.chart = null;
+		this.position = '';
+		this.title = '';
+		this.labelFormat = '';
+		this.valueFormat = '';
+		this.visibleKeys = '';
+		this.colorScheme = null;
+		this.margin = 24;
+	}
 
-const calculateTooltipXPosition = (
-	elementCoords,
-	chartCoords,
-	tooltipSize,
-	tooltipMargin,
-	elementWidthRatio,
-	tooltipPosition
-) => {
-	const d3BaseCoords = d3Select( '.d3-base' ).node().getBoundingClientRect();
-	const leftMargin = Math.max( d3BaseCoords.left, chartCoords.left );
+	calculateXPosition(
+		elementCoords,
+		chartCoords,
+		elementWidthRatio,
+	) {
+		const tooltipSize = this.ref.getBoundingClientRect();
+		const d3BaseCoords = d3Select( '.d3-base' ).node().getBoundingClientRect();
+		const leftMargin = Math.max( d3BaseCoords.left, chartCoords.left );
 
-	if ( tooltipPosition === 'below' ) {
-		return Math.max(
-			tooltipMargin,
-			Math.min(
-				elementCoords.left + elementCoords.width * 0.5 - tooltipSize.width / 2 - leftMargin,
-				d3BaseCoords.width - tooltipSize.width - tooltipMargin
-			)
+		if ( this.position === 'below' ) {
+			return Math.max(
+				this.margin,
+				Math.min(
+					elementCoords.left + elementCoords.width * 0.5 - tooltipSize.width / 2 - leftMargin,
+					d3BaseCoords.width - tooltipSize.width - this.margin
+				)
+			);
+		}
+
+		const xPosition =
+			elementCoords.left + elementCoords.width * elementWidthRatio + this.margin - leftMargin;
+
+		if ( xPosition + tooltipSize.width + this.margin > d3BaseCoords.width ) {
+			return Math.max(
+				this.margin,
+				elementCoords.left +
+					elementCoords.width * ( 1 - elementWidthRatio ) -
+					tooltipSize.width -
+					this.margin -
+					leftMargin
+			);
+		}
+
+		return xPosition;
+	}
+
+	calculateYPosition(
+		elementCoords,
+		chartCoords,
+	) {
+		if ( this.position === 'below' ) {
+			return chartCoords.height;
+		}
+
+		const tooltipSize = this.ref.getBoundingClientRect();
+		const yPosition = elementCoords.top + this.margin - chartCoords.top;
+		if ( yPosition + tooltipSize.height + this.margin > chartCoords.height ) {
+			return Math.max( 0, elementCoords.top - tooltipSize.height - this.margin - chartCoords.top );
+		}
+
+		return yPosition;
+	}
+
+	calculatePosition( element, elementWidthRatio = 1 ) {
+		const elementCoords = element.getBoundingClientRect();
+		const chartCoords = this.chart.getBoundingClientRect();
+
+		if ( this.position === 'below' ) {
+			elementWidthRatio = 0;
+		}
+
+		return {
+			x: this.calculateXPosition(
+				elementCoords,
+				chartCoords,
+				elementWidthRatio,
+			),
+			y: this.calculateYPosition(
+				elementCoords,
+				chartCoords,
+			),
+		};
+	}
+
+	hide() {
+		d3Select( this.chart )
+			.selectAll( '.barfocus, .focus-grid' )
+			.attr( 'opacity', '0' );
+		d3Select( this.ref )
+			.style( 'visibility', 'hidden' );
+	}
+
+	getTooltipRowLabel( d, row ) {
+		if ( d[ row.key ].labelDate ) {
+			return this.labelFormat( moment( d[ row.key ].labelDate ).toDate() );
+		}
+		return row.key;
+	}
+
+	show( d, triggerElement, parentNode, elementWidthRatio = 1 ) {
+		if ( ! this.visibleKeys.length ) {
+			return;
+		}
+		d3Select( parentNode )
+			.select( '.focus-grid, .barfocus' )
+			.attr( 'opacity', '1' );
+		const position = this.calculatePosition( triggerElement, elementWidthRatio );
+
+		const keys = this.visibleKeys.map(
+			row => `
+					<li class="key-row">
+						<div class="key-container">
+							<span
+								class="key-color"
+								style="background-color: ${ getColor( row.key, this.visibleKeys, this.colorScheme ) }">
+							</span>
+							<span class="key-key">${ this.getTooltipRowLabel( d, row ) }</span>
+						</div>
+						<span class="key-value">${ this.valueFormat( d[ row.key ].value ) }</span>
+					</li>
+				`
 		);
+
+		const tooltipTitle = this.title
+			? this.title
+			: this.labelFormat( moment( d.date ).toDate() );
+
+		d3Select( this.ref )
+			.style( 'left', position.x + 'px' )
+			.style( 'top', position.y + 'px' )
+			.style( 'visibility', 'visible' ).html( `
+				<div>
+					<h4>${ tooltipTitle }</h4>
+					<ul>
+					${ keys.join( '' ) }
+					</ul>
+				</div>
+			` );
 	}
+}
 
-	const xPosition =
-		elementCoords.left + elementCoords.width * elementWidthRatio + tooltipMargin - leftMargin;
-
-	if ( xPosition + tooltipSize.width + tooltipMargin > d3BaseCoords.width ) {
-		return Math.max(
-			tooltipMargin,
-			elementCoords.left +
-				elementCoords.width * ( 1 - elementWidthRatio ) -
-				tooltipSize.width -
-				tooltipMargin -
-				leftMargin
-		);
-	}
-
-	return xPosition;
-};
-
-const calculateTooltipYPosition = (
-	elementCoords,
-	chartCoords,
-	tooltipSize,
-	tooltipMargin,
-	tooltipPosition
-) => {
-	if ( tooltipPosition === 'below' ) {
-		return chartCoords.height;
-	}
-
-	const yPosition = elementCoords.top + tooltipMargin - chartCoords.top;
-	if ( yPosition + tooltipSize.height + tooltipMargin > chartCoords.height ) {
-		return Math.max( 0, elementCoords.top - tooltipSize.height - tooltipMargin - chartCoords.top );
-	}
-
-	return yPosition;
-};
-
-export const calculateTooltipPosition = ( element, chart, tooltipPosition, elementWidthRatio = 1 ) => {
-	const elementCoords = element.getBoundingClientRect();
-	const chartCoords = chart.getBoundingClientRect();
-	const tooltipSize = d3Select( '.d3-chart__tooltip' )
-		.node()
-		.getBoundingClientRect();
-	const tooltipMargin = 24;
-
-	if ( tooltipPosition === 'below' ) {
-		elementWidthRatio = 0;
-	}
-
-	return {
-		x: calculateTooltipXPosition(
-			elementCoords,
-			chartCoords,
-			tooltipSize,
-			tooltipMargin,
-			elementWidthRatio,
-			tooltipPosition
-		),
-		y: calculateTooltipYPosition(
-			elementCoords,
-			chartCoords,
-			tooltipSize,
-			tooltipMargin,
-			tooltipPosition
-		),
-	};
-};
-
-const getTooltipRowLabel = ( d, row, params ) => {
-	if ( d[ row.key ].labelDate ) {
-		return params.tooltipLabelFormat( moment( d[ row.key ].labelDate ).toDate() );
-	}
-	return row.key;
-};
-
-export const showTooltip = ( params, d, position ) => {
-	const keys = params.visibleKeys.map(
-		row => `
-				<li class="key-row">
-					<div class="key-container">
-						<span
-							class="key-color"
-							style="background-color:${ getColor( row.key, params.visibleKeys, params.colorScheme ) }">
-						</span>
-						<span class="key-key">${ getTooltipRowLabel( d, row, params ) }</span>
-					</div>
-					<span class="key-value">${ params.tooltipValueFormat( d[ row.key ].value ) }</span>
-				</li>
-			`
-	);
-
-	const tooltipTitle = params.tooltipTitle
-		? params.tooltipTitle
-		: params.tooltipLabelFormat( moment( d.date ).toDate() );
-
-	d3Select( params.tooltip )
-		.style( 'left', position.x + 'px' )
-		.style( 'top', position.y + 'px' )
-		.style( 'visibility', 'visible' ).html( `
-			<div>
-				<h4>${ tooltipTitle }</h4>
-				<ul>
-				${ keys.join( '' ) }
-				</ul>
-			</div>
-		` );
-};
+export default ChartTooltip;


### PR DESCRIPTION
Fixes #1492.
Fixes #1514.

This PR refactors `<D3Chart />` with a couple of goals:
- Split the `params` variable into smaller ones (`formats`, `params` and `scales`).
- Move variables as close as possible to the place they are used. For example `dateSpaces` is only used in line charts, so it makes more sense to create it in `drawLines()` than doing it in `<D3Chart />`.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Detailed test instructions:
For #1492:
- Go to the _Products_ report, for example.
- In the date picker, select a single day that you know has orders.
- In the chart interval, select _By day_.
- Verify the dots are centered.
![image](https://user-images.githubusercontent.com/3616980/52655734-2985a380-2ef5-11e9-9b84-185dfb0eaed2.png)

For #1514:
- Go to the _Products_ report in IE 11.
- Under the _Show_ filter, select _Product Comparison_.
- Select 2 or more products.
- In the date picker, select a wide range.
- Select the _bar chart_.
- Verify the X-axis labels are visible.
![image](https://user-images.githubusercontent.com/3616980/52655993-b4669e00-2ef5-11e9-9444-5b6c3757a287.png)

In addition to that, playing a bit with the chart: switching between line and bar types, trying different date ranges/intervals, resizing the viewport and hovering the lines/bars would help in order to detect any regression.
