### PR TITLE
Fix date picker tab styling across gutenberg versions

### DIFF
--- a/packages/components/src/filters/date/style.scss
+++ b/packages/components/src/filters/date/style.scss
@@ -38,7 +38,7 @@
 	@include set-grid-item-position( 2, 2 );
 }
 
-.woocommerce-filters-date__tab.components-button {
+button.woocommerce-filters-date__tab {
 	outline: none;
 	border: 1px solid $woocommerce;
 	padding: $gap-smaller;


### PR DESCRIPTION
Fixes #1757 

Changes date picker button css selector to work between gutenberg versions.

### Before
<img width="330" alt="Screen Shot 2019-03-18 at 2 31 00 PM" src="https://user-images.githubusercontent.com/10561050/54511022-84923680-498a-11e9-93f3-7d8d748003f6.png">

### After
<img width="335" alt="Screen Shot 2019-03-18 at 2 30 04 PM" src="https://user-images.githubusercontent.com/10561050/54511025-865bfa00-498a-11e9-9c67-3718803730e8.png">

### Detailed test instructions:

1.  Activate the Gutenberg plugin >= 5.1.
2.  Open any report and click the date picker.
3.  Make sure styles are correct for the buttons.
4.  Deactivate the Gutenberg plugin and make sure styles still look correct.