### PR TITLE
Onboarding: Add levels REST API

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -52,55 +52,76 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 
 	/**
 	 * Get an array of all levels and child tasks.
+	 *
+	 * @todo Status values below should pull from the database task status once implemented.
 	 */
 	public function get_levels() {
 		$levels = array(
 			array(
-				'slug'  => '',
+				'id'    => 'account',
 				'tasks' => array(
 					array(
-						'slug'                     => '',
-						'description'              => '',
-						'illustration'             => '',
-						'status'                   => '',
-						'is_visible_conditional'   => '',
-						'in_progress_conditional'  => '',
-						'is_completed_conditional' => '',
-						'is_required'              => '',
+						'id'           => 'create_account',
+						'label'        => __( 'Create an account', 'woocommerce-admin' ),
+						'description'  => __( 'Speed up & secure your store', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => false,
 					),
 				),
 			),
 			array(
-				'slug'  => '',
+				'id'    => 'storefront',
 				'tasks' => array(
 					array(
-						'slug'                     => '',
-						'description'              => '',
-						'illustration'             => '',
-						'status'                   => '',
-						'is_visible_conditional'   => '',
-						'in_progress_conditional'  => '',
-						'is_completed_conditional' => '',
-						'is_required'              => '',
+						'id'           => 'add_products',
+						'label'        => __( 'Add your products', 'woocommerce-admin' ),
+						'description'  => __( 'Bring your store to life', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => true,
+					),
+					array(
+						'id'           => 'customize_appearance',
+						'label'        => __( 'Customize Appearance', 'woocommerce-admin' ),
+						'description'  => __( 'Ensure your store is on-brand', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => false,
 					),
 				),
 			),
 			array(
-				'slug'  => '',
+				'id'    => 'checkout',
 				'tasks' => array(
 					array(
-						'slug'                     => '',
-						'description'              => '',
-						'illustration'             => '',
-						'status'                   => '',
-						'is_visible_conditional'   => '',
-						'in_progress_conditional'  => '',
-						'is_completed_conditional' => '',
-						'is_required'              => '',
+						'id'           => 'configure_shipping',
+						'label'        => __( 'Configure shipping', 'woocommerce-admin' ),
+						'description'  => __( 'Set up prices and destinations', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => true,
+					),
+					array(
+						'id'           => 'configure_taxes',
+						'label'        => __( 'Configure taxes', 'woocommerce-admin' ),
+						'description'  => __( 'Set up sales tax rates', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => false,
+					),
+					array(
+						'id'           => 'configure_payments',
+						'label'        => __( 'Configure payments', 'woocommerce-admin' ),
+						'description'  => __( 'Choose payment providers', 'woocommerce-admin' ),
+						'illustration' => '',
+						'status'       => 'visible',
+						'is_required'  => true,
 					),
 				),
 			),
 		);
+
 		return apply_filters( 'woocommerce_onboarding_levels', $levels );
 	}
 
@@ -162,7 +183,7 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	protected function prepare_links( $item ) {
 		$links = array(
 			'collection' => array(
-				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+				'href' => rest_url( sprintf( '/%s/onboarding/tasks?level=%s', $this->namespace, $item['id'] ) ),
 			),
 		);
 		return $links;
@@ -179,17 +200,53 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 			'title'      => 'onboarding_level',
 			'type'       => 'object',
 			'properties' => array(
-				'slug' => array(
+				'id'    => array(
 					'type'        => 'string',
-					'description' => __( 'Level slug.', 'woocommerce-admin' ),
+					'description' => __( 'Level ID.', 'woocommerce-admin' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'tasks' => array(
 					'type'        => 'array',
-					'description' => __( 'Array of task under the level.', 'woocommerce-admin' ),
+					'description' => __( 'Array of tasks under the level.', 'woocommerce-admin' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Task ID.', 'woocommerce-admin' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'label'  => array(
+								'description' => __( 'Task label.', 'woocommerce-admin' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'description'  => array(
+								'description' => __( 'Task description.', 'woocommerce-admin' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'illustration'  => array(
+								'description' => __( 'URL for illustration used.', 'woocommerce-admin' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'status'  => array(
+								'description' => __( 'Task status.', 'woocommerce-admin' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'enum'        => array( 'visible', 'hidden', 'in-progress', 'skipped', 'completed' ),
+							),
+						),
+					),
 				),
 			),
 		);

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * REST API Data Download IP Controller
+ * REST API Onboarding Levels Controller
  *
- * Handles requests to /data/download-ips
+ * Handles requests to /onboarding/levels
  *
  * @package WooCommerce Admin/API
  */
@@ -10,12 +10,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Data Download IP controller.
+ * Onboarding Levels controller.
  *
  * @package WooCommerce Admin/API
  * @extends WC_REST_Data_Controller
  */
-class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller {
+class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller {
 	/**
 	 * Endpoint namespace.
 	 *
@@ -28,7 +28,7 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'data/download-ips';
+	protected $rest_base = 'onboarding/levels';
 
 	/**
 	 * Register routes.
@@ -51,7 +51,61 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	}
 
 	/**
-	 * Return the download IPs matching the passed parameters.
+	 * Get an array of all levels and child tasks.
+	 */
+	public function get_levels() {
+		$levels = array(
+			array(
+				'slug'  => '',
+				'tasks' => array(
+					array(
+						'slug'                     => '',
+						'description'              => '',
+						'illustration'             => '',
+						'status'                   => '',
+						'is_visible_conditional'   => '',
+						'in_progress_conditional'  => '',
+						'is_completed_conditional' => '',
+						'is_required'              => '',
+					),
+				),
+			),
+			array(
+				'slug'  => '',
+				'tasks' => array(
+					array(
+						'slug'                     => '',
+						'description'              => '',
+						'illustration'             => '',
+						'status'                   => '',
+						'is_visible_conditional'   => '',
+						'in_progress_conditional'  => '',
+						'is_completed_conditional' => '',
+						'is_required'              => '',
+					),
+				),
+			),
+			array(
+				'slug'  => '',
+				'tasks' => array(
+					array(
+						'slug'                     => '',
+						'description'              => '',
+						'illustration'             => '',
+						'status'                   => '',
+						'is_visible_conditional'   => '',
+						'in_progress_conditional'  => '',
+						'is_completed_conditional' => '',
+						'is_required'              => '',
+					),
+				),
+			),
+		);
+		return apply_filters( 'woocommerce_onboarding_levels', $levels );
+	}
+
+	/**
+	 * Return all level items and child tasks.
 	 *
 	 * @since  3.5.0
 	 * @param  WP_REST_Request $request Request data.
@@ -60,24 +114,12 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	public function get_items( $request ) {
 		global $wpdb;
 
-		if ( isset( $request['match'] ) ) {
-			$downloads = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT DISTINCT( user_ip_address ) FROM {$wpdb->prefix}wc_download_log
-					WHERE user_ip_address LIKE %s
-					LIMIT 10",
-					$request['match'] . '%'
-				)
-			);
-		} else {
-			return new WP_Error( 'woocommerce_rest_data_download_ips_invalid_request', __( 'Invalid request. Please pass the match parameter.', 'woocommerce-admin' ), array( 'status' => 400 ) );
-		}
+		$levels = $this->get_levels();
+		$data   = array();
 
-		$data = array();
-
-		if ( ! empty( $downloads ) ) {
-			foreach ( $downloads as $download ) {
-				$response = $this->prepare_item_for_response( $download, $request );
+		if ( ! empty( $levels ) ) {
+			foreach ( $levels as $level ) {
+				$response = $this->prepare_item_for_response( $level, $request );
 				$data[]   = $this->prepare_response_for_collection( $response );
 			}
 		}
@@ -107,7 +149,7 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 		 * @param array            $item     The original item.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_data_download_ip', $response, $item, $request );
+		return apply_filters( 'woocommerce_rest_prepare_onboarding_level', $response, $item, $request );
 	}
 
 	/**
@@ -115,6 +157,7 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	 *
 	 * @param object $item Data object.
 	 * @return array Links for the given object.
+	 * @todo Check to make sure this generates a valid URL after #1897.
 	 */
 	protected function prepare_links( $item ) {
 		$links = array(
@@ -126,23 +169,6 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	}
 
 	/**
-	 * Get the query params for collections.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$params            = array();
-		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['match']   = array(
-			'description'       => __( 'A partial IP address can be passed and matching results will be returned.', 'woocommerce-admin' ),
-			'type'              => 'string',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		return $params;
-	}
-
-
-	/**
 	 * Get the schema, conforming to JSON Schema.
 	 *
 	 * @return array
@@ -150,12 +176,18 @@ class WC_Admin_REST_Data_Download_Ips_Controller extends WC_REST_Data_Controller
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'data_download_ips',
+			'title'      => 'onboarding_level',
 			'type'       => 'object',
 			'properties' => array(
-				'user_ip_address' => array(
+				'slug' => array(
 					'type'        => 'string',
-					'description' => __( 'IP address.', 'woocommerce-admin' ),
+					'description' => __( 'Level slug.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'tasks' => array(
+					'type'        => 'array',
+					'description' => __( 'Array of task under the level.', 'woocommerce-admin' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -32,8 +32,6 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 
 	/**
 	 * Register routes.
-	 *
-	 * @since 3.5.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -128,7 +126,6 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	/**
 	 * Return all level items and child tasks.
 	 *
-	 * @since  3.5.0
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
@@ -151,7 +148,6 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	/**
 	 * Prepare the data object for response.
 	 *
-	 * @since  3.5.0
 	 * @param object          $item Data object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -214,13 +214,13 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'id' => array(
+							'id'           => array(
 								'description' => __( 'Task ID.', 'woocommerce-admin' ),
 								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'label'  => array(
+							'label'        => array(
 								'description' => __( 'Task label.', 'woocommerce-admin' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -55,11 +55,9 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	 */
 	public function get_levels() {
 		$levels = array(
-			array(
-				'id'    => 'account',
+			'account'    => array(
 				'tasks' => array(
-					array(
-						'id'           => 'create_account',
+					'create_account' => array(
 						'label'        => __( 'Create an account', 'woocommerce-admin' ),
 						'description'  => __( 'Speed up & secure your store', 'woocommerce-admin' ),
 						'illustration' => '',
@@ -68,19 +66,16 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 					),
 				),
 			),
-			array(
-				'id'    => 'storefront',
+			'storefront' => array(
 				'tasks' => array(
-					array(
-						'id'           => 'add_products',
+					'add_products'         => array(
 						'label'        => __( 'Add your products', 'woocommerce-admin' ),
 						'description'  => __( 'Bring your store to life', 'woocommerce-admin' ),
 						'illustration' => '',
 						'status'       => 'visible',
 						'is_required'  => true,
 					),
-					array(
-						'id'           => 'customize_appearance',
+					'customize_appearance' => array(
 						'label'        => __( 'Customize Appearance', 'woocommerce-admin' ),
 						'description'  => __( 'Ensure your store is on-brand', 'woocommerce-admin' ),
 						'illustration' => '',
@@ -89,27 +84,24 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 					),
 				),
 			),
-			array(
+			'checkout'   => array(
 				'id'    => 'checkout',
 				'tasks' => array(
-					array(
-						'id'           => 'configure_shipping',
+					'configure_shipping' => array(
 						'label'        => __( 'Configure shipping', 'woocommerce-admin' ),
 						'description'  => __( 'Set up prices and destinations', 'woocommerce-admin' ),
 						'illustration' => '',
 						'status'       => 'visible',
 						'is_required'  => true,
 					),
-					array(
-						'id'           => 'configure_taxes',
+					'configure_taxes'    => array(
 						'label'        => __( 'Configure taxes', 'woocommerce-admin' ),
 						'description'  => __( 'Set up sales tax rates', 'woocommerce-admin' ),
 						'illustration' => '',
 						'status'       => 'visible',
 						'is_required'  => false,
 					),
-					array(
-						'id'           => 'configure_payments',
+					'configure_payments' => array(
 						'label'        => __( 'Configure payments', 'woocommerce-admin' ),
 						'description'  => __( 'Choose payment providers', 'woocommerce-admin' ),
 						'illustration' => '',
@@ -136,7 +128,8 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 		$data   = array();
 
 		if ( ! empty( $levels ) ) {
-			foreach ( $levels as $level ) {
+			foreach ( $levels as $id => $level ) {
+				$level    = $this->convert_to_non_associative( $level, $id );
 				$response = $this->prepare_item_for_response( $level, $request );
 				$data[]   = $this->prepare_response_for_collection( $response );
 			}
@@ -167,6 +160,25 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
 		return apply_filters( 'woocommerce_rest_prepare_onboarding_level', $response, $item, $request );
+	}
+
+	/**
+	 * Convert the associative levels and tasks to non-associative for JSON use.
+	 *
+	 * @param array  $item Level.
+	 * @param string $id Level ID.
+	 * @return array
+	 */
+	public function convert_to_non_associative( $item, $id ) {
+		$item = array( 'id' => $id ) + $item;
+
+		$tasks = array();
+		foreach ( $item['tasks'] as $key => $task ) {
+			$tasks[] = array( 'id' => $key ) + $task;
+		}
+		$item['tasks'] = $tasks;
+
+		return $item;
 	}
 
 	/**

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -105,6 +105,7 @@ class WC_Admin_Api_Init {
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-data-controller.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-data-countries-controller.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-data-download-ips-controller.php';
+		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-onboarding-levels-controller.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-orders-controller.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-products-controller.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/api/class-wc-admin-rest-product-categories-controller.php';
@@ -145,6 +146,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Data_Controller',
 				'WC_Admin_REST_Data_Countries_Controller',
 				'WC_Admin_REST_Data_Download_Ips_Controller',
+				'WC_Admin_REST_Onboarding_Levels_Controller',
 				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Categories_Controller',

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -9,8 +9,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Orders_Stats_Data_Store.
- *
- * @version  3.5.0
  */
 class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Store implements WC_Admin_Reports_Data_Store_Interface {
 

--- a/includes/interfaces/class-wc-admin-reports-data-store-interface.php
+++ b/includes/interfaces/class-wc-admin-reports-data-store-interface.php
@@ -2,7 +2,6 @@
 /**
  * Reports Data Store Interface
  *
- * @version  3.5.0
  * @package  WooCommerce Admin/Interface
  */
 

--- a/tests/api/onboarding-levels.php
+++ b/tests/api/onboarding-levels.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Onboarding Levels REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Onboarding Levels
+ */
+class WC_Tests_API_Onboarding_Levels extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v4/onboarding/levels';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that levels are returned by the endpoint.
+	 */
+	public function test_get_level_items() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'account', $data[0]['id'] );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 2, $properties );
+		$this->assert_item_schema( $properties );
+	}
+
+	/**
+	 * Asserts the item schema is correct.
+	 *
+	 * @param array $schema Item to check schema.
+	 */
+	public function assert_item_schema( $schema ) {
+		$this->assertArrayHasKey( 'id', $schema );
+		$this->assertArrayHasKey( 'tasks', $schema );
+
+		$task_properties = $schema['tasks']['items']['properties'];
+		$this->assertCount( 5, $task_properties );
+		$this->assertArrayHasKey( 'id', $task_properties );
+		$this->assertArrayHasKey( 'label', $task_properties );
+		$this->assertArrayHasKey( 'description', $task_properties );
+		$this->assertArrayHasKey( 'illustration', $task_properties );
+		$this->assertArrayHasKey( 'status', $task_properties );
+	}
+
+	/**
+	 * Test that levels response changes based on applied filters.
+	 */
+	public function test_filter_levels() {
+		wp_set_current_user( $this->user );
+
+		add_filter(
+			'woocommerce_onboarding_levels',
+			function( $levels ) {
+				$levels[] = array(
+					'id' => 'test_level',
+				);
+				return $levels;
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'test_level', end( $data )['id'] );
+
+	}
+}

--- a/tests/api/onboarding-levels.php
+++ b/tests/api/onboarding-levels.php
@@ -88,8 +88,9 @@ class WC_Tests_API_Onboarding_Levels extends WC_REST_Unit_Test_Case {
 		add_filter(
 			'woocommerce_onboarding_levels',
 			function( $levels ) {
-				$levels[] = array(
-					'id' => 'test_level',
+				$levels['test_level'] = array(
+					'id'    => 'test_level',
+					'tasks' => array(),
 				);
 				return $levels;
 			}

--- a/tests/framework/helpers/class-wc-test-action-queue.php
+++ b/tests/framework/helpers/class-wc-test-action-queue.php
@@ -2,7 +2,6 @@
 /**
  * Action Queue Test Helper
  *
- * @version 3.5.0
  * @package WooCommerce/Tests
  */
 


### PR DESCRIPTION
Fixes (part of) #1897

Adds the levels API to request all levels and related tasks.

### Screenshots
<img width="767" alt="Screen Shot 2019-03-28 at 4 57 47 PM" src="https://user-images.githubusercontent.com/10561050/55143888-a2c21880-517a-11e9-9799-075f771dafdd.png">


### Detailed test instructions:

1.  Make a GET request to `/wp-json/wc/v4/onboarding/levels`.
2.  Make sure you get a valid response with intial levels and tasks.
3.  Check that tests are passing.

### Questions / Thoughts

@justinshreve I followed your outline in #1897 pretty closely which was fantastic and very thorough- thanks!  I made a couple minor changes in this PR, but mainly wanted to get your thoughts on conditional fields.

I removed all conditional fields in tasks.  I may have misunderstand the purpose of these, but my thinking is two-fold:
   1. We can change the status using the `woocommerce_onboarding_levels` filter if we want to verify that something is complete or should be hidden.  We can also conditionally remove a task entirely if conditions are met.
  2.  Other status changes that we don't want to handle on API request we can handle prior to this request by updating the `wp_wc_task_status` table.

What do you think?
