### PR TITLE
Fix deleted product error

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -90,6 +90,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 */
 	public static function init() {
 		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 10 );
+		add_action( 'delete_post', array( __CLASS__, 'delete_product_id' ) );
 	}
 
 	/**
@@ -473,5 +474,25 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		 * @param int $order_id   Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_product', 0, $order_id );
+	}
+
+	/**
+	 * Deletes the product ID when a product is deleted.
+	 * This keeps data consistent if it gets resynced at any point.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function delete_product_id( $post_id ) {
+		global $wpdb;
+
+		if ( 'product' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$wpdb->update(
+			$wpdb->prefix . self::TABLE_NAME,
+			array( 'product_id' => 0 ),
+			array( 'product_id' => $post_id )
+		);
 	}
 }

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -90,7 +90,6 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 */
 	public static function init() {
 		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 10 );
-		add_action( 'delete_post', array( __CLASS__, 'delete_product_id' ) );
 	}
 
 	/**
@@ -403,8 +402,8 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 					array(
 						'order_item_id'         => $order_item_id,
 						'order_id'              => $order->get_id(),
-						'product_id'            => $order_item->get_product_id( 'edit' ),
-						'variation_id'          => $order_item->get_variation_id( 'edit' ),
+						'product_id'            => wc_get_order_item_meta( $order_item_id, '_product_id' ),
+						'variation_id'          => wc_get_order_item_meta( $order_item_id, '_variation_id' ),
 						'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
 						'product_qty'           => $product_qty,
 						'product_net_revenue'   => $net_revenue,
@@ -474,25 +473,5 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		 * @param int $order_id   Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_product', 0, $order_id );
-	}
-
-	/**
-	 * Deletes the product ID when a product is deleted.
-	 * This keeps data consistent if it gets resynced at any point.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public static function delete_product_id( $post_id ) {
-		global $wpdb;
-
-		if ( 'product' !== get_post_type( $post_id ) ) {
-			return;
-		}
-
-		$wpdb->update(
-			$wpdb->prefix . self::TABLE_NAME,
-			array( 'product_id' => 0 ),
-			array( 'product_id' => $post_id )
-		);
 	}
 }

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -193,7 +193,13 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new ArrayObject();
 			if ( $query_args['extended_info'] ) {
-				$product             = wc_get_product( $product_data['product_id'] );
+				$product = wc_get_product( $product_data['product_id'] );
+				// Product was deleted.
+				if ( ! $product ) {
+					$products_data[ $key ]['extended_info']['name'] = __( '(Deleted)', 'wc-admin' );
+					continue;
+				}
+
 				$extended_attributes = apply_filters( 'woocommerce_rest_reports_products_extended_attributes', $this->extended_attributes, $product_data );
 				foreach ( $extended_attributes as $extended_attribute ) {
 					if ( 'variations' === $extended_attribute ) {


### PR DESCRIPTION
Fixes #1669 

* Adds `(Deleted)` to the name of deleted products
* Prevents the 500 API error that occurs
* Grabs the ID for deleted products from the meta table to keep stats accurate

### Screenshots
<img width="1085" alt="screen shot 2019-03-06 at 2 29 05 pm" src="https://user-images.githubusercontent.com/10561050/53865898-3b0d2780-402b-11e9-86f3-8ce05a9dcaca.png">

### Detailed test instructions:

1. Create an order with a product
2. Delete that product permanently ☠️ 
3. View a timeframe in the products report with that product.
4. Update the order to trigger a sync.
5. Note the lack of error and the product name should display `(Deleted)`.
6. Repeat these steps with a second product.
7. Note that the ID for the products is still retained and that stats are not grouped together by an ID of `0`.