### PR TITLE
Fix IE11 leaderboard display issue.

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -5,8 +5,17 @@
 	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});
 	grid-column-gap: $gap-large;
 
+	// Auto-position fix for IE11.
+	> div {
+		@include set-grid-item-position( 2, 14 );
+	}
+
 	@include breakpoint( '<960px' ) {
 		grid-template-columns: 100%;
+
+		> div {
+			@include set-grid-item-position( 1, 14 );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1675 

Set dashboard (leaderboard/chart) grid item position manually for IE11.

Note: this only fixes items overlapping. There is still a lack of horizontal spacing in IE11 - it was taking way too much time to attempt to fix, so I left it.

### Screenshots

Before:

![screen shot 2019-03-05 at 4 20 26 pm](https://user-images.githubusercontent.com/63922/53844337-a212d980-3f62-11e9-8b0c-4cde5e7dd9f4.png)

After:

![screen shot 2019-03-05 at 4 18 26 pm](https://user-images.githubusercontent.com/63922/53844333-9fb07f80-3f62-11e9-9afc-dbf46a725aae.png)


### Detailed test instructions:

- Open WooCommerce > Dashboard in IE11
- Verify that leaderboards and charts are no longer stacked
- Verify that all blocks display in single column (narrower viewport)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
