### PR TITLE
Display table placeholder instead of empty table when loading search terms

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -65,6 +65,7 @@ class ReportTable extends Component {
 			getHeadersContent,
 			getRowsContent,
 			getSummary,
+			isRequesting,
 			itemIdField,
 			primaryData,
 			tableData,
@@ -84,7 +85,7 @@ class ReportTable extends Component {
 			return <ReportError isError />;
 		}
 
-		const isRequesting = tableData.isRequesting || primaryData.isRequesting;
+		const isLoading = isRequesting || tableData.isRequesting || primaryData.isRequesting;
 		const totals = get( primaryData, [ 'data', 'totals' ], {} );
 		const totalResults = items.totalResults;
 		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
@@ -104,7 +105,7 @@ class ReportTable extends Component {
 				downloadable
 				headers={ filteredHeaders }
 				ids={ ids }
-				isLoading={ isRequesting }
+				isLoading={ isLoading }
 				onQueryChange={ onQueryChange }
 				onColumnsChange={ this.onColumnsChange }
 				rows={ rows }
@@ -190,8 +191,16 @@ ReportTable.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, getSummary, query, tableData, tableQuery, columnPrefsKey } = props;
-		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
+		const {
+			endpoint,
+			getSummary,
+			isRequesting,
+			query,
+			tableData,
+			tableQuery,
+			columnPrefsKey,
+		} = props;
+		if ( isRequesting || ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) ) {
 			return {};
 		}
 		const chartEndpoint = [ 'variations', 'categories' ].includes( endpoint )

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -37,7 +37,7 @@ export default class CategoriesReport extends Component {
 	}
 
 	render() {
-		const { query, path } = this.props;
+		const { isRequesting, query, path } = this.props;
 		const { mode, itemsLabel } = this.getChartMeta();
 
 		const chartQuery = {
@@ -67,7 +67,7 @@ export default class CategoriesReport extends Component {
 					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<CategoriesReportTable query={ query } />
+				<CategoriesReportTable isRequesting={ isRequesting } query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -134,7 +134,7 @@ class CategoriesReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { isRequesting, query } = this.props;
 
 		const labels = {
 			helpText: __( 'Select at least two categories to compare', 'wc-admin' ),
@@ -148,6 +148,7 @@ class CategoriesReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
+				isRequesting={ isRequesting }
 				itemIdField="category_id"
 				query={ query }
 				searchBy="categories"
@@ -166,8 +167,8 @@ class CategoriesReportTable extends Component {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query } = props;
-		if ( query.search && ! ( query.categories && query.categories.length ) ) {
+		const { isRequesting, query } = props;
+		if ( isRequesting || ( query.search && ! ( query.categories && query.categories.length ) ) ) {
 			return {};
 		}
 
@@ -177,9 +178,9 @@ export default compose(
 		};
 
 		const categories = getItems( 'categories', tableQuery );
-		const isError = Boolean( getItemsError( 'categories', tableQuery ) );
-		const isRequesting = isGetItemsRequesting( 'categories', tableQuery );
+		const isCategoriesError = Boolean( getItemsError( 'categories', tableQuery ) );
+		const isCategoriesRequesting = isGetItemsRequesting( 'categories', tableQuery );
 
-		return { categories, isError, isRequesting };
+		return { categories, isError: isCategoriesError, isRequesting: isCategoriesRequesting };
 	} )
 )( CategoriesReportTable );

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -37,7 +37,7 @@ export default class CouponsReport extends Component {
 	}
 
 	render() {
-		const { query, path } = this.props;
+		const { isRequesting, query, path } = this.props;
 		const { mode, itemsLabel } = this.getChartMeta();
 
 		const chartQuery = {
@@ -67,7 +67,7 @@ export default class CouponsReport extends Component {
 					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<CouponsReportTable query={ query } />
+				<CouponsReportTable isRequesting={ isRequesting } query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -156,7 +156,7 @@ export default class CouponsReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { isRequesting, query } = this.props;
 
 		return (
 			<ReportTable
@@ -165,6 +165,7 @@ export default class CouponsReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
+				isRequesting={ isRequesting }
 				itemIdField="coupon_id"
 				query={ query }
 				searchBy="coupons"

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -18,7 +18,7 @@ import CustomersReportTable from './table';
 
 export default class CustomersReport extends Component {
 	render() {
-		const { query, path } = this.props;
+		const { isRequesting, query, path } = this.props;
 		const tableQuery = {
 			orderby: 'date_last_active',
 			order: 'desc',
@@ -34,7 +34,7 @@ export default class CustomersReport extends Component {
 					showDatePicker={ false }
 					advancedFilters={ advancedFilters }
 				/>
-				<CustomersReportTable query={ tableQuery } />
+				<CustomersReportTable isRequesting={ isRequesting } query={ tableQuery } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -218,7 +218,7 @@ export default class CustomersReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { isRequesting, query } = this.props;
 
 		return (
 			<ReportTable
@@ -226,6 +226,7 @@ export default class CustomersReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
+				isRequesting={ isRequesting }
 				itemIdField="id"
 				query={ query }
 				labels={ { placeholder: __( 'Search by customer name', 'wc-admin' ) } }

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -29,6 +29,7 @@ import TaxesReport from './taxes';
 import DownloadsReport from './downloads';
 import StockReport from './stock';
 import CustomersReport from './customers';
+import ReportError from 'analytics/components/report-error';
 import { searchItemsByString } from 'wc-api/items/utils';
 import withSelect from 'wc-api/with-select';
 
@@ -114,7 +115,12 @@ class Report extends Component {
 			return null;
 		}
 
-		const { params } = this.props;
+		const { params, isError } = this.props;
+
+		if ( isError ) {
+			return <ReportError isError />;
+		}
+
 		const report = find( getReports(), { report: params.report } );
 		if ( ! report ) {
 			return null;
@@ -146,10 +152,13 @@ export default compose(
 
 		const { report } = props.params;
 		const searchWords = search.split( ',' ).map( searchWord => searchWord.replace( '%2C', ',' ) );
-		const items = searchItemsByString( select, report, searchWords );
+		const itemsResult = searchItemsByString( select, report, searchWords );
+		const { isError, isRequesting, items } = itemsResult;
 		const ids = Object.keys( items );
 		if ( ! ids.length ) {
 			return {
+				isError,
+				isRequesting,
 				query: {
 					...props.query,
 					search: searchWords,
@@ -158,6 +167,8 @@ export default compose(
 		}
 
 		return {
+			isError,
+			isRequesting,
 			query: {
 				...props.query,
 				search: searchWords,

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -56,19 +56,13 @@ class ProductsReport extends Component {
 
 	render() {
 		const { compareObject, itemsLabel, mode } = this.getChartMeta();
-		const {
-			path,
-			query,
-			isProductsError,
-			isProductsRequesting,
-			isSingleProductVariable,
-		} = this.props;
+		const { path, query, isError, isRequesting, isSingleProductVariable } = this.props;
 
-		if ( isProductsError ) {
+		if ( isError ) {
 			return <ReportError isError />;
 		}
 
-		if ( isProductsRequesting ) {
+		if ( isRequesting ) {
 			return (
 				<Fragment>
 					<ReportFilters query={ query } path={ path } filters={ filters } />
@@ -81,7 +75,7 @@ class ProductsReport extends Component {
 							<ChartPlaceholder height={ 220 } />
 						</div>
 					</div>
-					<ProductsReportTable query={ query } />
+					<ProductsReportTable isRequesting={ true } query={ query } />
 				</Fragment>
 			);
 		}
@@ -131,10 +125,20 @@ ProductsReport.propTypes = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query } = props;
-		const { getItems, isGetItemsRequesting, getItemsError } = select( 'wc-api' );
+		const { query, isRequesting } = props;
 		const isSingleProductView =
 			! query.search && query.products && 1 === query.products.split( ',' ).length;
+		if ( isRequesting ) {
+			return {
+				query: {
+					...query,
+				},
+				isSingleProductView,
+				isRequesting,
+			};
+		}
+
+		const { getItems, isGetItemsRequesting, getItemsError } = select( 'wc-api' );
 		if ( isSingleProductView ) {
 			const productId = parseInt( query.products );
 			const includeArgs = { include: productId };
@@ -151,8 +155,8 @@ export default compose(
 				},
 				isSingleProductView,
 				isSingleProductVariable: isVariable,
-				isProductsRequesting,
-				isProductsError,
+				isRequesting: isProductsRequesting,
+				isError: isProductsError,
 			};
 		}
 

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -224,7 +224,7 @@ class ProductsReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, isRequesting } = this.props;
 
 		const labels = {
 			helpText: __( 'Select at least two products to compare', 'wc-admin' ),
@@ -239,6 +239,7 @@ class ProductsReportTable extends Component {
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
 				itemIdField="product_id"
+				isRequesting={ isRequesting }
 				labels={ labels }
 				query={ query }
 				searchBy="products"
@@ -256,8 +257,8 @@ class ProductsReportTable extends Component {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query } = props;
-		if ( query.search && ! ( query.products && query.products.length ) ) {
+		const { query, isRequesting } = props;
+		if ( isRequesting || ( query.search && ! ( query.products && query.products.length ) ) ) {
 			return {};
 		}
 
@@ -268,8 +269,8 @@ export default compose(
 
 		const categories = getItems( 'categories', tableQuery );
 		const isError = Boolean( getItemsError( 'categories', tableQuery ) );
-		const isRequesting = isGetItemsRequesting( 'categories', tableQuery );
+		const isLoading = isGetItemsRequesting( 'categories', tableQuery );
 
-		return { categories, isError, isRequesting };
+		return { categories, isError, isRequesting: isLoading };
 	} )
 )( ProductsReportTable );

--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -21,7 +21,7 @@ import TaxesReportTable from './table';
 
 export default class TaxesReport extends Component {
 	render() {
-		const { query, path } = this.props;
+		const { isRequesting, query, path } = this.props;
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } filters={ filters } />
@@ -38,7 +38,7 @@ export default class TaxesReport extends Component {
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<TaxesReportTable query={ query } />
+				<TaxesReportTable isRequesting={ isRequesting } query={ query } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -143,7 +143,7 @@ export default class TaxesReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { isRequesting, query } = this.props;
 
 		return (
 			<ReportTable
@@ -152,6 +152,7 @@ export default class TaxesReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
+				isRequesting={ isRequesting }
 				itemIdField="tax_rate_id"
 				query={ query }
 				searchBy="taxes"

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -10,21 +10,30 @@
  * @param  {Object}   select    Instance of @wordpress/select
  * @param  {String}   endpoint  Report API Endpoint
  * @param  {String[]} search    Array of search strings.
- * @return {Object}   Object containing the matching items.
+ * @return {Object}   Object containing API request information and the matching items.
  */
 export function searchItemsByString( select, endpoint, search ) {
-	const { getItems } = select( 'wc-api' );
+	const { getItems, getItemsError, isGetItemsRequesting } = select( 'wc-api' );
 
 	const items = {};
+	let isRequesting = false;
+	let isError = false;
 	search.forEach( searchWord => {
-		const newItems = getItems( endpoint, {
+		const query = {
 			search: searchWord,
 			per_page: 10,
-		} );
+		};
+		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {
 			items[ id ] = item;
 		} );
+		if ( isGetItemsRequesting( endpoint, query ) ) {
+			isRequesting = true;
+		}
+		if ( getItemsError( endpoint, query ) ) {
+			isError = true;
+		}
 	} );
 
-	return items;
+	return { items, isRequesting, isError };
 }

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -194,7 +194,7 @@ function getRequestQuery( endpoint, dataType, query ) {
  *
  * @param  {String} endpoint Report  API Endpoint
  * @param  {Object} query  query parameters in the url
- * @param {object} select Instance of @wordpress/select
+ * @param  {Object} select Instance of @wordpress/select
  * @return {Object}  Object containing summary number responses.
  */
 export function getSummaryNumbers( endpoint, query, select ) {
@@ -237,7 +237,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
  * @param  {String} endpoint Report  API Endpoint
  * @param  {String} dataType 'primary' or 'secondary'
  * @param  {Object} query  query parameters in the url
- * @param {object} select Instance of @wordpress/select
+ * @param  {Object} select Instance of @wordpress/select
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( endpoint, dataType, query, select ) {


### PR DESCRIPTION
Fixes #1676.

Prevent the report table showing an empty state when loading the search terms, instead, display the table placeholder.

### Screenshots
_Before (notice an empty table is visible for a fraction of a second):_
![empty-table](https://user-images.githubusercontent.com/3616980/53256054-4d9c6e00-36c7-11e9-9254-4ceb65570bc3.gif)

_After:_
![search-3](https://user-images.githubusercontent.com/3616980/53288521-59506900-3789-11e9-8905-41646a04309b.gif)

### Detailed test instructions:
- Go to the _Products_ report, for example.
- Search for a product using the table search input.
- Verify the table is never empty: it goes from displaying all products → placeholder → displaying the searched product.
- Repeat the same for the other reports that have search inputs in the tables.