### PR TITLE
Prevent hash creation from breadcrumbs

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 /**
  * WooCommerce dependencies
  */
-import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
+import { getNewPath } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
 
 /**
@@ -89,7 +89,7 @@ class Header extends Component {
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = Array.isArray( section ) ? (
 							<Link
-								href={ getNewPath( getPersistedQuery(), section[ 0 ], {} ) }
+								href={ getNewPath( {}, section[ 0 ], {} ) }
 								type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
 							>
 								{ section[ 1 ] }


### PR DESCRIPTION
Fixes #1480 

Removes persisted query from breadcrumbs to avoid appending hashes on non-wc-admin pages.

### Before
<img width="570" alt="screen shot 2019-02-13 at 5 05 03 pm" src="https://user-images.githubusercontent.com/10561050/52699878-bee66d80-2fb1-11e9-95dd-4efedf7af127.png">

### After
<img width="578" alt="screen shot 2019-02-13 at 5 05 14 pm" src="https://user-images.githubusercontent.com/10561050/52699871-bd1caa00-2fb1-11e9-8297-0498b259a4ab.png">


### Detailed test instructions:
1.  Visit any page that contains the wc-admin breadcrumbs, but is not a wc-admin route (e.g., single orders or products).
2.  After the page has loaded, verify that no has `#/' is appended to the URL.