### PR TITLE
Add profile wizard base page

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -16,9 +16,16 @@ import Leaderboards from './leaderboards';
 import { ReportFilters } from '@woocommerce/components';
 import StorePerformance from './store-performance';
 import TaskList from './task-list';
+import ProfileWizard from './profile-wizard';
 
 export default class Dashboard extends Component {
 	renderDashboardOutput() {
+		// @todo This should be replaced by a check from the REST API response from #1897.
+		const profileWizardComplete = true;
+		if ( window.wcAdminFeatures.onboarding && ! profileWizardComplete ) {
+			return <ProfileWizard />;
+		}
+
 		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
 		const requiredTasksComplete = true;
 		if ( window.wcAdminFeatures.onboarding && ! requiredTasksComplete ) {

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal depdencies
+ */
+import './style.scss';
+import { H } from '@woocommerce/components';
+
+export default class ProfileWizard extends Component {
+	componentDidMount() {
+		const body = document.querySelector( '.wp-admin' );
+		body.classList.add( 'woocommerce-profile-wizard__body' );
+	}
+
+	componentWillUnmount() {
+		const body = document.querySelector( '.wp-admin' );
+		body.classList.remove( 'woocommerce-profile-wizard__body' );
+	}
+
+	render() {
+		return (
+			<div>
+				<H className="woocommerce-profile-wizard__header-title">
+					{ __(
+						'Go beyond the confines of traditional eCommerce solutions, and be limited only be your own imagination.',
+						'woocommerce-admin'
+					) }
+				</H>
+			</div>
+		);
+	}
+}

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -13,24 +13,27 @@ import { H } from '@woocommerce/components';
 
 export default class ProfileWizard extends Component {
 	componentDidMount() {
-		const body = document.querySelector( '.wp-admin' );
-		body.classList.add( 'woocommerce-profile-wizard__body' );
+		document.body.classList.add( 'woocommerce-profile-wizard__body' );
 	}
 
 	componentWillUnmount() {
-		const body = document.querySelector( '.wp-admin' );
-		body.classList.remove( 'woocommerce-profile-wizard__body' );
+		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
 	}
 
 	render() {
 		return (
-			<div>
+			<div className="woocommerce-profile-wizard__container">
 				<H className="woocommerce-profile-wizard__header-title">
+					{ __( 'Start setting up your WooCommerce store', 'woocommerce-admin' ) }
+				</H>
+
+				<p>
 					{ __(
-						'Go beyond the confines of traditional eCommerce solutions, and be limited only be your own imagination.',
+						'Simplify and enhance the setup of your store with features and benefits offered by Jetpack ' +
+							'& WooCommerce Services.',
 						'woocommerce-admin'
 					) }
-				</H>
+				</p>
 			</div>
 		);
 	}

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -1,0 +1,27 @@
+/** @format */
+
+.woocommerce-profile-wizard__body {
+	background: #1d232f;
+
+	.woocommerce-profile-wizard__header-title {
+		color: #fff;
+	}
+
+	#woocommerce-layout__primary {
+		text-align: center;
+		margin-left: auto;
+		margin-right: auto;
+		width: 70%;
+	}
+
+	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/
+	#adminmenumain,
+	#wpadminbar,
+	.woocommerce-layout__header {
+		display: none;
+	}
+
+	#wpcontent {
+		margin-left: 0;
+	}
+}

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -1,17 +1,33 @@
 /** @format */
 
 .woocommerce-profile-wizard__body {
-	background: #1d232f;
+	background: #342248;
+	color: #beabce;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		'Helvetica Neue', sans-serif;
 
 	.woocommerce-profile-wizard__header-title {
 		color: #fff;
+		font-size: 24px;
+		line-height: 32px;
+		font-weight: 400;
+	}
+
+	.woocommerce-profile-wizard__container {
+		p {
+			font-size: 16px;
+			line-height: 24px;
+			font-weight: 400;
+		}
 	}
 
 	#woocommerce-layout__primary {
 		text-align: center;
 		margin-left: auto;
 		margin-right: auto;
-		width: 70%;
+		@include breakpoint( '>960px' ) {
+			width: 70%;
+		}
 	}
 
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/


### PR DESCRIPTION
Fixes #1881.

It creates a base page for the profile wizard work, and does some magic so we can hide wp-admin/WooCommerce elements and take over the page visually.

### Screenshots

<img width="1008" alt="Screen Shot 2019-05-02 at 12 16 31 PM" src="https://user-images.githubusercontent.com/689165/57090640-42704a80-6cd5-11e9-9c04-cc457db431c0.png">

### Detailed test instructions:

* Change `const profileWizardComplete` to `false` in `client/dashboard/index.js`. Since the onboarding routes are still early and have no method for hiding them, these are defaulted to true.
* Run `npm start`.
* Visit the main `wc-admin` route/dashboard and note that the profile wizard page is shown instead of wp-admin.
