### PR TITLE
Create DEFAULT_ACTIONABLE_STATUSES constant

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -12,6 +12,11 @@ import interpolateComponents from 'interpolate-components';
  */
 import { Link } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_ACTIONABLE_STATUSES } from 'wc-api/constants';
+
 const SETTINGS_FILTER = 'woocommerce_admin_analytics_settings';
 
 const defaultOrderStatuses = [
@@ -122,6 +127,6 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 			'woocommerce-admin'
 		),
 		initialValue: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [],
-		defaultValue: [ 'processing', 'on-hold' ],
+		defaultValue: DEFAULT_ACTIONABLE_STATUSES,
 	},
 ] );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -15,6 +15,7 @@ import { partial, uniqueId, find } from 'lodash';
  */
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
+import { DEFAULT_ACTIONABLE_STATUSES } from 'wc-api/constants';
 import { H, Section } from '@woocommerce/components';
 import InboxPanel from './panels/inbox';
 import OrdersPanel from './panels/orders';
@@ -271,10 +272,8 @@ export default withSelect( select => {
 		isGetNotesRequesting,
 		isReportItemsRequesting,
 	} = select( 'wc-api' );
-	const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
-		'processing',
-		'on-hold',
-	];
+	const orderStatuses =
+		wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || DEFAULT_ACTIONABLE_STATUSES;
 	const userData = getCurrentUserData();
 
 	const notesQuery = {

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -32,7 +32,7 @@ import { getAdminLink, getNewPath } from '@woocommerce/navigation';
 import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
 import ActivityOutboundLink from '../activity-outbound-link';
-import { QUERY_DEFAULTS } from 'wc-api/constants';
+import { DEFAULT_ACTIONABLE_STATUSES, QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
 function OrdersPanel( { orders, isRequesting, isError, orderStatuses } ) {
@@ -220,10 +220,9 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
 		const { isEmpty } = props;
-		const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
-			'processing',
-			'on-hold',
-		];
+		const orderStatuses =
+			wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses ||
+			DEFAULT_ACTIONABLE_STATUSES;
 
 		if ( ! orderStatuses.length ) {
 			return { orders: [], isError: true, isRequesting: false, orderStatuses };

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -14,6 +14,8 @@ export const DEFAULT_REQUIREMENT = {
 // WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter
 export const MAX_PER_PAGE = 100;
 
+export const DEFAULT_ACTIONABLE_STATUSES = [ 'processing', 'on-hold' ];
+
 export const QUERY_DEFAULTS = {
 	pageSize: 25,
 	period: 'month',


### PR DESCRIPTION
Given that we were defining actionable statuses in several places, I think it makes sense to store that in a constant.

### Detailed test instructions:
- Delete `woocommerce_actionable_order_statuses` from `wp_options` table in your site's database.
- Go to _Settings_ and verify _Actionable Statuses_ is set to _Processing_ and _On hold_.
- Verify only _Processing_ and _On hold_ orders appears in the _Orders_ tab of the _Activity Panel_.
