### PR TITLE
Update table columns visibility on finish loading

### DIFF
--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -58,8 +58,8 @@ class TableCard extends Component {
 		this.selectAllRows = this.selectAllRows.bind( this );
 	}
 
-	componentDidUpdate( { query: prevQuery } ) {
-		const { compareBy, onColumnsChange, query } = this.props;
+	componentDidUpdate( { headers: prevHeaders, isLoading: prevIsLoading, query: prevQuery } ) {
+		const { compareBy, headers, isLoading, onColumnsChange, query } = this.props;
 		const { showCols } = this.state;
 
 		if ( query.filter || prevQuery.filter ) {
@@ -72,6 +72,13 @@ class TableCard extends Component {
 				} );
 				/* eslint-enable react/no-did-update-set-state */
 			}
+		}
+		if ( ! isLoading && prevIsLoading && ! isEqual( headers, prevHeaders ) ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( {
+				showCols: headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean ),
+			} );
+			/* eslint-enable react/no-did-update-set-state */
 		}
 		if ( query.orderby !== prevQuery.orderby && ! showCols.includes( query.orderby ) ) {
 			const newShowCols = showCols.concat( query.orderby );


### PR DESCRIPTION
Fixes #1720.

Updates table columns visibility when `onLoading` prop goes from `false` to `true`. In some cases, we were rendering the table placeholder before `userPrefColumns` was available, so the setting was ignored.

### Screenshots
![columns-visibility](https://user-images.githubusercontent.com/3616980/53723757-b1156100-3e68-11e9-968a-75be18f04407.gif)

### Detailed test instructions:
* Go to any report.
* Toggle some columns' visibility.
* Reload the page.
* Verify columns visibility persists.
