### PR TITLE
Define extended_info in case query is filtered

### DIFF
--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -72,7 +72,8 @@ export default class CouponsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( coupons, coupon => {
-			const { amount, coupon_id, extended_info, orders_count } = coupon;
+			const { amount, coupon_id, orders_count } = coupon;
+			const extended_info = coupon.extended_info || {};
 			const { code, date_created, date_expires, discount_type } = extended_info;
 
 			const couponUrl = getNewPath( persistedQuery, '/analytics/coupons', {

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -98,13 +98,13 @@ export default class OrdersReportTable extends Component {
 				currency,
 				customer_type,
 				date_created,
-				extended_info,
 				net_total,
 				num_items_sold,
 				order_id,
 				order_number,
 				status,
 			} = row;
+			const extended_info = row.extended_info || {};
 			const { coupons, products } = extended_info;
 
 			const formattedProducts = products

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -82,7 +82,8 @@ export default class VariationsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( data, row => {
-			const { items_sold, net_revenue, orders_count, extended_info, product_id } = row;
+			const { items_sold, net_revenue, orders_count, product_id } = row;
+			const extended_info = row.extended_info || {};
 			const { stock_status, stock_quantity, low_stock_amount, sku } = extended_info;
 			const name = get( row, [ 'extended_info', 'name' ], '' );
 			const ordersLink = getNewPath( persistedQuery, 'orders', {

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -96,7 +96,8 @@ class ProductsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( data, row => {
-			const { product_id, extended_info, items_sold, net_revenue, orders_count } = row;
+			const { product_id, items_sold, net_revenue, orders_count } = row;
+			const extended_info = row.extended_info || {};
 			const {
 				category_ids,
 				low_stock_amount,

--- a/client/dashboard/leaderboards/top-selling-categories.js
+++ b/client/dashboard/leaderboards/top-selling-categories.js
@@ -57,7 +57,8 @@ export class TopSellingCategories extends Component {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		return map( data, row => {
-			const { category_id, items_sold, net_revenue, extended_info } = row;
+			const { category_id, items_sold, net_revenue } = row;
+			const extended_info = row.extended_info || {};
 			const name = get( extended_info, [ 'name' ] );
 			const categoryUrl = getNewPath( persistedQuery, 'analytics/categories', {
 				filter: 'single_category',

--- a/client/dashboard/leaderboards/top-selling-products.js
+++ b/client/dashboard/leaderboards/top-selling-products.js
@@ -57,7 +57,8 @@ export class TopSellingProducts extends Component {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		return map( data, row => {
-			const { product_id, items_sold, net_revenue, extended_info } = row;
+			const { product_id, items_sold, net_revenue } = row;
+			const extended_info = row.extended_info || {};
 			const name = get( extended_info, [ 'name' ] );
 
 			const productUrl = getNewPath( persistedQuery, 'analytics/products', {


### PR DESCRIPTION
Fixes #1595 

Creates an empty object for `extended_info` in the event that a filter is added and removes extended_info from the report.

### Detailed test instructions:

1.  Filter various report data.
```php
add_filter( 'woocommerce_reports_coupons_select_query', function ( $results ) {
	foreach ( $results->data as &$data ) {
		unset( $data['extended_info'] );
	}
	return $results;
} );
```
2.  Check that the reports continue to work as expected (less the altered data).