### PR TITLE
Add low product stock indicator

### DIFF
--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -1,0 +1,105 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_ACTIONABLE_STATUSES, DEFAULT_REVIEW_STATUSES } from 'wc-api/constants';
+
+export function getUnreadNotes( select ) {
+	const { getCurrentUserData, getNotes, getNotesError, isGetNotesRequesting } = select( 'wc-api' );
+	const userData = getCurrentUserData();
+	const notesQuery = {
+		page: 1,
+		per_page: 1,
+	};
+
+	const latestNote = getNotes( notesQuery );
+	return (
+		! Boolean( getNotesError( notesQuery ) ) &&
+		! isGetNotesRequesting( notesQuery ) &&
+		latestNote[ 0 ] &&
+		new Date( latestNote[ 0 ].date_created_gmt ).getTime() > userData.activity_panel_inbox_last_read
+	);
+}
+
+export function getUnreadOrders( select ) {
+	const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
+	const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || DEFAULT_ACTIONABLE_STATUSES;
+
+	if ( ! orderStatuses.length ) {
+		return false;
+	}
+
+	const ordersQuery = {
+		page: 1,
+		per_page: 0,
+		status_is: orderStatuses,
+	};
+
+	const totalOrders = getReportItems( 'orders', ordersQuery ).totalResults;
+	const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );
+	const isRequesting = isReportItemsRequesting( 'orders', ordersQuery );
+
+	if ( ! isError && ! isRequesting ) {
+		if ( totalOrders > 0 ) {
+			return true;
+		}
+		return false;
+	}
+	return null;
+}
+
+export function getUnreadReviews( select ) {
+	const {
+		getCurrentUserData,
+		getReviews,
+		getReviewsTotalCount,
+		getReviewsError,
+		isGetReviewsRequesting,
+	} = select( 'wc-api' );
+	const userData = getCurrentUserData();
+	let numberOfReviews = null;
+	let hasUnreadReviews = false;
+
+	if ( 'yes' === wcSettings.reviewsEnabled ) {
+		const reviewsQuery = {
+			order: 'desc',
+			orderby: 'date_gmt',
+			page: 1,
+			per_page: 1,
+			status: DEFAULT_REVIEW_STATUSES,
+		};
+		const reviews = getReviews( reviewsQuery );
+		const totalReviews = getReviewsTotalCount( reviewsQuery );
+		const isReviewsError = Boolean( getReviewsError( reviewsQuery ) );
+		const isReviewsRequesting = isGetReviewsRequesting( reviewsQuery );
+
+		if ( ! isReviewsError && ! isReviewsRequesting ) {
+			numberOfReviews = totalReviews;
+			hasUnreadReviews =
+				reviews.length &&
+				reviews[ 0 ].date_created_gmt &&
+				new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
+					userData.activity_panel_reviews_last_read;
+		}
+	}
+
+	return { numberOfReviews, hasUnreadReviews };
+}
+
+export function getUnreadStock( select ) {
+	const { getItems, getItemsError, getItemsTotalCount, isGetItemsRequesting } = select( 'wc-api' );
+	const productsQuery = {
+		page: 1,
+		per_page: 1,
+		low_in_stock: true,
+		status: 'publish',
+	};
+	getItems( 'products', productsQuery );
+	const lowInStockCount = getItemsTotalCount( 'products', productsQuery );
+
+	return ! getItemsError( 'products', productsQuery ) &&
+		! isGetItemsRequesting( 'products', productsQuery )
+		? lowInStockCount > 0
+		: false;
+}

--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -38,11 +38,14 @@ function read( resourceNames, fetch = apiFetch ) {
 		const url = NAMESPACE + `/${ endpoint }${ stringifyQuery( query ) }`;
 
 		try {
-			const items = await fetch( {
+			const response = await fetch( {
+				parse: false,
 				path: url,
 			} );
 
+			const items = await response.json();
 			const ids = items.map( item => item.id );
+			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
 			const itemResources = items.reduce( ( resources, item ) => {
 				resources[ getResourceName( `${ prefix }-item`, item.id ) ] = { data: item };
 				return resources;
@@ -51,7 +54,7 @@ function read( resourceNames, fetch = apiFetch ) {
 			return {
 				[ resourceName ]: {
 					data: ids,
-					totalCount: ids.length,
+					totalCount,
 				},
 				...itemResources,
 			};

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -127,7 +127,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		}
 
 		if ( $wp_query->get( 'low_in_stock' ) ) {
-			$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount', 2 );
+			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$where           .= " AND lis_postmeta2.meta_key = '_manage_stock' AND lis_postmeta2.meta_value = 'yes'
 			AND lis_postmeta.meta_key = '_stock' AND lis_postmeta.meta_value IS NOT NULL
 			AND (

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -81,7 +81,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		$args = parent::prepare_objects_query( $request );
 
 		if ( ! empty( $request['search'] ) ) {
-			$args['search'] = $request['search'];
+			$args['search'] = trim( $request['search'] );
 			unset( $args['s'] );
 		}
 		if ( ! empty( $request['low_in_stock'] ) ) {
@@ -118,7 +118,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_filter( $where, $wp_query ) {
 		global $wpdb;
 
-		$search = trim( $wp_query->get( 'search' ) );
+		$search = $wp_query->get( 'search' );
 		if ( $search ) {
 			$search = $wpdb->esc_like( $search );
 			$search = "'%" . $search . "%'";
@@ -151,7 +151,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public static function add_wp_query_join( $join, $wp_query ) {
 		global $wpdb;
 
-		$search = trim( $wp_query->get( 'search' ) );
+		$search = $wp_query->get( 'search' );
 		if ( $search && wc_product_sku_enabled() ) {
 			$join .= " INNER JOIN {$wpdb->postmeta} AS ps_post_meta ON ps_post_meta.post_id = {$wpdb->posts}.ID";
 		}
@@ -175,7 +175,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public function add_wp_query_group_by( $groupby, $wp_query ) {
 		global $wpdb;
 
-		$search       = trim( $wp_query->get( 'search' ) );
+		$search       = $wp_query->get( 'search' );
 		$low_in_stock = $wp_query->get( 'low_in_stock' );
 		if ( empty( $groupby ) && ( $search || $low_in_stock ) ) {
 			$groupby = $wpdb->posts . '.ID';

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -55,8 +55,14 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params           = parent::get_collection_params();
-		$params['search'] = array(
+		$params                 = parent::get_collection_params();
+		$params['low_in_stock'] = array(
+			'description'       => __( 'Limit result set to products that are low or out of stock.', 'woocommerce-admin' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'sanitize_callback' => 'wc_string_to_bool',
+		);
+		$params['search']       = array(
 			'description'       => __( 'Search by similar product name or sku.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -78,6 +84,9 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 			$args['search'] = $request['search'];
 			unset( $args['s'] );
 		}
+		if ( ! empty( $request['low_in_stock'] ) ) {
+			$args['low_in_stock'] = $request['low_in_stock'];
+		}
 
 		return $args;
 	}
@@ -89,50 +98,68 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10, 2 );
-		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10, 2 );
-		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10, 2 );
+		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
+		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
+		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
-		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10 );
-		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10 );
-		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10 );
+		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
+		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
+		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10 );
 		return $response;
 	}
 
 	/**
-	 * Allow searching by product name or sku in WP Query
+	 * Add in conditional search filters for products.
 	 *
 	 * @param string $where Where clause used to search posts.
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
-	public static function add_wp_query_product_search_filter( $where, $wp_query ) {
+	public static function add_wp_query_filter( $where, $wp_query ) {
 		global $wpdb;
 
 		$search = trim( $wp_query->get( 'search' ) );
 		if ( $search ) {
 			$search = $wpdb->esc_like( $search );
 			$search = "'%" . $search . "%'";
-			$where .= ' AND (' . $wpdb->posts . '.post_title LIKE ' . $search;
+			$where .= " AND ({$wpdb->posts}.post_title LIKE {$search}";
 			$where .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $search . ')' : ')';
+		}
+
+		if ( $wp_query->get( 'low_in_stock' ) ) {
+			$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount', 2 );
+			$where           .= " AND lis_postmeta2.meta_key = '_manage_stock' AND lis_postmeta2.meta_value = 'yes'
+			AND lis_postmeta.meta_key = '_stock' AND lis_postmeta.meta_value IS NOT NULL
+			AND (
+				lis_postmeta3.meta_key = '_low_stock_amount' AND lis_postmeta.meta_value IS NOT NULL
+				AND lis_postmeta3.meta_key = '_low_stock_amount' AND CAST(lis_postmeta.meta_value AS SIGNED) <= CAST(lis_postmeta3.meta_value AS SIGNED)
+				OR lis_postmeta3.meta_key = '_low_stock_amount' AND lis_postmeta.meta_value IS NULL
+				AND lis_postmeta.meta_key = '_stock' AND CAST(lis_postmeta.meta_value AS SIGNED) <= '{$low_stock_amount}'
+			)";
 		}
 
 		return $where;
 	}
 
 	/**
-	 * Join posts meta table when product search is present and meta query is not present.
+	 * Join posts meta tables when product search or low stock query is present.
 	 *
 	 * @param string $join Join clause used to search posts.
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
-	public static function add_wp_query_product_search_join( $join, $wp_query ) {
+	public static function add_wp_query_join( $join, $wp_query ) {
 		global $wpdb;
 
 		$search = trim( $wp_query->get( 'search' ) );
 		if ( $search && wc_product_sku_enabled() ) {
-			$join .= ' INNER JOIN ' . $wpdb->postmeta . ' AS ps_post_meta ON ps_post_meta.post_id = ' . $wpdb->posts . '.ID';
+			$join .= " INNER JOIN {$wpdb->postmeta} AS ps_post_meta ON ps_post_meta.post_id = {$wpdb->posts}.ID";
+		}
+
+		if ( $wp_query->get( 'low_in_stock' ) ) {
+			$join .= " INNER JOIN {$wpdb->postmeta} AS lis_postmeta ON {$wpdb->posts}.ID = lis_postmeta.post_id
+			INNER JOIN {$wpdb->postmeta} AS lis_postmeta2 ON {$wpdb->posts}.ID = lis_postmeta2.post_id
+			INNER JOIN {$wpdb->postmeta} AS lis_postmeta3 ON {$wpdb->posts}.ID = lis_postmeta3.post_id";
 		}
 
 		return $join;
@@ -145,14 +172,14 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
-	public function add_wp_query_product_search_group_by( $groupby, $wp_query ) {
+	public function add_wp_query_group_by( $groupby, $wp_query ) {
 		global $wpdb;
 
-		$search = trim( $wp_query->get( 'search' ) );
-		if ( $search && empty( $groupby ) ) {
+		$search       = trim( $wp_query->get( 'search' ) );
+		$low_in_stock = $wp_query->get( 'low_in_stock' );
+		if ( empty( $groupby ) && ( $search || $low_in_stock ) ) {
 			$groupby = $wpdb->posts . '.ID';
 		}
 		return $groupby;
 	}
-
 }

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -128,13 +128,16 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 
 		if ( $wp_query->get( 'low_in_stock' ) ) {
 			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
-			$where           .= " AND lis_postmeta2.meta_key = '_manage_stock' AND lis_postmeta2.meta_value = 'yes'
-			AND lis_postmeta.meta_key = '_stock' AND lis_postmeta.meta_value IS NOT NULL
+			$where           .= " AND lis_postmeta2.meta_key = '_manage_stock'
+			AND lis_postmeta2.meta_value = 'yes'
+			AND lis_postmeta.meta_key = '_stock'
+			AND lis_postmeta.meta_value IS NOT NULL
+			AND lis_postmeta3.meta_key = '_low_stock_amount'
 			AND (
-				lis_postmeta3.meta_key = '_low_stock_amount' AND lis_postmeta.meta_value IS NOT NULL
-				AND lis_postmeta3.meta_key = '_low_stock_amount' AND CAST(lis_postmeta.meta_value AS SIGNED) <= CAST(lis_postmeta3.meta_value AS SIGNED)
-				OR lis_postmeta3.meta_key = '_low_stock_amount' AND lis_postmeta.meta_value IS NULL
-				AND lis_postmeta.meta_key = '_stock' AND CAST(lis_postmeta.meta_value AS SIGNED) <= '{$low_stock_amount}'
+				lis_postmeta3.meta_value IS NOT NULL
+				AND CAST(lis_postmeta.meta_value AS SIGNED) <= CAST(lis_postmeta3.meta_value AS SIGNED)
+				OR lis_postmeta3.meta_value IS NULL
+				AND CAST(lis_postmeta.meta_value AS SIGNED) <= {$low_stock_amount}
 			)";
 		}
 

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -175,7 +175,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
-	public function add_wp_query_group_by( $groupby, $wp_query ) {
+	public static function add_wp_query_group_by( $groupby, $wp_query ) {
 		global $wpdb;
 
 		$search       = $wp_query->get( 'search' );

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -134,9 +134,9 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 			AND lis_postmeta.meta_value IS NOT NULL
 			AND lis_postmeta3.meta_key = '_low_stock_amount'
 			AND (
-				lis_postmeta3.meta_value IS NOT NULL
+				lis_postmeta3.meta_value > ''
 				AND CAST(lis_postmeta.meta_value AS SIGNED) <= CAST(lis_postmeta3.meta_value AS SIGNED)
-				OR lis_postmeta3.meta_value IS NULL
+				OR lis_postmeta3.meta_value <= ''
 				AND CAST(lis_postmeta.meta_value AS SIGNED) <= {$low_stock_amount}
 			)";
 		}


### PR DESCRIPTION
Fixes #1827 

* Adds a low stock option to the products REST API
* Adds totalCount to items in wc-api
* Adds the unread indicator to the stock panel
* Extracts previous unread indicators to separate file

### Screenshots
<img width="402" alt="Screen Shot 2019-03-21 at 3 14 39 PM" src="https://user-images.githubusercontent.com/10561050/54737672-16e54500-4bec-11e9-8fc4-32c5e2c54b18.png">

### Detailed test instructions:

#### Products API
1. Make a request to the products controller with `low_in_stock` param set to a true value `wp-json/wc/v4/products/?low_in_stock=1`
2. Check that products returned are in fact low in stock.
3. Make sure the products returned respect the WC low stock threshold.
4. Set a low stock threshold unique to a product.
5. Make sure that the product only shows up under low stock when its value is under its specific threshold.

#### Stock unread indicator
1. Add at least some products that are considered low in stock.
2. Check that the unread indicator for the stock status is present.
3. Adjust stock settings so that none are considered low.
4.  Check that the unread indicator is no longer present.
5. Check that no regressions have occurred with the other indicators (due to minor refactor).

### Thoughts
* My original plan was to use an option to mark when a product became low stock, but this would become tricky with many out of stock products and would require extra queries on each order placement and product updates.  Plus this groundwork would have been needed anyway for querying these products once we actually implement the stock panel.
* The current solution will probably benefit from caching.  I initially set this to use a transient in https://github.com/woocommerce/woocommerce-admin/commit/19c8228b4e87eceb905abb1b5429b2cd71dd2f11, but we lose the ability to poll this data with freshdata.  We might want to follow this one up with some caching since this is a relatively strenuous query.