### PR TITLE
Config: Enable Activity Panels and Alerts for plugin.

### DIFF
--- a/config/plugin.json
+++ b/config/plugin.json
@@ -1,9 +1,9 @@
 {
 	"features": {
-		"activity-panels": false,
+		"activity-panels": true,
 		"analytics": true,
 		"dashboard": true,
 		"devdocs": false,
-		"store-alerts": false
+		"store-alerts": true
 	}
 }


### PR DESCRIPTION
To prep for release to the .org repo, this PR enables Activity Panels and Store Alerts for the plugin build process.