### PR TITLE
Hide chart name on smaller viewports and move interval select

### DIFF
--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -32,6 +32,9 @@
 			line-height: 18px;
 			margin-left: $gap;
 			margin-right: $gap;
+			@include breakpoint( '<960px' ) {
+				display: none;
+			}
 		}
 	}
 
@@ -74,16 +77,11 @@
 	min-height: 50px;
 	padding: 8px $gap 0 $gap;
 
-	@include breakpoint( '<782px' ) {
-		padding: 0 $gap;
-		margin-top: -8px;
-	}
-
-	@include breakpoint( '<782px' ) {
+	@include breakpoint( '<960px' ) {
 		border-right: 0;
 		min-height: 0;
-		order: 1;
-		width: 100%;
+		margin-left: 0;
+		padding-left: $gap / 2;
 	}
 
 	#wpbody & .components-select-control__input {

--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -75,6 +75,7 @@
 	padding: 8px $gap 0 $gap;
 
 	@include breakpoint( '<960px' ) {
+		width: 100%;
 		order: 1;
 		margin-top: -8px;
 		margin-left: 0;
@@ -118,6 +119,7 @@
 		}
 
 		.woocommerce-chart__interval-select {
+			width: auto;
 			order: 0;
 			margin-top: 0;
 		}

--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -32,9 +32,6 @@
 			line-height: 18px;
 			margin-left: $gap;
 			margin-right: $gap;
-			@include breakpoint( '<960px' ) {
-				display: none;
-			}
 		}
 	}
 
@@ -78,10 +75,12 @@
 	padding: 8px $gap 0 $gap;
 
 	@include breakpoint( '<960px' ) {
-		border-right: 0;
-		min-height: 0;
+		order: 1;
+		margin-top: -8px;
 		margin-left: 0;
 		padding-left: $gap / 2;
+		border-right: 0;
+		min-height: 0;
 	}
 
 	#wpbody & .components-select-control__input {
@@ -108,6 +107,19 @@
 		}
 		&:hover {
 			box-shadow: none !important;
+		}
+	}
+}
+
+@include breakpoint( '<960px' ) {
+	.woocommerce-summary + .woocommerce-chart {
+		.woocommerce-chart__title {
+			display: none;
+		}
+
+		.woocommerce-chart__interval-select {
+			order: 0;
+			margin-top: 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1574 

Hides the chart name on smaller viewports since it's already displayed in the summary numbers.

### Before
<img width="673" alt="Screen Shot 2019-03-25 at 3 25 42 PM" src="https://user-images.githubusercontent.com/10561050/54901773-6ee4ba00-4f12-11e9-80c0-215b9b3219e4.png">

### After
<img width="611" alt="Screen Shot 2019-03-25 at 3 25 22 PM" src="https://user-images.githubusercontent.com/10561050/54901772-6db38d00-4f12-11e9-985c-44e68f8d86b3.png">

### Detailed test instructions:

1. Narrow your viewport to <960px.
2. Visit any report page.
3. Note that the title is hidden on the chart, but visible in summary numbers, and interval box is correctly positioned to the left.

### Question

Should we extract some of these styles to a separate stylesheet under `ReportTable`?

If another source were to use the table components from our packages, summary items may not be included adjacent to a chart.  Hiding the chart title in this case would not make sense and may be more specific to our use case.