### PR TITLE
Activity Panel: Hide Reviews Panel when Reviews are Disabled

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -112,13 +112,15 @@ class ActivityPanel extends Component {
 				icon: <Gridicon icon="clipboard" />,
 				unread: false,
 			},
-			{
-				name: 'reviews',
-				title: __( 'Reviews', 'woocommerce-admin' ),
-				icon: <Gridicon icon="star" />,
-				unread: false,
-			},
-		];
+			'yes' === wcSettings.reviewsEnabled
+				? {
+						name: 'reviews',
+						title: __( 'Reviews', 'woocommerce-admin' ),
+						icon: <Gridicon icon="star" />,
+						unread: false,
+					}
+				: null,
+		].filter( Boolean );
 	}
 
 	getPanelContent( tab ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -195,6 +195,7 @@ function wc_admin_print_script_settings() {
 		),
 		'currentUserData'  => $current_user_data,
 		'alertCount'       => WC_Admin_Notes::get_notes_count( 'error,update', 'unactioned' ),
+		'reviewsEnabled'   => get_option( 'woocommerce_enable_reviews' ),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 


### PR DESCRIPTION
Fixes #1825.

This PR is almost a copy & paste from #1841, so kudos to @joshuatf for leading the path here. :smile: 

It enables/disables the reviews panel in the Activity Panel when they are enabled/disabled from the settings.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54649830-0f1e8700-4aac-11e9-8214-49fa8db9193d.png)

### Detailed test instructions:
- Go to _Settings_ > _Products_, check/uncheck _Enable Products Reviews_ and click on _Save_.
- Verify Activity Panel reacts to it and _Reviews_ tab disappears/appears accordingly.