### PR TITLE
Don't store searchWords in the `query` prop

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -13,7 +13,7 @@ import { find } from 'lodash';
  * WooCommerce dependencies
  */
 import { useFilters } from '@woocommerce/components';
-import { getQuery } from '@woocommerce/navigation';
+import { getQuery, getSearchWords } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -138,29 +138,24 @@ Report.propTypes = {
 export default compose(
 	useFilters( REPORTS_FILTER ),
 	withSelect( ( select, props ) => {
-		const { search } = getQuery();
+		const query = getQuery();
+		const { search } = query;
 
 		if ( ! search ) {
 			return {};
 		}
 
 		const { report } = props.params;
-		const searchWords = search.split( ',' ).map( searchWord => searchWord.replace( '%2C', ',' ) );
+		const searchWords = getSearchWords( query );
 		const items = searchItemsByString( select, report, searchWords );
 		const ids = Object.keys( items );
 		if ( ! ids.length ) {
-			return {
-				query: {
-					...props.query,
-					search: searchWords,
-				},
-			};
+			return {};
 		}
 
 		return {
 			query: {
 				...props.query,
-				search: searchWords,
 				[ report ]: ids.join( ',' ),
 			},
 		};

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -17,7 +17,7 @@ import {
 	generateCSVDataFromTable,
 	generateCSVFileName,
 } from '@woocommerce/csv-export';
-import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
+import { getIdsFromQuery, getSearchWords, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -254,7 +254,8 @@ class TableCard extends Component {
 			totalRows,
 		} = this.props;
 		const { selectedRows, showCols } = this.state;
-		const searchedLabels = Array.isArray( query.search ) ? query.search.map( v => ( { id: v, label: v } ) ) : [];
+		const searchWords = getSearchWords( query );
+		const searchedLabels = searchWords.map( v => ( { id: v, label: v } ) );
 		const allHeaders = this.props.headers;
 		let headers = this.getVisibleHeaders();
 		let rows = this.getVisibleRows();

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,3 +1,6 @@
+# (unreleased)
+- New method `getSearchWords` that extracts search words given a query object.
+
 # 2.0.0
 
 - Replace `history` export with `getHistory` (allows for lazy-create of history)

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -71,6 +71,26 @@ export function getIdsFromQuery( queryString = '' ) {
 }
 
 /**
+ * Get an array of searched words given a query.
+ *
+ * @param {Object} query Query object.
+ * @return {Array} List of search words.
+ */
+export function getSearchWords( query = navUtils.getQuery() ) {
+	if ( typeof query !== 'object' ) {
+		throw new Error( 'Invalid parameter passed to getSearchWords, it expects an object or no parameters.' );
+	}
+	const { search } = query;
+	if ( ! search ) {
+		return [];
+	}
+	if ( typeof search !== 'string' ) {
+		throw new Error( 'Invalid \'search\' type. getSearchWords expects query\'s \'search\' property to be a string.' );
+	}
+	return search.split( ',' ).map( searchWord => searchWord.replace( '%2C', ',' ) );
+}
+
+/**
  * Return a URL with set query parameters.
  *
  * @param {Object} query object of params to be updated.

--- a/packages/navigation/src/test/index.js
+++ b/packages/navigation/src/test/index.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { getPersistedQuery } from '../index';
+import { getPersistedQuery, getSearchWords } from '../index';
 
 jest.mock( '../index', () => ( {
 	...require.requireActual( '../index' ),
@@ -14,6 +14,7 @@ jest.mock( '../index', () => ( {
 		after: '2018-02-01',
 		before: '2018-01-01',
 		interval: 'day',
+		search: 'lorem',
 	} ),
 } ) );
 
@@ -61,5 +62,50 @@ describe( 'getPersistedQuery', () => {
 		};
 
 		expect( getPersistedQuery() ).toEqual( persistedQuery );
+	} );
+} );
+
+describe( 'getSearchWords', () => {
+	it( 'should get the search words from a query object', () => {
+		const query = {
+			search: 'lorem,dolor sit',
+		};
+		const searchWords = [ 'lorem', 'dolor sit' ];
+
+		expect( getSearchWords( query ) ).toEqual( searchWords );
+	} );
+
+	it( 'should parse `%2C` as commas', () => {
+		const query = {
+			search: 'lorem%2Cipsum,dolor sit',
+		};
+		const searchWords = [ 'lorem,ipsum', 'dolor sit' ];
+
+		expect( getSearchWords( query ) ).toEqual( searchWords );
+	} );
+
+	it( 'should return an empty array if the query has no `search` property', () => {
+		const query = {};
+		const searchWords = [];
+
+		expect( getSearchWords( query ) ).toEqual( searchWords );
+	} );
+
+	it( 'should use the persisted query when it receives no params', () => {
+		const searchWords = [ 'lorem' ];
+
+		expect( getSearchWords() ).toEqual( searchWords );
+	} );
+
+	it( 'should throw an error if the param is not an object', () => {
+		expect( () => getSearchWords( 'lorem' ) ).toThrow( Error );
+	} );
+
+	it( 'should throw an error if the `search` property is not a string', () => {
+		const query = {
+			search: new Object(),
+		};
+
+		expect( () => getSearchWords( query ) ).toThrow( Error );
 	} );
 } );


### PR DESCRIPTION
Fixes #1683.

Fixes an error that was making the app crash when changing the date range if there was an active search.

### Screenshots
![search-param](https://user-images.githubusercontent.com/3616980/53349157-c0525700-391c-11e9-8660-9e91c1358879.gif)

### Detailed test instructions:
* Go to the _Products_ report, for example.
* Using the table search input, search for a product.
* Using the date picker, change to _Year to Date_, for example.
* Verify no JS error appears and everything keeps working.

Bonus points, given that this PR modifies some code introduced in #1605:
* Create a product with a comma in its name if you don't have one already.
* Go to the _Products_ report.
* Search for it in the table search input.
* Verify it appears in one single tag.
![image](https://user-images.githubusercontent.com/3616980/52967316-000fc080-33aa-11e9-8f4a-19f1f7542f29.png)