### PR TITLE
Add single customer filter and hook up customer link

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -19,6 +19,28 @@ export const filters = [
 		showFilters: () => true,
 		filters: [
 			{ label: __( 'All Customers', 'woocommerce-admin' ), value: 'all' },
+			{
+				label: __( 'Single Customer', 'woocommerce-admin' ),
+				value: 'select_customer',
+				chartMode: 'item-comparison',
+				subFilters: [
+					{
+						component: 'Search',
+						value: 'single_customer',
+						chartMode: 'item-comparison',
+						path: [ 'select_customer' ],
+						settings: {
+							type: 'customers',
+							param: 'customers',
+							getLabels: getCustomerLabels,
+							labels: {
+								placeholder: __( 'Type to search for a customer', 'woocommerce-admin' ),
+								button: __( 'Single Customer', 'woocommerce-admin' ),
+							},
+						},
+					},
+				],
+			},
 			{ label: __( 'Advanced Filters', 'woocommerce-admin' ), value: 'advanced' },
 		],
 	},

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -93,7 +93,7 @@ function OrdersPanel( { orders, isRequesting, isError } ) {
 		const customerUrl = customer.customer_id
 			? getNewPath( {}, '/analytics/customers', {
 					filter: 'single_customer',
-					customer_id: customer.customer_id,
+					customers: customer.customer_id,
 				} )
 			: null;
 

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -53,7 +53,7 @@ export const getCouponLabels = getRequestByIdString( NAMESPACE + '/coupons', cou
 
 export const getCustomerLabels = getRequestByIdString( NAMESPACE + '/customers', customer => ( {
 	id: customer.id,
-	label: customer.username,
+	label: customer.name,
 } ) );
 
 export const getProductLabels = getRequestByIdString( NAMESPACE + '/products', product => ( {


### PR DESCRIPTION
Fixes #1594 

* Adds a single customer filter
* Hooks up links in activity panel to individual customer report.
* Uses the customer name instead of username (since this is what is searched for and provided in autocomplete options)

### Screenshots
<img width="395" alt="Screen Shot 2019-03-14 at 2 04 01 PM" src="https://user-images.githubusercontent.com/10561050/54334800-09ffa900-4662-11e9-96fc-c68b160a86c2.png">
<img width="448" alt="Screen Shot 2019-03-14 at 2 03 51 PM" src="https://user-images.githubusercontent.com/10561050/54334802-09ffa900-4662-11e9-9e50-3251d5791a88.png">

### Detailed test instructions:

1.  Go to the customers report.
2.  Filter by single customer.
3.  Make sure filter is working as expected.
4.  Open the Orders tab in activity panel.
5.  Click a customer link and make sure it filters to the correct customer report.