### PR TITLE
Add/clear jobs setting

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -121,4 +121,34 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				} );
 		},
 	},
+	{
+		name: 'woocommerce_clear_pending_jobs',
+		label: __( 'Analytics jobs:', 'wc-admin' ),
+		inputType: 'button',
+		inputText: __( 'Clear analytics jobs', 'wc-admin' ),
+		helpText: __(
+			'This tool will cancel all pending jobs queued for building analytics report data.',
+			'wc-admin'
+		),
+		callback: ( resolve, reject, addNotice ) => {
+			const errorMessage = __( 'There was a problem clearing pending jobs.', 'wc-admin' );
+
+			apiFetch( { path: '/wc/v3/system_status/tools/clear_analytics_jobs', method: 'PUT' } )
+				.then( response => {
+					if ( response.success ) {
+						addNotice( { status: 'success', message: response.message } );
+						resolve();
+					} else {
+						addNotice( { status: 'error', message: errorMessage } );
+						reject();
+					}
+				} )
+				.catch( error => {
+					if ( error && error.message ) {
+						addNotice( { status: 'error', message: error.message } );
+					}
+					reject();
+				} );
+		},
+	},
 ] );

--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -123,11 +123,11 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 	},
 	{
 		name: 'woocommerce_clear_pending_jobs',
-		label: __( 'Analytics jobs:', 'wc-admin' ),
+		label: __( 'Pending analytics actions:', 'wc-admin' ),
 		inputType: 'button',
-		inputText: __( 'Clear analytics jobs', 'wc-admin' ),
+		inputText: __( 'Clear actions', 'wc-admin' ),
 		helpText: __(
-			'This tool will cancel all pending jobs queued for building analytics report data.',
+			'This tool will cancel all pending actions queued for building analytics report data.',
 			'wc-admin'
 		),
 		callback: ( resolve, reject, addNotice ) => {

--- a/includes/api/class-wc-admin-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-admin-rest-system-status-tools-controller.php
@@ -42,29 +42,4 @@ class WC_Admin_REST_System_Status_Tools_Controller extends WC_REST_System_Status
 			)
 		);
 	}
-
-	/**
-	 * Actually executes a tool.
-	 *
-	 * @param  string $tool Tool.
-	 * @return array
-	 */
-	public function execute_tool( $tool ) {
-		$ran     = true;
-		$message = '';
-
-		switch ( $tool ) {
-			case 'rebuild_stats':
-				WC_Admin_Api_Init::regenerate_report_data();
-				$message = __( 'Rebuilding reports data in the background . . .', 'wc-admin' );
-				break;
-			default:
-				return parent::execute_tool( $tool );
-		}
-
-		return array(
-			'success' => $ran,
-			'message' => $message,
-		);
-	}
 }

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -80,7 +80,7 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function init() {
 		// Add report regeneration to tools REST API.
-		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'add_regenerate_tool' ) );
+		add_filter( 'woocommerce_debug_tools', array( __CLASS__, 'add_debug_tools' ) );
 
 		// Initialize syncing hooks.
 		add_action( 'wp_loaded', array( __CLASS__, 'orders_lookup_update_init' ) );
@@ -119,15 +119,17 @@ class WC_Admin_Reports_Sync {
 		} else {
 			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}
+
+		return __( 'Analytics jobs have been cleared.', 'wc-admin' );
 	}
 
 	/**
-	 * Adds regenerate tool to WC system status tools API.
+	 * Adds regenerate and job clearing tools to WC system status tools API.
 	 *
 	 * @param array $tools List of tools.
 	 * @return array
 	 */
-	public static function add_regenerate_tool( $tools ) {
+	public static function add_debug_tools( $tools ) {
 		if ( isset( $_GET['page'] ) && 'wc-status' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return $tools;
 		}
@@ -135,11 +137,17 @@ class WC_Admin_Reports_Sync {
 		return array_merge(
 			$tools,
 			array(
-				'rebuild_stats' => array(
+				'rebuild_stats'        => array(
 					'name'     => __( 'Rebuild reports data', 'wc-admin' ),
 					'button'   => __( 'Rebuild reports', 'wc-admin' ),
 					'desc'     => __( 'This tool will rebuild all of the information used by the reports.', 'wc-admin' ),
 					'callback' => array( __CLASS__, 'regenerate_report_data' ),
+				),
+				'clear_analytics_jobs' => array(
+					'name'     => __( 'Analytics jobs', 'wc-admin' ),
+					'button'   => __( 'Clear analytics jobs', 'wc-admin' ),
+					'desc'     => __( 'This tool will clear all background analytics jobs.', 'wc-admin' ),
+					'callback' => array( __CLASS__, 'clear_queued_actions' ),
 				),
 			)
 		);

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -144,9 +144,9 @@ class WC_Admin_Reports_Sync {
 					'callback' => array( __CLASS__, 'regenerate_report_data' ),
 				),
 				'clear_analytics_jobs' => array(
-					'name'     => __( 'Analytics jobs', 'wc-admin' ),
-					'button'   => __( 'Clear analytics jobs', 'wc-admin' ),
-					'desc'     => __( 'This tool will clear all background analytics jobs.', 'wc-admin' ),
+					'name'     => __( 'Pending analytics actions', 'wc-admin' ),
+					'button'   => __( 'Clear actions', 'wc-admin' ),
+					'desc'     => __( 'This tool will cancel all pending actions queued for building analytics report data.', 'wc-admin' ),
 					'callback' => array( __CLASS__, 'clear_queued_actions' ),
 				),
 			)


### PR DESCRIPTION
Fixes (partially) #1699

Adds the clear jobs tool to the settings page.

### Screenshots
<img width="735" alt="Screen Shot 2019-03-15 at 2 36 52 PM" src="https://user-images.githubusercontent.com/10561050/54413244-f7ec3c00-472f-11e9-8983-f9ebaff21024.png">

### Detailed test instructions:

1. Go to the Settings page.
2. Use the rebuild report data tool to queue some jobs.
3. Use the newly added clear jobs tool.
4. Note the jobs are trashed in the `wp_posts` table and a success notice displays after the tool is ran.
