### PR TITLE
Make EmptyContent component fit narrow viewports

### DIFF
--- a/packages/components/src/empty-content/index.js
+++ b/packages/components/src/empty-content/index.js
@@ -153,7 +153,6 @@ EmptyContent.propTypes = {
 
 EmptyContent.defaultProps = {
 	illustration: '/empty-content.svg',
-	illustrationHeight: 400,
 	illustrationWidth: 400,
 };
 

--- a/packages/components/src/empty-content/style.scss
+++ b/packages/components/src/empty-content/style.scss
@@ -1,7 +1,12 @@
 /** @format */
 
 .woocommerce-empty-content {
+	margin-bottom: $gap;
 	text-align: center;
+
+	.woocommerce-empty-content__illustration {
+		max-width: 100%;
+	}
 
 	.woocommerce-empty-content__actions {
 		.components-button + .components-button {


### PR DESCRIPTION
Fixes #1662.

Makes the `EmptyContent` component width adaptable so it fits narrow viewports.

The component has a lot of spacing on top of it because the [image](https://github.com/woocommerce/wc-admin/blob/master/images/empty-content.svg) has a lot of padding. @LevinMedia is that intentional?

### Screenshots
_Before:_
![screen shot 2019-02-27 at 16 30 26](https://user-images.githubusercontent.com/3616980/53501820-279f1100-3aad-11e9-9f85-d5d7623c6cd4.png)

_After:_
![screen shot 2019-02-27 at 16 27 01](https://user-images.githubusercontent.com/3616980/53501491-8e6ffa80-3aac-11e9-9c57-8284f008ef0d.png)

### Detailed test instructions:
Modify [this line](https://github.com/woocommerce/wc-admin/blob/master/client/analytics/components/report-chart/index.js#L153) from:
```ES6
if ( ! primaryData || primaryData.isError || secondaryData.isError ) {
```
to:
```ES6
if ( true || ! primaryData || primaryData.isError || secondaryData.isError ) {
```
so an error is shown in all reports.
- With a device with a narrow viewport go to any report.
- Verify the error fits the screen.
