### PR TITLE
Add rebuild tool to settings page

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -100,21 +100,17 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 			'wc-admin'
 		),
 		callback: ( resolve, reject, addNotice ) => {
-			const startedMessage = __(
-				'Report table data is being rebuilt.  Please allow some time for data to fully populate.',
-				'wc-admin'
-			);
 			const errorMessage = __( 'There was a problem rebuilding your report data.', 'wc-admin' );
 
 			apiFetch( { path: '/wc/v3/system_status/tools/rebuild_stats', method: 'PUT' } )
 				.then( response => {
 					if ( response.success ) {
-						addNotice( { status: 'success', message: startedMessage } );
+						addNotice( { status: 'success', message: response.message } );
 						// @todo This should be changed to detect when the lookup table population is complete.
 						setTimeout( () => resolve(), 300000 );
 					} else {
 						addNotice( { status: 'error', message: errorMessage } );
-						resolve();
+						reject();
 					}
 				} )
 				.catch( error => {

--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import interpolateComponents from 'interpolate-components';
 
@@ -87,5 +88,41 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 		),
 		initialValue: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [],
 		defaultValue: [ 'processing', 'on-hold' ],
+	},
+	{
+		name: 'woocommerce_rebuild_reports_data',
+		label: __( 'Rebuild reports data:', 'wc-admin' ),
+		inputType: 'button',
+		inputText: __( 'Rebuild reports', 'wc-admin' ),
+		helpText: __(
+			'This tool will rebuild all of the information used by the reports. ' +
+				'Data will be processed in the background and may take some time depending on the size of your store.',
+			'wc-admin'
+		),
+		callback: ( resolve, reject, addNotice ) => {
+			const startedMessage = __(
+				'Report table data is being rebuilt.  Please allow some time for data to fully populate.',
+				'wc-admin'
+			);
+			const errorMessage = __( 'There was a problem rebuilding your report data.', 'wc-admin' );
+
+			apiFetch( { path: '/wc/v3/system_status/tools/rebuild_stats', method: 'PUT' } )
+				.then( response => {
+					if ( response.success ) {
+						addNotice( { status: 'success', message: startedMessage } );
+						// @todo This should be changed to detect when the lookup table population is complete.
+						setTimeout( () => resolve(), 300000 );
+					} else {
+						addNotice( { status: 'error', message: errorMessage } );
+						resolve();
+					}
+				} )
+				.catch( error => {
+					if ( error && error.message ) {
+						addNotice( { status: 'error', message: error.message } );
+					}
+					reject();
+				} );
+		},
 	},
 ] );

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -125,6 +125,7 @@ class Settings extends Component {
 						<Setting
 							handleChange={ this.handleInputChange }
 							value={ this.state.settings[ setting.name ] }
+							key={ setting.name }
 							{ ...setting }
 						/>
 					) ) }

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -124,13 +124,8 @@ class Settings extends Component {
 					{ analyticsSettings.map( setting => (
 						<Setting
 							handleChange={ this.handleInputChange }
-							helpText={ setting.helpText }
-							inputType={ setting.inputType }
-							key={ setting.name }
-							label={ setting.label }
-							name={ setting.name }
-							options={ setting.options }
 							value={ this.state.settings[ setting.name ] }
+							{ ...setting }
 						/>
 					) ) }
 					<div className="woocommerce-settings__actions">

--- a/client/analytics/settings/setting.js
+++ b/client/analytics/settings/setting.js
@@ -78,9 +78,13 @@ class Setting extends Component {
 		return new Promise( ( resolve, reject ) => {
 			this.setState( { disabled: true } );
 			callback( resolve, reject, addNotice );
-		} ).then( () => {
-			this.setState( { disabled: false } );
-		} );
+		} )
+			.then( () => {
+				this.setState( { disabled: false } );
+			} )
+			.catch( () => {
+				this.setState( { disabled: false } );
+			} );
 	};
 
 	renderCheckboxOptions( options ) {

--- a/client/analytics/settings/setting.js
+++ b/client/analytics/settings/setting.js
@@ -33,12 +33,14 @@ class Setting extends Component {
 					optionGroup =>
 						optionGroup.options.length > 0 && (
 							<div
-								className="woocommerce-sinput-group"
+								className="woocommerce-setting__options-group"
 								key={ optionGroup.key }
 								aria-labelledby={ name + '-label' }
 							>
 								{ optionGroup.label && (
-									<span className="woocommerce-sinput-group-label">{ optionGroup.label }</span>
+									<span className="woocommerce-setting__options-group-label">
+										{ optionGroup.label }
+									</span>
 								) }
 								{ this.renderCheckboxOptions( optionGroup.options ) }
 							</div>

--- a/client/analytics/settings/setting.js
+++ b/client/analytics/settings/setting.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
@@ -13,7 +14,7 @@ import './setting.scss';
 
 class Setting extends Component {
 	renderInput = () => {
-		const { handleChange, name, inputType, options, value } = this.props;
+		const { callback, handleChange, name, inputText, inputType, options, value } = this.props;
 		const id = uniqueId( name );
 
 		switch ( inputType ) {
@@ -22,14 +23,12 @@ class Setting extends Component {
 					optionGroup =>
 						optionGroup.options.length > 0 && (
 							<div
-								className="woocommerce-setting__options-group"
+								className="woocommerce-sinput-group"
 								key={ optionGroup.key }
 								aria-labelledby={ name + '-label' }
 							>
 								{ optionGroup.label && (
-									<span className="woocommerce-setting__options-group-label">
-										{ optionGroup.label }
-									</span>
+									<span className="woocommerce-sinput-group-label">{ optionGroup.label }</span>
 								) }
 								{ this.renderCheckboxOptions( optionGroup.options ) }
 							</div>
@@ -37,10 +36,23 @@ class Setting extends Component {
 				);
 			case 'checkbox':
 				return this.renderCheckboxOptions( options );
+			case 'button':
+				return (
+					<Button isDefault onClick={ callback }>
+						{ inputText }
+					</Button>
+				);
 			case 'text':
 			default:
 				return (
-					<input id={ id } type="text" name={ name } onChange={ handleChange } value={ value } />
+					<input
+						id={ id }
+						type="text"
+						name={ name }
+						onChange={ handleChange }
+						value={ value }
+						placeholder={ inputText }
+					/>
 				);
 		}
 	};
@@ -75,7 +87,7 @@ class Setting extends Component {
 				<div className="woocommerce-setting__label" id={ name + '-label' }>
 					{ label }
 				</div>
-				<div className="woocommerce-setting__options">
+				<div className="woocommerce-setting__input">
 					{ this.renderInput() }
 					{ helpText && <span className="woocommerce-setting__help">{ helpText }</span> }
 				</div>
@@ -93,6 +105,10 @@ Setting.propTypes = {
 	 * Optional help text displayed underneath the setting.
 	 */
 	helpText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+	/**
+	 * Text used as placeholder or button text in the input area.
+	 */
+	inputText: PropTypes.string,
 	/**
 	 * Type of input to use; defaults to a text input.
 	 */

--- a/client/analytics/settings/setting.scss
+++ b/client/analytics/settings/setting.scss
@@ -18,7 +18,7 @@
 	}
 }
 
-.woocommerce-setting__options {
+.woocommerce-setting__input {
 	display: flex;
 	flex-direction: column;
 	@include breakpoint( '>1280px' ) {
@@ -34,6 +34,11 @@
 
 	input[type='checkbox'] {
 		margin-right: $gap-small;
+	}
+
+	button {
+		margin-bottom: $gap-small;
+		align-self: flex-start;
 	}
 }
 

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -79,8 +79,9 @@ class WC_Admin_Reports_Sync {
 	 * Hook in sync methods.
 	 */
 	public static function init() {
-		// Add report regeneration to tools menu.
+		// Add report regeneration to tools REST API.
 		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'add_regenerate_tool' ) );
+		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'remove_regenerate_tool' ) );
 
 		// Initialize syncing hooks.
 		add_action( 'wp_loaded', array( __CLASS__, 'orders_lookup_update_init' ) );
@@ -103,6 +104,20 @@ class WC_Admin_Reports_Sync {
 		self::customer_lookup_batch_init();
 		// Queue orders lookup to occur after customers lookup generation is done.
 		self::queue_dependent_action( self::ORDERS_LOOKUP_BATCH_INIT, array(), self::CUSTOMERS_BATCH_ACTION );
+	}
+
+	/**
+	 * Remove the regenerate tool from system status tools while
+	 * still allowing use of the tool through the REST API.
+	 *
+	 * @param array $tools Array of tools.
+	 * @return array
+	 */
+	public static function remove_regenerate_tool( $tools ) {
+		if ( isset( $_GET['page'] ) && 'wc-status' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			unset( $tools['rebuild_stats'] );
+		}
+		return $tools;
 	}
 
 	/**

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -81,7 +81,6 @@ class WC_Admin_Reports_Sync {
 	public static function init() {
 		// Add report regeneration to tools REST API.
 		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'add_regenerate_tool' ) );
-		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'remove_regenerate_tool' ) );
 
 		// Initialize syncing hooks.
 		add_action( 'wp_loaded', array( __CLASS__, 'orders_lookup_update_init' ) );
@@ -109,20 +108,6 @@ class WC_Admin_Reports_Sync {
 	}
 
 	/**
-	 * Remove the regenerate tool from system status tools while
-	 * still allowing use of the tool through the REST API.
-	 *
-	 * @param array $tools Array of tools.
-	 * @return array
-	 */
-	public static function remove_regenerate_tool( $tools ) {
-		if ( isset( $_GET['page'] ) && 'wc-status' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			unset( $tools['rebuild_stats'] );
-		}
-		return $tools;
-	}
-
-	/**
 	 * Clears all queued actions.
 	 */
 	public static function clear_queued_actions() {
@@ -140,12 +125,16 @@ class WC_Admin_Reports_Sync {
 	}
 
 	/**
-	 * Adds regenerate tool.
+	 * Adds regenerate tool to WC system status tools API.
 	 *
 	 * @param array $tools List of tools.
 	 * @return array
 	 */
 	public static function add_regenerate_tool( $tools ) {
+		if ( isset( $_GET['page'] ) && 'wc-status' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return $tools;
+		}
+
 		return array_merge(
 			$tools,
 			array(

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -104,6 +104,8 @@ class WC_Admin_Reports_Sync {
 		self::customer_lookup_batch_init();
 		// Queue orders lookup to occur after customers lookup generation is done.
 		self::queue_dependent_action( self::ORDERS_LOOKUP_BATCH_INIT, array(), self::CUSTOMERS_BATCH_ACTION );
+
+		return __( 'Report table data is being rebuilt.  Please allow some time for data to fully populate.', 'wc-admin' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1691  fixes #1641 

Moves the rebuild tool to the settings page and adds in 'button' type settings as well as callbacks for custom actions to settings.

### Screenshots
<img width="692" alt="screen shot 2019-03-05 at 2 54 10 pm" src="https://user-images.githubusercontent.com/10561050/53786390-91f4fd00-3f56-11e9-851b-679e77d6a4a4.png">
<img width="495" alt="screen shot 2019-03-05 at 2 54 04 pm" src="https://user-images.githubusercontent.com/10561050/53786392-91f4fd00-3f56-11e9-98e3-6c5c61da96d9.png">

### Detailed test instructions:

1.  Go to the settings page `/wp-admin/admin.php?page=wc-admin#/analytics/settings`
2.  Make sure that "Rebuild reports" rebuilds report data.
3.  The button should be disabled after clicking regenerate (currently for 5 minutes, but this has a todo noting that we should check for population completion).
