### PR TITLE
Fix CSS linter errors

### DIFF
--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -77,7 +77,7 @@
 		@include visually-hidden;
 	}
 
-	& > [role="menu"] {
+	& > [role='menu'] {
 		border: 1px solid $core-grey-light-500;
 		border-bottom: none;
 	}
@@ -126,19 +126,19 @@
 		}
 
 		// Anything deeper than 5 levels will use this fallback depth
-		&[class*="depth-"] .woocommerce-search-list__item-label:before {
+		&[class*='depth-'] .woocommerce-search-list__item-label::before {
 			margin-right: $gap-smallest;
-			content: str-repeat( '— ', 5 );
+			content: str-repeat('— ', 5);
 		}
 
-		&.depth-0 .woocommerce-search-list__item-label:before {
+		&.depth-0 .woocommerce-search-list__item-label::before {
 			margin-right: 0;
 			content: '';
 		}
 
 		@for $i from 1 to 5 {
-			&.depth-#{$i} .woocommerce-search-list__item-label:before {
-				content: str-repeat( '— ', $i );
+			&.depth-#{$i} .woocommerce-search-list__item-label::before {
+				content: str-repeat('— ', $i);
 			}
 		}
 
@@ -161,9 +161,9 @@
 			.woocommerce-search-list__item-prefix {
 				display: inline;
 
-				&:after {
+				&::after {
 					margin-right: $gap-smallest;
-					content: " ›";
+					content: ' ›';
 				}
 			}
 		}

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -4,7 +4,7 @@
 	position: relative;
 	min-width: 0;
 
-	>div {
+	> div {
 		min-width: 0;
 	}
 


### PR DESCRIPTION
Running `npm run lint` caught a couple of CSS errors. This PR fixes those.

Note: I did not update a change log entry. I don't think we need to since it's just a code style change and the CSS gets minified anyway.

To Test:
* Run `npm run lint` and make sure no errors are caught
* Bonus points for visually looking at the Search or SearchList components in devdocs