### PR TITLE
Convert unreadReviews to a boolean so it doesn't render any character

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -333,11 +333,12 @@ export default withSelect( select => {
 
 		if ( ! isReviewsError && ! isReviewsRequesting ) {
 			numberOfReviews = totalReviews;
-			unreadReviews =
+			unreadReviews = Boolean(
 				reviews.length &&
-				reviews[ 0 ].date_created_gmt &&
-				new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
-					userData.activity_panel_reviews_last_read;
+					reviews[ 0 ].date_created_gmt &&
+					new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
+						userData.activity_panel_reviews_last_read
+			);
 		}
 	}
 


### PR DESCRIPTION
Fixes #1889.

Makes sure `unreadReviews` is a boolean. Otherwise when `reviews.length` was a `0`, it was a number that was later displayed to users.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/55096299-e86adc80-50b9-11e9-99ea-ec6520a8bf6c.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/55096327-f3257180-50b9-11e9-8157-c90e12b27d21.png)

### Detailed test instructions:
- Remove all reviews (comments) from your store.
- Go to any WooCommerce Admin page.
- Verify there is no `0` rendered after `Reviews`.