### PR TITLE
Up freshness interval default.

### DIFF
--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -11,7 +11,7 @@ export const SWAGGERNAMESPACE = 'https://virtserver.swaggerhub.com/peterfabian/w
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,
-	freshness: 5 * MINUTE,
+	freshness: 30 * MINUTE,
 };
 
 // WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter


### PR DESCRIPTION
While testing out the reports, I often find myself with an open/stale tab and have witnessed the loading indicators come on randomly - which I fear to some users might be a bit odd. Also I fear by having a default freshness level of 5 minutes - we could potentially be performing many requests for the same set of data over and over again while users are digesting a report.

As such I'm proposing we up the default freshness interval to 30 minutes. I still would like to explore making the freshness requirement a bit more intelligent in our reports - where we would put the requirement even higher ( longer ) on reports that don't include today - or reports where we don't have changing data.

__To Test__
Nothing really to test here unless you want to keep a tab open for 30 minutes :) - but boot up wc-admin and verify all loads as expected still.