### PR TITLE
Hook up customers report table search box

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -59,7 +59,7 @@ export const advancedFilters = {
 				type: 'customers',
 				getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
 					id: customer.id,
-					label: [ customer.first_name, customer.last_name ].filter( Boolean ).join( ' ' ),
+					label: customer.name,
 				} ) ),
 			},
 		},

--- a/includes/api/class-wc-admin-rest-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-customers-controller.php
@@ -13,46 +13,14 @@ defined( 'ABSPATH' ) || exit;
  * Customers controller.
  *
  * @package WooCommerce Admin/API
- * @extends WC_REST_Customers_Controller
+ * @extends WC_Admin_REST_Reports_Customers_Controller
  */
-class WC_Admin_REST_Customers_Controller extends WC_REST_Customers_Controller {
-
-	// @todo Add support for guests here. See https://wp.me/p7bje6-1dM.
+class WC_Admin_REST_Customers_Controller extends WC_Admin_REST_Reports_Customers_Controller {
 
 	/**
-	 * Endpoint namespace.
+	 * Route base.
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v4';
-
-	/**
-	 * Searches emails by partial search instead of a strict match.
-	 * See "search parameters" under https://codex.wordpress.org/Class_Reference/WP_User_Query.
-	 *
-	 * @param array $prepared_args Prepared search filter args from the customer endpoint.
-	 * @param array $request Request/query arguments.
-	 * @return array
-	 */
-	public static function update_search_filters( $prepared_args, $request ) {
-		if ( ! empty( $request['email'] ) ) {
-			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
-		}
-		return $prepared_args;
-	}
-
-	/**
-	 * Get the query params for collections.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		// Allow partial email matches. Previously, this was of format 'email' which required a strict "test@example.com" format.
-		// This, in combination with `update_search_filters` allows us to do partial searches.
-		$params['email']['format'] = '';
-		return $params;
-	}
+	protected $rest_base = 'customers';
 }
-
-add_filter( 'woocommerce_rest_customer_query', array( 'WC_Admin_REST_Customers_Controller', 'update_search_filters' ), 10, 2 );

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -172,7 +172,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'title'      => 'report_customers',
 			'type'       => 'object',
 			'properties' => array(
-				'customer_id'          => array(
+				'id'                   => array(
 					'description' => __( 'Customer ID.', 'wc-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -60,6 +60,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
+		$args['customers']           = $request['customers'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -446,6 +447,17 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		$params['customers']               = array(
+			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'integer',
+			),
+
+		);
+
 		return $params;
 	}
 }

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -46,7 +46,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['order']               = $request['order'];
 		$args['orderby']             = $request['orderby'];
 		$args['match']               = $request['match'];
-		$args['name']                = $request['name'];
+		$args['search']              = $request['search'];
 		$args['username']            = $request['username'];
 		$args['email']               = $request['email'];
 		$args['country']             = $request['country'];
@@ -333,8 +333,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']                    = array(
-			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
+		$params['search']                  = array(
+			'description'       => __( 'Limit response to objects with a customer name containing the search term.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -41,7 +41,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['registered_before']   = $request['registered_before'];
 		$args['registered_after']    = $request['registered_after'];
 		$args['match']               = $request['match'];
-		$args['name']                = $request['name'];
+		$args['search']              = $request['search'];
 		$args['username']            = $request['username'];
 		$args['email']               = $request['email'];
 		$args['country']             = $request['country'];
@@ -246,7 +246,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name']                    = array(
+		$params['search']                  = array(
 			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -55,6 +55,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
+		$args['customers']           = $request['customers'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -358,6 +359,16 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['customers']              = array(
+			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'integer',
+			),
+
 		);
 
 		return $params;

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -173,7 +173,6 @@ class WC_Admin_Api_Init {
 	public function rest_api_init() {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-admin-notes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-coupons-controller.php';
-		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-countries-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-data-download-ips-controller.php';
@@ -205,6 +204,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-stock-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-taxes-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-customers-controller.php';
 
 		$controllers = apply_filters(
 			'woocommerce_admin_rest_controllers',

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -25,7 +25,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @var array
 	 */
 	protected $column_types = array(
-		'customer_id'     => 'intval',
+		'id'              => 'intval',
 		'user_id'         => 'intval',
 		'orders_count'    => 'intval',
 		'total_spend'     => 'floatval',
@@ -38,7 +38,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @var array
 	 */
 	protected $report_columns = array(
-		'customer_id'      => 'customer_id',
+		'id'               => 'customer_id as id',
 		'user_id'          => 'user_id',
 		'username'         => 'username',
 		'name'             => "CONCAT_WS( ' ', first_name, last_name ) as name", // @todo What does this mean for RTL?
@@ -60,7 +60,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		global $wpdb;
 
 		// Initialize some report columns that need disambiguation.
-		$this->report_columns['customer_id']     = $wpdb->prefix . self::TABLE_NAME . '.customer_id';
+		$this->report_columns['id']              = $wpdb->prefix . self::TABLE_NAME . '.customer_id as id';
 		$this->report_columns['date_last_order'] = "MAX( {$wpdb->prefix}wc_order_stats.date_created ) as date_last_order";
 	}
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -230,8 +230,10 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			}
 		}
 
-		if ( ! empty( $query_args['name'] ) ) {
-			$where_clauses[] = $wpdb->prepare( "CONCAT_WS( ' ', first_name, last_name ) = %s", $query_args['name'] );
+		if ( ! empty( $query_args['search'] ) ) {
+			$name_like = '%' . $wpdb->esc_like( $query_args['search'] ) . '%';
+			$where_clauses[] = $wpdb->prepare( "CONCAT_WS( ' ', first_name, last_name ) LIKE %s", $name_like );
+		}
 		}
 
 		$numeric_params = array(

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -234,6 +234,11 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			$name_like = '%' . $wpdb->esc_like( $query_args['search'] ) . '%';
 			$where_clauses[] = $wpdb->prepare( "CONCAT_WS( ' ', first_name, last_name ) LIKE %s", $name_like );
 		}
+
+		// Allow a list of customer IDs to be specified.
+		if ( ! empty( $query_args['customers'] ) ) {
+			$included_customers = implode( ',', $query_args['customers'] );
+			$where_clauses[] = "{$customer_lookup_table}.customer_id IN ({$included_customers})";
 		}
 
 		$numeric_params = array(

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -16,8 +16,6 @@ import { stringifyQuery } from '@woocommerce/navigation';
  */
 import { computeSuggestionMatch } from './utils';
 
-const getName = customer => [ customer.first_name, customer.last_name ].filter( Boolean ).join( ' ' );
-
 /**
  * A customer completer.
  * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
@@ -40,7 +38,7 @@ export default {
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {
-		return [ getName( customer ) ];
+		return [ customer.name ];
 	},
 	getFreeTextOptions( query ) {
 		const label = (
@@ -56,15 +54,15 @@ export default {
 		const nameOption = {
 			key: 'name',
 			label: label,
-			value: { id: query, first_name: query },
+			value: { id: query, name: query },
 		};
 
 		return [ nameOption ];
 	},
 	getOptionLabel( customer, query ) {
-		const match = computeSuggestionMatch( getName( customer ), query ) || {};
+		const match = computeSuggestionMatch( customer.name, query ) || {};
 		return [
-			<span key="name" className="woocommerce-search__result-name" aria-label={ getName( customer ) }>
+			<span key="name" className="woocommerce-search__result-name" aria-label={ customer.name }>
 				{ match.suggestionBeforeMatch }
 				<strong className="components-form-token-field__suggestion-match">
 					{ match.suggestionMatch }
@@ -78,7 +76,7 @@ export default {
 	getOptionCompletion( customer ) {
 		return {
 			id: customer.id,
-			label: getName( customer ),
+			label: customer.name,
 		};
 	},
 };

--- a/tests/api/reports-customers-stats.php
+++ b/tests/api/reports-customers-stats.php
@@ -142,7 +142,7 @@ class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
 		// Test name parameter (case with no matches).
 		$request->set_query_params(
 			array(
-				'name' => 'Nota Customername',
+				'search' => 'Nota Customername',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -157,8 +157,8 @@ class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
 		// Test name and last_order parameters.
 		$request->set_query_params(
 			array(
-				'name'             => 'Jeff',
-				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
+				'search'             => 'Jeff',
+				'last_order_after'   => date( 'Y-m-d' ) . 'T00:00:00Z',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -52,7 +52,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 	 * @param array $schema Item to check schema.
 	 */
 	public function assert_report_item_schema( $schema ) {
-		$this->assertArrayHasKey( 'customer_id', $schema );
+		$this->assertArrayHasKey( 'id', $schema );
 		$this->assertArrayHasKey( 'user_id', $schema );
 		$this->assertArrayHasKey( 'name', $schema );
 		$this->assertArrayHasKey( 'username', $schema );

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -163,7 +163,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Test name parameter (case with no matches).
 		$request->set_query_params(
 			array(
-				'name' => 'Nota Customername',
+				'search' => 'Nota Customername',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -175,8 +175,8 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Test name and last_order parameters.
 		$request->set_query_params(
 			array(
-				'name'             => 'Justin',
-				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
+				'search'             => 'Justin',
+				'last_order_after'   => date( 'Y-m-d' ) . 'T00:00:00Z',
 			)
 		);
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Fixes #1455.

This PR hooks the customers report table search header to the customer lookup table data.

Supporting changes introduced:
* Rewire the `v4/customers` endpoint to use the customer lookup table data
* Add support for fuzzy name searching to customers report data store and controllers
* Add support for specifying customer IDs to the customers report data store and controllers
* Rename `customer_id` to `id` in customers endpoint responses for `wc-api` compatibility

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

![screen shot 2019-02-12 at 11 38 07 am](https://user-images.githubusercontent.com/63922/52663112-b9f2c280-2eba-11e9-93bb-756b1b862c17.png)


### Detailed test instructions:

- Navigate to Customers Report
- Verify that searching at the top of the table has autocomplete results
- Verify that selecting the first "partial match" option has reasonable/expected results

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Known Issue?

I believe there are some faults in the way these table search components work. When there are more than 10 results, no paging controls are displayed and the stats are only for the results shown in the table. This seems to be true for all report tables using this search box.