### PR TITLE
Close the mobile WP menu after navigating between reports

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -169,6 +169,9 @@ window.wpNavMenuClassChange = function( page ) {
 	closedMenu.classList.remove( 'wp-has-current-submenu' );
 	closedMenu.classList.remove( 'wp-menu-open' );
 	closedMenu.classList.add( 'wp-not-current-submenu' );
+
+	const wpWrap = document.querySelector( '#wpwrap' );
+	wpWrap.classList.remove( 'wp-responsive-open' );
 };
 
 export { Controller, getPages };


### PR DESCRIPTION
Fixes #1624.

This PR closes the responsive menu when the route/page changes.

### Detailed test instructions:

Using a device with a narrow-viewport:

1. Go to any report.
2. Navigate to another report.
3. Notice the menu is closed.