### PR TITLE
Add tax refund calculations

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -268,15 +268,24 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 		$num_updated = 0;
 
 		foreach ( $tax_items as $tax_item ) {
+			$item_refunds     = 0;
+			$shipping_refunds = 0;
+			foreach ( $order->get_items() as $item_id => $item ) {
+				$item_refunds += $order->get_tax_refunded_for_item( $item_id, $tax_item->get_rate_id() );
+			}
+			foreach ( $order->get_items( 'shipping' ) as $item_id => $item ) {
+				$shipping_refunds += $order->get_tax_refunded_for_item( $item_id, $tax_item->get_rate_id(), 'shipping' );
+			}
+
 			$result = $wpdb->replace(
 				$wpdb->prefix . self::TABLE_NAME,
 				array(
 					'order_id'     => $order->get_id(),
 					'date_created' => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 					'tax_rate_id'  => $tax_item->get_rate_id(),
-					'shipping_tax' => $tax_item->get_shipping_tax_total(),
-					'order_tax'    => $tax_item->get_tax_total(),
-					'total_tax'    => $tax_item->get_tax_total() + $tax_item->get_shipping_tax_total(),
+					'shipping_tax' => $tax_item->get_shipping_tax_total() - $shipping_refunds,
+					'order_tax'    => $tax_item->get_tax_total() - $item_refunds,
+					'total_tax'    => $tax_item->get_tax_total() + $tax_item->get_shipping_tax_total() - $item_refunds - $shipping_refunds,
 				),
 				array(
 					'%d',

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -71,6 +71,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	public static function init() {
 		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15 );
+		add_action( 'woocommerce_refund_deleted', array( __CLASS__, 'sync_on_refund_delete' ), 10, 2 );
 	}
 
 	/**
@@ -335,5 +336,15 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 		 * @param int $order_id    Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_tax', 0, $order_id );
+	}
+
+	/**
+	 * Syncs tax information when a refund is deleted.
+	 *
+	 * @param int $refund_id Refund ID.
+	 * @param int $order_id Order ID.
+	 */
+	public static function sync_on_refund_delete( $refund_id, $order_id ) {
+		self::sync_order_taxes( $order_id );
 	}
 }

--- a/tests/api/reports-taxes-stats.php
+++ b/tests/api/reports-taxes-stats.php
@@ -55,52 +55,34 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 		WC_Helper_Reports::reset_stats_dbs();
 
 		// Populate all of the data.
+		$tax = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '7',
+				'tax_rate_name'     => 'TestTax',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
 		$product->set_regular_price( 25 );
+		$product->set_tax_class( 'TestTax' );
 		$product->save();
 
-		$wpdb->insert(
-			$wpdb->prefix . 'woocommerce_tax_rates',
-			array(
-				'tax_rate_id'       => 1,
-				'tax_rate'          => '7',
-				'tax_rate_country'  => 'US',
-				'tax_rate_state'    => 'GA',
-				'tax_rate_name'     => 'TestTax',
-				'tax_rate_priority' => 1,
-				'tax_rate_order'    => 1,
-			)
-		);
-
+		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$order = WC_Helper_Order::create_order( 1, $product );
 		$order->set_status( 'completed' );
 		$order->set_total( 100 ); // $25 x 4.
+		$order->calculate_taxes();
 		$order->save();
 
-		// @todo Remove this once order data is synced to wc_order_tax_lookup
-		$wpdb->insert(
-			$wpdb->prefix . 'wc_order_tax_lookup',
-			array(
-				'order_id'     => 1,
-				'tax_rate_id'  => 1,
-				'date_created' => date( 'Y-m-d H:i:s' ),
-				'shipping_tax' => 2,
-				'order_tax'    => 5,
-				'total_tax'    => 7,
-			)
-		);
-		$wpdb->insert(
-			$wpdb->prefix . 'wc_order_tax_lookup',
-			array(
-				'order_id'     => 2,
-				'tax_rate_id'  => 1,
-				'date_created' => date( 'Y-m-d H:i:s' ),
-				'shipping_tax' => 1,
-				'order_tax'    => 8,
-				'total_tax'    => 9,
-			)
-		);
+		WC_Helper_Queue::run_all_pending();
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
 		$reports  = $response->get_data();
@@ -111,10 +93,10 @@ class WC_Tests_API_Reports_Taxes_Stats extends WC_REST_Unit_Test_Case {
 		$tax_report = reset( $reports );
 
 		$this->assertEquals( 1, $tax_report['tax_codes'] );
-		$this->assertEquals( 16, $tax_report['total_tax'] );
-		$this->assertEquals( 13, $tax_report['order_tax'] );
-		$this->assertEquals( 3, $tax_report['shipping_tax'] );
-		$this->assertEquals( 2, $tax_report['orders_count'] );
+		$this->assertEquals( 7.7, $tax_report['total_tax'] );
+		$this->assertEquals( 7, $tax_report['order_tax'] );
+		$this->assertEquals( 0.7, $tax_report['shipping_tax'] );
+		$this->assertEquals( 1, $tax_report['orders_count'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1449 

Adjusts the tax amounts when an order is refunded or when a refund is deleted.

### Screenshots
<img width="931" alt="screen shot 2019-02-14 at 1 49 58 pm" src="https://user-images.githubusercontent.com/10561050/52765629-a339a080-305f-11e9-9b6f-0634443b1cbe.png">
<img width="498" alt="screen shot 2019-02-14 at 1 51 09 pm" src="https://user-images.githubusercontent.com/10561050/52765627-a2a10a00-305f-11e9-84a7-3d521c35e001.png">

### Detailed test instructions:

1.  Make an order that is taxed and has shipping that is taxed.
2.  Refund a partial amount of tax on the product line item and on the shipping line item.
3.  Check that taxes are correctly updated to reflect the refunded amounts.
4.  Delete the refund from the order page.
5.  Check that the original tax amounts are once again shown.