### PR TITLE
Refactor notes controller and add ordering params

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -113,6 +113,8 @@ export default compose(
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
 			type: 'info,warning',
+			orderby: 'date',
+			order: 'desc',
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -11,6 +11,9 @@ export function getUnreadNotes( select ) {
 	const notesQuery = {
 		page: 1,
 		per_page: 1,
+		type: 'info,warning',
+		orderby: 'date',
+		order: 'desc',
 	};
 
 	const latestNote = getNotes( notesQuery );

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -121,7 +121,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', WC_Admin_Notes::get_notes_count( $type, $status ) );
+		$response->header( 'X-WP-Total', WC_Admin_Notes::get_notes_count( $query_args['type'], $query_args['status'] ) );
 
 		return $response;
 	}
@@ -136,6 +136,8 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$args            = array();
 		$args['order']   = $request['order'];
 		$args['orderby'] = $request['orderby'];
+		$args['type']    = isset( $request['type'] ) ? $request['type'] : array();
+		$args['status']  = isset( $request['status'] ) ? $request['status'] : array();
 
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date_created';
@@ -149,18 +151,6 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$args['page'] = isset( $request['page'] ) ? intval( $request['page'] ) : 1;
 		if ( $args['page'] <= 0 ) {
 			$args['page'] = 1;
-		}
-
-		$type = isset( $request['type'] ) ? $request['type'] : '';
-		$type = sanitize_text_field( $type );
-		if ( ! empty( $type ) ) {
-			$args['type'] = $type;
-		}
-
-		$status = isset( $request['status'] ) ? $request['status'] : '';
-		$status = sanitize_text_field( $status );
-		if ( ! empty( $status ) ) {
-			$args['status'] = $status;
 		}
 
 		/**
@@ -378,9 +368,13 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 		$params['status']   = array(
 			'description'       => __( 'Status of note.', 'woocommerce-admin' ),
-			'type'              => 'string',
-			'enum'              => WC_Admin_Note::get_allowed_statuses(),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'enum' => WC_Admin_Note::get_allowed_statuses(),
+				'type' => 'string',
+			),
 		);
 		return $params;
 	}

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -142,7 +142,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		$args['page'] = isset( $request['page'] ) ? intval( $request['page'] ) : 1;
-		if ( $page <= 0 ) {
+		if ( $args['page'] <= 0 ) {
 			$args['page'] = 1;
 		}
 

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -344,9 +344,13 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		);
 		$params['type']     = array(
 			'description'       => __( 'Type of note.', 'woocommerce-admin' ),
-			'type'              => 'string',
-			'enum'              => WC_Admin_Note::get_allowed_types(),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'enum' => WC_Admin_Note::get_allowed_types(),
+				'type' => 'string',
+			),
 		);
 		$params['status']   = array(
 			'description'       => __( 'Status of note.', 'woocommerce-admin' ),

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -133,24 +133,16 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function prepare_objects_query( $request ) {
-		$args            = array();
-		$args['order']   = $request['order'];
-		$args['orderby'] = $request['orderby'];
-		$args['type']    = isset( $request['type'] ) ? $request['type'] : array();
-		$args['status']  = isset( $request['status'] ) ? $request['status'] : array();
+		$args             = array();
+		$args['order']    = $request['order'];
+		$args['orderby']  = $request['orderby'];
+		$args['per_page'] = $request['per_page'];
+		$args['page']     = $request['page'];
+		$args['type']     = isset( $request['type'] ) ? $request['type'] : array();
+		$args['status']   = isset( $request['status'] ) ? $request['status'] : array();
 
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date_created';
-		}
-
-		$args['per_page'] = isset( $request['per_page'] ) ? intval( $request['per_page'] ) : 10;
-		if ( $args['per_page'] <= 0 ) {
-			$args['per_page'] = 10;
-		}
-
-		$args['page'] = isset( $request['page'] ) ? intval( $request['page'] ) : 1;
-		if ( $args['page'] <= 0 ) {
-			$args['page'] = 1;
 		}
 
 		/**

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -43,6 +43,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -137,6 +137,10 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		$args['order']   = $request['order'];
 		$args['orderby'] = $request['orderby'];
 
+		if ( 'date' === $args['orderby'] ) {
+			$args['orderby'] = 'date_created';
+		}
+
 		$args['per_page'] = isset( $request['per_page'] ) ? intval( $request['per_page'] ) : 10;
 		if ( $args['per_page'] <= 0 ) {
 			$args['per_page'] = 10;
@@ -325,6 +329,26 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	public function get_collection_params() {
 		$params             = array();
 		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['order']    = array(
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'default'           => 'desc',
+			'enum'              => array( 'asc', 'desc' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orderby']  = array(
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'default'           => 'date',
+			'enum'              => array(
+				'note_id',
+				'date',
+				'type',
+				'title',
+				'status',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 		$params['page']     = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
 			'type'              => 'integer',

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -277,7 +277,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	 * @param string $status Comma separated list of statuses.
 	 * @return array An array of objects containing a note id.
 	 */
-	public function get_notes_count( $type = '', $status = '' ) {
+	public function get_notes_count( $type = array(), $status = array() ) {
 		global $wpdb;
 
 		$where_clauses = $this->get_notes_where_clauses(

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -250,27 +250,21 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_notes( $args = array() ) {
 		global $wpdb;
 
-		$order   = isset( $args['order'] ) ? $args['order'] : 'DESC';
-		$orderby = isset( $args['orderby'] ) ? $args['orderby'] : 'date_created';
+		$defaults = array(
+			'per_page' => get_option( 'posts_per_page' ),
+			'page'     => 1,
+			'order'    => 'DESC',
+			'orderby'  => 'date_created',
+		);
+		$args     = wp_parse_args( $args, $defaults );
 
-		$per_page = isset( $args['per_page'] ) ? intval( $args['per_page'] ) : 10;
-		if ( $per_page <= 0 ) {
-			$per_page = 10;
-		}
-
-		$page = isset( $args['page'] ) ? intval( $args['page'] ) : 1;
-		if ( $page <= 0 ) {
-			$page = 1;
-		}
-
-		$offset = $per_page * ( $page - 1 );
-
+		$offset        = $args['per_page'] * ( $args['page'] - 1 );
 		$where_clauses = $this->get_notes_where_clauses( $args );
 
 		$query = $wpdb->prepare(
-			"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$orderby} {$order} LIMIT %d, %d",
+			"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
 			$offset,
-			$per_page
+			$args['per_page']
 		); // WPCS: unprepared SQL ok.
 
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -250,6 +250,9 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_notes( $args = array() ) {
 		global $wpdb;
 
+		$order   = isset( $args['order'] ) ? $args['order'] : 'DESC';
+		$orderby = isset( $args['orderby'] ) ? $args['orderby'] : 'date_created';
+
 		$per_page = isset( $args['per_page'] ) ? intval( $args['per_page'] ) : 10;
 		if ( $per_page <= 0 ) {
 			$per_page = 10;
@@ -265,7 +268,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$where_clauses = $this->get_notes_where_clauses( $args );
 
 		$query = $wpdb->prepare(
-			"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY note_id DESC LIMIT %d, %d",
+			"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$orderby} {$order} LIMIT %d, %d",
 			$offset,
 			$per_page
 		); // WPCS: unprepared SQL ok.

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -311,8 +311,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$allowed_types    = WC_Admin_Note::get_allowed_types();
 		$where_type_array = array();
 		if ( isset( $args['type'] ) ) {
-			$args_types = explode( ',', $args['type'] );
-			foreach ( (array) $args_types as $args_type ) {
+			foreach ( $args['type'] as $args_type ) {
 				$args_type = trim( $args_type );
 				if ( in_array( $args_type, $allowed_types, true ) ) {
 					$where_type_array[] = "'" . esc_sql( $args_type ) . "'";
@@ -323,8 +322,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 		$allowed_statuses   = WC_Admin_Note::get_allowed_statuses();
 		$where_status_array = array();
 		if ( isset( $args['status'] ) ) {
-			$args_statuses = explode( ',', $args['status'] );
-			foreach ( (array) $args_statuses as $args_status ) {
+			foreach ( $args['status'] as $args_status ) {
 				$args_status = trim( $args_status );
 				if ( in_array( $args_status, $allowed_statuses, true ) ) {
 					$where_status_array[] = "'" . esc_sql( $args_status ) . "'";

--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -86,7 +86,7 @@ class WC_Admin_Notes {
 	 * @param string $status Comma separated list of statuses.
 	 * @return int
 	 */
-	public static function get_notes_count( $type = '', $status = '' ) {
+	public static function get_notes_count( $type = array(), $status = array() ) {
 		$data_store = WC_Data_Store::load( 'admin-note' );
 		return $data_store->get_notes_count( $type, $status );
 	}

--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -112,7 +112,7 @@ class WC_Admin_Notes {
 		$data_store = WC_Data_Store::load( 'admin-note' );
 		$raw_notes  = $data_store->get_notes(
 			array(
-				'status' => WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED,
+				'status' => array( WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED ),
 			)
 		);
 		$now        = new DateTime();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -194,7 +194,7 @@ function wc_admin_print_script_settings() {
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
 		'currentUserData'   => $current_user_data,
-		'alertCount'        => WC_Admin_Notes::get_notes_count( 'error,update', 'unactioned' ),
+		'alertCount'        => WC_Admin_Notes::get_notes_count( array( 'error', 'update' ), array( 'unactioned' ) ),
 		'reviewsEnabled'    => get_option( 'woocommerce_enable_reviews' ),
 		'manageStock'       => get_option( 'woocommerce_manage_stock' ),
 		'commentModeration' => get_option( 'comment_moderation' ),

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -229,6 +229,44 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test ordering of notes.
+	 */
+	public function test_order_notes() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'orderby' => 'title',
+				'order'   => 'asc',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, count( $notes ) );
+		$this->assertEquals( $notes[0]['title'], 'PHPUNIT_TEST_NOTE_1_TITLE' );
+		$this->assertEquals( $notes[1]['title'], 'PHPUNIT_TEST_NOTE_2_TITLE' );
+		$this->assertEquals( $notes[2]['title'], 'PHPUNIT_TEST_NOTE_3_TITLE' );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'orderby' => 'status',
+				'order'   => 'desc',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 3, count( $notes ) );
+		$this->assertEquals( $notes[0]['status'], WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$this->assertEquals( $notes[1]['status'], WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED );
+		$this->assertEquals( $notes[2]['status'], WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+	}
+
+	/**
 	 * Test getting lots of notes without permission. It should fail.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
Fixes #1865 

* Refactors collection params in notes controller
* Adds `order` and `orderby` params to the controller and data store
* Sets the default order for inbox and unread notes

### Detailed test instructions:

1.  Make requests to the notes REST endpoint ``
2. Test with the `order` and `orderby` params.  Order by:
- note_id
- date
- type
- title
- status
3. Check that inbox is still working and ordered by date in descending order.
4. Read notes to mark the last read time.
5. Add a note that is not of type `info` or `warning`.
6. Make sure the unread indicator does not activate for that note.
7. Try making a request to the notes endpoint with an invalid `orderby` param to verify that the invalid error message shows.