### PR TITLE
Fix date range dropdown for RTL locales

### DIFF
--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -164,10 +164,12 @@
 	display: none;
 
 	.is-error .woocommerce-calendar__input-text:focus + span & {
+		/* rtl:begin:ignore */
 		display: block;
 		left: 50% !important;
 		position: absolute;
 		top: auto !important;
+		/* rtl:end:ignore */
 	}
 
 	.components-popover__content {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -151,10 +151,6 @@
 		&::placeholder {
 			color: $core-grey-dark-300;
 		}
-
-		&:focus + span .woocommerce-calendar__input-error {
-			display: block;
-		}
 	}
 }
 
@@ -166,6 +162,13 @@
 
 .woocommerce-calendar__input-error {
 	display: none;
+
+	.is-error .woocommerce-calendar__input-text:focus + span & {
+		display: block;
+		left: 50% !important;
+		position: absolute;
+		top: auto !important;
+	}
 
 	.components-popover__content {
 		background-color: $core-grey-dark-400;

--- a/packages/components/src/filters/date/style.scss
+++ b/packages/components/src/filters/date/style.scss
@@ -111,8 +111,3 @@
 		margin: 0 $gap-small;
 	}
 }
-
-.woocommerce-filters-date__content.is-center:not(.is-mobile) > .components-popover__content {
-	transform: none;
-	margin-left: -160px;
-}


### PR DESCRIPTION
Fixes second issue from #1776.

* Fixes date range dropdown alignment for RTL locales.
* Fixes calendar error tooltips positioning, until now they were not visible neither in RTL nor LTR locales.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/54357315-14b83f00-465e-11e9-82ca-f8b64554827b.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/54357287-0bc76d80-465e-11e9-8be9-049e5e5eaabc.png)

### Detailed test instructions:
- Using a RTL language, go to any report.
- Open the date picker dropdown.
- Verify the dropdown is correctly aligned.
- Enter an invalid date.
- Verify the '_Invalid Date_' popover is correctly positioned.
- Bonus points for testing there are no regressions in mobile and LTR languages.