### PR TITLE
Only update search labels when IDs are mismatched

### DIFF
--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -40,7 +40,12 @@ class SearchFilter extends Component {
 	}
 
 	updateLabels( selected ) {
-		this.setState( { selected } );
+		const prevIds = this.state.selected.map( item => item.id );
+		const ids = selected.map( item => item.id );
+
+		if ( ! isEqual( ids.sort(), prevIds.sort() ) ) {
+			this.setState( { selected } );
+		}
 	}
 
 	onSearchChange( values ) {


### PR DESCRIPTION
Fixes #1520

Prevents reordering of labels when adding new selections in advanced filters.

### Before
![old](https://user-images.githubusercontent.com/10561050/52698319-39ad8980-2fae-11e9-8abd-d13ebf8a3e1d.gif)

### After
![new](https://user-images.githubusercontent.com/10561050/52698348-4205c480-2fae-11e9-96f4-1843594c4da8.gif)

### Detailed test instructions:

1.  Open any report with advanced filters.
2.  Add a filter that allows adding multiple selections via autocomplete search (products, customers, etc).
3.  Add multiple selections.
4.  Verify that selections don't get reordered when adding.