### PR TITLE
Fix long search tags

### DIFF
--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -2,6 +2,11 @@
 
 .woocommerce-search {
 	position: relative;
+	min-width: 0;
+
+	>div {
+		min-width: 0;
+	}
 
 	.woocommerce-search__icon {
 		position: absolute;

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -10,6 +10,14 @@
 		fill: $core-grey-light-900;
 	}
 
+	.woocommerce-tag {
+		max-width: 100%;
+	}
+
+	.woocommerce-tag .woocommerce-tag__text {
+		max-width: calc( 100% - 24px );
+	}
+
 	&:not(.has-inline-tags) {
 		.woocommerce-tag {
 			margin: 8px 6px 0 0;
@@ -25,7 +33,7 @@
 
 	.woocommerce-search__inline-container {
 		width: 100%;
-		padding: 4px 2px 4px 36px;
+		padding: 4px 36px 4px;
 		border: 1px solid $core-grey-light-700;
 		background-color: $white;
 		display: flex;
@@ -38,6 +46,7 @@
 		}
 
 		.woocommerce-search__token-list {
+			max-width: 100%;
 			display: inline-block;
 			padding: 1px 0;
 		}

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	.woocommerce-tag .woocommerce-tag__text {
-		max-width: calc( 100% - 24px );
+		max-width: calc(100% - 24px);
 	}
 
 	&:not(.has-inline-tags) {


### PR DESCRIPTION
Fixes #1575

In narrow viewports, this cuts off long tags to use only ellipsis.

### Screenshots
<img width="489" alt="screen shot 2019-02-18 at 3 46 24 pm" src="https://user-images.githubusercontent.com/10561050/52935531-a0f38100-3394-11e9-9083-f6402ba6ea42.png">
<img width="400" alt="screen shot 2019-02-18 at 3 49 02 pm" src="https://user-images.githubusercontent.com/10561050/52935574-ba94c880-3394-11e9-9d7c-68d24ac2e6cd.png">

### Detailed test instructions:

1.  Create a really unnecessarily long, lengthy, elongated, protracted, stretched out, and never-ending product name.
2.  Narrow your viewport 📱 
3.  Check the advanced filters and add the newly created product name to make sure it is cut off with an ellipsis and that the remove button is still visible.
4.  Check an inline search (top of products table) to make sure the tag is also visible here and that the remove all button is not overlapped.

@LevinMedia @josemarques Is the Gutenberg-way of using ellipsis okay here?  Or do we want to not limit the height of tags and show the full name?