### PR TITLE
Allow sorting by tax_code in Taxes report

### DIFF
--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -32,8 +32,7 @@ export default class TaxesReportTable extends Component {
 		return [
 			{
 				label: __( 'Tax Code', 'woocommerce-admin' ),
-				// @todo It should be the tax code, not the ID
-				key: 'tax_rate_id',
+				key: 'tax_code',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
@@ -72,19 +71,20 @@ export default class TaxesReportTable extends Component {
 
 	getRowsContent( taxes ) {
 		return map( taxes, tax => {
-			const { order_tax, orders_count, tax_rate, tax_rate_id, total_tax, shipping_tax } = tax;
+			const { order_tax, orders_count, tax_rate, total_tax, shipping_tax } = tax;
+			const taxCode = getTaxCode( tax );
 
 			// @todo Must link to the tax detail report
 			const taxLink = (
 				<Link href="" type="wc-admin">
-					{ getTaxCode( tax ) }
+					{ taxCode }
 				</Link>
 			);
 
 			return [
 				{
 					display: taxLink,
-					value: tax_rate_id,
+					value: taxCode,
 				},
 				{
 					display: tax_rate.toFixed( 2 ) + '%',

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -264,6 +264,7 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 			'enum'              => array(
 				'name',
 				'tax_rate_id',
+				'tax_code',
 				'rate',
 				'order_tax',
 				'total_tax',

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -295,7 +295,9 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	protected function normalize_order_by( $order_by ) {
 		global $wpdb;
 
-		if ( 'rate' === $order_by ) {
+		if ( 'tax_code' === $order_by ) {
+			return 'CONCAT_WS( "-", NULLIF(tax_rate_country, ""), NULLIF(tax_rate_state, ""), NULLIF(tax_rate_name, ""), NULLIF(tax_rate_priority, "") )';
+		} else if ( 'rate' === $order_by ) {
 			return "CAST({$wpdb->prefix}woocommerce_tax_rates.tax_rate as DECIMAL(7,4))";
 		}
 

--- a/tests/api/reports-taxes.php
+++ b/tests/api/reports-taxes.php
@@ -270,6 +270,61 @@ class WC_Tests_API_Reports_Taxes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting reports with param `orderby=tax_code`.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_orderby_tax_code() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 1,
+				'tax_rate'          => '7',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'GA',
+				'tax_rate_name'     => 'TestTax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_id'       => 2,
+				'tax_rate'          => '10',
+				'tax_rate_country'  => 'CA',
+				'tax_rate_state'    => 'ON',
+				'tax_rate_name'     => 'TestTax 2',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'order'   => 'asc',
+				'orderby' => 'tax_code',
+				'taxes'   => '1,2',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		$this->assertEquals( 2, $reports[0]['tax_rate_id'] );
+
+		$this->assertEquals( 1, $reports[1]['tax_rate_id'] );
+	}
+
+	/**
 	 * Test getting reports without valid permissions.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
Fixes #1811.

Allows sorting by `tax_code` in the Taxes report table.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/54447002-94223d00-4748-11e9-9b2b-54c2ac6dfccd.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/54446956-7654d800-4748-11e9-9367-c4b73523352a.png)

### Detailed test instructions:
1. Go to the _Taxes_ report.
2. Click on _Tax Code_ header to sort taxes by their code.
3. Verify they are correctly sorted.