### PR TITLE
Components: Bump @woocommerce/components to 1.6.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/components",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "UI components for WooCommerce.",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
This has [been published on npm,](https://www.npmjs.com/package/@woocommerce/components) just bumping the package version here.