### PR TITLE
Fix variation name format to match core

### DIFF
--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -84,7 +84,7 @@ export default class VariationsReportTable extends Component {
 		return map( data, row => {
 			const { items_sold, net_revenue, orders_count, extended_info, product_id } = row;
 			const { stock_status, stock_quantity, low_stock_amount, sku } = extended_info;
-			const name = get( row, [ 'extended_info', 'name' ], '' ).replace( ' - ', ' / ' );
+			const name = get( row, [ 'extended_info', 'name' ], '' );
 			const ordersLink = getNewPath( persistedQuery, 'orders', {
 				filter: 'advanced',
 				product_includes: query.products,

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -67,11 +67,9 @@ export default class StockReportTable extends Component {
 				products: parent_id || id,
 			} );
 
-			const formattedName = name.replace( ' - ', ' / ' );
-
 			const nameLink = (
 				<Link href={ productDetailLink } type="wc-admin">
-					{ formattedName }
+					{ name }
 				</Link>
 			);
 
@@ -84,7 +82,7 @@ export default class StockReportTable extends Component {
 			return [
 				{
 					display: nameLink,
-					value: formattedName,
+					value: name,
 				},
 				{
 					display: sku,


### PR DESCRIPTION
We were replacing `-` with ` / ` in variation names, but not consistently in all places. This PR removes the replacement, which matches how the variations are presented on other pages like the order pages.

Before:

<img width="1331" alt="screen shot 2019-02-15 at 8 45 01 am" src="https://user-images.githubusercontent.com/689165/52860740-4b9e4200-30fe-11e9-90db-48418e326908.png">

After:

<img width="704" alt="screen shot 2019-02-15 at 8 58 51 am" src="https://user-images.githubusercontent.com/689165/52861391-5528a980-3100-11e9-93de-6c36c2eabf29.png">

<img width="1038" alt="screen shot 2019-02-15 at 9 02 27 am" src="https://user-images.githubusercontent.com/689165/52861431-6ffb1e00-3100-11e9-80ee-ff5d7c4d2879.png">


To Test:
* View a variation and check the title.