### PR TITLE
Fix product category report views

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -36,7 +36,7 @@ export const charts = [
 export const filters = [
 	{
 		label: __( 'Show', 'wc-admin' ),
-		staticParams: [ 'chart' ],
+		staticParams: [],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [
@@ -83,13 +83,13 @@ export const filters = [
 				label: __( 'Top Categories by Items Sold', 'wc-admin' ),
 				value: 'top_items',
 				chartMode: 'item-comparison',
-				query: { orderby: 'items_sold', order: 'desc' },
+				query: { orderby: 'items_sold', order: 'desc', chart: 'items_sold' },
 			},
 			{
 				label: __( 'Top Categories by Net Revenue', 'wc-admin' ),
 				value: 'top_revenue',
 				chartMode: 'item-comparison',
-				query: { orderby: 'net_revenue', order: 'desc' },
+				query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
 			},
 		],
 	},

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -23,14 +23,11 @@ import ReportSummary from 'analytics/components/report-summary';
 export default class CategoriesReport extends Component {
 	getChartMeta() {
 		const { query } = this.props;
-		const isCategoryDetailsView =
-			'top_items' === query.filter ||
-			'top_revenue' === query.filter ||
-			'compare-categories' === query.filter;
 
-		const isSingleCategoryView = query.categories && 1 === query.categories.split( ',' ).length;
-		const mode =
-			isCategoryDetailsView || isSingleCategoryView ? 'item-comparison' : 'time-comparison';
+		const isCategoryDetailsView = [ 'top_items', 'top_revenue', 'compare-categories' ].includes(
+			query.filter
+		);
+		const mode = isCategoryDetailsView ? 'item-comparison' : 'time-comparison';
 		const itemsLabel = __( '%d categories', 'wc-admin' );
 
 		return {

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -28,10 +28,13 @@ class ProductsReport extends Component {
 	getChartMeta() {
 		const { query, isSingleProductView, isSingleProductVariable } = this.props;
 
-		const isProductDetailsView =
-			'top_items' === query.filter ||
-			'top_sales' === query.filter ||
-			'compare-products' === query.filter;
+		const isProductDetailsView = [
+			'top_items',
+			'top_sales',
+			'compare-products',
+			'single_category',
+			'compare-categories',
+		].includes( query.filter );
 
 		const mode =
 			isProductDetailsView || ( isSingleProductView && isSingleProductVariable )


### PR DESCRIPTION
Fixes #1585.

This PR views the following views:

* Products > Compare Categories. `item-comparison` mode is now used.
* Products > Single Product Category. `item-comparison` mode is now used.
* Categories > Single Category. `time-comparison` mode is now used.
* Top Categories by Items Sold now displays the correct chart / ordering.
* Top Categories by Net Revenue now displays the correct chart / ordering.

### Screenshots

Products > Compare Categories

<img width="1323" alt="screen shot 2019-02-15 at 9 45 01 am" src="https://user-images.githubusercontent.com/689165/52863619-62e12d80-3106-11e9-8ece-82a5a9817bf9.png">

Products > Single Product Category

<img width="1331" alt="screen shot 2019-02-15 at 9 41 38 am" src="https://user-images.githubusercontent.com/689165/52863466-f36b3e00-3105-11e9-9e6b-db11efedf530.png">

Categories > Single Category

<img width="1319" alt="screen shot 2019-02-15 at 9 46 05 am" src="https://user-images.githubusercontent.com/689165/52863718-902ddb80-3106-11e9-9e3b-b930e7b39364.png">

### Detailed test instructions:

* Make sure you have some products assigned to categories.
* Test out the views mentioned above.