### PR TITLE
Add onChange event to search focus to restore search results

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # (unreleased)
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
 - Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
+- Expand search results and allow searching when input is refocused in autocompleter.
 
 # 1.6.0
 - Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -147,8 +147,11 @@ class Search extends Component {
 		) : null;
 	}
 
-	onFocus() {
-		this.setState( { isActive: true } );
+	onFocus( onChange ) {
+		return event => {
+			this.setState( { isActive: true } );
+			onChange( event );
+		};
 	}
 
 	onBlur() {
@@ -229,7 +232,7 @@ class Search extends Component {
 										onChange={ this.updateSearch( onChange ) }
 										aria-owns={ listBoxId }
 										aria-activedescendant={ activeId }
-										onFocus={ this.onFocus }
+										onFocus={ this.onFocus( onChange ) }
 										onBlur={ this.onBlur }
 										onKeyDown={ this.onKeyDown }
 										aria-describedby={


### PR DESCRIPTION
Fixes #1806 

Triggers the `onChange` event when the search input is focused to:
* Restore search results.
* Allow free text searching again.

### Screenshots
![Mar-15-2019 13-48-21](https://user-images.githubusercontent.com/10561050/54411089-0a16ac00-4729-11e9-8393-6d52f54d2035.gif)

### Detailed test instructions:

1. Type a query into any autocompleter.
2. Click outside the input to lose focus.
3. Click inside the input to refocus.
4. Note the results are restored and pressing 'enter' allows free text search.