### PR TITLE
Make 'Rows Per Table' <select> accessible

### DIFF
--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -95,7 +95,9 @@ class Leaderboards extends Component {
 			},
 		];
 		return (
-			<EllipsisMenu label={ __( 'Choose which leaderboards to display', 'wc-admin' ) }>
+			<EllipsisMenu
+				label={ __( 'Choose which leaderboards to display and the number of rows', 'wc-admin' ) }
+			>
 				<Fragment>
 					<MenuTitle>{ __( 'Leaderboards', 'wc-admin' ) }</MenuTitle>
 					{ allLeaderboards.map( leaderboard => {
@@ -109,9 +111,9 @@ class Leaderboards extends Component {
 							</MenuItem>
 						);
 					} ) }
-					<MenuTitle>{ __( 'Rows Per Table', 'wc-admin' ) }</MenuTitle>
 					<SelectControl
-						className="woocommerce-ellipsis-menu__item"
+						className="woocommerce-dashboard__dashboard-leaderboards__select"
+						label={ <MenuTitle>{ __( 'Rows Per Table', 'wc-admin' ) }</MenuTitle> }
 						value={ rowsPerTable }
 						options={ Array.from( { length: 20 }, ( v, key ) => ( {
 							v: key + 1,

--- a/client/dashboard/leaderboards/style.scss
+++ b/client/dashboard/leaderboards/style.scss
@@ -8,4 +8,12 @@
 		border: 1px solid $core-grey-light-700;
 		height: 34px;
 	}
+	.woocommerce-dashboard__dashboard-leaderboards__select {
+		.components-base-control__field {
+			padding: 0 12px 4px;
+		}
+		.woocommerce-ellipsis-menu__title {
+			padding: 10px 0 14px;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #1644.

Makes the '_Rows Per Table_' `<select>` accessible, so it's read by screen reader and is marked as the label.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/53242479-1f0d9b80-36a5-11e9-9a4e-fd20a744ce97.png)

### Detailed test instructions:
With a screen reader go to the _Dashboard_:
- Navigate with the keyboard to the _Leaderboards_ menu and open it.
- With the <kbd>Tab</kbd> key, focus the `<select>` element and verify the label is read.