### PR TITLE
Add actionable order statuses settings

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -65,4 +65,27 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 		initialValue: wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses || [],
 		defaultValue: [ 'pending', 'cancelled', 'failed' ],
 	},
+	{
+		name: 'woocommerce_actionable_order_statuses',
+		label: __( 'Actionable Statuses:', 'wc-admin' ),
+		inputType: 'checkboxGroup',
+		options: [
+			{
+				key: 'defaultStatuses',
+				options: orderStatuses.filter( status => defaultOrderStatuses.includes( status.value ) ),
+			},
+			{
+				key: 'customStatuses',
+				label: __( 'Custom Statuses', 'wc-admin' ),
+				options: orderStatuses.filter( status => ! defaultOrderStatuses.includes( status.value ) ),
+			},
+		],
+		helpText: __(
+			'Orders with these statuses require action on behalf of the store admin.' +
+				'These orders will show up in the Orders tab under the activity panel.',
+			'wc-admin'
+		),
+		initialValue: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [],
+		defaultValue: [ 'processing', 'on-hold' ],
+	},
 ] );

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -205,7 +205,10 @@ export default compose(
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
-			status_is: [ 'processing', 'on-hold' ],
+			status_is: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
+				'processing',
+				'on-hold',
+			],
 			extended_info: true,
 		};
 

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -202,15 +202,20 @@ OrdersPanel.defaultProps = {
 export default compose(
 	withSelect( select => {
 		const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
+		const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
+			'processing',
+			'on-hold',
+		];
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
-			status_is: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
-				'processing',
-				'on-hold',
-			],
+			status_is: orderStatuses,
 			extended_info: true,
 		};
+
+		if ( ! orderStatuses.length ) {
+			return { orders: [], isError: false, isRequesting: false };
+		}
 
 		const orders = getReportItems( 'orders', ordersQuery ).data;
 		const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );

--- a/client/wc-api/settings/operations.js
+++ b/client/wc-api/settings/operations.js
@@ -36,7 +36,10 @@ function readSettings( resourceNames, fetch ) {
 
 function updateSettings( resourceNames, data, fetch ) {
 	const resourceName = 'settings';
-	const settingsFields = [ 'woocommerce_excluded_report_order_statuses' ];
+	const settingsFields = [
+		'woocommerce_excluded_report_order_statuses',
+		'woocommerce_actionable_order_statuses',
+	];
 
 	if ( resourceNames.includes( resourceName ) ) {
 		const url = NAMESPACE + '/settings/wc_admin/';

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -518,7 +518,16 @@ function wc_admin_add_settings( $settings ) {
 		'option_key'  => 'woocommerce_excluded_report_order_statuses',
 		'label'       => __( 'Excluded report order statuses', 'wc-admin' ),
 		'description' => __( 'Statuses that should not be included when calculating report totals.', 'wc-admin' ),
-		'default'     => '',
+		'default'     => array( 'pending', 'cancelled', 'failed' ),
+		'type'        => 'multiselect',
+		'options'     => format_order_statuses( wc_get_order_statuses() ),
+	);
+	$settings[] = array(
+		'id'          => 'woocommerce_actionable_order_statuses',
+		'option_key'  => 'woocommerce_actionable_order_statuses',
+		'label'       => __( 'Actionable order statuses', 'wc-admin' ),
+		'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'wc-admin' ),
+		'default'     => array( 'processing', 'on-hold' ),
 		'type'        => 'multiselect',
 		'options'     => format_order_statuses( wc_get_order_statuses() ),
 	);


### PR DESCRIPTION
Fixes #1593 

Adds a setting for order statuses that required admin action and uses these statuses to pull orders in the orders activity panel.

### Screenshots
<img width="522" alt="screen shot 2019-03-04 at 11 38 16 am" src="https://user-images.githubusercontent.com/10561050/53709241-29345480-3e72-11e9-932f-6370b8e22ffe.png">
<img width="690" alt="screen shot 2019-03-04 at 11 38 01 am" src="https://user-images.githubusercontent.com/10561050/53709242-29cceb00-3e72-11e9-8a69-713bd8205015.png">


### Detailed test instructions:

1. Go to the analytics settings ``.
2. Add/remove actionable order statuses.
3. Refresh the page and check that the new order statuses show up for recent orders in the activiy panel.
4. Uncheck all order statuses and make sure no orders are shown and no additional requests are made.