### PR TITLE
lookup product title in order meta if product has been deleted

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -190,7 +190,7 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 			$extended_info = new ArrayObject();
 			if ( $query_args['extended_info'] ) {
 				$product_id = $product_data['product_id'];
-				$product = wc_get_product( $product_id );
+				$product    = wc_get_product( $product_id );
 				// Product was deleted.
 				if ( ! $product ) {
 					if ( ! isset( $product_names[ $product_id ] ) ) {

--- a/includes/data-stores/class-wc-admin-reports-products-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-products-data-store.php
@@ -183,13 +183,33 @@ class WC_Admin_Reports_Products_Data_Store extends WC_Admin_Reports_Data_Store i
 	 * @param array $query_args  Query parameters.
 	 */
 	protected function include_extended_info( &$products_data, $query_args ) {
+		global $wpdb;
+		$product_names = array();
+
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new ArrayObject();
 			if ( $query_args['extended_info'] ) {
-				$product = wc_get_product( $product_data['product_id'] );
+				$product_id = $product_data['product_id'];
+				$product = wc_get_product( $product_id );
 				// Product was deleted.
 				if ( ! $product ) {
-					$products_data[ $key ]['extended_info']['name'] = __( '(Deleted)', 'woocommerce-admin' );
+					if ( ! isset( $product_names[ $product_id ] ) ) {
+						$product_names[ $product_id ] = $wpdb->get_var(
+							$wpdb->prepare(
+								"SELECT i.order_item_name
+								FROM {$wpdb->prefix}woocommerce_order_items i, {$wpdb->prefix}woocommerce_order_itemmeta m
+								WHERE i.order_item_id = m.order_item_id
+								AND m.meta_key = '_product_id'
+								AND m.meta_value = %s
+								ORDER BY i.order_item_id DESC
+								LIMIT 1",
+								$product_id
+							)
+						);
+					}
+
+					/* translators: %s is product name */
+					$products_data[ $key ]['extended_info']['name'] = $product_names[ $product_id ] ? sprintf( __( '%s (Deleted)', 'woocommerce-admin' ), $product_names[ $product_id ] ) : __( '(Deleted)', 'woocommerce-admin' );
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #1783 

This PR adds a DB query to lookup the last known product name used for a product that has been deleted from the database. To minimize queries, a local cache is used to ensure that only one query is run per deleted product. The product name is shown as `Sample Product (Deleted)`.


### Screenshots

<img width="277" alt="Screen Shot 2019-04-02 at 9 35 40 AM" src="https://user-images.githubusercontent.com/343847/55402817-c2669180-552a-11e9-95a1-09bc38fc8fa0.png">


### Detailed test instructions:

- Permanently delete a product that has been purchased.
- Enable the report rebuild data tool
- Rebuild report data
- Visit Analytics -> Products
- Select a date range including orders where the deleted product was purchased
- See product name in data table

