### PR TITLE
Add button focus style to report chart interval selection.

### DIFF
--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -100,6 +100,10 @@
 		@include font-size( 13 );
 		border: 0;
 		box-shadow: none;
+
+		&:not(:disabled):not([aria-disabled='true']):focus {
+			@include button-style__focus-active();
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1608.

Add button focus style to report chart interval selection.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] ~I've tested using a screen reader~
- [ ] ~All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)~
- [ ] ~All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)~

### Screenshots

![screen shot 2019-03-05 at 12 12 43 pm](https://user-images.githubusercontent.com/63922/53830580-02445400-3f40-11e9-9cef-8475e8ab9f68.png)

### Detailed test instructions:

- Go to a Report
- Tab to the interval
- Verify it is highlighted (outline)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
