### PR TITLE
Try: Extension Examples

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -33,7 +33,7 @@ import ReportError from 'analytics/components/report-error';
 import { searchItemsByString } from 'wc-api/items/utils';
 import withSelect from 'wc-api/with-select';
 
-const REPORTS_FILTER = 'woocommerce-reports-list';
+const REPORTS_FILTER = 'woocommerce_admin_reports_list';
 
 const getReports = () => {
 	const reports = [

--- a/docs/examples/extensions/README.md
+++ b/docs/examples/extensions/README.md
@@ -1,0 +1,25 @@
+# WooCommerce Admin Extension Examples
+
+Examples for extending WooCommerce Admin
+
+## Directions
+
+Install dependencies, if you haven't already.
+
+```bash
+npm install
+```
+
+Build the example extension by running the npm script and passing the example name.
+
+```bash
+npm run example -- --ext=<example>
+```
+
+Go to your Wordpress installation's plugins page and activate the plugin. WooCommerce Analytics reports will now reflect the changes made by the example extension.
+
+You can make changes to Javascript and PHP files in the example and see changes reflected upon refresh.
+
+## Example Extensions
+
+`add-report` - Create a "Hello World" report page.

--- a/docs/examples/extensions/add-report/js/index.js
+++ b/docs/examples/extensions/add-report/js/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ReportFilters } from '@woocommerce/components';
+
+const Report = ( { path, query } ) => {
+	return (
+		<Fragment>
+			<ReportFilters
+				query={ query }
+				path={ path }
+				filters={ [] }
+				advancedFilters={ {} }
+			/>
+		</Fragment>
+	);
+};
+
+/**
+ * Use the 'woocommerce_admin_reports_list' filter to add a report page.
+ */
+addFilter( 'woocommerce_admin_reports_list', 'plugin-domain', reports => {
+	return [
+		...reports,
+		{
+			report: 'example',
+			title: __( 'Example', 'plugin-domain' ),
+			component: Report,
+		},
+	];
+} );

--- a/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
+++ b/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Admin Add Report Example
+ *
+ * @package WC_Admin
+ */
+
+/**
+ * Register the JS.
+ */
+function add_report_register_script() {
+
+	if ( ! class_exists( 'WC_Admin_Loader' ) || ! WC_Admin_Loader::is_admin_page() ) {
+		return;
+	}
+
+	wp_register_script(
+		'add-report',
+		plugins_url( '/dist/index.js', __FILE__ ),
+		array(
+			'wp-hooks',
+			'wp-element',
+			'wp-i18n',
+			'wc-components',
+		),
+		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		true
+	);
+
+	wp_enqueue_script( 'add-report' );
+}
+add_action( 'admin_enqueue_scripts', 'add_report_register_script' );

--- a/docs/examples/extensions/examples.config.js
+++ b/docs/examples/extensions/examples.config.js
@@ -1,0 +1,104 @@
+/** @format */
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const fs = require( 'fs' );
+
+const extArg = process.argv.find( arg => arg.startsWith( '--ext=' ) );
+
+if ( ! extArg ) {
+	throw new Error( 'Please provide an extension.' );
+}
+
+const extension = extArg.slice( 6 );
+const extensionPath = path.join( __dirname, `${ extension }/js/index.js` );
+
+if ( ! fs.existsSync( extensionPath ) ) {
+	throw new Error( 'Extension example does not exist.' );
+}
+
+const externals = {
+	'@wordpress/api-fetch': 'window.wp.apiFetch',
+	'@wordpress/blocks': 'window.wp.blocks',
+	'@wordpress/components': 'window.wp.components',
+	'@wordpress/compose': 'window.wp.compose',
+	'@wordpress/data': 'window.wp.data',
+	'@wordpress/editor': 'window.wp.editor',
+	'@wordpress/element': 'window.wp.element',
+	'@wordpress/hooks': 'window.wp.hooks',
+	'@wordpress/html-entities': 'window.wp.htmlEntities',
+	'@wordpress/i18n': 'window.wp.i18n',
+	'@wordpress/keycodes': 'window.wp.keycodes',
+	tinymce: 'tinymce',
+	moment: 'moment',
+	react: 'React',
+	lodash: 'lodash',
+	'react-dom': 'ReactDOM',
+	'@woocommerce/components': 'window.wc.components',
+	'@woocommerce/csv-export': 'window.wc.csvExport',
+	'@woocommerce/currency': 'window.wc.currency',
+	'@woocommerce/date': 'window.wc.date',
+	'@woocommerce/navigation': 'window.wc.navigation',
+	'@woocommerce/number': 'window.wc.number',
+};
+
+const webpackConfig = {
+	mode: 'development',
+	entry: {
+		[ extension ]: extensionPath,
+	},
+	output: {
+		filename: '[name]/dist/index.js',
+		path: path.resolve( __dirname ),
+	},
+	externals,
+	module: {
+		rules: [
+			{
+				parser: {
+					amd: false,
+				},
+			},
+			{
+				test: /\.jsx?$/,
+				loader: 'babel-loader',
+				exclude: /node_modules/,
+			},
+			{
+				test: /\.js?$/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							[ '@babel/preset-env', { loose: true, modules: 'commonjs' } ],
+						],
+						plugins: [ 'transform-es2015-template-literals' ],
+					},
+				},
+			},
+		],
+	},
+	resolve: {
+		extensions: [ '.json', '.js', '.jsx' ],
+		modules: [
+			'node_modules',
+		],
+		alias: {
+			'gutenberg-components': path.resolve( __dirname, 'node_modules/@wordpress/components/src' ),
+		},
+	},
+	plugins: [
+		new CopyWebpackPlugin( [
+			{
+				from: path.join( __dirname, `${ extension }/` ),
+				to: path.resolve( __dirname, `../../../../${ extension }/` ),
+			},
+		] ),
+	],
+};
+
+webpackConfig.devtool = 'source-map';
+
+module.exports = webpackConfig;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
     "test:help": "wp-scripts test-unit-js --help",
     "test:update-snapshots": "jest --updateSnapshot --config tests/js/jest.config.json",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "example": "webpack --config docs/examples/extensions/examples.config.js --watch"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Create an environment to develop example extension plugins that can be activated, tinkered with, and viewed locally. This makes for an ideal setup to test and develop hooks and filters.

These changes introduce a simple "Hello World" report extension with a build step that places the plugin files including webpacked js code in your plugins folder.

### Screenshots

![Screen Shot 2019-04-09 at 3 13 06 PM](https://user-images.githubusercontent.com/1922453/55770885-07b23280-5ada-11e9-9c4f-07538d814e46.png)

### Detailed test instructions:

1. `npm run example -- --ext=add-report`.
2. Activate the WooCommerce Admin Add Report Example plugin
3. Visit `/wp-admin/admin.php?page=wc-admin#/analytics/example` to see the report.
4. Change the javascript in `docs/examples/extensions/add-report/js/index.js` and make sure the report reflects those changes.
5. Make any change in a PHP file, docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php`, and see the change reflected in the plugin.

### Alternative

We could also house extension examples in a separate repo such as https://github.com/psealock/woocommerce-admin-extension-examples. While this alleviates the need to copy files outside of the `wc-admin` repo, it requires its own build step and package.json while requiring integrations with our team's current communications, such as Slack and notifications. Plus, the examples may get outdated and unhelpful if they lack attention from being separate.

~One drawback to the examples-in-repo approach here is the `npm run example -- add-report` command needs to be re-run everytime PHP changes are made in order to see them. A solution to this is to establish a symlink between folders in this repo and the ones in the plugins folder. This may introduce a whole new kettle of fish, so I'm open to suggestions here.~

EDIT: You can now make changes to PHP files and see them reflected in the plugins folder. Webpack now copies the whole folder on any changes.


