### PR TITLE
Customers API: Fix exact match filters

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -48,9 +48,14 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args['match']               = $request['match'];
 		$args['search']              = $request['search'];
 		$args['searchby']            = $request['searchby'];
-		$args['username']            = $request['username'];
-		$args['email']               = $request['email'];
-		$args['country']             = $request['country'];
+		$args['name_includes']       = $request['name_includes'];
+		$args['name_excludes']       = $request['name_excludes'];
+		$args['username_includes']   = $request['username_includes'];
+		$args['username_excludes']   = $request['username_excludes'];
+		$args['email_includes']      = $request['email_includes'];
+		$args['email_excludes']      = $request['email_excludes'];
+		$args['country_includes']    = $request['country_includes'];
+		$args['country_excludes']    = $request['country_excludes'];
 		$args['last_active_before']  = $request['last_active_before'];
 		$args['last_active_after']   = $request['last_active_after'];
 		$args['orders_count_min']    = $request['orders_count_min'];
@@ -350,18 +355,43 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 				'email',
 			),
 		);
-		$params['username']                = array(
-			'description'       => __( 'Limit response to objects with a specfic username.', 'woocommerce-admin' ),
+		$params['name_includes']                = array(
+			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email']                   = array(
-			'description'       => __( 'Limit response to objects equal to an email.', 'woocommerce-admin' ),
+		$params['name_excludes']                = array(
+			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['country']                 = array(
-			'description'       => __( 'Limit response to objects with a specfic country.', 'woocommerce-admin' ),
+		$params['username_includes']                = array(
+			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['username_excludes']                = array(
+			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['email_includes']                   = array(
+			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['email_excludes']                   = array(
+			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['country_includes']        = array(
+			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['country_excludes']        = array(
+			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -42,9 +42,14 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 		$args['registered_after']    = $request['registered_after'];
 		$args['match']               = $request['match'];
 		$args['search']              = $request['search'];
-		$args['username']            = $request['username'];
-		$args['email']               = $request['email'];
-		$args['country']             = $request['country'];
+		$args['name_includes']       = $request['name_includes'];
+		$args['name_excludes']       = $request['name_excludes'];
+		$args['username_includes']   = $request['username_includes'];
+		$args['username_excludes']   = $request['username_excludes'];
+		$args['email_includes']      = $request['email_includes'];
+		$args['email_excludes']      = $request['email_excludes'];
+		$args['country_includes']    = $request['country_includes'];
+		$args['country_excludes']    = $request['country_excludes'];
 		$args['last_active_before']  = $request['last_active_before'];
 		$args['last_active_after']   = $request['last_active_after'];
 		$args['orders_count_min']    = $request['orders_count_min'];
@@ -211,18 +216,43 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 				'email',
 			),
 		);
-		$params['username']                = array(
-			'description'       => __( 'Limit response to objects with a specfic username.', 'woocommerce-admin' ),
+		$params['name_includes']                = array(
+			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email']                   = array(
-			'description'       => __( 'Limit response to objects equal to an email.', 'woocommerce-admin' ),
+		$params['name_excludes']                = array(
+			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['country']                 = array(
-			'description'       => __( 'Limit response to objects with a specfic country.', 'woocommerce-admin' ),
+		$params['username_includes']                = array(
+			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['username_excludes']                = array(
+			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['email_includes']                   = array(
+			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['email_excludes']                   = array(
+			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['country_includes']        = array(
+			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['country_excludes']        = array(
+			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/1617

Customers Report advanced filters by `country`, `email`, `name`, and `usersname` now can include/exclude by exact match (in other words, no fuzzy search).

### Screenshots

![Screen Shot 2019-03-20 at 8 49 58 AM](https://user-images.githubusercontent.com/1922453/54637308-36e20f00-4aed-11e9-92ab-87f3669ed5d2.png)

### Detailed test instructions:

1. Customers Report > Advanced Filters.
2. Filter by country, email, name, and username using included and excluded.
3. Ensure the filters are working correctly.
