### PR TITLE
Swap order of charts and leaderboards on the dashboard

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -23,8 +23,8 @@ export default class Dashboard extends Component {
 				<Header sections={ [ __( 'Dashboard', 'woocommerce-admin' ) ] } />
 				<ReportFilters query={ query } path={ path } />
 				<StorePerformance query={ query } />
-				<Leaderboards query={ query } />
 				<DashboardCharts query={ query } path={ path } />
+				<Leaderboards query={ query } />
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
Per the original designs - this swaps the order of charts and leaderboards section in the dashboard - Charts come first now. 

