### PR TITLE
Activity Panel: set orders unread indicator based on real data

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -217,22 +217,28 @@ OrdersPanel.defaultProps = {
 };
 
 export default compose(
-	withSelect( select => {
+	withSelect( ( select, props ) => {
 		const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
+		const { isEmpty } = props;
 		const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
 			'processing',
 			'on-hold',
 		];
+
+		if ( ! orderStatuses.length ) {
+			return { orders: [], isError: true, isRequesting: false, orderStatuses };
+		}
+
+		if ( isEmpty ) {
+			return { orders: [], isError: false, isRequesting: false, orderStatuses };
+		}
+
 		const ordersQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
 			status_is: orderStatuses,
 			extended_info: true,
 		};
-
-		if ( ! orderStatuses.length ) {
-			return { orders: [], isError: true, isRequesting: false, orderStatuses };
-		}
 
 		const orders = getReportItems( 'orders', ordersQuery ).data;
 		const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );

--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -244,7 +244,7 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
-			'minimum'           => 1,
+			'minimum'           => 0,
 			'maximum'           => 100,
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -179,6 +179,10 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 			$total_pages = (int) ceil( $db_records_count / $sql_query_params['per_page'] );
 			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
+				$data = (object) array(
+					'data'    => array(),
+					'total'   => $db_records_count,
+				);
 				return $data;
 			}
 


### PR DESCRIPTION
Fixes #1818.

Uses real data in order to show or hide the unread indicator next to the _Orders_ Activity Panel tab.

In this implementation, it queries `reports/coupons` with `per_page=0` in order to know if there are actionable orders or not. There were two other solutions I considered:
* Querying `reports/coupons` with default page size, so we fetch orders beforehand. That would prevent making another request when opening the panel, but it has the drawback that, on page load, we would be querying for a lot of data that might never be shown to the user if they don't open the tab.
* Creating a specific endpoint for Activity Panel unread indicators, as proposed in #1817. Didn't want to do that before knowing how are we going to implement this for the other tabs. But it will be easy to change it if we go this path in the future.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54550216-e1521900-49ab-11e9-9a6f-98b61ff030e5.png)

### Detailed test instructions:
- Create an order in an actionable status (_Processing_, for example).
- Go to any `wc-admin` page and verify an unread indicator (red dot) appears next to the _Orders_ tab of the Activity Panel.
- Click on the tab and verify the processing order appears.
- Remove that order or set its status to a non-actionable one (_Completed_, for example).
- Go again to any `wc-admin` page and verify there is no unread indicator next to the _Orders_ tab.
- Open your browser _Network_ devtools and click on the _Orders_ tab.
- Verify no orders are shown and no extra API call was made.

You could also try changing _Actionable Statuses_ settings to check that the unread indicator react to those changes.