### PR TITLE
Skip dispatching fresh data requests when the window/tab is hidden.

### DIFF
--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -19,6 +19,9 @@ function createStore( name ) {
 function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
+			if ( document.hidden ) {
+				return;
+			}
 			store.dispatch( {
 				type: 'FRESH_DATA_REQUESTED',
 				resourceNames,


### PR DESCRIPTION
Fixes #1565.

Prevents `FRESH_DATA_REQUESTED` from being dispatched when the window/tab isn't visible.

### Accessibility

N/A

### Detailed test instructions:

- Temporarily decrease the default freshness to something like 15 seconds (in `client/wc-api/constants.js`)
- Visit the WC Admin dashboard
- Open Redux DevTools, filter actions by "req"
- Verify that `FRESH_DATA_REQUESTED` occurs again after your new freshness interval
- Switch tabs
- Wait a minute or so, switch back
- Verify no `FRESH_DATA_REQUESTED` were dispatched while tab was hidden

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
