### PR TITLE
Display order number on reports

### DIFF
--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -51,8 +51,8 @@ export default class CouponsReportTable extends Component {
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
-				screenReaderLabel: __( 'Order ID', 'wc-admin' ),
-				key: 'order_id',
+				screenReaderLabel: __( 'Order Number', 'wc-admin' ),
+				key: 'order_number',
 			},
 			{
 				label: __( 'User Name', 'wc-admin' ),
@@ -77,6 +77,7 @@ export default class CouponsReportTable extends Component {
 				file_path,
 				ip_address,
 				order_id,
+				order_number,
 				product_id,
 				username,
 			} = download;
@@ -111,10 +112,10 @@ export default class CouponsReportTable extends Component {
 				{
 					display: (
 						<Link href={ `post.php?post=${ order_id }&action=edit` } type="wp-admin">
-							{ order_id }
+							{ order_number }
 						</Link>
 					),
-					value: order_id,
+					value: order_number,
 				},
 				{
 					display: username,

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -42,8 +42,8 @@ export default class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'Order #', 'wc-admin' ),
-				screenReaderLabel: __( 'Order ID', 'wc-admin' ),
-				key: 'id',
+				screenReaderLabel: __( 'Order Number', 'wc-admin' ),
+				key: 'order_number',
 				required: true,
 			},
 			{
@@ -102,6 +102,7 @@ export default class OrdersReportTable extends Component {
 				net_total,
 				num_items_sold,
 				order_id,
+				order_number,
 				status,
 			} = row;
 			const { coupons, products } = extended_info;
@@ -133,10 +134,10 @@ export default class OrdersReportTable extends Component {
 				{
 					display: (
 						<Link href={ 'post.php?post=' + order_id + '&action=edit' } type="wp-admin">
-							{ order_id }
+							{ order_number }
 						</Link>
 					),
-					value: order_id,
+					value: order_number,
 				},
 				{
 					display: (

--- a/includes/api/class-wc-admin-rest-reports-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-controller.php
@@ -174,6 +174,20 @@ class WC_Admin_REST_Reports_Controller extends WC_REST_Reports_Controller {
 	}
 
 	/**
+	 * Get the order number for an order. If no filter is present for `woocommerce_order_number`, we can just return the ID.
+	 *
+	 * @param  int $order_id Order ID.
+	 * @return string
+	 */
+	public function get_order_number( $order_id ) {
+		if ( ! has_filter( 'woocommerce_order_number' ) ) {
+			return $order_id;
+		}
+		$order = new WC_Order( $order_id );
+		return $order->get_order_number();
+	}
+
+	/**
 	 * Prepare a report object for serialization.
 	 *
 	 * @param stdClass        $report  Report data.

--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Controller {
+class WC_Admin_REST_Reports_Downloads_Controller extends WC_Admin_REST_Reports_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -111,8 +111,7 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 		$response->data['file_path']    = $file_path;
 		$customer                       = new WC_Customer( $data['user_id'] );
 		$response->data['username']     = $customer->get_username();
-		$order                          = new WC_Order( $data['order_id'] );
-		$response->data['order_number'] = $order->get_order_number();
+		$response->data['order_number'] = $this->get_order_number( $data['order_id'] );
 
 		/**
 		 * Filter a report returned from the API.

--- a/includes/api/class-wc-admin-rest-reports-downloads-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-downloads-controller.php
@@ -103,15 +103,16 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 
 		// Figure out file name.
 		// Matches https://github.com/woocommerce/woocommerce/blob/4be0018c092e617c5d2b8c46b800eb71ece9ddef/includes/class-wc-download-handler.php#L197.
-		$product_id                  = intval( $data['product_id'] );
-		$_product                    = wc_get_product( $product_id );
-		$file_path                   = $_product->get_file_download_path( $data['download_id'] );
-
-		$filename                    = basename( $file_path );
-		$response->data['file_name'] = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
-		$response->data['file_path'] = $file_path;
-		$customer                    = new WC_Customer( $data['user_id'] );
-		$response->data['username']  = $customer->get_username();
+		$product_id                     = intval( $data['product_id'] );
+		$_product                       = wc_get_product( $product_id );
+		$file_path                      = $_product->get_file_download_path( $data['download_id'] );
+		$filename                       = basename( $file_path );
+		$response->data['file_name']    = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
+		$response->data['file_path']    = $file_path;
+		$customer                       = new WC_Customer( $data['user_id'] );
+		$response->data['username']     = $customer->get_username();
+		$order                          = new WC_Order( $data['order_id'] );
+		$response->data['order_number'] = $order->get_order_number();
 
 		/**
 		 * Filter a report returned from the API.
@@ -206,6 +207,12 @@ class WC_Admin_REST_Reports_Downloads_Controller extends WC_REST_Reports_Control
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'Order ID.', 'wc-admin' ),
+				),
+				'order_number' => array(
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'description' => __( 'Order Number.', 'wc-admin' ),
 				),
 				'user_id' => array(
 					'type'        => 'integer',

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -161,6 +161,12 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'order_number'           => array(
+					'description' => __( 'Order Number.', 'wc-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'date_created'       => array(
 					'description' => __( 'Date the order was created.', 'wc-admin' ),
 					'type'        => 'string',

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -70,8 +70,9 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 		$data = array();
 
 		foreach ( $report_data->data as $orders_data ) {
-			$item   = $this->prepare_item_for_response( $orders_data, $request );
-			$data[] = $this->prepare_response_for_collection( $item );
+			$orders_data['order_number'] = $this->get_order_number( $orders_data['order_id'] );
+			$item                        = $this->prepare_item_for_response( $orders_data, $request );
+			$data[]                      = $this->prepare_response_for_collection( $item );
 		}
 
 		$response = rest_ensure_response( $data );

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -207,6 +207,11 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				$this->include_extended_info( $orders_data, $query_args );
 			}
 
+			foreach ( $orders_data as $key => $order_data ) {
+				$wc_order                            = new WC_Order( $order_data['order_id'] );
+				$orders_data[ $key ]['order_number'] = $wc_order->get_order_number();
+			}
+
 			$orders_data = array_map( array( $this, 'cast_numbers' ), $orders_data );
 			$data        = (object) array(
 				'data'    => $orders_data,

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -207,11 +207,6 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 				$this->include_extended_info( $orders_data, $query_args );
 			}
 
-			foreach ( $orders_data as $key => $order_data ) {
-				$wc_order                            = new WC_Order( $order_data['order_id'] );
-				$orders_data[ $key ]['order_number'] = $wc_order->get_order_number();
-			}
-
 			$orders_data = array_map( array( $this, 'cast_numbers' ), $orders_data );
 			$data        = (object) array(
 				'data'    => $orders_data,

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -88,6 +88,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 1, $download_report['download_id'] );
 		$this->assertEquals( $product->get_id(), $download_report['product_id'] );
 		$this->assertEquals( $order->get_id(), $download_report['order_id'] );
+		$this->assertEquals( $order->get_order_number(), $download_report['order_number'] );
 		$this->assertEquals( $this->user, $download_report['user_id'] );
 		$this->assertEquals( '1.2.3.4', $download_report['ip_address'] );
 		$this->assertEquals( 'help.png', $download_report['file_name'] );
@@ -396,7 +397,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 11, count( $properties ) );
+		$this->assertEquals( 12, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
@@ -405,6 +406,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'file_name', $properties );
 		$this->assertArrayHasKey( 'file_path', $properties );
 		$this->assertArrayHasKey( 'order_id', $properties );
+		$this->assertArrayHasKey( 'order_number', $properties );
 		$this->assertArrayHasKey( 'user_id', $properties );
 		$this->assertArrayHasKey( 'username', $properties );
 		$this->assertArrayHasKey( 'ip_address', $properties );

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -80,6 +80,7 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$order_report = reset( $reports );
 
 		$this->assertEquals( $order->get_id(), $order_report['order_id'] );
+		$this->assertEquals( $order->get_order_number(), $order_report['order_number'] );
 		$this->assertEquals( date( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ), $order_report['date_created'] );
 		$this->assertEquals( $expected_customer_id, $order_report['customer_id'] );
 		$this->assertEquals( 4, $order_report['num_items_sold'] );
@@ -113,8 +114,9 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 8, count( $properties ) );
+		$this->assertEquals( 9, count( $properties ) );
 		$this->assertArrayHasKey( 'order_id', $properties );
+		$this->assertArrayHasKey( 'order_number', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'customer_id', $properties );


### PR DESCRIPTION
Fixes #1613.

This PR updates the orders and downloads report to show the order number instead of order ID. It also adds the number to the API response so we can actually show it on the JS side.

### Screenshots

<img width="516" alt="screen shot 2019-02-27 at 2 03 27 pm" src="https://user-images.githubusercontent.com/689165/53515635-7b532f80-3a98-11e9-9deb-e714224accca.png">

### Detailed test instructions:

* Use a plugin with custom order numbers, WCCOM Staging, or a snip-it like [this](https://gist.github.com/justinshreve/6ea581827c770da955e5f4e95e342e89) to display an order number separate from the order ID.
* View the orders and downloads report, make sure the new order number displays.
* Run `phpunit` and make sure all tests pass.