### PR TITLE
Add tax include param to tax REST API

### DIFF
--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -3,17 +3,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-import { find } from 'lodash';
-
-/**
- * WooCommerce dependencies
- */
-import { getIdsFromQuery, stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getRequestByIdString } from 'lib/async-requests';
 import { getTaxCode } from './utils';
 import { NAMESPACE } from 'wc-api/constants';
 
@@ -63,25 +57,10 @@ export const filters = [
 				settings: {
 					type: 'taxes',
 					param: 'taxes',
-					// @TODO: Core /taxes endpoint should support a collection param 'include'.
-					getLabels: function( queryString = '' ) {
-						const idList = getIdsFromQuery( queryString );
-						if ( idList.length < 1 ) {
-							return Promise.resolve( [] );
-						}
-						const payload = stringifyQuery( {
-							per_page: -1,
-						} );
-						return apiFetch( { path: NAMESPACE + '/taxes' + payload } ).then( taxes => {
-							return idList.map( id => {
-								const tax = find( taxes, { id } );
-								return {
-									id: tax.id,
-									label: getTaxCode( tax ),
-								};
-							} );
-						} );
-					},
+					getLabels: getRequestByIdString( NAMESPACE + '/taxes', tax => ( {
+						id: tax.id,
+						label: getTaxCode( tax ),
+					} ) ),
 					labels: {
 						helpText: __( 'Select at least two tax codes to compare', 'wc-admin' ),
 						placeholder: __( 'Search for tax codes to compare', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -45,10 +45,19 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params         = parent::get_collection_params();
-		$params['code'] = array(
+		$params            = parent::get_collection_params();
+		$params['code']    = array(
 			'description'       => __( 'Search by similar tax code.', 'wc-admin' ),
 			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['include'] = array(
+			'description'       => __( 'Limit result set to items that have the specified rate ID(s) assigned.', 'wc-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $params;
@@ -78,6 +87,7 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 		$prepared_args['orderby'] = $orderby_possibles[ $request['orderby'] ];
 		$prepared_args['class']   = $request['class'];
 		$prepared_args['code']    = $request['code'];
+		$prepared_args['include'] = $request['include'];
 
 		/**
 		 * Filter arguments, before passing to $wpdb->get_results(), when querying taxes via the REST API.
@@ -105,6 +115,13 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 			$tax_code_search = $wpdb->esc_like( $tax_code_search );
 			$tax_code_search = ' \'%' . $tax_code_search . '%\'';
 			$query          .= ' AND CONCAT_WS( "-", NULLIF(tax_rate_country, ""), NULLIF(tax_rate_state, ""), NULLIF(tax_rate_name, ""), NULLIF(tax_rate_priority, "") ) LIKE ' . $tax_code_search;
+		}
+
+		// Filter by included tax rate IDs.
+		$included_taxes = $prepared_args['include'];
+		if ( ! empty( $included_taxes ) ) {
+			$included_taxes = implode( ',', $prepared_args['include'] );
+			$query         .= " AND tax_rate_id IN ({$included_taxes})";
 		}
 
 		// Order tax rates.

--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -30,21 +30,6 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params         = parent::get_collection_params();
-		$params['code'] = array(
-			'description'       => __( 'Search by similar tax code.', 'wc-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		return $params;
-	}
-
-	/**
-	 * Get the query params for collections.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
 		$params            = parent::get_collection_params();
 		$params['code']    = array(
 			'description'       => __( 'Search by similar tax code.', 'wc-admin' ),

--- a/includes/api/class-wc-admin-rest-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-taxes-controller.php
@@ -40,6 +40,21 @@ class WC_Admin_REST_Taxes_Controller extends WC_REST_Taxes_Controller {
 	}
 
 	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params         = parent::get_collection_params();
+		$params['code'] = array(
+			'description'       => __( 'Search by similar tax code.', 'wc-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+	/**
 	 * Get all taxes and allow filtering by tax code.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.


### PR DESCRIPTION
Fixes #1640 

Adds an `include` param to the tax rest endpoint so we can filter by tax rate IDs and return the correct tax codes.

### Screenshots
<img width="438" alt="screen shot 2019-02-22 at 5 04 55 pm" src="https://user-images.githubusercontent.com/10561050/53231569-360fb600-36c4-11e9-9b50-e05cc546cd49.png">
<img width="515" alt="screen shot 2019-02-22 at 5 04 51 pm" src="https://user-images.githubusercontent.com/10561050/53231570-360fb600-36c4-11e9-943e-40aadbb02bbf.png">


### Detailed test instructions:

1.  Go to the tax report and filter by tax comparison.
2.  Add various tax codes and check that the label is correct even after refreshing.
3.  Test calls to the rest endpoint `wp-json/wc/v4/taxes` with the `include` param and a comma separated list of rate IDs.