### PR TITLE
Update plugin header to better match the readme

### DIFF
--- a/wc-admin.php
+++ b/wc-admin.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: WooCommerce Admin
  * Plugin URI: https://github.com/woocommerce/wc-admin
- * Description: A feature plugin for a modern, javascript-driven WooCommerce admin experience.
- * Author: Automattic
+ * Description: A new JavaScript-driven interface for managing your store. The plugin includes new and improved reports, and a dashboard to monitor all the important key metrics of your site.
+ * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: wc-admin
  * Domain Path: /languages


### PR DESCRIPTION
This tiny PR updates the plugin header in `wc-admin.php` to better match the readme.txt description, and show WooCommerce as the plugin byline like other WooCommerce plugins.

### Screenshots

<img width="967" alt="screen shot 2019-03-07 at 1 47 59 am" src="https://user-images.githubusercontent.com/689165/53937559-77687400-407b-11e9-9b8b-3591d3c40a0b.png">

### Detailed test instructions:

* Visit the plugin page and see the updated description / author.
