### PR TITLE
Phpcs sniff fixes for unit tests

### DIFF
--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -129,7 +129,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	public function test_get_warning_notes() {
 		wp_set_current_user( $this->user );
 
-		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'type' => 'warning' ) );
 		$response = $this->server->dispatch( $request );
 		$notes    = $response->get_data();

--- a/tests/api/product-reviews.php
+++ b/tests/api/product-reviews.php
@@ -23,7 +23,7 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 
-		$this->user     = $this->factory->user->create(
+		$this->user = $this->factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
@@ -35,7 +35,7 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_product_review_embed() {
 		wp_set_current_user( $this->user );
-		$product    = WC_Helper_Product::create_simple_product();
+		$product = WC_Helper_Product::create_simple_product();
 		WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v4/products/reviews' );

--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -23,7 +23,7 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 
-		$this->user     = $this->factory->user->create(
+		$this->user = $this->factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
@@ -52,7 +52,7 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 		);
 
 		foreach ( $properties as $property_key => $property ) {
-			if ( in_array( $property_key, $properties_to_embed ) ) {
+			if ( in_array( $property_key, $properties_to_embed, true ) ) {
 				$this->assertEquals( array( 'view', 'edit', 'embed' ), $property['context'] );
 			}
 		}

--- a/tests/api/reports-customers-stats.php
+++ b/tests/api/reports-customers-stats.php
@@ -40,7 +40,7 @@ class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
 	 *
 	 * @since 3.5.0
 	 */
-	public function _test_register_routes() {
+	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
 		$this->assertArrayHasKey( $this->endpoint, $routes );
@@ -156,8 +156,8 @@ class WC_Tests_API_Reports_Customers_Stats extends WC_REST_Unit_Test_Case {
 		// Test name and last_order parameters.
 		$request->set_query_params(
 			array(
-				'search'             => 'Jeff',
-				'last_order_after'   => date( 'Y-m-d' ) . 'T00:00:00Z',
+				'search'           => 'Jeff',
+				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -136,7 +136,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending();
 
-		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
 				'per_page' => 5,
@@ -175,8 +175,8 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Test name and last_order parameters.
 		$request->set_query_params(
 			array(
-				'search'             => 'Justin',
-				'last_order_after'   => date( 'Y-m-d' ) . 'T00:00:00Z',
+				'search'           => 'Justin',
+				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -77,7 +77,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		$object->set_user_ip_address( '1.2.3.4' );
 		$id = $object->save();
 
-		$time = time();
+		$time    = time();
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(

--- a/tests/api/reports-interval.php
+++ b/tests/api/reports-interval.php
@@ -847,9 +847,9 @@ class WC_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 		$params   = array( 'a', 'b', 'c', 'd' );
 		$result   = WC_Admin_Reports_Interval::normalize_between_params( $request, $params, true );
 		$expected = array(
-			'b_after' => 1,
+			'b_after'  => 1,
 			'b_before' => 5,
-			'c_after' => 2,
+			'c_after'  => 2,
 			'c_before' => 4,
 		);
 

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -61,7 +61,8 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $reports ) ); // totals and intervals.
-		// $this->assertEquals( array(), $reports ); // @todo Update results after implement report interface.
+		// @todo Update results after implement report interface.
+		// $this->assertEquals( array(), $reports ); // @codingStandardsIgnoreLine.
 	}
 
 	/**

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -86,13 +86,13 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 
 		WC_Helper_Queue::run_all_pending();
 
-		$time = time();
+		$time    = time();
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'before'   => date( 'Y-m-d 23:59:59', $time ),
-				'after'    => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
-				'stats' => 'orders/orders_count,downloads/download_count,test/bogus_stat',
+				'before' => date( 'Y-m-d 23:59:59', $time ),
+				'after'  => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
+				'stats'  => 'orders/orders_count,downloads/download_count,test/bogus_stat',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -126,8 +126,8 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'before'   => date( 'Y-m-d 23:59:59', $time ),
-				'after'    => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
+				'before' => date( 'Y-m-d 23:59:59', $time ),
+				'after'  => date( 'Y-m-d H:00:00', $time - ( 7 * DAY_IN_SECONDS ) ),
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/reports-stock-stats.php
+++ b/tests/api/reports-stock-stats.php
@@ -74,7 +74,7 @@ class WC_Tests_API_Reports_Stock_Stats extends WC_REST_Unit_Test_Case {
 			$in_stock->save();
 		}
 
-		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
 		$reports  = $response->get_data();
 
@@ -94,7 +94,7 @@ class WC_Tests_API_Reports_Stock_Stats extends WC_REST_Unit_Test_Case {
 		$backorder_stock->set_stock_status( 'onbackorder' );
 		$backorder_stock->save();
 
-		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
 		$reports  = $response->get_data();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -116,7 +116,7 @@ require_once dirname( __FILE__ ) . '/framework/helpers/class-wc-helper-queue.php
  * This matches how we mock the flags in jest.
  */
 function wc_admin_get_feature_config() {
-	$config = json_decode( file_get_contents( dirname( dirname( __FILE__ ) ) . '/config/development.json' ) );
+	$config = json_decode( file_get_contents( dirname( dirname( __FILE__ ) ) . '/config/development.json' ) ); // @codingStandardsIgnoreLine.
 	$flags  = array();
 	foreach ( $config->features as $feature => $bool ) {
 		$flags[ $feature ] = $bool;

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -100,7 +100,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		);
 
 		// Test retrieving the stats from the data store.
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $args ) ), true ) );
 
 		// Test retrieving the stats through the query class.
 		$query          = new WC_Admin_Reports_Orders_Stats_Query( $args );
@@ -141,7 +141,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $query->get_data() ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $query->get_data() ), true ) );
 	}
 
 	/**
@@ -239,7 +239,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $args ) ), true ) );
 
 		// Query an excluded status which should still return orders with the queried status.
 		$args           = array(
@@ -294,7 +294,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $args ) ), true ) );
 	}
 
 	/**
@@ -573,7 +573,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// * Order status filter
 		// ** Status is, positive filter for 2 statuses, i.e. all orders.
@@ -587,7 +587,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is, positive filter for 1 status -> half orders.
 		$query_args = array(
@@ -662,7 +662,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is not, negative filter for 1 status -> half orders.
 		$query_args = array(
@@ -737,7 +737,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is not, negative filter for 2 statuses -> no orders.
 		$query_args = array(
@@ -795,7 +795,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is + Status is not, positive filter for 2 statuses, negative for 1 -> half of orders.
 		$query_args = array(
@@ -874,7 +874,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// * Product filter
 		// ** Product includes, positive filter for 2 products, i.e. 2 orders out of 3.
@@ -949,7 +949,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product includes, positive filter for 1 product, 1/3 of orders
 		$query_args = array(
@@ -1021,7 +1021,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product excludes, negative filter for 1 product, 2/3 of orders.
 		$query_args = array(
@@ -1094,7 +1094,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product excludes, negative filter for 2 products, 1/3 of orders
 		$query_args = array(
@@ -1166,7 +1166,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product includes + product excludes, positive filter for 2 products, negative for 1 -> 1/3 of orders, only orders with product 2 and product 2 + product 4
 		$query_args = array(
@@ -1241,7 +1241,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// * Coupon filters
 		// ** Coupon includes, positive filter for 2 coupons, i.e. 2/3 of orders.
@@ -1318,7 +1318,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon includes, positive filter for 1 coupon, 1/3 of orders
 		$query_args = array(
@@ -1392,7 +1392,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon excludes, negative filter for 1 coupon, 2/3 of orders
 		$query_args = array(
@@ -1466,7 +1466,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon excludes, negative filter for 2 coupons, 1/3 of orders
 		$query_args = array(
@@ -1542,7 +1542,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon includes + coupon excludes, positive filter for 2 coupon, negative for 1, 1/3 orders
 		$query_args = array(
@@ -1621,7 +1621,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// * Customer filters
 		// ** Customer new
@@ -1684,7 +1684,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ** Customer returning
 		$query_args = array(
@@ -1759,7 +1759,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query};" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query};" );
 
 		// Combinations: match all
 		// status_is + product_includes.
@@ -1834,7 +1834,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + coupon_includes.
 		$query_args = array(
@@ -1912,7 +1912,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// product_includes + coupon_includes.
 		$query_args = array(
@@ -1986,7 +1986,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + product_includes + coupon_includes.
 		$query_args = array(
@@ -2063,7 +2063,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes.
 		$query_args = array(
@@ -2144,7 +2144,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes.
 		$query_args = array(
@@ -2226,7 +2226,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes + coupon_includes.
 		$query_args = array(
@@ -2310,7 +2310,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes + coupon_includes + coupon_excludes.
 		$query_args = array(
@@ -2398,7 +2398,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Combinations: match any
 		// status_is + status_is_not, all orders.
@@ -2478,7 +2478,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR product_includes.
 		$query_args = array(
@@ -2557,7 +2557,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR coupon_includes.
 		$query_args = array(
@@ -2636,7 +2636,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR coupon_excludes.
 		$query_args = array(
@@ -2715,7 +2715,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// product_includes OR coupon_includes.
 		$query_args = array(
@@ -2794,7 +2794,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR product_includes OR coupon_includes.
 		$query_args = array(
@@ -2876,7 +2876,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes.
 		$query_args = array(
@@ -2961,7 +2961,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes.
 		$query_args = array(
@@ -3046,7 +3046,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes.
 		$query_args = array(
@@ -3134,7 +3134,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes OR coupon_excludes.
 		$query_args = array(
@@ -3225,7 +3225,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 	}
 
@@ -3558,7 +3558,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 					array(
 						'segment_id'    => $product_1->get_id(),
 						'segment_label' => $product_1->get_name(),
-						'subtotals'  => array(
+						'subtotals'     => array(
 							'orders_count'            => $p1_orders_count,
 							'num_items_sold'          => $p1_num_items_sold,
 							'gross_revenue'           => $p1_gross_revenue,
@@ -3576,7 +3576,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 					array(
 						'segment_id'    => $product_2->get_id(),
 						'segment_label' => $product_2->get_name(),
-						'subtotals'  => array(
+						'subtotals'     => array(
 							'orders_count'            => $p2_orders_count,
 							'num_items_sold'          => $p2_num_items_sold,
 							'gross_revenue'           => $p2_gross_revenue,
@@ -3594,7 +3594,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 					array(
 						'segment_id'    => $product_3->get_id(),
 						'segment_label' => $product_3->get_name(),
-						'subtotals'  => array(
+						'subtotals'     => array(
 							'orders_count'            => 0,
 							'num_items_sold'          => 0,
 							'gross_revenue'           => 0,
@@ -3635,7 +3635,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 							array(
 								'segment_id'    => $product_1->get_id(),
 								'segment_label' => $product_1->get_name(),
-								'subtotals'  => array(
+								'subtotals'     => array(
 									'orders_count'        => $i3_p1_orders_count,
 									'num_items_sold'      => $i3_p1_num_items_sold,
 									'gross_revenue'       => $i3_p1_gross_revenue,
@@ -3651,9 +3651,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_2->get_id(),
-								'segment_label'  => $product_2->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_2->get_id(),
+								'segment_label' => $product_2->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => $i3_p2_orders_count,
 									'num_items_sold'      => $i3_p2_num_items_sold,
 									'gross_revenue'       => $i3_p2_gross_revenue,
@@ -3669,9 +3669,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_3->get_id(),
-								'segment_label'  => $product_3->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_3->get_id(),
+								'segment_label' => $product_3->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
 									'gross_revenue'       => 0,
@@ -3710,9 +3710,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'num_new_customers'       => $i2_tot_new_customers,
 						'segments'                => array(
 							array(
-								'segment_id'     => $product_1->get_id(),
-								'segment_label'  => $product_1->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_1->get_id(),
+								'segment_label' => $product_1->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => $i2_p1_orders_count,
 									'num_items_sold'      => $i2_p1_num_items_sold,
 									'gross_revenue'       => $i2_p1_gross_revenue,
@@ -3728,9 +3728,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_2->get_id(),
-								'segment_label'  => $product_2->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_2->get_id(),
+								'segment_label' => $product_2->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => $i2_p2_orders_count,
 									'num_items_sold'      => $i2_p2_num_items_sold,
 									'gross_revenue'       => $i2_p2_gross_revenue,
@@ -3746,9 +3746,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_3->get_id(),
-								'segment_label'  => $product_3->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_3->get_id(),
+								'segment_label' => $product_3->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
 									'gross_revenue'       => 0,
@@ -3787,9 +3787,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 						'num_new_customers'       => 0,
 						'segments'                => array(
 							array(
-								'segment_id'     => $product_1->get_id(),
-								'segment_label'  => $product_1->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_1->get_id(),
+								'segment_label' => $product_1->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
 									'gross_revenue'       => 0,
@@ -3805,9 +3805,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_2->get_id(),
-								'segment_label'  => $product_2->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_2->get_id(),
+								'segment_label' => $product_2->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
 									'gross_revenue'       => 0,
@@ -3823,9 +3823,9 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 								),
 							),
 							array(
-								'segment_id'     => $product_3->get_id(),
-								'segment_label'  => $product_3->get_name(),
-								'subtotals'  => array(
+								'segment_id'    => $product_3->get_id(),
+								'segment_label' => $product_3->get_name(),
+								'subtotals'     => array(
 									'orders_count'        => 0,
 									'num_items_sold'      => 0,
 									'gross_revenue'       => 0,
@@ -3848,7 +3848,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$actual         = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Segmenting by product, expected: ' . print_r( $expected_stats, true ) . '; actual: ' . print_r( $actual, true ) );
 	}
 
@@ -4049,7 +4049,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- only 1 interval, so should be the same.
 		$query_args = array(
@@ -4059,7 +4059,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'orderby'  => 'date',
 			'order'    => 'asc',
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-5 hours, now] -- partial 1 page.
@@ -4093,7 +4093,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = 0; $i < $interval_count; $i ++ ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_5_hours;
 				$date_end   = new DateTime( $minus_5_hours->format( 'Y-m-d H:59:59' ) );
@@ -4186,11 +4186,11 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- reverse the intervals array, but numbers stay the same.
-		$query_args = array(
+		$query_args                  = array(
 			'after'    => $minus_5_hours->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'before'   => $current_hour_end->format( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'interval' => 'hour',
@@ -4199,7 +4199,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		);
 		$expected_stats['intervals'] = array_reverse( $expected_stats['intervals'] );
 
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
@@ -4231,7 +4231,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = 0; $i < $interval_count; $i ++ ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_9_hours;
 				$date_end   = new DateTime( $minus_9_hours->format( 'Y-m-d H:59:59' ) );
@@ -4325,7 +4325,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- same values, just reverse order of intervals.
 		$query_args = array(
@@ -4338,7 +4338,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		$expected_stats['intervals'] = array_reverse( $expected_stats['intervals'] );
 
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
@@ -4380,7 +4380,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = 0; $i < $interval_count; $i ++ ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_10_hours;
 				$date_end   = new DateTime( $minus_10_hours->format( 'Y-m-d H:59:59' ) );
@@ -4474,7 +4474,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -4509,7 +4509,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -4563,7 +4563,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -4599,7 +4599,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Now the same should be done for days, weeks, months and years. But I'm too low on mana to do that.
 	}
@@ -4684,8 +4684,8 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$order[1]['hour']  = (int) $order_1_datetime->format( 'H' );
 
 		// 2 orders within 1 hour before now to test multiple orders within one time interval.
-		$order_2_time = $order_3_time;
-		$order_during_this_['hour-1']  = array( 2, 3 );
+		$order_2_time                 = $order_3_time;
+		$order_during_this_['hour-1'] = array( 2, 3 );
 
 		// In case some of the orders end up on different day/hour/month/year, we need to find out where exactly they ended up.
 		foreach ( array( 3, 4, 5, 6, 7 ) as $order_no ) {
@@ -4812,7 +4812,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- only 1 interval, so should be the same.
@@ -4823,7 +4823,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'orderby'  => 'orders_count',
 			'order'    => 'asc',
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-5 hours, now] -- partial 1 page.
@@ -4856,7 +4856,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = $interval_count - 1; $i >= 0; $i -- ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_5_hours;
 				$date_end   = new DateTime( $minus_5_hours->format( 'Y-m-d H:59:59' ) );
@@ -4932,7 +4932,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		 * This means we need to put last two to the beginning of the array.
 		 */
 		$to_be_second = array_pop( $expected_intervals );
-		$to_be_first = array_pop( $expected_intervals );
+		$to_be_first  = array_pop( $expected_intervals );
 		array_unshift( $expected_intervals, $to_be_second );
 		array_unshift( $expected_intervals, $to_be_first );
 
@@ -4966,7 +4966,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
@@ -4980,7 +4980,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		 *  - [5] => 0 orders, hour - 5
 		 * so we need to revert first two and put them at the bottom of the array.
 		 */
-		$to_be_last = array_shift( $expected_stats['intervals'] );
+		$to_be_last        = array_shift( $expected_stats['intervals'] );
 		$to_be_second_last = array_shift( $expected_stats['intervals'] );
 		array_push( $expected_stats['intervals'], $to_be_second_last );
 		array_push( $expected_stats['intervals'], $to_be_last );
@@ -4993,7 +4993,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'order'    => 'asc',
 		);
 
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
@@ -5031,7 +5031,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = $interval_count - 1; $i >= 0; $i -- ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_9_hours;
 				$date_end   = new DateTime( $minus_9_hours->format( 'Y-m-d H:59:59' ) );
@@ -5129,7 +5129,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * ASC ordering -- same values, different intervals order.
@@ -5157,7 +5157,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'order'    => 'asc',
 		);
 
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
@@ -5198,7 +5198,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		for ( $i = $interval_count - 1; $i >= 0; $i -- ) {
 			if ( 0 === $i ) {
 				$date_start = new DateTime( $current_hour_end->format( 'Y-m-d H:00:00' ) );
-				$date_end = $current_hour_end;
+				$date_end   = $current_hour_end;
 			} elseif ( $hour_offset === $i ) {
 				$date_start = $minus_10_hours;
 				$date_end   = new DateTime( $minus_10_hours->format( 'Y-m-d H:59:59' ) );
@@ -5210,21 +5210,21 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			}
 
 			if ( 0 === $i ) {
-				$orders_count   = count( $order_during_this_['hour'] );
-				$num_items_sold = $orders_count * $qty_per_product;
-				$coupons        = 0;
-				$shipping       = $orders_count * 10;
-				$net_revenue    = $product_price * $qty_per_product * $orders_count - $coupons;
-				$gross_revenue  = $net_revenue + $shipping;
-				$returning_customers  = 1;
+				$orders_count        = count( $order_during_this_['hour'] );
+				$num_items_sold      = $orders_count * $qty_per_product;
+				$coupons             = 0;
+				$shipping            = $orders_count * 10;
+				$net_revenue         = $product_price * $qty_per_product * $orders_count - $coupons;
+				$gross_revenue       = $net_revenue + $shipping;
+				$returning_customers = 1;
 			} elseif ( 1 === $i ) {
-				$orders_count   = count( $order_during_this_['hour-1'] );
-				$num_items_sold = $orders_count * $qty_per_product;
-				$coupons        = 0;
-				$shipping       = $orders_count * 10;
-				$net_revenue    = $product_price * $qty_per_product * $orders_count - $coupons;
-				$gross_revenue  = $net_revenue + $shipping;
-				$returning_customers  = 1;
+				$orders_count        = count( $order_during_this_['hour-1'] );
+				$num_items_sold      = $orders_count * $qty_per_product;
+				$coupons             = 0;
+				$shipping            = $orders_count * 10;
+				$net_revenue         = $product_price * $qty_per_product * $orders_count - $coupons;
+				$gross_revenue       = $net_revenue + $shipping;
+				$returning_customers = 1;
 			} else {
 				$orders_count        = 0;
 				$num_items_sold      = $orders_count * $qty_per_product;
@@ -5295,7 +5295,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 2,
 			'page_no'   => 1,
 		);
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
@@ -5330,7 +5330,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 2,
 			'page_no'   => 2,
 		);
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -5385,7 +5385,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$actual = json_decode( json_encode( $data_store->get_data( $query_args ) ), true );
+		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
 		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
@@ -5422,6 +5422,6 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
 	}
 }

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -573,7 +573,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// * Order status filter
 		// ** Status is, positive filter for 2 statuses, i.e. all orders.
@@ -587,7 +587,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is, positive filter for 1 status -> half orders.
 		$query_args = array(
@@ -662,7 +662,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is not, negative filter for 1 status -> half orders.
 		$query_args = array(
@@ -737,7 +737,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is not, negative filter for 2 statuses -> no orders.
 		$query_args = array(
@@ -795,7 +795,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Status is + Status is not, positive filter for 2 statuses, negative for 1 -> half of orders.
 		$query_args = array(
@@ -874,7 +874,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// * Product filter
 		// ** Product includes, positive filter for 2 products, i.e. 2 orders out of 3.
@@ -949,7 +949,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product includes, positive filter for 1 product, 1/3 of orders
 		$query_args = array(
@@ -1021,7 +1021,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product excludes, negative filter for 1 product, 2/3 of orders.
 		$query_args = array(
@@ -1094,7 +1094,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product excludes, negative filter for 2 products, 1/3 of orders
 		$query_args = array(
@@ -1166,7 +1166,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Product includes + product excludes, positive filter for 2 products, negative for 1 -> 1/3 of orders, only orders with product 2 and product 2 + product 4
 		$query_args = array(
@@ -1241,7 +1241,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// * Coupon filters
 		// ** Coupon includes, positive filter for 2 coupons, i.e. 2/3 of orders.
@@ -1318,7 +1318,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon includes, positive filter for 1 coupon, 1/3 of orders
 		$query_args = array(
@@ -1392,7 +1392,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon excludes, negative filter for 1 coupon, 2/3 of orders
 		$query_args = array(
@@ -1466,7 +1466,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon excludes, negative filter for 2 coupons, 1/3 of orders
 		$query_args = array(
@@ -1542,7 +1542,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Coupon includes + coupon excludes, positive filter for 2 coupon, negative for 1, 1/3 orders
 		$query_args = array(
@@ -1621,7 +1621,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// * Customer filters
 		// ** Customer new
@@ -1684,7 +1684,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ** Customer returning
 		$query_args = array(
@@ -1759,7 +1759,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query};" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query};" );
 
 		// Combinations: match all
 		// status_is + product_includes.
@@ -1834,7 +1834,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + coupon_includes.
 		$query_args = array(
@@ -1912,7 +1912,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// product_includes + coupon_includes.
 		$query_args = array(
@@ -1986,7 +1986,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + product_includes + coupon_includes.
 		$query_args = array(
@@ -2063,7 +2063,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes.
 		$query_args = array(
@@ -2144,7 +2144,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes.
 		$query_args = array(
@@ -2226,7 +2226,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes + coupon_includes.
 		$query_args = array(
@@ -2310,7 +2310,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is + status_is_not + product_includes + product_excludes + coupon_includes + coupon_excludes.
 		$query_args = array(
@@ -2398,7 +2398,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Combinations: match any
 		// status_is + status_is_not, all orders.
@@ -2478,7 +2478,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR product_includes.
 		$query_args = array(
@@ -2557,7 +2557,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR coupon_includes.
 		$query_args = array(
@@ -2636,7 +2636,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR coupon_excludes.
 		$query_args = array(
@@ -2715,7 +2715,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// product_includes OR coupon_includes.
 		$query_args = array(
@@ -2794,7 +2794,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR product_includes OR coupon_includes.
 		$query_args = array(
@@ -2876,7 +2876,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes.
 		$query_args = array(
@@ -2961,7 +2961,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes.
 		$query_args = array(
@@ -3046,7 +3046,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes.
 		$query_args = array(
@@ -3134,7 +3134,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// status_is OR status_is_not OR product_includes OR product_excludes OR coupon_includes OR coupon_excludes.
 		$query_args = array(
@@ -3225,7 +3225,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 	}
 
@@ -3849,7 +3849,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Segmenting by product, expected: ' . print_r( $expected_stats, true ) . '; actual: ' . print_r( $actual, true ) );
+		$this->assertEquals( $expected_stats, $actual, 'Segmenting by product, expected: ' . $this->return_print_r( $expected_stats ) . '; actual: ' . $this->return_print_r( $actual ) );
 	}
 
 	/**
@@ -4049,7 +4049,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 1,
 			'page_no'   => 1,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- only 1 interval, so should be the same.
 		$query_args = array(
@@ -4059,7 +4059,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'orderby'  => 'date',
 			'order'    => 'asc',
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-5 hours, now] -- partial 1 page.
@@ -4187,7 +4187,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- reverse the intervals array, but numbers stay the same.
 		$query_args                  = array(
@@ -4200,7 +4200,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$expected_stats['intervals'] = array_reverse( $expected_stats['intervals'] );
 
 		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-9 hours, now] -- full 1 page.
@@ -4325,7 +4325,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- same values, just reverse order of intervals.
 		$query_args = array(
@@ -4339,7 +4339,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$expected_stats['intervals'] = array_reverse( $expected_stats['intervals'] );
 
 		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -4474,7 +4474,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -4509,7 +4509,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -4563,7 +4563,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -4599,7 +4599,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Now the same should be done for days, weeks, months and years. But I'm too low on mana to do that.
 	}
@@ -4813,7 +4813,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// ASC -- only 1 interval, so should be the same.
 		$query_args = array(
@@ -4823,7 +4823,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'orderby'  => 'orders_count',
 			'order'    => 'asc',
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-5 hours, now] -- partial 1 page.
@@ -4967,7 +4967,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * 5 hour time window, ASC ordering -- numbers stay the same, but first include zero intervals in asc order, then the rest.
@@ -4994,7 +4994,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		);
 
 		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-9 hours, now] -- full 1 page.
@@ -5129,7 +5129,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * ASC ordering -- same values, different intervals order.
@@ -5158,7 +5158,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		);
 
 		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -5296,7 +5296,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$actual         = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -5330,7 +5330,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'pages'     => 2,
 			'page_no'   => 2,
 		);
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		/*
 		 * Test for [-10 hours, now] -- 1 page full, 1 interval on 2nd page.
@@ -5386,7 +5386,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		);
 
 		$actual = json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true );
-		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, $actual, 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
 
 		// Page 2.
 		$query_args = array(
@@ -5422,6 +5422,19 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 2,
 		);
 
-		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . print_r( $query_args, true ) . "; query: {$wpdb->last_query}" );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $query_args ) ), true ), 'Query args: ' . $this->return_print_r( $query_args ) . "; query: {$wpdb->last_query}" );
+	}
+
+	/**
+	 * Pass input variable through print_r.
+	 *
+	 * @since 3.5.4
+	 * @param  string|array|object $data Variable data to be passed through print_r.
+	 * @return string
+	 */
+	private function return_print_r( $data ) {
+		// @codingStandardsIgnoreStart
+		return print_r( $data, true );
+		// @codingStandardsIgnoreEnd
 	}
 }

--- a/tests/reports/class-wc-tests-reports-revenue-stats.php
+++ b/tests/reports/class-wc-tests-reports-revenue-stats.php
@@ -97,7 +97,7 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 		);
 
 		// Test retrieving the stats from the data store.
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $data_store->get_data( $args ) ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $data_store->get_data( $args ) ), true ) );
 
 		// Test retrieving the stats through the query class.
 		$expected_stats = array(
@@ -138,6 +138,6 @@ class WC_Admin_Tests_Reports_Revenue_Stats extends WC_Unit_Test_Case {
 			'page_no'   => 1,
 		);
 		$query          = new WC_Admin_Reports_Revenue_Query( $args );
-		$this->assertEquals( $expected_stats, json_decode( json_encode( $query->get_data() ), true ) );
+		$this->assertEquals( $expected_stats, json_decode( wp_json_encode( $query->get_data() ), true ) );
 	}
 }


### PR DESCRIPTION
See #675

This has phpcs fixes only. There are several hundred phpcs warnings/errors so I'll approach this with multiple PRs to minimize merge conflicts with other PRs/WIP.

This PR fixes all the sniffs in the `/tests/` folder. The only code change is to replace all the uses of `print_r` with a private function.

### Detailed test instructions:

- If this passes Travis CI testing then it should be good to merge 

