### PR TITLE
Add defaults to Revenue table data

### DIFF
--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -240,8 +240,8 @@ export default compose(
 		return {
 			tableData: {
 				items: {
-					data: get( revenueData, [ 'data', 'intervals' ] ),
-					totalResults: get( revenueData, [ 'totalResults' ] ),
+					data: get( revenueData, [ 'data', 'intervals' ], [] ),
+					totalResults: get( revenueData, [ 'totalResults' ], 0 ),
 				},
 				isError,
 				isRequesting,


### PR DESCRIPTION
Fixes #1542.

Fixes a JS error due to `tableData` having `undefined` values before data was fetched from the server.

### Detailed test instructions:
- Go to the _Revenue_ report.
- Verify there are no JS errors.