### PR TITLE
Show chart hover circles in the correct order

### DIFF
--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -22,8 +22,10 @@ import { smallBreak, wideBreak } from './breakpoints';
  * @param {function} xScale - from `getXLineScale`
  * @returns {array} that includes the date, start (x position) and width to mode the mouseover rectangles
  */
-export const getDateSpaces = ( data, uniqueDates, visibleKeys, width, xScale ) =>
-	uniqueDates.map( ( d, i ) => {
+export const getDateSpaces = ( data, uniqueDates, visibleKeys, width, xScale ) => {
+	const reversedKeys = visibleKeys.slice().reverse();
+
+	return uniqueDates.map( ( d, i ) => {
 		const datapoints = first( data.filter( item => item.date === d ) );
 		const xNow = xScale( moment( d ).toDate() );
 		const xPrev =
@@ -41,7 +43,7 @@ export const getDateSpaces = ( data, uniqueDates, visibleKeys, width, xScale ) =
 			date: d,
 			start: uniqueDates.length > 1 ? xStart : 0,
 			width: uniqueDates.length > 1 ? xWidth : width,
-			values: visibleKeys.map( ( { key } ) => {
+			values: reversedKeys.map( ( { key } ) => {
 				const datapoint = datapoints[ key ];
 				if ( ! datapoint ) {
 					return null;
@@ -54,6 +56,7 @@ export const getDateSpaces = ( data, uniqueDates, visibleKeys, width, xScale ) =
 			} ).filter( Boolean ),
 		};
 	} );
+};
 
 /**
  * Describes getLine
@@ -101,8 +104,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 		.attr( 'class', 'line-g' )
 		.attr( 'role', 'region' )
 		.attr( 'aria-label', d => d.label || d.key );
-	const reversedKeys = params.visibleKeys.slice().reverse();
-	const dateSpaces = getDateSpaces( data, params.uniqueDates, reversedKeys, width, scales.xScale );
+	const dateSpaces = getDateSpaces( data, params.uniqueDates, params.visibleKeys, width, scales.xScale );
 
 	let lineStroke = width <= wideBreak || params.uniqueDates.length > 50 ? 2 : 3;
 	lineStroke = width <= smallBreak ? 1.25 : lineStroke;

--- a/packages/components/src/chart/d3chart/utils/test/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/test/line-chart.js
@@ -28,7 +28,8 @@ const testXLineScale = getXLineScale( testUniqueDates, 100 );
 
 describe( 'getDateSpaces', () => {
 	it( 'return an array used to space out the mouseover rectangles, used for tooltips', () => {
-		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, 100, testXLineScale );
+		const reversedKeys = testOrderedKeys.slice();
+		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, reversedKeys, 100, testXLineScale );
 		expect( testDateSpaces[ 0 ].date ).toEqual( '2018-05-30T00:00:00' );
 		expect( testDateSpaces[ 0 ].start ).toEqual( 0 );
 		expect( testDateSpaces[ 0 ].width ).toEqual( 10 );

--- a/packages/components/src/chart/d3chart/utils/test/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/test/line-chart.js
@@ -28,8 +28,8 @@ const testXLineScale = getXLineScale( testUniqueDates, 100 );
 
 describe( 'getDateSpaces', () => {
 	it( 'return an array used to space out the mouseover rectangles, used for tooltips', () => {
-		const reversedKeys = testOrderedKeys.slice();
-		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, reversedKeys, 100, testXLineScale );
+		const visibleKeys = testOrderedKeys.slice();
+		const testDateSpaces = getDateSpaces( dummyOrders, testUniqueDates, visibleKeys, 100, testXLineScale );
 		expect( testDateSpaces[ 0 ].date ).toEqual( '2018-05-30T00:00:00' );
 		expect( testDateSpaces[ 0 ].start ).toEqual( 0 );
 		expect( testDateSpaces[ 0 ].width ).toEqual( 10 );


### PR DESCRIPTION
Fixes #1815.

When hovering line charts, show circles in the same stacking order as the lines (following the legend order).

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/54460389-ae204780-4769-11e9-91b4-6775aea9412d.png)

_After (notice `Long Sleeve Tee` circle appears on top of `V-Neck T-Shirt`):_
![image](https://user-images.githubusercontent.com/3616980/54460370-a2cd1c00-4769-11e9-9d2c-da5a2c0cd0c0.png)

### Detailed test instructions:
- Go to any report.
- In `time-comparison` charts, make sure the `Current Period` circles appear always on top of `Previous Period` when hovering the lines.
- In `item-comparison` charts, make sure circles of items with higher total values always appear on top of items with lower values.