### PR TITLE
add build:feature-config to readme instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild": "npm run -s install-if-deps-outdated",
     "build:packages": "node ./bin/packages/build.js",
     "build:core": "cross-env NODE_ENV=production webpack",
-    "build": "npm run build:packages && npm run build:core",
+    "build": "npm run build:feature-config && npm run build:packages && npm run build:core",
     "build:release": "cross-env WC_ADMIN_PHASE=plugin ./bin/build-plugin-zip.sh",
     "build:feature-config": "php bin/generate-feature-config.php",
     "postbuild": "npm run -s i18n:php && npm run -s i18n:pot",


### PR DESCRIPTION
#1500 added `npm build:feature-config` to the build process. This PR adds that to the `npm run build` command.

*Testing instructions*
1. Delete `includes/feature-config.php` if it exists.
2. Run `npm run build`
3. Load the dashboard of the site without error.