### PR TITLE
Add StoreAlerts placeholder

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -20,6 +20,7 @@ import { Card } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import sanitizeHTML from 'lib/sanitize-html';
+import StoreAlertsPlaceholder from './placeholder';
 
 import './style.scss';
 
@@ -60,12 +61,13 @@ class StoreAlerts extends Component {
 	}
 
 	render() {
-		const { alerts } = this.props;
+		const hasAlerts = Boolean( wcSettings.alertCount ) || null;
 
-		if ( ! alerts || alerts.length === 0 ) {
+		if ( ! hasAlerts ) {
 			return null;
 		}
 
+		const { alerts } = this.props;
 		const { currentIndex } = this.state;
 		const numberOfAlerts = alerts.length;
 		const alert = alerts[ currentIndex ] ? alerts[ currentIndex ] : null;
@@ -82,7 +84,7 @@ class StoreAlerts extends Component {
 				</Button>
 			) );
 
-		return (
+		return alert ? (
 			<Card
 				title={ [
 					alert.icon && <Dashicon key="icon" icon={ alert.icon } />,
@@ -127,6 +129,8 @@ class StoreAlerts extends Component {
 				/>
 				{ actions && <div className="woocommerce-store-alerts__actions">{ actions }</div> }
 			</Card>
+		) : (
+			<StoreAlertsPlaceholder hasMultipleAlerts={ wcSettings.alertCount > 1 } />
 		);
 	}
 }

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -61,30 +61,30 @@ class StoreAlerts extends Component {
 	}
 
 	render() {
-		const hasAlerts = Boolean( wcSettings.alertCount ) || null;
+		const alerts = this.props.alerts || [];
+		const preloadAlertCount = wcSettings.alertCount && parseInt( wcSettings.alertCount );
 
-		if ( ! hasAlerts ) {
+		if ( preloadAlertCount > 0 && 0 === alerts.length ) {
+			return <StoreAlertsPlaceholder hasMultipleAlerts={ preloadAlertCount > 1 } />;
+		} else if ( 0 === alerts.length ) {
 			return null;
 		}
 
-		const { alerts } = this.props;
 		const { currentIndex } = this.state;
 		const numberOfAlerts = alerts.length;
-		const alert = alerts[ currentIndex ] ? alerts[ currentIndex ] : null;
-		const type = alert && alert.type ? alert.type : null;
+		const alert = alerts[ currentIndex ];
+		const type = alert.type;
 		const className = classnames( 'woocommerce-store-alerts', {
 			'is-alert-error': 'error' === type,
 			'is-alert-update': 'update' === type,
 		} );
-		const actions =
-			alert &&
-			alert.actions.map( action => (
-				<Button key={ action.name } isDefault href={ action.url }>
-					{ action.label }
-				</Button>
-			) );
+		const actions = alert.actions.map( action => (
+			<Button key={ action.name } isDefault href={ action.url }>
+				{ action.label }
+			</Button>
+		) );
 
-		return alert ? (
+		return (
 			<Card
 				title={ [
 					alert.icon && <Dashicon key="icon" icon={ alert.icon } />,
@@ -129,8 +129,6 @@ class StoreAlerts extends Component {
 				/>
 				{ actions && <div className="woocommerce-store-alerts__actions">{ actions }</div> }
 			</Card>
-		) : (
-			<StoreAlertsPlaceholder hasMultipleAlerts={ wcSettings.alertCount > 1 } />
 		);
 	}
 }

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -135,12 +135,6 @@ class StoreAlerts extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { alertCount } = wcSettings;
-
-		if ( ! alertCount || 0 === alertCount ) {
-			return { alerts: null };
-		}
-
 		const { getNotes } = select( 'wc-api' );
 		const alertsQuery = {
 			page: 1,

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -137,6 +137,12 @@ class StoreAlerts extends Component {
 
 export default compose(
 	withSelect( select => {
+		const { alertCount } = wcSettings;
+
+		if ( ! alertCount || 0 === alertCount ) {
+			return { alerts: null };
+		}
+
 		const { getNotes } = select( 'wc-api' );
 		const alertsQuery = {
 			page: 1,

--- a/client/layout/store-alerts/placeholder.js
+++ b/client/layout/store-alerts/placeholder.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class StoreAlertsPlaceholder extends Component {
+	render() {
+		const { hasMultipleAlerts } = this.props;
+
+		return (
+			<div className="woocommerce-card woocommerce-store-alerts is-loading" aria-hidden>
+				<div className="woocommerce-card__header">
+					<div className="woocommerce-card__title woocommerce-card__header-item">
+						<span className="is-placeholder" />
+					</div>
+					{ hasMultipleAlerts && (
+						<div className="woocommerce-card__action woocommerce-card__header-item">
+							<span className="is-placeholder" />
+						</div>
+					) }
+				</div>
+				<div className="woocommerce-card__body">
+					<div className="woocommerce-store-alerts__message">
+						<span className="is-placeholder" />
+						<span className="is-placeholder" />
+					</div>
+					<div className="woocommerce-store-alerts__actions">
+						<span className="is-placeholder" />
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default StoreAlertsPlaceholder;

--- a/client/layout/store-alerts/placeholder.js
+++ b/client/layout/store-alerts/placeholder.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
 
 class StoreAlertsPlaceholder extends Component {
 	render() {
@@ -35,3 +36,14 @@ class StoreAlertsPlaceholder extends Component {
 }
 
 export default StoreAlertsPlaceholder;
+
+StoreAlertsPlaceholder.propTypes = {
+	/**
+	 * Whether multiple alerts exists.
+	 */
+	hasMultipleAlerts: PropTypes.bool,
+};
+
+StoreAlertsPlaceholder.defaultProps = {
+	hasMultipleAlerts: false,
+};

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -1,13 +1,21 @@
 /** @format */
-@mixin store-alerts-box-shadow( $color ) {
-	box-shadow: 0 0 8px -2px rgba(0, 0, 0, 0.3), inset 4px 0 0 0 $color;
-}
-
 .woocommerce-store-alerts {
+	position: relative;
 	margin: 0 0 $gap-largest 0;
 	margin-right: var(--large-gap);
 	padding: $gap-large;
 	border: 0;
+	box-shadow: 0 0 8px -2px rgba(0, 0, 0, 0.3);
+
+	&:before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 4px;
+		height: 100%;
+		background: transparent;
+	}
 
 	.woocommerce-card__header {
 		padding: 0;
@@ -49,9 +57,18 @@
 	}
 }
 
+.woocommerce-embed-page {
+	.woocommerce-store-alerts {
+		margin: 20px;
+	}
+}
+
 .is-alert-error {
 	$alert-color: #dc3232;
-	@include store-alerts-box-shadow( $alert-color );
+
+	&:before {
+		background-color: $alert-color;
+	}
 
 	.woocommerce-card__title {
 		svg {
@@ -62,7 +79,10 @@
 
 .is-alert-update {
 	$alert-color: #11a0d2;
-	@include store-alerts-box-shadow( $alert-color );
+
+	&:before {
+		background-color: $alert-color;
+	}
 
 	.woocommerce-card__title {
 		svg {
@@ -103,6 +123,65 @@
 
 		.woocommerce-store-alerts__pagination-label {
 			text-align: center;
+		}
+	}
+}
+
+.woocommerce-store-alerts.is-loading {
+	&:before {
+		@include placeholder();
+	}
+
+	.is-placeholder {
+		@include placeholder();
+		display: inline-block;
+		height: 16px;
+	}
+
+	.woocommerce-card__title {
+		.is-placeholder {
+			width: 340px;
+			height: 20px;
+		}
+	}
+
+	.woocommerce-card__action {
+		.is-placeholder {
+			min-width: 120px;
+			height: 30px;
+		}
+	}
+
+	.woocommerce-store-alerts__message {
+		.is-placeholder {
+			&:nth-child(1) {
+				width: 75%;
+			}
+
+			&:nth-child(2) {
+				width: 45%;
+			}
+		}
+	}
+
+	.woocommerce-store-alerts__actions {
+		.is-placeholder {
+			width: 110px;
+			height: 26px;
+		}
+	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-card__title {
+			width: 100%;
+
+			.is-placeholder {
+				width: 50%;
+			}
+		}
+
+		.woocommerce-card__action {
+			margin-bottom: 14px;
 		}
 	}
 }

--- a/includes/class-wc-admin-notes.php
+++ b/includes/class-wc-admin-notes.php
@@ -63,11 +63,12 @@ class WC_Admin_Notes {
 	/**
 	 * Get the total number of notes
 	 *
+	 * @param string $type Comma separated list of note types.
 	 * @return int
 	 */
-	public static function get_notes_count() {
+	public static function get_notes_count( $type = '' ) {
 		$data_store = WC_Data_Store::load( 'admin-note' );
-		return $data_store->get_notes_count();
+		return $data_store->get_notes_count( $type );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -292,10 +292,30 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Return a count of notes.
 	 *
+	 * @param string $type Comma separated list of note types.
 	 * @return array An array of objects containing a note id.
 	 */
-	public function get_notes_count() {
+	public function get_notes_count( $type = '' ) {
 		global $wpdb;
+
+		$allowed_types    = WC_Admin_Note::get_allowed_types();
+		$where_type_array = array();
+		if ( ! empty( $type ) ) {
+			$args_types = explode( ',', $type );
+			foreach ( (array) $args_types as $args_type ) {
+				$args_type = trim( $args_type );
+				if ( in_array( $args_type, $allowed_types, true ) ) {
+					$where_type_array[] = "'" . esc_sql( $args_type ) . "'";
+				}
+			}
+		}
+		$escaped_where_types = implode( ',', $where_type_array );
+
+		if ( ! empty( $escaped_where_types ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE type IN ($escaped_where_types)" );
+		}
+
 		return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes" );
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -149,8 +149,8 @@ function wc_admin_print_script_settings() {
 	global $wp_locale;
 
 	$preload_data_endpoints = array(
-		'countries'              => '/wc/v4/data/countries',
-		'performanceIndicators'  => '/wc/v4/reports/performance-indicators/allowed',
+		'countries'             => '/wc/v4/data/countries',
+		'performanceIndicators' => '/wc/v4/reports/performance-indicators/allowed',
 	);
 
 	if ( function_exists( 'gutenberg_preload_api_request' ) ) {
@@ -191,7 +191,7 @@ function wc_admin_print_script_settings() {
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
 		'currentUserData'  => $current_user_data,
-		'alertCount'       => WC_Admin_Notes::get_notes_count(),
+		'alertCount'       => WC_Admin_Notes::get_notes_count( 'error,update' ),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -190,7 +190,8 @@ function wc_admin_print_script_settings() {
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
-		'currentUserData'       => $current_user_data,
+		'currentUserData'  => $current_user_data,
+		'alertCount'       => WC_Admin_Notes::get_notes_count(),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 


### PR DESCRIPTION
Fixes #1736 

* Adds alert count via the `wcSettings` global and logic to stop alerts from trying to load when no alerts exist.
* Adds `StoreAlertsPlaceholder` a placeholder component and logic to whether to display the placeholder or `StoreAlerts`.

### Screenshots

![alerts-placeholder](https://user-images.githubusercontent.com/1177726/53920604-98be6580-4065-11e9-80bf-7a12b4f8eda7.gif)

### Detailed test instructions:

- Create a couple of test alerts. See https://github.com/woocommerce/wc-admin/pull/1723 for quick snippet to add a new note.
- Reload a wc-admin page, you should see the placeholder and then the alerts after loading.