### PR TITLE
Activity Panel: add overlay to product placeholder images

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -243,6 +243,26 @@
 			position: relative;
 			top: -42px;
 			border: 2px solid $white;
+			z-index: 2;
+		}
+
+		.woocommerce-review-activity-card__image-overlay__product {
+			display: inline-block;
+			height: 60px;
+			position: relative;
+			width: 60px;
+
+			&.is-placeholder::before {
+				background: $core-grey-dark-500;
+				border-radius: 50%;
+				content: '';
+				position: absolute;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				top: 0;
+				opacity: 0.1;
+			}
 		}
 	}
 
@@ -251,15 +271,17 @@
 			margin-top: $gap-smallest;
 		}
 
-		.woocommerce-activity-card__icon img.woocommerce-gravatar {
+		.woocommerce-review-activity-card__image-overlay__product .woocommerce-gravatar {
 			margin-left: 0;
 			width: 18px;
 			height: 18px;
 			left: 32px;
 			top: -28px;
+			z-index: 1;
 		}
 
-		.woocommerce-activity-card__icon img.woocommerce-product-image {
+		.woocommerce-review-activity-card__image-overlay__product,
+		.woocommerce-review-activity-card__image-overlay__product .woocommerce-product-image {
 			width: 38px;
 			height: 38px;
 		}

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -253,7 +253,7 @@
 			width: 60px;
 
 			&.is-placeholder::before {
-				background: $core-grey-dark-500;
+				background-color: $core-grey-dark-500;
 				border-radius: 50%;
 				content: '';
 				position: absolute;

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -3,12 +3,13 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
 import moment from 'moment';
-import { noop, isNull } from 'lodash';
+import { get, noop, isNull } from 'lodash';
 import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
 
@@ -84,10 +85,19 @@ class ReviewsPanel extends Component {
 			</Fragment>
 		);
 
+		const productImage = get( product, [ 'images', 0 ] ) || get( product, [ 'image' ] );
+		const productImageClasses = classnames(
+			'woocommerce-review-activity-card__image-overlay__product',
+			{
+				'is-placeholder': ! productImage || ! productImage.src,
+			}
+		);
 		const icon = (
 			<div className="woocommerce-review-activity-card__image-overlay">
 				<Gravatar user={ review.reviewer_email } size={ 24 } />
-				<ProductImage product={ product } />
+				<div className={ productImageClasses }>
+					<ProductImage product={ product } />
+				</div>
 			</div>
 		);
 


### PR DESCRIPTION
Fixes #1067.

Adds an overlay to placeholder product images in the _Reviews_ panel of the Activity Panel.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/54820253-c549c280-4c9e-11e9-90df-0137251f4b3a.png)

### Detailed test instructions
- Create a review in a product without an image and in a product with an image.
- Go to the _Reviews_ panel of the Activity Panel.
- Verify there is an overlay in the product placeholder image but it's not in the product with an image.