### PR TITLE
Update CSV filenames and remove item IDs

### DIFF
--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -129,6 +129,7 @@ class TableCard extends Component {
 
 	onClickDownload() {
 		const { query, onClickDownload, title } = this.props;
+		delete query.extended_info;
 
 		// @todo The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -128,8 +128,13 @@ class TableCard extends Component {
 	}
 
 	onClickDownload() {
-		const { query, onClickDownload, title } = this.props;
+		const { query, onClickDownload, searchBy, title } = this.props;
+
+		// Delete unnecessary items from filename.
 		delete query.extended_info;
+		if ( query.search ) {
+			delete query[ searchBy ];
+		}
 
 		// @todo The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -129,17 +129,18 @@ class TableCard extends Component {
 
 	onClickDownload() {
 		const { query, onClickDownload, searchBy, title } = this.props;
+		const params = Object.assign( {}, query );
 
 		// Delete unnecessary items from filename.
-		delete query.extended_info;
-		if ( query.search ) {
-			delete query[ searchBy ];
+		delete params.extended_info;
+		if ( params.search ) {
+			delete params[ searchBy ];
 		}
 
 		// @todo The current implementation only downloads the contents displayed in the table.
 		// Another solution is required when the data set is larger (see #311).
 		downloadCSVFile(
-			generateCSVFileName( title, query ),
+			generateCSVFileName( title, params ),
 			generateCSVDataFromTable( this.getVisibleHeaders(), this.getVisibleRows() )
 		);
 

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -44,11 +44,13 @@ export function generateCSVDataFromTable( headers, rows ) {
  */
 export function generateCSVFileName( name = '', params = {} ) {
 	const fileNameSections = [
-		name.toLowerCase().replace( /\s+|_/g, '-' ),
+		name.toLowerCase().replace( /[^a-z0-9]/g, '-' ),
 		moment().format( 'YYYY-MM-DD' ),
 		Object.keys( params )
-			.map( key => key.toLowerCase().replace( /\s+|_/g, '-' ) + '-' + params[ key ].toLowerCase().replace( /\s+|_/g, '-' ) )
-			.join( '_' ),
+			.map( key =>
+				key.toLowerCase().replace( /[^a-z0-9]/g, '-' ) +
+				'-' + decodeURIComponent( params[ key ] ).toLowerCase().replace( /[^a-z0-9]/g, '-' )
+			).join( '_' ),
 	].filter( text => text.length );
 
 	return fileNameSections.join( '_' ) + '.csv';

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -44,10 +44,10 @@ export function generateCSVDataFromTable( headers, rows ) {
  */
 export function generateCSVFileName( name = '', params = {} ) {
 	const fileNameSections = [
-		name.toLowerCase().replace( ' ', '-' ),
+		name.toLowerCase().replace( /\s+|_/g, '-' ),
 		moment().format( 'YYYY-MM-DD' ),
 		Object.keys( params )
-			.map( key => key + '-' + params[ key ] )
+			.map( key => key.toLowerCase().replace( /\s+|_/g, '-' ) + '-' + params[ key ].toLowerCase().replace( /\s+|_/g, '-' ) )
 			.join( '_' ),
 	].filter( text => text.length );
 

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -48,10 +48,10 @@ export function generateCSVFileName( name = '', params = {} ) {
 		moment().format( 'YYYY-MM-DD' ),
 		Object.keys( params )
 			.map( key => key + '-' + params[ key ] )
-			.join( '-' ),
+			.join( '_' ),
 	].filter( text => text.length );
 
-	return fileNameSections.join( '-' ) + '.csv';
+	return fileNameSections.join( '_' ) + '.csv';
 }
 
 /**

--- a/packages/csv-export/src/test/index.js
+++ b/packages/csv-export/src/test/index.js
@@ -35,13 +35,13 @@ describe( 'generateCSVFileName', () => {
 
 	it( 'should generate a file name with the `name` and the date', () => {
 		const fileName = generateCSVFileName( 'Revenue table' );
-		expect( fileName ).toBe( 'revenue-table-' + moment().format( 'YYYY-MM-DD' ) + '.csv' );
+		expect( fileName ).toBe( 'revenue-table_' + moment().format( 'YYYY-MM-DD' ) + '.csv' );
 	} );
 
 	it( 'should generate a file name with the `name` and `params`', () => {
 		const fileName = generateCSVFileName( 'Revenue table', { orderby: 'revenue', order: 'desc' } );
 		expect( fileName ).toBe(
-			'revenue-table-' + moment().format( 'YYYY-MM-DD' ) + '-orderby-revenue-order-desc.csv'
+			'revenue-table_' + moment().format( 'YYYY-MM-DD' ) + '_orderby-revenue_order-desc.csv'
 		);
 	} );
 } );


### PR DESCRIPTION
Fixes #1642 

* Separates params by underscores
* Replaces spaces and underscores in values with hyphens
* Removes the list of IDs from the end of the string caused by found item IDs from search in favor of the search query

### Screenshots
<img width="901" alt="screen shot 2019-03-05 at 6 15 21 pm" src="https://user-images.githubusercontent.com/10561050/53798175-a810b680-3f72-11e9-8397-4b17938e7cea.png">
Produces:

`products_2019-03-05_orderby-net-revenue_order-desc_period-last-year_compare-previous-year_search-sed-aliquid-non-voluptates-non.csv`

### Detailed test instructions:

1. Go to the any report that allows searching in the table.
2. Enter a search term that matches multiple items.
3. Download the CSV.
4. Check that the item IDs aren't in the filename, but the search term is.
5. Check that item names don't contain spaces.
6. Check that `extended_info` is not included in the filename.
7. Play around with various parameters and make sure filenames look correct.