### PR TITLE
Date picker: fix tabs CSS

### DIFF
--- a/packages/components/src/filters/date/style.scss
+++ b/packages/components/src/filters/date/style.scss
@@ -38,7 +38,7 @@
 	@include set-grid-item-position( 2, 2 );
 }
 
-.woocommerce-filters-date__tab {
+.woocommerce-filters-date__tab.components-button {
 	outline: none;
 	border: 1px solid $woocommerce;
 	padding: $gap-smaller;
@@ -46,6 +46,7 @@
 	border-radius: 4px 0 0 4px;
 	color: $woocommerce;
 	background-color: transparent;
+	justify-content: center;
 
 	&:hover {
 		background-color: lighten($woocommerce, 50%);
@@ -56,7 +57,8 @@
 		border-radius: 0 4px 4px 0;
 	}
 
-	&.is-active {
+	&.is-active,
+	&.is-active:focus {
 		background-color: $woocommerce;
 		color: $white;
 	}


### PR DESCRIPTION
Fix tabpanels in datepicker CSS broken by Gutenberg update. The white outline seen in the screen shot below is a tab's focus state.

### Before

![screen shot 2019-03-01 at 4 30 30 pm](https://user-images.githubusercontent.com/1922453/53614633-7e3c5480-3c3f-11e9-8ca1-900ce17019c9.png)

### After

![screen shot 2019-03-01 at 4 30 14 pm](https://user-images.githubusercontent.com/1922453/53614653-872d2600-3c3f-11e9-8bb4-7e845df7e886.png)

### Detailed test instructions:

1. Any report with date range picker (such as Revenue).
2. Open the date range picker and make sure the tabs render and work correctly. Note the focus state when using the keyboard.
