### PR TITLE
Fix style of dashboard summary number placeholder

### DIFF
--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -22,7 +22,6 @@ import { formatCurrency } from '@woocommerce/currency';
  * Internal dependencies
  */
 import {
-	Card,
 	EllipsisMenu,
 	MenuItem,
 	MenuTitle,
@@ -160,7 +159,7 @@ class StorePerformance extends Component {
 		return (
 			<Fragment>
 				<SectionHeader title={ __( 'Store Performance', 'wc-admin' ) } menu={ this.renderMenu() } />
-				<Card className="woocommerce-dashboard__store-performance">{ this.renderList() }</Card>
+				<div className="woocommerce-dashboard__store-performance">{ this.renderList() }</div>
 			</Fragment>
 		);
 	}

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -1,15 +1,10 @@
 /** @format */
 
 .woocommerce-dashboard__store-performance {
-	border-bottom: 0;
-	border-right: 0;
+	margin-bottom: $gap-large;
 
-	.woocommerce-card__header {
-		border-right: 1px solid $core-grey-light-700;
-	}
-
-	.woocommerce-card__body {
-		padding: 0;
+	@include breakpoint( '<782px' ) {
+		border-width: 0;
 	}
 
 	.woocommerce-summary {

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -23,11 +23,6 @@
 					}
 				}
 			}
-
-			.woocommerce-summary__item-container {
-				margin-left: -16px;
-				margin-right: -16px;
-			}
 		}
 	}
 

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -8,6 +8,38 @@
 	}
 
 	.woocommerce-summary {
+		background-color: $core-grey-light-100;
 		margin: 0;
+
+		@include breakpoint( '<782px' ) {
+			&.is-placeholder {
+				border-top: 0;
+			}
+
+			&:not(.is-placeholder) {
+				.woocommerce-summary__item-container:first-child {
+					.woocommerce-summary__item {
+						border-top: 1px solid $core-grey-light-700;
+					}
+				}
+			}
+
+			.woocommerce-summary__item-container {
+				margin-left: -16px;
+				margin-right: -16px;
+			}
+		}
+	}
+
+	.woocommerce-summary__item {
+		background-color: $white;
+
+		&:hover {
+			background-color: $core-grey-light-200;
+		}
+
+		&:active {
+			background-color: $core-grey-light-300;
+		}
 	}
 }

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -47,6 +47,10 @@ $inner-border: $core-grey-light-500;
 	box-shadow: inset -1px -1px 0 $outer-border;
 
 	@include breakpoint( '<782px' ) {
+		& {
+			border-width: 0;
+		}
+
 		&.is-placeholder {
 			border-top: 0;
 		}
@@ -203,7 +207,6 @@ $inner-border: $core-grey-light-500;
 
 .woocommerce-summary__item-container {
 	margin-bottom: 0;
-	width: 100%;
 
 	&:last-of-type .woocommerce-summary__item {
 		// Make sure the last item always uses the outer-border color.
@@ -387,29 +390,5 @@ $inner-border: $core-grey-light-500;
 		.woocommerce-summary__item-prev-value {
 			@include font-size( 11 );
 		}
-	}
-}
-
-.woocommerce-card {
-	.woocommerce-summary {
-		background-color: $core-grey-light-100;
-		border: none;
-	}
-
-	.woocommerce-summary__item {
-		background-color: $white;
-
-		&:hover {
-			background-color: $core-grey-light-200;
-		}
-
-		&:active {
-			background-color: $core-grey-light-300;
-		}
-	}
-
-	.woocommerce-summary__item.is-selected {
-		margin-top: 0;
-		box-shadow: none;
 	}
 }

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -51,10 +51,8 @@ $inner-border: $core-grey-light-500;
 			border-top: 0;
 		}
 
-		.woocommerce-layout__main > & {
-			.woocommerce-summary__item-container.is-placeholder {
-				border-top: 1px solid $outer-border;
-			}
+		.woocommerce-summary__item-container.is-placeholder {
+			border-top: 1px solid $outer-border;
 		}
 	}
 
@@ -180,26 +178,24 @@ $inner-border: $core-grey-light-500;
 	}
 
 	@include breakpoint( '<782px' ) {
-		.woocommerce-layout__main > & {
-			.woocommerce-summary__item-container.is-dropdown-button,
-			.woocommerce-summary__item-container:only-child {
-				margin-left: -16px;
-				margin-right: -16px;
-				width: auto;
+		.woocommerce-summary__item-container.is-dropdown-button,
+		.woocommerce-summary__item-container:only-child {
+			margin-left: -16px;
+			margin-right: -16px;
+			width: auto;
 
-				.woocommerce-summary__item {
-					// Remove the border when the button is edge-to-edge
-					border-right: none;
-				}
+			.woocommerce-summary__item {
+				// Remove the border when the button is edge-to-edge
+				border-right: none;
 			}
-			.components-popover.components-popover {
-				margin-left: -16px;
-				margin-right: -16px;
+		}
+		.components-popover.components-popover {
+			margin-left: -16px;
+			margin-right: -16px;
 
-				.woocommerce-summary__item-container {
-					margin-left: 0;
-					margin-right: 0;
-				}
+			.woocommerce-summary__item-container {
+				margin-left: 0;
+				margin-right: 0;
 			}
 		}
 	}

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -182,8 +182,7 @@ $inner-border: $core-grey-light-500;
 	}
 
 	@include breakpoint( '<782px' ) {
-		.woocommerce-summary__item-container.is-dropdown-button,
-		.woocommerce-summary__item-container:only-child {
+		.woocommerce-summary__item-container {
 			margin-left: -16px;
 			margin-right: -16px;
 			width: auto;

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -51,8 +51,10 @@ $inner-border: $core-grey-light-500;
 			border-top: 0;
 		}
 
-		.woocommerce-summary__item-container.is-placeholder {
-			border-top: 1px solid $outer-border;
+		.woocommerce-layout__main > & {
+			.woocommerce-summary__item-container.is-placeholder {
+				border-top: 1px solid $outer-border;
+			}
 		}
 	}
 
@@ -178,24 +180,26 @@ $inner-border: $core-grey-light-500;
 	}
 
 	@include breakpoint( '<782px' ) {
-		.woocommerce-summary__item-container.is-dropdown-button,
-		.woocommerce-summary__item-container:only-child {
-			margin-left: -16px;
-			margin-right: -16px;
-			width: auto;
+		.woocommerce-layout__main > & {
+			.woocommerce-summary__item-container.is-dropdown-button,
+			.woocommerce-summary__item-container:only-child {
+				margin-left: -16px;
+				margin-right: -16px;
+				width: auto;
 
-			.woocommerce-summary__item {
-				// Remove the border when the button is edge-to-edge
-				border-right: none;
+				.woocommerce-summary__item {
+					// Remove the border when the button is edge-to-edge
+					border-right: none;
+				}
 			}
-		}
-		.components-popover.components-popover {
-			margin-left: -16px;
-			margin-right: -16px;
+			.components-popover.components-popover {
+				margin-left: -16px;
+				margin-right: -16px;
 
-			.woocommerce-summary__item-container {
-				margin-left: 0;
-				margin-right: 0;
+				.woocommerce-summary__item-container {
+					margin-left: 0;
+					margin-right: 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1621.

Fix wrong padding/border of summary numbers in the Dashboard. It also removes 1px border around summary numbers in reports.

### Screenshots
#### Padding/border of summary numbers in the Dashboard
_Before:_
![screenshot from 2019-02-19 14-10-37](https://user-images.githubusercontent.com/3616980/53021938-8f74ac80-345a-11e9-95ea-c236842be8f1.png)

_After:_
![screenshot from 2019-02-19 14-18-21](https://user-images.githubusercontent.com/3616980/53021953-93a0ca00-345a-11e9-87fc-b5df8c8fd2f3.png)

#### Border around summary numbers in reports
_Before:_
![image](https://user-images.githubusercontent.com/3616980/53027645-9fde5480-3465-11e9-8967-f89a739ce736.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/53027611-91903880-3465-11e9-8553-060abbf1bf3e.png)

### Detailed test instructions:
With a small viewport:
- Go to the _Dashboard_.
- While loading, verify the summary numbers have enough padding on the left and right and the top border is only 1px wide.
- Go to any report and verify there is no border around summary numbers.