### PR TITLE
Add comparison support to the coupons report

### DIFF
--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -70,8 +70,18 @@ export const filters = [
 					},
 				},
 			},
-			{ label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ), value: 'top_orders' },
-			{ label: __( 'Top Coupons by Amount Discounted', 'wc-admin' ), value: 'top_discount' },
+			{
+				label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ),
+				value: 'top_orders',
+				chartMode: 'item-comparison',
+				query: { orderby: 'orders_count', order: 'desc', chart: 'orders_count' },
+			},
+			{
+				label: __( 'Top Coupons by Amount Discounted', 'wc-admin' ),
+				value: 'top_discount',
+				chartMode: 'item-comparison',
+				query: { orderby: 'amount', order: 'desc', chart: 'amount' },
+			},
 		],
 	},
 ];

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -4,6 +4,7 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * WooCommerce dependencies
@@ -20,8 +21,32 @@ import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 
 export default class CouponsReport extends Component {
+	getChartMeta() {
+		const { query } = this.props;
+		const isCompareView = [ 'top_orders', 'top_discount', 'compare-coupons' ].includes(
+			query.filter
+		);
+
+		const mode = isCompareView ? 'item-comparison' : 'time-comparison';
+		const itemsLabel = __( '%d coupons', 'wc-admin' );
+
+		return {
+			itemsLabel,
+			mode,
+		};
+	}
+
 	render() {
 		const { query, path } = this.props;
+		const { mode, itemsLabel } = this.getChartMeta();
+
+		const chartQuery = {
+			...query,
+		};
+
+		if ( 'item-comparison' === mode ) {
+			chartQuery.segmentby = 'coupon';
+		}
 
 		return (
 			<Fragment>
@@ -29,14 +54,17 @@ export default class CouponsReport extends Component {
 				<ReportSummary
 					charts={ charts }
 					endpoint="coupons"
-					query={ query }
+					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
+					filters={ filters }
 					charts={ charts }
+					mode={ mode }
 					endpoint="coupons"
 					path={ path }
-					query={ query }
+					query={ chartQuery }
+					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<CouponsReportTable query={ query } />

--- a/includes/class-wc-admin-reports-segmenting.php
+++ b/includes/class-wc-admin-reports-segmenting.php
@@ -361,10 +361,14 @@ class WC_Admin_Reports_Segmenting {
 			$segment_labels = wp_list_pluck( $categories, 'name', 'cat_ID' );
 
 		} elseif ( 'coupon' === $this->query_args['segmentby'] ) {
-			// @todo Switch to a non-direct-SQL way to get all coupons?
-			// @todo These are only currently existing coupons, but we should add also deleted ones, if they have been used at least once.
-			$coupon_ids = $wpdb->get_results( "SELECT ID FROM {$wpdb->prefix}posts WHERE post_type='shop_coupon' AND post_status='publish'", ARRAY_A ); // WPCS: cache ok, DB call ok, unprepared SQL ok.
-			$segments   = wp_list_pluck( $coupon_ids, 'ID' );
+			$args = array();
+			if ( isset( $this->query_args['coupons'] ) ) {
+				$args['include'] = $this->query_args['coupons'];
+			}
+			$coupons        = WC_Admin_Reports_Coupons_Data_Store::get_coupons( $args );
+			$segments       = wp_list_pluck( $coupons, 'ID' );
+			$segment_labels = wp_list_pluck( $coupons, 'post_title', 'ID' );
+			$segment_labels = array_map( 'wc_format_coupon_code', $segment_labels );
 		} elseif ( 'customer_type' === $this->query_args['segmentby'] ) {
 			// 0 -- new customer
 			// 1 -- returning customer

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -385,4 +385,22 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 		do_action( 'woocommerce_reports_delete_coupon', 0, $order_id );
 	}
 
+	/**
+	 * Gets coupons based on the provided arguments.
+	 *
+	 * @todo Upon core merge, including this in core's `class-wc-coupon-data-store-cpt.php` might make more sense.
+	 * @param array $args Array of args to filter the query by. Supports `include`.
+	 * @return array Array of results.
+	 */
+	public static function get_coupons( $args ) {
+		global $wpdb;
+		$query = "SELECT ID, post_title FROM {$wpdb->prefix}posts WHERE post_type='shop_coupon'";
+
+		if ( ! empty( $args['include'] ) ) {
+			$included_coupons = implode( ',', $args['include'] );
+			$query .= " AND ID IN ({$included_coupons})";
+		}
+
+		return $wpdb->get_results( $query );  // WPCS: cache ok, DB call ok, unprepared SQL ok.
+	}
 }


### PR DESCRIPTION
Fixes #1607.

This PR adds comparison support to the coupons support, so you can compare coupons manually, or by using the `Top Coupons by Discounted Orders|Amount Discounted` filters.

### Screenshots

<img width="1042" alt="screen shot 2019-02-20 at 2 07 37 pm" src="https://user-images.githubusercontent.com/689165/53117433-e771e880-3518-11e9-8cd0-fdfa1930cfd5.png">
<img width="1039" alt="screen shot 2019-02-20 at 2 07 05 pm" src="https://user-images.githubusercontent.com/689165/53117434-e80a7f00-3518-11e9-97b9-61d9b796a7b6.png">


### Detailed test instructions:

* Run `phpunit` and make sure all tests pass
* Go to Analytics > Coupons
* Change to a date range with multiple coupons in report
* Select 2+ coupons, click "compare"
* Test the "Top Coupons by" filters