### PR TITLE
Fix table links to internal reports

### DIFF
--- a/client/analytics/report/categories/breadcrumbs.js
+++ b/client/analytics/report/categories/breadcrumbs.js
@@ -56,7 +56,7 @@ export default class CategoryBreadcrumbs extends Component {
 			<div className="woocommerce-table__breadcrumbs">
 				{ this.getCategoryAncestors( category, categories ) }
 				<Link
-					href={ getNewPath( persistedQuery, 'categories', {
+					href={ getNewPath( persistedQuery, '/analytics/categories', {
 						filter: 'single_category',
 						categories: category.id,
 					} ) }

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -92,7 +92,7 @@ class CategoriesReportTable extends Component {
 				{
 					display: category && (
 						<Link
-							href={ getNewPath( persistedQuery, 'categories', {
+							href={ getNewPath( persistedQuery, '/analytics/categories', {
 								filter: 'single_category',
 								categories: category.id,
 							} ) }

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -83,7 +83,7 @@ export default class CouponsReportTable extends Component {
 			} = download;
 			const { name: productName } = _embedded.product[ 0 ];
 
-			const productLink = getNewPath( persistedQuery, 'products', {
+			const productLink = getNewPath( persistedQuery, '/analytics/products', {
 				filter: 'single_product',
 				products: product_id,
 			} );

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -112,7 +112,7 @@ export default class OrdersReportTable extends Component {
 				.map( item => ( {
 					label: item.name,
 					quantity: item.quantity,
-					href: getNewPath( persistedQuery, 'products', {
+					href: getNewPath( persistedQuery, '/analytics/products', {
 						filter: 'single_product',
 						products: item.id,
 					} ),
@@ -120,7 +120,7 @@ export default class OrdersReportTable extends Component {
 
 			const formattedCoupons = coupons.map( coupon => ( {
 				label: coupon.code,
-				href: getNewPath( persistedQuery, 'coupons', {
+				href: getNewPath( persistedQuery, '/analytics/coupons', {
 					filter: 'single_coupon',
 					coupons: coupon.id,
 				} ),

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -85,7 +85,7 @@ export default class VariationsReportTable extends Component {
 			const extended_info = row.extended_info || {};
 			const { stock_status, stock_quantity, low_stock_amount, sku } = extended_info;
 			const name = get( row, [ 'extended_info', 'name' ], '' );
-			const ordersLink = getNewPath( persistedQuery, 'orders', {
+			const ordersLink = getNewPath( persistedQuery, '/analytics/orders', {
 				filter: 'advanced',
 				product_includes: query.products,
 			} );

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -108,11 +108,11 @@ class ProductsReportTable extends Component {
 				stock_quantity,
 				variations = [],
 			} = extended_info;
-			const ordersLink = getNewPath( persistedQuery, 'orders', {
+			const ordersLink = getNewPath( persistedQuery, '/analytics/orders', {
 				filter: 'advanced',
 				product_includes: product_id,
 			} );
-			const productDetailLink = getNewPath( persistedQuery, 'products', {
+			const productDetailLink = getNewPath( persistedQuery, '/analytics/products', {
 				filter: 'single_product',
 				products: product_id,
 			} );

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -62,7 +62,7 @@ export default class StockReportTable extends Component {
 		return products.map( product => {
 			const { id, manage_stock, name, parent_id, sku, stock_quantity, stock_status } = product;
 
-			const productDetailLink = getNewPath( persistedQuery, 'products', {
+			const productDetailLink = getNewPath( persistedQuery, '/analytics/products', {
 				filter: 'single_product',
 				products: parent_id || id,
 			} );


### PR DESCRIPTION
Table links were pointed to incorrect URL in all tables except the Coupons Report 🤷‍♂️ .

I'm not sure what changed, but they were missing the `/analytics/` portion of the path.

### Detailed test instructions:

Go to all tables and hover over links to ensure the base url paths are correctly constructed.

