### PR TITLE
Fix customer filters and download user filtering

### DIFF
--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -66,7 +66,7 @@ export const advancedFilters = {
 				getLabels: getProductLabels,
 			},
 		},
-		user: {
+		customer: {
 			labels: {
 				add: __( 'Username', 'wc-admin' ),
 				placeholder: __( 'Search customer username', 'wc-admin' ),

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -70,9 +70,17 @@ export default class CouponsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( downloads, download => {
-			const { _embedded, date, file_name, file_path, ip_address, order_id, product_id } = download;
+			const {
+				_embedded,
+				date,
+				file_name,
+				file_path,
+				ip_address,
+				order_id,
+				product_id,
+				username,
+			} = download;
 			const { name: productName } = _embedded.product[ 0 ];
-			const { name: userName } = _embedded.user[ 0 ];
 
 			const productLink = getNewPath( persistedQuery, 'products', {
 				filter: 'single_product',
@@ -109,8 +117,8 @@ export default class CouponsReportTable extends Component {
 					value: order_id,
 				},
 				{
-					display: userName,
-					value: userName,
+					display: username,
+					value: username,
 				},
 				{
 					display: ip_address,

--- a/includes/api/class-wc-admin-rest-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-customers-controller.php
@@ -23,4 +23,28 @@ class WC_Admin_REST_Customers_Controller extends WC_Admin_REST_Reports_Customers
 	 * @var string
 	 */
 	protected $rest_base = 'customers';
+
+	/**
+	 * Maps query arguments from the REST request.
+	 *
+	 * @param array $request Request array.
+	 * @return array
+	 */
+	protected function prepare_reports_query( $request ) {
+		$args = parent::prepare_reports_query( $request );
+		$args['customers'] = $request['include'];
+		return $args;
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+		$params['include'] = $params['customers'];
+		unset( $params['customers'] );
+		return $params;
+	}
 }

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -61,7 +61,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
-		$args['include']             = $request['include'];
+		$args['customers']           = $request['customers'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -458,7 +458,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['include']               = array(
+		$params['customers']               = array(
 			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -47,6 +47,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['orderby']             = $request['orderby'];
 		$args['match']               = $request['match'];
 		$args['search']              = $request['search'];
+		$args['searchby']            = $request['searchby'];
 		$args['username']            = $request['username'];
 		$args['email']               = $request['email'];
 		$args['country']             = $request['country'];
@@ -60,7 +61,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
-		$args['customers']           = $request['customers'];
+		$args['include']             = $request['include'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -335,9 +336,19 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['search']                  = array(
-			'description'       => __( 'Limit response to objects with a customer name containing the search term.', 'wc-admin' ),
+			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['searchby']     = array(
+			'description'       => 'Limit results with `search` and `searchby` to specific fields containing the search term.',
+			'type'              => 'string',
+			'default'           => 'name',
+			'enum'              => array(
+				'name',
+				'username',
+				'email',
+			),
 		);
 		$params['username']                = array(
 			'description'       => __( 'Limit response to objects with a specfic username.', 'wc-admin' ),
@@ -447,7 +458,7 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['customers']               = array(
+		$params['include']               = array(
 			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -455,7 +466,6 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 			'items'             => array(
 				'type' => 'integer',
 			),
-
 		);
 
 		return $params;

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -55,7 +55,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
-		$args['include']             = $request['include'];
+		$args['customers']           = $request['customers'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -319,7 +319,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['include']               = array(
+		$params['customers']               = array(
 			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -55,7 +55,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['avg_order_value_max'] = $request['avg_order_value_max'];
 		$args['last_order_before']   = $request['last_order_before'];
 		$args['last_order_after']    = $request['last_order_after'];
-		$args['customers']           = $request['customers'];
+		$args['include']             = $request['include'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = WC_Admin_Reports_Interval::normalize_between_params( $request, $between_params_numeric, false );
@@ -197,9 +197,19 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['search']                  = array(
-			'description'       => __( 'Limit response to objects with a specfic customer name.', 'wc-admin' ),
+			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'wc-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['searchby']     = array(
+			'description'       => 'Limit results with `search` and `searchby` to specific fields containing the search term.',
+			'type'              => 'string',
+			'default'           => 'name',
+			'enum'              => array(
+				'name',
+				'username',
+				'email',
+			),
 		);
 		$params['username']                = array(
 			'description'       => __( 'Limit response to objects with a specfic username.', 'wc-admin' ),
@@ -309,7 +319,7 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['customers']              = array(
+		$params['include']               = array(
 			'description'       => __( 'Limit result to items with specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -317,7 +327,6 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 			'items'             => array(
 				'type' => 'integer',
 			),
-
 		);
 
 		return $params;

--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -35,7 +35,6 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 	 * Get items.
 	 *
 	 * @param WP_REST_Request $request Request data.
-	 *
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
@@ -111,6 +110,8 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 		$filename                    = basename( $file_path );
 		$response->data['file_name'] = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
 		$response->data['file_path'] = $file_path;
+		$customer                    = new WC_Customer( $data['user_id'] );
+		$response->data['username']  = $customer->get_username();
 
 		/**
 		 * Filter a report returned from the API.
@@ -134,10 +135,6 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 		$links = array(
 			'product' => array(
 				'href'       => rest_url( sprintf( '/%s/%s/%d', $this->namespace, 'products', $object['product_id'] ) ),
-				'embeddable' => true,
-			),
-			'user' => array(
-				'href'       => rest_url( 'wp/v2/users/' . $object['user_id'] ),
 				'embeddable' => true,
 			),
 		);
@@ -215,6 +212,12 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'User ID for the downloader.', 'wc-admin' ),
+				),
+				'username' => array(
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'User name of the downloader.', 'wc-admin' ),
 				),
 				'ip_address' => array(
 					'type'        => 'string',
@@ -330,7 +333,7 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 				'type' => 'integer',
 			),
 		);
-		$params['user_includes'] = array(
+		$params['customer_includes'] = array(
 			'description'       => __( 'Limit response to objects that have the specified user ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -339,7 +342,7 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 				'type' => 'integer',
 			),
 		);
-		$params['user_excludes'] = array(
+		$params['customer_excludes'] = array(
 			'description'       => __( 'Limit response to objects that don\'t have the specified user ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
@@ -49,8 +49,8 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 		$args['match']               = $request['match'];
 		$args['product_includes']    = (array) $request['product_includes'];
 		$args['product_excludes']    = (array) $request['product_excludes'];
-		$args['user_includes']       = (array) $request['user_includes'];
-		$args['user_excludes']       = (array) $request['user_excludes'];
+		$args['customer_includes']   = (array) $request['customer_includes'];
+		$args['customer_excludes']   = (array) $request['customer_excludes'];
 		$args['order_includes']      = (array) $request['order_includes'];
 		$args['order_excludes']      = (array) $request['order_excludes'];
 		$args['ip_address_includes'] = (array) $request['ip_address_includes'];
@@ -331,8 +331,8 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 				'type' => 'integer',
 			),
 		);
-		$params['user_includes'] = array(
-			'description'       => __( 'Limit response to objects that have the specified user ids.', 'wc-admin' ),
+		$params['customer_includes'] = array(
+			'description'       => __( 'Limit response to objects that have the specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -340,8 +340,8 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 				'type' => 'integer',
 			),
 		);
-		$params['user_excludes'] = array(
-			'description'       => __( 'Limit response to objects that don\'t have the specified user ids.', 'wc-admin' ),
+		$params['customer_excludes'] = array(
+			'description'       => __( 'Limit response to objects that don\'t have the specified customer ids.', 'wc-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-stats-controller.php
@@ -49,6 +49,8 @@ class WC_Admin_REST_Reports_Downloads_Stats_Controller extends WC_REST_Reports_C
 		$args['match']               = $request['match'];
 		$args['product_includes']    = (array) $request['product_includes'];
 		$args['product_excludes']    = (array) $request['product_excludes'];
+		$args['user_includes']       = (array) $request['user_includes'];
+		$args['user_excludes']       = (array) $request['user_excludes'];
 		$args['order_includes']      = (array) $request['order_includes'];
 		$args['order_excludes']      = (array) $request['order_excludes'];
 		$args['ip_address_includes'] = (array) $request['ip_address_includes'];

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -230,14 +230,27 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			}
 		}
 
+		$search_params = array(
+			'name',
+			'username',
+			'email',
+		);
+
 		if ( ! empty( $query_args['search'] ) ) {
 			$name_like = '%' . $wpdb->esc_like( $query_args['search'] ) . '%';
-			$where_clauses[] = $wpdb->prepare( "CONCAT_WS( ' ', first_name, last_name ) LIKE %s", $name_like );
+
+			if ( empty( $query_args['searchby'] ) || 'name' === $query_args['searchby'] || ! in_array( $query_args['searchby'], $search_params ) ) {
+				$searchby = "CONCAT_WS( ' ', first_name, last_name )";
+			} else {
+				$searchby = $query_args['searchby'];
+			}
+
+			$where_clauses[] = $wpdb->prepare( "{$searchby} LIKE %s", $name_like ); // WPCS: unprepared SQL ok.
 		}
 
 		// Allow a list of customer IDs to be specified.
-		if ( ! empty( $query_args['customers'] ) ) {
-			$included_customers = implode( ',', $query_args['customers'] );
+		if ( ! empty( $query_args['include'] ) ) {
+			$included_customers = implode( ',', $query_args['include'] );
 			$where_clauses[] = "{$customer_lookup_table}.customer_id IN ({$included_customers})";
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -249,8 +249,8 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		}
 
 		// Allow a list of customer IDs to be specified.
-		if ( ! empty( $query_args['include'] ) ) {
-			$included_customers = implode( ',', $query_args['include'] );
+		if ( ! empty( $query_args['customers'] ) ) {
+			$included_customers = implode( ',', $query_args['customers'] );
 			$where_clauses[] = "{$customer_lookup_table}.customer_id IN ({$included_customers})";
 		}
 

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -30,6 +30,7 @@ export default {
 		if ( name ) {
 			const query = {
 				search: name,
+				searchby: 'name',
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -27,7 +27,8 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				email: search,
+				search,
+				searchby: 'email',
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/packages/components/src/search/autocompleters/usernames.js
+++ b/packages/components/src/search/autocompleters/usernames.js
@@ -24,7 +24,8 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				username: search,
+				search,
+				searchby: 'username',
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -112,14 +112,23 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_get_reports() {
+		global $wpdb;
+
 		wp_set_current_user( $this->user );
 		WC_Helper_Reports::reset_stats_dbs();
 
 		$test_customers = array();
 
+		$customer_names = array( 'Alice', 'Betty', 'Catherine', 'Dan', 'Eric', 'Fred', 'Greg', 'Henry', 'Ivan', 'Justin' );
+
 		// Create 10 test customers.
 		for ( $i = 1; $i <= 10; $i++ ) {
-			$test_customers[] = WC_Helper_Customer::create_customer( "customer{$i}", 'password', "customer{$i}@example.com" );
+			$name = $customer_names[ $i - 1 ];
+			$email = 'customer+' . strtolower( $name ) . '@example.com';
+			$customer = WC_Helper_Customer::create_customer( "customer{$i}", 'password', $email );
+			$customer->set_first_name( $name );
+			$customer->save();
+			$test_customers[] = $customer;
 		}
 
 		// Create a test product for use in an order.
@@ -172,10 +181,49 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $reports );
 
+		// Test name parameter (partial match).
+		$request->set_query_params(
+			array(
+				'search' => 're',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 2, $reports );
+
+		// Test email search.
+		$request->set_query_params(
+			array(
+				'search'   => 'customer+justin',
+				'searchby' => 'email',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+
+		// Test username search.
+		$request->set_query_params(
+			array(
+				'search'   => 'customer1',
+				'searchby' => 'username',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		// customer1 and customer10.
+		$this->assertCount( 2, $reports );
+
 		// Test name and last_order parameters.
 		$request->set_query_params(
 			array(
-				'search'           => 'Justin',
+				'search'           => 'Alice',
 				'last_order_after' => date( 'Y-m-d' ) . 'T00:00:00Z',
 			)
 		);
@@ -184,8 +232,29 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 1, $reports );
+
 		$this->assertEquals( $test_customers[0]->get_id(), $reports[0]['user_id'] );
 		$this->assertEquals( 1, $reports[0]['orders_count'] );
 		$this->assertEquals( 100, $reports[0]['total_spend'] );
+
+		$customer_id = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT customer_id FROM {$wpdb->prefix}wc_customer_lookup WHERE user_id = %d",
+				$reports[0]['user_id']
+			)
+		);
+
+		// Test include param.
+		$request->set_query_params(
+			array(
+				'include' => $customer_id,
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+		$this->assertEquals( $test_customers[0]->get_id(), $reports[0]['user_id'] );
 	}
 }

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -244,10 +244,10 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		// Test include param.
+		// Test customers param.
 		$request->set_query_params(
 			array(
-				'include' => $customer_id,
+				'customers' => $customer_id,
 			)
 		);
 

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -185,11 +185,18 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		$object->set_user_ip_address( '5.4.3.2.1' );
 		$object->save();
 
+		$customer_id = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT customer_id FROM {$wpdb->prefix}wc_customer_lookup WHERE user_id = %d",
+				1
+			)
+		);
+
 		// Test includes filtering.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'user_includes' => 1,
+				'customer_includes' => $customer_id,
 			)
 		);
 		$response        = $this->server->dispatch( $request );
@@ -202,7 +209,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'user_excludes' => 1,
+				'customer_excludes' => $customer_id,
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -126,6 +126,93 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting report with user filter.
+	 */
+	public function test_get_report_with_user_filter() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+		$time = time();
+
+		// First set of data.
+		$prod_download = new WC_Product_Download();
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_id( 1 );
+
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_downloadable( 'yes' );
+		$product->set_downloads( array( $prod_download ) );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 25 );
+		$order->save();
+		$order_1 = $order->get_id();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( 1 );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( $prod_download->get_id() );
+		$download->save();
+
+		for ( $i = 1; $i < 3; $i++ ) {
+			$object = new WC_Customer_Download_Log();
+			$object->set_permission_id( $download->get_id() );
+			$object->set_user_id( 1 );
+			$object->set_user_ip_address( '1.2.3.4' );
+			$id = $object->save();
+		}
+
+		$order = WC_Helper_Order::create_order( 2, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 10 );
+		$order->save();
+
+		$download = new WC_Customer_Download();
+		$download->set_user_id( 2 );
+		$download->set_order_id( $order->get_id() );
+		$download->set_product_id( $product->get_id() );
+		$download->set_download_id( $prod_download->get_id() );
+		$download->save();
+
+		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( 2 );
+		$object->set_user_ip_address( '5.4.3.2.1' );
+		$object->save();
+
+		// Test includes filtering.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'user_includes' => 1,
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$reports         = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, $reports['totals']['download_count'] );
+
+		// Test excludes filtering.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'user_excludes' => 1,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $reports['totals']['download_count'] );
+	}
+
+	/**
 	 * Test getting report ordering.
 	 */
 	public function test_get_report_orderby() {

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -297,12 +297,20 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_report_with_user_filter() {
 		$test_info = $this->filter_setup();
+		global $wpdb;
+
+		$customer_id = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT customer_id FROM {$wpdb->prefix}wc_customer_lookup WHERE user_id = %d",
+				1
+			)
+		);
 
 		// Test includes filtering.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'user_includes' => 1,
+				'customer_includes' => $customer_id,
 			)
 		);
 		$response        = $this->server->dispatch( $request );
@@ -318,7 +326,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'user_excludes' => 1,
+				'customer_excludes' => $customer_id,
 			)
 		);
 		$response        = $this->server->dispatch( $request );
@@ -388,7 +396,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 10, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
@@ -398,6 +406,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'file_path', $properties );
 		$this->assertArrayHasKey( 'order_id', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
+		$this->assertArrayHasKey( 'username', $properties );
 		$this->assertArrayHasKey( 'ip_address', $properties );
 	}
 }


### PR DESCRIPTION
Fixes #1616, fixes #1614.

This PR does the following:

* A new `searchby` parameter is added, allowing us to fuzzy search name, email, and username. Customer autocompletors are updated to use the new search.
* Renames the `customers` parameter `include`. This is the parameter used in the autocompletor to pull in label IDs and matches other endpoints.
* Fixes an issue where `user_includes`/`user_excludes` was not passed along to one of the downloads controllers.

### Detailed test instructions:

* Run `phpunit` and make sure all tests run.
* Go to Downloads Report
* Add a username advanced filter
* Type a partial username
* See options appear
* Select one and filter the download results
* Verify results update
* Try switching the option to exclude, see options update
* Go to the customers report
* Try the same thing for name and email (Note that filtering does not actually work here or on master #1617). 
