### PR TITLE
Activity Panel: Add a mobile app note

### DIFF
--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -72,6 +72,7 @@ class WC_Admin_Install {
 
 		delete_transient( 'wc_admin_installing' );
 
+		update_option( 'wc_admin_install_timestamp', time() );
 		do_action( 'wc_admin_installed' );
 	}
 

--- a/includes/notes/class-wc-admin-notes-mobile-app.php
+++ b/includes/notes/class-wc-admin-notes-mobile-app.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * WooCommerce Admin Mobile App Note Provider.
+ *
+ * Adds a note to the merchant's inbox showing the benefits of the mobile app.
+ *
+ * @package WooCommerce Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Mobile_App
+ */
+class WC_Admin_Notes_Mobile_App {
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-mobile-app';
+
+	/**
+	 * Possibly add mobile app note.
+	 */
+	public static function possibly_add_mobile_app_note() {
+
+		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
+		if ( false === $wc_admin_installed ) {
+			$wc_admin_installed = time();
+			update_option( 'wc_admin_install_timestamp', $wc_admin_installed );
+		}
+
+		$current_time        = time();
+		$two_days_in_seconds = 172800;
+
+		// We want to show the mobile app note after day 2.
+		if ( $current_time - $wc_admin_installed < $two_days_in_seconds ) {
+			return;
+		}
+
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$content = __( 'Install the WooCommerce mobile app to manage orders, receive sales notifications, and view key metrics — wherever you are.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Install Woo mobile app', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'phone' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/' );
+		$note->save();
+	}
+}

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -98,6 +98,7 @@ function wc_admin_build_file_exists() {
  */
 function wc_admin_do_wc_admin_daily() {
 	WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
+	WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
 }
 add_action( 'wc_admin_daily', 'wc_admin_do_wc_admin_daily' );
 
@@ -160,6 +161,7 @@ function wc_admin_plugins_loaded() {
 
 	// Admin note providers.
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-new-sales-record.php';
+	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-mobile-app.php';
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-settings-notes.php';
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-woo-subscriptions-notes.php';
 	require_once WC_ADMIN_ABSPATH . '/includes/notes/class-wc-admin-notes-historical-data.php';


### PR DESCRIPTION
Fixes #1980.

This PR adds a nudge for installing the mobile app. It displays two days after setting up WooCommerce Admin.

There is a small bug present with the notes where the timestamp may display wrong. See https://github.com/woocommerce/woocommerce-admin/issues/2006.

### Screenshots

<img width="531" alt="Screen Shot 2019-04-05 at 10 38 37 AM" src="https://user-images.githubusercontent.com/689165/55636669-59348780-5791-11e9-90de-160a8a06cf2a.png">

### Detailed test instructions:

* Install the `WP Crontrol` plugin.
* You either need to deactivate/uninstall WooCommerce and reinstall (to get the correct option set), or repeat the following step twice.
* Go under `Tools > Cron Events` and run `wc_admin_daily`. (You may need to do this twice since the note is triggered based on number of days since install, and we are depending on an option to be set).
* Refresh the Inbox and see the mobile app note.

