### PR TITLE
Table: update columns visibility on headers change

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -50,7 +50,7 @@ class ReportTable extends Component {
 	}
 
 	filterShownHeaders( headers, hiddenKeys ) {
-		if ( ! hiddenKeys ) {
+		if ( ! hiddenKeys || ! hiddenKeys.length ) {
 			return headers;
 		}
 

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -200,8 +200,19 @@ export default compose(
 			tableQuery,
 			columnPrefsKey,
 		} = props;
+
+		let userPrefColumns = [];
+		if ( columnPrefsKey ) {
+			const { getCurrentUserData } = select( 'wc-api' );
+			const userData = getCurrentUserData();
+
+			userPrefColumns = userData[ columnPrefsKey ];
+		}
+
 		if ( isRequesting || ( query.search && ! ( query[ endpoint ] && query[ endpoint ].length ) ) ) {
-			return {};
+			return {
+				userPrefColumns,
+			};
 		}
 		const chartEndpoint = [ 'variations', 'categories' ].includes( endpoint )
 			? 'products'
@@ -212,20 +223,12 @@ export default compose(
 		const queriedTableData = tableData || getReportTableData( endpoint, query, select, tableQuery );
 		const extendedTableData = extendTableData( select, props, queriedTableData );
 
-		const selectProps = {
+		return {
 			primaryData,
 			tableData: extendedTableData,
 			query: { ...tableQuery, ...query },
+			userPrefColumns,
 		};
-
-		if ( columnPrefsKey ) {
-			const { getCurrentUserData } = select( 'wc-api' );
-			const userData = getCurrentUserData();
-
-			selectProps.userPrefColumns = userData[ columnPrefsKey ];
-		}
-
-		return selectProps;
 	} ),
 	withDispatch( dispatch => {
 		const { updateCurrentUserData } = dispatch( 'wc-api' );

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -8,8 +8,8 @@ import { DEFAULT_REQUIREMENT } from '../constants';
 const getCurrentUserData = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const initalState = wcSettings.currentUserData;
-	return requireResource( requirement, 'current-user-data' ).data || initalState;
+	const initialState = wcSettings.currentUserData;
+	return requireResource( requirement, 'current-user-data' ).data || initialState;
 };
 
 export default {

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -24,7 +24,7 @@ import { getIdsFromQuery, getSearchWords, updateQueryString } from '@woocommerce
  */
 import Card from '../card';
 import CompareButton from '../filters/compare/button';
-import DowloadIcon from './download-icon';
+import DownloadIcon from './download-icon';
 import EllipsisMenu from '../ellipsis-menu';
 import MenuItem from '../ellipsis-menu/menu-item';
 import MenuTitle from '../ellipsis-menu/menu-title';
@@ -317,7 +317,7 @@ class TableCard extends Component {
 							onClick={ this.onClickDownload }
 							isLink
 						>
-							<DowloadIcon />
+							<DownloadIcon />
 							<span className="woocommerce-table__download-button__label">
 								{ labels.downloadButton || __( 'Download', 'woocommerce-admin' ) }
 							</span>

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -73,7 +73,7 @@ class TableCard extends Component {
 				/* eslint-enable react/no-did-update-set-state */
 			}
 		}
-		if ( ! isEqual( prevHeaders, headers ) ) {
+		if ( ! isEqual( headers, prevHeaders ) ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( {
 				showCols: this.getShowCols( headers ),

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -46,7 +46,7 @@ class TableCard extends Component {
 	constructor( props ) {
 		super( props );
 		const { query, compareBy } = this.props;
-		const showCols = props.headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean );
+		const showCols = this.getShowCols( props.headers );
 		const selectedRows = query.filter ? getIdsFromQuery( query[ compareBy ] ) : [];
 
 		this.state = { showCols, selectedRows };
@@ -58,8 +58,8 @@ class TableCard extends Component {
 		this.selectAllRows = this.selectAllRows.bind( this );
 	}
 
-	componentDidUpdate( { headers: prevHeaders, isLoading: prevIsLoading, query: prevQuery } ) {
-		const { compareBy, headers, isLoading, onColumnsChange, query } = this.props;
+	componentDidUpdate( { headers: prevHeaders, query: prevQuery } ) {
+		const { compareBy, headers, onColumnsChange, query } = this.props;
 		const { showCols } = this.state;
 
 		if ( query.filter || prevQuery.filter ) {
@@ -73,10 +73,10 @@ class TableCard extends Component {
 				/* eslint-enable react/no-did-update-set-state */
 			}
 		}
-		if ( ! isLoading && prevIsLoading && ! isEqual( headers, prevHeaders ) ) {
+		if ( ! isEqual( prevHeaders, headers ) ) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( {
-				showCols: headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean ),
+				showCols: this.getShowCols( headers ),
 			} );
 			/* eslint-enable react/no-did-update-set-state */
 		}
@@ -89,6 +89,10 @@ class TableCard extends Component {
 			/* eslint-enable react/no-did-update-set-state */
 			onColumnsChange( newShowCols );
 		}
+	}
+
+	getShowCols( headers ) {
+		return headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean );
 	}
 
 	getVisibleHeaders() {


### PR DESCRIPTION
Fixes #1840.

This PR:
- Sets `userPrefColumns` early in `<ReportTable>`, so that prop isn't undefined in loading tables.
- Makes it so table column's visibility updates when headers change, without checking whether `isLoading` prop is different.
- Fixes a couple of typos I found. :writing_hand: 

### Screenshots
![userprefs](https://user-images.githubusercontent.com/3616980/54648549-f9f32980-4aa6-11e9-84f1-3b9036aad6f5.gif)

### Detailed test instructions:
* Go to the _Products_ report.
* Hide or unhide some columns.
* Refresh the page.
* Verify columns visibility is persisted.
* Repeat the same for _Categories_, _Downloads_ and _Stock_ reports.