### PR TITLE
Add the number of pending report jobs to wcSettings

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -125,6 +125,20 @@ class WC_Admin_Reports_Sync {
 		);
 	}
 
+	/**
+	 * Get the number of pending actions for reports.
+	 *
+	 * @return int
+	 */
+	public static function get_pending_actions() {
+		$query   = array(
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+			'group'  => self::QUEUE_GROUP,
+		);
+		$store   = ActionScheduler::store();
+		$pending = $store->query_actions( $query, 'count' );
+		return $pending;
+	}
 
 	/**
 	 * Schedule an action to process a single Order.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -205,6 +205,7 @@ function wc_admin_print_script_settings() {
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
 		'currentUserData'       => $current_user_data,
+		'pendingReportActions'  => intval( WC_Admin_Reports_Sync::get_pending_actions() ),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -205,7 +205,7 @@ function wc_admin_print_script_settings() {
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
 		'currentUserData'       => $current_user_data,
-		'pendingReportActions'  => intval( WC_Admin_Reports_Sync::get_pending_actions() ),
+		'reportActionCounts'    => WC_Admin_Reports_Sync::get_action_counts(),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 


### PR DESCRIPTION
Fixes #1692.

This PR adds the number of pending report jobs to `wcSettings`. This is not yet used/displayed anywhere but will be used for showing report generation status.

### Detailed test instructions:

* Queue up some jobs (run the regen tool).
* Refresh a page and view source. Look for `pendingReportActions`.

