### PR TITLE
RTL charts

### DIFF
--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -55,7 +55,8 @@ class D3Chart extends Component {
 	}
 
 	getScaleParams( uniqueDates ) {
-		const { data, height, margin, orderedKeys, chartType } = this.props;
+		const { data, height, orderedKeys, chartType } = this.props;
+		const margin = this.getMargin();
 
 		const adjHeight = height - margin.top - margin.bottom;
 		const adjWidth = this.getWidth() - margin.left - margin.right;
@@ -113,7 +114,8 @@ class D3Chart extends Component {
 	}
 
 	drawChart( node ) {
-		const { data, dateParser, margin, chartType } = this.props;
+		const { data, dateParser, chartType } = this.props;
+		const margin = this.getMargin();
 		const uniqueDates = getUniqueDates( data, dateParser );
 		const formats = this.getFormatParams();
 		const params = this.getParams( uniqueDates );
@@ -132,7 +134,8 @@ class D3Chart extends Component {
 	}
 
 	shouldBeCompact() {
-		const {	data, margin, chartType, width } = this.props;
+		const {	data, chartType, width } = this.props;
+		const margin = this.getMargin();
 		if ( chartType !== 'bar' ) {
 			return false;
 		}
@@ -143,8 +146,24 @@ class D3Chart extends Component {
 		return widthWithoutMargins < minimumWideWidth;
 	}
 
+	getMargin() {
+		const { margin } = this.props;
+
+		if ( window.isRtl ) {
+			return {
+				bottom: margin.bottom,
+				left: margin.right,
+				right: margin.left,
+				top: margin.top,
+			};
+		}
+
+		return margin;
+	}
+
 	getWidth() {
-		const {	data, margin, chartType, width } = this.props;
+		const {	data, chartType, width } = this.props;
+		const margin = this.getMargin();
 		if ( chartType !== 'bar' ) {
 			return width;
 		}

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -241,6 +241,7 @@ const drawXAxis = ( node, params, scales, formats ) => {
 const drawYAxis = ( node, scales, formats, margin ) => {
 	const yGrids = getYGrids( scales.yScale.domain()[ 1 ] );
 	const width = scales.xScale.range()[ 1 ];
+	const xPosition = window.isRtl ? width + margin.left + margin.right / 2 - 15 : -margin.left / 2 - 15;
 
 	node
 		.append( 'g' )
@@ -257,7 +258,7 @@ const drawYAxis = ( node, scales, formats, margin ) => {
 		.append( 'g' )
 		.attr( 'class', 'axis y-axis' )
 		.attr( 'aria-hidden', 'true' )
-		.attr( 'transform', 'translate(-50, 12)' )
+		.attr( 'transform', 'translate(' + xPosition + ', 12)' )
 		.attr( 'text-anchor', 'start' )
 		.call(
 			d3AxisLeft( scales.yScale )

--- a/packages/components/src/chart/d3chart/utils/tooltip.js
+++ b/packages/components/src/chart/d3chart/utils/tooltip.js
@@ -25,7 +25,7 @@ class ChartTooltip {
 		elementWidthRatio,
 	) {
 		const tooltipSize = this.ref.getBoundingClientRect();
-		const d3BaseCoords = d3Select( '.d3-base' ).node().getBoundingClientRect();
+		const d3BaseCoords = this.ref.parentNode.querySelector( '.d3-base' ).getBoundingClientRect();
 		const leftMargin = Math.max( d3BaseCoords.left, chartCoords.left );
 
 		if ( this.position === 'below' ) {


### PR DESCRIPTION
Fixes part of #1776.

Chart improvements for RTL locales.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54284494-4ff43880-45a0-11e9-8550-828afb8d3b72.png)
![image](https://user-images.githubusercontent.com/3616980/54284532-6bf7da00-45a0-11e9-93ab-b887843baf01.png)

### Detailed test instructions:
- Install a RTL language in your WordPress, for example, Arabic.
- Go to _Settings_ and change the default language to that one.
- Go to the _Dashboard_ and enable at least two charts.
- Hover the chart and verify the tooltip position is correct.
- Verify the chart Y axis is rendered on the right side.
- Go to any report and verify the chart looks correct, with the Y axis on the right.
- Switch back to a LTR language.
- Verify there are no regressions and charts look good.