### PR TITLE
Don't Run Lookup Table Population on Activate

### DIFF
--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -74,7 +74,6 @@ class WC_Admin_Install {
 		wc_maybe_define_constant( 'WC_ADMIN_INSTALLING', true );
 
 		self::create_tables();
-		WC_Admin_Reports_Sync::regenerate_report_data();
 		self::update_wc_admin_version();
 
 		delete_transient( 'wc_admin_installing' );


### PR DESCRIPTION
Fixes #1666.

This PR stops look-up table queuing from happening on plugin activation.

### Detailed test instructions:

* Delete the `wp_option` `wc_admin_version`, to make sure the `install` or `update` step runs. You can also add an error log between `self::create_tables()` and `self::update_wc_admin_version()` in the `install` method of `class-wc-admin-install.php`.
* Deactivate WooCommerce Admin, and make sure there are no pending `wc-admin` jobs.
* Reactivate WooCommerce Admin, make sure there are still no pending jobs.