### PR TITLE
Check if dependencies are met before running deactivation hook

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -123,8 +123,10 @@ add_action( 'admin_init', 'wc_admin_possibly_deactivate_wc_admin_plugin' );
  * On deactivating the wc-admin plugin.
  */
 function wc_admin_deactivate_wc_admin_plugin() {
-	wp_clear_scheduled_hook( 'wc_admin_daily' );
-	WC_Admin_Reports_Sync::clear_queued_actions();
+	if ( wc_admin_dependencies_satisfied() ) {
+		wp_clear_scheduled_hook( 'wc_admin_daily' );
+		WC_Admin_Reports_Sync::clear_queued_actions();
+	}
 }
 register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_deactivate_wc_admin_plugin' );
 


### PR DESCRIPTION
Fixes #1752 

Classes aren't available to remove scheduled actions if dependencies were never met.

### Detailed test instructions:

1. Deactivate wc-admin.
2. Don't meet the dependencies (you can deactivate WooCommerce to do this or throw `return false;` into `dependencies_satisfied()`).
3. Activate wc-admin.
4. Note the plugin is deactivated automatically with the dependencies notice and no fatal errors are thrown.