### PR TITLE
Show error in activity panel if no actionable order statuses exist

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -35,8 +35,21 @@ import ActivityOutboundLink from '../activity-outbound-link';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
-function OrdersPanel( { orders, isRequesting, isError } ) {
+function OrdersPanel( { orders, isRequesting, isError, orderStatuses } ) {
 	if ( isError ) {
+		if ( ! orderStatuses.length ) {
+			return (
+				<EmptyContent
+					title={
+						"You currently don't have any actionable statuses. " +
+						'To display orders here, select orders that require further review in settings.'
+					}
+					actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
+					actionURL={ getAdminLink( 'admin.php?page=wc-admin#/analytics/settings' ) }
+				/>
+			);
+		}
+
 		const title = __(
 			'There was an error getting your orders. Please try again.',
 			'woocommerce-admin'
@@ -217,13 +230,13 @@ export default compose(
 		};
 
 		if ( ! orderStatuses.length ) {
-			return { orders: [], isError: false, isRequesting: false };
+			return { orders: [], isError: true, isRequesting: false, orderStatuses };
 		}
 
 		const orders = getReportItems( 'orders', ordersQuery ).data;
 		const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );
 		const isRequesting = isReportItemsRequesting( 'orders', ordersQuery );
 
-		return { orders, isError, isRequesting };
+		return { orders, isError, isRequesting, orderStatuses };
 	} )
 )( OrdersPanel );

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -40,10 +40,11 @@ function OrdersPanel( { orders, isRequesting, isError, orderStatuses } ) {
 		if ( ! orderStatuses.length ) {
 			return (
 				<EmptyContent
-					title={
+					title={ __(
 						"You currently don't have any actionable statuses. " +
-						'To display orders here, select orders that require further review in settings.'
-					}
+							'To display orders here, select orders that require further review in settings.',
+						'woocommerce-admin'
+					) }
 					actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
 					actionURL={ getAdminLink( 'admin.php?page=wc-admin#/analytics/settings' ) }
 				/>

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -237,6 +237,11 @@
 			animation: none;
 		}
 	}
+
+	.woocommerce-empty-content {
+		padding-left: $gap-large;
+		padding-right: $gap-large;
+	}
 }
 
 .woocommerce-layout__activity-panel-avatar-flag-overlay {


### PR DESCRIPTION
Fixes #1749 

Adds an error message and link to settings if no actionable statuses are set instead of a blank panel.

### Screenshots
<img width="448" alt="Screen Shot 2019-03-14 at 2 29 53 PM" src="https://user-images.githubusercontent.com/10561050/54336003-babb7780-4665-11e9-9c6f-f10c8d285b1e.png">
<img width="529" alt="Screen Shot 2019-03-14 at 2 29 31 PM" src="https://user-images.githubusercontent.com/10561050/54336004-babb7780-4665-11e9-94c3-33980a922703.png">

### Detailed test instructions:

1.  Go to Settings and uncheck all actionable statuses.
2.  Save and refresh.
3.  Note the error message and correct link in the Orders tab of the activity panel.
4.  Make sure orders continue to show correctly when actionable statuses are added.