### PR TITLE
Show compared keys in chart legends even if their values are 0

### DIFF
--- a/client/analytics/components/report-chart/test/index.js
+++ b/client/analytics/components/report-chart/test/index.js
@@ -8,7 +8,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { ReportChart } from '../';
-import { getChartMode } from '../utils';
+import { getChartMode, getSelectedFilter } from '../utils';
 
 jest.mock( '@woocommerce/components', () => ( {
 	...require.requireActual( '@woocommerce/components' ),
@@ -63,7 +63,8 @@ describe( 'ReportChart', () => {
 			},
 		];
 		const query = { filter: 'lorem-ipsum', filter2: 'ipsum-lorem' };
-		const mode = getChartMode( filters, query );
+		const selectedFilter = getSelectedFilter( filters, query );
+		const mode = getChartMode( selectedFilter, query );
 		expect( mode ).toEqual( 'item-comparison' );
 	} );
 } );

--- a/client/analytics/components/report-chart/utils.js
+++ b/client/analytics/components/report-chart/utils.js
@@ -17,28 +17,26 @@ export function getSelectedFilter( filters, query, selectedFilterArgs = {} ) {
 		return null;
 	}
 
-	const filterConfig = filters.pop();
+	const clonedFilters = filters.slice( 0 );
+	const filterConfig = clonedFilters.pop();
 
 	if ( filterConfig.showFilters( query, selectedFilterArgs ) ) {
 		const allFilters = flattenFilters( filterConfig.filters );
 		const value = query[ filterConfig.param ] || DEFAULT_FILTER;
-		const selectedFilter = find( allFilters, { value } );
+		return find( allFilters, { value } );
+	}
+
+	return getSelectedFilter( clonedFilters, query, selectedFilterArgs );
+}
+
+export function getChartMode( selectedFilter, query ) {
+	if ( selectedFilter && query ) {
 		const selectedFilterParam = get( selectedFilter, [ 'settings', 'param' ] );
 
 		if ( ! selectedFilterParam || Object.keys( query ).includes( selectedFilterParam ) ) {
-			return selectedFilter;
+			return get( selectedFilter, [ 'chartMode' ] );
 		}
 	}
 
-	return getSelectedFilter( filters, query, selectedFilterArgs );
-}
-
-export function getChartMode( filters, query, selectedFilterArgs ) {
-	if ( ! filters ) {
-		return;
-	}
-	const clonedFilters = filters.slice( 0 );
-	const selectedFilter = getSelectedFilter( clonedFilters, query, selectedFilterArgs );
-
-	return get( selectedFilter, [ 'chartMode' ] );
+	return null;
 }

--- a/client/analytics/components/report-chart/utils.js
+++ b/client/analytics/components/report-chart/utils.js
@@ -13,7 +13,7 @@ import { flattenFilters } from '@woocommerce/navigation';
 export const DEFAULT_FILTER = 'all';
 
 export function getSelectedFilter( filters, query, selectedFilterArgs = {} ) {
-	if ( filters.length === 0 ) {
+	if ( ! filters || filters.length === 0 ) {
 		return null;
 	}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,6 @@
 # (unreleased)
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
+- Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
 
 # 1.6.0
 - Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -16,7 +16,7 @@ import { withViewportMatch } from '@wordpress/viewport';
 /**
  * WooCommerce dependencies
  */
-import { updateQueryString } from '@woocommerce/navigation';
+import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -74,7 +74,9 @@ function getOrderedKeys( props, previousOrderedKeys = [] ) {
 	if ( 'item-comparison' === props.mode ) {
 		updatedKeys.sort( ( a, b ) => b.total - a.total );
 		if ( isEmpty( previousOrderedKeys ) ) {
-			return updatedKeys.filter( key => key.total > 0 ).map( ( key, index ) => {
+			const selectedIds = props.filterParam ? getIdsFromQuery( props.query[ props.filterParam ] ) : [];
+			const filteredKeys = updatedKeys.filter( key => key.total > 0 || selectedIds.includes( parseInt( key.key, 10 ) ) );
+			return filteredKeys.map( ( key, index ) => {
 				return {
 					...key,
 					visible: index < selectionLimit || key.visible,

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -446,6 +446,12 @@ Chart.propTypes = {
 	 */
 	emptyMessage: PropTypes.string,
 	/**
+	 * Name of the param used to filter items. If specified, it will be used, in combination
+	 * with query, to detect which elements are being used by the current filter and must be
+	 * displayed even if their value is 0.
+	 */
+	filterParam: PropTypes.string,
+	/**
 	 * Label describing the legend items.
 	 */
 	itemsLabel: PropTypes.string,


### PR DESCRIPTION
Fixes the chart part of  #1704.

Makes sure compared items are shown in charts even if their values are 0.

### Screenshots
#### Product Comparison with selected items
_Before:_
![image](https://user-images.githubusercontent.com/3616980/53872727-1f8c2780-3fff-11e9-8b44-003b6494aaa5.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/53872541-ca501600-3ffe-11e9-82d3-ece44b09c580.png)

#### Product Comparison without selected items
![image](https://user-images.githubusercontent.com/3616980/53872663-fcfa0e80-3ffe-11e9-831e-0641cf41de4e.png)

### Detailed test instructions:
- Go to the _Products_ report or any other with a chart and which allows comparisons.
- Select _Product Comparison_ filter without choosing any product yet.
- Verify only items with _values > 0_ appear in the chart legend (see screenshot above).
- Now select some products using the filter text input, selecting items with _values > 0_ and others with _values = 0_ for that period.
- Verify all selected items, including the ones with _values = 0_ appear in the chart.