### PR TITLE
Update react router to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "react-click-outside": "3.0.1",
     "react-dates": "^18.0.4",
     "react-live": "1.12.0",
-    "react-router-dom": "4.3.1",
+    "react-router-dom": "^5.0.0",
     "react-slot-fill": "^2.0.1",
     "react-transition-group": "^2.4.0",
     "redux": "^4.0.0"


### PR DESCRIPTION
Fixes #1828 

Updates react router and router dom to v5 to fix existing errors.

### Questions

V5 was just released and while v4.4.x versions would work, they were all released as alpha/beta versions.  While v5 is testing really well, I'm not finding any changelog or summary of differences for v5.  

Do we want to continue with v5 or downgrade back to an earlier version?

### Detailed test instructions:

1.  Run `rm -rf node_modules` from the wc-admin directory.
2.  Run `npm install`.
3.  Start wc-admin and check that no console errors are thrown and test routing thoroughly to make sure there are no regressions.