### PR TITLE
Fix wrong dates in Reviews and Orders panels of the Activity Panel

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -90,7 +90,11 @@ class InboxPanel extends Component {
 								title={ note.title }
 								date={ note.date_created }
 								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-								unread={ ! lastRead || new Date( note.date_created_gmt ).getTime() > lastRead }
+								unread={
+									! lastRead ||
+									! note.date_created_gmt ||
+									new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
+								}
 								actions={ getButtonsFromActions( note.actions ) }
 							>
 								<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -151,7 +151,7 @@ function OrdersPanel( { orders, isRequesting, isError, orderStatuses } ) {
 				key={ order.order_id }
 				className="woocommerce-order-activity-card"
 				title={ orderCardTitle( order ) }
-				date={ order.date_created }
+				date={ order.date_created_gmt }
 				subtitle={
 					<div>
 						<span>

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -8,7 +8,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
-import moment from 'moment';
 import { get, noop, isNull } from 'lodash';
 import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
@@ -135,11 +134,7 @@ class ReviewsPanel extends Component {
 				key={ review.id }
 				title={ title }
 				subtitle={ subtitle }
-				date={
-					review.date_created_gmt
-						? moment( review.date_created_gmt + 'Z' ).format( 'YYYY-MM-DDTH:mm:ss' )
-						: null
-				}
+				date={ review.date_created_gmt }
 				icon={ icon }
 				actions={ cardActions() }
 				unread={

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -21,7 +21,8 @@ export function getUnreadNotes( select ) {
 		! Boolean( getNotesError( notesQuery ) ) &&
 		! isGetNotesRequesting( notesQuery ) &&
 		latestNote[ 0 ] &&
-		new Date( latestNote[ 0 ].date_created_gmt ).getTime() > userData.activity_panel_inbox_last_read
+		new Date( latestNote[ 0 ].date_created_gmt + 'Z' ).getTime() >
+			userData.activity_panel_inbox_last_read
 	);
 }
 

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -17,9 +17,14 @@ export function getUnreadNotes( select ) {
 	};
 
 	const latestNote = getNotes( notesQuery );
+	const isError = Boolean( getNotesError( notesQuery ) );
+	const isRequesting = isGetNotesRequesting( notesQuery );
+
+	if ( isError || isRequesting ) {
+		return null;
+	}
+
 	return (
-		! Boolean( getNotesError( notesQuery ) ) &&
-		! isGetNotesRequesting( notesQuery ) &&
 		latestNote[ 0 ] &&
 		new Date( latestNote[ 0 ].date_created_gmt + 'Z' ).getTime() >
 			userData.activity_panel_inbox_last_read
@@ -45,13 +50,11 @@ export function getUnreadOrders( select ) {
 	const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );
 	const isRequesting = isReportItemsRequesting( 'orders', ordersQuery );
 
-	if ( ! isError && ! isRequesting ) {
-		if ( totalOrders > 0 ) {
-			return true;
-		}
-		return false;
+	if ( isError || isRequesting ) {
+		return null;
 	}
-	return null;
+
+	return totalOrders > 0;
 }
 
 export function getUnreadReviews( select ) {
@@ -120,9 +123,12 @@ export function getUnreadStock( select ) {
 	};
 	getItems( 'products', productsQuery );
 	const lowInStockCount = getItemsTotalCount( 'products', productsQuery );
+	const isError = Boolean( getItemsError( 'products', productsQuery ) );
+	const isRequesting = isGetItemsRequesting( 'products', productsQuery );
 
-	return ! getItemsError( 'products', productsQuery ) &&
-		! isGetItemsRequesting( 'products', productsQuery )
-		? lowInStockCount > 0
-		: false;
+	if ( isError || isRequesting ) {
+		return null;
+	}
+
+	return lowInStockCount > 0;
 }


### PR DESCRIPTION
Fixes #1890 and some other issues with the date handling of the Activity Panel.

### Screenshots
_Before:_
![Screenshot from 2019-04-08 15-17-07](https://user-images.githubusercontent.com/3616980/55727783-01a54e80-5a13-11e9-8129-8bfd2afbecf4.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/55727769-fc480400-5a12-11e9-8be1-003ca644bd08.png)


### Detailed test instructions:
First, you will need the fix from #1872, so in order to test this, run `git merge add/1831-order-milestone-notifications`.
- Change your store timezone to UTC+14 or something similar.
- Create a new note/order/review.
- Verify the _Unread_ notification appears on the corresponding tab.
- Open the activity panel and verify the corresponding element is highlighted.