### PR TITLE
Update numeric comparisons for customer data

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -253,17 +253,18 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			$subclauses = array();
 			$min_param  = $numeric_param . '_min';
 			$max_param  = $numeric_param . '_max';
+			$or_equal   = isset( $query_args[ $min_param ] ) && isset( $query_args[ $max_param ] ) ? '=' : '';
 
 			if ( isset( $query_args[ $min_param ] ) ) {
 				$subclauses[] = $wpdb->prepare(
-					"{$param_info['column']} >= {$param_info['format']}",
+					"{$param_info['column']} >{$or_equal} {$param_info['format']}",
 					$query_args[ $min_param ]
 				); // WPCS: unprepared SQL ok.
 			}
 
 			if ( isset( $query_args[ $max_param ] ) ) {
 				$subclauses[] = $wpdb->prepare(
-					"{$param_info['column']} <= {$param_info['format']}",
+					"{$param_info['column']} <{$or_equal} {$param_info['format']}",
 					$query_args[ $max_param ]
 				); // WPCS: unprepared SQL ok.
 			}


### PR DESCRIPTION
Fixes #1507 

Updates the customer comparison filters (avg order value, order count, etc) to be < and > to match phrasing instead of <= and >=.

If `Between` is selected instead of `More than` or `Less than` then the comparison becomes >= and <= so that if you selected "Between 0 and 1 orders" you would see all customers having 0 and 1 orders.  (Does this match your expectations?)

### Screenshots
<img width="931" alt="screen shot 2019-02-13 at 5 22 03 pm" src="https://user-images.githubusercontent.com/10561050/52700964-14237e80-2fb4-11e9-9047-5bb5dbb56cb4.png">

### Detailed test instructions:

1.  Open the Customers report.
2.  Add advanced filters that allow Less Than, More Than, and Between comparisons.
3.  Verify that Less Than results are actually less than the value and not less than or equal to.
4.  Verify the same with More Than.
5.  Verify that between is inclusive of both values (i.e. >= value1 and <= value2).