### PR TITLE
Move IE11 specific CSS to ie.scss file

### DIFF
--- a/packages/components/src/ie.scss
+++ b/packages/components/src/ie.scss
@@ -1,5 +1,6 @@
 /**
  * Internal Dependencies
  */
+@import 'segmented-selection/ie.scss';
 @import 'summary/ie.scss';
 @import 'table/ie.scss';

--- a/packages/components/src/segmented-selection/ie.scss
+++ b/packages/components/src/segmented-selection/ie.scss
@@ -1,0 +1,5 @@
+/** @format */
+
+.woocommerce-segmented-selection__item {
+	@include set-grid-item-position( 2, 10 );
+}

--- a/packages/components/src/segmented-selection/style.scss
+++ b/packages/components/src/segmented-selection/style.scss
@@ -15,9 +15,6 @@
 }
 
 .woocommerce-segmented-selection__item {
-	display: block;
-	@include set-grid-item-position( 2, 10 );
-
 	&:nth-child(2n) {
 		border-left: 1px solid $core-grey-light-700;
 		border-top: 1px solid $core-grey-light-700;


### PR DESCRIPTION
This is a follow-up of #1547.

This declaration:

```SCSS
@include set-grid-item-position( 2, 10 );
```

is only required in IE and it generates 90 lines of CSS. I expected it to be more, but still, I think it's not a bad idea to have it in a specific IE file.

Also, I think this declaration is not needed:

```SCSS
display: block;
```

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/52782445-5f3e9f80-304f-11e9-844f-c7fef1882baf.png)

### Detailed test instructions:
* Go to any date related report, such as Products.
* Open the Datepicker and verify borders are still visible and there are no regressions.