### PR TITLE
Don't update state on user preferences props change

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
-import { isEqual, xor } from 'lodash';
+import { xor } from 'lodash';
 import PropTypes from 'prop-types';
 import { ToggleControl, IconButton, NavigableMenu, SelectControl } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
@@ -36,35 +36,6 @@ class DashboardCharts extends Component {
 		};
 
 		this.toggle = this.toggle.bind( this );
-	}
-
-	componentDidUpdate( {
-		userPrefCharts: prevUserPrefCharts,
-		userPrefChartType: prevUserPrefChartType,
-		userPrefChartInterval: prevUserPrefChartInterval,
-	} ) {
-		const { userPrefCharts, userPrefChartInterval, userPrefChartType } = this.props;
-		if ( userPrefCharts && ! isEqual( userPrefCharts, prevUserPrefCharts ) ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				hiddenChartKeys: userPrefCharts,
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
-		if ( userPrefChartType && userPrefChartType !== prevUserPrefChartType ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				chartType: userPrefChartType,
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
-		if ( userPrefChartInterval !== prevUserPrefChartInterval ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				interval: userPrefChartInterval,
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
 	}
 
 	toggle( key ) {

--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { isEqual, xor } from 'lodash';
+import { xor } from 'lodash';
 import PropTypes from 'prop-types';
 import { SelectControl, ToggleControl } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
@@ -33,30 +33,6 @@ class Leaderboards extends Component {
 		};
 
 		this.toggle = this.toggle.bind( this );
-	}
-
-	componentDidUpdate( {
-		userPrefLeaderboardRows: prevUserPrefLeaderboardRows,
-		userPrefLeaderboards: prevUserPrefLeaderboards,
-	} ) {
-		const { userPrefLeaderboardRows, userPrefLeaderboards } = this.props;
-		if ( userPrefLeaderboards && ! isEqual( userPrefLeaderboards, prevUserPrefLeaderboards ) ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				hiddenLeaderboardKeys: userPrefLeaderboards,
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
-		if (
-			userPrefLeaderboardRows &&
-			parseInt( userPrefLeaderboardRows ) !== parseInt( prevUserPrefLeaderboardRows )
-		) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				rowsPerTable: parseInt( userPrefLeaderboardRows ),
-			} );
-			/* eslint-enable react/no-did-update-set-state */
-		}
 	}
 
 	toggle( key ) {


### PR DESCRIPTION
Fixes #1687

Prevents toggle flash when quickly toggling user preferences.  Relies on initial state hydration instead of updating the state whenever props are changed after user preferences update.

### Detailed test instructions:

1.  Toggle the user dashboard charts, chart types, leaderboard, and leaderboard rows quickly on and off.
2.  Check that no flash is produced when toggling quickly.
3.  Make sure preferences are still correct and persist after refreshing.