### PR TITLE
Add stock stats endpoint and hook up to the stock report.

### DIFF
--- a/client/analytics/report/stock/config.js
+++ b/client/analytics/report/stock/config.js
@@ -17,6 +17,7 @@ export const filters = [
 			{ label: __( 'Out of Stock', 'wc-admin' ), value: 'outofstock' },
 			{ label: __( 'Low Stock', 'wc-admin' ), value: 'lowstock' },
 			{ label: __( 'In Stock', 'wc-admin' ), value: 'instock' },
+			{ label: __( 'On Backorder', 'wc-admin' ), value: 'onbackorder' },
 		],
 	},
 ];

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -103,23 +103,27 @@ export default class StockReportTable extends Component {
 	}
 
 	getSummary( totals ) {
-		const { products = 0, out_of_stock = 0, low_stock = 0, in_stock = 0 } = totals;
+		const { products = 0, outofstock = 0, lowstock = 0, instock = 0, onbackorder = 0 } = totals;
 		return [
 			{
 				label: _n( 'product', 'products', products, 'wc-admin' ),
 				value: numberFormat( products ),
 			},
 			{
-				label: __( 'out of stock', out_of_stock, 'wc-admin' ),
-				value: numberFormat( out_of_stock ),
+				label: __( 'out of stock', outofstock, 'wc-admin' ),
+				value: numberFormat( outofstock ),
 			},
 			{
-				label: __( 'low stock', low_stock, 'wc-admin' ),
-				value: numberFormat( low_stock ),
+				label: __( 'low stock', lowstock, 'wc-admin' ),
+				value: numberFormat( lowstock ),
 			},
 			{
-				label: __( 'in stock', in_stock, 'wc-admin' ),
-				value: numberFormat( in_stock ),
+				label: __( 'on backorder', onbackorder, 'wc-admin' ),
+				value: numberFormat( onbackorder ),
+			},
+			{
+				label: __( 'in stock', instock, 'wc-admin' ),
+				value: numberFormat( instock ),
 			},
 		];
 	}
@@ -132,7 +136,7 @@ export default class StockReportTable extends Component {
 				endpoint="stock"
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
-				// getSummary={ this.getSummary }
+				getSummary={ this.getSummary }
 				query={ query }
 				tableQuery={ {
 					orderby: query.orderby || 'stock_status',

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -21,6 +21,7 @@ const statEndpoints = [
 	'orders',
 	'products',
 	'revenue',
+	'stock',
 	'taxes',
 	'customers',
 ];
@@ -34,6 +35,7 @@ const typeEndpointMap = {
 	'report-stats-query-categories': 'categories',
 	'report-stats-query-downloads': 'downloads',
 	'report-stats-query-coupons': 'coupons',
+	'report-stats-query-stock': 'stock',
 	'report-stats-query-taxes': 'taxes',
 	'report-stats-query-customers': 'customers',
 };

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -77,8 +77,6 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$report_data     = $customers_query->get_data();
 		$out_data        = array(
 			'totals'    => $report_data,
-			// @todo Is this needed? the single element array tricks the isReportDataEmpty() selector.
-			'intervals' => array( (object) array() ),
 		);
 
 		return rest_ensure_response( $out_data );
@@ -160,55 +158,6 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
-				),
-				'intervals' => array( // @todo Remove this?
-					'description' => __( 'Reports data grouped by intervals.', 'wc-admin' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'wc-admin' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'wc-admin' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'wc-admin' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'wc-admin' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'wc-admin' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'wc-admin' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $totals,
-							),
-						),
-					),
 				),
 			),
 		);

--- a/includes/api/class-wc-admin-rest-reports-stock-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-stats-controller.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * REST API Reports stock stats controller
+ *
+ * Handles requests to the /reports/stock/stats endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Reports stock stats controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Reports_Controller
+ */
+class WC_Admin_REST_Reports_Stock_Stats_Controller extends WC_REST_Reports_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'reports/stock/stats';
+
+	/**
+	 * Get all reports.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return array|WP_Error
+	 */
+	public function get_items( $request ) {
+		$stock_query = new WC_Admin_Reports_Stock_Stats_Query();
+		$report_data = $stock_query->get_data();
+		$out_data = array(
+			'totals' => $report_data,
+		);
+		return rest_ensure_response( $out_data );
+	}
+
+	/**
+	 * Prepare a report object for serialization.
+	 *
+	 * @param  WC_Product      $report  Report data.
+	 * @param  WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $report, $request ) {
+		$data = $report;
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter a report returned from the API.
+		 *
+		 * Allows modification of the report data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WC_Product       $product   The original bject.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_report_stock_stats', $response, $product, $request );
+	}
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$totals = array(
+			'products'     => array(
+				'description' => __( 'Number of products.', 'wc-admin' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'lowstock'     => array(
+				'description' => __( 'Number of low stock products.', 'wc-admin' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+
+		$status_options = wc_get_product_stock_status_options();
+		foreach ( $status_options as $status => $label ) {
+			$totals[ $status ] = array(
+				/* translators: Stock status. Example: "Number of low stock products */
+				'description' => sprintf( __( 'Number of %s products.', 'wc-admin' ), $label ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			);
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_customers_stats',
+			'type'       => 'object',
+			'properties' => array(
+				'totals'    => array(
+					'description' => __( 'Totals data.', 'wc-admin' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => $totals,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params            = array();
+		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
+		return $params;
+	}
+}

--- a/includes/api/class-wc-admin-rest-reports-stock-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-stats-controller.php
@@ -32,7 +32,7 @@ class WC_Admin_REST_Reports_Stock_Stats_Controller extends WC_REST_Reports_Contr
 	protected $rest_base = 'reports/stock/stats';
 
 	/**
-	 * Get all reports.
+	 * Get Stock Status Totals.
 	 *
 	 * @param  WP_REST_Request $request Request data.
 	 * @return array|WP_Error

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -141,6 +141,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-downloads-stats-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-customers-query.php';
 		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-customers-stats-query.php';
+		require_once dirname( __FILE__ ) . '/class-wc-admin-reports-stock-stats-query.php';
 
 		// Data stores.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-data-store.php';
@@ -158,6 +159,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-downloads-stats-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-customers-data-store.php';
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-customers-stats-data-store.php';
+		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-reports-stock-stats-data-store.php';
 
 		// Data triggers.
 		require_once dirname( __FILE__ ) . '/data-stores/class-wc-admin-notes-data-store.php';
@@ -204,6 +206,7 @@ class WC_Admin_Api_Init {
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-taxes-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-stock-controller.php';
+		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-reports-stock-stats-controller.php';
 		require_once dirname( __FILE__ ) . '/api/class-wc-admin-rest-taxes-controller.php';
 
 		$controllers = apply_filters(
@@ -236,6 +239,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Reports_Coupons_Controller',
 				'WC_Admin_REST_Reports_Coupons_Stats_Controller',
 				'WC_Admin_REST_Reports_Stock_Controller',
+				'WC_Admin_REST_Reports_Stock_Stats_Controller',
 				'WC_Admin_REST_Reports_Downloads_Controller',
 				'WC_Admin_REST_Reports_Downloads_Stats_Controller',
 				'WC_Admin_REST_Reports_Customers_Controller',
@@ -756,22 +760,23 @@ class WC_Admin_Api_Init {
 		return array_merge(
 			$data_stores,
 			array(
-				'report-revenue-stats'  => 'WC_Admin_Reports_Orders_Stats_Data_Store',
-				'report-orders'         => 'WC_Admin_Reports_Orders_Data_Store',
-				'report-orders-stats'   => 'WC_Admin_Reports_Orders_Stats_Data_Store',
-				'report-products'       => 'WC_Admin_Reports_Products_Data_Store',
-				'report-variations'     => 'WC_Admin_Reports_Variations_Data_Store',
-				'report-products-stats' => 'WC_Admin_Reports_Products_Stats_Data_Store',
-				'report-categories'     => 'WC_Admin_Reports_Categories_Data_Store',
-				'report-taxes'          => 'WC_Admin_Reports_Taxes_Data_Store',
-				'report-taxes-stats'    => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
-				'report-coupons'        => 'WC_Admin_Reports_Coupons_Data_Store',
-				'report-coupons-stats'  => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
-				'report-downloads'      => 'WC_Admin_Reports_Downloads_Data_Store',
+				'report-revenue-stats'   => 'WC_Admin_Reports_Orders_Stats_Data_Store',
+				'report-orders'          => 'WC_Admin_Reports_Orders_Data_Store',
+				'report-orders-stats'    => 'WC_Admin_Reports_Orders_Stats_Data_Store',
+				'report-products'        => 'WC_Admin_Reports_Products_Data_Store',
+				'report-variations'      => 'WC_Admin_Reports_Variations_Data_Store',
+				'report-products-stats'  => 'WC_Admin_Reports_Products_Stats_Data_Store',
+				'report-categories'      => 'WC_Admin_Reports_Categories_Data_Store',
+				'report-taxes'           => 'WC_Admin_Reports_Taxes_Data_Store',
+				'report-taxes-stats'     => 'WC_Admin_Reports_Taxes_Stats_Data_Store',
+				'report-coupons'         => 'WC_Admin_Reports_Coupons_Data_Store',
+				'report-coupons-stats'   => 'WC_Admin_Reports_Coupons_Stats_Data_Store',
+				'report-downloads'       => 'WC_Admin_Reports_Downloads_Data_Store',
 				'report-downloads-stats' => 'WC_Admin_Reports_Downloads_Stats_Data_Store',
 				'admin-note'             => 'WC_Admin_Notes_Data_Store',
 				'report-customers'       => 'WC_Admin_Reports_Customers_Data_Store',
 				'report-customers-stats' => 'WC_Admin_Reports_Customers_Stats_Data_Store',
+				'report-stock-stats'     => 'WC_Admin_Reports_Stock_Stats_Data_Store',
 			)
 		);
 	}

--- a/includes/class-wc-admin-reports-stock-stats-query.php
+++ b/includes/class-wc-admin-reports-stock-stats-query.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class for stock stats report querying
+ *
+ * $report = new WC_Admin_Reports_Stock__Stats_Query();
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Reports_Stock_Stats_Query
+ */
+class WC_Admin_Reports_Stock_Stats_Query extends WC_Admin_Reports_Query {
+
+	/**
+	 * Get product data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$data_store = WC_Data_Store::load( 'report-stock-stats' );
+		$results    = $data_store->get_data();
+		return apply_filters( 'woocommerce_reports_stock_stats_query', $results );
+	}
+
+}

--- a/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * WC_Admin_Reports_Stock_Stats_Data_Store class file.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Reports_Stock_Stats_Data_Store.
+ */
+class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
+
+	/**
+	 * Get stock counts for the whole store.
+	 *
+	 * @param array $query Not used for the stock stats data store, but needed for the interface.
+	 * @return array Array of counts.
+	 */
+	public function get_data( $query ) {
+		$report_data = array();
+		$low_stock_transient_name = 'wc_admin_stock_count_lowstock';
+		$low_stock_count          = get_transient( $low_stock_transient_name );
+		if ( false === $low_stock_count ) {
+			$low_stock_count = $this->get_low_stock_count();
+			set_transient( $low_stock_transient_name, $low_stock_count, DAY_IN_SECONDS * 30 );
+		}
+		$report_data['lowstock'] = $low_stock_count;
+
+		$status_options = wc_get_product_stock_status_options();
+		foreach ( $status_options as $status => $label ) {
+			$transient_name = 'wc_admin_stock_count_' . $status;
+			$count          = get_transient( $transient_name );
+			if ( false === $count ) {
+				$count = $this->get_count( $status );
+				set_transient( $transient_name, $count, DAY_IN_SECONDS * 30 );
+			}
+			$report_data[ $status ] = $count;
+		}
+
+		$product_count_transient_name = 'wc_admin_product_count';
+		$product_count                = get_transient( $product_count_transient_name );
+		if ( false === $product_count ) {
+			$product_count = $this->get_product_count();
+			set_transient( $product_count_transient_name, $product_count, DAY_IN_SECONDS * 30 );
+		}
+		$report_data['products'] = $product_count;
+		return $report_data;
+	}
+
+	/**
+	 * Get low stock count.
+	 *
+	 * @return int Low stock count.
+	 */
+	private function get_low_stock_count() {
+		$query_args               = array();
+		$query_args['post_type']  = array( 'product', 'product_variation' );
+		$low_stock                = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+		$no_stock                 = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
+		$query_args['meta_query'] = array( // WPCS: slow query ok.
+			array(
+				'key'   => '_manage_stock',
+				'value' => 'yes',
+			),
+			array(
+				'key'     => '_stock',
+				'value'   => array( $no_stock, $low_stock ),
+				'compare' => 'BETWEEN',
+				'type'    => 'NUMERIC',
+			),
+			array(
+				'key'   => '_stock_status',
+				'value' => 'instock',
+			),
+		);
+
+		$query = new WP_Query();
+		$query->query( $query_args );
+		return intval( $query->found_posts );
+	}
+
+	/**
+	 * Get count for the passed in stock status.
+	 *
+	 * @param  string $status Status slug.
+	 * @return int Count.
+	 */
+	private function get_count( $status ) {
+		$query_args               = array();
+		$query_args['post_type']  = array( 'product', 'product_variation' );
+		$query_args['meta_query'] = array( // WPCS: slow query ok.
+			array(
+				'key'   => '_stock_status',
+				'value' => $status,
+			),
+		);
+
+		$query = new WP_Query();
+		$query->query( $query_args );
+		return intval( $query->found_posts );
+	}
+
+	/**
+	 * Get product count for the store.
+	 *
+	 * @return int Product count.
+	 */
+	private function get_product_count() {
+		$query_args               = array();
+		$query_args['post_type']  = array( 'product', 'product_variation' );
+		$query = new WP_Query();
+		$query->query( $query_args );
+		return intval( $query->found_posts );
+	}
+}
+
+/**
+ * Clear the count cache when products are added or updated, or when
+ * the no/low stock options are changed.
+ *
+ * @param int $id Post/product ID.
+ */
+function wc_admin_clear_stock_count_cache( $id ) {
+	delete_transient( 'wc_admin_stock_count_lowstock' );
+	delete_transient( 'wc_admin_product_count' );
+	$status_options = wc_get_product_stock_status_options();
+	foreach ( $status_options as $status => $label ) {
+		delete_transient( 'wc_admin_stock_count_' . $status );
+	}
+}
+
+add_action( 'woocommerce_update_product', 'wc_admin_clear_stock_count_cache' );
+add_action( 'woocommerce_new_product', 'wc_admin_clear_stock_count_cache' );
+add_action( 'update_option_woocommerce_notify_low_stock_amount', 'wc_admin_clear_stock_count_cache' );
+add_action( 'update_option_woocommerce_notify_no_stock_amount', 'wc_admin_clear_stock_count_cache' );

--- a/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
@@ -19,12 +19,13 @@ class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 	 * @return array Array of counts.
 	 */
 	public function get_data( $query ) {
-		$report_data = array();
+		$report_data              = array();
+		$cache_expire             = DAY_IN_SECONDS * 30;
 		$low_stock_transient_name = 'wc_admin_stock_count_lowstock';
 		$low_stock_count          = get_transient( $low_stock_transient_name );
 		if ( false === $low_stock_count ) {
 			$low_stock_count = $this->get_low_stock_count();
-			set_transient( $low_stock_transient_name, $low_stock_count, DAY_IN_SECONDS * 30 );
+			set_transient( $low_stock_transient_name, $low_stock_count, $cache_expire );
 		}
 		$report_data['lowstock'] = $low_stock_count;
 
@@ -34,7 +35,7 @@ class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 			$count          = get_transient( $transient_name );
 			if ( false === $count ) {
 				$count = $this->get_count( $status );
-				set_transient( $transient_name, $count, DAY_IN_SECONDS * 30 );
+				set_transient( $transient_name, $count, $cache_expire );
 			}
 			$report_data[ $status ] = $count;
 		}
@@ -43,7 +44,7 @@ class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 		$product_count                = get_transient( $product_count_transient_name );
 		if ( false === $product_count ) {
 			$product_count = $this->get_product_count();
-			set_transient( $product_count_transient_name, $product_count, DAY_IN_SECONDS * 30 );
+			set_transient( $product_count_transient_name, $product_count, $cache_expire );
 		}
 		$report_data['products'] = $product_count;
 		return $report_data;

--- a/tests/api/reports-customers-stats.php
+++ b/tests/api/reports-customers-stats.php
@@ -59,9 +59,8 @@ class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 2, $properties );
+		$this->assertCount( 1, $properties );
 		$this->assertArrayHasKey( 'totals', $properties );
-		$this->assertArrayHasKey( 'intervals', $properties );
 		$this->assertCount( 4, $properties['totals']['properties'] );
 		$this->assertArrayHasKey( 'customers_count', $properties['totals']['properties'] );
 		$this->assertArrayHasKey( 'avg_orders_count', $properties['totals']['properties'] );

--- a/tests/api/reports-stock-stats.php
+++ b/tests/api/reports-stock-stats.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Reports Stock Stats REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Class WC_Tests_API_Reports_Stock_Stats
+ */
+class WC_Tests_API_Reports_Stock_Stats extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v4/reports/stock/stats';
+
+	/**
+	 * Setup test reports stock data.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 */
+	public function test_get_reports() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$number_of_low_stock = 3;
+		for ( $i = 1; $i <= $number_of_low_stock; $i++ ) {
+			$low_stock = new WC_Product_Simple();
+			$low_stock->set_name( "Test low stock {$i}" );
+			$low_stock->set_regular_price( 5 );
+			$low_stock->set_manage_stock( true );
+			$low_stock->set_stock_quantity( 1 );
+			$low_stock->set_stock_status( 'instock' );
+			$low_stock->save();
+		}
+
+		$number_of_out_of_stock = 6;
+		for ( $i = 1; $i <= $number_of_out_of_stock; $i++ ) {
+			$out_of_stock = new WC_Product_Simple();
+			$out_of_stock->set_name( "Test out of stock {$i}" );
+			$out_of_stock->set_regular_price( 5 );
+			$out_of_stock->set_stock_status( 'outofstock' );
+			$out_of_stock->save();
+		}
+
+		$number_of_in_stock = 10;
+		for ( $i = 1; $i <= $number_of_in_stock; $i++ ) {
+			$in_stock = new WC_Product_Simple();
+			$in_stock->set_name( "Test in stock {$i}" );
+			$in_stock->set_regular_price( 25 );
+			$in_stock->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertArrayHasKey( 'totals', $reports );
+		$this->assertEquals( 19, $reports['totals']['products'] );
+		$this->assertEquals( 6, $reports['totals']['outofstock'] );
+		$this->assertEquals( 0, $reports['totals']['onbackorder'] );
+		$this->assertEquals( 3, $reports['totals']['lowstock'] );
+		$this->assertEquals( 13, $reports['totals']['instock'] );
+
+		// Test backorder and cache update.
+		$backorder_stock = new WC_Product_Simple();
+		$backorder_stock->set_name( 'Test backorder' );
+		$backorder_stock->set_regular_price( 5 );
+		$backorder_stock->set_stock_status( 'onbackorder' );
+		$backorder_stock->save();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( 20, $reports['totals']['products'] );
+		$this->assertEquals( 6, $reports['totals']['outofstock'] );
+		$this->assertEquals( 1, $reports['totals']['onbackorder'] );
+		$this->assertEquals( 3, $reports['totals']['lowstock'] );
+		$this->assertEquals( 13, $reports['totals']['instock'] );
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 1, $properties );
+		$this->assertArrayHasKey( 'totals', $properties );
+		$this->assertCount( 5, $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'products', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'outofstock', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'onbackorder', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'lowstock', $properties['totals']['properties'] );
+		$this->assertArrayHasKey( 'instock', $properties['totals']['properties'] );
+	}
+}


### PR DESCRIPTION
Closes #174, closes #920, closes #1527.

This PR adds a `/reports/stock/stats` endpoint that returns the number of products per stock status. The results are cached per the issue, since these can be slower meta queries. I followed the caching we are using on Store on WP.com (the `/data/counts` endpoint) which seems like it has been working well.

This PR also adds a "on backorder" filter and summary.

I also did a little cleanup on the customers endpoint, since it also does not contain an intervals object.

### Detailed test instructions:

* Run `phpunit` and make sure all tests are passing.
* Run `npm test` and make sure all tests are passing.
* Go to the stock report, and verify the summary numbers load. Smooth generator products should contain a variety of statuses.
* Go change a product's inventory so it's status changes. Go back to the report and make sure the cache busted.
* Spot check the customers report and revenue report for the summary number, since this PR makes a slight adjustment to the report util method.