### PR TITLE
Remove margin between chart legends in column direction

### DIFF
--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -138,11 +138,11 @@
 	}
 
 	.woocommerce-legend__direction-column & {
-		margin: 2px 0;
+		margin: 0;
 		padding: 0;
 
 		& > button {
-			height: 32px;
+			height: 36px;
 			padding: 0 17px;
 		}
 


### PR DESCRIPTION
Fixes #1402 

Remove gap between legends to improve transition between multiple chart entries. Notice the flashing switching from legend to legend in the "Before" gif.

Before:

![1402_before](https://user-images.githubusercontent.com/1177726/52802003-eeab7900-3076-11e9-887c-c4f7f241d8d8.gif)

After:

![1402_after](https://user-images.githubusercontent.com/1177726/52802044-0420a300-3077-11e9-9b21-f86a01272401.gif)

### Detailed test instructions:

- Go to wc-admin#/analytics/products?type=line&filter=compare-products
- Hover the legends