### PR TITLE
Allow negative values in charts

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,6 @@
 # (unreleased)
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
+- Chart component now accepts data with negative values.
 - Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
 - Expand search results and allow searching when input is refocused in autocompleter.
 

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -22,7 +22,7 @@ import {
 	getXScale,
 	getXGroupScale,
 	getXLineScale,
-	getYMax,
+	getYAxisLimits,
 	getYScale,
 } from './utils/scales';
 import { drawAxis } from './utils/axis';
@@ -57,18 +57,19 @@ class D3Chart extends Component {
 	}
 
 	getScaleParams( uniqueDates ) {
-		const { data, height, orderedKeys, chartType } = this.props;
+		const { baseValue, data, height, orderedKeys, chartType } = this.props;
 		const margin = this.getMargin();
 
 		const adjHeight = height - margin.top - margin.bottom;
 		const adjWidth = this.getWidth() - margin.left - margin.right;
-		const yMax = getYMax( data );
-		const yScale = getYScale( adjHeight, yMax );
+		const { upper: yMax, lower: yMin } = getYAxisLimits( data, baseValue );
+		const yScale = getYScale( adjHeight, yMin, yMax, baseValue );
 
 		if ( chartType === 'line' ) {
 			return {
 				xScale: getXLineScale( uniqueDates, adjWidth ),
 				yMax,
+				yMin,
 				yScale,
 			};
 		}
@@ -80,6 +81,7 @@ class D3Chart extends Component {
 			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
 			xScale,
 			yMax,
+			yMin,
 			yScale,
 		};
 	}
@@ -116,7 +118,7 @@ class D3Chart extends Component {
 	}
 
 	drawChart( node ) {
-		const { data, dateParser, chartType } = this.props;
+		const { baseValue, data, dateParser, chartType } = this.props;
 		const margin = this.getMargin();
 		const uniqueDates = getUniqueDates( data, dateParser );
 		const formats = this.getFormatParams();
@@ -130,7 +132,7 @@ class D3Chart extends Component {
 
 		this.createTooltip( g.node(), params.getColor, params.visibleKeys );
 
-		drawAxis( g, params, scales, formats, margin, isRTL() );
+		drawAxis( g, params, scales, formats, margin, baseValue, isRTL() );
 		chartType === 'line' && drawLines( g, data, params, scales, formats, this.tooltip );
 		chartType === 'bar' && drawBars( g, data, params, scales, formats, this.tooltip );
 	}

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -22,8 +22,8 @@ import {
 	getXScale,
 	getXGroupScale,
 	getXLineScale,
-	getYScaleLimits,
 	getYScale,
+	getYScaleLimits,
 } from './utils/scales';
 import { drawAxis } from './utils/axis';
 import { drawBars } from './utils/bar-chart';

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -22,7 +22,7 @@ import {
 	getXScale,
 	getXGroupScale,
 	getXLineScale,
-	getYAxisLimits,
+	getYScaleLimits,
 	getYScale,
 } from './utils/scales';
 import { drawAxis } from './utils/axis';
@@ -62,11 +62,12 @@ class D3Chart extends Component {
 
 		const adjHeight = height - margin.top - margin.bottom;
 		const adjWidth = this.getWidth() - margin.left - margin.right;
-		const { upper: yMax, lower: yMin } = getYAxisLimits( data );
+		const { upper: yMax, lower: yMin, step } = getYScaleLimits( data );
 		const yScale = getYScale( adjHeight, yMin, yMax );
 
 		if ( chartType === 'line' ) {
 			return {
+				step,
 				xScale: getXLineScale( uniqueDates, adjWidth ),
 				yMax,
 				yMin,
@@ -78,6 +79,7 @@ class D3Chart extends Component {
 		const xScale = getXScale( uniqueDates, adjWidth, compact );
 
 		return {
+			step,
 			xGroupScale: getXGroupScale( orderedKeys, xScale, compact ),
 			xScale,
 			yMax,

--- a/packages/components/src/chart/d3chart/chart.js
+++ b/packages/components/src/chart/d3chart/chart.js
@@ -57,13 +57,13 @@ class D3Chart extends Component {
 	}
 
 	getScaleParams( uniqueDates ) {
-		const { baseValue, data, height, orderedKeys, chartType } = this.props;
+		const { data, height, orderedKeys, chartType } = this.props;
 		const margin = this.getMargin();
 
 		const adjHeight = height - margin.top - margin.bottom;
 		const adjWidth = this.getWidth() - margin.left - margin.right;
-		const { upper: yMax, lower: yMin } = getYAxisLimits( data, baseValue );
-		const yScale = getYScale( adjHeight, yMin, yMax, baseValue );
+		const { upper: yMax, lower: yMin } = getYAxisLimits( data );
+		const yScale = getYScale( adjHeight, yMin, yMax );
 
 		if ( chartType === 'line' ) {
 			return {
@@ -118,7 +118,7 @@ class D3Chart extends Component {
 	}
 
 	drawChart( node ) {
-		const { baseValue, data, dateParser, chartType } = this.props;
+		const { data, dateParser, chartType } = this.props;
 		const margin = this.getMargin();
 		const uniqueDates = getUniqueDates( data, dateParser );
 		const formats = this.getFormatParams();
@@ -132,7 +132,7 @@ class D3Chart extends Component {
 
 		this.createTooltip( g.node(), params.getColor, params.visibleKeys );
 
-		drawAxis( g, params, scales, formats, margin, baseValue, isRTL() );
+		drawAxis( g, params, scales, formats, margin, isRTL() );
 		chartType === 'line' && drawLines( g, data, params, scales, formats, this.tooltip );
 		chartType === 'bar' && drawBars( g, data, params, scales, formats, this.tooltip );
 	}

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -29,10 +29,12 @@
 		margin: 0 auto;
 		max-width: 50%;
 		padding-bottom: 48px;
+		pointer-events: none;
 		position: absolute;
 		right: 0;
 		top: 0;
 		text-align: center;
+		z-index: 1;
 
 		@include breakpoint( '<782px' ) {
 			@include font-size( 13 );

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -129,13 +129,10 @@
 					stroke: $core-grey-dark-500;
 				}
 			}
-
-			&:last-child {
-				line {
-					opacity: 0;
-				}
-			}
 		}
+	}
+	.grid.with-positive-ticks .tick:last-child line {
+		opacity: 0;
 	}
 	.tick {
 		padding-top: 10px;

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -173,40 +173,36 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 	return diff;
 };
 
-const getNegativeYGrids = ( yMin, step ) => {
-	if ( yMin >= 0 ) {
-		return [];
-	}
+const calculateYGridValues = ( numberOfTicks, limit, roundValues ) => {
 	const grids = [];
-	const negativeTicks = yMin >= 0 ? 0 : Math.ceil( Math.abs( yMin ) / step );
 
-	for ( let i = 0; i < negativeTicks; i++ ) {
-		const val = ( i + 1 ) / negativeTicks * yMin;
-		const roundedVal = yMin < -1 ? Math.round( val ) : val;
-		if ( grids[ grids.length - 1 ] !== roundedVal ) {
-			grids.push( roundedVal );
+	for ( let i = 0; i < numberOfTicks; i++ ) {
+		const val = ( i + 1 ) / numberOfTicks * limit;
+		const rVal = roundValues ? Math.round( val ) : val;
+		if ( grids[ grids.length - 1 ] !== rVal ) {
+			grids.push( rVal );
 		}
 	}
 
 	return grids;
 };
 
+const getNegativeYGrids = ( yMin, step ) => {
+	if ( yMin >= 0 ) {
+		return [];
+	}
+
+	const numberOfTicks = Math.ceil( -yMin / step );
+	return calculateYGridValues( numberOfTicks, yMin, yMin < -1 );
+};
+
 const getPositiveYGrids = ( yMax, step ) => {
 	if ( yMax <= 0 ) {
 		return [];
 	}
-	const grids = [];
-	const positiveTicks = yMax <= 0 ? 0 : Math.ceil( Math.abs( yMax ) / step );
 
-	for ( let i = 0; i < positiveTicks; i++ ) {
-		const val = ( i + 1 ) / positiveTicks * yMax;
-		const roundedVal = yMax > 1 ? Math.round( val ) : val;
-		if ( grids[ grids.length - 1 ] !== roundedVal ) {
-			grids.push( roundedVal );
-		}
-	}
-
-	return grids;
+	const numberOfTicks = Math.ceil( yMax / step );
+	return calculateYGridValues( numberOfTicks, yMax, yMax > 1 );
 };
 
 export const getYGrids = ( yMin, yMax, step ) => {

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -173,16 +173,16 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 	return diff;
 };
 
-const getNegativeYGrids = ( yMin, baseValue, domain ) => {
-	if ( yMin >= baseValue ) {
+const getNegativeYGrids = ( yMin, domain ) => {
+	if ( yMin >= 0 ) {
 		return [];
 	}
 	const grids = [];
-	const negativeTicks = Math.ceil( yMin >= baseValue ? 0 : 3 * ( Math.abs( yMin - baseValue ) / domain ) );
+	const negativeTicks = Math.ceil( yMin >= 0 ? 0 : 3 * ( Math.abs( yMin ) / domain ) );
 
 	for ( let i = 0; i < negativeTicks; i++ ) {
-		const val = ( i + 1 ) / negativeTicks * ( yMin - baseValue ) + baseValue;
-		const value = yMin - baseValue < -1 ? Math.round( val ) : val;
+		const val = ( i + 1 ) / negativeTicks * yMin;
+		const value = yMin < -1 ? Math.round( val ) : val;
 		if ( grids[ grids.length - 1 ] !== value ) {
 			grids.push( value );
 		}
@@ -191,16 +191,16 @@ const getNegativeYGrids = ( yMin, baseValue, domain ) => {
 	return grids;
 };
 
-const getPositiveYGrids = ( yMax, baseValue, domain ) => {
-	if ( yMax <= baseValue ) {
+const getPositiveYGrids = ( yMax, domain ) => {
+	if ( yMax <= 0 ) {
 		return [];
 	}
 	const grids = [];
-	const positiveTicks = Math.ceil( yMax <= baseValue ? 0 : 3 * ( Math.abs( yMax - baseValue ) / domain ) );
+	const positiveTicks = Math.ceil( yMax <= 0 ? 0 : 3 * ( Math.abs( yMax ) / domain ) );
 
 	for ( let i = 0; i < positiveTicks; i++ ) {
-		const val = ( i + 1 ) / positiveTicks * ( yMax - baseValue ) + baseValue;
-		const value = yMax - baseValue > 1 ? Math.round( val ) : val;
+		const val = ( i + 1 ) / positiveTicks * yMax;
+		const value = yMax > 1 ? Math.round( val ) : val;
 		if ( grids[ grids.length - 1 ] !== value ) {
 			grids.push( value );
 		}
@@ -209,13 +209,13 @@ const getPositiveYGrids = ( yMax, baseValue, domain ) => {
 	return grids;
 };
 
-export const getYGrids = ( yMin, yMax, baseValue ) => {
-	const domain = Math.max( yMax, baseValue ) - Math.min( yMin, baseValue );
+export const getYGrids = ( yMin, yMax ) => {
+	const domain = yMax - yMin || 1;
 
 	const yGrids = [
-		baseValue,
-		...getNegativeYGrids( yMin, baseValue, domain ),
-		...getPositiveYGrids( yMax, baseValue, domain ),
+		0,
+		...getNegativeYGrids( yMin, domain ),
+		...getPositiveYGrids( yMax, domain ),
 	];
 
 	return yGrids;
@@ -273,12 +273,12 @@ const drawXAxis = ( node, params, scales, formats ) => {
 		);
 };
 
-const drawYAxis = ( node, scales, formats, margin, baseValue, isRTL ) => {
-	const yGrids = getYGrids( scales.yScale.domain()[ 0 ], scales.yScale.domain()[ 1 ], baseValue );
+const drawYAxis = ( node, scales, formats, margin, isRTL ) => {
+	const yGrids = getYGrids( scales.yScale.domain()[ 0 ], scales.yScale.domain()[ 1 ] );
 	const width = scales.xScale.range()[ 1 ];
 	const xPosition = isRTL ? width + margin.left + margin.right / 2 - 15 : -margin.left / 2 - 15;
 
-	const withPositiveValuesClass = scales.yMin >= baseValue || scales.yMax > baseValue ? ' with-positive-ticks' : '';
+	const withPositiveValuesClass = scales.yMin >= 0 || scales.yMax > 0 ? ' with-positive-ticks' : '';
 	node
 		.append( 'g' )
 		.attr( 'class', 'grid' + withPositiveValuesClass )
@@ -298,14 +298,14 @@ const drawYAxis = ( node, scales, formats, margin, baseValue, isRTL ) => {
 		.attr( 'text-anchor', 'start' )
 		.call(
 			d3AxisLeft( scales.yScale )
-				.tickValues( scales.yMax === baseValue && scales.yMin === baseValue ? [ yGrids[ 0 ] ] : yGrids )
+				.tickValues( scales.yMax === 0 && scales.yMin === 0 ? [ yGrids[ 0 ] ] : yGrids )
 				.tickFormat( d => formats.yFormat( d !== 0 ? d : 0 ) )
 		);
 };
 
-export const drawAxis = ( node, params, scales, formats, margin, baseValue, isRTL ) => {
+export const drawAxis = ( node, params, scales, formats, margin, isRTL ) => {
 	drawXAxis( node, params, scales, formats );
-	drawYAxis( node, scales, formats, margin, baseValue, isRTL );
+	drawYAxis( node, scales, formats, margin, isRTL );
 
 	node.selectAll( '.domain' ).remove();
 	node.selectAll( '.axis .tick line' ).remove();

--- a/packages/components/src/chart/d3chart/utils/axis.js
+++ b/packages/components/src/chart/d3chart/utils/axis.js
@@ -173,52 +173,48 @@ export const compareStrings = ( s1, s2, splitChar = new RegExp( [ ' |,' ], 'g' )
 	return diff;
 };
 
-const getNegativeYGrids = ( yMin, domain ) => {
+const getNegativeYGrids = ( yMin, step ) => {
 	if ( yMin >= 0 ) {
 		return [];
 	}
 	const grids = [];
-	const negativeTicks = Math.ceil( yMin >= 0 ? 0 : 3 * ( Math.abs( yMin ) / domain ) );
+	const negativeTicks = yMin >= 0 ? 0 : Math.ceil( Math.abs( yMin ) / step );
 
 	for ( let i = 0; i < negativeTicks; i++ ) {
 		const val = ( i + 1 ) / negativeTicks * yMin;
-		const value = yMin < -1 ? Math.round( val ) : val;
-		if ( grids[ grids.length - 1 ] !== value ) {
-			grids.push( value );
+		const roundedVal = yMin < -1 ? Math.round( val ) : val;
+		if ( grids[ grids.length - 1 ] !== roundedVal ) {
+			grids.push( roundedVal );
 		}
 	}
 
 	return grids;
 };
 
-const getPositiveYGrids = ( yMax, domain ) => {
+const getPositiveYGrids = ( yMax, step ) => {
 	if ( yMax <= 0 ) {
 		return [];
 	}
 	const grids = [];
-	const positiveTicks = Math.ceil( yMax <= 0 ? 0 : 3 * ( Math.abs( yMax ) / domain ) );
+	const positiveTicks = yMax <= 0 ? 0 : Math.ceil( Math.abs( yMax ) / step );
 
 	for ( let i = 0; i < positiveTicks; i++ ) {
 		const val = ( i + 1 ) / positiveTicks * yMax;
-		const value = yMax > 1 ? Math.round( val ) : val;
-		if ( grids[ grids.length - 1 ] !== value ) {
-			grids.push( value );
+		const roundedVal = yMax > 1 ? Math.round( val ) : val;
+		if ( grids[ grids.length - 1 ] !== roundedVal ) {
+			grids.push( roundedVal );
 		}
 	}
 
 	return grids;
 };
 
-export const getYGrids = ( yMin, yMax ) => {
-	const domain = yMax - yMin || 1;
-
-	const yGrids = [
+export const getYGrids = ( yMin, yMax, step ) => {
+	return [
 		0,
-		...getNegativeYGrids( yMin, domain ),
-		...getPositiveYGrids( yMax, domain ),
+		...getNegativeYGrids( yMin, step ),
+		...getPositiveYGrids( yMax, step ),
 	];
-
-	return yGrids;
 };
 
 const removeDuplicateDates = ( d, i, ticks, formatter ) => {
@@ -274,7 +270,7 @@ const drawXAxis = ( node, params, scales, formats ) => {
 };
 
 const drawYAxis = ( node, scales, formats, margin, isRTL ) => {
-	const yGrids = getYGrids( scales.yScale.domain()[ 0 ], scales.yScale.domain()[ 1 ] );
+	const yGrids = getYGrids( scales.yScale.domain()[ 0 ], scales.yScale.domain()[ 1 ], scales.step );
 	const width = scales.xScale.range()[ 1 ];
 	const xPosition = isRTL ? width + margin.left + margin.right / 2 - 15 : -margin.left / 2 - 15;
 

--- a/packages/components/src/chart/d3chart/utils/bar-chart.js
+++ b/packages/components/src/chart/d3chart/utils/bar-chart.js
@@ -40,6 +40,7 @@ export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 		} )
 		.on( 'mouseout', () => tooltip.hide() );
 
+	const basePosition = scales.yScale( 0 );
 	barGroup
 		.selectAll( '.bar' )
 		.data( d =>
@@ -56,9 +57,9 @@ export const drawBars = ( node, data, params, scales, formats, tooltip ) => {
 		.append( 'rect' )
 		.attr( 'class', 'bar' )
 		.attr( 'x', d => scales.xGroupScale( d.key ) )
-		.attr( 'y', d => scales.yScale( d.value ) )
+		.attr( 'y', d => Math.min( basePosition, scales.yScale( d.value ) ) )
 		.attr( 'width', scales.xGroupScale.bandwidth() )
-		.attr( 'height', d => height - scales.yScale( d.value ) )
+		.attr( 'height', d => Math.abs( basePosition - scales.yScale( d.value ) ) )
 		.attr( 'fill', d => params.getColor( d.key ) )
 		.attr( 'pointer-events', 'none' )
 		.attr( 'tabindex', '0' )

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -78,7 +78,7 @@ const calculateStep = ( minValue, maxValue ) => {
 	const maxLimit = 4 / 3 * maxAbsValue;
 	const pow3Y = Math.pow( 10, ( ( Math.log( maxLimit ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
 
-	return Math.max( Math.ceil( Math.ceil( maxLimit / pow3Y ) * pow3Y / 3 ), 1 );
+	return Math.max( Math.ceil( Math.ceil( maxLimit / pow3Y ) * pow3Y / 3 ), 1 / 3 );
 };
 
 /**
@@ -94,13 +94,13 @@ export const getYScaleLimits = data => {
 
 	if ( Number.isFinite( minValue ) || minValue < 0 ) {
 		limits.lower = Math.floor( minValue / step ) * step;
-		if ( limits.lower === minValue ) {
+		if ( limits.lower === minValue && minValue !== 0 ) {
 			limits.lower -= step;
 		}
 	}
 	if ( Number.isFinite( maxValue ) || maxValue > 0 ) {
 		limits.upper = Math.ceil( maxValue / step ) * step;
-		if ( limits.upper === maxValue ) {
+		if ( limits.upper === maxValue && maxValue !== 0 ) {
 			limits.upper += step;
 		}
 	}

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -69,10 +69,12 @@ const getYValueLimits = data => {
 	return { upper: maxYValue, lower: minYValue };
 };
 
-const expandDomain = ( val ) => {
-  const yMax = 4 / 3 * val;
-  const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
-  return Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y );
+const calculateStep = ( minValue, maxValue ) => {
+	const domain = Math.max( maxValue, -minValue );
+	const yMax = 4 / 3 * domain;
+	const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
+
+	return Math.max( Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y / 3 ), 1 );
 };
 
 /**
@@ -80,22 +82,21 @@ const expandDomain = ( val ) => {
  * @param {array} data - The chart component's `data` prop.
  * @returns {number} the maximum value in the timeseries multiplied by 4/3
  */
-export const getYAxisLimits = data => {
-	const { upper: maxValue, lower: minValue } = getYValueLimits( data );
-	const limits = { upper: 0, lower: 0 };
-	const domain = Math.max( maxValue, -minValue );
-	const domainSpace = Math.max( expandDomain( domain ) / 3, 1 );
+export const getYScaleLimits = data => {
+	const { lower: minValue, upper: maxValue } = getYValueLimits( data );
+	const step = calculateStep( minValue, maxValue );
+	const limits = { lower: 0, upper: 0, step };
 
-	if ( Number.isFinite( maxValue ) || maxValue > 0 ) {
-		limits.upper = Math.ceil( maxValue / domainSpace ) * domainSpace;
-		if ( limits.upper === maxValue ) {
-			limits.upper += domainSpace;
+	if ( Number.isFinite( minValue ) || minValue < 0 ) {
+		limits.lower = Math.floor( minValue / step ) * step;
+		if ( limits.lower === minValue ) {
+			limits.lower -= step;
 		}
 	}
-	if ( Number.isFinite( minValue ) || minValue < 0 ) {
-		limits.lower = Math.floor( minValue / domainSpace ) * domainSpace;
-		if ( limits.lower === minValue ) {
-			limits.lower -= domainSpace;
+	if ( Number.isFinite( maxValue ) || maxValue > 0 ) {
+		limits.upper = Math.ceil( maxValue / step ) * step;
+		if ( limits.upper === maxValue ) {
+			limits.upper += step;
 		}
 	}
 

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -78,23 +78,22 @@ const expandDomain = ( val ) => {
 /**
  * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
  * @param {array} data - The chart component's `data` prop.
- * @param {number} baseValue - base value to test data values against
  * @returns {number} the maximum value in the timeseries multiplied by 4/3
  */
-export const getYAxisLimits = ( data, baseValue ) => {
+export const getYAxisLimits = data => {
 	const { upper: maxValue, lower: minValue } = getYValueLimits( data );
-	const limits = { upper: baseValue, lower: baseValue };
-	const domain = Math.max( maxValue - baseValue, baseValue - minValue );
+	const limits = { upper: 0, lower: 0 };
+	const domain = Math.max( maxValue, -minValue );
 	const domainSpace = Math.max( expandDomain( domain ) / 3, 1 );
 
-	if ( Number.isFinite( maxValue ) || maxValue > baseValue ) {
-		limits.upper = Math.ceil( ( maxValue - baseValue ) / domainSpace ) * domainSpace + baseValue;
+	if ( Number.isFinite( maxValue ) || maxValue > 0 ) {
+		limits.upper = Math.ceil( maxValue / domainSpace ) * domainSpace;
 		if ( limits.upper === maxValue ) {
 			limits.upper += domainSpace;
 		}
 	}
-	if ( Number.isFinite( minValue ) || minValue < baseValue ) {
-		limits.lower = Math.floor( ( minValue - baseValue ) / domainSpace ) * domainSpace + baseValue;
+	if ( Number.isFinite( minValue ) || minValue < 0 ) {
+		limits.lower = Math.floor( minValue / domainSpace ) * domainSpace;
 		if ( limits.lower === minValue ) {
 			limits.lower -= domainSpace;
 		}
@@ -108,10 +107,9 @@ export const getYAxisLimits = ( data, baseValue ) => {
  * @param {number} height - calculated height of the charting space
  * @param {number} yMin - minimum y value
  * @param {number} yMax - maximum y value
- * @param {number} baseValue - base value to test data values against
  * @returns {function} the D3 linear scale from 0 to the value from `getYMax`
  */
-export const getYScale = ( height, yMin, yMax, baseValue ) =>
+export const getYScale = ( height, yMin, yMax ) =>
 	d3ScaleLinear()
-		.domain( [ Math.min( yMin, baseValue ), yMax === baseValue && yMin === baseValue ? baseValue + 1 : Math.max( yMax, baseValue ) ] )
+		.domain( [ Math.min( yMin, 0 ), yMax === 0 && yMin === 0 ? 1 : Math.max( yMax, 0 ) ] )
 		.rangeRound( [ height, 0 ] );

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -70,17 +70,22 @@ const getYValueLimits = data => {
 };
 
 const calculateStep = ( minValue, maxValue ) => {
-	const domain = Math.max( maxValue, -minValue );
-	const yMax = 4 / 3 * domain;
-	const pow3Y = Math.pow( 10, ( ( Math.log( yMax ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
+	if ( ! Number.isFinite( minValue ) || ! Number.isFinite( maxValue ) ) {
+		return 1;
+	}
 
-	return Math.max( Math.ceil( Math.ceil( yMax / pow3Y ) * pow3Y / 3 ), 1 );
+	const maxAbsValue = Math.max( -minValue, maxValue );
+	const maxLimit = 4 / 3 * maxAbsValue;
+	const pow3Y = Math.pow( 10, ( ( Math.log( maxLimit ) * Math.LOG10E + 1 ) | 0 ) - 2 ) * 3;
+
+	return Math.max( Math.ceil( Math.ceil( maxLimit / pow3Y ) * pow3Y / 3 ), 1 );
 };
 
 /**
- * Describes and rounds the maximum y value to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
+ * Returns the lower and upper limits of the Y scale and the calculated step to use in the axis, rounding
+ * them to the nearest thousand, ten-thousand, million etc. In case it is a decimal number, ceils it.
  * @param {array} data - The chart component's `data` prop.
- * @returns {number} the maximum value in the timeseries multiplied by 4/3
+ * @returns {object} Object containing the `lower` and `upper` limits and a `step` value.
  */
 export const getYScaleLimits = data => {
 	const { lower: minValue, upper: maxValue } = getYValueLimits( data );

--- a/packages/components/src/chart/d3chart/utils/test/axis.js
+++ b/packages/components/src/chart/d3chart/utils/test/axis.js
@@ -240,19 +240,94 @@ describe( 'compareStrings', () => {
 } );
 
 describe( 'getYGrids', () => {
-	it( 'returns a single 0 when yMax is 0', () => {
-		expect( getYGrids( 0 ) ).toEqual( [ 0 ] );
+	describe( 'when baseValue is 0', () => {
+		it( 'returns a single 0 when yMax, yMin are 0', () => {
+			expect( getYGrids( 0, 0, 0 ) ).toEqual( [ 0 ] );
+		} );
+
+		describe( 'positive charts', () => {
+			it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
+				expect( getYGrids( 0, 1, 0 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
+			} );
+
+			it( 'returns decimal values when yMax and yMin are <= 1', () => {
+				expect( getYGrids( 1, 1, 0 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
+			} );
+
+			it( 'doesn\'t return decimal values when yMax is > 1', () => {
+				expect( getYGrids( 0, 2, 0 ) ).toEqual( [ 0, 1, 2 ] );
+			} );
+
+			it( 'returns up to four values when yMax is a big number', () => {
+				expect( getYGrids( 0, 10000, 0 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
+			} );
+		} );
+
+		describe( 'negative charts', () => {
+			it( 'returns decimal values when yMin is >= -1 and yMax and baseValue are 0', () => {
+				expect( getYGrids( -1, 0, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
+			} );
+
+			it( 'returns decimal values when yMax and yMin are >= -1', () => {
+				expect( getYGrids( -1, -1, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
+			} );
+
+			it( 'doesn\'t return decimal values when yMin is < -1', () => {
+				expect( getYGrids( -2, 0, 0 ) ).toEqual( [ 0, -1, -2 ] );
+			} );
+
+			it( 'returns up to four values when yMin is a big negative number', () => {
+				expect( getYGrids( -10000, 0, 0 ) ).toEqual( [ 0, -3333, -6667, -10000 ] );
+			} );
+		} );
+
+		describe( 'positive & negative charts', () => {
+			it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
+				expect( getYGrids( -1, 1, 0 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
+			} );
+
+			it( 'doesn\'t return decimal values when yMax is >1', () => {
+				expect( getYGrids( -2, 2, 0 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
+			} );
+
+			it( 'returns up to four values when yMax is a big number', () => {
+				expect( getYGrids( -10000, 10000, 0 ) ).toEqual( [ 0, -5000, -10000, 5000, 10000 ] );
+			} );
+		} );
 	} );
 
-	it( 'returns decimal values when yMax is <= 1', () => {
-		expect( getYGrids( 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
-	} );
+	describe( 'when baseValue is not 0', () => {
+		it( 'returns a single value when yMax, yMin = baseValue', () => {
+			expect( getYGrids( 100, 100, 100 ) ).toEqual( [ 100 ] );
+		} );
 
-	it( 'doesn\'t return decimal values when yMax is >1', () => {
-		expect( getYGrids( 2 ) ).toEqual( [ 0, 1, 2 ] );
-	} );
+		it( 'returns decimal values when yMax and yMin are 1 unit higher than baseValue', () => {
+			expect( getYGrids( 101, 101, 100 ) ).toEqual( [ 100, 100.3333333333333333, 100.6666666666666666, 101 ] );
+		} );
 
-	it( 'returns up to four values when yMax is a big number', () => {
-		expect( getYGrids( 10000 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
+		it( 'returns decimal values when yMax and yMin are 1 unit lower than baseValue', () => {
+			expect( getYGrids( 99, 99, 100 ) ).toEqual( [ 100, 99.6666666666666666, 99.3333333333333333, 99 ] );
+		} );
+
+		it( 'returns decimal values when yMax and yMin are 1 unit higher/lower than baseValue', () => {
+			expect( getYGrids( 99, 101, 100 ) ).toEqual( [ 100, 99.5, 99, 100.5, 101 ] );
+		} );
+
+		it( 'doesn\'t return decimal values when the differente between yMax or yMin and baseValue is bigger than 1 unit', () => {
+			expect( getYGrids( 100, 102, 100 ) ).toEqual( [ 100, 101, 102 ] );
+			expect( getYGrids( 98, 100, 100 ) ).toEqual( [ 100, 99, 98 ] );
+		} );
+
+		it( 'returns up to five values when yMax and yMin difference with baseValue is bigger than 1', () => {
+			expect( getYGrids( 98, 102, 100 ) ).toEqual( [ 100, 99, 98, 101, 102 ] );
+		} );
+
+		it( 'returns up to four values when yMax difference with baseValue is bigger than 1', () => {
+			expect( getYGrids( 100, 10100, 100 ) ).toEqual( [ 100, 3433, 6767, 10100 ] );
+		} );
+
+		it( 'returns up to four values when yMin difference with baseValue is bigger than 1', () => {
+			expect( getYGrids( -9900, 100, 100 ) ).toEqual( [ 100, -3233, -6567, -9900 ] );
+		} );
 	} );
 } );

--- a/packages/components/src/chart/d3chart/utils/test/axis.js
+++ b/packages/components/src/chart/d3chart/utils/test/axis.js
@@ -240,7 +240,7 @@ describe( 'compareStrings', () => {
 } );
 
 describe( 'getYGrids', () => {
-	it( 'returns a single 0 when yMax, yMin are 0', () => {
+	it( 'returns a single 0 when yMax and yMin are 0', () => {
 		expect( getYGrids( 0, 0 ) ).toEqual( [ 0 ] );
 	} );
 
@@ -285,11 +285,11 @@ describe( 'getYGrids', () => {
 			expect( getYGrids( -1, 1 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
 		} );
 
-		it( 'doesn\'t return decimal values when yMax is >1', () => {
+		it( 'doesn\'t return decimal values when yMax is > 1', () => {
 			expect( getYGrids( -2, 2 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
 		} );
 
-		it( 'returns up to four values when yMax is a big number', () => {
+		it( 'returns up to five values when yMax is a big number', () => {
 			expect( getYGrids( -10000, 10000 ) ).toEqual( [ 0, -5000, -10000, 5000, 10000 ] );
 		} );
 	} );

--- a/packages/components/src/chart/d3chart/utils/test/axis.js
+++ b/packages/components/src/chart/d3chart/utils/test/axis.js
@@ -241,56 +241,56 @@ describe( 'compareStrings', () => {
 
 describe( 'getYGrids', () => {
 	it( 'returns a single 0 when yMax and yMin are 0', () => {
-		expect( getYGrids( 0, 0 ) ).toEqual( [ 0 ] );
+		expect( getYGrids( 0, 0, 0 ) ).toEqual( [ 0 ] );
 	} );
 
 	describe( 'positive charts', () => {
 		it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
-			expect( getYGrids( 0, 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
+			expect( getYGrids( 0, 1, 0.3333333333333333 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
 		} );
 
 		it( 'returns decimal values when yMax and yMin are <= 1', () => {
-			expect( getYGrids( 1, 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
+			expect( getYGrids( 1, 1, 0.3333333333333333 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
 		} );
 
 		it( 'doesn\'t return decimal values when yMax is > 1', () => {
-			expect( getYGrids( 0, 2 ) ).toEqual( [ 0, 1, 2 ] );
+			expect( getYGrids( 0, 2, 1 ) ).toEqual( [ 0, 1, 2 ] );
 		} );
 
 		it( 'returns up to four values when yMax is a big number', () => {
-			expect( getYGrids( 0, 10000 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
+			expect( getYGrids( 0, 12000, 4000 ) ).toEqual( [ 0, 4000, 8000, 12000 ] );
 		} );
 	} );
 
 	describe( 'negative charts', () => {
 		it( 'returns decimal values when yMin is >= -1 and yMax is 0', () => {
-			expect( getYGrids( -1, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
+			expect( getYGrids( -1, 0, 0.3333333333333333 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
 		} );
 
 		it( 'returns decimal values when yMax and yMin are >= -1', () => {
-			expect( getYGrids( -1, -1 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
+			expect( getYGrids( -1, -1, 0.3333333333333333 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
 		} );
 
 		it( 'doesn\'t return decimal values when yMin is < -1', () => {
-			expect( getYGrids( -2, 0 ) ).toEqual( [ 0, -1, -2 ] );
+			expect( getYGrids( -2, 0, 1 ) ).toEqual( [ 0, -1, -2 ] );
 		} );
 
 		it( 'returns up to four values when yMin is a big negative number', () => {
-			expect( getYGrids( -10000, 0 ) ).toEqual( [ 0, -3333, -6667, -10000 ] );
+			expect( getYGrids( -12000, 0, 4000 ) ).toEqual( [ 0, -4000, -8000, -12000 ] );
 		} );
 	} );
 
 	describe( 'positive & negative charts', () => {
 		it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
-			expect( getYGrids( -1, 1 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
+			expect( getYGrids( -1, 1, 0.5 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
 		} );
 
 		it( 'doesn\'t return decimal values when yMax is > 1', () => {
-			expect( getYGrids( -2, 2 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
+			expect( getYGrids( -2, 2, 1 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
 		} );
 
-		it( 'returns up to five values when yMax is a big number', () => {
-			expect( getYGrids( -10000, 10000 ) ).toEqual( [ 0, -5000, -10000, 5000, 10000 ] );
+		it( 'returns up to six values when yMax is a big number', () => {
+			expect( getYGrids( -12000, 12000, 6000 ) ).toEqual( [ 0, -6000, -12000, 6000, 12000 ] );
 		} );
 	} );
 } );

--- a/packages/components/src/chart/d3chart/utils/test/axis.js
+++ b/packages/components/src/chart/d3chart/utils/test/axis.js
@@ -240,94 +240,57 @@ describe( 'compareStrings', () => {
 } );
 
 describe( 'getYGrids', () => {
-	describe( 'when baseValue is 0', () => {
-		it( 'returns a single 0 when yMax, yMin are 0', () => {
-			expect( getYGrids( 0, 0, 0 ) ).toEqual( [ 0 ] );
+	it( 'returns a single 0 when yMax, yMin are 0', () => {
+		expect( getYGrids( 0, 0 ) ).toEqual( [ 0 ] );
+	} );
+
+	describe( 'positive charts', () => {
+		it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
+			expect( getYGrids( 0, 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
 		} );
 
-		describe( 'positive charts', () => {
-			it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
-				expect( getYGrids( 0, 1, 0 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
-			} );
-
-			it( 'returns decimal values when yMax and yMin are <= 1', () => {
-				expect( getYGrids( 1, 1, 0 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
-			} );
-
-			it( 'doesn\'t return decimal values when yMax is > 1', () => {
-				expect( getYGrids( 0, 2, 0 ) ).toEqual( [ 0, 1, 2 ] );
-			} );
-
-			it( 'returns up to four values when yMax is a big number', () => {
-				expect( getYGrids( 0, 10000, 0 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
-			} );
+		it( 'returns decimal values when yMax and yMin are <= 1', () => {
+			expect( getYGrids( 1, 1 ) ).toEqual( [ 0, 0.3333333333333333, 0.6666666666666666, 1 ] );
 		} );
 
-		describe( 'negative charts', () => {
-			it( 'returns decimal values when yMin is >= -1 and yMax and baseValue are 0', () => {
-				expect( getYGrids( -1, 0, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
-			} );
-
-			it( 'returns decimal values when yMax and yMin are >= -1', () => {
-				expect( getYGrids( -1, -1, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
-			} );
-
-			it( 'doesn\'t return decimal values when yMin is < -1', () => {
-				expect( getYGrids( -2, 0, 0 ) ).toEqual( [ 0, -1, -2 ] );
-			} );
-
-			it( 'returns up to four values when yMin is a big negative number', () => {
-				expect( getYGrids( -10000, 0, 0 ) ).toEqual( [ 0, -3333, -6667, -10000 ] );
-			} );
+		it( 'doesn\'t return decimal values when yMax is > 1', () => {
+			expect( getYGrids( 0, 2 ) ).toEqual( [ 0, 1, 2 ] );
 		} );
 
-		describe( 'positive & negative charts', () => {
-			it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
-				expect( getYGrids( -1, 1, 0 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
-			} );
-
-			it( 'doesn\'t return decimal values when yMax is >1', () => {
-				expect( getYGrids( -2, 2, 0 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
-			} );
-
-			it( 'returns up to four values when yMax is a big number', () => {
-				expect( getYGrids( -10000, 10000, 0 ) ).toEqual( [ 0, -5000, -10000, 5000, 10000 ] );
-			} );
+		it( 'returns up to four values when yMax is a big number', () => {
+			expect( getYGrids( 0, 10000 ) ).toEqual( [ 0, 3333, 6667, 10000 ] );
 		} );
 	} );
 
-	describe( 'when baseValue is not 0', () => {
-		it( 'returns a single value when yMax, yMin = baseValue', () => {
-			expect( getYGrids( 100, 100, 100 ) ).toEqual( [ 100 ] );
+	describe( 'negative charts', () => {
+		it( 'returns decimal values when yMin is >= -1 and yMax is 0', () => {
+			expect( getYGrids( -1, 0 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
 		} );
 
-		it( 'returns decimal values when yMax and yMin are 1 unit higher than baseValue', () => {
-			expect( getYGrids( 101, 101, 100 ) ).toEqual( [ 100, 100.3333333333333333, 100.6666666666666666, 101 ] );
+		it( 'returns decimal values when yMax and yMin are >= -1', () => {
+			expect( getYGrids( -1, -1 ) ).toEqual( [ 0, -0.3333333333333333, -0.6666666666666666, -1 ] );
 		} );
 
-		it( 'returns decimal values when yMax and yMin are 1 unit lower than baseValue', () => {
-			expect( getYGrids( 99, 99, 100 ) ).toEqual( [ 100, 99.6666666666666666, 99.3333333333333333, 99 ] );
+		it( 'doesn\'t return decimal values when yMin is < -1', () => {
+			expect( getYGrids( -2, 0 ) ).toEqual( [ 0, -1, -2 ] );
 		} );
 
-		it( 'returns decimal values when yMax and yMin are 1 unit higher/lower than baseValue', () => {
-			expect( getYGrids( 99, 101, 100 ) ).toEqual( [ 100, 99.5, 99, 100.5, 101 ] );
+		it( 'returns up to four values when yMin is a big negative number', () => {
+			expect( getYGrids( -10000, 0 ) ).toEqual( [ 0, -3333, -6667, -10000 ] );
+		} );
+	} );
+
+	describe( 'positive & negative charts', () => {
+		it( 'returns decimal values when yMax is <= 1 and yMin is 0', () => {
+			expect( getYGrids( -1, 1 ) ).toEqual( [ 0, -0.5, -1, 0.5, 1 ] );
 		} );
 
-		it( 'doesn\'t return decimal values when the differente between yMax or yMin and baseValue is bigger than 1 unit', () => {
-			expect( getYGrids( 100, 102, 100 ) ).toEqual( [ 100, 101, 102 ] );
-			expect( getYGrids( 98, 100, 100 ) ).toEqual( [ 100, 99, 98 ] );
+		it( 'doesn\'t return decimal values when yMax is >1', () => {
+			expect( getYGrids( -2, 2 ) ).toEqual( [ 0, -1, -2, 1, 2 ] );
 		} );
 
-		it( 'returns up to five values when yMax and yMin difference with baseValue is bigger than 1', () => {
-			expect( getYGrids( 98, 102, 100 ) ).toEqual( [ 100, 99, 98, 101, 102 ] );
-		} );
-
-		it( 'returns up to four values when yMax difference with baseValue is bigger than 1', () => {
-			expect( getYGrids( 100, 10100, 100 ) ).toEqual( [ 100, 3433, 6767, 10100 ] );
-		} );
-
-		it( 'returns up to four values when yMin difference with baseValue is bigger than 1', () => {
-			expect( getYGrids( -9900, 100, 100 ) ).toEqual( [ 100, -3233, -6567, -9900 ] );
+		it( 'returns up to four values when yMax is a big number', () => {
+			expect( getYGrids( -10000, 10000 ) ).toEqual( [ 0, -5000, -10000, 5000, 10000 ] );
 		} );
 	} );
 } );

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -12,7 +12,7 @@ import {
 	getOrderedKeys,
 	getUniqueDates,
 } from '../index';
-import { getXGroupScale, getXScale, getXLineScale, getYAxisLimits, getYScale } from '../scales';
+import { getXGroupScale, getXScale, getXLineScale, getYScaleLimits, getYScale } from '../scales';
 
 jest.mock( 'd3-scale', () => ( {
 	...require.requireActual( 'd3-scale' ),
@@ -88,13 +88,13 @@ describe( 'X scales', () => {
 } );
 
 describe( 'Y scales', () => {
-	describe( 'getYAxisLimits', () => {
+	describe( 'getYScaleLimits', () => {
 		it( 'calculate the correct y value limits', () => {
-			expect( getYAxisLimits( dummyOrders ) ).toEqual( { lower: 0, upper: 15000000 } );
+			expect( getYScaleLimits( dummyOrders ) ).toEqual( { lower: 0, upper: 15000000, step: 5000000 } );
 		} );
 
 		it( 'return 0 if there is no line data', () => {
-			expect( getYAxisLimits( [] ) ).toEqual( { lower: 0, upper: 0 } );
+			expect( getYScaleLimits( [] ) ).toEqual( { lower: 0, upper: 0, step: 1 } );
 		} );
 	} );
 

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -99,10 +99,17 @@ describe( 'Y scales', () => {
 	} );
 
 	describe( 'getYScale', () => {
-		it( 'creates linear scale with correct parameters', () => {
+		it( 'creates positive linear scale with correct parameters', () => {
 			getYScale( 100, 0, 15000000 );
 
 			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
+			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 100, 0 ] );
+		} );
+
+		it( 'creates negative linear scale with correct parameters', () => {
+			getYScale( 100, -15000000, 0 );
+
+			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ -15000000, 0 ] );
 			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 100, 0 ] );
 		} );
 

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -90,24 +90,24 @@ describe( 'X scales', () => {
 describe( 'Y scales', () => {
 	describe( 'getYAxisLimits', () => {
 		it( 'calculate the correct y value limits', () => {
-			expect( getYAxisLimits( dummyOrders, 100 ) ).toEqual( { lower: 0, upper: 15000000 } );
+			expect( getYAxisLimits( dummyOrders ) ).toEqual( { lower: 0, upper: 15000000 } );
 		} );
 
-		it( 'return baseValue if there is no line data', () => {
-			expect( getYAxisLimits( [], 100 ) ).toEqual( { lower: 100, upper: 100 } );
+		it( 'return 0 if there is no line data', () => {
+			expect( getYAxisLimits( [] ) ).toEqual( { lower: 0, upper: 0 } );
 		} );
 	} );
 
 	describe( 'getYScale', () => {
 		it( 'creates linear scale with correct parameters', () => {
-			getYScale( 100, 0, 15000000, 100 );
+			getYScale( 100, 0, 15000000 );
 
 			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
 			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 100, 0 ] );
 		} );
 
-		it( 'avoids the domain starting and ending at the same point when yMin, yMax and baseValue are the same', () => {
-			getYScale( 100, 100, 100, 100 );
+		it( 'avoids the domain starting and ending at the same point when yMin, yMax are 0', () => {
+			getYScale( 100, 0, 0 );
 
 			const args = scaleLinear().domain.mock.calls;
 			const lastArgs = args[ args.length - 1 ][ 0 ];

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -12,7 +12,7 @@ import {
 	getOrderedKeys,
 	getUniqueDates,
 } from '../index';
-import { getXGroupScale, getXScale, getXLineScale, getYMax, getYScale } from '../scales';
+import { getXGroupScale, getXScale, getXLineScale, getYAxisLimits, getYScale } from '../scales';
 
 jest.mock( 'd3-scale', () => ( {
 	...require.requireActual( 'd3-scale' ),
@@ -88,26 +88,26 @@ describe( 'X scales', () => {
 } );
 
 describe( 'Y scales', () => {
-	describe( 'getYMax', () => {
-		it( 'calculate the correct maximum y value', () => {
-			expect( getYMax( dummyOrders ) ).toEqual( 15000000 );
+	describe( 'getYAxisLimits', () => {
+		it( 'calculate the correct y value limits', () => {
+			expect( getYAxisLimits( dummyOrders, 100 ) ).toEqual( { lower: 0, upper: 15000000 } );
 		} );
 
-		it( 'return 0 if there is no line data', () => {
-			expect( getYMax( [] ) ).toEqual( 0 );
+		it( 'return baseValue if there is no line data', () => {
+			expect( getYAxisLimits( [], 100 ) ).toEqual( { lower: 100, upper: 100 } );
 		} );
 	} );
 
 	describe( 'getYScale', () => {
 		it( 'creates linear scale with correct parameters', () => {
-			getYScale( 100, 15000000 );
+			getYScale( 100, 0, 15000000, 100 );
 
 			expect( scaleLinear().domain ).toHaveBeenLastCalledWith( [ 0, 15000000 ] );
 			expect( scaleLinear().rangeRound ).toHaveBeenLastCalledWith( [ 100, 0 ] );
 		} );
 
-		it( 'avoids the domain starting and ending at the same point when yMax is 0', () => {
-			getYScale( 100, 0 );
+		it( 'avoids the domain starting and ending at the same point when yMin, yMax and baseValue are the same', () => {
+			getYScale( 100, 100, 100, 100 );
 
 			const args = scaleLinear().domain.mock.calls;
 			const lastArgs = args[ args.length - 1 ][ 0 ];

--- a/packages/components/src/chart/d3chart/utils/test/scales.js
+++ b/packages/components/src/chart/d3chart/utils/test/scales.js
@@ -93,7 +93,7 @@ describe( 'Y scales', () => {
 			expect( getYScaleLimits( dummyOrders ) ).toEqual( { lower: 0, upper: 15000000, step: 5000000 } );
 		} );
 
-		it( 'return 0 if there is no line data', () => {
+		it( 'return defaults if there is no line data', () => {
 			expect( getYScaleLimits( [] ) ).toEqual( { lower: 0, upper: 0, step: 1 } );
 		} );
 	} );


### PR DESCRIPTION
Fixes #1959.

Adds the ability to display negative numbers to `<Chart>` component.

### Screenshots
_All negative:_
![image](https://user-images.githubusercontent.com/3616980/55423087-78f36200-557d-11e9-944d-75afb47f3cd4.png)
_Positive and negative values:_
![image](https://user-images.githubusercontent.com/3616980/55423669-a987cb80-557e-11e9-8f60-cd043876b9c2.png)
_Bar charts:_
![image](https://user-images.githubusercontent.com/3616980/55423365-0767e380-557e-11e9-94ab-064a5470b887.png)

### Detailed test instructions:
Currently all our charts only display positive values, so you need to overwrite `chartData` before rendering them.

In https://github.com/woocommerce/woocommerce-admin/blob/master/client/analytics/components/report-chart/index.js#L125, add these lines:
```ES6
for ( let i = 0; i < chartData.length; i++ ) {
	chartData[ i ].primary.value = ( Math.random() - 0.5 ) * 100;
	chartData[ i ].secondary.value = ( Math.random() - 0.5 ) * 100;
}
```
- Go to any report and verify charts look good.
- Switch between line and bar chart.
- Try modifying the code snippet above to force other data combinations:

**Only negative values:**
```ES6
for ( let i = 0; i < chartData.length; i++ ) {
	chartData[ i ].primary.value = Math.random() * -100;
	chartData[ i ].secondary.value = Math.random() * -100;
}
```
  **All 0's:**
```ES6
for ( let i = 0; i < chartData.length; i++ ) {
	chartData[ i ].primary.value = 0;
	chartData[ i ].secondary.value = 0;
}
```
  **Beautiful data going up (used for the screenshots above) :chart_with_upwards_trend: :**
```ES6
for ( let i = 0; i < chartData.length; i++ ) {
	chartData[ i ].primary.value = ( Math.random() - 0.7 + i / 30 ) * 100;
	chartData[ i ].secondary.value = ( Math.random() - 0.7 + i / 30 ) * 100;
}
```