### PR TITLE
Fix SKU sorting in the Variations report when a comparison is active

### DIFF
--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -40,7 +40,7 @@ export default class VariationsReportTable extends Component {
 				label: __( 'SKU', 'woocommerce-admin' ),
 				key: 'sku',
 				hiddenByDefault: true,
-               isSortable: true,
+				isSortable: true,
 			},
 			{
 				label: __( 'Items Sold', 'woocommerce-admin' ),

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -93,30 +93,6 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	}
 
 	/**
-	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
-	 *
-	 * @param array $query_args Parameters supplied by the user.
-	 * @return array
-	 */
-	protected function get_order_by_sql_params( $query_args ) {
-		global $wpdb;
-		$order_product_lookup_table = $wpdb->prefix . self::TABLE_NAME;
-
-		$sql_query['order_by_clause'] = '';
-		if ( isset( $query_args['orderby'] ) ) {
-			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
-		}
-
-		if ( isset( $query_args['order'] ) ) {
-			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
-		} else {
-			$sql_query['order_by_clause'] .= ' DESC';
-		}
-
-		return $sql_query;
-	}
-
-	/**
 	 * Fills FROM clause of SQL request based on user supplied parameters.
 	 *
 	 * @param array  $query_args Parameters supplied by the user.

--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -79,30 +79,6 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 	}
 
 	/**
-	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
-	 *
-	 * @param array $query_args Parameters supplied by the user.
-	 * @return array
-	 */
-	protected function get_order_by_sql_params( $query_args ) {
-		global $wpdb;
-		$order_product_lookup_table = $wpdb->prefix . self::TABLE_NAME;
-
-		$sql_query['order_by_clause'] = '';
-		if ( isset( $query_args['orderby'] ) ) {
-			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
-		}
-
-		if ( isset( $query_args['order'] ) ) {
-			$sql_query['order_by_clause'] .= ' ' . $query_args['order'];
-		} else {
-			$sql_query['order_by_clause'] .= ' DESC';
-		}
-
-		return $sql_query;
-	}
-
-	/**
 	 * Fills FROM clause of SQL request based on user supplied parameters.
 	 *
 	 * @param array  $query_args Parameters supplied by the user.

--- a/includes/data-stores/class-wc-admin-reports-variations-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-variations-data-store.php
@@ -81,12 +81,12 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 	/**
 	 * Fills ORDER BY clause of SQL request based on user supplied parameters.
 	 *
-	 * @param array  $query_args    Parameters supplied by the user.
-	 * @param string $from_arg_name Name of the FROM sql param.
+	 * @param array  $query_args Parameters supplied by the user.
+	 * @param string $from_arg   Name of the FROM sql param.
 	 *
 	 * @return array
 	 */
-	protected function get_order_by_sql_params( $query_args, $from_arg_name ) {
+	protected function get_order_by_sql_params( $query_args, $from_arg ) {
 		global $wpdb;
 		$order_product_lookup_table = $wpdb->prefix . self::TABLE_NAME;
 
@@ -95,8 +95,8 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 			$sql_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
 		}
 
-		if ( 'meta_value' === $sql_query['order_by_clause'] ) {
-			$sql_query['from_clause'] .= " JOIN {$wpdb->prefix}postmeta AS postmeta ON {$order_product_lookup_table}.variation_id = postmeta.post_id AND postmeta.meta_key = '_sku'";
+		if ( 'postmeta.meta_value' === $sql_query['order_by_clause'] ) {
+			$sql_query[ $from_arg ] .= " JOIN {$wpdb->prefix}postmeta AS postmeta ON {$order_product_lookup_table}.variation_id = postmeta.post_id AND postmeta.meta_key = '_sku'";
 		}
 
 		if ( isset( $query_args['order'] ) ) {
@@ -111,12 +111,10 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 	/**
 	 * Updates the database query with parameters used for Products report: categories and order status.
 	 *
-	 * @param array  $query_args Query arguments supplied by the user.
-	 * @param string $from_arg   Name of the FROM sql param.
-	 *
-	 * @return array             Array of parameters used for SQL query.
+	 * @param array $query_args Query arguments supplied by the user.
+	 * @return array Array of parameters used for SQL query.
 	 */
-	protected function get_sql_query_params( $query_args, $from_arg ) {
+	protected function get_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_product_lookup_table = $wpdb->prefix . self::TABLE_NAME;
 
@@ -143,7 +141,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 
 		$order_status_filter                   = $this->get_status_subquery( $query_args );
 		if ( $order_status_filter ) {
-			$sql_query_params[ $from_arg ]    .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
+			$sql_query_params['from_clause']  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
 			$sql_query_params['where_clause'] .= " AND ( {$order_status_filter} )";
 			$sql_query_params['where_clause'] .= ' AND variation_id > 0';
 		}
@@ -264,7 +262,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 			$included_products = $this->get_included_products_array( $query_args );
 
 			if ( count( $included_products ) > 0 && count( $query_args['variations'] ) > 0 ) {
-				$sql_query_params = $this->get_sql_query_params( $query_args, 'from_clause' );
+				$sql_query_params = $this->get_sql_query_params( $query_args );
 
 				if ( 'date' === $query_args['orderby'] ) {
 					$selections .= ", {$table_name}.date_created";
@@ -282,7 +280,7 @@ class WC_Admin_Reports_Variations_Data_Store extends WC_Admin_Reports_Data_Store
 				$right_join = "RIGHT JOIN ( {$ids_table} ) AS default_results
 					ON default_results.variation_id = {$table_name}.variation_id";
 			} else {
-				$sql_query_params = $this->get_sql_query_params( $query_args, 'from_clause' );
+				$sql_query_params = $this->get_sql_query_params( $query_args );
 
 				$db_records_count = (int) $wpdb->get_var(
 					"SELECT COUNT(*) FROM (


### PR DESCRIPTION
Follow-up of #1837.

Fix SKU sorting in the Variations report when a comparison is active.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/55293698-7f58d100-53f9-11e9-95df-deb802f24445.png)

### Detailed test instructions:
- First, you will need the fix from #1949, otherwise the Variations autocompleter doesn't work:
`git merge fix/1948-update-variations-controller-filter-names`
- Go to the _Products_ report and filter by a single product, select one that is a variable product.
- Once the variations appear on the table, enable the `sku` column and try sorting by it. Verify it works.
- Now, enable the variations comparison and select some of the comparisons in the input text box.
- Try sorting again by `sku` and verify it works.