### PR TITLE
Fix  chart comparison mode and single Category

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -188,10 +188,10 @@ ReportChart.propTypes = {
 	 */
 	itemsLabel: PropTypes.string,
 	/**
-	 * Allows specifying a property different from the `endpoint` that will be used
+	 * Allows specifying properties different from the `endpoint` that will be used
 	 * to limit the items when there is an active search.
 	 */
-	limitProperty: PropTypes.string,
+	limitProperties: PropTypes.array,
 	/**
 	 * `items-comparison` (default) or `time-comparison`, this is used to generate correct
 	 * ARIA properties.
@@ -239,8 +239,8 @@ ReportChart.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, filters, isRequesting, limitProperty, query } = props;
-		const limitBy = limitProperty || endpoint;
+		const { endpoint, filters, isRequesting, limitProperties, query } = props;
+		const limitBy = limitProperties || [ endpoint ];
 		const selectedFilter = getSelectedFilter( filters, query );
 		const filterParam = get( selectedFilter, [ 'settings', 'param' ] );
 		const chartMode = props.mode || getChartMode( selectedFilter, query ) || 'time-comparison';
@@ -254,7 +254,9 @@ export default compose(
 			return newProps;
 		}
 
-		if ( query.search && ! ( query[ limitBy ] && query[ limitBy ].length ) ) {
+		const hasLimitByParam = limitBy.some( item => query[ item ] && query[ item ].length );
+
+		if ( query.search && ! hasLimitByParam ) {
 			return {
 				...newProps,
 				emptySearchResults: true,

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -109,10 +109,10 @@ ReportSummary.propTypes = {
 	 */
 	endpoint: PropTypes.string.isRequired,
 	/**
-	 * Allows specifying a property different from the `endpoint` that will be used
+	 * Allows specifying properties different from the `endpoint` that will be used
 	 * to limit the items when there is an active search.
 	 */
-	limitProperty: PropTypes.string,
+	limitProperties: PropTypes.array,
 	/**
 	 * The query string represented in object form.
 	 */
@@ -149,14 +149,16 @@ ReportSummary.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, isRequesting, limitProperty, query } = props;
-		const limitBy = limitProperty || endpoint;
+		const { endpoint, isRequesting, limitProperties, query } = props;
+		const limitBy = limitProperties || [ endpoint ];
 
 		if ( isRequesting ) {
 			return {};
 		}
 
-		if ( query.search && ! ( query[ limitBy ] && query[ limitBy ].length ) ) {
+		const hasLimitByParam = limitBy.some( item => query[ item ] && query[ item ].length );
+
+		if ( query.search && ! hasLimitByParam ) {
 			return {
 				emptySearchResults: true,
 			};

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -19,18 +19,24 @@ import CategoriesReportTable from './table';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
+import ProductsReportTable from '../products/table';
 
 export default class CategoriesReport extends Component {
 	getChartMeta() {
 		const { query } = this.props;
+		const isCompareView =
+			'compare-categories' === query.filter &&
+			query.categories &&
+			query.categories.split( ',' ).length > 1;
+		const isSingleCategoryView = 'single_category' === query.filter && !! query.categories;
 
-		const isCategoryDetailsView = [ 'top_items', 'top_revenue', 'compare-categories' ].includes(
-			query.filter
-		);
-		const mode = isCategoryDetailsView ? 'item-comparison' : 'time-comparison';
-		const itemsLabel = __( '%d categories', 'wc-admin' );
+		const mode = isCompareView || isSingleCategoryView ? 'item-comparison' : 'time-comparison';
+		const itemsLabel = isSingleCategoryView
+			? __( '%d products', 'wc-admin' )
+			: __( '%d categories', 'wc-admin' );
 
 		return {
+			isSingleCategoryView,
 			itemsLabel,
 			mode,
 		};
@@ -38,14 +44,14 @@ export default class CategoriesReport extends Component {
 
 	render() {
 		const { isRequesting, query, path } = this.props;
-		const { mode, itemsLabel } = this.getChartMeta();
+		const { mode, itemsLabel, isSingleCategoryView } = this.getChartMeta();
 
 		const chartQuery = {
 			...query,
 		};
 
 		if ( 'item-comparison' === mode ) {
-			chartQuery.segmentby = 'category';
+			chartQuery.segmentby = isSingleCategoryView ? 'product' : 'category';
 		}
 
 		return (
@@ -55,7 +61,7 @@ export default class CategoriesReport extends Component {
 					charts={ charts }
 					endpoint="categories"
 					isRequesting={ isRequesting }
-					limitProperty="categories"
+					limitProperties={ isSingleCategoryView ? [ 'products', 'categories' ] : [ 'categories' ] }
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
@@ -64,14 +70,23 @@ export default class CategoriesReport extends Component {
 					charts={ charts }
 					mode={ mode }
 					endpoint="categories"
-					limitProperty="categories"
+					limitProperties={ isSingleCategoryView ? [ 'products', 'categories' ] : [ 'categories' ] }
 					path={ path }
 					query={ chartQuery }
 					isRequesting={ isRequesting }
 					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<CategoriesReportTable isRequesting={ isRequesting } query={ query } />
+				{ isSingleCategoryView ? (
+					<ProductsReportTable
+						isRequesting={ isRequesting }
+						query={ query }
+						baseSearchQuery={ { filter: 'single_category' } }
+						hideCompare={ isSingleCategoryView }
+					/>
+				) : (
+					<CategoriesReportTable isRequesting={ isRequesting } query={ query } />
+				) }
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -23,9 +23,8 @@ import ReportSummary from 'analytics/components/report-summary';
 export default class CouponsReport extends Component {
 	getChartMeta() {
 		const { query } = this.props;
-		const isCompareView = [ 'top_orders', 'top_discount', 'compare-coupons' ].includes(
-			query.filter
-		);
+		const isCompareView =
+			'compare-coupons' === query.filter && query.coupons && query.coupons.split( ',' ).length > 1;
 
 		const mode = isCompareView ? 'item-comparison' : 'time-comparison';
 		const itemsLabel = __( '%d coupons', 'wc-admin' );

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -153,7 +153,10 @@ export default compose(
 
 		const { report } = props.params;
 		const searchWords = getSearchWords( query );
-		const itemsResult = searchItemsByString( select, report, searchWords );
+		// Single Category view in Categories Report uses the products endpoint, so search must also.
+		const mappedReport =
+			'categories' === report && 'single_category' === query.filter ? 'products' : report;
+		const itemsResult = searchItemsByString( select, mappedReport, searchWords );
 		const { isError, isRequesting, items } = itemsResult;
 		const ids = Object.keys( items );
 		if ( ! ids.length ) {
@@ -168,7 +171,7 @@ export default compose(
 			isRequesting,
 			query: {
 				...props.query,
-				[ report ]: ids.join( ',' ),
+				[ mappedReport ]: ids.join( ',' ),
 			},
 		};
 	} )

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -27,17 +27,13 @@ import withSelect from 'wc-api/with-select';
 class ProductsReport extends Component {
 	getChartMeta() {
 		const { query, isSingleProductView, isSingleProductVariable } = this.props;
-
-		const isProductDetailsView = [
-			'top_items',
-			'top_sales',
-			'compare-products',
-			'single_category',
-			'compare-categories',
-		].includes( query.filter );
+		const isCompareView =
+			'compare-products' === query.filter &&
+			query.products &&
+			query.products.split( ',' ).length > 1;
 
 		const mode =
-			isProductDetailsView || ( isSingleProductView && isSingleProductVariable )
+			isCompareView || ( isSingleProductView && isSingleProductVariable )
 				? 'item-comparison'
 				: 'time-comparison';
 		const compareObject =

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -225,7 +225,7 @@ class ProductsReportTable extends Component {
 	}
 
 	render() {
-		const { query, isRequesting } = this.props;
+		const { query, isRequesting, baseSearchQuery, hideCompare } = this.props;
 
 		const labels = {
 			helpText: __( 'Select at least two products to compare', 'wc-admin' ),
@@ -234,7 +234,7 @@ class ProductsReportTable extends Component {
 
 		return (
 			<ReportTable
-				compareBy="products"
+				compareBy={ hideCompare ? undefined : 'products' }
 				endpoint="products"
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
@@ -244,10 +244,17 @@ class ProductsReportTable extends Component {
 				labels={ labels }
 				query={ query }
 				searchBy="products"
+				baseSearchQuery={ baseSearchQuery }
 				tableQuery={ {
 					orderby: query.orderby || 'items_sold',
 					order: query.order || 'desc',
 					extended_info: true,
+					/**
+					 * @TODO: Add this parameter because the filterQuery will be derived from the wrong config
+					 * because it will always look for products config, not categories. The solution is to pass
+					 * down the configs explicitly.
+					 */
+					categories: query.categories,
 				} }
 				title={ __( 'Products', 'wc-admin' ) }
 				columnPrefsKey="products_report_columns"

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -38,10 +38,11 @@ const reportConfigs = {
 
 export function getFilterQuery( endpoint, query, limitBy ) {
 	if ( query.search ) {
-		const limitProperty = limitBy || endpoint;
-		return {
-			[ limitProperty ]: query[ limitProperty ],
-		};
+		const limitProperties = limitBy || [ endpoint ];
+		return limitProperties.reduce( ( result, limitProperty ) => {
+			result[ limitProperty ] = query[ limitProperty ];
+			return result;
+		}, {} );
 	}
 
 	if ( reportConfigs[ endpoint ] ) {
@@ -168,7 +169,7 @@ export function isReportDataEmpty( report, endpoint ) {
  * @param  {String} endpoint  Report API Endpoint
  * @param  {String} dataType  'primary' or 'secondary'.
  * @param  {Object} query     Query parameters in the url.
- * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
+ * @param  {Array}  [limitBy] Properties used to limit the results. It will be used in the API call to send the IDs.
  * @returns {Object} data request query parameters.
  */
 function getRequestQuery( endpoint, dataType, query, limitBy ) {
@@ -197,7 +198,7 @@ function getRequestQuery( endpoint, dataType, query, limitBy ) {
  * @param  {String} endpoint  Report API Endpoint
  * @param  {Object} query     Query parameters in the url
  * @param  {Object} select    Instance of @wordpress/select
- * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
+ * @param  {Array}  [limitBy] Properties used to limit the results. It will be used in the API call to send the IDs.
  * @return {Object} Object containing summary number responses.
  */
 export function getSummaryNumbers( endpoint, query, select, limitBy ) {
@@ -242,7 +243,7 @@ export function getSummaryNumbers( endpoint, query, select, limitBy ) {
  * @param  {String} dataType  'primary' or 'secondary'
  * @param  {Object} query     Query parameters in the url
  * @param  {Object} select    Instance of @wordpress/select
- * @param  {String} [limitBy] Property used to limit the results. It will be used in the API call to send the IDs.
+ * @param  {Array}  [limitBy] Properties used to limit the results. It will be used in the API call to send the IDs.
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( endpoint, dataType, query, select, limitBy ) {

--- a/includes/class-wc-admin-reports-segmenting.php
+++ b/includes/class-wc-admin-reports-segmenting.php
@@ -311,6 +311,7 @@ class WC_Admin_Reports_Segmenting {
 				'limit'  => -1,
 			);
 
+			// @todo: filter by categories if $this->query_args['categories'] is set.
 			if ( isset( $this->query_args['product_includes'] ) ) {
 				$args['include'] = $this->query_args['product_includes'];
 			}

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -165,7 +165,7 @@ class TableCard extends Component {
 	}
 
 	onSearch( values ) {
-		const { compareParam, searchBy } = this.props;
+		const { compareParam, searchBy, baseSearchQuery } = this.props;
 		// A comma is used as a separator between search terms, so we want to escape
 		// any comma they contain.
 		const labels = values.map( v => v.label.replace( ',', '%2C' ) );
@@ -174,6 +174,7 @@ class TableCard extends Component {
 				filter: undefined,
 				[ compareParam ]: undefined,
 				[ searchBy ]: undefined,
+				...baseSearchQuery,
 				search: uniq( labels ).join( ',' ),
 			} );
 		} else {
@@ -489,6 +490,10 @@ TableCard.propTypes = {
 	 * The total number of rows (across all pages).
 	 */
 	totalRows: PropTypes.number.isRequired,
+	/**
+	 * Pass in query parameters to be included in the path when onSearch creates a new url.
+	 */
+	baseSearchQuery: PropTypes.object,
 };
 
 TableCard.defaultProps = {
@@ -501,6 +506,7 @@ TableCard.defaultProps = {
 	rowHeader: 0,
 	rows: [],
 	showMenu: true,
+	baseSearchQuery: {},
 };
 
 export default TableCard;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1761
Fixes https://github.com/woocommerce/wc-admin/issues/1760

There are two changes in this PR:

Show > Comparison now doesn't change anything until two items are selected and "compare" is clicked. The chart will then switch to "comparison" mode.

Secondly, Categories Report > Show > Single Category now produces segmentation by products in the Chart in comparison mode and uses the Products Table to display tabular results.

### Detailed test instructions:

1. Categories, Products, or Coupons Report > Show > Comparison.
2. Ensure no change in the chart.
3. Select at least 2 values and click "compare"
4. See the charts update to comparison mode.
5. Categories Report > Show > Single Category and make a selection.
6. See the chart enter comparison mode of products and the table display product results
7. Search in the table for a product, including a fuzzy search. Ensure the chart and summary numbers update accordingly.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
