### PR TITLE
Update tracking to use wcTracks method

### DIFF
--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -9,7 +9,6 @@
 
 export function recordEvent( eventName, eventProperties ) {
 	if (
-		! wcSettings.trackingEnabled ||
 		! window.wcTracks ||
 		'function' !== typeof window.wcTracks.recordEvent ||
 		'development' === process.env.NODE_ENV

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -8,18 +8,16 @@
  */
 
 export function recordEvent( eventName, eventProperties ) {
-	if ( ! wcSettings.trackingEnabled || 'development' === process.env.NODE_ENV ) {
+	if (
+		! wcSettings.trackingEnabled ||
+		! window.wcTracks ||
+		'function' !== typeof window.wcTracks.recordEvent ||
+		'development' === process.env.NODE_ENV
+	) {
 		return false;
 	}
 
-	// @todo Should we add validation/whitelist of tracks
-	// @todo Don't send tracks in dev envs maybe based off WP_DEBUG?
-	const event = `wca_${ eventName }`;
-
-	// Should already be initialized via inline ./lib/clicent-assets.php
-	// but just being extra safe
-	window._tkq = window._tkq || [];
-	window._tkq.push( [ 'recordEvent', event, eventProperties ] );
+	window.wcTracks.recordEvent( eventName, eventProperties );
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -148,19 +148,6 @@ function format_order_statuses( $statuses ) {
 function wc_admin_print_script_settings() {
 	global $wp_locale;
 
-	// Add Tracks script to the DOM if tracking is opted in, and Jetpack is installed/activated.
-	$tracking_enabled = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
-	$tracking_script  = '';
-	if ( $tracking_enabled && defined( 'JETPACK__VERSION' ) ) {
-		$tracking_script  = "var wc_tracking_script = document.createElement( 'script' );\n";
-		$tracking_script .= "wc_tracking_script.src = '//stats.wp.com/w.js';\n"; // @todo Version/cache buster.
-		$tracking_script .= "wc_tracking_script.type = 'text/javascript';\n";
-		$tracking_script .= "wc_tracking_script.async = true;\n";
-		$tracking_script .= "wc_tracking_script.defer = true;\n";
-		$tracking_script .= "window._tkq = window._tkq || [];\n";
-		$tracking_script .= "document.head.appendChild( wc_tracking_script );\n";
-	}
-
 	$preload_data_endpoints = array(
 		'countries'              => '/wc/v4/data/countries',
 		'performanceIndicators'  => '/wc/v4/reports/performance-indicators/allowed',
@@ -189,18 +176,18 @@ function wc_admin_print_script_settings() {
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
 	 */
 	$settings = array(
-		'adminUrl'              => admin_url(),
-		'wcAssetUrl'            => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'wcAdminAssetUrl'       => plugins_url( 'images/', wc_admin_dir_path( 'wc-admin.php' ) ), // Temporary for plugin. See above.
-		'embedBreadcrumbs'      => wc_admin_get_embed_breadcrumbs(),
-		'siteLocale'            => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'              => wc_admin_currency_settings(),
-		'orderStatuses'         => format_order_statuses( wc_get_order_statuses() ),
-		'stockStatuses'         => wc_get_product_stock_status_options(),
-		'siteTitle'             => get_bloginfo( 'name' ),
-		'trackingEnabled'       => $tracking_enabled,
-		'dataEndpoints'         => array(),
-		'l10n'                  => array(
+		'adminUrl'         => admin_url(),
+		'wcAssetUrl'       => plugins_url( 'assets/', WC_PLUGIN_FILE ),
+		'wcAdminAssetUrl'  => plugins_url( 'images/', wc_admin_dir_path( 'wc-admin.php' ) ), // Temporary for plugin. See above.
+		'embedBreadcrumbs' => wc_admin_get_embed_breadcrumbs(),
+		'siteLocale'       => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'         => wc_admin_currency_settings(),
+		'orderStatuses'    => format_order_statuses( wc_get_order_statuses() ),
+		'stockStatuses'    => wc_get_product_stock_status_options(),
+		'siteTitle'        => get_bloginfo( 'name' ),
+		'trackingEnabled'  => 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ),
+		'dataEndpoints'    => array(),
+		'l10n'             => array(
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
@@ -215,9 +202,6 @@ function wc_admin_print_script_settings() {
 	$settings = apply_filters( 'wc_admin_wc_settings', $settings );
 	?>
 	<script type="text/javascript">
-		<?php
-		echo $tracking_script; // WPCS: XSS ok.
-		?>
 		var wcSettings = <?php echo wp_json_encode( $settings ); ?>;
 	</script>
 	<?php

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -185,7 +185,6 @@ function wc_admin_print_script_settings() {
 		'orderStatuses'    => format_order_statuses( wc_get_order_statuses() ),
 		'stockStatuses'    => wc_get_product_stock_status_options(),
 		'siteTitle'        => get_bloginfo( 'name' ),
-		'trackingEnabled'  => 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ),
 		'dataEndpoints'    => array(),
 		'l10n'             => array(
 			'userLocale'    => get_user_locale(),


### PR DESCRIPTION
Fixes #1697 

Uses the core method for tracking and relies on it to add scripts.

### Detailed test instructions:

1.  Set your node env to anything but `development`.
2.  Checkout the `feature/add-tracks` of WooCommerce.
3. Check that events are recorded on page change.
4. Note that the initial page load will not be tracked until https://github.com/woocommerce/woocommerce/pull/22914 is merged in.
5.  Check that no console errors are thrown when tracking is enabled or disabled.