### PR TITLE
Cast order totals as floats when calculating net total

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -493,11 +493,11 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 	 * @return float
 	 */
 	protected static function get_net_total( $order ) {
-		$net_total = $order->get_total() - $order->get_total_tax() - $order->get_shipping_total();
+		$net_total = floatval( $order->get_total() ) - floatval( $order->get_total_tax() ) - floatval( $order->get_shipping_total() );
 
 		$refunds = $order->get_refunds();
 		foreach ( $refunds as $refund ) {
-			$net_total += $refund->get_total() - $refund->get_total_tax() - $refund->get_shipping_total();
+			$net_total += floatval( $refund->get_total() ) - floatval( $refund->get_total_tax() ) - floatval( $refund->get_shipping_total() );
 		}
 
 		return $net_total > 0 ? (float) $net_total : 0;


### PR DESCRIPTION
Fixes #1944

Cast to float values just in case nothing is returned when shipping total is not set.

### Detailed test instructions:

1.  Create a site with no shipping methods (this seems to work for me, but not sure if other factors are at play here).
2.  Create an order.
3.  Make sure the non-numerical warning is not logged.