### PR TITLE
Sync: Avoid infinite loop when REPLACE-ing SQL rows

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -399,7 +399,8 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 			 */
 			do_action( 'woocommerce_reports_update_coupon', $coupon_id, $order_id );
 
-			$num_updated += intval( $result );
+			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
+			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
 		}
 
 		return ( $coupon_items_count === $num_updated );

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -431,7 +431,8 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		 */
 		do_action( 'woocommerce_reports_update_order_stats', $order->get_id() );
 
-		return ( 1 === $result );
+		// Check the rows affected for success. Using REPLACE can affect 2 rows if the row already exists.
+		return ( 1 === $result || 2 === $result );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -488,7 +488,8 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 				do_action( 'woocommerce_reports_update_product', $order_item_id, $order->get_id() );
 			}
 
-			$num_updated += intval( $result );
+			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
+			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
 		}
 
 		return ( count( $order_items ) === $num_updated );

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -360,7 +360,8 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 			 */
 			do_action( 'woocommerce_reports_update_tax', $tax_item->get_rate_id(), $order->get_id() );
 
-			$num_updated += intval( $result );
+			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
+			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
 		}
 
 		return ( count( $tax_items ) === $num_updated );


### PR DESCRIPTION
When the sync process uses `$wpdb->replace` the returned value is the number of affected rows. If the database row already exists this number will be `2`. This can occur if you rebuild your tables and you have guest customers. A new id is created and the row is replaced with a new row and an updated `customer_id`.

Checks to make sure the sync process went smoothly operated under the assumption of a successful `$wpdb->replace` always being `1`.

https://github.com/woocommerce/woocommerce-admin/blob/fc678aa68583bc7db4df5184d11aa03ca81b7b72/includes/class-wc-admin-reports-sync.php#L266-L284

This PR includes a check for a value of `2` as a success indicator.

Thanks @jeffstieler for the pre-flight hand holding while we tracked this one down.

### Detailed test instructions:

1. Make sure you have some guest checkouts.
2. Analytics > Settings > Rebuild reports.
3. Ensure that no infinite loop is kicked off. Previously, this would result in runaway creation of customers.

