### PR TITLE
Fix table search position in small viewports

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -197,6 +197,7 @@ class Search extends Component {
 							<div
 								className={ classnames( 'woocommerce-search__inline-container', {
 									'is-active': isActive,
+									'has-tags': inlineTags && shouldRenderTags,
 								} ) }
 								onClick={ () => {
 									this.input.current.focus();

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -38,7 +38,7 @@
 
 	.woocommerce-search__inline-container {
 		width: 100%;
-		padding: 4px 36px 4px;
+		padding: 4px 2px 4px 36px;
 		border: 1px solid $core-grey-light-700;
 		background-color: $white;
 		display: flex;
@@ -48,6 +48,10 @@
 		&.is-active {
 			border-color: $input-active-border;
 			box-shadow: inset 0 0 0 $input-active-inner, 0 0 1px 2px $input-active-outer;
+		}
+
+		&.has-tags {
+			padding-right: 36px;
 		}
 
 		.woocommerce-search__token-list {
@@ -64,6 +68,7 @@
 		box-shadow: none;
 		padding: 2px 0;
 		line-height: 20px;
+		max-width: 100%;
 		min-width: 70px;
 		font-size: inherit;
 		vertical-align: middle;


### PR DESCRIPTION
Fixes #1625.

Fixes the table search input overflowing the viewport.

### Screenshots
_Before:_
![screenshot from 2019-02-20 16-46-32](https://user-images.githubusercontent.com/3616980/53110389-1b5e0580-353b-11e9-834b-3d5bb9de1b70.png)

_After:_
![screenshot from 2019-02-20 16-45-20](https://user-images.githubusercontent.com/3616980/53110092-89ee9380-353a-11e9-88de-58819942e4d7.png)

### Detailed test instructions:
With a narrow viewport:
- Go to any report with a search input in the table.
- Verify the table search input doesn't overflow the screen (see screenshots above).