### PR TITLE
Fix logic used to show legend total block

### DIFF
--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -61,7 +61,7 @@ class D3Legend extends Component {
 		} = this.props;
 		const { isScrollable } = this.state;
 		const numberOfRowsVisible = data.filter( row => row.visible ).length;
-		const showTotalLabel = legendDirection === 'column' && data.length > numberOfRowsVisible && totalLabel;
+		const showTotalLabel = legendDirection === 'column' && data.length > selectionLimit && totalLabel;
 
 		const visibleKeys = data.filter( key => key.visible );
 


### PR DESCRIPTION
Fixes #1531

Avoids the legend total block appearing in wrong occasions.

### Screenshots
_Before:_
![legend-total-1](https://user-images.githubusercontent.com/3616980/52784346-1db0f300-3055-11e9-9d1f-c7e15b7d6a61.gif)

_After:_
![legend-total-2](https://user-images.githubusercontent.com/3616980/52784348-1ee22000-3055-11e9-8960-c9e58573c5bb.gif)


### Detailed test instructions:
* Go to the _Products_ report.
* Resize the viewport so the legend appears at the bottom of the chart.
* Unselect one item.
* Verify a total box **doesn't appear** below the legend.
* Select _Top Products by Items Sold_ as the filter.
* Verify a total box **does appear** below the legend.