### PR TITLE
Add product name filtering

### DIFF
--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -49,4 +49,35 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		return $schema;
 	}
 
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                 = parent::get_collection_params();
+		$params['product_name'] = array(
+			'description'       => __( 'Search for a similar product name.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+	/**
+	 * Add product name filtering to the WC API.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args = parent::prepare_objects_query( $request );
+
+		if ( ! empty( $request['product_name'] ) ) {
+			$args['post_title__like'] = $request['product_name'];
+		}
+
+		return $args;
+	}
+
 }

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -80,4 +80,37 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		return $args;
 	}
 
+	/**
+	 * Get a collection of posts and add the post title filter option to WP_Query.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10, 2 );
+		$response = parent::get_items( $request );
+		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10 );
+		return $response;
+	}
+
+	/**
+	 * Add post title searching to WP Query
+	 *
+	 * @param string $where Where clause used to search posts.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public static function add_wp_query_post_title_filter( $where, $wp_query ) {
+		global $wpdb;
+
+		$post_title_search = $wp_query->get( 'post_title__like' );
+		if ( $post_title_search ) {
+			$post_title_search = $wpdb->esc_like( $post_title_search );
+			$post_title_search = ' \'%' . $post_title_search . '%\'';
+			$where            .= ' AND ' . $wpdb->posts . '.post_title LIKE ' . $post_title_search;
+		}
+
+		return $where;
+	}
+
 }

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -26,9 +26,6 @@ class WC_Admin_Api_Init {
 
 		// Add currency symbol to orders endpoint response.
 		add_filter( 'woocommerce_rest_prepare_shop_order_object', array( __CLASS__, 'add_currency_symbol_to_order_response' ) );
-
-		// Add WP Query where filters.
-		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10, 2 );
 	}
 
 	/**
@@ -409,26 +406,6 @@ class WC_Admin_Api_Init {
 		$response->set_data( $response_data );
 
 		return $response;
-	}
-
-	/**
-	 * Add post title searching to WP Query
-	 *
-	 * @param string $where Where clause used to search posts.
-	 * @param object $wp_query WP_Query object.
-	 * @return string
-	 */
-	public static function add_wp_query_post_title_filter( $where, $wp_query ) {
-		global $wpdb;
-
-		$post_title_search = $wp_query->get( 'post_title__like' );
-		if ( $post_title_search ) {
-			$post_title_search = $wpdb->esc_like( $post_title_search );
-			$post_title_search = ' \'%' . $post_title_search . '%\'';
-			$where            .= ' AND ' . $wpdb->posts . '.post_title LIKE ' . $post_title_search;
-		}
-
-		return $where;
 	}
 }
 

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -418,7 +418,7 @@ class WC_Admin_Api_Init {
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
-	public function add_wp_query_post_title_filter( $where, &$wp_query ) {
+	public static function add_wp_query_post_title_filter( $where, $wp_query ) {
 		global $wpdb;
 
 		$post_title_search = $wp_query->get( 'post_title__like' );

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -26,6 +26,9 @@ class WC_Admin_Api_Init {
 
 		// Add currency symbol to orders endpoint response.
 		add_filter( 'woocommerce_rest_prepare_shop_order_object', array( __CLASS__, 'add_currency_symbol_to_order_response' ) );
+
+		// Add WP Query where filters.
+		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10, 2 );
 	}
 
 	/**
@@ -406,6 +409,26 @@ class WC_Admin_Api_Init {
 		$response->set_data( $response_data );
 
 		return $response;
+	}
+
+	/**
+	 * Add post title searching to WP Query
+	 *
+	 * @param string $where Where clause used to search posts.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public function add_wp_query_post_title_filter( $where, &$wp_query ) {
+		global $wpdb;
+
+		$post_title_search = $wp_query->get( 'post_title__like' );
+		if ( $post_title_search ) {
+			$post_title_search = $wpdb->esc_like( $post_title_search );
+			$post_title_search = ' \'%' . $post_title_search . '%\'';
+			$where            .= ' AND ' . $wpdb->posts . '.post_title LIKE ' . $post_title_search;
+		}
+
+		return $where;
 	}
 }
 

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -30,7 +30,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search,
+				product_name: search,
 				per_page: 10,
 				orderby: 'popularity',
 			};


### PR DESCRIPTION
Fixes #1635 

Allows filtering by product name in search results instead of searching entire post content.

### Detailed test instructions:

1.  Go to the products report and use the product comparison advanced filter.
2.  Search for a product name.
3.  Make sure the results returned are associated with the product name/title and not the content or excerpt.