### PR TITLE
Fix empty chart and summary numbers when searching in the Categories report

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -179,6 +179,11 @@ ReportChart.propTypes = {
 	 */
 	itemsLabel: PropTypes.string,
 	/**
+	 * Allows specifying a property different from the `endpoint` that will be used
+	 * to limit the items when there is an active search.
+	 */
+	limitProperty: PropTypes.string,
+	/**
 	 * `items-comparison` (default) or `time-comparison`, this is used to generate correct
 	 * ARIA properties.
 	 */
@@ -224,10 +229,11 @@ ReportChart.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query, endpoint, filters } = props;
+		const { filters, endpoint, limitProperty, query } = props;
+		const limitBy = limitProperty || endpoint;
 		const chartMode = props.mode || getChartMode( filters, query ) || 'time-comparison';
 
-		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
+		if ( query.search && ! ( query[ limitBy ] && query[ limitBy ].length ) ) {
 			return {
 				emptySearchResults: true,
 				mode: chartMode,
@@ -235,15 +241,15 @@ export default compose(
 		}
 
 		if ( 'item-comparison' === chartMode ) {
-			const primaryData = getReportChartData( endpoint, 'primary', query, select );
+			const primaryData = getReportChartData( endpoint, 'primary', query, select, limitBy );
 			return {
 				mode: chartMode,
 				primaryData,
 			};
 		}
 
-		const primaryData = getReportChartData( endpoint, 'primary', query, select );
-		const secondaryData = getReportChartData( endpoint, 'secondary', query, select );
+		const primaryData = getReportChartData( endpoint, 'primary', query, select, limitBy );
+		const secondaryData = getReportChartData( endpoint, 'secondary', query, select, limitBy );
 		return {
 			mode: chartMode,
 			primaryData,

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -109,6 +109,11 @@ ReportSummary.propTypes = {
 	 */
 	endpoint: PropTypes.string.isRequired,
 	/**
+	 * Allows specifying a property different from the `endpoint` that will be used
+	 * to limit the items when there is an active search.
+	 */
+	limitProperty: PropTypes.string,
+	/**
 	 * The query string represented in object form.
 	 */
 	query: PropTypes.object.isRequired,
@@ -140,13 +145,14 @@ ReportSummary.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { query, endpoint } = props;
-		if ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) {
+		const { endpoint, limitProperty, query } = props;
+		const limitBy = limitProperty || endpoint;
+		if ( query.search && ! ( query[ limitBy ] && query[ limitBy ].length ) ) {
 			return {
 				emptySearchResults: true,
 			};
 		}
-		const summaryData = getSummaryNumbers( endpoint, query, select );
+		const summaryData = getSummaryNumbers( endpoint, query, select, limitBy );
 
 		return {
 			summaryData,

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -54,6 +54,7 @@ export default class CategoriesReport extends Component {
 				<ReportSummary
 					charts={ charts }
 					endpoint="products"
+					limitProperty="categories"
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
@@ -62,6 +63,7 @@ export default class CategoriesReport extends Component {
 					charts={ charts }
 					mode={ mode }
 					endpoint="products"
+					limitProperty="categories"
 					path={ path }
 					query={ chartQuery }
 					itemsLabel={ itemsLabel }

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -36,10 +36,11 @@ const reportConfigs = {
 	taxes: taxesConfig,
 };
 
-export function getFilterQuery( endpoint, query ) {
+export function getFilterQuery( endpoint, query, limitBy ) {
 	if ( query.search ) {
+		const limitProperty = limitBy || endpoint;
 		return {
-			[ endpoint ]: query[ endpoint ],
+			[ limitProperty ]: query[ limitProperty ],
 		};
 	}
 
@@ -164,15 +165,16 @@ export function isReportDataEmpty( report, endpoint ) {
 /**
  * Constructs and returns a query associated with a Report data request.
  *
- * @param  {String} endpoint Report API Endpoint
- * @param  {String} dataType 'primary' or 'secondary'.
- * @param  {Object} query  query parameters in the url.
+ * @param  {String} endpoint  Report API Endpoint
+ * @param  {String} dataType  'primary' or 'secondary'.
+ * @param  {Object} query     Query parameters in the url.
+ * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
  * @returns {Object} data request query parameters.
  */
-function getRequestQuery( endpoint, dataType, query ) {
+function getRequestQuery( endpoint, dataType, query, limitBy ) {
 	const datesFromQuery = getCurrentDates( query );
 	const interval = getIntervalForQuery( query );
-	const filterQuery = getFilterQuery( endpoint, query );
+	const filterQuery = getFilterQuery( endpoint, query, limitBy );
 	const end = datesFromQuery[ dataType ].before;
 
 	const noIntervals = includes( noIntervalEndpoints, endpoint );
@@ -192,12 +194,13 @@ function getRequestQuery( endpoint, dataType, query ) {
 /**
  * Returns summary number totals needed to render a report page.
  *
- * @param  {String} endpoint Report  API Endpoint
- * @param  {Object} query  query parameters in the url
- * @param  {Object} select Instance of @wordpress/select
- * @return {Object}  Object containing summary number responses.
+ * @param  {String} endpoint  Report API Endpoint
+ * @param  {Object} query     Query parameters in the url
+ * @param  {Object} select    Instance of @wordpress/select
+ * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
+ * @return {Object} Object containing summary number responses.
  */
-export function getSummaryNumbers( endpoint, query, select ) {
+export function getSummaryNumbers( endpoint, query, select, limitBy ) {
 	const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 	const response = {
 		isRequesting: false,
@@ -208,7 +211,7 @@ export function getSummaryNumbers( endpoint, query, select ) {
 		},
 	};
 
-	const primaryQuery = getRequestQuery( endpoint, 'primary', query );
+	const primaryQuery = getRequestQuery( endpoint, 'primary', query, limitBy );
 	const primary = getReportStats( endpoint, primaryQuery );
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
@@ -234,13 +237,14 @@ export function getSummaryNumbers( endpoint, query, select ) {
 /**
  * Returns all of the data needed to render a chart with summary numbers on a report page.
  *
- * @param  {String} endpoint Report  API Endpoint
- * @param  {String} dataType 'primary' or 'secondary'
- * @param  {Object} query  query parameters in the url
- * @param  {Object} select Instance of @wordpress/select
+ * @param  {String} endpoint  Report API Endpoint
+ * @param  {String} dataType  'primary' or 'secondary'
+ * @param  {Object} query     Query parameters in the url
+ * @param  {Object} select    Instance of @wordpress/select
+ * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
-export function getReportChartData( endpoint, dataType, query, select ) {
+export function getReportChartData( endpoint, dataType, query, select, limitBy ) {
 	const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
 
 	const response = {
@@ -253,7 +257,7 @@ export function getReportChartData( endpoint, dataType, query, select ) {
 		},
 	};
 
-	const requestQuery = getRequestQuery( endpoint, dataType, query );
+	const requestQuery = getRequestQuery( endpoint, dataType, query, limitBy );
 	const stats = getReportStats( endpoint, requestQuery );
 
 	if ( isReportStatsRequesting( endpoint, requestQuery ) ) {


### PR DESCRIPTION
Fixes #1690.

Fixes the _Categories_ report displaying an empty chart and empty summary numbers when a search was active.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/53424280-3620f600-39e3-11e9-9212-ca2650fe2ede.png)

### Detailed test instructions:
* Go to the _Categories_ report.
* Search for one or more categories using the table search input.
* Verify the correct data appears in the chart and summary numbers.