### PR TITLE
Check if resources are still loading before skipping dispatch

### DIFF
--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -20,8 +20,8 @@ function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
 			const { resources } = store.getState();
-			const newResources = resourceNames.filter( resourceName => ! resources[ resourceName ] );
-			if ( ! newResources.length && document.hidden ) {
+			const newResources = resourceNames.some( resourceName => ! resources[ resourceName ] );
+			if ( ! newResources && document.hidden ) {
 				return;
 			}
 			store.dispatch( {

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -19,7 +19,9 @@ function createStore( name ) {
 function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
-			if ( document.hidden ) {
+			const { resources } = store.getState();
+			const newResources = resourceNames.filter( resourceName => ! resources[ resourceName ] );
+			if ( ! newResources.length && document.hidden ) {
 				return;
 			}
 			store.dispatch( {


### PR DESCRIPTION
Fixes #1814 

Checks if new resources are being requested before skipping dispatch when the browser tab is not active as opposed to updating freshness when a tab is inactive.

### Detailed test instructions:

1. Load/refresh any report and switch to another browser tab while the page is still loading.
2. Come back to the page after resources should have loaded and check that loading is not stalled.
3. Also check that freshness requests are not made when the tab is not active.  You can speed up testing by reducing default freshness in https://github.com/woocommerce/woocommerce-admin/blob/6f9e87ae02d3389a126f2056478372a8a36f3062/client/wc-api/constants.js#L11 

### Question
Are there performance issues with checking on all requests?  

I don't think there are any real performance implications since the array of resource names is generally small and we're checking if a property exists in the existing state, but we could move this inside the `document.hidden` block if this is a concern.