### PR TITLE
Add "remind me later" functionality to StoreAlert component.

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -130,6 +130,7 @@ class StoreAlerts extends Component {
 
 		const snooze = alert.is_snoozable && (
 			<Dropdown
+				className="woocommerce-store-alerts__snooze"
 				position="bottom"
 				expandOnMobile
 				renderToggle={ ( { isOpen, onToggle } ) => (

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -10,6 +10,7 @@ import interpolateComponents from 'interpolate-components';
 import { compose } from '@wordpress/compose';
 import { noop } from 'lodash';
 import { withDispatch } from '@wordpress/data';
+import moment from 'moment';
 
 /**
  * WooCommerce dependencies
@@ -63,9 +64,10 @@ class StoreAlerts extends Component {
 	}
 
 	renderActions( alert ) {
+		const { updateNote } = this.props;
 		const actions = alert.actions.map( action => {
 			const markStatus = () => {
-				this.props.updateNote( alert.id, { status: action.status } );
+				updateNote( alert.id, { status: action.status } );
 			};
 			return (
 				<Button
@@ -79,29 +81,50 @@ class StoreAlerts extends Component {
 			);
 		} );
 
+		// TODO: should "next X" be the start, or exactly 1X from the current date?
 		const snoozeOptions = [
 			{
-				value: 0,
+				newDate: moment()
+					.add( 4, 'hours' )
+					.unix(),
 				label: __( 'Later Today', 'woocommerce-admin' ),
 			},
 			{
-				value: 1,
+				newDate: moment()
+					.add( 1, 'day' )
+					.hour( 9 )
+					.minute( 0 )
+					.second( 0 )
+					.millisecond( 0 )
+					.unix(),
 				label: __( 'Tomorrow', 'woocommerce-admin' ),
 			},
 			{
-				value: 2,
+				newDate: moment()
+					.add( 1, 'week' )
+					.hour( 9 )
+					.minute( 0 )
+					.second( 0 )
+					.millisecond( 0 )
+					.unix(),
 				label: __( 'Next Week', 'woocommerce-admin' ),
 			},
 			{
-				value: 3,
+				newDate: moment()
+					.add( 1, 'month' )
+					.hour( 9 )
+					.minute( 0 )
+					.second( 0 )
+					.millisecond( 0 )
+					.unix(),
 				label: __( 'Next Month', 'woocommerce-admin' ),
 			},
 		];
 
-		const onNavigate = ( key, onClose ) => {
+		const setReminderDate = ( newDate, onClose ) => {
 			return () => {
 				onClose();
-				console.log( 'onNavigate', snoozeOptions[ key ] );
+				updateNote( alert.id, { status: 'snoozed', date_reminder: newDate } );
 			};
 		};
 
@@ -122,7 +145,7 @@ class StoreAlerts extends Component {
 							<Button
 								className="components-dropdown-menu__menu-item"
 								key={ idx }
-								onClick={ onNavigate( idx, onClose ) }
+								onClick={ setReminderDate( option.newDate, onClose ) }
 							>
 								{ option.label }
 							</Button>

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { IconButton, Button, Dashicon } from '@wordpress/components';
+import { IconButton, Button, Dashicon, Dropdown, NavigableMenu } from '@wordpress/components';
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
 import { compose } from '@wordpress/compose';
@@ -14,7 +14,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { Card } from '@woocommerce/components';
+import { Card, DropdownButton } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -62,6 +62,86 @@ class StoreAlerts extends Component {
 		}
 	}
 
+	renderActions( alert ) {
+		const actions = alert.actions.map( action => {
+			const markStatus = () => {
+				this.props.updateNote( alert.id, { status: action.status } );
+			};
+			return (
+				<Button
+					key={ action.name }
+					isDefault
+					href={ action.url }
+					onClick={ '' === action.status ? noop : markStatus }
+				>
+					{ action.label }
+				</Button>
+			);
+		} );
+
+		const snoozeOptions = [
+			{
+				value: 0,
+				label: __( 'Later Today', 'woocommerce-admin' ),
+			},
+			{
+				value: 1,
+				label: __( 'Tomorrow', 'woocommerce-admin' ),
+			},
+			{
+				value: 2,
+				label: __( 'Next Week', 'woocommerce-admin' ),
+			},
+			{
+				value: 3,
+				label: __( 'Next Month', 'woocommerce-admin' ),
+			},
+		];
+
+		const onNavigate = ( key, onClose ) => {
+			return () => {
+				onClose();
+				console.log( 'onNavigate', snoozeOptions[ key ] );
+			};
+		};
+
+		const snooze = alert.is_snoozable && (
+			<Dropdown
+				position="bottom"
+				expandOnMobile
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<DropdownButton
+						onClick={ onToggle }
+						isOpen={ isOpen }
+						labels={ [ __( 'Remind Me Later', 'woocommerce-admin' ) ] }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<NavigableMenu className="components-dropdown-menu__menu">
+						{ snoozeOptions.map( ( option, idx ) => (
+							<Button
+								className="components-dropdown-menu__menu-item"
+								key={ idx }
+								onClick={ onNavigate( idx, onClose ) }
+							>
+								{ option.label }
+							</Button>
+						) ) }
+					</NavigableMenu>
+				) }
+			/>
+		);
+
+		if ( actions || snooze ) {
+			return (
+				<div className="woocommerce-store-alerts__actions">
+					{ actions }
+					{ snooze }
+				</div>
+			);
+		}
+	}
+
 	render() {
 		const alerts = this.props.alerts || [];
 		const preloadAlertCount = wcSettings.alertCount && parseInt( wcSettings.alertCount );
@@ -79,22 +159,6 @@ class StoreAlerts extends Component {
 		const className = classnames( 'woocommerce-store-alerts', {
 			'is-alert-error': 'error' === type,
 			'is-alert-update': 'update' === type,
-		} );
-
-		const actions = alert.actions.map( action => {
-			const markStatus = () => {
-				this.props.updateNote( alert.id, { status: action.status } );
-			};
-			return (
-				<Button
-					key={ action.name }
-					isDefault
-					href={ action.url }
-					onClick={ '' === action.status ? noop : markStatus }
-				>
-					{ action.label }
-				</Button>
-			);
 		} );
 
 		return (
@@ -140,7 +204,7 @@ class StoreAlerts extends Component {
 					className="woocommerce-store-alerts__message"
 					dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
 				/>
-				{ actions && <div className="woocommerce-store-alerts__actions">{ actions }</div> }
+				{ this.renderActions( alert ) }
 			</Card>
 		);
 	}

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -36,6 +36,9 @@
 	}
 
 	a.components-button {
+		min-height: 36px;
+		padding: 4px 16px;
+
 		+ .components-button {
 			margin-left: 10px;
 		}
@@ -183,5 +186,15 @@
 		.woocommerce-card__action {
 			margin-bottom: 14px;
 		}
+	}
+}
+
+.woocommerce-store-alerts__snooze {
+	display: inline-flex;
+	margin-left: 10px;
+	min-height: 34px;
+
+	.woocommerce-dropdown-button__labels {
+		min-height: 34px;
 	}
 }

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -257,6 +257,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$data['date_reminder']     = wc_rest_prepare_date_response( $data['date_reminder'], false );
 		$data['title']             = stripslashes( $data['title'] );
 		$data['content']           = stripslashes( $data['content'] );
+		$data['is_snoozable']      = (bool) $data['is_snoozable'];
 		foreach ( (array) $data['actions'] as $key => $value ) {
 			$data['actions'][ $key ]->label  = stripslashes( $data['actions'][ $key ]->label );
 			$data['actions'][ $key ]->url    = $this->prepare_query_for_response( $data['actions'][ $key ]->query );
@@ -402,6 +403,12 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 				'date_reminder_gmt' => array(
 					'description' => __( 'Date after which the user should be reminded of the note, if any (GMT).', 'woocommerce-admin' ),
 					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'is_snoozable'      => array(
+					'description' => __( 'Whether or a user can request to be reminded about the note.', 'woocommerce-admin' ),
+					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -202,6 +202,11 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 			$note_changed = true;
 		}
 
+		if ( ! is_null( $request->get_param( 'date_reminder' ) ) ) {
+			$note->set_date_reminder( $request->get_param( 'date_reminder' ) );
+			$note_changed = true;
+		}
+
 		if ( $note_changed ) {
 			$note->save();
 		}

--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -168,6 +168,7 @@ class WC_Admin_Install {
 			source varchar(200) NOT NULL,
 			date_created datetime NOT NULL default '0000-00-00 00:00:00',
 			date_reminder datetime NULL default null,
+			is_snoozable boolean DEFAULT 0 NOT NULL,
 			PRIMARY KEY (note_id)
 		) $collate;
 		CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (

--- a/includes/class-wc-admin-note.php
+++ b/includes/class-wc-admin-note.php
@@ -23,6 +23,7 @@ class WC_Admin_Note extends WC_Data {
 	// Note status codes.
 	const E_WC_ADMIN_NOTE_UNACTIONED = 'unactioned'; // the note has not yet been actioned by a user.
 	const E_WC_ADMIN_NOTE_ACTIONED   = 'actioned';   // the note has had its action completed by a user.
+	const E_WC_ADMIN_NOTE_SNOOZED    = 'snoozed';    // the note has been snoozed by a user.
 
 	/**
 	 * This is the name of this object type.
@@ -119,6 +120,7 @@ class WC_Admin_Note extends WC_Data {
 		$allowed_statuses = array(
 			self::E_WC_ADMIN_NOTE_ACTIONED,
 			self::E_WC_ADMIN_NOTE_UNACTIONED,
+			self::E_WC_ADMIN_NOTE_SNOOZED,
 		);
 
 		return apply_filters( 'woocommerce_admin_note_statuses', $allowed_statuses );

--- a/includes/class-wc-admin-note.php
+++ b/includes/class-wc-admin-note.php
@@ -48,6 +48,7 @@ class WC_Admin_Note extends WC_Data {
 		'source'        => 'woocommerce',
 		'date_created'  => '0000-00-00 00:00:00',
 		'date_reminder' => '',
+		'is_snoozable'  => false,
 		'actions'       => array(),
 	);
 
@@ -244,6 +245,16 @@ class WC_Admin_Note extends WC_Data {
 	}
 
 	/**
+	 * Get note snoozability.
+	 *
+	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return bool   Whether or not the note can be snoozed.
+	 */
+	public function get_is_snoozable( $context = 'view' ) {
+		return $this->get_prop( 'is_snoozable', $context );
+	}
+
+	/**
 	 * Get actions on the note (if any).
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
@@ -436,6 +447,15 @@ class WC_Admin_Note extends WC_Data {
 	 */
 	public function set_date_reminder( $date ) {
 		$this->set_date_prop( 'date_reminder', $date );
+	}
+
+	/**
+	 * Set note snoozability.
+	 *
+	 * @param bool $is_snoozable Whether or not the note can be snoozed.
+	 */
+	public function set_is_snoozable( $is_snoozable ) {
+		return $this->set_prop( 'is_snoozable', $is_snoozable );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -23,14 +23,15 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		global $wpdb;
 
 		$note_to_be_inserted = array(
-			'name'    => $note->get_name(),
-			'type'    => $note->get_type(),
-			'locale'  => $note->get_locale(),
-			'title'   => $note->get_title(),
-			'content' => $note->get_content(),
-			'icon'    => $note->get_icon(),
-			'status'  => $note->get_status(),
-			'source'  => $note->get_source(),
+			'name'         => $note->get_name(),
+			'type'         => $note->get_type(),
+			'locale'       => $note->get_locale(),
+			'title'        => $note->get_title(),
+			'content'      => $note->get_content(),
+			'icon'         => $note->get_icon(),
+			'status'       => $note->get_status(),
+			'source'       => $note->get_source(),
+			'is_snoozable' => $note->get_is_snoozable(),
 		);
 
 		$note_to_be_inserted['content_data']  = wp_json_encode( $note->get_content_data() );
@@ -68,7 +69,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		if ( 0 !== $note_id || '0' !== $note_id ) {
 			$note_row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT name, type, locale, title, content, icon, content_data, status, source, date_created, date_reminder FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
+					"SELECT name, type, locale, title, content, icon, content_data, status, source, date_created, date_reminder, is_snoozable FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
 					$note->get_id()
 				)
 			);
@@ -97,6 +98,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 			$note->set_source( $note_row->source );
 			$note->set_date_created( $note_row->date_created );
 			$note->set_date_reminder( $note_row->date_reminder );
+			$note->set_is_snoozable( $note_row->is_snoozable );
 			$this->read_actions( $note );
 			$note->read_meta_data();
 			$note->set_object_read( true );
@@ -147,6 +149,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 					'source'        => $note->get_source(),
 					'date_created'  => $date_created_to_db,
 					'date_reminder' => $date_reminder_to_db,
+					'is_snoozable'  => $note->get_is_snoozable(),
 				),
 				array( 'note_id' => $note->get_id() )
 			);

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -157,7 +157,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$notes    = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( 3, count( $notes ) );
 	}
 
 	/**
@@ -200,7 +200,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$notes    = $response->get_data();
 
 		// get_notes returns all results since 'status' is not one of actioned or unactioned.
-		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( 3, count( $notes ) );
 	}
 
 	/**
@@ -226,7 +226,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 15, count( $properties ) );
+		$this->assertEquals( 16, count( $properties ) );
 
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
@@ -245,5 +245,6 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'date_reminder', $properties );
 		$this->assertArrayHasKey( 'date_reminder_gmt', $properties );
 		$this->assertArrayHasKey( 'actions', $properties );
+		$this->assertArrayHasKey( 'is_snoozable', $properties );
 	}
 }

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -204,6 +204,31 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test note "unsnoozing".
+	 */
+	public function test_note_unsnoozing() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'status' => 'snoozed' ) );
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $notes ) );
+		$this->assertEquals( $notes[0]['title'], 'PHPUNIT_TEST_NOTE_3_TITLE' );
+
+		// The test snoozed note's reminder date is an hour ago.
+		WC_Admin_Notes::unsnooze_notes();
+
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEmpty( $notes );
+	}
+
+	/**
 	 * Test getting lots of notes without permission. It should fail.
 	 *
 	 * @since 3.5.0

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -59,5 +59,18 @@ class WC_Helper_Admin_Notes {
 		// This note has no actions.
 		$note_2->save();
 
+		$note_3 = new WC_Admin_Note();
+		$note_3->set_title( 'PHPUNIT_TEST_NOTE_3_TITLE' );
+		$note_3->set_content( 'PHPUNIT_TEST_NOTE_3_CONTENT' );
+		$note_3->set_content_data( (object) array( 'amount' => 7.89 ) );
+		$note_3->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note_3->set_icon( 'info' );
+		$note_3->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
+		$note_3->set_source( 'PHPUNIT_TEST' );
+		$note_3->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED );
+		$note_3->set_date_reminder( time() - HOUR_IN_SECONDS );
+		// This note has no actions.
+		$note_3->save();
+
 	}
 }


### PR DESCRIPTION
Fixes #1756.

This PR seeks to add the ability to "snooze" `StoreAlert`s by:

* Introducing a new boolean `is_snoozable` column to `wc_admin_notes`
* Hook up `date_reminder` column to endpoint
* Add "remind me later" selection to `<StoreAlert/>` when `is_snoozable` is `true`
* Add recurring scheduled action to "unsnooze" actions when their `date_reminder` is reached

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2019-03-19 at 4 10 07 PM](https://user-images.githubusercontent.com/63922/54645425-9b578c80-4a61-11e9-9bbe-ea7f31b608aa.png)

![Screen Shot 2019-03-19 at 4 10 25 PM](https://user-images.githubusercontent.com/63922/54645435-9eeb1380-4a61-11e9-9abb-c99dfd50618b.png)

### Detailed test instructions:

- Update your `wc_admin_version` option to be something less than `0.8.0`
- Verify that your `wc_admin_notes` table has the `is_snoozable` column
- Create a admin note with the `is_snoozable` set to `true`
- Verify that the note displays with the "remind me later" dropdown button
- Choose an option from that button
- Verify that the note disappears and has status `snoozed` with `date_reminder` populated
- Test "unsnooze" by modifying the `date_reminder` value to be in the past and running the `wc_admin_unsnooze_admin_notes` scheduled action _( Tools > Scheduled Actions > Pending )_
- Verify that the note reappears


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
