### PR TITLE
Fix date filter layout on Android

### DIFF
--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -8,7 +8,6 @@
 
 	&.is-mobile {
 		height: 100%;
-		min-height: 537px;
 	}
 }
 

--- a/packages/components/src/filters/date/content.js
+++ b/packages/components/src/filters/date/content.js
@@ -16,8 +16,6 @@ import DateRange from '../../calendar/date-range';
 import { H, Section } from '../../section';
 import PresetPeriods from './preset-periods';
 
-const isMobileViewport = () => window.innerWidth < 782;
-
 class DatePickerContent extends Component {
 	constructor() {
 		super();
@@ -102,7 +100,6 @@ class DatePickerContent extends Component {
 								) }
 								<div
 									className={ classnames( 'woocommerce-filters-date__content-controls', {
-										'is-sticky-bottom': selected.name === 'custom' && isMobileViewport(),
 										'is-custom': selected.name === 'custom',
 									} ) }
 								>

--- a/packages/components/src/filters/date/style.scss
+++ b/packages/components/src/filters/date/style.scss
@@ -13,6 +13,7 @@
 
 		.components-tab-panel__tab-content {
 			height: calc(100% - 46px);
+			overflow: auto;
 		}
 	}
 }

--- a/packages/components/src/filters/date/style.scss
+++ b/packages/components/src/filters/date/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		.components-tab-panel__tab-content {
-			height: calc(100% - 36px);
+			height: calc(100% - 46px);
 		}
 	}
 }
@@ -90,11 +90,6 @@ button.woocommerce-filters-date__tab {
 
 	&.is-custom {
 		border-top: 1px solid $core-grey-light-700;
-	}
-
-	&.is-sticky-bottom {
-		position: absolute;
-		bottom: 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #1767.

Refactors the date filter CSS so it's not broken on Android when the keyboard is open.

### Screenshots
_Before:_
<img src="https://user-images.githubusercontent.com/3616980/54047953-b6f8a280-41d8-11e9-8389-593b187adfaf.png" width="300" />
_After:_
<img src="https://user-images.githubusercontent.com/3616980/55553083-83c60800-56df-11e9-99a0-e50f27968484.png" width="300" />

### Detailed test instructions:
You will need an Android device to test it.
- Go to any report.
- Open the date picker and choose the _Custom_ tab.
- Focus on an input so the keyboard appears.
- Verify the layout is not broken.
- Verify there are no regressions when the keyboard is not open.