### PR TITLE
 Load RTL CSS files 

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -110,6 +110,7 @@ function wc_admin_register_script() {
 		array( 'wp-edit-blocks' ),
 		filemtime( wc_admin_dir_path( 'dist/components/style.css' ) )
 	);
+	wp_style_add_data( 'wc-components', 'rtl', 'replace' );
 
 	wp_register_style(
 		'wc-components-ie',
@@ -117,6 +118,7 @@ function wc_admin_register_script() {
 		array( 'wp-edit-blocks' ),
 		filemtime( wc_admin_dir_path( 'dist/components/ie.css' ) )
 	);
+	wp_style_add_data( 'wc-components-ie', 'rtl', 'replace' );
 
 	wp_register_style(
 		WC_ADMIN_APP,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -126,6 +126,7 @@ function wc_admin_register_script() {
 		array( 'wc-components' ),
 		filemtime( wc_admin_dir_path( "dist/{$entry}/style.css" ) )
 	);
+	wp_style_add_data( WC_ADMIN_APP, 'rtl', 'replace' );
 }
 add_action( 'admin_enqueue_scripts', 'wc_admin_register_script' );
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "stylelint": "9.9.0",
     "stylelint-config-wordpress": "13.1.0",
     "webpack": "4.28.3",
-    "webpack-cli": "3.1.2"
+    "webpack-cli": "3.1.2",
+    "webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
   },
   "dependencies": {
     "@fresh-data/framework": "^0.5.1",

--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -79,16 +79,6 @@
 		margin-top: -8px;
 	}
 
-	.rtl & {
-		margin: 0 auto 0 0;
-		border-right: 0;
-		border-left: 1px solid $core-grey-light-700;
-
-		@include breakpoint( '<782px' ) {
-			border-left: 0;
-		}
-	}
-
 	@include breakpoint( '<782px' ) {
 		border-right: 0;
 		min-height: 0;

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -214,10 +214,6 @@
 	&:not(.is-left-aligned) {
 		text-align: right;
 
-		.rtl & {
-			text-align: left;
-		}
-
 		button {
 			justify-content: flex-end;
 		}
@@ -255,11 +251,6 @@ th.woocommerce-table__item {
 
 	& + .woocommerce-table__header {
 		border-left: 1px solid $core-grey-light-700;
-
-		.rtl & {
-			border-left: 0;
-			border-right: 1px solid $core-grey-light-700;
-		}
 	}
 
 	&.is-left-aligned.is-sortable {
@@ -280,10 +271,6 @@ th.woocommerce-table__item {
 		border: none;
 		background: transparent;
 		box-shadow: none !important;
-
-		.rtl & {
-			padding: $gap-smaller 0 $gap-smaller $gap-large;
-		}
 
 		// @todo Add interactive styles
 		&:hover {

--- a/packages/components/src/view-more-list/style.scss
+++ b/packages/components/src/view-more-list/style.scss
@@ -4,10 +4,6 @@
 	padding-left: 4px;
 	margin: 0 0 0 $gap-smallest;
 	vertical-align: middle;
-
-	.rtl & {
-		margin: 0 $gap-smallest 0 0;
-	}
 }
 
 .woocommerce-view-more-list__popover {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	plugins: [
-		require( './node_modules/@wordpress/postcss-themes' )( {
+		require( '@wordpress/postcss-themes' )( {
 			// @todo A default is required for now. Fix postcss-themes to allow no default
 			defaults: {
 				primary: '#0085ba',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const { get } = require( 'lodash' );
 const path = require( 'path' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const { DefinePlugin } = require( 'webpack' );
+const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 
 /**
  * WordPress dependencies
@@ -156,6 +157,9 @@ const webpackConfig = {
 				}
 				return outputPath;
 			},
+		} ),
+		new WebpackRTLPlugin( {
+			suffix: '-rtl',
 		} ),
 		new MiniCssExtractPlugin( {
 			filename: './dist/[name]/style.css',


### PR DESCRIPTION
Fixes most issues (but not all) from #1776.

This PR:
- Installs `webpack-rtl-plugin` so we generate an automated RTL CSS file. It uses a fork of the plugin, as it's done in Gutenberg (https://github.com/WordPress/gutenberg/pull/3844).
- Loads RTL CSS files when using an RTL locale.
- Removes legacy RTL styles from our current CSS.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54226935-21725100-44ff-11e9-960c-a1cfb833a467.png)

### Detailed test instructions:
- Install an RTL language in your WordPress, for example, Arabic.
- Go to _Settings_ and change the default language to that one.
- Press <kbd>Ctrl</kbd>+<kbd>U</kbd> to view the page source and verify wc-admin CSS files contain `rtl` in their name.
- If you want, you can take a look at #1776 and verify most issues are gone! :fire: 
