### PR TITLE
Hook up StoreAlerts component to notes endpoint

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -61,6 +61,11 @@ class StoreAlerts extends Component {
 
 	render() {
 		const { alerts } = this.props;
+
+		if ( ! alerts || alerts.length === 0 ) {
+			return null;
+		}
+
 		const { currentIndex } = this.state;
 		const numberOfAlerts = alerts.length;
 		const alert = alerts[ currentIndex ] ? alerts[ currentIndex ] : null;
@@ -78,52 +83,50 @@ class StoreAlerts extends Component {
 			) );
 
 		return (
-			numberOfAlerts > 0 && (
-				<Card
-					title={ [
-						alert.icon && <Dashicon key="icon" icon={ alert.icon } />,
-						<Fragment key="title">{ alert.title }</Fragment>,
-					] }
-					className={ className }
-					action={
-						numberOfAlerts > 1 && (
-							<div className="woocommerce-store-alerts__pagination">
-								<IconButton
-									icon="arrow-left-alt2"
-									onClick={ this.previousAlert }
-									disabled={ 0 === currentIndex }
-									label={ __( 'Previous Alert', 'wc-admin' ) }
-								/>
-								<span
-									className="woocommerce-store-alerts__pagination-label"
-									role="status"
-									aria-live="polite"
-								>
-									{ interpolateComponents( {
-										mixedString: __( '{{current /}} of {{total /}}', 'wc-admin' ),
-										components: {
-											current: <Fragment>{ currentIndex + 1 }</Fragment>,
-											total: <Fragment>{ numberOfAlerts }</Fragment>,
-										},
-									} ) }
-								</span>
-								<IconButton
-									icon="arrow-right-alt2"
-									onClick={ this.nextAlert }
-									disabled={ numberOfAlerts - 1 === currentIndex }
-									label={ __( 'Next Alert', 'wc-admin' ) }
-								/>
-							</div>
-						)
-					}
-				>
-					<div
-						className="woocommerce-store-alerts__message"
-						dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
-					/>
-					{ actions && <div className="woocommerce-store-alerts__actions">{ actions }</div> }
-				</Card>
-			)
+			<Card
+				title={ [
+					alert.icon && <Dashicon key="icon" icon={ alert.icon } />,
+					<Fragment key="title">{ alert.title }</Fragment>,
+				] }
+				className={ className }
+				action={
+					numberOfAlerts > 1 && (
+						<div className="woocommerce-store-alerts__pagination">
+							<IconButton
+								icon="arrow-left-alt2"
+								onClick={ this.previousAlert }
+								disabled={ 0 === currentIndex }
+								label={ __( 'Previous Alert', 'wc-admin' ) }
+							/>
+							<span
+								className="woocommerce-store-alerts__pagination-label"
+								role="status"
+								aria-live="polite"
+							>
+								{ interpolateComponents( {
+									mixedString: __( '{{current /}} of {{total /}}', 'wc-admin' ),
+									components: {
+										current: <Fragment>{ currentIndex + 1 }</Fragment>,
+										total: <Fragment>{ numberOfAlerts }</Fragment>,
+									},
+								} ) }
+							</span>
+							<IconButton
+								icon="arrow-right-alt2"
+								onClick={ this.nextAlert }
+								disabled={ numberOfAlerts - 1 === currentIndex }
+								label={ __( 'Next Alert', 'wc-admin' ) }
+							/>
+						</div>
+					)
+				}
+			>
+				<div
+					className="woocommerce-store-alerts__message"
+					dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
+				/>
+				{ actions && <div className="woocommerce-store-alerts__actions">{ actions }</div> }
+			</Card>
 		);
 	}
 }

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -27,8 +27,14 @@
 		padding: 0;
 	}
 
-	a.components-button.is-button {
-		color: $core-grey-dark-500;
+	a.components-button {
+		+ .components-button {
+			margin-left: 10px;
+		}
+
+		&.is-button {
+			color: $core-grey-dark-500;
+		}
 	}
 
 	@include breakpoint( '<782px' ) {
@@ -43,7 +49,7 @@
 	}
 }
 
-.is-alert-emergency {
+.is-alert-error {
 	$alert-color: #dc3232;
 	@include store-alerts-box-shadow( $alert-color );
 
@@ -54,19 +60,8 @@
 	}
 }
 
-.is-alert-alert {
+.is-alert-update {
 	$alert-color: #11a0d2;
-	@include store-alerts-box-shadow( $alert-color );
-
-	.woocommerce-card__title {
-		svg {
-			color: $alert-color;
-		}
-	}
-}
-
-.is-alert-critical {
-	$alert-color: #ffb900;
 	@include store-alerts-box-shadow( $alert-color );
 
 	.woocommerce-card__title {


### PR DESCRIPTION
Fixes #1708

![alerts](https://user-images.githubusercontent.com/1177726/53656081-fc9df400-3c49-11e9-80fb-175149c6e4e0.gif)

Refactors and hook up the StoreAlerts component to the notes endpoint.

### Detailed test instructions:

- Create a few notes with the type `update` and error`. Example below.
- Reload a WC Admin page, you should see the alerts at the top

```
$name = 'wc-admin-test-alert-1';
$data_store = WC_Data_Store::load( 'admin-note' );
$note = new WC_Admin_Note();
$note->set_title( __( 'Sed bibendum non augue tincidunt mollis', 'wc-admin' ) );
$note->set_content( __( 'Quisque in efficitur nisi. In hac habitasse platea dictumst. Vivamus ut congue diam.', 'wc-admin' ) );
$note->set_content_data( (object) array() );
$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
$note->set_icon( 'flag' );
$note->set_name( $name );
$note->set_source( 'wc-admin' );
$note->add_action(
  'action-1',
  __( 'Do something', 'wc-admin' ),
  '#'
);
$note->save();
```
