### PR TITLE
Add mocks path to the ignored patterns in Jest

### DIFF
--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -12,6 +12,9 @@
     "tinymce": "<rootDir>/tests/js/mocks/tinymce",
     "@woocommerce/(.*)": "<rootDir>/packages/$1/src"
   },
+  "modulePathIgnorePatterns": [
+    "<rootDir>/.*/__mocks__"
+  ],
   "setupFiles": [
     "<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/setup-globals.js",
     "<rootDir>/tests/js/setup-globals"


### PR DESCRIPTION
Fixes #1917.

Adds mock paths to [`modulePathIgnorePatterns`](https://jestjs.io/docs/en/configuration#modulepathignorepatterns-array-string) in Jest config preventing several warnings to appear when running tests.

### Detailed test instructions:
- Run `npm test` and verify there isn't any warning like this:
![image](https://user-images.githubusercontent.com/3616980/54995899-30113b80-4fc8-11e9-927a-d6d92f5e69d4.png)