### PR TITLE
Clear scheduled actions on plugin deactivate

### DIFF
--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -14,7 +14,7 @@ class WC_Admin_Install {
 	/**
 	 * Plugin version.
 	 *
-	 * @TODO: get this dynamically?
+	 * @todo get this dynamically?
 	 */
 	const VERSION_NUMBER = '0.6.0';
 

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -42,7 +42,7 @@ class WC_Admin_Reports_Sync {
 	const SINGLE_ORDER_ACTION = 'wc-admin_process_order';
 
 	/**
-	 * Action hook for processing a batch of orders.
+	 * Action scheduler group.
 	 */
 	const QUEUE_GROUP = 'wc-admin-data';
 
@@ -103,6 +103,23 @@ class WC_Admin_Reports_Sync {
 		self::customer_lookup_batch_init();
 		// Queue orders lookup to occur after customers lookup generation is done.
 		self::queue_dependent_action( self::ORDERS_LOOKUP_BATCH_INIT, array(), self::CUSTOMERS_BATCH_ACTION );
+	}
+
+	/**
+	 * Clears all queued actions.
+	 */
+	public static function clear_queued_actions() {
+		$hooks = array(
+			self::QUEUE_BATCH_ACTION,
+			self::QUEUE_DEPEDENT_ACTION,
+			self::CUSTOMERS_BATCH_ACTION,
+			self::ORDERS_BATCH_ACTION,
+			self::ORDERS_LOOKUP_BATCH_INIT,
+			self::SINGLE_ORDER_ACTION,
+		);
+		foreach ( $hooks as $hook ) {
+			self::queue()->cancel_all( $hook, null, self::QUEUE_GROUP );
+		}
 	}
 
 	/**

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -124,6 +124,7 @@ add_action( 'admin_init', 'possibly_deactivate_wc_admin_plugin' );
  */
 function deactivate_wc_admin_plugin() {
 	wp_clear_scheduled_hook( 'wc_admin_daily' );
+	WC_Admin_Reports_Sync::clear_queued_actions();
 }
 register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'deactivate_wc_admin_plugin' );
 


### PR DESCRIPTION
Fixes #1699.

This PR clears all scheduled `wc-admin` report generation actions when the plugin is deactivated.

<img width="1489" alt="screen shot 2019-02-28 at 12 34 26 pm" src="https://user-images.githubusercontent.com/689165/53586263-c717de80-3b55-11e9-8280-f64c0ec99804.png">

Note: There is no UI for this yet, pending designs at #1691.

### Detailed test instructions:

* Queue up some jobs. For example, by running the regen report tool under system status.
* Deactivate the `wc-admin` plugin. You should see some canceled jobs start showing up under the canceled tab.