### PR TITLE
Make customer name extendable

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -622,12 +622,13 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			return false;
 		}
 
-		$last_active = $customer->get_meta( 'wc_last_active', true, 'edit' );
-		$data        = array(
+		$customer_name = self::get_customer_name( $user_id, $customer->get_last_order() );
+		$last_active   = $customer->get_meta( 'wc_last_active', true, 'edit' );
+		$data          = array(
 			'user_id'          => $user_id,
 			'username'         => $customer->get_username( 'edit' ),
-			'first_name'       => $customer->get_first_name( 'edit' ),
-			'last_name'        => $customer->get_last_name( 'edit' ),
+			'first_name'       => $customer_name[0],
+			'last_name'        => $customer_name[1],
 			'email'            => $customer->get_email( 'edit' ),
 			'city'             => $customer->get_billing_city( 'edit' ),
 			'postcode'         => $customer->get_billing_postcode( 'edit' ),
@@ -635,7 +636,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			'date_registered'  => $customer->get_date_created( 'edit' )->date( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'date_last_active' => $last_active ? date( 'Y-m-d H:i:s', $last_active ) : null,
 		);
-		$format      = array(
+		$format        = array(
 			'%d',
 			'%s',
 			'%s',

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -540,7 +540,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			$last_name  = $order->get_shipping_last_name( 'edit' );
 		}
 
-		return apply_filters( 'woocommerce_customer_name', array( $first_name, $last_name ), $order );
+		return apply_filters( 'woocommerce_reports_customer_name', array( $first_name, $last_name ), $order );
 	}
 
 	/**

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -326,4 +326,80 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$this->assertCount( 1, $reports );
 		$this->assertEquals( $test_customers[0]->get_id(), $reports[0]['user_id'] );
 	}
+
+	/**
+	 * Test customer first and last name.
+	 */
+	public function test_customer_name() {
+		wp_set_current_user( $this->user );
+
+		$customer = wp_insert_user(
+			array(
+				'user_login' => 'daenerys',
+				'user_pass'  => null,
+				'role'       => 'customer',
+			)
+		);
+
+		// Test shipping name and empty billing name.
+		$order = WC_Helper_Order::create_order( $customer );
+		$order->set_billing_first_name( '' );
+		$order->set_billing_last_name( '' );
+		$order->set_shipping_first_name( 'Daenerys' );
+		$order->set_shipping_last_name( 'Targaryen' );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 );
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+		$this->assertEquals( 'Daenerys Targaryen', $reports[0]['name'] );
+
+		// Test billing name.
+		$order->set_billing_first_name( 'Jon' );
+		$order->set_billing_last_name( 'Snow' );
+		$order->save();
+		do_action( 'woocommerce_update_customer', $customer );
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'orderby' => 'username' ) ); // Cache busting.
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+		$this->assertEquals( 'Jon Snow', $reports[0]['name'] );
+
+		// Test user profile name.
+		wp_update_user(
+			array(
+				'ID'         => $customer,
+				'first_name' => 'Tyrion',
+				'last_name'  => 'Lanister',
+			)
+		);
+		do_action( 'woocommerce_update_customer', $customer );
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'orderby' => 'name' ) ); // Cache busting.
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+		$this->assertEquals( 'Tyrion Lanister', $reports[0]['name'] );
+	}
 }


### PR DESCRIPTION
Fixes #1579

* Cycles through each name option if one isn't available - billing, shipping, or user profile.
* Adds a filter to hook in and change a customer name.

### Screenshots
<img width="534" alt="Screen Shot 2019-04-02 at 6 56 46 PM" src="https://user-images.githubusercontent.com/10561050/55397553-1730f900-5579-11e9-98d3-a1a3abe7bbb3.png">
<img width="631" alt="Screen Shot 2019-04-02 at 6 56 34 PM" src="https://user-images.githubusercontent.com/10561050/55397554-17c98f80-5579-11e9-8955-1dc2b58be8cd.png">

### Detailed test instructions:

1. Add the checkout field editor plugin and make shipping/billing name fields optional.
2. Make a new order with each of the following and make sure that the customer name shows up.
  * Registered user name fields
  * Billing name fields
  * Shipping name fields