### PR TITLE
Add order milestone notifications.

### DIFF
--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -30,7 +30,9 @@ class ActivityCard extends Component {
 					<H className="woocommerce-activity-card__title">{ title }</H>
 					{ subtitle && <div className="woocommerce-activity-card__subtitle">{ subtitle }</div> }
 					{ date && (
-						<span className="woocommerce-activity-card__date">{ moment( date ).fromNow() }</span>
+						<span className="woocommerce-activity-card__date">
+							{ moment.utc( date ).fromNow() }
+						</span>
 					) }
 				</header>
 				<Section className="woocommerce-activity-card__body">{ children }</Section>

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -88,7 +88,7 @@ class InboxPanel extends Component {
 								key={ note.id }
 								className="woocommerce-inbox-activity-card"
 								title={ note.title }
-								date={ note.date_created }
+								date={ note.date_created_gmt }
 								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
 								unread={ ! lastRead || new Date( note.date_created_gmt ).getTime() > lastRead }
 								actions={ getButtonsFromActions( note.actions ) }

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -33,27 +33,6 @@ class WC_Admin_Note extends WC_Data {
 	protected $object_type = 'admin-note';
 
 	/**
-	 * Data array, with defaults.
-	 *
-	 * @var array
-	 */
-	protected $data = array(
-		'name'          => '-',
-		'type'          => self::E_WC_ADMIN_NOTE_INFORMATIONAL,
-		'locale'        => 'en_US',
-		'title'         => '-',
-		'content'       => '-',
-		'icon'          => 'info',
-		'content_data'  => array(),
-		'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
-		'source'        => 'woocommerce',
-		'date_created'  => '0000-00-00 00:00:00',
-		'date_reminder' => '',
-		'is_snoozable'  => false,
-		'actions'       => array(),
-	);
-
-	/**
 	 * Cache group.
 	 *
 	 * @var string
@@ -66,6 +45,23 @@ class WC_Admin_Note extends WC_Data {
 	 * @param mixed $data Note data, object, or ID.
 	 */
 	public function __construct( $data = '' ) {
+		// Set default data here to allow `content_data` to be an object.
+		$this->data = array(
+			'name'          => '-',
+			'type'          => self::E_WC_ADMIN_NOTE_INFORMATIONAL,
+			'locale'        => 'en_US',
+			'title'         => '-',
+			'content'       => '-',
+			'icon'          => 'info',
+			'content_data'  => new stdClass(),
+			'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
+			'source'        => 'woocommerce',
+			'date_created'  => '0000-00-00 00:00:00',
+			'date_reminder' => '',
+			'is_snoozable'  => false,
+			'actions'       => array(),
+		);
+
 		parent::__construct( $data );
 
 		if ( $data instanceof WC_Admin_Note ) {

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -24,6 +24,16 @@ class WC_Admin_Notes_Order_Milestones {
 	const TEN_ORDERS_NOTE_NAME = 'wc-admin-ten-orders';
 
 	/**
+	 * Name of the "other milestones" note.
+	 */
+	const ORDERS_MILESTONE_NOTE_NAME = 'wc-admin-orders-milestone';
+
+	/**
+	 * Option key name to store last order milestone.
+	 */
+	const LAST_ORDER_MILESTONE_OPTION_KEY = 'wc_admin_last_orders_milestone';
+
+	/**
 	 * Allowed order statuses for calculating milestones.
 	 *
 	 * @var array
@@ -42,12 +52,41 @@ class WC_Admin_Notes_Order_Milestones {
 	protected $orders_count = null;
 
 	/**
-	 * Hook everything up.
+	 * Further order milestone thresholds.
+	 *
+	 * @var array
+	 */
+	protected $milestones = array(
+		100,
+		250,
+		500,
+		1000,
+		5000,
+		10000,
+		500000,
+		1000000,
+	);
+
+	/**
+	 * Delay hook attachment until after the WC post types have been registered.
+	 *
+	 * This is required for retrieving the order count.
 	 */
 	public function __construct() {
+		add_action( 'woocommerce_after_register_post_type', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Hook everything up.
+	 */
+	public function init() {
+		add_action( 'wc_admin_installed', array( $this, 'backfill_last_milestone' ) );
+
 		if ( 10 <= $this->get_orders_count() ) {
 			add_action( 'woocommerce_new_order', array( $this, 'first_two_milestones' ) );
 		}
+
+		add_action( 'wc_admin_daily', array( $this, 'other_milestones' ) );
 	}
 
 	/**
@@ -97,7 +136,13 @@ class WC_Admin_Notes_Order_Milestones {
 		if ( 10 === $orders_count ) {
 			// Add the first ten orders note.
 			$note = new WC_Admin_Note();
-			$note->set_title( __( 'Congratulations on processing 10 orders!', 'woocommerce-admin' ) );
+			$note->set_title(
+				sprintf(
+					/* translators: Number of orders processed. */
+					__( 'Congratulations on processing %s orders!', 'woocommerce-admin' ),
+					wc_format_decimal( 10 )
+				)
+			);
 			$note->set_content(
 				__( "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration.", 'woocommerce-admin' )
 			);
@@ -108,6 +153,86 @@ class WC_Admin_Notes_Order_Milestones {
 			$note->add_action( 'browse', __( 'Browse', 'woocommerce-admin' ), 'https://woocommerce.com/success-stories/' );
 			$note->save();
 		}
+	}
+
+	/**
+	 * Backfill the store's current milestone.
+	 *
+	 * Used to avoid celebrating milestones that were reached before plugin activation.
+	 */
+	public function backfill_last_milestone() {
+		$this->set_last_milestone( $this->get_current_milestone() );
+	}
+
+	/**
+	 * Get the store's last milestone.
+	 *
+	 * @return int Last milestone reached.
+	 */
+	public function get_last_milestone() {
+		return get_option( self::LAST_ORDER_MILESTONE_OPTION_KEY, 0 );
+	}
+
+	/**
+	 * Update the last reached milestone.
+	 *
+	 * @param int $milestone Last milestone reached.
+	 */
+	public function set_last_milestone( $milestone ) {
+		update_option( self::LAST_ORDER_MILESTONE_OPTION_KEY, $milestone );
+	}
+
+	/**
+	 * Calculate the current orders milestone.
+	 *
+	 * Based on the threshold values in $this->milestones.
+	 *
+	 * @return int Current orders milestone.
+	 */
+	public function get_current_milestone() {
+		$milestone_reached = 0;
+		$orders_count      = $this->get_orders_count();
+
+		foreach ( $this->milestones as $milestone ) {
+			if ( $milestone <= $orders_count ) {
+				$milestone_reached = $milestone;
+			}
+		}
+
+		return $milestone_reached;
+	}
+
+	/**
+	 * Add milestone notes for other significant thresholds.
+	 */
+	public function other_milestones() {
+		$last_milestone    = $this->get_last_milestone();
+		$current_milestone = $this->get_current_milestone();
+
+		if ( $current_milestone <= $last_milestone ) {
+			return;
+		}
+
+		$this->set_last_milestone( $current_milestone );
+
+		// Add the milestone note.
+		$note = new WC_Admin_Note();
+		$note->set_title(
+			sprintf(
+				/* translators: Number of orders processed. */
+				__( 'Congratulations on processing %s orders!', 'woocommerce-admin' ),
+				wc_format_decimal( $current_milestone )
+			)
+		);
+		$note->set_content(
+			__( "Another order milestone! Have you shared news with your subscribers lately? Maybe it's time for an update.", 'woocommerce-admin' )
+		);
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'trophy' );
+		$note->set_name( self::ORDERS_MILESTONE_NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'review', __( 'Review processed orders', 'woocommerce-admin' ), '?page=wc-admin#/analytics/orders' );
+		$note->save();
 	}
 }
 

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -78,6 +78,15 @@ class WC_Admin_Notes_Order_Milestones {
 	 * This is required for retrieving the order count.
 	 */
 	public function __construct() {
+		/**
+		 * Filter Order statuses that will count towards milestones.
+		 *
+		 * @since 3.5.0
+		 *
+		 * @param array $allowed_statuses Order statuses that will count towards milestones.
+		 */
+		$this->allowed_statuses = apply_filters( 'woocommerce_admin_order_milestone_statuses', $this->allowed_statuses );
+
 		add_action( 'woocommerce_after_register_post_type', array( $this, 'init' ) );
 	}
 

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -237,13 +237,13 @@ class WC_Admin_Notes_Order_Milestones {
 			)
 		);
 		$note->set_content(
-			__( "Another order milestone! Have you shared news with your subscribers lately? Maybe it's time for an update.", 'woocommerce-admin' )
+			__( 'Another order milestone! Take a look at your Orders Report to review your orders to date.', 'woocommerce-admin' )
 		);
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'trophy' );
 		$note->set_name( self::ORDERS_MILESTONE_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'review', __( 'Review processed orders', 'woocommerce-admin' ), '?page=wc-admin#/analytics/orders' );
+		$note->add_action( 'review-orders', __( 'Review your orders', 'woocommerce-admin' ), '?page=wc-admin#/analytics/orders' );
 		$note->save();
 	}
 }

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * WooCommerce Admin (Dashboard) Order Milestones Note Provider.
+ *
+ * Adds a note to the merchant's inbox when certain order milestones are reached.
+ *
+ * @package WooCommerce Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Order_Milestones
+ */
+class WC_Admin_Notes_Order_Milestones {
+	/**
+	 * Name of the "first order" note.
+	 */
+	const FIRST_ORDER_NOTE_NAME = 'wc-admin-first-order';
+
+	/**
+	 * Allowed order statuses for calculating milestones.
+	 *
+	 * @var array
+	 */
+	protected $allowed_statuses = array(
+		'pending',
+		'processing',
+		'completed',
+	);
+
+	/**
+	 * Hook everything up.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_new_order', array( $this, 'add_first_order_note' ) );
+	}
+
+	/**
+	 * Get the total count of orders (in the allowed statuses).
+	 *
+	 * @return int Total orders count.
+	 */
+	public function get_orders_count() {
+		$status_counts = array_map( 'wc_orders_count', $this->allowed_statuses );
+		$orders_count  = array_sum( $status_counts );
+
+		return $orders_count;
+	}
+
+	/**
+	 * Add a milestone note for the store's first order.
+	 *
+	 * @param int $order_id WC_Order ID.
+	 */
+	public function add_first_order_note( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		// Make sure this is the first pending/processing/completed order.
+		if ( ! in_array( $order->get_status(), $this->allowed_statuses ) ) {
+			return;
+		}
+
+		$orders_count = $this->get_orders_count();
+
+		if ( 1 === $orders_count ) {
+			// Add the first order note.
+			$note = new WC_Admin_Note();
+			$note->set_title( __( 'First order', 'woocommerce-admin' ) );
+			$note->set_content(
+				__( 'Congratulations on getting your first order from a customer! Learn how to manage your orders.', 'woocommerce-admin' )
+			);
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_icon( 'trophy' );
+			$note->set_name( self::FIRST_ORDER_NOTE_NAME );
+			$note->set_source( 'woocommerce-admin' );
+			$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://docs.woocommerce.com/document/managing-orders/' );
+			$note->save();
+		}
+	}
+}
+
+new WC_Admin_Notes_Order_Milestones();

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -110,10 +110,11 @@ class WC_Admin_Notes_Order_Milestones {
 	/**
 	 * Get the total count of orders (in the allowed statuses).
 	 *
+	 * @param bool $no_cache Optional. Skip cache.
 	 * @return int Total orders count.
 	 */
-	public function get_orders_count() {
-		if ( is_null( $this->orders_count ) ) {
+	public function get_orders_count( $no_cache = false ) {
+		if ( $no_cache || is_null( $this->orders_count ) ) {
 			$status_counts       = array_map( 'wc_orders_count', $this->allowed_statuses );
 			$this->orders_count  = array_sum( $status_counts );
 		}
@@ -134,7 +135,8 @@ class WC_Admin_Notes_Order_Milestones {
 			return;
 		}
 
-		$orders_count = $this->get_orders_count();
+		// Retrieve the orders count, forcing a cache refresh.
+		$orders_count = $this->get_orders_count( true );
 
 		if ( 1 === $orders_count ) {
 			// Add the first order note.

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -88,6 +88,7 @@ class WC_Admin_Notes_Order_Milestones {
 		$this->allowed_statuses = apply_filters( 'woocommerce_admin_order_milestone_statuses', $this->allowed_statuses );
 
 		add_action( 'woocommerce_after_register_post_type', array( $this, 'init' ) );
+		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'clear_scheduled_event' ) );
 	}
 
 	/**
@@ -105,6 +106,13 @@ class WC_Admin_Notes_Order_Milestones {
 		}
 
 		add_action( self::PROCESS_ORDERS_MILESTONE_HOOK, array( $this, 'other_milestones' ) );
+	}
+
+	/**
+	 * Clear out our hourly milestone hook upon plugin deactivation.
+	 */
+	public function clear_scheduled_event() {
+		wp_clear_scheduled_hook( self::PROCESS_ORDERS_MILESTONE_HOOK );
 	}
 
 	/**

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -100,7 +100,7 @@ class WC_Admin_Notes_Order_Milestones {
 
 		add_action( 'wc_admin_installed', array( $this, 'backfill_last_milestone' ) );
 
-		if ( 10 <= $this->get_orders_count() ) {
+		if ( $this->get_orders_count() <= 10 ) {
 			add_action( 'woocommerce_new_order', array( $this, 'first_two_milestones' ) );
 		}
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -95,6 +95,8 @@ function wc_admin_build_file_exists() {
 
 /**
  * Daily events to run.
+ *
+ * Note: WC_Admin_Notes_Order_Milestones::other_milestones is hooked to this as well.
  */
 function wc_admin_do_wc_admin_daily() {
 	WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -163,6 +163,7 @@ function wc_admin_plugins_loaded() {
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-settings-notes.php';
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-woo-subscriptions-notes.php';
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-historical-data.php';
+	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-order-milestones.php';
 
 	// Verify we have a proper build.
 	if ( ! wc_admin_build_file_exists() ) {


### PR DESCRIPTION
Fixes #1831, #2006.

**Functionality Introduced:**

Introduces a new class to manage order milestone notifications.

Milestones:
* First order
* Ten orders
* 100, 250, 500, 1000, 5000, 10000, 500000, 1000000

The first and ten order milestones are triggered immediately as orders are created.

Subsequent milestones are processed hourly. Only one notification is visible at any one time.

Upon plugin activation, the orders count is cached to avoid celebrating milestones passed before activation.

**Changes made to existing code:**

* `WC_Admin_Note`'s default value for `content_data` broke note retrieval - fixed in db97d51
* Inbox item dates weren't being handled properly - notes created were showing future dates - fixed in 1a3aa53

### Screenshots

<img width="536" alt="Screen Shot 2019-03-20 at 3 53 27 PM" src="https://user-images.githubusercontent.com/63922/54775875-85b6a400-4bd4-11e9-99a4-ecc8f74d232f.png">

![Screen Shot 2019-03-21 at 12 25 26 PM](https://user-images.githubusercontent.com/63922/54775869-83544a00-4bd4-11e9-8702-0d067e61d0e3.png)

### Detailed test instructions:

- Starting on a fresh store with no orders, place an order
- Verify the "first order" note is in the inbox
- Verify CTA goes to https://docs.woocommerce.com/document/managing-orders/
- Place 10 orders
- Verify the "ten orders" note is in the inbox
- Verify CTA goes to https://woocommerce.com/success-stories/
- Place 100 orders (smooth generator can really help here)
- Trigger the `wc_admin_process_orders_milestone` cron event to run (use Crontrol to delete job)
- Verify the "100 orders" note is in the inbox
- Verify CTA goes to Orders Report
- Delete all milestone notes from `wc_admin_notes` table
- Delete `wc_admin_version` and `wc_admin_last_orders_milestone` options
- Load an admin page
- Trigger the `wc_admin_process_orders_milestone` cron event to run (use Crontrol to delete job)
- Verify no new order milestone notes in inbox

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
