### PR TITLE
Don't query products all products for empty categories

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -730,6 +730,11 @@ class WC_Admin_Reports_Data_Store {
 				$cat_slugs[] = $product_cat->slug;
 			}
 		}
+
+		if ( empty( $cat_slugs ) ) {
+			return array();
+		}
+
 		$args = array(
 			'category' => $cat_slugs,
 			'limit'    => -1,
@@ -749,7 +754,7 @@ class WC_Admin_Reports_Data_Store {
 
 		if ( isset( $query_args['categories'] ) && is_array( $query_args['categories'] ) && count( $query_args['categories'] ) > 0 ) {
 			$included_products = $this->get_products_by_cat_ids( $query_args['categories'] );
-			$included_products = wc_list_pluck( $included_products, 'get_id' );
+			$included_products = empty( $included_products ) ? array( '-1' ) : wc_list_pluck( $included_products, 'get_id' );
 		}
 
 		if ( isset( $query_args['product_includes'] ) && is_array( $query_args['product_includes'] ) && count( $query_args['product_includes'] ) > 0 ) {


### PR DESCRIPTION
Fixes #1908 

Empty product categories were not filtering in product stats, affecting the products report when filtered by a category and category summary numbers.

This PR checks if no category slugs are found and adds `-1` to the products SQL query if a category param is set but no products are found.

### Before
<img width="821" alt="Screen Shot 2019-03-25 at 5 48 00 PM" src="https://user-images.githubusercontent.com/10561050/54910095-a2c9da80-4f26-11e9-869d-59a8660a5aa6.png">

### After
<img width="823" alt="Screen Shot 2019-03-25 at 5 47 10 PM" src="https://user-images.githubusercontent.com/10561050/54910091-9fceea00-4f26-11e9-97b4-37c3e13993d1.png">

### Detailed test instructions:

1. Create at least 2 categories with no products directly underneath (this can be a parent category as long as there are no products directly under it).
2. Make an order not in those categories.
3. Visit the categories report.
4. Check that the stats/summary numbers are correct on the Categories report and don't show revenue for the period with the 2 empty categories.