### PR TITLE
Return an error when installing unit tests if WP < 5

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -17,6 +17,14 @@ TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
+# Error if WP < 5
+if [[ $WP_VERSION =~ ^([0-9]+)[0-9\.]+\-? ]]; then
+	if [ "5" -gt "${BASH_REMATCH[1]}" ]; then
+		echo "You must use WordPress 5.0 or greater."
+		exit 1
+	fi
+fi
+
 download() {
     if [ `which curl` ]; then
         curl -s "$1" > "$2";
@@ -167,13 +175,6 @@ install_deps() {
 	curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
-
-	# Install Gutenberg if WP < 5
-	if [[ $WP_VERSION =~ ^([0-9]+)[0-9\.]+\-? ]]; then
-		if [ "5" -gt "${BASH_REMATCH[1]}" ]; then
-			php wp-cli.phar plugin install gutenberg --activate
-		fi
-	fi
 
 	# Install WooCommerce
 	cd "wp-content/plugins/"


### PR DESCRIPTION
Closes #847.

We already removed the Gutenberg dependency in the PHP bootstrap [here](https://github.com/woocommerce/wc-admin/commit/2c6a6ab65c9f4d3c50edaec65325bd994afe8b34#diff-10eafd8bf5fbdde867b86fe38d30b9bbL104) and require WP 5.0 to be used.

This updates the install script to error if you try to pass a version to test/install lower than WP 5.0, instead of installing Gutenberg. This would only happen if you manually type in a version (if you copy and paste from our documentation, the latest version will be installed).

I also updated the wiki here: https://github.com/woocommerce/wc-admin/wiki/Running-PHP-unit-tests/_compare/f99c045f5709e53d8494c6565e1026e715a13195...3179be2515c9383feaf0783e8236b3a3c45d11e5

To Test:
* Follow the steps at https://github.com/woocommerce/wc-admin/wiki/Running-PHP-unit-tests/, specifically around running `install-wp-tests.sh`.
* Test again, but instead of passing `latest`, pass `4.9.9`: `./bin/install-wp-tests.sh $DB_NAME $MYSQL_USER $MYSQL_PASSWD localhost 4.9.9`. You should see an error.
* `phpunit` should still run.
