### PR TITLE
update missed version `or greater` in update message

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -35,7 +35,7 @@ function wc_admin_plugins_notice() {
 	if ( $wordpress_includes_gutenberg ) {
 		$message = sprintf(
 			/* translators: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> (>3.5) to be installed and active.', 'wc-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> 3.5 or greater to be installed and active.', 'wc-admin' ),
 			'https://wordpress.org/plugins/woocommerce/'
 		);
 	} else {


### PR DESCRIPTION
Fixes #

This was a missed text change on #1521. For consistency update `(>3.5)` to `3.5 or greater`. 

