### PR TITLE
Updated is_returning_customer definition to use refactored function.

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -525,9 +525,8 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		$second_order      = isset( $oldest_orders[1] ) ? $oldest_orders[1] : false;
 		$excluded_statuses = self::get_excluded_report_order_statuses();
 
-		$local_tz = new DateTimeZone( wc_timezone_string() );
 		// Order is older than previous first order.
-		if ( $order->get_date_created() < new WC_DateTime( $first_order->date_created, $local_tz ) &&
+		if ( $order->get_date_created() < wc_string_to_datetime( $first_order->date_created ) &&
 			! in_array( $order->get_status(), $excluded_statuses, true )
 		) {
 			self::set_customer_first_order( $customer_id, $order->get_id() );
@@ -538,8 +537,8 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		$is_first_order = (int) $order->get_id() === (int) $first_order->order_id;
 		// Order date has changed and next oldest is now the first order.
 		$date_change = $second_order &&
-			$order->get_date_created() > new WC_DateTime( $first_order->date_created, $local_tz ) &&
-			new WC_DateTime( $second_order->date_created, $local_tz ) < $order->get_date_created();
+			$order->get_date_created() > wc_string_to_datetime( $first_order->date_created ) &&
+			wc_string_to_datetime( $second_order->date_created ) < $order->get_date_created();
 		// Status has changed to an excluded status and next oldest order is now the first order.
 		$status_change = $second_order &&
 			in_array( $order->get_status(), $excluded_statuses, true );

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -525,8 +525,9 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		$second_order      = isset( $oldest_orders[1] ) ? $oldest_orders[1] : false;
 		$excluded_statuses = self::get_excluded_report_order_statuses();
 
+		$local_tz = new DateTimeZone( wc_timezone_string() );
 		// Order is older than previous first order.
-		if ( $order->get_date_created() < new WC_DateTime( $first_order->date_created ) &&
+		if ( $order->get_date_created() < new WC_DateTime( $first_order->date_created, $local_tz ) &&
 			! in_array( $order->get_status(), $excluded_statuses, true )
 		) {
 			self::set_customer_first_order( $customer_id, $order->get_id() );
@@ -537,8 +538,8 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		$is_first_order = (int) $order->get_id() === (int) $first_order->order_id;
 		// Order date has changed and next oldest is now the first order.
 		$date_change = $second_order &&
-			$order->get_date_created() > new WC_DateTime( $first_order->date_created ) &&
-			new WC_DateTime( $second_order->date_created ) < $order->get_date_created();
+			$order->get_date_created() > new WC_DateTime( $first_order->date_created, $local_tz ) &&
+			new WC_DateTime( $second_order->date_created, $local_tz ) < $order->get_date_created();
 		// Status has changed to an excluded status and next oldest order is now the first order.
 		$status_change = $second_order &&
 			in_array( $order->get_status(), $excluded_statuses, true );

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -509,7 +509,7 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 	 * @return bool
 	 */
 	protected static function is_returning_customer( $order ) {
-		$customer_id = WC_Admin_Reports_Customers_Data_Store::get_customer_id_by_user_id( $order->get_user_id() );
+		$customer_id = WC_Admin_Reports_Customers_Data_Store::get_existing_customer_id_from_order( $order );
 
 		if ( ! $customer_id ) {
 			return false;

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -5442,7 +5442,6 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 	 * Test new and returning guest customer.
 	 */
 	public function test_guest_returning_customer() {
-		global $wpdb;
 		WC_Helper_Reports::reset_stats_dbs();
 
 		// Create a test product for use in an order.

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -5437,4 +5437,114 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		return print_r( $data, true );
 		// @codingStandardsIgnoreEnd
 	}
+
+	/**
+	 * Test new and returning guest customer.
+	 */
+	public function test_guest_returning_customer() {
+		global $wpdb;
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a test product for use in an order.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$data_store = new WC_Admin_Reports_Orders_Stats_Data_Store();
+
+		// All empty in the beginning.
+		$query_args = array(
+			'interval' => 'hour',
+		);
+		$actual_data = json_decode( json_encode( $data_store->get_data( $query_args ) ) );
+		$this->assertEquals( 0, $actual_data->totals->num_returning_customers );
+		$this->assertEquals( 0, $actual_data->totals->num_new_customers );
+
+		// Create an order an hour before the order 1, so that the guest customer will become returning customer later.
+		$order_1_time = time();
+
+		$order_0_time = $order_1_time - HOUR_IN_SECONDS;
+
+		$order_0 = WC_Helper_Order::create_order( 0, $product );
+		$order_0->set_date_created( $order_0_time );
+		$order_0->set_status( 'processing' );
+		$order_0->set_total( 100 );
+		$order_0->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$start_time = date( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:59:59', $order_0->get_date_created()->getOffsetTimestamp() );
+		$query_args = array(
+			'interval' => 'hour',
+			'after'    => $start_time,
+			'before'   => $end_time,
+		);
+		$actual_data = json_decode( json_encode( $data_store->get_data( $query_args ) ) );
+		$this->assertEquals( 0, $actual_data->totals->num_returning_customers );
+		$this->assertEquals( 1, $actual_data->totals->num_new_customers );
+
+		// Place an order 'one hour later', 2 orders, but still just one customer.
+		$order_1 = WC_Helper_Order::create_order( 0, $product );
+		$order_1->set_date_created( $order_1_time );
+		$order_1->set_status( 'processing' );
+		$order_1->set_total( 100 );
+		$order_1->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Time frame includes both orders -> customer is a new customer.
+		$start_time = date( 'Y-m-d H:00:00', $order_0->get_date_created()->getOffsetTimestamp() );
+		$end_time   = date( 'Y-m-d H:59:59', $order_1->get_date_created()->getOffsetTimestamp() );
+		$query_args = array(
+			'interval' => 'hour',
+			'after'    => $start_time,
+			'before'   => $end_time,
+		);
+
+		$actual_data = json_decode( json_encode( $data_store->get_data( $query_args ) ) );
+		$this->assertEquals( 0, $actual_data->totals->num_returning_customers );
+		$this->assertEquals( 1, $actual_data->totals->num_new_customers );
+
+		// Time frame includes only second order -> customer is a returning customer.
+		$after_order_0 = new DateTime();
+		$after_order_0->setTimestamp( $order_0_time + 1 );
+
+		$start_time   = date( 'Y-m-d H:i:s', $order_0_time + 1 );
+		$end_time     = date( 'Y-m-d H:59:59', $order_1->get_date_created()->getOffsetTimestamp() );
+		$query_args   = array(
+			'interval' => 'hour',
+			'after'    => $start_time,
+			'before'   => $end_time,
+		);
+
+		$actual_data = json_decode( json_encode( $data_store->get_data( $query_args ) ) );
+		$this->assertEquals( 1, $actual_data->totals->num_returning_customers );
+		$this->assertEquals( 0, $actual_data->totals->num_new_customers );
+
+		// Wait a bit so that orders are not created at the same second.
+		sleep( 1 );
+
+		$order_2 = WC_Helper_Order::create_order( 0, $product );
+		$order_2->set_date_created( $order_1_time );
+		$order_2->set_status( 'processing' );
+		$order_2->set_total( 100 );
+		$order_2->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Time frame includes second and third order -> there is one returning customer.
+		$start_time   = date( 'Y-m-d H:i:s', $order_0_time + 1 );
+		$end_time   = date( 'Y-m-d H:59:59', $order_2->get_date_created()->getOffsetTimestamp() );
+		$query_args = array(
+			'interval' => 'day', // to skip cache.
+			'after'    => $start_time,
+			'before'   => $end_time,
+		);
+		$actual_data = json_decode( json_encode( $data_store->get_data( $query_args ) ) );
+		// It's still the same customer who ordered for the first time in this hour, they just placed 2 orders.
+		$this->assertEquals( 1, $actual_data->totals->num_returning_customers );
+		$this->assertEquals( 0, $actual_data->totals->num_new_customers );
+	}
 }


### PR DESCRIPTION
This should be the last part of fix for #1476, first attempted in #1479, that was later refactored by @joshuatf in #1619 and additional fixes were applied in #1517 (kudos for tackling that, it was a tricky one).

If my understanding is correct, @joshuatf mentioned in the comment 
https://github.com/woocommerce/wc-admin/pull/1517#issuecomment-463078718
that `is_returning_customer` needs to be updated similarly to #1479. 
So to clean things up a bit this PR supersedes #1479 and adds last remaining fix and tests.

### Detailed test instructions:

1. Check out as guest twice using the same billing email
2. Check the `wc_order_stats`: first order should have `returning_customer` set to 0, the second set to 1.
3. Check out as logged in customer twice
4. Check the `wc_order_stats`: first order should have `returning_customer` set to 0, the second set to 1.
5. Tests shall pass