### PR TITLE
Stop Hello Dolly lyrics from displaying in the notices tab

### DIFF
--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -135,6 +135,11 @@ class WordPressNotices extends Component {
 		if ( 'message' === element.id && 'updated' === element.className ) {
 			return false;
 		}
+
+		if ( 'dolly' === element.id ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -137,6 +137,7 @@ class WordPressNotices extends Component {
 		}
 
 		if ( 'dolly' === element.id ) {
+			element.style.display = 'none';
 			return false;
 		}
 

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -116,32 +116,38 @@ class WordPressNotices extends Component {
 
 	// Some messages should not be displayed in the toggle, like Jetpack JITM messages or update/success messages
 	shouldCollapseNotice( element ) {
-		if ( element.classList.contains( 'jetpack-jitm-message' ) ) {
-			return false;
-		}
+		const noticesToHide = [
+			[ null, [ 'jetpack-jitm-message' ] ], // ID and/or array of classes
+			[ 'woocommerce_errors', null ],
+			[ null, [ 'hidden' ] ],
+			[ 'message', [ 'notice', 'updated' ] ],
+			[ 'dolly', null ],
+		];
 
-		if ( 'woocommerce_errors' === element.id ) {
-			return false;
-		}
+		let collapse = true;
+		for ( let i = 0; collapse && i < noticesToHide.length; i++ ) {
+			const [ id, classes ] = noticesToHide[ i ];
 
-		if ( element.classList.contains( 'hidden' ) ) {
-			return false;
-		}
-
-		if ( 'message' === element.id && element.classList.contains( 'notice' ) ) {
-			return false;
-		}
-
-		if ( 'message' === element.id && 'updated' === element.className ) {
-			return false;
+			if ( Array.isArray( classes ) ) {
+				for ( let j = 0; j < classes.length; j++ ) {
+					if (
+						element.classList.contains( classes[ j ] ) &&
+						( ! id || ( id && id === element.id ) )
+					) {
+						collapse = false;
+						break;
+					}
+				}
+			} else if ( id && id === element.id ) {
+				collapse = false;
+			}
 		}
 
 		if ( 'dolly' === element.id ) {
 			element.style.display = 'none';
-			return false;
 		}
 
-		return true;
+		return collapse;
 	}
 
 	updateCount() {

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -121,7 +121,6 @@ class WordPressNotices extends Component {
 			[ 'woocommerce_errors', null ],
 			[ null, [ 'hidden' ] ],
 			[ 'message', [ 'notice', 'updated' ] ],
-			[ 'dolly', null ],
 		];
 
 		let collapse = true;
@@ -141,10 +140,6 @@ class WordPressNotices extends Component {
 			} else if ( id && id === element.id ) {
 				collapse = false;
 			}
-		}
-
-		if ( 'dolly' === element.id ) {
-			element.style.display = 'none';
 		}
 
 		return collapse;

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -278,6 +278,21 @@ function wc_admin_admin_body_class( $admin_body_class = '' ) {
 add_filter( 'admin_body_class', 'wc_admin_admin_body_class' );
 
 /**
+ * Removes notices that should not be displayed on WC Admin pages.
+ */
+function wc_admin_remove_notices() {
+	if ( ! wc_admin_is_admin_page() && ! wc_admin_is_embed_enabled_wc_page() ) {
+		return;
+	}
+
+	// Hello Dolly.
+	if ( function_exists( 'hello_dolly' ) ) {
+		remove_action( 'admin_notices', 'hello_dolly' );
+	}
+}
+add_action( 'admin_head', 'wc_admin_remove_notices' );
+
+/**
  * Runs before admin notices action and hides them.
  */
 function wc_admin_admin_before_notices() {


### PR DESCRIPTION
Fixes #1429

Blacklists the Hello Dolly lyrics from showing up in the notices tab by targeting the `#dolly` id.

However, stopping the notice from displaying in the tab creates a few different issues:

<img width="1455" alt="screenshot 2019-02-14 at 15 41 13" src="https://user-images.githubusercontent.com/1177726/52798012-febf5a80-306e-11e9-86ff-f58cabbf10c3.png">

<img width="1464" alt="screenshot 2019-02-14 at 15 42 01" src="https://user-images.githubusercontent.com/1177726/52798061-1b5b9280-306f-11e9-8e96-e8cfa0d38186.png">

My suggestion would be to hide the lyrics, but that kinda defeats the purpose of moving them to the uncollapsed area.

Any other suggestions? :) @timmyc 

### Detailed test instructions:

- Install Hello Dolly
- Check if lyrics show up in as a Notice

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
