### PR TITLE
CSSLint: Remove whitespace at the end of line

### DIFF
--- a/client/analytics/settings/index.scss
+++ b/client/analytics/settings/index.scss
@@ -8,7 +8,7 @@
 
 .woocommerce-settings__actions {
 	margin-bottom: $gap-largest;
-	
+
 	@include breakpoint( '>1280px' ) {
 		margin-left: 15%;
 	}


### PR DESCRIPTION
Fixes a minor issue introduced in #1842 that we didn't notice because Travis was not working. :sweat_smile: 
### Detailed test instructions:
- Run `npm run lint:css`.
- Verify there are no errors.