### PR TITLE
Update compare button help text

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -72,7 +72,7 @@ export const filters = [
 					param: 'categories',
 					getLabels: getCategoryLabels,
 					labels: {
-						helpText: __( 'Select at least two categories to compare', 'woocommerce-admin' ),
+						helpText: __( 'Check at least two categories below to compare', 'woocommerce-admin' ),
 						placeholder: __( 'Search for categories to compare', 'woocommerce-admin' ),
 						title: __( 'Compare Categories', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -137,7 +137,7 @@ class CategoriesReportTable extends Component {
 		const { isRequesting, query } = this.props;
 
 		const labels = {
-			helpText: __( 'Select at least two categories to compare', 'woocommerce-admin' ),
+			helpText: __( 'Check at least two categories below to compare', 'woocommerce-admin' ),
 			placeholder: __( 'Search by category name', 'woocommerce-admin' ),
 		};
 

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -66,7 +66,7 @@ export const filters = [
 					labels: {
 						title: __( 'Compare Coupon Codes', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),
-						helpText: __( 'Select at least two coupon codes to compare', 'woocommerce-admin' ),
+						helpText: __( 'Check at least two coupon codes below to compare', 'woocommerce-admin' ),
 					},
 				},
 			},

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -71,7 +71,7 @@ const filterConfig = {
 				param: 'products',
 				getLabels: getProductLabels,
 				labels: {
-					helpText: __( 'Select at least two products to compare', 'woocommerce-admin' ),
+					helpText: __( 'Check at least two products below to compare', 'woocommerce-admin' ),
 					placeholder: __( 'Search for products to compare', 'woocommerce-admin' ),
 					title: __( 'Compare Products', 'woocommerce-admin' ),
 					update: __( 'Compare', 'woocommerce-admin' ),
@@ -101,7 +101,7 @@ const variationsConfig = {
 				param: 'variations',
 				getLabels: getVariationLabels,
 				labels: {
-					helpText: __( 'Select at least two variations to compare', 'woocommerce-admin' ),
+					helpText: __( 'Check at least two variations below to compare', 'woocommerce-admin' ),
 					placeholder: __( 'Search for variations to compare', 'woocommerce-admin' ),
 					title: __( 'Compare Variations', 'woocommerce-admin' ),
 					update: __( 'Compare', 'woocommerce-admin' ),

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -164,7 +164,7 @@ export default class VariationsReportTable extends Component {
 		const { isRequesting, query } = this.props;
 
 		const labels = {
-			helpText: __( 'Select at least two variations to compare', 'woocommerce-admin' ),
+			helpText: __( 'Check at least two variations below to compare', 'woocommerce-admin' ),
 			placeholder: __( 'Search by variation name', 'woocommerce-admin' ),
 		};
 

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -228,7 +228,7 @@ class ProductsReportTable extends Component {
 		const { query, isRequesting, baseSearchQuery, hideCompare } = this.props;
 
 		const labels = {
-			helpText: __( 'Select at least two products to compare', 'woocommerce-admin' ),
+			helpText: __( 'Check at least two products below to compare', 'woocommerce-admin' ),
 			placeholder: __( 'Search by product name or SKU', 'woocommerce-admin' ),
 		};
 

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -62,7 +62,7 @@ export const filters = [
 						label: getTaxCode( tax ),
 					} ) ),
 					labels: {
-						helpText: __( 'Select at least two tax codes to compare', 'woocommerce-admin' ),
+						helpText: __( 'Check at least two tax codes below to compare', 'woocommerce-admin' ),
 						placeholder: __( 'Search for tax codes to compare', 'woocommerce-admin' ),
 						title: __( 'Compare Tax Codes', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -290,7 +290,7 @@ class TableCard extends Component {
 							className="woocommerce-table__compare"
 							count={ selectedRows.length }
 							helpText={
-								labels.helpText || __( 'Select at least two items to compare', 'woocommerce-admin' )
+								labels.helpText || __( 'Check at least two items below to compare', 'woocommerce-admin' )
 							}
 							onClick={ this.onCompare }
 						>


### PR DESCRIPTION
Fixes #1636 

Nitpicky language change that changes "Select" to "Check" on the compare button help text to avoid people like myself trying to compare items from the select dropdown 🤕 

### Screenshots
<img width="394" alt="Screen Shot 2019-03-14 at 12 27 04 PM" src="https://user-images.githubusercontent.com/10561050/54331398-cd798080-4654-11e9-9faf-a4f1274e73e7.png">

### Detailed test instructions:

1.  Hover the compare button.
2.  Did you try to click the compare button after selecting autocomplete options from the search box?
