### PR TITLE
Execute single order pending jobs immediately when wp_debug is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ There are also some helper scripts:
  - `npm run i18n` : A multi-step process, used to create a pot file from both the JS and PHP gettext calls. First it runs `i18n:js`, which creates a temporary `.pot` file from the JS files. Next it runs `i18n:php`, which converts that `.pot` file to a PHP file. Lastly, it runs `i18n:pot`, which creates the final `.pot` file from all the PHP files in the plugin (including the generated one with the JS strings).
  - `npm test` : Run the JS test suite
 
- To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_scheduling` hook.
+ To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_order_scheduling` hook.
 
-`add_filter( 'woocommerce_disable_scheduling', '__return_true' );`
+`add_filter( 'woocommerce_disable_order_scheduling', '__return_true' );`
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ There are also some helper scripts:
  - `npm run i18n` : A multi-step process, used to create a pot file from both the JS and PHP gettext calls. First it runs `i18n:js`, which creates a temporary `.pot` file from the JS files. Next it runs `i18n:php`, which converts that `.pot` file to a PHP file. Lastly, it runs `i18n:pot`, which creates the final `.pot` file from all the PHP files in the plugin (including the generated one with the JS strings).
  - `npm test` : Run the JS test suite
 
+ To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_scheduling` hook.
+
+`add_filter( 'woocommerce_disable_scheduling', '__return_true' );`
+
 ## Privacy
 
 If you have enabled WooCommerce usage tracking ( option `woocommerce_allow_tracking` ) then, in addition to the tracking described in https://woocommerce.com/usage-tracking/, this plugin also sends information about the actions that site administrators perform to Automattic - see https://automattic.com/privacy/#information-we-collect-automatically for more information.

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -412,7 +412,7 @@ class WC_Admin_Reports_Sync {
 	 * Execute jobs immediately when debugging.
 	 */
 	public static function execute_jobs_in_debug_mode() {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		if ( apply_filters( 'woocommerce_disable_scheduling', false ) ) {
 			$jobs = self::queue()->search(
 				array(
 					'per_page' => -1,

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -132,7 +132,7 @@ class WC_Admin_Reports_Sync {
 			return;
 		}
 
-		if ( apply_filters( 'woocommerce_disable_scheduling', false ) ) {
+		if ( apply_filters( 'woocommerce_disable_order_scheduling', false ) ) {
 			self::orders_lookup_process_order( $order_id );
 			return;
 		}

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -220,7 +220,7 @@ class WC_Admin_Reports_Sync {
 				'order'   => 'ASC',
 			)
 		);
-		$order_ids = $order_query->get_orders();
+		$order_ids   = $order_query->get_orders();
 
 		foreach ( $order_ids as $order_id ) {
 			self::orders_lookup_process_order( $order_id );
@@ -421,8 +421,11 @@ class WC_Admin_Reports_Sync {
 				)
 			);
 
+			// Only run single orders to avoid processing large batches.
 			foreach ( $jobs as $job ) {
-				$job->execute();
+				if ( self::SINGLE_ORDER_ACTION === $job->get_hook() ) {
+					$job->execute();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1580 

Executes any single order pending jobs immediately to avoid the delay in order syncing when developing.

**Questions**
* Does this cause any issues for debugging the action scheduler itself?  My hunch is no, but want to make sure.

### Detailed test instructions:

1.  Save/update an order.
2.  Note the order is immediately updated.
3.  Run the rebuild tool at WooCommerce->Status->Tools->Rebuild Reports.
4.  Make sure the rebuild is not processed right away and is handled in the background.