### PR TITLE
Fix withSelect to release resources on unmount

### DIFF
--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -13,6 +13,7 @@ import user from './user';
 
 function createWcApiSpec() {
 	return {
+		name: 'wcApi',
 		mutations: {
 			...settings.mutations,
 			...user.mutations,

--- a/client/wc-api/with-select.js
+++ b/client/wc-api/with-select.js
@@ -59,7 +59,6 @@ const withSelect = mapSelectToProps =>
 			getNextMergeProps( props ) {
 				const storeSelectors = {};
 				const onCompletes = [];
-				const onUnmounts = {};
 				const componentContext = { component: this };
 
 				const getStoreFromRegistry = ( key, registry, context ) => {
@@ -72,7 +71,7 @@ const withSelect = mapSelectToProps =>
 						// We give it a context, and we check for a "resolve"
 						const { selectors, onComplete, onUnmount } = selectorsForKey( context );
 						onComplete && onCompletes.push( onComplete );
-						onUnmount && ( onUnmounts[ key ] = onUnmount );
+						onUnmount && ( this.onUnmounts[ key ] = onUnmount );
 						storeSelectors[ key ] = selectors;
 					} else {
 						storeSelectors[ key ] = selectorsForKey;

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -29,6 +29,9 @@ function createWcApiStore() {
 					apiClient.setComponentRequirements( component, componentRequirements );
 				}
 			},
+			onUnmount: () => {
+				apiClient.clearComponentRequirements( component );
+			},
 		};
 	}
 

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -10,6 +10,10 @@ import { registerGenericStore } from '@wordpress/data';
 import createApiClient from './create-api-client';
 import wcApiSpec from '../wc-api-spec';
 
+if ( 'development' === process.env.NODE_ENV ) {
+	window.__FRESH_DATA_DEV_INFO__ = true;
+}
+
 function createWcApiStore() {
 	const apiClient = createApiClient( 'wc-api', wcApiSpec );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -738,6 +738,7 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
       "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
+      "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -789,11 +790,11 @@
       }
     },
     "@fresh-data/framework": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.1.tgz",
-      "integrity": "sha512-pCrY2AYZgsGo4/smCNQM2NHf37yPMuzg4RCXHJAnOHIpo6eMgz1jlvlCN4JLxrcdoeEq3uIWMD/3F3k/MefLJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.6.0.tgz",
+      "integrity": "sha512-6cVi0RHwgpbS3u0fEM9nMz8bYb2cL83REAL7jgHR2+zY0hcpynm+JiXZnOXt0f+4Caq3JavOAIlYiZsqlAzkTg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.1.5"
+        "@babel/runtime": "^7.4.2"
       }
     },
     "@jest/console": {
@@ -8801,8 +8802,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8820,13 +8820,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8839,18 +8837,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8953,8 +8948,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8964,7 +8958,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8977,20 +8970,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9007,7 +8997,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9080,8 +9069,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9091,7 +9079,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9167,8 +9154,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9198,7 +9184,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9216,7 +9201,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9255,13 +9239,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
   },
   "dependencies": {
-    "@fresh-data/framework": "^0.5.1",
+    "@fresh-data/framework": "^0.6.0",
     "@wordpress/api-fetch": "2.2.6",
     "@wordpress/components": "7.0.5",
     "@wordpress/data": "4.2.0",


### PR DESCRIPTION
Previously, withSelect wasn't releasing resources from fresh-data when
it was unmounting. This fixes that behavior and now clears a component's
requirements correctly when unmounting.

### Detailed test instructions:

1. Use `npm start` for dev build.
2. Go to any analytics page
3. Open JS console and inspect `freshData.wcApi`
4. Click the "eye" icon to add freshData.wcApi.summary as a "live expression", which stays in place even after refreshes. You can then watch the summary change as resources are fetched and received.
5. Click through all the different reports, the number of components should not climb above 6 or 9 at a time, and the number of resources no longer required should be much higher

![DevTools_-_two_wordpress_test_wp-admin_admin_php_page_wc-admin](https://user-images.githubusercontent.com/945228/55583641-0226a800-56e8-11e9-9117-ec2698a3ae3f.png)


