### PR TITLE
Minify in safe mode for RTL styles to prevent stripping z-index

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,6 +160,9 @@ const webpackConfig = {
 		} ),
 		new WebpackRTLPlugin( {
 			suffix: '-rtl',
+			minify: {
+				safe: true,
+			},
 		} ),
 		new MiniCssExtractPlugin( {
 			filename: './dist/[name]/style.css',


### PR DESCRIPTION
Fixes #1829 

The forked `WebpackRTLPlugin` that we're using relies on cssnano v.3.7.1 which minimizes z-index values by default before it was removed by default in v4.

This PR turns that off 🚫 

### Screenshots
<img width="1029" alt="Screen Shot 2019-03-19 at 3 04 28 PM" src="https://user-images.githubusercontent.com/10561050/54587511-3e58d800-4a5b-11e9-8c5a-801f531058a2.png">


### Detailed test instructions:

1.  Run `npm start` to rebuild with the new cssnano config.
2.  Check that z-index is not stripped.  ( `.woocommerce-layout__header` should not overlap editor and have a z-index of "99991".)