### PR TITLE
Don't call updateLabels on SearchFilter updates

### DIFF
--- a/packages/components/src/filters/advanced/search-filter.js
+++ b/packages/components/src/filters/advanced/search-filter.js
@@ -4,7 +4,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
-import { find, isEqual, partial } from 'lodash';
+import { find, partial } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
@@ -26,15 +26,6 @@ class SearchFilter extends Component {
 		this.updateLabels = this.updateLabels.bind( this );
 
 		if ( filter.value.length ) {
-			config.input.getLabels( filter.value, query ).then( this.updateLabels );
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		const { config, filter, query } = this.props;
-		const { filter: prevFilter } = prevProps;
-
-		if ( filter.value.length && ! isEqual( prevFilter, filter ) ) {
 			config.input.getLabels( filter.value, query ).then( this.updateLabels );
 		}
 	}


### PR DESCRIPTION
Fixes #1520;

As @joshuatf found out [here](https://github.com/woocommerce/wc-admin/pull/1539#discussion_r256293936), it's no longer necessary to call `updateLabels` in `SearchFilter` updates, this PR removes that.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52712202-2a214700-2f94-11e9-9d51-b4fe5cdfdeb9.png)

### Detailed test instructions:
- Go to the _Customers_ report.
- Add _Advanced Filters_ > _Name_.
- Add some names alphabetically unordered.
- Verify their order doesn't change and there are no regressions.