### PR TITLE
Fix CSS Lint issues in store-alerts CSS

### DIFF
--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -7,7 +7,7 @@
 	border: 0;
 	box-shadow: 0 0 8px -2px rgba(0, 0, 0, 0.3);
 
-	&:before {
+	&::before {
 		content: '';
 		position: absolute;
 		top: 0;
@@ -66,7 +66,7 @@
 .is-alert-error {
 	$alert-color: #dc3232;
 
-	&:before {
+	&::before {
 		background-color: $alert-color;
 	}
 
@@ -80,7 +80,7 @@
 .is-alert-update {
 	$alert-color: #11a0d2;
 
-	&:before {
+	&::before {
 		background-color: $alert-color;
 	}
 
@@ -128,7 +128,7 @@
 }
 
 .woocommerce-store-alerts.is-loading {
-	&:before {
+	&::before {
 		@include placeholder();
 	}
 


### PR DESCRIPTION
Fixes some CSS Lint issues that were making Travis to be read in most PRs.

### Detailed test instructions:
- Run `npm run lint:css` and verify there are no errors.