### PR TITLE
Scroll to top when navigating pages

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -104,6 +104,7 @@ class Controller extends Component {
 		const page = find( getPages(), { path } );
 		window.wpNavMenuUrlUpdate( page, query );
 		window.wpNavMenuClassChange( page );
+		window.document.documentElement.scrollTop = 0;
 		return createElement( page.container, { params, path: url, pathMatch: path, query } );
 	}
 }


### PR DESCRIPTION
Fixes #1956.

Scrolls the page to the top when navigating between reports.

### Detailed test instructions:

1. Go to the _Dashboard_.
2. Scroll to the bottom.
3. Go to _Analytics_ > _Revenue_, for example.
4. Verify the _Revenue_ report is scrolled to the top, so filters, summary numbers and chart are visible by default.

