### PR TITLE
Change fixed legend button height to min-height

### DIFF
--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -142,8 +142,9 @@
 		padding: 0;
 
 		& > button {
-			height: 36px;
+			min-height: 36px;
 			padding: 0 17px;
+			text-align: left;
 		}
 
 		&:first-child {


### PR DESCRIPTION
Fixes #1573 

Sets a minimum height instead of fixed for legend buttons and left-aligns the text.

### Before
<img width="353" alt="screen shot 2019-02-18 at 5 55 32 pm" src="https://user-images.githubusercontent.com/10561050/52942793-a6f25d80-33a6-11e9-8fc2-23f57630a15c.png">

### After
<img width="409" alt="screen shot 2019-02-18 at 5 54 32 pm" src="https://user-images.githubusercontent.com/10561050/52942790-a5289a00-33a6-11e9-8cc9-eaf58a05d8c0.png">

### Detailed test instructions:

1.  Add a really long product name.
2.  Use the advanced filter to compare multiple products, including the long-name product.
3.  Check that the product name is legible and doesn't overlap other columns.