### PR TITLE
Clear advanced filters when last one is removed

### DIFF
--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -19,6 +19,7 @@ import {
 	getDefaultOptionValue,
 	getNewPath,
 	getQueryFromActiveFilters,
+	getHistory,
 } from '@woocommerce/navigation';
 
 /**
@@ -103,6 +104,10 @@ class AdvancedFilters extends Component {
 		const index = findIndex( activeFilters, filter => filter.key === key );
 		activeFilters.splice( index, 1 );
 		this.setState( { activeFilters } );
+		if ( 0 === activeFilters.length ) {
+			const history = getHistory();
+			history.push( this.getUpdateHref( [] ) );
+		}
 	}
 
 	getTitle() {


### PR DESCRIPTION
When removing the last advanced filter, automatically "clear all". 

It seemed odd to me that you can remove the last filter and then have to press "clear all" in order to fully remove the filter from the report. I went ahead and removed all filters from the report when the user x's out of the last advanced filter.

### Screenshots

![remove](https://user-images.githubusercontent.com/1922453/54725730-0aa1bd80-4bd5-11e9-9052-0e5ac7c56771.gif)

### Detailed test instructions:

1. Go to a report with advanced filters, such as Orders Report.
2. Filter by an advanced filter.
3. Press filter and see the report refresh.
4. Remove the filter by clicking the "X".
5. See the report go back to its unfiltered state and the "Filter" button disabled.
