### PR TITLE
Scroll to top only when URL changes

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -72,6 +72,10 @@ const getPages = () => {
 };
 
 class Controller extends Component {
+	componentDidMount() {
+		window.document.documentElement.scrollTop = 0;
+	}
+
 	componentDidUpdate( prevProps ) {
 		const prevQuery = this.getQuery( prevProps.location.search );
 		const prevBaseQuery = this.getBaseQuery( prevProps.location.search );
@@ -79,6 +83,10 @@ class Controller extends Component {
 
 		if ( prevQuery.page > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
 			getHistory().replace( getNewPath( { page: 1 } ) );
+		}
+
+		if ( prevProps.match.url !== this.props.match.url ) {
+			window.document.documentElement.scrollTop = 0;
 		}
 	}
 
@@ -104,7 +112,6 @@ class Controller extends Component {
 		const page = find( getPages(), { path } );
 		window.wpNavMenuUrlUpdate( page, query );
 		window.wpNavMenuClassChange( page );
-		window.document.documentElement.scrollTop = 0;
 		return createElement( page.container, { params, path: url, pathMatch: path, query } );
 	}
 }


### PR DESCRIPTION
Fixes #1974.

Related to #1958.

Only scroll to top when URL changes, but not when the query does.

### Detailed test instructions:

1. Go to the _Dashboard_.
2. Scroll to the bottom.
3. Go to _Analytics_ > _Revenue_, for example.
4. Verify the _Revenue_ report is scrolled to the top, so filters, summary numbers and chart are visible by default.
5. Scroll down a bit and switch to a bar chart.
6. Verify the page is not scrolled to top.