### PR TITLE
Table: reset search on compare and reset comparison on search

### DIFF
--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -160,7 +160,7 @@ class TableCard extends Component {
 	}
 
 	onSearch( values ) {
-		const { compareParam } = this.props;
+		const { compareParam, searchBy } = this.props;
 		// A comma is used as a separator between search terms, so we want to escape
 		// any comma they contain.
 		const labels = values.map( v => v.label.replace( ',', '%2C' ) );
@@ -168,6 +168,7 @@ class TableCard extends Component {
 			updateQueryString( {
 				filter: undefined,
 				[ compareParam ]: undefined,
+				[ searchBy ]: undefined,
 				search: uniq( labels ).join( ',' ),
 			} );
 		} else {

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -110,7 +110,11 @@ export function onQueryChange( param, path = getPath(), query = getQuery() ) {
 			return ( key, dir ) => updateQueryString( { orderby: key, order: dir }, path, query );
 		case 'compare':
 			return ( key, queryParam, ids ) =>
-				updateQueryString( { [ queryParam ]: `compare-${ key }`, [ key ]: ids }, path, query );
+				updateQueryString( {
+					[ queryParam ]: `compare-${ key }`,
+					[ key ]: ids,
+					search: undefined,
+				}, path, query );
 		default:
 			return value => updateQueryString( { [ param ]: value }, path, query );
 	}


### PR DESCRIPTION
Fixes #1660.

### Screenshots
![reset-search](https://user-images.githubusercontent.com/3616980/53262073-f81b8d80-36d5-11e9-8a5e-446bca0d9a1b.gif)

### Detailed test instructions:
- Go to the _Products_ report, for example.
- Search for three products.
- Select the checkboxes of two of them and click on _Compare_.
- Verify the search is reset and only the compared products appear in the table.
- Now, search for another product.
- Verify the comparison is reset.