### PR TITLE
Update activity panels order endpoint

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -64,7 +64,8 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 	);
 
 	const getCustomerString = order => {
-		const { first_name, last_name } = order.extended_info.customer;
+		const extended_info = order.extended_info || {};
+		const { first_name, last_name } = extended_info.customer || {};
 
 		if ( ! first_name && ! last_name ) {
 			return '';
@@ -84,6 +85,9 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 	};
 
 	const orderCardTitle = order => {
+		const { extended_info, order_id } = order;
+		const { customer } = extended_info || {};
+
 		return (
 			<Fragment>
 				{ interpolateComponents( {
@@ -93,16 +97,14 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 							'wc-admin'
 						),
 						{
-							orderNumber: order.order_id,
+							orderNumber: order_id,
 							customerString: getCustomerString( order ),
 						}
 					),
 					components: {
-						orderLink: (
-							<Link href={ 'post.php?action=edit&post=' + order.order_id } type="wp-admin" />
-						),
-						destinationFlag: order.extended_info.customer.country ? (
-							<Flag code={ order.extended_info.customer.country } round={ false } />
+						orderLink: <Link href={ 'post.php?action=edit&post=' + order_id } type="wp-admin" />,
+						destinationFlag: customer.country ? (
+							<Flag code={ customer.country } round={ false } />
 						) : null,
 						// @todo Hook up customer name link
 						customerLink: <Link href={ '#' } type="wp-admin" />,
@@ -114,7 +116,9 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 
 	const cards = [];
 	orders.forEach( order => {
-		const productsCount = order.extended_info.products.length;
+		const extended_info = order.extended_info || {};
+		const productsCount =
+			extended_info && extended_info.products ? extended_info.products.length : 0;
 
 		const total = order.gross_total;
 		const refundValue = order.refund_total;

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -196,7 +196,7 @@ export default compose(
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
-			status_is: 'processing',
+			status_is: [ 'processing', 'on-hold' ],
 			extended_info: true,
 		};
 

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -24,7 +24,7 @@ import {
 	Section,
 } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getAdminLink, getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -87,6 +87,12 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 	const orderCardTitle = order => {
 		const { extended_info, order_id } = order;
 		const { customer } = extended_info || {};
+		const customerUrl = customer.customer_id
+			? getNewPath( {}, '/analytics/customers', {
+					filter: 'single_customer',
+					customer_id: customer.customer_id,
+				} )
+			: null;
 
 		return (
 			<Fragment>
@@ -106,8 +112,7 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 						destinationFlag: customer.country ? (
 							<Flag code={ customer.country } round={ false } />
 						) : null,
-						// @todo Hook up customer name link
-						customerLink: <Link href={ '#' } type="wp-admin" />,
+						customerLink: customerUrl ? <Link href={ customerUrl } type="wc-admin" /> : <span />,
 					},
 				} ) }
 			</Fragment>

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -30,6 +30,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		'status'         => 'strval',
 		'customer_id'    => 'intval',
 		'net_total'      => 'floatval',
+		'gross_total'    => 'floatval',
+		'refund_total'   => 'floatval',
 		'num_items_sold' => 'intval',
 		'customer_type'  => 'strval',
 	);
@@ -45,6 +47,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		'status'         => 'REPLACE(status, "wc-", "") as status',
 		'customer_id'    => 'customer_id',
 		'net_total'      => 'net_total',
+		'gross_total'    => 'gross_total',
+		'refund_total'   => 'refund_total',
 		'num_items_sold' => 'num_items_sold',
 		'customer_type'  => '(CASE WHEN returning_customer <> 0 THEN "returning" ELSE "new" END) as customer_type',
 	);

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -242,6 +242,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		$mapped_products    = $this->map_array_by_key( $products, 'product_id' );
 		$coupons            = $this->get_coupons_by_order_ids( array_keys( $mapped_orders ) );
 		$product_categories = $this->get_product_categories_by_product_ids( array_keys( $mapped_products ) );
+		$customers          = $this->get_customers_by_orders( $orders_data );
+		$mapped_customers   = $this->map_array_by_key( $customers, 'customer_id' );
 
 		$mapped_data = array();
 		foreach ( $products as $product ) {
@@ -279,8 +281,12 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				'products'   => array(),
 				'categories' => array(),
 				'coupons'    => array(),
+				'customer'   => array(),
 			);
 			$orders_data[ $key ]['extended_info'] = isset( $mapped_data[ $order_data['order_id'] ] ) ? array_merge( $defaults, $mapped_data[ $order_data['order_id'] ] ) : $defaults;
+			if ( $order_data['customer_id'] && isset( $mapped_customers[ $order_data['customer_id'] ] ) ) {
+				$orders_data[ $key ]['extended_info']['customer'] = $mapped_customers[ $order_data['customer_id'] ];
+			}
 		}
 	}
 
@@ -321,6 +327,32 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 		return $products;
+	}
+
+	/**
+	 * Get customer data from order IDs.
+	 *
+	 * @param array $orders Array of orders.
+	 * @return array
+	 */
+	protected function get_customers_by_orders( $orders ) {
+		global $wpdb;
+		$customer_lookup_table = $wpdb->prefix . 'wc_customer_lookup';
+
+		$customer_ids = array();
+		foreach ( $orders as $order ) {
+			if ( $order['customer_id'] ) {
+				$customer_ids[] = $order['customer_id'];
+			}
+		}
+		$customer_ids = implode( ',', $customer_ids );
+
+		$customers = $wpdb->get_results(
+			"SELECT * FROM {$customer_lookup_table} WHERE customer_id IN ({$customer_ids})",
+			ARRAY_A
+		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+		return $customers;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1428 

* Hooks up the orders activity panel to use the data from `wc_order_stats` for better performance and so that we can later grab user profile information indirectly from the `wc_customer_lookup` table.
* Allows nameless customers in the activity panel
* Adds customer data to the extended info in the orders API response

### Screenshots
<img width="514" alt="screen shot 2019-02-15 at 2 42 44 pm" src="https://user-images.githubusercontent.com/10561050/52839324-b1a3bd00-3130-11e9-9ec6-eda9d14c5163.png">

### Detailed test instructions:

1.  Check that orders display correctly still in the activity panel.
2.  Install the checkout field editor plugin and set name fields to optional.
3. Create an order with a nameless customer.
4. Note that the `placed by {customer_name}` string does not appear for customers without names.