### PR TITLE
Preserve chart colors when changing visible keys in charts with less keys than 'selectionLimit'

### DIFF
--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -30,6 +30,7 @@ import { drawBars } from './utils/bar-chart';
 import { drawLines } from './utils/line-chart';
 import { getColor } from './utils/color';
 import ChartTooltip from './utils/tooltip';
+import { selectionLimit } from '../constants';
 
 /**
  * A simple D3 line and bar chart component for timeseries data in React.
@@ -83,7 +84,7 @@ class D3Chart extends Component {
 		const { chartType, colorScheme, data, interval, mode, orderedKeys } = this.props;
 		const newOrderedKeys = orderedKeys || getOrderedKeys( data );
 		const visibleKeys = newOrderedKeys.filter( key => key.visible );
-		const colorKeys = mode === 'time-comparison' ? newOrderedKeys : visibleKeys;
+		const colorKeys = newOrderedKeys.length > selectionLimit ? visibleKeys : newOrderedKeys;
 
 		return {
 			getColor: getColor( colorKeys, colorScheme ),

--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -57,14 +57,14 @@ class D3Legend extends Component {
 			interactive,
 			legendDirection,
 			legendValueFormat,
-			mode,
 			totalLabel,
 		} = this.props;
 		const { isScrollable } = this.state;
-		const numberOfRowsVisible = data.filter( row => row.visible ).length;
+		const visibleData = data.filter( key => key.visible );
+		const numberOfRowsVisible = visibleData.length;
 		const showTotalLabel = legendDirection === 'column' && data.length > selectionLimit && totalLabel;
 
-		const keys = mode === 'time-comparison' ? data : data.filter( key => key.visible );
+		const keys = data.length > selectionLimit ? visibleData : data;
 
 		return (
 			<div

--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -57,13 +57,14 @@ class D3Legend extends Component {
 			interactive,
 			legendDirection,
 			legendValueFormat,
+			mode,
 			totalLabel,
 		} = this.props;
 		const { isScrollable } = this.state;
 		const numberOfRowsVisible = data.filter( row => row.visible ).length;
 		const showTotalLabel = legendDirection === 'column' && data.length > selectionLimit && totalLabel;
 
-		const visibleKeys = data.filter( key => key.visible );
+		const keys = mode === 'time-comparison' ? data : data.filter( key => key.visible );
 
 		return (
 			<div
@@ -113,7 +114,7 @@ class D3Legend extends Component {
 											'woocommerce-legend__item-checkmark-checked': row.visible,
 										} ) }
 										id={ row.key }
-										style={ { color: getColor( row.key, visibleKeys, colorScheme ) } }
+										style={ { color: getColor( keys, colorScheme )( row.key ) } }
 									/>
 									<span className="woocommerce-legend__item-title" id={ row.key }>
 										{ row.key }

--- a/packages/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/components/src/chart/d3chart/utils/bar-chart.js
@@ -7,11 +7,6 @@ import { get } from 'lodash';
 import { event as d3Event } from 'd3-selection';
 import moment from 'moment';
 
-/**
- * Internal dependencies
- */
-import { getColor } from './color';
-
 export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 	const height = scales.yScale.range()[ 0 ];
 	const barGroup = node
@@ -64,7 +59,7 @@ export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 		.attr( 'y', d => scales.yScale( d.value ) )
 		.attr( 'width', scales.xGroupScale.bandwidth() )
 		.attr( 'height', d => height - scales.yScale( d.value ) )
-		.attr( 'fill', d => getColor( d.key, params.visibleKeys, params.colorScheme ) )
+		.attr( 'fill', d => params.getColor( d.key ) )
 		.attr( 'pointer-events', 'none' )
 		.attr( 'tabindex', '0' )
 		.attr( 'aria-label', d => {

--- a/packages/components/src/chart/d3chart/utils/color.js
+++ b/packages/components/src/chart/d3chart/utils/color.js
@@ -10,7 +10,7 @@ import { colorScales, selectionLimit } from '../../constants';
  */
 import { findIndex } from 'lodash';
 
-export const getColor = ( key, orderedKeys, colorScheme ) => {
+export const getColor = ( orderedKeys, colorScheme ) => key => {
 	const len = orderedKeys.length > selectionLimit ? selectionLimit : orderedKeys.length;
 	const idx = findIndex( orderedKeys, d => d.key === key );
 	const keyValue = idx <= ( selectionLimit - 1 ) ? colorScales[ len ][ idx ] : 0;

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -11,7 +11,6 @@ import { first, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getColor } from './color';
 import { smallBreak, wideBreak } from './breakpoints';
 
 /**
@@ -112,7 +111,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'stroke-width', lineStroke )
 			.attr( 'stroke-linejoin', 'round' )
 			.attr( 'stroke-linecap', 'round' )
-			.attr( 'stroke', d => getColor( d.key, params.visibleKeys, params.colorScheme ) )
+			.attr( 'stroke', d => params.getColor( d.key ) )
 			.style( 'opacity', d => {
 				const opacity = d.focus ? 1 : 0.1;
 				return d.visible ? opacity : 0;
@@ -128,7 +127,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.enter()
 			.append( 'circle' )
 			.attr( 'r', dotRadius )
-			.attr( 'fill', d => getColor( d.key, params.visibleKeys, params.colorScheme ) )
+			.attr( 'fill', d => params.getColor( d.key ) )
 			.attr( 'stroke', '#fff' )
 			.attr( 'stroke-width', lineStroke + 1 )
 			.style( 'opacity', d => {
@@ -176,7 +175,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 		.enter()
 		.append( 'circle' )
 		.attr( 'r', dotRadius + 2 )
-		.attr( 'fill', d => getColor( d.key, params.visibleKeys, params.colorScheme ) )
+		.attr( 'fill', d => params.getColor( d.key ) )
 		.attr( 'stroke', '#fff' )
 		.attr( 'stroke-width', lineStroke + 2 )
 		.attr( 'cx', d => scales.xScale( moment( d.date ).toDate() ) )

--- a/packages/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/components/src/chart/d3chart/utils/tooltip.js
@@ -6,11 +6,6 @@
 import { select as d3Select } from 'd3-selection';
 import moment from 'moment';
 
-/**
- * Internal dependencies
- */
-import { getColor } from './color';
-
 class ChartTooltip {
 	constructor() {
 		this.ref = null;
@@ -20,7 +15,7 @@ class ChartTooltip {
 		this.labelFormat = '';
 		this.valueFormat = '';
 		this.visibleKeys = '';
-		this.colorScheme = null;
+		this.getColor = null;
 		this.margin = 24;
 	}
 
@@ -128,7 +123,7 @@ class ChartTooltip {
 						<div class="key-container">
 							<span
 								class="key-color"
-								style="background-color: ${ getColor( row.key, this.visibleKeys, this.colorScheme ) }">
+								style="background-color: ${ this.getColor( row.key ) }">
 							</span>
 							<span class="key-key">${ this.getTooltipRowLabel( d, row ) }</span>
 						</div>

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -267,6 +267,7 @@ class Chart extends Component {
 		const { interactiveLegend, orderedKeys, visibleData, width } = this.state;
 		const {
 			baseValue,
+			chartType,
 			dateParser,
 			emptyMessage,
 			interval,
@@ -279,7 +280,6 @@ class Chart extends Component {
 			tooltipLabelFormat,
 			tooltipValueFormat,
 			tooltipTitle,
-			chartType,
 			valueType,
 			xFormat,
 			x2Format,
@@ -300,7 +300,6 @@ class Chart extends Component {
 				interactive={ interactiveLegend }
 				legendDirection={ legendDirection }
 				legendValueFormat={ tooltipValueFormat }
-				mode={ mode }
 				totalLabel={ sprintf( itemsLabel, orderedKeys.length ) }
 			/>
 		);

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -300,6 +300,7 @@ class Chart extends Component {
 				interactive={ interactiveLegend }
 				legendDirection={ legendDirection }
 				legendValueFormat={ tooltipValueFormat }
+				mode={ mode }
 				totalLabel={ sprintf( itemsLabel, orderedKeys.length ) }
 			/>
 		);
@@ -379,6 +380,7 @@ class Chart extends Component {
 							width > 0 && (
 								<D3Chart
 									baseValue={ baseValue }
+									chartType={ chartType }
 									colorScheme={ d3InterpolateViridis }
 									data={ visibleData }
 									dateParser={ dateParser }
@@ -392,7 +394,6 @@ class Chart extends Component {
 									tooltipValueFormat={ tooltipValueFormat }
 									tooltipPosition={ isViewportLarge ? 'over' : 'below' }
 									tooltipTitle={ tooltipTitle }
-									chartType={ chartType }
 									width={ chartDirection === 'row' ? width - 320 : width }
 									xFormat={ xFormat }
 									x2Format={ x2Format }


### PR DESCRIPTION
Fixes #1604.

Avoids lines/bars changing its color when one legend item is deactivated in `time-comparison` charts.

### Screenshots
_Before:_
![chart-colors](https://user-images.githubusercontent.com/3616980/52949874-d17bf080-337d-11e9-862b-780460601b5f.gif)

_After:_
![chart-colors-](https://user-images.githubusercontent.com/3616980/52970689-1111ff00-33b5-11e9-81a4-d7e650f1a042.gif)

### Detailed test instructions:
* Go to the _Products_ report.
* Deactivate a chart legend item.
* Verify the active item didn't change its color.
