### PR TITLE
PHP Lint fixes

### DIFF
--- a/includes/api/class-wc-admin-rest-leaderboards-controller.php
+++ b/includes/api/class-wc-admin-rest-leaderboards-controller.php
@@ -451,7 +451,7 @@ class WC_Admin_REST_Leaderboards_Controller extends WC_REST_Data_Controller {
 						),
 					),
 				),
-				'rows' => array(
+				'rows'    => array(
 					'type'        => 'array',
 					'description' => __( 'Table rows.', 'woocommerce-admin' ),
 					'context'     => array( 'view' ),

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -240,13 +240,13 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'illustration'  => array(
+							'illustration' => array(
 								'description' => __( 'URL for illustration used.', 'woocommerce-admin' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'status'  => array(
+							'status'       => array(
 								'description' => __( 'Task status.', 'woocommerce-admin' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -355,32 +355,32 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 				'email',
 			),
 		);
-		$params['name_includes']                = array(
+		$params['name_includes']           = array(
 			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name_excludes']                = array(
+		$params['name_excludes']           = array(
 			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username_includes']                = array(
+		$params['username_includes']       = array(
 			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username_excludes']                = array(
+		$params['username_excludes']       = array(
 			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email_includes']                   = array(
+		$params['email_includes']          = array(
 			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email_excludes']                   = array(
+		$params['email_excludes']          = array(
 			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-stats-controller.php
@@ -216,32 +216,32 @@ class WC_Admin_REST_Reports_Customers_Stats_Controller extends WC_REST_Reports_C
 				'email',
 			),
 		);
-		$params['name_includes']                = array(
+		$params['name_includes']           = array(
 			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['name_excludes']                = array(
+		$params['name_excludes']           = array(
 			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username_includes']                = array(
+		$params['username_includes']       = array(
 			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['username_excludes']                = array(
+		$params['username_excludes']       = array(
 			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email_includes']                   = array(
+		$params['email_includes']          = array(
 			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['email_excludes']                   = array(
+		$params['email_excludes']          = array(
 			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
@@ -180,7 +180,7 @@ class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_Admin_REST_Report
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'coupons'           => array(
+			'coupons'                 => array(
 				'description' => __( 'Amount discounted by coupons.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
@@ -152,7 +152,7 @@ class WC_Admin_REST_Reports_Revenue_Stats_Controller extends WC_REST_Reports_Con
 				'indicator'   => true,
 				'format'      => 'currency',
 			),
-			'coupons'           => array(
+			'coupons'        => array(
 				'description' => __( 'Amount discounted by coupons.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -123,8 +123,8 @@ class WC_Admin_Notes_Order_Milestones {
 	 */
 	public function get_orders_count( $no_cache = false ) {
 		if ( $no_cache || is_null( $this->orders_count ) ) {
-			$status_counts       = array_map( 'wc_orders_count', $this->allowed_statuses );
-			$this->orders_count  = array_sum( $status_counts );
+			$status_counts      = array_map( 'wc_orders_count', $this->allowed_statuses );
+			$this->orders_count = array_sum( $status_counts );
 		}
 
 		return $this->orders_count;


### PR DESCRIPTION
Fixes several PHP lint issues.

### Detailed test instructions:
- Run `npm run lint:php-fix` and verify it returns with `No fixable errors were found`.