### PR TITLE
Escape commas in search terms

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -145,15 +145,22 @@ export default compose(
 		}
 
 		const { report } = props.params;
-		const items = searchItemsByString( select, report, search );
+		const searchWords = search.split( ',' ).map( searchWord => searchWord.replace( '%2C', ',' ) );
+		const items = searchItemsByString( select, report, searchWords );
 		const ids = Object.keys( items );
 		if ( ! ids.length ) {
-			return {};
+			return {
+				query: {
+					...props.query,
+					search: searchWords,
+				},
+			};
 		}
 
 		return {
 			query: {
 				...props.query,
+				search: searchWords,
 				[ report ]: ids.join( ',' ),
 			},
 		};

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -7,17 +7,16 @@
 /**
  * Returns items based on a search query.
  *
- * @param  {Object} select    Instance of @wordpress/select
- * @param  {String} endpoint  Report API Endpoint
- * @param  {String} search    Search strings separated by commas.
- * @return {Object} Object    Object containing the matching items.
+ * @param  {Object}   select    Instance of @wordpress/select
+ * @param  {String}   endpoint  Report API Endpoint
+ * @param  {String[]} search    Array of search strings.
+ * @return {Object}   Object containing the matching items.
  */
 export function searchItemsByString( select, endpoint, search ) {
 	const { getItems } = select( 'wc-api' );
-	const searchWords = search.split( ',' );
 
 	const items = {};
-	searchWords.forEach( searchWord => {
+	search.forEach( searchWord => {
 		const newItems = getItems( endpoint, {
 			search: searchWord,
 			per_page: 10,

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -161,7 +161,9 @@ class TableCard extends Component {
 
 	onSearch( values ) {
 		const { compareParam } = this.props;
-		const labels = values.map( v => v.label );
+		// A comma is used as a separator between search terms, so we want to escape
+		// any comma they contain.
+		const labels = values.map( v => v.label.replace( ',', '%2C' ) );
 		if ( labels.length ) {
 			updateQueryString( {
 				filter: undefined,
@@ -252,8 +254,7 @@ class TableCard extends Component {
 			totalRows,
 		} = this.props;
 		const { selectedRows, showCols } = this.state;
-		const searchedValues = query.search ? query.search.split( ',' ) : [];
-		const searchedLabels = searchedValues.map( v => ( { id: v, label: v } ) );
+		const searchedLabels = Array.isArray( query.search ) ? query.search.map( v => ( { id: v, label: v } ) ) : [];
 		const allHeaders = this.props.headers;
 		let headers = this.getVisibleHeaders();
 		let rows = this.getVisibleRows();


### PR DESCRIPTION
Fixes #1598.

This PR allows searching for product names that contain a comma.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/52967363-26356080-33aa-11e9-98f6-1f32368ca0fd.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/52967316-000fc080-33aa-11e9-8f4a-19f1f7542f29.png)

### Detailed test instructions:
- Create a product with a comma in its name.
- Go to the _Products_ report.
- Search for it in the table search input.
- Verify it appears in one single tag.