### PR TITLE
Reference correct roadmap blogpost

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Bugs should be reported in the [WooCommerce Admin GitHub repository](https://git
 
 Yes, you can! Join our [GitHub repository](https://github.com/woocommerce/woocommerce-admin/)
 
-Release and roadmap notes are available on the [WooCommerce Developers Blog](https://woocommerce.wordpress.com/2019/01/15/woocommerce-blocks-1-3-0-release-notes/)
+Release and roadmap notes are available on the [WooCommerce Developers Blog](https://woocommerce.wordpress.com/2019/04/05/woocommerce-admin-v0-10-0-release-notes/)
 
 == Screenshots ==
 


### PR DESCRIPTION
Fixes #

Links to the correct blog post showing release notes for the latest version. Would be nice to be able to link to a category or tag dedicated to WooCommerce Admin instead of having to update this every time.
