### PR TITLE
Check if customer creation date is not null before formatting

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -474,7 +474,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			$customer                = new WC_Customer( $user_id );
 			$data['user_id']         = $user_id;
 			$data['username']        = $customer->get_username( 'edit' );
-			$data['date_registered'] = $customer->get_date_created( 'edit' )->date( WC_Admin_Reports_Interval::$sql_datetime_format );
+			$data['date_registered'] = $customer->get_date_created( 'edit' ) ? $customer->get_date_created( 'edit' )->date( WC_Admin_Reports_Interval::$sql_datetime_format ) : null;
 			$format[]                = '%d';
 			$format[]                = '%s';
 			$format[]                = '%s';


### PR DESCRIPTION
Fixes #1925 

Checks if the customer date exists before calling date formatting function on it.

### Detailed test instructions:

1. Import orders with associated registered customers.
2. Note that import succeeds despite not having imported users.
