### PR TITLE
Load on hold reviews in the Activity Panel

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -15,6 +15,7 @@ import { partial, uniqueId, find } from 'lodash';
  */
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
+import { DEFAULT_REVIEW_STATUSES } from 'wc-api/constants';
 import { H, Section } from '@woocommerce/components';
 import InboxPanel from './panels/inbox';
 import OrdersPanel from './panels/orders';
@@ -326,6 +327,7 @@ export default withSelect( select => {
 			orderby: 'date_gmt',
 			page: 1,
 			per_page: 1,
+			status: DEFAULT_REVIEW_STATUSES,
 		};
 		const reviews = getReviews( reviewsQuery );
 		const totalReviews = getReviewsTotalCount( reviewsQuery );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -340,6 +340,23 @@ export default withSelect( select => {
 				new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
 					userData.activity_panel_reviews_last_read;
 		}
+
+		if ( ! unreadReviews && '1' === wcSettings.commentModeration ) {
+			const actionableReviewsQuery = {
+				page: 1,
+				// @todo we are not using this review, so when the endpoint supports it,
+				// it could be replaced with `per_page: 0`
+				per_page: 1,
+				status: 'hold',
+			};
+			const totalActionableReviews = getReviewsTotalCount( actionableReviewsQuery );
+			const isActionableReviewsError = Boolean( getReviewsError( actionableReviewsQuery ) );
+			const isActionableReviewsRequesting = isGetReviewsRequesting( actionableReviewsQuery );
+
+			if ( ! isActionableReviewsError && ! isActionableReviewsRequesting ) {
+				unreadReviews = totalActionableReviews > 0;
+			}
+		}
 	}
 
 	return { unreadNotes, unreadOrders, unreadReviews, numberOfReviews };

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -30,7 +30,7 @@ import {
  */
 import { ActivityCard, ActivityCardPlaceholder } from '../activity-card';
 import ActivityHeader from '../activity-header';
-import { QUERY_DEFAULTS } from 'wc-api/constants';
+import { DEFAULT_REVIEW_STATUSES, QUERY_DEFAULTS } from 'wc-api/constants';
 import sanitizeHTML from 'lib/sanitize-html';
 import withSelect from 'wc-api/with-select';
 
@@ -228,6 +228,7 @@ export default compose(
 		const reviewsQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
+			status: DEFAULT_REVIEW_STATUSES,
 			_embed: 1,
 		};
 

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -133,6 +133,7 @@ class ReviewsPanel extends Component {
 				icon={ icon }
 				actions={ cardActions() }
 				unread={
+					review.status === 'hold' ||
 					! lastRead ||
 					! review.date_created_gmt ||
 					new Date( review.date_created_gmt + 'Z' ).getTime() > lastRead

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -14,6 +14,8 @@ export const DEFAULT_REQUIREMENT = {
 // WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter
 export const MAX_PER_PAGE = 100;
 
+export const DEFAULT_REVIEW_STATUSES = [ 'approved', 'hold' ];
+
 export const QUERY_DEFAULTS = {
 	pageSize: 25,
 	period: 'month',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -179,24 +179,25 @@ function wc_admin_print_script_settings() {
 	 * `wcAssetUrl` can be used in its place throughout the codebase.
 	 */
 	$settings = array(
-		'adminUrl'         => admin_url(),
-		'wcAssetUrl'       => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'wcAdminAssetUrl'  => plugins_url( 'images/', wc_admin_dir_path( 'wc-admin.php' ) ), // Temporary for plugin. See above.
-		'embedBreadcrumbs' => wc_admin_get_embed_breadcrumbs(),
-		'siteLocale'       => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'         => wc_admin_currency_settings(),
-		'orderStatuses'    => wc_admin_format_order_statuses( wc_get_order_statuses() ),
-		'stockStatuses'    => wc_get_product_stock_status_options(),
-		'siteTitle'        => get_bloginfo( 'name' ),
-		'dataEndpoints'    => array(),
-		'l10n'             => array(
+		'adminUrl'          => admin_url(),
+		'wcAssetUrl'        => plugins_url( 'assets/', WC_PLUGIN_FILE ),
+		'wcAdminAssetUrl'   => plugins_url( 'images/', wc_admin_dir_path( 'wc-admin.php' ) ), // Temporary for plugin. See above.
+		'embedBreadcrumbs'  => wc_admin_get_embed_breadcrumbs(),
+		'siteLocale'        => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'          => wc_admin_currency_settings(),
+		'orderStatuses'     => wc_admin_format_order_statuses( wc_get_order_statuses() ),
+		'stockStatuses'     => wc_get_product_stock_status_options(),
+		'siteTitle'         => get_bloginfo( 'name' ),
+		'dataEndpoints'     => array(),
+		'l10n'              => array(
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
-		'currentUserData'  => $current_user_data,
-		'alertCount'       => WC_Admin_Notes::get_notes_count( 'error,update', 'unactioned' ),
-		'reviewsEnabled'   => get_option( 'woocommerce_enable_reviews' ),
-		'manageStock'      => get_option( 'woocommerce_manage_stock' ),
+		'currentUserData'   => $current_user_data,
+		'alertCount'        => WC_Admin_Notes::get_notes_count( 'error,update', 'unactioned' ),
+		'reviewsEnabled'    => get_option( 'woocommerce_enable_reviews' ),
+		'manageStock'       => get_option( 'woocommerce_manage_stock' ),
+		'commentModeration' => get_option( 'comment_moderation' ),
 	);
 	$settings = wc_admin_add_custom_settings( $settings );
 


### PR DESCRIPTION
Fixes #1868.

In addition to approved reviews, load also on hold reviews in the Activity Panel.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54760561-9aa13080-4bf0-11e9-8008-2d10515778a3.png)

Detailed test instructions:
- Go to _Settings_ > _Discussion_ and check _Comment must be manually approved_.
- Create a product review.
- Go to any WooCommerce Admin page and verify an unread indicator (red dot) appears next to the _Reviews_ tab of the Activity Panel.
- Click on the tab and verify the new review appears and is marked with a red dot.