### PR TITLE
Support Sequential Order Numbers in Downloads Report order number filter

### DIFF
--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -30,6 +30,7 @@ class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
 	 */
 	public function get_collection_params() {
 		$params           = parent::get_collection_params();
+		// This needs to remain a string to support extensions that filter Order Number.
 		$params['number'] = array(
 			'description'       => __( 'Limit result set to orders matching part of an order number.', 'woocommerce-admin' ),
 			'type'              => 'string',

--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -32,8 +32,7 @@ class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
 		$params           = parent::get_collection_params();
 		$params['number'] = array(
 			'description'       => __( 'Limit result set to orders matching part of an order number.', 'woocommerce-admin' ),
-			'type'              => 'integer',
-			'sanitize_callback' => 'absint',
+			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $params;
@@ -51,15 +50,22 @@ class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
 
 		// Search by partial order number.
 		if ( ! empty( $request['number'] ) ) {
-			$order_ids = $wpdb->get_col(
+			$partial_number = trim( $request['number'] );
+			$limit          = intval( $args['posts_per_page'] );
+			$order_ids      = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->prefix}posts WHERE post_type = 'shop_order' AND ID LIKE %s",
-					intval( $request['number'] ) . '%'
+					"SELECT ID
+					FROM {$wpdb->prefix}posts
+					WHERE post_type = 'shop_order'
+					AND ID LIKE %s
+					LIMIT %d",
+					$wpdb->esc_like( absint( $partial_number ) ) . '%',
+					$limit
 				)
 			);
 
 			// Force WP_Query return empty if don't found any order.
-			$order_ids        = ! empty( $order_ids ) ? $order_ids : array( 0 );
+			$order_ids        = empty( $order_ids ) ? array( 0 ) : $order_ids;
 			$args['post__in'] = $order_ids;
 		}
 

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { isNaN } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -24,18 +23,11 @@ import { computeSuggestionMatch } from './utils';
 export default {
 	name: 'orders',
 	className: 'woocommerce-search__order-result',
-	inputType: 'number',
 	options( search ) {
 		let payload = '';
 		if ( search ) {
-			const number = parseInt( search );
-
-			if ( isNaN( number ) ) {
-				return;
-			}
-
 			const query = {
-				number,
+				number: search,
 				per_page: 10,
 			};
 			payload = stringifyQuery( query );

--- a/tests/api/orders.php
+++ b/tests/api/orders.php
@@ -46,7 +46,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'number' => $order->get_id(),
+				'number' => (string) $order->get_id(),
 			)
 		);
 


### PR DESCRIPTION
Fixes #1615.

This PR seeks to add support for Sequential Order Numbers when filtering the Downloads Report by order number.

It also introduces `order` and `limit` to the number filter query to avoid problems when there are many orders.

### Screenshots

![Screen Shot 2019-03-22 at 2 32 41 PM](https://user-images.githubusercontent.com/63922/54851399-6771a680-4caf-11e9-9219-5a5ff022fa87.png)

### Detailed test instructions:

_Note: It's easiest to test on the WCCOM data as it already has data populated by Sequential Order Numbers Pro._

- Without Sequential Order Numbers (or Pro) enabled
- Go to Downloads Report
- Add advanced filter "order number"
- Type a number that will match the beginning of an order ID (I used `3`)
- Verify that the matches are order IDs
- Verify the filter works
- Enable Sequential Order Numbers (or Pro)
- Go to Downloads Report
- Add advanced filter "order number"
- Type a number that will match the beginning of a sequential order number (I used `5`)
- Verify that the matches are order numbers
- Verify the filter works

Optionally test with the non-pro/free version of Sequential Order Numbers.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
