### PR TITLE
Activity Panel: Reviews tab fixes

### DIFF
--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -84,6 +84,23 @@ export function getUnreadReviews( select ) {
 						userData.activity_panel_reviews_last_read
 			);
 		}
+
+		if ( ! hasUnreadReviews && '1' === wcSettings.commentModeration ) {
+			const actionableReviewsQuery = {
+				page: 1,
+				// @todo we are not using this review, so when the endpoint supports it,
+				// it could be replaced with `per_page: 0`
+				per_page: 1,
+				status: 'hold',
+			};
+			const totalActionableReviews = getReviewsTotalCount( actionableReviewsQuery );
+			const isActionableReviewsError = Boolean( getReviewsError( actionableReviewsQuery ) );
+			const isActionableReviewsRequesting = isGetReviewsRequesting( actionableReviewsQuery );
+
+			if ( ! isActionableReviewsError && ! isActionableReviewsRequesting ) {
+				hasUnreadReviews = totalActionableReviews > 0;
+			}
+		}
 	}
 
 	return { numberOfReviews, hasUnreadReviews };

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -24,7 +24,8 @@ export function getUnreadNotes( select ) {
 
 export function getUnreadOrders( select ) {
 	const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
-	const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || DEFAULT_ACTIONABLE_STATUSES;
+	const orderStatuses =
+		wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || DEFAULT_ACTIONABLE_STATUSES;
 
 	if ( ! orderStatuses.length ) {
 		return false;
@@ -76,11 +77,12 @@ export function getUnreadReviews( select ) {
 
 		if ( ! isReviewsError && ! isReviewsRequesting ) {
 			numberOfReviews = totalReviews;
-			hasUnreadReviews =
+			hasUnreadReviews = Boolean(
 				reviews.length &&
-				reviews[ 0 ].date_created_gmt &&
-				new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
-					userData.activity_panel_reviews_last_read;
+					reviews[ 0 ].date_created_gmt &&
+					new Date( reviews[ 0 ].date_created_gmt + 'Z' ).getTime() >
+						userData.activity_panel_reviews_last_read
+			);
 		}
 	}
 


### PR DESCRIPTION
Includes some fixes from #1930 and #1871 that were lost in a later merge.

### Screenshots #1930
_Before:_
![image](https://user-images.githubusercontent.com/3616980/55096299-e86adc80-50b9-11e9-99ea-ec6520a8bf6c.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/55096327-f3257180-50b9-11e9-8157-c90e12b27d21.png)

### Detailed test instructions for #1930
- Remove all reviews (comments) from your store.
- Go to any WooCommerce Admin page.
- Verify there is no `0` rendered after `Reviews`.

### Detailed test instructions for #1871
- Go to _Settings_ > _Discussion_ and check _Comment must be manually approved_.
- Create a product review.
- Go to any WooCommerce Admin page and verify an unread indicator (red dot) appears next to the _Reviews_ tab of the Activity Panel.
- Click on the tab and verify the new review appears and is marked with a red dot.
- Close the panel and verify the unread indicator persists.