### PR TITLE
Taxes Report: fix comparison mode and segmentation labels

### DIFF
--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -4,6 +4,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -20,22 +21,46 @@ import ReportSummary from 'analytics/components/report-summary';
 import TaxesReportTable from './table';
 
 export default class TaxesReport extends Component {
+	getChartMeta() {
+		const { query } = this.props;
+		const isCompareTaxView = 'compare-taxes' === query.filter;
+		const mode = isCompareTaxView ? 'item-comparison' : 'time-comparison';
+		const itemsLabel = __( '%d taxes', 'wc-admin' );
+
+		return {
+			itemsLabel,
+			mode,
+		};
+	}
+
 	render() {
 		const { query, path } = this.props;
+		const { mode, itemsLabel } = this.getChartMeta();
+
+		const chartQuery = {
+			...query,
+		};
+
+		if ( 'item-comparison' === mode ) {
+			chartQuery.segmentby = 'tax_rate_id';
+		}
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
 					charts={ charts }
 					endpoint="taxes"
-					query={ query }
+					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
+					filters={ filters }
 					charts={ charts }
+					mode={ mode }
 					endpoint="taxes"
+					query={ chartQuery }
 					path={ path }
-					query={ query }
+					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<TaxesReportTable query={ query } />

--- a/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-stats-data-store.php
@@ -103,6 +103,30 @@ class WC_Admin_Reports_Taxes_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 	}
 
 	/**
+	 * Get taxes associated with a store.
+	 *
+	 * @param array $args Array of args to filter the query by. Supports `include`.
+	 * @return array An array of all taxes.
+	 */
+	public static function get_taxes( $args ) {
+		global $wpdb;
+		$query = "
+			SELECT 
+				tax_rate_id, 
+				tax_rate_country, 
+				tax_rate_state, 
+				tax_rate_name, 
+				tax_rate_priority 
+			FROM {$wpdb->prefix}woocommerce_tax_rates
+		";
+		if ( ! empty( $args['include'] ) ) {
+			$included_taxes = implode( ',', $args['include'] );
+			$query .= " WHERE tax_rate_id IN ({$included_taxes})";
+		}
+		return $wpdb->get_results( $query, ARRAY_A ); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+	}
+
+	/**
 	 * Returns the report data based on parameters supplied by the user.
 	 *
 	 * @param array $query_args  Query parameters.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1554

When a user selects "Comparison" in the Taxes Report, change the chart mode to `item-comparison` and include `?segmentby=tax_rate_id` in the API request. Also, construct the labels correctly in the segments portion of the response. 

### Detailed test instructions:

1. Taxes Report.
2. See the chart appear as `time-comparison` for two periods (selected, previous).
2. Show > Comparison.
3. See the chart in `item-comparison` mode.
4. Check that labels in the chart match those found on the table.
