### PR TITLE
Taxes report: sort tax rates numerically instead of alphabetically

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -296,7 +296,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 		global $wpdb;
 
 		if ( 'rate' === $order_by ) {
-			return $wpdb->prefix . 'woocommerce_tax_rates.tax_rate';
+			return "CAST({$wpdb->prefix}woocommerce_tax_rates.tax_rate as DECIMAL(18,4))";
 		}
 
 		return $order_by;

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -296,7 +296,7 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 		global $wpdb;
 
 		if ( 'rate' === $order_by ) {
-			return "CAST({$wpdb->prefix}woocommerce_tax_rates.tax_rate as DECIMAL(18,4))";
+			return "CAST({$wpdb->prefix}woocommerce_tax_rates.tax_rate as DECIMAL(7,4))";
 		}
 
 		return $order_by;

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -213,6 +213,63 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting reports with param `orderby=rate`.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_orderby_tax_rate() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 1,
+				'tax_rate'          => '7',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'GA',
+				'tax_rate_name'     => 'TestTax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 2,
+				'tax_rate'          => '10',
+				'tax_rate_country'  => 'CA',
+				'tax_rate_state'    => 'ON',
+				'tax_rate_name'     => 'TestTax 2',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'order'   => 'asc',
+				'orderby' => 'rate',
+				'taxes'   => '1,2',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		$this->assertEquals( 1, $reports[0]['tax_rate_id'] );
+		$this->assertEquals( 7, $reports[0]['tax_rate'] );
+
+		$this->assertEquals( 2, $reports[1]['tax_rate_id'] );
+		$this->assertEquals( 10, $reports[1]['tax_rate'] );
+	}
+
+	/**
 	 * Test getting reports without valid permissions.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
Fixes #1721.

Sort tax rates as numeric values instead of alphabetically.

### Screenshots
_Before (notice `10%` is not correctly sorted):_
![image](https://user-images.githubusercontent.com/3616980/54038702-717cab00-41c1-11e9-8585-138c378651af.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/54038667-5873fa00-41c1-11e9-86ce-1832a77b78c3.png)

### Detailed test instructions:
* Create two taxes with different order of magnitude (10% and 2.50%, for example) if you don't have them.
* Go to the _Taxes_ report.
* Sort taxes by _Rate_.
* Verify they are sorted numerically, so 10% is considered bigger than 2.50%.