### PR TITLE
Fix/products stats segment product filter cats

### DIFF
--- a/includes/class-wc-admin-reports-segmenting.php
+++ b/includes/class-wc-admin-reports-segmenting.php
@@ -311,9 +311,17 @@ class WC_Admin_Reports_Segmenting {
 				'limit'  => -1,
 			);
 
-			// @todo: filter by categories if $this->query_args['categories'] is set.
 			if ( isset( $this->query_args['product_includes'] ) ) {
 				$args['include'] = $this->query_args['product_includes'];
+			}
+
+			if ( isset( $this->query_args['categories'] ) ) {
+				$categories       = $this->query_args['categories'];
+				$args['category'] = array();
+				foreach ( $categories as $category_id ) {
+					$terms            = get_term_by( 'id', $category_id, 'product_cat' );
+					$args['category'] = $terms->slug;
+				}
 			}
 
 			$segment_objects = wc_get_products( $args );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/wc-admin/issues/1772

When segmenting `/reports/products/stats` by `product` segments were not filtered properly by caetgory, if supplied as an argument.

### Detailed test instructions:

1. Using postman, segment by product and filter by a known category id (or ids): `/wp-json/wc/v4/reports/products/stats?categories=<my-category-id>&segmentby=product`
2. See the segments in the response limited to products in the category supplied.

### Question

Performance wise, would it be better to write a query with a join than to continue using `wc_get_products`, which requires the `category` [argument to be an array of slugs](https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query), which means a `get_term_by` call for each category? 
