### PR TITLE
Fix double focus on autocomplete search list after options are loaded

### DIFF
--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -44,6 +44,7 @@ function filterOptions( search, options = [], exclude = [], maxResults = 10 ) {
 export class Autocomplete extends Component {
 	static getInitialState() {
 		return {
+			isFocused: false,
 			search: /./,
 			selectedIndex: 0,
 			query: undefined,
@@ -156,7 +157,7 @@ export class Autocomplete extends Component {
 		const promise = ( this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( optionsData => {
-			if ( ! optionsData ) {
+			if ( ! optionsData || ! this.state.isFocused ) {
 				return;
 			}
 			const { selected } = this.props;
@@ -209,7 +210,7 @@ export class Autocomplete extends Component {
 		// filter the options we already have
 		const filteredOptions = filterOptions( search, this.state.options, selected );
 		// update the state
-		this.setState( { selectedIndex: 0, filteredOptions, search, query } );
+		this.setState( { isFocused: true, selectedIndex: 0, filteredOptions, search, query } );
 		// announce the count of filtered options but only if they have loaded
 		if ( this.state.options ) {
 			this.announce( filteredOptions );
@@ -275,7 +276,13 @@ export class Autocomplete extends Component {
 	}
 
 	isExpanded( props, state ) {
-		return state.filteredOptions.length > 0 || ( props.completer.getFreeTextOptions && state.query );
+		const { filteredOptions, isFocused, query } = state;
+
+		if ( ! isFocused ) {
+			return false;
+		}
+
+		return filteredOptions.length > 0 || ( props.completer.getFreeTextOptions && query );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {

--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -44,7 +44,6 @@ function filterOptions( search, options = [], exclude = [], maxResults = 10 ) {
 export class Autocomplete extends Component {
 	static getInitialState() {
 		return {
-			isFocused: false,
 			search: /./,
 			selectedIndex: 0,
 			query: undefined,
@@ -157,7 +156,7 @@ export class Autocomplete extends Component {
 		const promise = ( this.activePromise = Promise.resolve(
 			typeof options === 'function' ? options( query ) : options
 		).then( optionsData => {
-			if ( ! optionsData || ! this.state.isFocused ) {
+			if ( ! optionsData || ! this.state.query ) {
 				return;
 			}
 			const { selected } = this.props;
@@ -210,7 +209,7 @@ export class Autocomplete extends Component {
 		// filter the options we already have
 		const filteredOptions = filterOptions( search, this.state.options, selected );
 		// update the state
-		this.setState( { isFocused: true, selectedIndex: 0, filteredOptions, search, query } );
+		this.setState( { selectedIndex: 0, filteredOptions, search, query } );
 		// announce the count of filtered options but only if they have loaded
 		if ( this.state.options ) {
 			this.announce( filteredOptions );
@@ -276,11 +275,7 @@ export class Autocomplete extends Component {
 	}
 
 	isExpanded( props, state ) {
-		const { filteredOptions, isFocused, query } = state;
-
-		if ( ! isFocused ) {
-			return false;
-		}
+		const { filteredOptions, query } = state;
 
 		return filteredOptions.length > 0 || ( props.completer.getFreeTextOptions && query );
 	}

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -10,6 +10,13 @@
 		fill: $core-grey-light-900;
 	}
 
+	.woocommerce-tag {
+		max-width: 100%;
+	}
+	.woocommerce-tag .woocommerce-tag__text {
+		max-width: calc(100% - 24px);
+	}
+
 	&:not(.has-inline-tags) {
 		.woocommerce-tag {
 			margin: 8px 6px 0 0;

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -10,13 +10,6 @@
 		fill: $core-grey-light-900;
 	}
 
-	.woocommerce-tag {
-		max-width: 100%;
-	}
-	.woocommerce-tag .woocommerce-tag__text {
-		max-width: calc(100% - 24px);
-	}
-
 	&:not(.has-inline-tags) {
 		.woocommerce-tag {
 			margin: 8px 6px 0 0;


### PR DESCRIPTION
Fixes #1576 

Adds `isFocused` to state to prevent re-opening the options list after options are loaded asynchronously.

### Screenshots
![feb-15-2019 17-30-24](https://user-images.githubusercontent.com/10561050/52847595-97290e00-3147-11e9-8b2b-a5ff79b3b6db.gif)

### Detailed test instructions:

1.  Type in a search in the Customers table search box.
2.  Quickly select an option for autocomplete options are loaded asynchronously.
3.  Note that the list does not re-open.