### PR TITLE
Add tax code filter to tax REST API

### DIFF
--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -24,4 +24,106 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 	 */
 	protected $namespace = 'wc/v4';
 
+	/**
+	 * Get all taxes and allow filtering by tax code.
+	 *
+	 * @todo This is mostly copied from
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		global $wpdb;
+
+		$prepared_args           = array();
+		$prepared_args['order']  = $request['order'];
+		$prepared_args['number'] = $request['per_page'];
+		if ( ! empty( $request['offset'] ) ) {
+			$prepared_args['offset'] = $request['offset'];
+		} else {
+			$prepared_args['offset'] = ( $request['page'] - 1 ) * $prepared_args['number'];
+		}
+		$orderby_possibles        = array(
+			'id'    => 'tax_rate_id',
+			'order' => 'tax_rate_order',
+		);
+		$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
+		$prepared_args['class']   = $request['class'];
+
+		/**
+		 * Filter arguments, before passing to $wpdb->get_results(), when querying taxes via the REST API.
+		 *
+		 * @param array           $prepared_args Array of arguments for $wpdb->get_results().
+		 * @param WP_REST_Request $request       The current request.
+		 */
+		$prepared_args = apply_filters( 'woocommerce_rest_tax_query', $prepared_args, $request );
+
+		$query = "
+			SELECT *
+			FROM {$wpdb->prefix}woocommerce_tax_rates
+			WHERE 1 = 1
+		";
+
+		// Filter by tax class.
+		if ( ! empty( $prepared_args['class'] ) ) {
+			$class  = 'standard' !== $prepared_args['class'] ? sanitize_title( $prepared_args['class'] ) : '';
+			$query .= " AND tax_rate_class = '$class'";
+		}
+
+		/**
+		 * Filter the query string to conditionally return tax codes in the REST API.
+		 *
+		 * @todo Remove this if https://github.com/woocommerce/woocommerce/pull/22813 gets merged.
+		 * @param string $query         Query string used to look up tax codes.
+		 * @param array  $prepared_args Array of arguments for $wpdb->get_results().
+		 */
+		$query = apply_filters( 'woocommerce_rest_tax_query_string', $query, $prepared_args );
+
+		// Order tax rates.
+		$order_by = sprintf( ' ORDER BY %s', sanitize_key( $prepared_args['orderby'] ) );
+
+		// Pagination.
+		$pagination = sprintf( ' LIMIT %d, %d', $prepared_args['offset'], $prepared_args['number'] );
+
+		// Query taxes.
+		$results = $wpdb->get_results( $query . $order_by . $pagination ); // @codingStandardsIgnoreLine.
+
+		$taxes = array();
+		foreach ( $results as $tax ) {
+			$data    = $this->prepare_item_for_response( $tax, $request );
+			$taxes[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$response = rest_ensure_response( $taxes );
+
+		// Store pagination values for headers then unset for count query.
+		$per_page = (int) $prepared_args['number'];
+		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
+
+		// Query only for ids.
+		$wpdb->get_results( str_replace( 'SELECT *', 'SELECT tax_rate_id', $query ) ); // @codingStandardsIgnoreLine.
+
+		// Calculate totals.
+		$total_taxes = (int) $wpdb->num_rows;
+		$response->header( 'X-WP-Total', (int) $total_taxes );
+		$max_pages = ceil( $total_taxes / $per_page );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
 }

--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -33,6 +33,21 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 	}
 
 	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params         = parent::get_collection_params();
+		$params['code'] = array(
+			'description'       => __( 'Search by similar tax code.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+	/**
 	 * Get all taxes and allow filtering by tax code.
 	 *
 	 * @todo This is mostly copied from

--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -177,7 +177,7 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 		if ( $tax_code_search ) {
 			$tax_code_search = $wpdb->esc_like( $tax_code_search );
 			$tax_code_search = ' \'%' . $tax_code_search . '%\'';
-			$query          .= ' AND CONCAT( tax_rate_name, "-", tax_rate_priority ) LIKE ' . $tax_code_search;
+			$query          .= ' AND CONCAT_WS( "-", NULLIF(tax_rate_country, ""), NULLIF(tax_rate_state, ""), NULLIF(tax_rate_name, ""), NULLIF(tax_rate_priority, "") ) LIKE ' . $tax_code_search;
 		}
 
 		return $query;

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -29,7 +29,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				search,
+				code: search,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );


### PR DESCRIPTION
Fixes #1639 

Adds in a `code` parameter to the tax rest controller so we can search for taxes.

Note that `get_items()` will be removed if https://github.com/woocommerce/woocommerce/pull/22813 gets merged.

### Detailed test instructions:

1.  Create more than 10 tax codes.
2.  Go to the tax report and search using the tax comparison filter.
3.  Check that the response is accurately searched.
4.  Check the ability to search by the full code (country-state-name-priority).