### PR TITLE
Components: Update changelog to release 1.6.0

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.0 (unreleased)
+# 1.6.0
 - Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.
 - Chart component: remove d3-array dependency.
 - Chart component: fix display when there is no data.


### PR DESCRIPTION
Removes the `unreleased` from 1.6.0, so we can tag and release this version.