### PR TITLE
Fix missing date picker calendar in RTL locales

### DIFF
--- a/packages/components/src/calendar/date-range.js
+++ b/packages/components/src/calendar/date-range.js
@@ -25,6 +25,8 @@ import DateInput from './input';
 import phrases from './phrases';
 import { getOutsideRange } from './utils';
 
+const isRTL = () => document.documentElement.dir === 'rtl';
+
 /**
  * This is wrapper for a [react-dates](https://github.com/airbnb/react-dates) powered calendar.
  */
@@ -150,6 +152,7 @@ class DateRange extends Component {
 						minimumNights={ 0 }
 						hideKeyboardShortcutsPanel
 						noBorder
+						isRTL={ isRTL() }
 						initialVisibleMonth={ this.setTnitialVisibleMonth( isDoubleCalendar, before ) }
 						phrases={ phrases }
 					/>

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -32,6 +32,8 @@ import { getColor } from './utils/color';
 import ChartTooltip from './utils/tooltip';
 import { selectionLimit } from '../constants';
 
+const isRTL = () => document.documentElement.dir === 'rtl';
+
 /**
  * A simple D3 line and bar chart component for timeseries data in React.
  */
@@ -128,7 +130,7 @@ class D3Chart extends Component {
 
 		this.createTooltip( g.node(), params.getColor, params.visibleKeys );
 
-		drawAxis( g, params, scales, formats, margin );
+		drawAxis( g, params, scales, formats, margin, isRTL() );
 		chartType === 'line' && drawLines( g, data, params, scales, formats, this.tooltip );
 		chartType === 'bar' && drawBars( g, data, params, scales, formats, this.tooltip );
 	}
@@ -149,7 +151,7 @@ class D3Chart extends Component {
 	getMargin() {
 		const { margin } = this.props;
 
-		if ( window.isRtl ) {
+		if ( isRTL() ) {
 			return {
 				bottom: margin.bottom,
 				left: margin.right,

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -238,10 +238,10 @@ const drawXAxis = ( node, params, scales, formats ) => {
 		);
 };
 
-const drawYAxis = ( node, scales, formats, margin ) => {
+const drawYAxis = ( node, scales, formats, margin, isRTL ) => {
 	const yGrids = getYGrids( scales.yScale.domain()[ 1 ] );
 	const width = scales.xScale.range()[ 1 ];
-	const xPosition = window.isRtl ? width + margin.left + margin.right / 2 - 15 : -margin.left / 2 - 15;
+	const xPosition = isRTL ? width + margin.left + margin.right / 2 - 15 : -margin.left / 2 - 15;
 
 	node
 		.append( 'g' )
@@ -267,9 +267,9 @@ const drawYAxis = ( node, scales, formats, margin ) => {
 		);
 };
 
-export const drawAxis = ( node, params, scales, formats, margin ) => {
+export const drawAxis = ( node, params, scales, formats, margin, isRTL ) => {
 	drawXAxis( node, params, scales, formats );
-	drawYAxis( node, scales, formats, margin );
+	drawYAxis( node, scales, formats, margin, isRTL );
 
 	node.selectAll( '.domain' ).remove();
 	node.selectAll( '.axis .tick line' ).remove();


### PR DESCRIPTION
Fixes the last issue in #1776.

- Fix the date picker calendar not visible in RTL locales.
- Create a `isRTL()` function instead of relying on `window.isRtl` to detect if the page is RTL or not. This way the components can be used in other environments.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/54112813-4bd0eb00-43e7-11e9-9c58-2aae5ac8c673.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/54431351-7c39c180-4726-11e9-8658-6b6662fd5551.png)

### Detailed test instructions:
- With a RTL locale, go to any report and open the date picker.
- Verify the calendar appears and you can go to the next and previous month.
- Make sure charts still render the Y-axis on the right side.