### PR TITLE
Hide woo notices button when side menu is open

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -158,6 +158,10 @@
 	}
 }
 
+.wp-responsive-open .woocommerce-layout__activity-panel-mobile-toggle {
+	display: none;
+}
+
 .woocommerce-layout__activity-panel-toggle-bubble.has-unread::after {
 	content: ' ';
 	position: absolute;


### PR DESCRIPTION
Fixes #1648 

Prevents weird overlapping with woo notice icon and header.

### Before
<img width="395" alt="screen shot 2019-02-21 at 4 00 05 pm" src="https://user-images.githubusercontent.com/10561050/53152951-eb256e00-35f1-11e9-8d42-e80a3fcc9e45.png">

### After
<img width="407" alt="screen shot 2019-02-21 at 3 59 40 pm" src="https://user-images.githubusercontent.com/10561050/53152959-ed87c800-35f1-11e9-9c08-de53ec8c0634.png">

### Detailed test instructions:

1.  Narrow your viewport to <=782px.
2.  Open the 🍔 menu.
3.  Say 👋 to woo notice.