### PR TITLE
Add PHP autofix to pre-commit hook

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -102,7 +102,7 @@ files.forEach( file => {
 
 	try {
 		// Apply auto-fix
-		execSync( `./vendor/bin/phpcbf --standard=phpcs.xml.dist ${ file } > /dev/null` );
+		execSync( `./vendor/bin/phpcbf --standard=phpcs.xml.dist ${ file }` );
 	} catch( e ) {
 		try {
 			// Check if there are still errors

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -101,7 +101,7 @@ files.forEach( file => {
 	}
 
 	try {
-		// Check if PHP PHP_CodeSniffer is installed
+		// Check if PHP PHP_CodeSniffer is installed.
 		execSync( `./vendor/bin/phpcbf -h` );
 		execSync( `./vendor/bin/phpcs -h` );
 	} catch( e ) {
@@ -113,11 +113,11 @@ files.forEach( file => {
 	}
 
 	try {
-		// Apply auto-fix
+		// Apply auto-fix.
 		execSync( `./vendor/bin/phpcbf --standard=phpcs.xml.dist ${ file }` );
 	} catch( e ) {
 		try {
-			// Check if there are still errors
+			// Check if there are still errors.
 			execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist ${ file }` );
 		} catch( err ) {
 			fileHasPhpLintErrors = true;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -101,6 +101,18 @@ files.forEach( file => {
 	}
 
 	try {
+		// Check if PHP PHP_CodeSniffer is installed
+		execSync( `./vendor/bin/phpcbf -h` );
+		execSync( `./vendor/bin/phpcs -h` );
+	} catch( e ) {
+		console.log(
+			'PHP_CodeSniffer is not installed. ' +
+			'Please, run `composer install` ' +
+			'and run the command again.' );
+		process.exit( 1 );
+	}
+
+	try {
 		// Apply auto-fix
 		execSync( `./vendor/bin/phpcbf --standard=phpcs.xml.dist ${ file }` );
 	} catch( e ) {

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -101,7 +101,7 @@ files.forEach( file => {
 	}
 
 	try {
-		// Check if PHP PHP_CodeSniffer is installed.
+		// Check if PHP_CodeSniffer is installed.
 		execSync( `./vendor/bin/phpcbf -h` );
 		execSync( `./vendor/bin/phpcs -h` );
 	} catch( e ) {


### PR DESCRIPTION
Fixes #2021.

Add PHP Lint autofix to pre-commit hook.

### Detailed test instructions:
- Edit any PHP file and add something like this:
```PHP
if ( 1 == 1 ) {
   return; // Spaces instead of tabs
}
```
- With git, add that file and do a commit.
- Notice the spaces instead of tabs issue if automatically fixed.
- Notice not adding a period in the comment prevents you from committing and you manually have to fix that issue.
