### PR TITLE
Retain size of order status indicator in smaller screen

### DIFF
--- a/packages/components/src/order-status/style.scss
+++ b/packages/components/src/order-status/style.scss
@@ -6,6 +6,7 @@
 }
 
 .woocommerce-order-status__indicator {
+	min-width: 16px;
 	width: 16px;
 	height: 16px;
 	display: block;


### PR DESCRIPTION
Fixes #1650 

Retain size of order status indicator in flex-box

### Screenshot

![status-indicator-on-hold-gets-squished-and-looks-like-an-egg](https://user-images.githubusercontent.com/3380686/53468965-34f2d600-3a82-11e9-979f-6f1914ba70d9.png)
