### PR TITLE
Stock Report: fix stock link

### DIFF
--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -76,7 +76,7 @@ export default class StockReportTable extends Component {
 			);
 
 			const stockStatusLink = (
-				<Link href={ 'post.php?action=edit&post=' + parent_id || id } type="wp-admin">
+				<Link href={ 'post.php?action=edit&post=' + ( parent_id || id ) } type="wp-admin">
 					{ stockStatuses[ stock_status ] }
 				</Link>
 			);


### PR DESCRIPTION
Links to edit product pages from Stock Report Table had an incorrect url for products whose `parent_id` was zero.

### Detailed test instructions:

1. Stock Report
2. See links for products with no parent, ie not a variation
3. They should point to the corresponding product edit page in wp-admin
