### PR TITLE
Add a custom “cancel all” method to our scheduled action data store.

### DIFF
--- a/includes/class-wc-admin-actionscheduler-wppoststore.php
+++ b/includes/class-wc-admin-actionscheduler-wppoststore.php
@@ -33,4 +33,35 @@ class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
 
 		return $postdata;
 	}
+
+	/**
+	 * Forcefully delete all pending WC Admin scheduled actions.
+	 *
+	 * Directly deletes items from the database for performance.
+	 */
+	public function clear_pending_wcadmin_actions() {
+		global $wpdb;
+
+		// Remove all scheduled action posts and their metadata.
+		$delete_pending_sql =
+			"DELETE p.*, pm.* FROM {$wpdb->posts} p
+			JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+			WHERE post_type = 'scheduled-action'
+			AND post_status = 'pending'
+			AND post_title LIKE 'wc-admin_%'";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL
+		$wpdb->query( $delete_pending_sql );
+
+		// Delete all taxonomy data related to the WC Admin scheduled action group.
+		$group_term = get_term_by( 'slug', WC_Admin_Reports_Sync::QUEUE_GROUP, parent::GROUP_TAXONOMY );
+
+		if ( $group_term ) {
+			$wpdb->delete( $wpdb->term_relationships, array( 'term_taxonomy_id' => $group_term->term_taxonomy_id ), array( '%d' ) );
+			$wpdb->delete( $wpdb->term_taxonomy, array( 'term_id' => $group_term->term_id ), array( '%d' ) );
+			$wpdb->delete( $wpdb->terms, array( 'term_id' => $group_term->term_id ), array( '%d' ) );
+
+			clean_taxonomy_cache( parent::GROUP_TAXONOMY );
+		}
+	}
 }

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -111,16 +111,13 @@ class WC_Admin_Reports_Sync {
 	 * Clears all queued actions.
 	 */
 	public static function clear_queued_actions() {
-		$hooks = array(
-			self::QUEUE_BATCH_ACTION,
-			self::QUEUE_DEPEDENT_ACTION,
-			self::CUSTOMERS_BATCH_ACTION,
-			self::ORDERS_BATCH_ACTION,
-			self::ORDERS_LOOKUP_BATCH_INIT,
-			self::SINGLE_ORDER_ACTION,
-		);
-		foreach ( $hooks as $hook ) {
-			self::queue()->cancel_all( $hook, null, self::QUEUE_GROUP );
+		$store = ActionScheduler::store();
+
+		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
+			// If we're using our data store, call our bespoke deletion method.
+			$store->clear_pending_wcadmin_actions();
+		} else {
+			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}
 	}
 


### PR DESCRIPTION
Performs direct database manipulation for performance (with large datasets).

Fixes #1699.

This PR introduces direct SQL queries to clear all pending WC Admin actions and the associated metadata.

In my testing, the new `clear_pending_wcadmin_actions()` method cleared `46430` actions in `1.392324924469s` (tested using `microtime()`).

### Detailed test instructions:

- Disable default AS queue runner (https://github.com/Prospress/action-scheduler-disable-default-runner/)
- Queue a lot of WC Admin jobs (can call `WC_Admin_Reports_Sync::queue()->schedule_single()` many times in a loop, etc)
- Use WP CLI to kick off AS runner (`wp action-scheduler run`)
- Deactivate the WC Admin plugin
- Verify all pending WC Admin jobs are gone

**NOTE:** If you encounter a PHP Fatal error in the CLI session, that is fixed with: https://github.com/Prospress/action-scheduler/pull/258