### PR TITLE
getItems: modify parse flag by isUnboundedRequest

### DIFF
--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -36,16 +36,36 @@ function read( resourceNames, fetch = apiFetch ) {
 		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
 		const url = NAMESPACE + `/${ endpoint }${ stringifyQuery( query ) }`;
+		const isUnboundedRequest = -1 === query.per_page;
 
 		try {
 			const response = await fetch( {
-				parse: false,
+				/* eslint-disable max-len */
+				/**
+				 * A false parse flag allows a full response including headers which are useful
+				 * to determine totalCount. However, this invalidates an unbounded request, ie
+				 * `per_page: -1` by skipping middleware in apiFetch.
+				 *
+				 * See the Gutenberg code for more:
+				 * https://github.com/WordPress/gutenberg/blob/dee3dcf49028717b4af3164e3096bfe747c41ed2/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L39-L45
+				 */
+				/* eslint-enable max-len */
+				parse: isUnboundedRequest,
 				path: url,
 			} );
 
-			const items = await response.json();
+			let items;
+			let totalCount;
+
+			if ( isUnboundedRequest ) {
+				items = response;
+				totalCount = items.length;
+			} else {
+				items = await response.json();
+				totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
+			}
+
 			const ids = items.map( item => item.id );
-			const totalCount = parseInt( response.headers.get( 'x-wp-total' ) );
 			const itemResources = items.reduce( ( resources, item ) => {
 				resources[ getResourceName( `${ prefix }-item`, item.id ) ] = { data: item };
 				return resources;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/1953

Products and Categories reports tables weren't loading due to an error `/wc/v4/products/categories: per_page must be between 1 (inclusive) and 100 (inclusive)`.

https://github.com/woocommerce/woocommerce-admin/pull/1866 introduced a `parse: false` flag to `apiFetch` usage in `getItems`. This allows us to get the response headers but also invalidates the usage of `per_page: -1`. Below is a link to that logic.

https://github.com/WordPress/gutenberg/blob/dee3dcf49028717b4af3164e3096bfe747c41ed2/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L39-L45

This PR changes the logic to reflect the need for each case, ie when we need all the categories vs. when a paginated response along with totals is needed.

### Detailed test instructions:

1. Go to the Products Report and Categories Report and make sure the tables load.
2. Add at least some products that are considered low in stock.
3. Check that the unread indicator for the stock status is present.
