### PR TITLE
Update generic method prefixes to wc_admin_

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -381,7 +381,7 @@ function wc_admin_output_breadcrumb( $section ) {
  *
  * @todo Icon Placeholders for the ActivityPanel, when we implement the new designs.
  */
-function woocommerce_embed_page_header() {
+function wc_admin_embed_page_header() {
 	if ( ! wc_admin_is_embed_enabled_wc_page() ) {
 		return;
 	}
@@ -406,7 +406,7 @@ function woocommerce_embed_page_header() {
 	</div>
 	<?php
 }
-add_action( 'in_admin_header', 'woocommerce_embed_page_header' );
+add_action( 'in_admin_header', 'wc_admin_embed_page_header' );
 
 /**
  * Registers WooCommerce specific user data to the WordPress user API.
@@ -520,7 +520,7 @@ function wc_admin_add_settings( $settings ) {
 		'description' => __( 'Statuses that should not be included when calculating report totals.', 'wc-admin' ),
 		'default'     => array( 'pending', 'cancelled', 'failed' ),
 		'type'        => 'multiselect',
-		'options'     => format_order_statuses( wc_get_order_statuses() ),
+		'options'     => wc_admin_format_order_statuses( wc_get_order_statuses() ),
 	);
 	$settings[] = array(
 		'id'          => 'woocommerce_actionable_order_statuses',
@@ -529,7 +529,7 @@ function wc_admin_add_settings( $settings ) {
 		'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'wc-admin' ),
 		'default'     => array( 'processing', 'on-hold' ),
 		'type'        => 'multiselect',
-		'options'     => format_order_statuses( wc_get_order_statuses() ),
+		'options'     => wc_admin_format_order_statuses( wc_get_order_statuses() ),
 	);
 	return $settings;
 };

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -133,7 +133,7 @@ add_action( 'admin_enqueue_scripts', 'wc_admin_register_script' );
  * @param array $statuses Order statuses.
  * @return array formatted statuses.
  */
-function format_order_statuses( $statuses ) {
+function wc_admin_format_order_statuses( $statuses ) {
 	$formatted_statuses = array();
 	foreach ( $statuses as $key => $value ) {
 		$formatted_key                        = preg_replace( '/^wc-/', '', $key );
@@ -182,7 +182,7 @@ function wc_admin_print_script_settings() {
 		'embedBreadcrumbs' => wc_admin_get_embed_breadcrumbs(),
 		'siteLocale'       => esc_attr( get_bloginfo( 'language' ) ),
 		'currency'         => wc_admin_currency_settings(),
-		'orderStatuses'    => format_order_statuses( wc_get_order_statuses() ),
+		'orderStatuses'    => wc_admin_format_order_statuses( wc_get_order_statuses() ),
 		'stockStatuses'    => wc_get_product_stock_status_options(),
 		'siteTitle'        => get_bloginfo( 'name' ),
 		'dataEndpoints'    => array(),

--- a/wc-admin.php
+++ b/wc-admin.php
@@ -67,7 +67,7 @@ function wc_admin_build_notice() {
  *
  * @return bool
  */
-function dependencies_satisfied() {
+function wc_admin_dependencies_satisfied() {
 	$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
 	if ( ! $woocommerce_minimum_met ) {
 		return false;
@@ -89,16 +89,16 @@ function wc_admin_build_file_exists() {
 /**
  * Daily events to run.
  */
-function do_wc_admin_daily() {
+function wc_admin_do_daily_notes() {
 	WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
 }
-add_action( 'wc_admin_daily', 'do_wc_admin_daily' );
+add_action( 'wc_admin_daily', 'wc_admin_do_daily_notes' );
 
 /**
  * Initializes wc-admin daily action when plugin activated.
  */
-function activate_wc_admin_plugin() {
-	if ( ! dependencies_satisfied() ) {
+function wc_admin_activate_plugin() {
+	if ( ! wc_admin_dependencies_satisfied() ) {
 		return;
 	}
 
@@ -106,33 +106,33 @@ function activate_wc_admin_plugin() {
 		wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
 	}
 }
-register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'activate_wc_admin_plugin' );
+register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_activate_plugin' );
 
 /**
  * Deactivate wc-admin plugin if dependencies not satisfied.
  */
-function possibly_deactivate_wc_admin_plugin() {
-	if ( ! dependencies_satisfied() ) {
+function wc_admin_possibly_deactivate_plugin() {
+	if ( ! wc_admin_dependencies_satisfied() ) {
 		deactivate_plugins( plugin_basename( WC_ADMIN_PLUGIN_FILE ) );
 		unset( $_GET['activate'] );
 	}
 }
-add_action( 'admin_init', 'possibly_deactivate_wc_admin_plugin' );
+add_action( 'admin_init', 'wc_admin_possibly_deactivate_plugin' );
 
 /**
  * On deactivating the wc-admin plugin.
  */
-function deactivate_wc_admin_plugin() {
+function wc_admin_deactivate_plugin() {
 	wp_clear_scheduled_hook( 'wc_admin_daily' );
 	WC_Admin_Reports_Sync::clear_queued_actions();
 }
-register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'deactivate_wc_admin_plugin' );
+register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_deactivate_plugin' );
 
 /**
  * Set up the plugin, only if we can detect both Gutenberg and WooCommerce
  */
 function wc_admin_plugins_loaded() {
-	if ( ! dependencies_satisfied() ) {
+	if ( ! wc_admin_dependencies_satisfied() ) {
 		add_action( 'admin_notices', 'wc_admin_plugins_notice' );
 		return;
 	}


### PR DESCRIPTION
Fixes #1734 

Updates the generically named functions to be prefixed with `wc_admin_`.

### Detailed test instructions:

1.  Any functions not prefixed with `wc_admin_`?
2.  Plugin still working?