### PR TITLE
fix warning in some versions of PHP

### DIFF
--- a/includes/class-wc-admin-order.php
+++ b/includes/class-wc-admin-order.php
@@ -161,7 +161,7 @@ class WC_Admin_Order extends WC_Order {
 			if ( $tax_data ) {
 				foreach ( $order_taxes as $tax_item ) {
 					$tax_item_id    = $tax_item->get_rate_id();
-					$tax_item_total = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : '';
+					$tax_item_total = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
 					$refunded       = $this->get_tax_refunded_for_item( $item_id, $tax_item_id, 'shipping' );
 					if ( $refunded ) {
 						$total_shipping_tax_amount += $tax_item_total - $refunded;


### PR DESCRIPTION
Fixes #

While testing #1664 I was getting a debug warning in my debug log. I think this is triggering the warning because the variable is immediately after a `+=` operator. The warning was

`PHP Warning:  A non-numeric value encountered in /Users/ronrennick/Sites/ron/wp-content/plugins/wc-admin/includes/class-wc-admin-order.php on line 169`
