### PR TITLE
Autocompleter: increase debounce

### DIFF
--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -59,7 +59,7 @@ export class Autocomplete extends Component {
 		this.reset = this.reset.bind( this );
 		this.search = this.search.bind( this );
 		this.handleKeyDown = this.handleKeyDown.bind( this );
-		this.debouncedLoadOptions = debounce( this.loadOptions, 250 );
+		this.debouncedLoadOptions = debounce( this.loadOptions, 400 );
 
 		this.state = this.constructor.getInitialState();
 	}

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -20,6 +20,7 @@ import Flag from '../../flag';
 export default {
 	name: 'countries',
 	className: 'woocommerce-search__country-result',
+	isDebounced: true,
 	options() {
 		return wcSettings.dataEndpoints.countries || [];
 	},


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1436

It turns out debounce was turned on for almost all autocompleters (`isDebounced: true`), but it was only 250ms. This PR increases the pause before a request is made to 400ms.

### Detailed test instructions:

1. Go to Products Report
2. Show > Single Product
3. Watch the requests as you type. The request will wait 400ms after your last keystroke to fire.
