### PR TITLE
Advanced filters alignment in IE11

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -39,7 +39,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer name filter', 'wc-admin' ),
 				rule: __( 'Select a customer name filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Name {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Name', 'wc-admin' ),
 				filter: __( 'Select customer name', 'wc-admin' ),
 			},
 			rules: [
@@ -70,7 +70,7 @@ export const advancedFilters = {
 				remove: __( 'Remove country filter', 'wc-admin' ),
 				rule: __( 'Select a country filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Country {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Country', 'wc-admin' ),
 				filter: __( 'Select country', 'wc-admin' ),
 			},
 			rules: [
@@ -111,7 +111,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer username filter', 'wc-admin' ),
 				rule: __( 'Select a customer username filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Username {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Username', 'wc-admin' ),
 				filter: __( 'Select customer username', 'wc-admin' ),
 			},
 			rules: [
@@ -139,7 +139,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer email filter', 'wc-admin' ),
 				rule: __( 'Select a customer email filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Email {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Email', 'wc-admin' ),
 				filter: __( 'Select customer email', 'wc-admin' ),
 			},
 			rules: [
@@ -168,7 +168,7 @@ export const advancedFilters = {
 				add: __( 'No. of Orders', 'wc-admin' ),
 				remove: __( 'Remove order  filter', 'wc-admin' ),
 				rule: __( 'Select an order count filter match', 'wc-admin' ),
-				title: __( 'No. of Orders {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'No. of Orders', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -196,7 +196,7 @@ export const advancedFilters = {
 				add: __( 'Total Spend', 'wc-admin' ),
 				remove: __( 'Remove total spend filter', 'wc-admin' ),
 				rule: __( 'Select a total spend filter match', 'wc-admin' ),
-				title: __( 'Total Spend {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Total Spend', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -224,7 +224,7 @@ export const advancedFilters = {
 				add: __( 'AOV', 'wc-admin' ),
 				remove: __( 'Remove average older value filter', 'wc-admin' ),
 				rule: __( 'Select an average order value filter match', 'wc-admin' ),
-				title: __( 'AOV {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'AOV', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -254,7 +254,7 @@ export const advancedFilters = {
 				remove: __( 'Remove registered filter', 'wc-admin' ),
 				rule: __( 'Select a registered filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Registered {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Registered', 'wc-admin' ),
 				filter: __( 'Select registered date', 'wc-admin' ),
 			},
 			rules: [
@@ -284,7 +284,7 @@ export const advancedFilters = {
 				remove: __( 'Remove last active filter', 'wc-admin' ),
 				rule: __( 'Select a last active filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Last active {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Last active', 'wc-admin' ),
 				filter: __( 'Select registered date', 'wc-admin' ),
 			},
 			rules: [

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -39,7 +39,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer name filter', 'wc-admin' ),
 				rule: __( 'Select a customer name filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Name', 'wc-admin' ),
+				title: __( '{{title}}Name{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select customer name', 'wc-admin' ),
 			},
 			rules: [
@@ -70,7 +70,7 @@ export const advancedFilters = {
 				remove: __( 'Remove country filter', 'wc-admin' ),
 				rule: __( 'Select a country filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Country', 'wc-admin' ),
+				title: __( '{{title}}Country{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select country', 'wc-admin' ),
 			},
 			rules: [
@@ -111,7 +111,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer username filter', 'wc-admin' ),
 				rule: __( 'Select a customer username filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Username', 'wc-admin' ),
+				title: __( '{{title}}Username{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select customer username', 'wc-admin' ),
 			},
 			rules: [
@@ -139,7 +139,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer email filter', 'wc-admin' ),
 				rule: __( 'Select a customer email filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Email', 'wc-admin' ),
+				title: __( '{{title}}Email{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select customer email', 'wc-admin' ),
 			},
 			rules: [
@@ -168,7 +168,7 @@ export const advancedFilters = {
 				add: __( 'No. of Orders', 'wc-admin' ),
 				remove: __( 'Remove order  filter', 'wc-admin' ),
 				rule: __( 'Select an order count filter match', 'wc-admin' ),
-				title: __( 'No. of Orders', 'wc-admin' ),
+				title: __( '{{title}}No. of Orders{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -196,7 +196,7 @@ export const advancedFilters = {
 				add: __( 'Total Spend', 'wc-admin' ),
 				remove: __( 'Remove total spend filter', 'wc-admin' ),
 				rule: __( 'Select a total spend filter match', 'wc-admin' ),
-				title: __( 'Total Spend', 'wc-admin' ),
+				title: __( '{{title}}Total Spend{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -224,7 +224,7 @@ export const advancedFilters = {
 				add: __( 'AOV', 'wc-admin' ),
 				remove: __( 'Remove average older value filter', 'wc-admin' ),
 				rule: __( 'Select an average order value filter match', 'wc-admin' ),
-				title: __( 'AOV', 'wc-admin' ),
+				title: __( '{{title}}AOV{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 			},
 			rules: [
 				{
@@ -254,7 +254,7 @@ export const advancedFilters = {
 				remove: __( 'Remove registered filter', 'wc-admin' ),
 				rule: __( 'Select a registered filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Registered', 'wc-admin' ),
+				title: __( '{{title}}Registered{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select registered date', 'wc-admin' ),
 			},
 			rules: [
@@ -284,7 +284,7 @@ export const advancedFilters = {
 				remove: __( 'Remove last active filter', 'wc-admin' ),
 				rule: __( 'Select a last active filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( 'Last active', 'wc-admin' ),
+				title: __( '{{title}}Last active{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select registered date', 'wc-admin' ),
 			},
 			rules: [

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -45,7 +45,7 @@ export const advancedFilters = {
 				remove: __( 'Remove product filter', 'wc-admin' ),
 				rule: __( 'Select a product filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Product', 'wc-admin' ),
+				title: __( '{{title}}Product{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select product', 'wc-admin' ),
 			},
 			rules: [
@@ -73,7 +73,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer username filter', 'wc-admin' ),
 				rule: __( 'Select a customer username filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Username', 'wc-admin' ),
+				title: __( '{{title}}Username{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select customer username', 'wc-admin' ),
 			},
 			rules: [
@@ -101,7 +101,7 @@ export const advancedFilters = {
 				remove: __( 'Remove order number filter', 'wc-admin' ),
 				rule: __( 'Select a order number filter match', 'wc-admin' ),
 				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Order number', 'wc-admin' ),
+				title: __( '{{title}}Order number{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select order number', 'wc-admin' ),
 			},
 			rules: [
@@ -135,7 +135,7 @@ export const advancedFilters = {
 				remove: __( 'Remove IP address filter', 'wc-admin' ),
 				rule: __( 'Select an IP address filter match', 'wc-admin' ),
 				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'IP Address', 'wc-admin' ),
+				title: __( '{{title}}IP Address{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select IP address', 'wc-admin' ),
 			},
 			rules: [

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -45,7 +45,7 @@ export const advancedFilters = {
 				remove: __( 'Remove product filter', 'wc-admin' ),
 				rule: __( 'Select a product filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Product {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Product', 'wc-admin' ),
 				filter: __( 'Select product', 'wc-admin' ),
 			},
 			rules: [
@@ -73,7 +73,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer username filter', 'wc-admin' ),
 				rule: __( 'Select a customer username filter match', 'wc-admin' ),
 				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Username {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Username', 'wc-admin' ),
 				filter: __( 'Select customer username', 'wc-admin' ),
 			},
 			rules: [
@@ -101,7 +101,7 @@ export const advancedFilters = {
 				remove: __( 'Remove order number filter', 'wc-admin' ),
 				rule: __( 'Select a order number filter match', 'wc-admin' ),
 				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'Order number {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Order number', 'wc-admin' ),
 				filter: __( 'Select order number', 'wc-admin' ),
 			},
 			rules: [
@@ -135,7 +135,7 @@ export const advancedFilters = {
 				remove: __( 'Remove IP address filter', 'wc-admin' ),
 				rule: __( 'Select an IP address filter match', 'wc-admin' ),
 				/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
-				title: __( 'IP Address {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'IP Address', 'wc-admin' ),
 				filter: __( 'Select IP address', 'wc-admin' ),
 			},
 			rules: [

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -61,7 +61,7 @@ export const advancedFilters = {
 				remove: __( 'Remove order status filter', 'wc-admin' ),
 				rule: __( 'Select an order status filter match', 'wc-admin' ),
 				/* translators: A sentence describing an Order Status filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Order Status {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Order Status', 'wc-admin' ),
 				filter: __( 'Select an order status', 'wc-admin' ),
 			},
 			rules: [
@@ -91,7 +91,7 @@ export const advancedFilters = {
 				remove: __( 'Remove products filter', 'wc-admin' ),
 				rule: __( 'Select a product filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Product {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Product', 'wc-admin' ),
 				filter: __( 'Select products', 'wc-admin' ),
 			},
 			rules: [
@@ -119,7 +119,7 @@ export const advancedFilters = {
 				remove: __( 'Remove coupon filter', 'wc-admin' ),
 				rule: __( 'Select a coupon filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Coupon filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Coupon Code {{rule /}} {{filter /}}', 'wc-admin' ),
+				title: __( 'Coupon Code', 'wc-admin' ),
 				filter: __( 'Select coupon codes', 'wc-admin' ),
 			},
 			rules: [
@@ -146,7 +146,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer filter', 'wc-admin' ),
 				rule: __( 'Select a customer filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Customer filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Customer is {{filter /}}', 'wc-admin' ),
+				title: __( 'Customer is', 'wc-admin' ),
 				filter: __( 'Select a customer type', 'wc-admin' ),
 			},
 			input: {

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -61,7 +61,7 @@ export const advancedFilters = {
 				remove: __( 'Remove order status filter', 'wc-admin' ),
 				rule: __( 'Select an order status filter match', 'wc-admin' ),
 				/* translators: A sentence describing an Order Status filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Order Status', 'wc-admin' ),
+				title: __( '{{title}}Order Status{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select an order status', 'wc-admin' ),
 			},
 			rules: [
@@ -91,7 +91,7 @@ export const advancedFilters = {
 				remove: __( 'Remove products filter', 'wc-admin' ),
 				rule: __( 'Select a product filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Product', 'wc-admin' ),
+				title: __( '{{title}}Product{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select products', 'wc-admin' ),
 			},
 			rules: [
@@ -119,7 +119,7 @@ export const advancedFilters = {
 				remove: __( 'Remove coupon filter', 'wc-admin' ),
 				rule: __( 'Select a coupon filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Coupon filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Coupon Code', 'wc-admin' ),
+				title: __( '{{title}}Coupon Code{{/title}} {{rule /}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select coupon codes', 'wc-admin' ),
 			},
 			rules: [
@@ -146,7 +146,7 @@ export const advancedFilters = {
 				remove: __( 'Remove customer filter', 'wc-admin' ),
 				rule: __( 'Select a customer filter match', 'wc-admin' ),
 				/* translators: A sentence describing a Customer filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( 'Customer is', 'wc-admin' ),
+				title: __( '{{title}}Customer is{{/title}} {{filter /}}', 'wc-admin' ),
 				filter: __( 'Select a customer type', 'wc-admin' ),
 			},
 			input: {

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -186,7 +186,7 @@ class DateFilter extends Component {
 	}
 
 	render() {
-		const { config, filter, isEnglish } = this.props;
+		const { className, config, filter, isEnglish } = this.props;
 		const { rule } = filter;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
@@ -195,7 +195,7 @@ class DateFilter extends Component {
 			components: {
 				rule: (
 					<SelectControl
-						className="woocommerce-filters-advanced__rule"
+						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }
 						options={ rules }
 						value={ rule }
 						onChange={ this.onRuleChange }
@@ -204,7 +204,7 @@ class DateFilter extends Component {
 				),
 				filter: (
 					<div
-						className={ classnames( 'woocommerce-filters-advanced__input-range', {
+						className={ classnames( className, 'woocommerce-filters-advanced__input-range', {
 							'is-between': 'between' === rule,
 						} ) }
 					>

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -215,7 +215,7 @@ class DateFilter extends Component {
 		} );
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
-			<fieldset tabIndex="0">
+			<fieldset className="woocommerce-filters-advanced__line-item" tabIndex="0">
 				<legend className="screen-reader-text">{ labels.add || '' }</legend>
 				<div
 					className={ classnames( 'woocommerce-filters-advanced__fieldset', {

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -7,7 +7,7 @@ import interpolateComponents from 'interpolate-components';
 import { SelectControl } from '@wordpress/components';
 import { find, partial } from 'lodash';
 import classnames from 'classnames';
-import { sprintf, __, _x } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -191,10 +191,7 @@ class DateFilter extends Component {
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
 		const children = interpolateComponents( {
-			mixedString: sprintf(
-				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
-				labels.title
-			),
+			mixedString: labels.title,
 			components: {
 				title: <span className={ className } />,
 				rule: (

--- a/packages/components/src/filters/advanced/date-filter.js
+++ b/packages/components/src/filters/advanced/date-filter.js
@@ -7,7 +7,7 @@ import interpolateComponents from 'interpolate-components';
 import { SelectControl } from '@wordpress/components';
 import { find, partial } from 'lodash';
 import classnames from 'classnames';
-import { __, _x } from '@wordpress/i18n';
+import { sprintf, __, _x } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -191,8 +191,12 @@ class DateFilter extends Component {
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
 		const children = interpolateComponents( {
-			mixedString: labels.title,
+			mixedString: sprintf(
+				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
+				labels.title
+			),
 			components: {
+				title: <span className={ className } />,
 				rule: (
 					<SelectControl
 						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -9,6 +9,7 @@ import { partial, findIndex, difference, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
+import classnames from 'classnames';
 
 /**
  * WooCommerce dependencies
@@ -234,7 +235,10 @@ class AdvancedFilters extends Component {
 									/>
 								) }
 								<IconButton
-									className="woocommerce-filters-advanced__remove"
+									className={ classnames(
+										'woocommerce-filters-advanced__line-item',
+										'woocommerce-filters-advanced__remove'
+									) }
 									label={ labels.remove }
 									onClick={ partial( this.removeFilter, key ) }
 									icon={ <Gridicon icon="cross-small" /> }

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -191,6 +191,7 @@ class AdvancedFilters extends Component {
 							<li className="woocommerce-filters-advanced__list-item" key={ key }>
 								{ 'SelectControl' === input.component && (
 									<SelectFilter
+										className="woocommerce-filters-advanced__fieldset-item"
 										filter={ filter }
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }
@@ -199,6 +200,7 @@ class AdvancedFilters extends Component {
 								) }
 								{ 'Search' === input.component && (
 									<SearchFilter
+										className="woocommerce-filters-advanced__fieldset-item"
 										filter={ filter }
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }
@@ -208,6 +210,7 @@ class AdvancedFilters extends Component {
 								) }
 								{ 'Number' === input.component && (
 									<NumberFilter
+										className="woocommerce-filters-advanced__fieldset-item"
 										filter={ filter }
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }
@@ -217,6 +220,7 @@ class AdvancedFilters extends Component {
 								) }
 								{ 'Currency' === input.component && (
 									<NumberFilter
+										className="woocommerce-filters-advanced__fieldset-item"
 										filter={ filter }
 										config={ { ...config.filters[ key ], ...{ input: { type: 'currency', component: 'Currency' } } } }
 										onFilterChange={ this.onFilterChange }
@@ -226,6 +230,7 @@ class AdvancedFilters extends Component {
 								) }
 								{ 'Date' === input.component && (
 									<DateFilter
+										className="woocommerce-filters-advanced__fieldset-item"
 										filter={ filter }
 										config={ config.filters[ key ] }
 										onFilterChange={ this.onFilterChange }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -185,7 +185,7 @@ class NumberFilter extends Component {
 	}
 
 	render() {
-		const { config, filter, onFilterChange, isEnglish } = this.props;
+		const { className, config, filter, onFilterChange, isEnglish } = this.props;
 		const { key, rule } = filter;
 		const { labels, rules } = config;
 
@@ -194,7 +194,7 @@ class NumberFilter extends Component {
 			components: {
 				rule: (
 					<SelectControl
-						className="woocommerce-filters-advanced__rule"
+						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }
 						options={ rules }
 						value={ rule }
 						onChange={ partial( onFilterChange, key, 'rule' ) }
@@ -203,7 +203,7 @@ class NumberFilter extends Component {
 				),
 				filter: (
 					<div
-						className={ classnames( 'woocommerce-filters-advanced__input-range', {
+						className={ classnames( className, 'woocommerce-filters-advanced__input-range', {
 							'is-between': 'between' === rule,
 						} ) }
 					>

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -190,8 +190,12 @@ class NumberFilter extends Component {
 		const { labels, rules } = config;
 
 		const children = interpolateComponents( {
-			mixedString: labels.title,
+			mixedString: sprintf(
+				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
+				labels.title
+			),
 			components: {
+				title: <span className={ className } />,
 				rule: (
 					<SelectControl
 						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -217,7 +217,7 @@ class NumberFilter extends Component {
 
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
-			<fieldset tabIndex="0">
+			<fieldset className="woocommerce-filters-advanced__line-item" tabIndex="0">
 				<legend className="screen-reader-text">
 					{ labels.add || '' }
 				</legend>

--- a/packages/components/src/filters/advanced/number-filter.js
+++ b/packages/components/src/filters/advanced/number-filter.js
@@ -190,10 +190,7 @@ class NumberFilter extends Component {
 		const { labels, rules } = config;
 
 		const children = interpolateComponents( {
-			mixedString: sprintf(
-				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
-				labels.title
-			),
+			mixedString: labels.title,
 			components: {
 				title: <span className={ className } />,
 				rule: (

--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -72,7 +72,7 @@ class SearchFilter extends Component {
 	}
 
 	render() {
-		const { config, filter, onFilterChange, isEnglish } = this.props;
+		const { className, config, filter, onFilterChange, isEnglish } = this.props;
 		const { selected } = this.state;
 		const { key, rule } = filter;
 		const { input, labels, rules } = config;
@@ -81,7 +81,7 @@ class SearchFilter extends Component {
 			components: {
 				rule: (
 					<SelectControl
-						className="woocommerce-filters-advanced__rule"
+						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }
 						options={ rules }
 						value={ rule }
 						onChange={ partial( onFilterChange, key, 'rule' ) }
@@ -90,7 +90,7 @@ class SearchFilter extends Component {
 				),
 				filter: (
 					<Search
-						className="woocommerce-filters-advanced__input"
+						className={ classnames( className, 'woocommerce-filters-advanced__input' ) }
 						onChange={ this.onSearchChange }
 						type={ input.type }
 						placeholder={ labels.placeholder }

--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -8,7 +8,6 @@ import { find, isEqual, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
-import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -78,10 +77,7 @@ class SearchFilter extends Component {
 		const { key, rule } = filter;
 		const { input, labels, rules } = config;
 		const children = interpolateComponents( {
-			mixedString: sprintf(
-				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
-				labels.title
-			),
+			mixedString: labels.title,
 			components: {
 				title: <span className={ className } />,
 				rule: (

--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -8,6 +8,7 @@ import { find, isEqual, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
+import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -77,8 +78,12 @@ class SearchFilter extends Component {
 		const { key, rule } = filter;
 		const { input, labels, rules } = config;
 		const children = interpolateComponents( {
-			mixedString: labels.title,
+			mixedString: sprintf(
+				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
+				labels.title
+			),
 			components: {
+				title: <span className={ className } />,
 				rule: (
 					<SelectControl
 						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }

--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -106,7 +106,7 @@ class SearchFilter extends Component {
 
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
-			<fieldset tabIndex="0">
+			<fieldset className="woocommerce-filters-advanced__line-item" tabIndex="0">
 				<legend className="screen-reader-text">
 					{ labels.add || '' }
 				</legend>

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -71,7 +71,7 @@ class SelectFilter extends Component {
 		const { labels, rules } = config;
 		const children = interpolateComponents( {
 			mixedString: sprintf(
-				'{{title}}%s{{/title}}' + ( rules ? ' {{rule /}}' : '' ) + ' {{filter /}}',
+				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
 				labels.title
 			),
 			components: {

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -71,7 +71,7 @@ class SelectFilter extends Component {
 		const { labels, rules } = config;
 		const children = interpolateComponents( {
 			mixedString: sprintf(
-				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
+				'{{title}}%s{{/title}}' + ( rules ? ' {{rule /}}' : '' ) + ' {{filter /}}',
 				labels.title
 			),
 			components: {

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -8,7 +8,6 @@ import { find, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
-import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -70,10 +69,7 @@ class SelectFilter extends Component {
 		const { key, rule, value } = filter;
 		const { labels, rules } = config;
 		const children = interpolateComponents( {
-			mixedString: sprintf(
-				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
-				labels.title
-			),
+			mixedString: labels.title,
 			components: {
 				title: <span className={ className } />,
 				rule: (

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -64,7 +64,7 @@ class SelectFilter extends Component {
 	}
 
 	render() {
-		const { config, filter, onFilterChange, isEnglish } = this.props;
+		const { className, config, filter, onFilterChange, isEnglish } = this.props;
 		const { options } = this.state;
 		const { key, rule, value } = filter;
 		const { labels, rules } = config;
@@ -73,7 +73,7 @@ class SelectFilter extends Component {
 			components: {
 				rule: (
 					<SelectControl
-						className="woocommerce-filters-advanced__rule"
+						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }
 						options={ rules }
 						value={ rule }
 						onChange={ partial( onFilterChange, key, 'rule' ) }
@@ -82,7 +82,7 @@ class SelectFilter extends Component {
 				),
 				filter: options ? (
 					<SelectControl
-						className="woocommerce-filters-advanced__input"
+						className={ classnames( className, 'woocommerce-filters-advanced__input' ) }
 						options={ options }
 						value={ value }
 						onChange={ partial( onFilterChange, filter.key, 'value' ) }

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -98,7 +98,7 @@ class SelectFilter extends Component {
 
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
-			<fieldset tabIndex="0">
+			<fieldset className="woocommerce-filters-advanced__line-item" tabIndex="0">
 				<legend className="screen-reader-text">
 					{ labels.add || '' }
 				</legend>

--- a/packages/components/src/filters/advanced/select-filter.js
+++ b/packages/components/src/filters/advanced/select-filter.js
@@ -8,6 +8,7 @@ import { find, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
+import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -69,8 +70,12 @@ class SelectFilter extends Component {
 		const { key, rule, value } = filter;
 		const { labels, rules } = config;
 		const children = interpolateComponents( {
-			mixedString: labels.title,
+			mixedString: sprintf(
+				'{{title}}%s{{/title}} {{rule /}} {{filter /}}',
+				labels.title
+			),
 			components: {
+				title: <span className={ className } />,
 				rule: (
 					<SelectControl
 						className={ classnames( className, 'woocommerce-filters-advanced__rule' ) }

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -129,7 +129,11 @@
 
 	&.is-english {
 		display: grid;
-		grid-template-columns: 100px 150px auto;
+		grid-template-columns: 100px 150px 1fr;
+
+		.woocommerce-filters-advanced__fieldset-item {
+			@include set-grid-item-position( 3, 3 );
+		}
 
 		@include breakpoint( '<782px' ) {
 			display: block;

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -45,16 +45,20 @@
 	padding: 0 $gap 0 0;
 	margin: 0;
 	display: grid;
-	grid-template-columns: auto 40px;
+	grid-template-columns: 1fr 40px;
 	background-color: $core-grey-light-100;
 	border-bottom: 1px solid $core-grey-light-700;
 
-	fieldset {
-		padding: $gap-smaller $gap-smaller $gap-smaller $gap;
-	}
-
 	&:hover {
 		background-color: $core-grey-light-200;
+	}
+
+	.woocommerce-filters-advanced__line-item {
+		@include set-grid-item-position( 2, 2 );
+	}
+
+	fieldset {
+		padding: $gap-smaller $gap-smaller $gap-smaller $gap;
 	}
 
 	.woocommerce-filters-advanced__remove {

--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -133,6 +133,11 @@
 
 		.woocommerce-filters-advanced__fieldset-item {
 			@include set-grid-item-position( 3, 3 );
+
+			&:nth-child(1) {
+				display: flex;
+				align-items: center;
+			}
 		}
 
 		@include breakpoint( '<782px' ) {


### PR DESCRIPTION
Fixes #1511

We are using CSS Grid for the layout of the filters, but unfortunately, support is very poor in IE11 so a few changes are required.

This PR:

* Adds a wrapper (`span`) around the title of the filter. Naked text nodes can't be used as grid columns in IE11. 
* Moves placeholders in the config files to the components 
* Adds IE11 compatibility CSS 

### Screenshots

Before:

![52513339-16a26480-2bbf-11e9-9faf-bb5297286ad7](https://user-images.githubusercontent.com/1177726/52659710-dd872e80-2ef5-11e9-8dc7-8488cffef329.png)

After:

<img width="861" alt="screenshot 2019-02-12 at 18 30 16" src="https://user-images.githubusercontent.com/1177726/52659681-c8120480-2ef5-11e9-8b6c-9a76f9f4c64f.png">

### Detailed test instructions:

* Open any report with advanced filters in IE11
* Add an advanced filter, and see what the styling looks like 