### PR TITLE
Add onboarding task list to dashboard

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,10 +10,11 @@ import { Component, Fragment } from '@wordpress/element';
  */
 import './style.scss';
 import DashboardCharts from './dashboard-charts';
-import { H, ReportFilters } from '@woocommerce/components';
 import Header from 'header';
 import Leaderboards from './leaderboards';
+import { ReportFilters } from '@woocommerce/components';
 import StorePerformance from './store-performance';
+import TaskList from './task-list';
 
 export default class Dashboard extends Component {
 	render() {
@@ -24,20 +25,7 @@ export default class Dashboard extends Component {
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'woocommerce-admin' ) ] } />
 				{ window.wcAdminFeatures.onboarding && ! requiredTasksComplete ? (
-					<div className="woocommerce-task-list">
-						<div className="woocommerce-task-list__header">
-							<H className="woocommerce-task-list__header-title">
-								{ __( 'Welcome to the WooCommerce Dashboard', 'woocommerce-admin' ) }
-							</H>
-							<H className="woocommerce-task-list__header-subtitle">
-								{ __(
-									"Here we'll guide you through the remaining tasks " +
-										'to get your store ready for launch',
-									'woocommerce-admin'
-								) }
-							</H>
-						</div>
-					</div>
+					<TaskList />
 				) : (
 					<Fragment>
 						<ReportFilters query={ query } path={ path } />

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -20,7 +20,7 @@ export default class Dashboard extends Component {
 	render() {
 		const { query, path } = this.props;
 		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
-		const requiredTasksComplete = false;
+		const requiredTasksComplete = true;
 		return (
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'woocommerce-admin' ) ] } />

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,21 +10,42 @@ import { Component, Fragment } from '@wordpress/element';
  */
 import './style.scss';
 import DashboardCharts from './dashboard-charts';
+import { H, ReportFilters } from '@woocommerce/components';
 import Header from 'header';
 import Leaderboards from './leaderboards';
-import { ReportFilters } from '@woocommerce/components';
 import StorePerformance from './store-performance';
 
 export default class Dashboard extends Component {
 	render() {
 		const { query, path } = this.props;
+		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
+		const requiredTasksComplete = false;
 		return (
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'woocommerce-admin' ) ] } />
-				<ReportFilters query={ query } path={ path } />
-				<StorePerformance query={ query } />
-				<DashboardCharts query={ query } path={ path } />
-				<Leaderboards query={ query } />
+				{ window.wcAdminFeatures.onboarding && ! requiredTasksComplete ? (
+					<div className="woocommerce-task-list">
+						<div className="woocommerce-task-list__header">
+							<H className="woocommerce-task-list__header-title">
+								{ __( 'Welcome to the WooCommerce Dashboard', 'woocommerce-admin' ) }
+							</H>
+							<H className="woocommerce-task-list__header-subtitle">
+								{ __(
+									"Here we'll guide you through the remaining tasks " +
+										'to get your store ready for launch',
+									'woocommerce-admin'
+								) }
+							</H>
+						</div>
+					</div>
+				) : (
+					<Fragment>
+						<ReportFilters query={ query } path={ path } />
+						<StorePerformance query={ query } />
+						<DashboardCharts query={ query } path={ path } />
+						<Leaderboards query={ query } />
+					</Fragment>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal depdencies
+ */
+import './style.scss';
+import { H } from '@woocommerce/components';
+
+export default class TaskList extends Component {
+	render() {
+		return (
+			<div className="woocommerce-task-list">
+				<div className="woocommerce-task-list__header">
+					<H className="woocommerce-task-list__header-title">
+						{ __( 'Welcome to the WooCommerce Dashboard', 'woocommerce-admin' ) }
+					</H>
+					<H className="woocommerce-task-list__header-subtitle">
+						{ __(
+							"Here we'll guide you through the remaining tasks " +
+								'to get your store ready for launch',
+							'woocommerce-admin'
+						) }
+					</H>
+				</div>
+			</div>
+		);
+	}
+}

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -1,0 +1,14 @@
+/** @format */
+
+.woocommerce-task-list__header {
+	text-align: center;
+	padding-top: $gap-large;
+
+	h2 {
+		margin: $gap-small 0;
+	}
+
+	.woocommerce-task-list__header-subtitle {
+		font-weight: 400;
+	}
+}

--- a/config/core.json
+++ b/config/core.json
@@ -4,6 +4,7 @@
 		"analytics": false,
 		"dashboard": false,
 		"devdocs": false,
+		"onboarding": false,
 		"store-alerts": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,7 @@
 		"analytics": true,
 		"dashboard": true,
 		"devdocs": true,
+		"onboarding": true,
 		"store-alerts": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -4,6 +4,7 @@
 		"analytics": true,
 		"dashboard": true,
 		"devdocs": false,
+		"onboarding": false,
 		"store-alerts": true
 	}
 }


### PR DESCRIPTION
Fixes #1896 

* Adds a feature flag for onboarding
* Shows the tasklist in the dashboard if the feature flag is enabled and required tasks aren't yet complete (REST API not yet in place).
* Creates a `TaskList` component to house the task list items.

### Screenshots
<img width="1533" alt="Screen Shot 2019-03-27 at 3 20 48 PM" src="https://user-images.githubusercontent.com/10561050/55058908-62926580-50a8-11e9-9af3-ae0b85105101.png">


### Detailed test instructions:

1.  Run `npm start`.
2. Visit the dashboard page.
3. Check that the task list header is showing.
4. Run `npm run-script build:release` to build a non-dev version and make sure the dashboard analytics are showing.