### PR TITLE
Fix PHP notices on orders data store

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -177,11 +177,17 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 					  		) AS tt"
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
-			$total_pages = (int) ceil( $db_records_count / $sql_query_params['per_page'] );
+			if ( 0 === $sql_query_params['per_page'] ) {
+				$total_pages = 0;
+			} else {
+				$total_pages = (int) ceil( $db_records_count / $sql_query_params['per_page'] );
+			}
 			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
 				$data = (object) array(
 					'data'    => array(),
 					'total'   => $db_records_count,
+					'pages'   => 0,
+					'page_no' => 0,
 				);
 				return $data;
 			}


### PR DESCRIPTION
Fixes #1862.

Fixes PHP notices appearing in some queries to `/reports/orders`.

### Notices
```
PHP Warning:  Division by zero in /wc-admin/includes/data-stores/class-wc-admin-reports-orders-data-store.php on line 180
PHP Notice:  Undefined property: stdClass::$pages in /wc-admin/includes/api/class-wc-admin-rest-reports-orders-controller.php on line 80
PHP Notice:  Undefined property: stdClass::$page_no in /wc-admin/includes/api/class-wc-admin-rest-reports-orders-controller.php on line 82
PHP Notice:  Undefined property: stdClass::$pages in /wc-admin/includes/api/class-wc-admin-rest-reports-orders-controller.php on line 83
```

### Detailed test instructions:
- Set `define( 'WP_DEBUG_LOG', true );` in your `wp-config.php` file, so error logs are stored in `wp-content/debug.log` (it might depend on your WP installation, though, for me they were stored in `/var/log/php-fpm/www-error.log`).
- Go to _WooCommerce_ > _Dashboard_.
- Verify the notices described above do not appear anymore in the error log.