### PR TITLE
Ensure that other scheduled actions are claimed before WC Admin actions.

### DIFF
--- a/includes/class-wc-admin-actionscheduler-wppoststore.php
+++ b/includes/class-wc-admin-actionscheduler-wppoststore.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WC Admin Action Scheduler Store.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+/**
+ * Class WC Admin Action Scheduler Store.
+ */
+class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
+	/**
+	 * Action scheduler job priority (lower numbers are claimed first).
+	 */
+	const JOB_PRIORITY = 30;
+
+	/**
+	 * Create the post array for storing actions as WP posts.
+	 *
+	 * For WC Admin actions, force a lower action claim
+	 * priority by setting a high value for `menu_order`.
+	 *
+	 * @param ActionScheduler_Action $action Action.
+	 * @param DateTime               $scheduled_date Action schedule.
+	 * @return array Post data array for usage in wp_insert_post().
+	 */
+	protected function create_post_array( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+		$postdata = parent::create_post_array( $action, $scheduled_date );
+
+		if ( 0 === strpos( $postdata['post_title'], 'wc-admin_' ) ) {
+			$postdata['menu_order'] = self::JOB_PRIORITY;
+		}
+
+		return $postdata;
+	}
+}

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -47,16 +47,6 @@ class WC_Admin_Reports_Sync {
 	const QUEUE_GROUP = 'wc-admin-data';
 
 	/**
-	 * Action scheduler post type.
-	 */
-	const ACTION_SCHEDULER_POST_TYPE = 'scheduled-action';
-
-	/**
-	 * Action scheduler job priority (lower numbers are claimed first).
-	 */
-	const JOB_PRIORITY = 30;
-
-	/**
 	 * Queue instance.
 	 *
 	 * @var WC_Queue_Interface
@@ -132,42 +122,6 @@ class WC_Admin_Reports_Sync {
 		foreach ( $hooks as $hook ) {
 			self::queue()->cancel_all( $hook, null, self::QUEUE_GROUP );
 		}
-	}
-
-	/**
-	 * Force a lower action claim priority by setting a high value for menu_order.
-	 *
-	 * Filters on "wp_insert_post_data" and changes `menu_order` for
-	 * scheduled actions originating from WC Admin.
-	 *
-	 * @param array $postdata Post data to insert.
-	 * @return array Filtered post data.
-	 */
-	public static function force_lower_action_priority( $postdata ) {
-		if (
-			( self::ACTION_SCHEDULER_POST_TYPE === $postdata['post_type'] ) &&
-			( 0 === strpos( $postdata['post_title'], 'wc-admin_' ) )
-		) {
-			$postdata['menu_order'] = self::JOB_PRIORITY;
-		}
-
-		return $postdata;
-	}
-
-	/**
-	 * Queue a single action.
-	 *
-	 * Defaults to our group and forces a lower priority (using menu_order).
-	 *
-	 * @param int    $timestamp When the job will run.
-	 * @param string $hook The hook to trigger.
-	 * @param array  $args Arguments to pass when the hook triggers.
-	 * @param string $group The group to assign this job to.
-	 */
-	public static function queue_action( $timestamp, $hook, $args = array(), $group = self::QUEUE_GROUP ) {
-		add_filter( 'wp_insert_post_data', array( __CLASS__, 'force_lower_action_priority' ), 10, 1 );
-		self::queue()->schedule_single( $timestamp, $hook, $args, $group );
-		remove_filter( 'wp_insert_post_data', array( __CLASS__, 'force_lower_action_priority' ), 10 );
 	}
 
 	/**
@@ -380,7 +334,7 @@ class WC_Admin_Reports_Sync {
 				$batch_start = $range_start + ( $i * $chunk_size );
 				$batch_end   = min( $range_end, $range_start + ( $chunk_size * ( $i + 1 ) ) - 1 );
 
-				self::queue_action(
+				self::queue()->schedule_single(
 					$action_timestamp,
 					self::QUEUE_BATCH_ACTION,
 					array( $batch_start, $batch_end, $single_batch_action ),
@@ -390,7 +344,7 @@ class WC_Admin_Reports_Sync {
 		} else {
 			// Otherwise, queue the single batches.
 			for ( $i = $range_start; $i <= $range_end; $i++ ) {
-				self::queue_action( $action_timestamp, $single_batch_action, array( $i ), self::QUEUE_GROUP );
+				self::queue()->schedule_single( $action_timestamp, $single_batch_action, array( $i ), self::QUEUE_GROUP );
 			}
 		}
 	}
@@ -431,14 +385,14 @@ class WC_Admin_Reports_Sync {
 			is_a( $next_job_schedule, 'DateTime' ) &&
 			( self::QUEUE_DEPEDENT_ACTION !== $blocking_job_hook )
 		) {
-			self::queue_action(
+			self::queue()->schedule_single(
 				$next_job_schedule->getTimestamp() + 5,
 				self::QUEUE_DEPEDENT_ACTION,
 				array( $action, $action_args, $prerequisite_action ),
 				self::QUEUE_GROUP
 			);
 		} else {
-			self::queue_action( time() + 5, $action, $action_args, self::QUEUE_GROUP );
+			self::queue()->schedule_single( time() + 5, $action, $action_args, self::QUEUE_GROUP );
 		}
 	}
 

--- a/tests/queue-priority.php
+++ b/tests/queue-priority.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Reports Generation Batch Queue Prioritizaion Tests
+ *
+ * @package WooCommerce\Tests\Reports
+ * @since 3.5.0
+ */
+
+/**
+ * Reports Generation Batch Queue Prioritizaion Test Class
+ *
+ * @package WooCommerce\Tests\Reports
+ * @since 3.5.0
+ */
+class WC_Tests_Reports_Queue_Prioritization extends WC_REST_Unit_Test_Case {
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+		if ( class_exists( 'ActionScheduler' ) ) {
+			remove_action( 'action_scheduler_run_queue', array( ActionScheduler::runner(), 'run' ) );
+		}
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		if ( class_exists( 'ActionScheduler' ) ) {
+			add_action( 'action_scheduler_run_queue', array( ActionScheduler::runner(), 'run' ) );
+		}
+	}
+
+	/**
+	 * Test that we're setting a priority on our actions.
+	 */
+	public function test_queue_action_sets_priority() {
+		WC_Admin_Reports_Sync::queue_action( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
+
+		$actions = WC_Admin_Reports_Sync::queue()->search(
+			array(
+				'status'  => 'pending',
+				'claimed' => false,
+				'hook'    => WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION,
+				'group'   => WC_Admin_Reports_Sync::QUEUE_GROUP,
+			)
+		);
+
+		$this->assertCount( 1, $actions );
+
+		$action_ids = array_keys( $actions );
+		$action_id  = $action_ids[0];
+		$action     = get_post( $action_id );
+
+		$this->assertEquals( WC_Admin_Reports_Sync::JOB_PRIORITY, $action->menu_order );
+
+		WC_Admin_Reports_Sync::queue()->cancel_all( WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
+	}
+}
+
+

--- a/tests/queue-priority.php
+++ b/tests/queue-priority.php
@@ -37,14 +37,13 @@ class WC_Tests_Reports_Queue_Prioritization extends WC_REST_Unit_Test_Case {
 	 * Test that we're setting a priority on our actions.
 	 */
 	public function test_queue_action_sets_priority() {
-		WC_Admin_Reports_Sync::queue_action( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
+		WC_Admin_Reports_Sync::queue()->schedule_single( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
 
 		$actions = WC_Admin_Reports_Sync::queue()->search(
 			array(
 				'status'  => 'pending',
 				'claimed' => false,
 				'hook'    => WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION,
-				'group'   => WC_Admin_Reports_Sync::QUEUE_GROUP,
 			)
 		);
 
@@ -54,7 +53,7 @@ class WC_Tests_Reports_Queue_Prioritization extends WC_REST_Unit_Test_Case {
 		$action_id  = $action_ids[0];
 		$action     = get_post( $action_id );
 
-		$this->assertEquals( WC_Admin_Reports_Sync::JOB_PRIORITY, $action->menu_order );
+		$this->assertEquals( WC_Admin_ActionScheduler_wpPostStore::JOB_PRIORITY, $action->menu_order );
 
 		WC_Admin_Reports_Sync::queue()->cancel_all( WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
 	}

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -181,3 +181,20 @@ add_action( 'woocommerce_updated', 'wc_admin_woocommerce_updated' );
  * Gutenberg has also disabled emojis. More on that here -> https://github.com/WordPress/gutenberg/pull/6151
  */
 remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+
+/**
+ * Filter in our ActionScheduler Store class.
+ *
+ * @return string ActionScheduler Store class name.
+ */
+function wc_admin_set_actionscheduler_store_class() {
+	// Include our store class here instead of wc_admin_plugins_loaded()
+	// because ActionScheduler is hooked into `plugins_loaded` at a
+	// much higher priority.
+	require_once WC_ADMIN_ABSPATH . '/includes/class-wc-admin-actionscheduler-wppoststore.php';
+
+	return 'WC_Admin_ActionScheduler_WPPostStore';
+}
+
+// Hook up our modified ActionScheduler Store.
+add_filter( 'action_scheduler_store_class', 'wc_admin_set_actionscheduler_store_class' );

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -185,9 +185,15 @@ remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 /**
  * Filter in our ActionScheduler Store class.
  *
+ * @param string $store_class ActionScheduler Store class name.
  * @return string ActionScheduler Store class name.
  */
-function wc_admin_set_actionscheduler_store_class() {
+function wc_admin_set_actionscheduler_store_class( $store_class ) {
+	// Don't override any other overrides.
+	if ( 'ActionScheduler_wpPostStore' !== $store_class ) {
+		return $store_class;
+	}
+
 	// Include our store class here instead of wc_admin_plugins_loaded()
 	// because ActionScheduler is hooked into `plugins_loaded` at a
 	// much higher priority.


### PR DESCRIPTION
This PR seeks to lower the priority of WC Admin scheduled actions so others are claimed first by Action Scheduler. This is an effort to prevent reporting table generation from stalling out important things like webhooks and subscription renewals.

It uses `menu_order` to lower the claim priority of WC Admin scheduled actions. (Exploits this `ORDER BY`: https://github.com/woocommerce/woocommerce/blob/e9f04908293048cf3a154a0771f5db61b01258e2/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php#L545)

**NOTE:** This doesn't guarantee that non-WC Admin actions will run first, it just ensures that non-WC Admin actions get _claimed_ first. A single claim could still contain WC Admin actions that might have been scheduled before the others.

### Detailed test instructions:

Testing this is a little tricky.. here's what I did:

- Queue up a WC Admin job: `WC_Admin_Reports_Sync::queue_action( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );`
- Queue up a non-WC Admin job, making sure it's definitely **after** the first: `WC()->queue()->schedule_single( time() + 10, 'some_hook' );`
- Use WP CLI to run a batch of 1: `wp action-scheduler --batch-size=1`
- Verify that the reported action ID matches the non-WC Admin action (checking DB is easy)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
