### PR TITLE
Refactor getFilterQuery by explicitly passing down configs

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -99,7 +99,12 @@ Leaderboard.propTypes = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const { endpoint, tableQuery, query } = props;
-		const tableData = getReportTableData( endpoint, query, select, tableQuery );
+		const tableData = getReportTableData( {
+			endpoint,
+			query,
+			select,
+			tableQuery,
+		} );
 
 		return { ...tableData };
 	} )

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -252,7 +252,7 @@ ReportChart.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, filters, isRequesting, limitProperties, query } = props;
+		const { endpoint, filters, isRequesting, limitProperties, query, advancedFilters } = props;
 		const limitBy = limitProperties || [ endpoint ];
 		const selectedFilter = getSelectedFilter( filters, query );
 		const filterParam = get( selectedFilter, [ 'settings', 'param' ] );
@@ -276,16 +276,32 @@ export default compose(
 			};
 		}
 
+		const primaryData = getReportChartData( {
+			endpoint,
+			dataType: 'primary',
+			query,
+			select,
+			limitBy,
+			filters,
+			advancedFilters,
+		} );
+
 		if ( 'item-comparison' === chartMode ) {
-			const primaryData = getReportChartData( endpoint, 'primary', query, select, limitBy );
 			return {
 				...newProps,
 				primaryData,
 			};
 		}
 
-		const primaryData = getReportChartData( endpoint, 'primary', query, select, limitBy );
-		const secondaryData = getReportChartData( endpoint, 'secondary', query, select, limitBy );
+		const secondaryData = getReportChartData( {
+			endpoint,
+			dataType: 'secondary',
+			query,
+			select,
+			limitBy,
+			filters,
+			advancedFilters,
+		} );
 		return {
 			...newProps,
 			primaryData,

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -149,7 +149,7 @@ ReportSummary.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { endpoint, isRequesting, limitProperties, query } = props;
+		const { endpoint, isRequesting, limitProperties, query, filters, advancedFilters } = props;
 		const limitBy = limitProperties || [ endpoint ];
 
 		if ( isRequesting ) {
@@ -164,7 +164,14 @@ export default compose(
 			};
 		}
 
-		const summaryData = getSummaryNumbers( endpoint, query, select, limitBy );
+		const summaryData = getSummaryNumbers( {
+			endpoint,
+			query,
+			select,
+			limitBy,
+			filters,
+			advancedFilters,
+		} );
 
 		return {
 			summaryData,

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -199,6 +199,8 @@ export default compose(
 			tableData,
 			tableQuery,
 			columnPrefsKey,
+			filters,
+			advancedFilters,
 		} = props;
 
 		let userPrefColumns = [];
@@ -214,13 +216,24 @@ export default compose(
 				userPrefColumns,
 			};
 		}
+		// Variations and Category charts are powered by the /reports/products/stats endpoint.
 		const chartEndpoint = [ 'variations', 'categories' ].includes( endpoint )
 			? 'products'
 			: endpoint;
 		const primaryData = getSummary
-			? getReportChartData( chartEndpoint, 'primary', query, select )
+			? getReportChartData( {
+					endpoint: chartEndpoint,
+					dataType: 'primary',
+					query,
+					select,
+					filters,
+					advancedFilters,
+					tableQuery,
+				} )
 			: {};
-		const queriedTableData = tableData || getReportTableData( endpoint, query, select, tableQuery );
+		const queriedTableData =
+			tableData ||
+			getReportTableData( { endpoint, query, select, tableQuery, filters, advancedFilters } );
 		const extendedTableData = extendTableData( select, props, queriedTableData );
 
 		return {

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -59,17 +59,18 @@ export default class CategoriesReport extends Component {
 				<ReportFilters query={ query } path={ path } filters={ filters } />
 				<ReportSummary
 					charts={ charts }
-					endpoint="categories"
+					endpoint="products"
 					isRequesting={ isRequesting }
 					limitProperties={ isSingleCategoryView ? [ 'products', 'categories' ] : [ 'categories' ] }
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
 				/>
 				<ReportChart
 					filters={ filters }
 					charts={ charts }
 					mode={ mode }
-					endpoint="categories"
+					endpoint="products"
 					limitProperties={ isSingleCategoryView ? [ 'products', 'categories' ] : [ 'categories' ] }
 					path={ path }
 					query={ chartQuery }
@@ -80,12 +81,17 @@ export default class CategoriesReport extends Component {
 				{ isSingleCategoryView ? (
 					<ProductsReportTable
 						isRequesting={ isRequesting }
-						query={ query }
+						query={ chartQuery }
 						baseSearchQuery={ { filter: 'single_category' } }
 						hideCompare={ isSingleCategoryView }
+						filters={ filters }
 					/>
 				) : (
-					<CategoriesReportTable isRequesting={ isRequesting } query={ query } />
+					<CategoriesReportTable
+						isRequesting={ isRequesting }
+						query={ query }
+						filters={ filters }
+					/>
 				) }
 			</Fragment>
 		);

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -134,7 +134,7 @@ class CategoriesReportTable extends Component {
 	}
 
 	render() {
-		const { isRequesting, query } = this.props;
+		const { isRequesting, query, filters } = this.props;
 
 		const labels = {
 			helpText: __( 'Check at least two categories below to compare', 'woocommerce-admin' ),
@@ -160,6 +160,7 @@ class CategoriesReportTable extends Component {
 				} }
 				title={ __( 'Categories', 'woocommerce-admin' ) }
 				columnPrefsKey="categories_report_columns"
+				filters={ filters }
 			/>
 		);
 	}

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -56,6 +56,7 @@ export default class CouponsReport extends Component {
 					isRequesting={ isRequesting }
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
 				/>
 				<ReportChart
 					filters={ filters }
@@ -68,7 +69,7 @@ export default class CouponsReport extends Component {
 					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<CouponsReportTable isRequesting={ isRequesting } query={ query } />
+				<CouponsReportTable isRequesting={ isRequesting } query={ query } filters={ filters } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -157,7 +157,7 @@ export default class CouponsReportTable extends Component {
 	}
 
 	render() {
-		const { isRequesting, query } = this.props;
+		const { isRequesting, query, filters } = this.props;
 
 		return (
 			<ReportTable
@@ -177,6 +177,7 @@ export default class CouponsReportTable extends Component {
 				} }
 				title={ __( 'Coupons', 'woocommerce-admin' ) }
 				columnPrefsKey="coupons_report_columns"
+				filters={ filters }
 			/>
 		);
 	}

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -34,7 +34,12 @@ export default class CustomersReport extends Component {
 					showDatePicker={ false }
 					advancedFilters={ advancedFilters }
 				/>
-				<CustomersReportTable isRequesting={ isRequesting } query={ tableQuery } />
+				<CustomersReportTable
+					isRequesting={ isRequesting }
+					query={ tableQuery }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -218,7 +218,7 @@ export default class CustomersReportTable extends Component {
 	}
 
 	render() {
-		const { isRequesting, query } = this.props;
+		const { isRequesting, query, filters, advancedFilters } = this.props;
 
 		return (
 			<ReportTable
@@ -233,6 +233,8 @@ export default class CustomersReportTable extends Component {
 				searchBy="customers"
 				title={ __( 'Customers', 'woocommerce-admin' ) }
 				columnPrefsKey="customers_report_columns"
+				filters={ filters }
+				advancedFilters={ advancedFilters }
 			/>
 		);
 	}

--- a/client/analytics/report/downloads/index.js
+++ b/client/analytics/report/downloads/index.js
@@ -36,6 +36,8 @@ export default class DownloadsReport extends Component {
 					endpoint="downloads"
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
 				/>
 				<ReportChart
 					charts={ charts }
@@ -43,8 +45,14 @@ export default class DownloadsReport extends Component {
 					path={ path }
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
 				/>
-				<DownloadsReportTable query={ query } />
+				<DownloadsReportTable
+					query={ query }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -150,7 +150,7 @@ export default class CouponsReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, filters, advancedFilters } = this.props;
 
 		return (
 			<ReportTable
@@ -164,6 +164,8 @@ export default class CouponsReportTable extends Component {
 				} }
 				title={ __( 'Downloads', 'woocommerce-admin' ) }
 				columnPrefsKey="downloads_report_columns"
+				filters={ filters }
+				advancedFilters={ advancedFilters }
 			/>
 		);
 	}

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -36,6 +36,8 @@ export default class OrdersReport extends Component {
 					endpoint="orders"
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
 				/>
 				<ReportChart
 					charts={ charts }
@@ -43,8 +45,14 @@ export default class OrdersReport extends Component {
 					path={ path }
 					query={ query }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
 				/>
-				<OrdersReportTable query={ query } />
+				<OrdersReportTable
+					query={ query }
+					filters={ filters }
+					advancedFilters={ advancedFilters }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -250,7 +250,7 @@ export default class OrdersReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, filters, advancedFilters } = this.props;
 
 		return (
 			<ReportTable
@@ -264,6 +264,8 @@ export default class OrdersReportTable extends Component {
 				} }
 				title={ __( 'Orders', 'woocommerce-admin' ) }
 				columnPrefsKey="orders_report_columns"
+				filters={ filters }
+				advancedFilters={ advancedFilters }
 			/>
 		);
 	}

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -76,6 +76,7 @@ class ProductsReport extends Component {
 					isRequesting={ isRequesting }
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
 				/>
 				<ReportChart
 					mode={ mode }
@@ -93,9 +94,10 @@ class ProductsReport extends Component {
 						baseSearchQuery={ { filter: 'single_product' } }
 						isRequesting={ isRequesting }
 						query={ query }
+						filters={ filters }
 					/>
 				) : (
-					<ProductsReportTable isRequesting={ isRequesting } query={ query } />
+					<ProductsReportTable isRequesting={ isRequesting } query={ query } filters={ filters } />
 				) }
 			</Fragment>
 		);

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -169,7 +169,7 @@ export default class VariationsReportTable extends Component {
 	}
 
 	render() {
-		const { baseSearchQuery, isRequesting, query } = this.props;
+		const { baseSearchQuery, isRequesting, query, filters } = this.props;
 
 		const labels = {
 			helpText: __( 'Check at least two variations below to compare', 'woocommerce-admin' ),
@@ -199,6 +199,7 @@ export default class VariationsReportTable extends Component {
 				} }
 				title={ __( 'Variations', 'woocommerce-admin' ) }
 				columnPrefsKey="variations_report_columns"
+				filters={ filters }
 			/>
 		);
 	}

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -235,7 +235,7 @@ class ProductsReportTable extends Component {
 	}
 
 	render() {
-		const { query, isRequesting, baseSearchQuery, hideCompare } = this.props;
+		const { query, isRequesting, baseSearchQuery, hideCompare, filters } = this.props;
 
 		const labels = {
 			helpText: __( 'Check at least two products below to compare', 'woocommerce-admin' ),
@@ -259,15 +259,11 @@ class ProductsReportTable extends Component {
 					orderby: query.orderby || 'items_sold',
 					order: query.order || 'desc',
 					extended_info: true,
-					/**
-					 * @TODO: Add this parameter because the filterQuery will be derived from the wrong config
-					 * because it will always look for products config, not categories. The solution is to pass
-					 * down the configs explicitly.
-					 */
-					categories: query.categories,
+					segmentby: query.segmentby,
 				} }
 				title={ __( 'Products', 'woocommerce-admin' ) }
 				columnPrefsKey="products_report_columns"
+				filters={ filters }
 			/>
 		);
 	}

--- a/client/analytics/report/stock/index.js
+++ b/client/analytics/report/stock/index.js
@@ -28,7 +28,7 @@ export default class StockReport extends Component {
 					showDatePicker={ showDatePicker }
 					filters={ filters }
 				/>
-				<StockReportTable query={ query } />
+				<StockReportTable query={ query } filters={ filters } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -127,7 +127,7 @@ export default class StockReportTable extends Component {
 	}
 
 	render() {
-		const { query } = this.props;
+		const { query, filters } = this.props;
 
 		return (
 			<ReportTable
@@ -142,6 +142,7 @@ export default class StockReportTable extends Component {
 					type: query.type || 'all',
 				} }
 				title={ __( 'Stock', 'woocommerce-admin' ) }
+				filters={ filters }
 			/>
 		);
 	}

--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -53,6 +53,7 @@ export default class TaxesReport extends Component {
 					isRequesting={ isRequesting }
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
+					filters={ filters }
 				/>
 				<ReportChart
 					filters={ filters }
@@ -65,7 +66,7 @@ export default class TaxesReport extends Component {
 					itemsLabel={ itemsLabel }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
-				<TaxesReportTable isRequesting={ isRequesting } query={ query } />
+				<TaxesReportTable isRequesting={ isRequesting } query={ query } filters={ filters } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -143,7 +143,7 @@ export default class TaxesReportTable extends Component {
 	}
 
 	render() {
-		const { isRequesting, query } = this.props;
+		const { isRequesting, query, filters } = this.props;
 
 		return (
 			<ReportTable
@@ -161,6 +161,7 @@ export default class TaxesReportTable extends Component {
 				} }
 				title={ __( 'Taxes', 'woocommerce-admin' ) }
 				columnPrefsKey="taxes_report_columns"
+				filters={ filters }
 			/>
 		);
 	}


### PR DESCRIPTION
### Problem

Configs have been mapped to appropriate files based on `endpoint` values to derive appropriate query objects. This worked well until Variations and Categories used the reports endpoint (`/reports/products`) while still having their own configs. 

I previously used mapping in various util functions to overcome this issue, which caused confusion and made changing things difficult, leading to the regression found in https://github.com/woocommerce/woocommerce-admin/issues/1847.

### Solution

Explicitly pass down `filters` and `advancedFilters` from report index files. This allows independent control over `endpoint` and relevant filter configs by decoupling the association.

This should make for easier debugging because inputs aren't being manipulated halfway through a process.

### Detailed test instructions:

1. Go to the category report
2. Compare a number of categories
3. Note the summary numbers at the bottom of the table match with other totals on the page.
4. Poke around other reports to ensure no regression has been introduced.

