### PR TITLE
SearchListControl: Add an onSearch callback to allow dynamic updating of the list

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,8 @@
 - Chart component now accepts data with negative values.
 - Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
 - Expand search results and allow searching when input is refocused in autocompleter.
-- Animation Slider: Remove `focusOnChange` in favor of `onExited` so consumers can pass a function to be exectuted after a transition has finished.
+- Animation Slider: Remove `focusOnChange` in favor of `onExited` so consumers can pass a function to be executed after a transition has finished.
+- SearchListControl: Add `onSearch` callback prop to let the parent component know about search changes.
 
 # 1.6.0
 - Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.

--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -48,6 +48,13 @@ export class SearchListControl extends Component {
 		this.renderList = this.renderList.bind( this );
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { onSearch, search } = this.props;
+		if ( search !== prevProps.search && 'function' === typeof onSearch ) {
+			onSearch( search );
+		}
+	}
+
 	onRemove( id ) {
 		const { isSingle, onChange, selected } = this.props;
 		return () => {
@@ -285,6 +292,10 @@ SearchListControl.propTypes = {
 	 * Passed an array of item objects (as passed in via props.list).
 	 */
 	onChange: PropTypes.func.isRequired,
+	/**
+	 * Callback fired when the search field is used.
+	 */
+	onSearch: PropTypes.func,
 	/**
 	 * Callback to render each item in the selection list, allows any custom object-type rendering.
 	 */


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/505 – We want to 

### Detailed test instructions:

- There should be no functionality change, since nothing is using this yet.
- You can add an `onSearch` callback to the example in devdocs, and see that it triggers when the search changes.

(once this is merged, I'd also like to do a packages update, so it can be used in the blocks)