### PR TITLE
Filters: Simplify options

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -79,18 +79,6 @@ export const filters = [
 					},
 				},
 			},
-			{
-				label: __( 'Top Categories by Items Sold', 'wc-admin' ),
-				value: 'top_items',
-				chartMode: 'item-comparison',
-				query: { orderby: 'items_sold', order: 'desc', chart: 'items_sold' },
-			},
-			{
-				label: __( 'Top Categories by Net Revenue', 'wc-admin' ),
-				value: 'top_revenue',
-				chartMode: 'item-comparison',
-				query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
-			},
 		],
 	},
 ];

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -53,7 +53,7 @@ export default class CategoriesReport extends Component {
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
 					charts={ charts }
-					endpoint="products"
+					endpoint="categories"
 					isRequesting={ isRequesting }
 					limitProperty="categories"
 					query={ chartQuery }
@@ -63,7 +63,7 @@ export default class CategoriesReport extends Component {
 					filters={ filters }
 					charts={ charts }
 					mode={ mode }
-					endpoint="products"
+					endpoint="categories"
 					limitProperty="categories"
 					path={ path }
 					query={ chartQuery }

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -70,18 +70,6 @@ export const filters = [
 					},
 				},
 			},
-			{
-				label: __( 'Top Coupons by Discounted Orders', 'wc-admin' ),
-				value: 'top_orders',
-				chartMode: 'item-comparison',
-				query: { orderby: 'orders_count', order: 'desc', chart: 'orders_count' },
-			},
-			{
-				label: __( 'Top Coupons by Amount Discounted', 'wc-admin' ),
-				value: 'top_discount',
-				chartMode: 'item-comparison',
-				query: { orderby: 'amount', order: 'desc', chart: 'amount' },
-			},
 		],
 	},
 ];

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getProductLabels, getCategoryLabels, getVariationLabels } from 'lib/async-requests';
+import { getProductLabels, getVariationLabels } from 'lib/async-requests';
 
 export const charts = [
 	{
@@ -63,29 +63,7 @@ const filterConfig = {
 			],
 		},
 		{
-			label: __( 'Single Product Category', 'wc-admin' ),
-			value: 'select_category',
-			chartMode: 'item-comparison',
-			subFilters: [
-				{
-					component: 'Search',
-					value: 'single_category',
-					chartMode: 'item-comparison',
-					path: [ 'select_category' ],
-					settings: {
-						type: 'categories',
-						param: 'categories',
-						getLabels: getCategoryLabels,
-						labels: {
-							placeholder: __( 'Type to search for a product category', 'wc-admin' ),
-							button: __( 'Single Product Category', 'wc-admin' ),
-						},
-					},
-				},
-			],
-		},
-		{
-			label: __( 'Product Comparison', 'wc-admin' ),
+			label: __( 'Comparison', 'wc-admin' ),
 			value: 'compare-products',
 			chartMode: 'item-comparison',
 			settings: {
@@ -99,34 +77,6 @@ const filterConfig = {
 					update: __( 'Compare', 'wc-admin' ),
 				},
 			},
-		},
-		{
-			label: __( 'Product Category Comparison', 'wc-admin' ),
-			value: 'compare-categories',
-			chartMode: 'item-comparison',
-			settings: {
-				type: 'categories',
-				param: 'categories',
-				getLabels: getCategoryLabels,
-				labels: {
-					helpText: __( 'Select at least two product categories to compare', 'wc-admin' ),
-					placeholder: __( 'Search for product categories to compare', 'wc-admin' ),
-					title: __( 'Compare Product Categories', 'wc-admin' ),
-					update: __( 'Compare', 'wc-admin' ),
-				},
-			},
-		},
-		{
-			label: __( 'Top Products by Items Sold', 'wc-admin' ),
-			value: 'top_items',
-			chartMode: 'item-comparison',
-			query: { orderby: 'items_sold', order: 'desc', chart: 'items_sold' },
-		},
-		{
-			label: __( 'Top Products by Net Revenue', 'wc-admin' ),
-			value: 'top_sales',
-			chartMode: 'item-comparison',
-			query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
 		},
 	],
 };
@@ -153,18 +103,6 @@ const variationsConfig = {
 					update: __( 'Compare', 'wc-admin' ),
 				},
 			},
-		},
-		{
-			label: __( 'Top Variations by Items Sold', 'wc-admin' ),
-			chartMode: 'item-comparison',
-			value: 'top_items',
-			query: { orderby: 'items_sold', order: 'desc', chart: 'item_sold' },
-		},
-		{
-			label: __( 'Top Variations by Net Revenue', 'wc-admin' ),
-			chartMode: 'item-comparison',
-			value: 'top_sales',
-			query: { orderby: 'net_revenue', order: 'desc', chart: 'net_revenue' },
 		},
 	],
 };

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -210,22 +210,23 @@ export function getSummaryNumbers( endpoint, query, select, limitBy ) {
 			secondary: null,
 		},
 	};
+	const mappedEndpoint = 'categories' === endpoint ? 'products' : endpoint;
 
 	const primaryQuery = getRequestQuery( endpoint, 'primary', query, limitBy );
-	const primary = getReportStats( endpoint, primaryQuery );
-	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
+	const primary = getReportStats( mappedEndpoint, primaryQuery );
+	if ( isReportStatsRequesting( mappedEndpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( getReportStatsError( endpoint, primaryQuery ) ) {
+	} else if ( getReportStatsError( mappedEndpoint, primaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
 	const primaryTotals = ( primary && primary.data && primary.data.totals ) || null;
 
-	const secondaryQuery = getRequestQuery( endpoint, 'secondary', query );
-	const secondary = getReportStats( endpoint, secondaryQuery );
-	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
+	const secondaryQuery = getRequestQuery( mappedEndpoint, 'secondary', query );
+	const secondary = getReportStats( mappedEndpoint, secondaryQuery );
+	if ( isReportStatsRequesting( mappedEndpoint, secondaryQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( getReportStatsError( endpoint, secondaryQuery ) ) {
+	} else if ( getReportStatsError( mappedEndpoint, secondaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
@@ -246,6 +247,7 @@ export function getSummaryNumbers( endpoint, query, select, limitBy ) {
  */
 export function getReportChartData( endpoint, dataType, query, select, limitBy ) {
 	const { getReportStats, getReportStatsError, isReportStatsRequesting } = select( 'wc-api' );
+	const mappedEndpoint = 'categories' === endpoint ? 'products' : endpoint;
 
 	const response = {
 		isEmpty: false,
@@ -258,13 +260,13 @@ export function getReportChartData( endpoint, dataType, query, select, limitBy )
 	};
 
 	const requestQuery = getRequestQuery( endpoint, dataType, query, limitBy );
-	const stats = getReportStats( endpoint, requestQuery );
+	const stats = getReportStats( mappedEndpoint, requestQuery );
 
-	if ( isReportStatsRequesting( endpoint, requestQuery ) ) {
+	if ( isReportStatsRequesting( mappedEndpoint, requestQuery ) ) {
 		return { ...response, isRequesting: true };
-	} else if ( getReportStatsError( endpoint, requestQuery ) ) {
+	} else if ( getReportStatsError( mappedEndpoint, requestQuery ) ) {
 		return { ...response, isError: true };
-	} else if ( isReportDataEmpty( stats, endpoint ) ) {
+	} else if ( isReportDataEmpty( stats, mappedEndpoint ) ) {
 		return { ...response, isEmpty: true };
 	}
 
@@ -281,11 +283,11 @@ export function getReportChartData( endpoint, dataType, query, select, limitBy )
 
 		for ( let i = 2; i <= totalPages; i++ ) {
 			const nextQuery = { ...requestQuery, page: i };
-			const _data = getReportStats( endpoint, nextQuery );
-			if ( isReportStatsRequesting( endpoint, nextQuery ) ) {
+			const _data = getReportStats( mappedEndpoint, nextQuery );
+			if ( isReportStatsRequesting( mappedEndpoint, nextQuery ) ) {
 				continue;
 			}
-			if ( getReportStatsError( endpoint, nextQuery ) ) {
+			if ( getReportStatsError( mappedEndpoint, nextQuery ) ) {
 				isError = true;
 				isFetching = false;
 				break;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1678
Fixes https://github.com/woocommerce/wc-admin/issues/1680

* Remove "Top *" from filters list for Coupons, Products, Categories, and Variations Reports.
* Remove "Single Category" and "Category Comparison" filters from Products Report.

The Categories Report uses the `/products/stats` endpoint under the hood. Since the Product Report had category related filters, the resulting filter query used them, but now it must use the Category filters config, so some endpoint mapping was required.

### Detailed test instructions:

1. Coupons, Products, Categories, and Variations Reports should no longer have "Top *" options in the Show menu. For example, `Top Categories by Items Sold` will no longer be there.
2. Ensure Single Category" and "Category Comparison" filters from Products Report are no longer available but are on the Categories Report.
3. Check that links to categories from other reports do not point to the Products Report.
