### PR TITLE
Travis: escape hashes (#) from branch names when downloading the ZIP file

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -184,6 +184,7 @@ install_deps() {
 	php wp-cli.phar plugin activate woocommerce
 
 	if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+		BRANCH="$(sed 's/#/%23/' <<<$BRANCH)"
 		# Install wc-admin, the correct branch, if running from Travis CI.
 		php wp-cli.phar plugin install https://github.com/$REPO/archive/$BRANCH.zip --activate
 	fi


### PR DESCRIPTION
Fixes #1843.

Escape hashes from branch names in `install-wp-tests.sh` before attempting to download the ZIP file.

### Detailed test instructions:
- If Travis passes in this PR, it means it's fixed. :slightly_smiling_face: 