### PR TITLE
Hide stock panel and menu if stock management is disabled

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -72,11 +72,13 @@ const getReports = () => {
 			title: __( 'Downloads', 'woocommerce-admin' ),
 			component: DownloadsReport,
 		},
-		{
-			report: 'stock',
-			title: __( 'Stock', 'woocommerce-admin' ),
-			component: StockReport,
-		},
+		'yes' === wcSettings.manageStock
+			? {
+					report: 'stock',
+					title: __( 'Stock', 'woocommerce-admin' ),
+					component: StockReport,
+				}
+			: null,
 		{
 			report: 'customers',
 			title: __( 'Customers', 'woocommerce-admin' ),
@@ -87,7 +89,7 @@ const getReports = () => {
 			title: __( 'Downloads', 'woocommerce-admin' ),
 			component: DownloadsReport,
 		},
-	];
+	].filter( Boolean );
 
 	return applyFilters( REPORTS_FILTER, reports );
 };

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -63,16 +63,20 @@ export default class VariationsReportTable extends Component {
 				isSortable: true,
 				isNumeric: true,
 			},
-			{
-				label: __( 'Status', 'woocommerce-admin' ),
-				key: 'stock_status',
-			},
-			{
-				label: __( 'Stock', 'woocommerce-admin' ),
-				key: 'stock',
-				isNumeric: true,
-			},
-		];
+			'yes' === wcSettings.manageStock
+				? {
+						label: __( 'Status', 'woocommerce-admin' ),
+						key: 'stock_status',
+					}
+				: null,
+			'yes' === wcSettings.manageStock
+				? {
+						label: __( 'Stock', 'woocommerce-admin' ),
+						key: 'stock',
+						isNumeric: true,
+					}
+				: null,
+		].filter( Boolean );
 	}
 
 	getRowsContent( data = [] ) {
@@ -120,21 +124,25 @@ export default class VariationsReportTable extends Component {
 					),
 					value: orders_count,
 				},
-				{
-					display: isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
-						<Link href={ editPostLink } type="wp-admin">
-							{ _x( 'Low', 'Indication of a low quantity', 'woocommerce-admin' ) }
-						</Link>
-					) : (
-						stockStatuses[ stock_status ]
-					),
-					value: stockStatuses[ stock_status ],
-				},
-				{
-					display: stock_quantity,
-					value: stock_quantity,
-				},
-			];
+				'yes' === wcSettings.manageStock
+					? {
+							display: isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
+								<Link href={ editPostLink } type="wp-admin">
+									{ _x( 'Low', 'Indication of a low quantity', 'woocommerce-admin' ) }
+								</Link>
+							) : (
+								stockStatuses[ stock_status ]
+							),
+							value: stockStatuses[ stock_status ],
+						}
+					: null,
+				'yes' === wcSettings.manageStock
+					? {
+							display: stock_quantity,
+							value: stock_quantity,
+						}
+					: null,
+			].filter( Boolean );
 		} );
 	}
 

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -78,16 +78,20 @@ class ProductsReportTable extends Component {
 				key: 'variations',
 				isSortable: true,
 			},
-			{
-				label: __( 'Status', 'woocommerce-admin' ),
-				key: 'stock_status',
-			},
-			{
-				label: __( 'Stock', 'woocommerce-admin' ),
-				key: 'stock',
-				isNumeric: true,
-			},
-		];
+			'yes' === wcSettings.manageStock
+				? {
+						label: __( 'Status', 'woocommerce-admin' ),
+						key: 'stock_status',
+					}
+				: null,
+			'yes' === wcSettings.manageStock
+				? {
+						label: __( 'Stock', 'woocommerce-admin' ),
+						key: 'stock',
+						isNumeric: true,
+					}
+				: null,
+		].filter( Boolean );
 	}
 
 	getRowsContent( data = [] ) {
@@ -190,15 +194,21 @@ class ProductsReportTable extends Component {
 					display: numberFormat( variations.length ),
 					value: variations.length,
 				},
-				{
-					display: manage_stock ? stockStatus : __( 'N/A', 'woocommerce-admin' ),
-					value: manage_stock ? stockStatuses[ stock_status ] : null,
-				},
-				{
-					display: manage_stock ? numberFormat( stock_quantity ) : __( 'N/A', 'woocommerce-admin' ),
-					value: stock_quantity,
-				},
-			];
+				'yes' === wcSettings.manageStock
+					? {
+							display: manage_stock ? stockStatus : __( 'N/A', 'woocommerce-admin' ),
+							value: manage_stock ? stockStatuses[ stock_status ] : null,
+						}
+					: null,
+				'yes' === wcSettings.manageStock
+					? {
+							display: manage_stock
+								? numberFormat( stock_quantity )
+								: __( 'N/A', 'woocommerce-admin' ),
+							value: stock_quantity,
+						}
+					: null,
+			].filter( Boolean );
 		} );
 	}
 

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -106,12 +106,14 @@ class ActivityPanel extends Component {
 				icon: <Gridicon icon="pages" />,
 				unread: unreadOrders,
 			},
-			{
-				name: 'stock',
-				title: __( 'Stock', 'woocommerce-admin' ),
-				icon: <Gridicon icon="clipboard" />,
-				unread: false,
-			},
+			'yes' === wcSettings.manageStock
+				? {
+						name: 'stock',
+						title: __( 'Stock', 'woocommerce-admin' ),
+						icon: <Gridicon icon="clipboard" />,
+						unread: false,
+					}
+				: null,
 			'yes' === wcSettings.reviewsEnabled
 				? {
 						name: 'reviews',

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -148,13 +148,15 @@ function wc_admin_register_pages() {
 			)
 		);
 
-		wc_admin_register_page(
-			array(
-				'title'  => __( 'Stock', 'woocommerce-admin' ),
-				'parent' => '/analytics/revenue',
-				'path'   => '/analytics/stock',
-			)
-		);
+		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
+			wc_admin_register_page(
+				array(
+					'title'  => __( 'Stock', 'woocommerce-admin' ),
+					'parent' => '/analytics/revenue',
+					'path'   => '/analytics/stock',
+				)
+			);
+		}
 
 		wc_admin_register_page(
 			array(

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -196,6 +196,7 @@ function wc_admin_print_script_settings() {
 		'currentUserData'  => $current_user_data,
 		'alertCount'       => WC_Admin_Notes::get_notes_count( 'error,update', 'unactioned' ),
 		'reviewsEnabled'   => get_option( 'woocommerce_enable_reviews' ),
+		'manageStock'      => get_option( 'woocommerce_manage_stock' ),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 


### PR DESCRIPTION
Fixes #1826 

If the stock management setting is unchecked in WooCommerce, remove the Stock activity panel and menu item.

### Question

Do we want to also remove the stock column from product/variation reports?

### Screenshots
<img width="186" alt="Screen Shot 2019-03-19 at 4 38 26 PM" src="https://user-images.githubusercontent.com/10561050/54591753-e4114480-4a65-11e9-9a06-2cf75fe22854.png">
<img width="418" alt="Screen Shot 2019-03-19 at 4 38 16 PM" src="https://user-images.githubusercontent.com/10561050/54591754-e4114480-4a65-11e9-8b51-33075f8786f4.png">


### Detailed test instructions:

1.  Disable/enable stock management `wp-admin/admin.php?page=wc-settings&tab=products&section=inventory`
2. Check that the activity panel and menu item have been removed when turned off.