### PR TITLE
Remove timezone from appendTimestamp() output.

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.6
+
+- Removed timezone from `appendTimestamp()` output.
+
 # 1.0.5
 
 - Fixed bug in getAllowedIntervalsForQuery() to not return `hour` for default intervals

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -63,15 +63,15 @@ export const periods = [
 export const appendTimestamp = ( date, timeOfDay ) => {
 	date = date.format( isoDateFormat );
 	if ( timeOfDay === 'start' ) {
-		return date + 'T00:00:00+00:00';
+		return date + 'T00:00:00';
 	}
 	if ( timeOfDay === 'now' ) {
 		// Set seconds to 00 to avoid consecutives calls happening before the previous
 		// one finished.
-		return date + 'T' + moment().format( 'HH:mm:00' ) + '+00:00';
+		return date + 'T' + moment().format( 'HH:mm:00' );
 	}
 	if ( timeOfDay === 'end' ) {
-		return date + 'T23:59:59+00:00';
+		return date + 'T23:59:59';
 	}
 	throw new Error( 'appendTimestamp requires second parameter to be either `start`, `now` or `end`' );
 };

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -26,16 +26,16 @@ import {
 
 describe( 'appendTimestamp', () => {
 	it( 'should append `start` timestamp', () => {
-		expect( appendTimestamp( moment( '2018-01-01' ), 'start' ) ).toEqual( '2018-01-01T00:00:00+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'start' ) ).toEqual( '2018-01-01T00:00:00' );
 	} );
 
 	it( 'should append `now` timestamp', () => {
 		const nowTimestamp = moment().format( 'HH:mm:00' );
-		expect( appendTimestamp( moment( '2018-01-01' ), 'now' ) ).toEqual( '2018-01-01T' + nowTimestamp + '+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'now' ) ).toEqual( '2018-01-01T' + nowTimestamp );
 	} );
 
 	it( 'should append `end` timestamp', () => {
-		expect( appendTimestamp( moment( '2018-01-01' ), 'end' ) ).toEqual( '2018-01-01T23:59:59+00:00' );
+		expect( appendTimestamp( moment( '2018-01-01' ), 'end' ) ).toEqual( '2018-01-01T23:59:59' );
 	} );
 
 	it( 'should throw and error if `timeOfDay` is not valid', () => {


### PR DESCRIPTION
Fixes #1651.

This PR seeks to fix issue #1651 where unexpected dates were being included in report intervals. It also corrects date ranges in queries for performance indicators as well.

**The problem:**

`appendTimestamp()` in `@woocommerce/date` forces all modified dates to be `0` offset from GMT. ([#](https://github.com/woocommerce/wc-admin/blob/76592e29dbfdbb1b370a84dbbcb2a3d40dcb3182/packages/date/src/index.js#L66)) When those dates are used in API calls, the PHP side offsets them to match the store's timezone ([#](https://github.com/woocommerce/wc-admin/blob/6641589ae450f9bd95e7f6793957fcc29e8b479c/includes/data-stores/class-wc-admin-reports-data-store.php#L176-L199)), which can turn `2019-01-01T00:00:00` into `2018-12-31T17:00:00` if the store is GMT `-7`.

**Proposed solution:**

Remove the `+00:00` appended to all datetimes by `appendTimestamp()`. This causes the PHP side to default to the store's timezone, which is likely the expected behavior.

### Screenshots

### Detailed test instructions:

- Set your store's timezone to a negative UTC offset, like -7
- Go to Revenue Report
- Select a preset range, like "Last Quarter"
- Verify that report table does not show a day outside (before) the quarter's date range
- Set your store's timezone to a negative UTC offset, like +7
- Go to Revenue Report
- Select a preset range, like "Last Quarter"
- Verify that report table does not show a day outside (after) the quarter's date range

Optional: verify that performance indicator values are correct for the specified date range. This is tricky since you'd have to have sales on the errant "extra" day in order to verify the fix. You can also verify the SQL generated for the query has the correct date range.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
