### PR TITLE
Update product searching to search by name or sku

### DIFF
--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -20,13 +20,9 @@ export function searchItemsByString( select, endpoint, search ) {
 	let isError = false;
 	search.forEach( searchWord => {
 		const query = {
+			search: searchWord,
 			per_page: 10,
 		};
-		if ( 'products' === endpoint ) {
-			query.product_search = searchWord;
-		} else {
-			query.search = searchWord;
-		}
 		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {
 			items[ id ] = item;

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -20,9 +20,13 @@ export function searchItemsByString( select, endpoint, search ) {
 	let isError = false;
 	search.forEach( searchWord => {
 		const query = {
-			search: searchWord,
 			per_page: 10,
 		};
+		if ( 'products' === endpoint ) {
+			query.product_search = searchWord;
+		} else {
+			query.search = searchWord;
+		}
 		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {
 			items[ id ] = item;

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -101,6 +101,8 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10, 2 );
 		$response = parent::get_items( $request );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10 );
+		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10 );
+		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10 );
 		return $response;
 	}
 

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -110,7 +110,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		$search = trim( $wp_query->get( 'search' ) );
 		if ( $search ) {
 			$search = $wpdb->esc_like( $search );
-			$search = ' \'%' . $search . '%\'';
+			$search = "'%" . $search . "%'";
 			$where .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $search;
 			$where .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $search . ')' : ')';
 		}

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -76,7 +76,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 
 		if ( ! empty( $request['search'] ) ) {
 			$args['search'] = $request['search'];
-			$args['s']      = false;
+			unset( $args['s'] );
 		}
 
 		return $args;

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -55,14 +55,15 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                   = parent::get_collection_params();
-		$params['product_search'] = array(
+		$params           = parent::get_collection_params();
+		$params['search'] = array(
 			'description'       => __( 'Search by similar product name or sku.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $params;
 	}
+
 
 	/**
 	 * Add product name and sku filtering to the WC API.
@@ -73,8 +74,9 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
 
-		if ( ! empty( $request['product_search'] ) ) {
-			$args['product_search'] = $request['product_search'];
+		if ( ! empty( $request['search'] ) ) {
+			$args['search'] = $request['search'];
+			$args['s']      = false;
 		}
 
 		return $args;
@@ -105,12 +107,12 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_product_search_filter( $where, $wp_query ) {
 		global $wpdb;
 
-		$product_search = trim( $wp_query->get( 'product_search' ) );
-		if ( $product_search ) {
-			$product_search = $wpdb->esc_like( $product_search );
-			$product_search = ' \'%' . $product_search . '%\'';
-			$where         .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $product_search;
-			$where         .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $product_search . ')' : ')';
+		$search = trim( $wp_query->get( 'search' ) );
+		if ( $search ) {
+			$search = $wpdb->esc_like( $search );
+			$search = ' \'%' . $search . '%\'';
+			$where .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $search;
+			$where .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $search . ')' : ')';
 		}
 
 		return $where;
@@ -126,8 +128,8 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_product_search_join( $join, $wp_query ) {
 		global $wpdb;
 
-		$product_search = trim( $wp_query->get( 'product_search' ) );
-		if ( $product_search && wc_product_sku_enabled() ) {
+		$search = trim( $wp_query->get( 'search' ) );
+		if ( $search && wc_product_sku_enabled() ) {
 			$join .= ' INNER JOIN ' . $wpdb->postmeta . ' AS ps_post_meta ON ps_post_meta.post_id = ' . $wpdb->posts . '.ID';
 		}
 

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -105,12 +105,12 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_product_search_filter( $where, $wp_query ) {
 		global $wpdb;
 
-		$product_search = $wp_query->get( 'product_search' );
+		$product_search = trim( $wp_query->get( 'product_search' ) );
 		if ( $product_search ) {
 			$product_search = $wpdb->esc_like( $product_search );
 			$product_search = ' \'%' . $product_search . '%\'';
-			$where         .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $product_search . ' OR ';
-			$where         .= 'ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $product_search . ')';
+			$where         .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $product_search;
+			$where         .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $product_search . ')' : ')';
 		}
 
 		return $where;
@@ -126,8 +126,8 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_product_search_join( $join, $wp_query ) {
 		global $wpdb;
 
-		$product_search = $wp_query->get( 'product_search' );
-		if ( $product_search ) {
+		$product_search = trim( $wp_query->get( 'product_search' ) );
+		if ( $product_search && wc_product_sku_enabled() ) {
 			$join .= ' INNER JOIN ' . $wpdb->postmeta . ' AS ps_post_meta ON ps_post_meta.post_id = ' . $wpdb->posts . '.ID';
 		}
 

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -55,12 +55,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                 = parent::get_collection_params();
-		$params['product_name'] = array(
-			'description'       => __( 'Search for a similar product name.', 'woocommerce-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
+		$params                   = parent::get_collection_params();
 		$params['product_search'] = array(
 			'description'       => __( 'Search by similar product name or sku.', 'woocommerce-admin' ),
 			'type'              => 'string',
@@ -78,10 +73,6 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
 
-		if ( ! empty( $request['product_name'] ) ) {
-			$args['post_title__like'] = $request['product_name'];
-		}
-
 		if ( ! empty( $request['product_search'] ) ) {
 			$args['product_search'] = $request['product_search'];
 		}
@@ -96,34 +87,12 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10, 2 );
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10, 2 );
 		$response = parent::get_items( $request );
-		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_post_title_filter' ), 10 );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10 );
 		return $response;
-	}
-
-	/**
-	 * Add post title searching to WP Query
-	 *
-	 * @param string $where Where clause used to search posts.
-	 * @param object $wp_query WP_Query object.
-	 * @return string
-	 */
-	public static function add_wp_query_post_title_filter( $where, $wp_query ) {
-		global $wpdb;
-
-		$post_title_search = $wp_query->get( 'post_title__like' );
-		if ( $post_title_search ) {
-			$post_title_search = $wpdb->esc_like( $post_title_search );
-			$post_title_search = ' \'%' . $post_title_search . '%\'';
-			$where            .= ' AND ' . $wpdb->posts . '.post_title LIKE ' . $post_title_search;
-		}
-
-		return $where;
 	}
 
 	/**

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -30,7 +30,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				product_search: search,
+				search: search,
 				per_page: 10,
 				orderby: 'popularity',
 			};

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -30,7 +30,7 @@ export default {
 		let payload = '';
 		if ( search ) {
 			const query = {
-				product_name: search,
+				product_search: search,
 				per_page: 10,
 				orderby: 'popularity',
 			};
@@ -40,7 +40,7 @@ export default {
 	},
 	isDebounced: true,
 	getOptionKeywords( product ) {
-		return [ product.name ];
+		return [ product.name, product.sku ];
 	},
 	getFreeTextOptions( query ) {
 		const label = (


### PR DESCRIPTION
Fixes #1739 

* Adds a `product_search` option to wp_query to allow searching by product name or sku.
* Swaps `search` for `product_search` in wc-api to retrieve searched products.
* Searches by product name or sku in product autocompleters.

### Screenshots
<img width="594" alt="Screen Shot 2019-03-13 at 3 15 14 PM" src="https://user-images.githubusercontent.com/10561050/54260056-d27df780-45a2-11e9-99aa-47a99eefb083.png">

### Detailed test instructions:

1.  Create a product with a variation in product name and sku.
2.  Also create a product that has the content of your keywords in the post content, but not the title or sku.
3.  Search the autocompleters and make sure options returned are being searched by name or sku.
4.  Type a query in the top of the products table search and make sure the search also works by name or sku.
5.  Make sure the product created from step 2 does not appear in the above searches.


### Question
Instead of keeping both `product_name` and `product_search`, I opted to drop the former and make all autocompleters for products allow sku searching as well.  Do we want to revert this back?  If not, should we mention the allowed sku searching in the autocompleter placeholder text (`Search for products to compare by product name or sku`)?