### PR TITLE
Update Variations controller filter names

### DIFF
--- a/includes/api/class-wc-admin-rest-product-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-product-variations-controller.php
@@ -62,13 +62,13 @@ class WC_Admin_REST_Product_Variations_Controller extends WC_REST_Product_Variat
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		add_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_filter' ), 10, 2 );
-		add_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_join' ), 10, 2 );
-		add_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_group_by' ), 10, 2 );
+		add_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_filter' ), 10, 2 );
+		add_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_join' ), 10, 2 );
+		add_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
-		remove_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_filter' ), 10 );
-		remove_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_join' ), 10 );
-		remove_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_group_by' ), 10 );
+		remove_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_filter' ), 10 );
+		remove_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_join' ), 10 );
+		remove_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_group_by' ), 10 );
 		return $response;
 	}
 }


### PR DESCRIPTION
Fixes #1948.

In #1866 we updated `WC_Admin_REST_Products_Controller` method names, but we also need to update those names when they are called from `WC_Admin_REST_Product_Variations_Controller`.

### Detailed test instructions:
1. Go to the _Products_ report.
2. Select _Single Product_ filter and choose a variable product.
3. Select _Comparison_ as the second filter.
4. Write something in the _Compare Variations_ input.
5. Verify the server doesn't return with an error.
