### PR TITLE
Fix deleted coupon data sync

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -56,6 +56,7 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 	 */
 	public static function init() {
 		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 5 );
+		add_action( 'delete_post', array( __CLASS__, 'delete_coupon' ) );
 	}
 
 	/**
@@ -383,6 +384,25 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 		 * @param int $order_id  Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_coupon', 0, $order_id );
+	}
+
+	/**
+	 * Deletes the coupon lookup information when a coupon is deleted.
+	 * This keeps data consistent if it gets resynced at any point.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function delete_coupon( $post_id ) {
+		global $wpdb;
+
+		if ( 'shop_coupon' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$wpdb->delete(
+			$wpdb->prefix . self::TABLE_NAME,
+			array( 'coupon_id' => $post_id )
+		);
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -325,12 +325,19 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 			return -1;
 		}
 
-		$coupon_items = $order->get_items( 'coupon' );
-		$num_updated  = 0;
+		$coupon_items       = $order->get_items( 'coupon' );
+		$coupon_items_count = count( $coupon_items );
+		$num_updated        = 0;
 
 		foreach ( $coupon_items as $coupon_item ) {
 			$coupon_id = wc_get_coupon_id_by_code( $coupon_item->get_code() );
-			$result    = $wpdb->replace(
+
+			if ( ! $coupon_id ) {
+				$coupon_items_count--;
+				continue;
+			}
+
+			$result = $wpdb->replace(
 				$wpdb->prefix . self::TABLE_NAME,
 				array(
 					'order_id'        => $order_id,
@@ -357,7 +364,7 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 			$num_updated += intval( $result );
 		}
 
-		return ( count( $coupon_items ) === $num_updated );
+		return ( $coupon_items_count === $num_updated );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1751 

Removes coupon data from lookup tables if permanently deleted and prevents coupon ID without an ID from syncing on order sync.

Initially, I tried to grab this under `wp_woocommerce_order_itemmeta` as it appears the ID is still stored under a `coupon_data` meta key.  However, the coupon data seemed to be corrupted (could not unserialize).  Curious if similar behavior has occurred in other installs.

Ideally, we can grab the ID from `coupon_data` since that would allow us to show `(Deleted)` and keep the coupon data information, but if it acts unreliably as it did in my environment then I think we should remove altogether when permanently deleted.

### Detailed test instructions:

1.  Create an order with a coupon.
2.  Delete the coupon permanently.
3.  Check that the data does not show stats for that coupon under the coupons report.
4.  Update  the order with the deleted coupon to trigger an order sync.
5.  Make sure an emtpy (ID-less) coupon is not created under the coupon report.
6.  Make sure that order data and discounts does not reflect the deletion of the coupon.