### PR TITLE
Don't show variations table when there is an active search

### DIFF
--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -130,7 +130,8 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { query } = props;
 		const { getItems, isGetItemsRequesting, getItemsError } = select( 'wc-api' );
-		const isSingleProductView = query.products && 1 === query.products.split( ',' ).length;
+		const isSingleProductView =
+			! query.search && query.products && 1 === query.products.split( ',' ).length;
 		if ( isSingleProductView ) {
 			const productId = parseInt( query.products );
 			const includeArgs = { include: productId };


### PR DESCRIPTION
When searching for a variable product in the table search, we don't want to change the autocompleter neither the table rows from products to variations. This PR fixes that.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/52940997-257bda80-3368-11e9-8f4c-6ac8e88e1bf3.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/52940961-0f6e1a00-3368-11e9-8f61-2c4073b4f7ae.png)

### Detailed test instructions:
- Go to the _Products_ report.
- Search for a product that you know is variable.
- Verify the table is still showing products instead of variations (the easiest way is to check the first column header is `Product Title` instead of `Product / Variation Title`).
