### PR TITLE
Fix null values in CSV columns export

### DIFF
--- a/packages/components/src/table/__mocks__/table-mock-csv.js
+++ b/packages/components/src/table/__mocks__/table-mock-csv.js
@@ -2,4 +2,4 @@
 
 export default `Date,Orders,Gross Revenue,Refunds,Taxes,Shipping,Net Revenue
 2018-10-01 00:00:00,1,411,0,0,0,411
-2018-10-02 00:00:00,0,0,0,0,0,0`;
+2018-10-02 00:00:00,0,0,,0,0,0`;

--- a/packages/components/src/table/__mocks__/table-mock-data.js
+++ b/packages/components/src/table/__mocks__/table-mock-data.js
@@ -50,7 +50,7 @@ export default [
 		},
 		{
 			display: '€0.00',
-			value: 0,
+			value: null,
 		},
 		{
 			display: '€0.00',

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+- Fix null values in columns
+
 # 1.0.0
 
 - Released package

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.1.0
 
-- Fix null values in columns
+- Fix error in `getCSVRows` when there is a null or undefined column value
 
 # 1.0.0
 

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -13,7 +13,7 @@ function getCSVRows( rows ) {
 	return Array.isArray( rows )
 		? rows
 				.map( row =>
-					row.map( rowItem => rowItem.value.toString().replace( /,/g, '' ) ).join( ',' )
+					row.map( rowItem => rowItem.value ? rowItem.value.toString().replace( /,/g, '' ) : '' ).join( ',' )
 				)
 				.join( '\n' )
 		: [];

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -13,7 +13,9 @@ function getCSVRows( rows ) {
 	return Array.isArray( rows )
 		? rows
 				.map( row =>
-					row.map( rowItem => rowItem.value ? rowItem.value.toString().replace( /,/g, '' ) : '' ).join( ',' )
+					row.map( rowItem =>
+						rowItem.value !== undefined && rowItem.value !== null ? rowItem.value.toString().replace( /,/g, ''
+					) : '' ).join( ',' )
 				)
 				.join( '\n' )
 		: [];


### PR DESCRIPTION
Fixes #1643 

Uses an empty string in CSV columns when a value is null.  Some columns may be null by default, so this safeguards against failed downloads.

### Detailed test instructions:

1. Find a report with a null value (e.g., customer sign up date for guests should be null by default).
2. Try to export a report with the above row.
3. Note the successful export and empty column when opening the CSV file.