### PR TITLE
Chart legend: show pointer in all clickable area

### DIFF
--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -57,6 +57,7 @@
 		align-items: center;
 		background-color: $white;
 		color: $core-grey-dark-500;
+		cursor: pointer;
 		display: inline-flex;
 		flex-direction: row;
 		flex-wrap: nowrap;
@@ -72,7 +73,6 @@
 			justify-content: space-between;
 			position: relative;
 			padding: 3px 0 3px 24px;
-			cursor: pointer;
 			font-size: 13px;
 			user-select: none;
 			width: 100%;


### PR DESCRIPTION
Noticed that when reviewing #1563.

Some clickable areas of the chart legend items don't show the pointer icon (see screenshots).

### Screenshots
_Before:_
![click-legend-01](https://user-images.githubusercontent.com/3616980/52806093-6df57880-3088-11e9-9d65-54472dc922b1.gif)

_After:_
![click-legend-02](https://user-images.githubusercontent.com/3616980/52806092-6df57880-3088-11e9-95da-387b4e5d8421.gif)

### Detailed test instructions:
- Go to any report with a chart.
- Hover the legend elements.
- Verify the pointer icon is shown when hovering any part of the clickable area.