### PR TITLE
Add margin to advanced filters Add button

### DIFF
--- a/packages/components/src/filters/advanced/style.scss
+++ b/packages/components/src/filters/advanced/style.scss
@@ -151,6 +151,7 @@
 
 	svg {
 		fill: currentColor;
+		margin: 0 6px 0 0;
 	}
 
 	&.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {


### PR DESCRIPTION
Fixes #1568 

Adds margin between the icon and the text in the "Add a Filter" button.

Before:

<img width="299" alt="screenshot 2019-02-14 at 17 51 14" src="https://user-images.githubusercontent.com/1177726/52808366-9c258900-3085-11e9-8b6d-cd6c0213ab08.png">

After:

<img width="300" alt="screenshot 2019-02-14 at 18 24 07" src="https://user-images.githubusercontent.com/1177726/52808406-bc554800-3085-11e9-98b0-0efa91d71072.png">

### Detailed test instructions

* Open any report with advanced filters
* Note the styling of the 'Add a filter' button