### PR TITLE
Add empty states for the Inbox and Orders panels

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -137,7 +137,7 @@ class ActivityPanel extends Component {
 				return <InboxPanel />;
 			case 'orders':
 				const { hasUnreadOrders } = this.props;
-				return <OrdersPanel isEmpty={ hasUnreadOrders === false } />;
+				return <OrdersPanel hasActionableOrders={ hasUnreadOrders } />;
 			case 'stock':
 				return <StockPanel />;
 			case 'reviews':

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -32,8 +32,64 @@ class InboxPanel extends Component {
 		this.props.updateCurrentUserData( userDataFields );
 	}
 
+	renderEmptyCard() {
+		return (
+			<ActivityCard
+				className="woocommerce-empty-review-activity-card"
+				title={ __( 'Your inbox is empty', 'woocommerce-admin' ) }
+				icon={ <Gridicon icon="checkmark" size={ 48 } /> }
+			>
+				{ __(
+					/* eslint-disable max-len */
+					"As things begin to happen in your store your inbox will start to fill up. You'll see things like achivements, new feature announcements, extension recommendations and more!",
+					/* eslint-enable */
+					'woocommerce-admin'
+				) }
+			</ActivityCard>
+		);
+	}
+
+	renderNotes() {
+		const { lastRead, notes } = this.props;
+
+		if ( Object.keys( notes ).length === 0 ) {
+			return this.renderEmptyCard();
+		}
+
+		const getButtonsFromActions = actions => {
+			if ( ! actions ) {
+				return [];
+			}
+			return actions.map( action => (
+				<Button isDefault href={ action.url }>
+					{ action.label }
+				</Button>
+			) );
+		};
+
+		const notesArray = Object.keys( notes ).map( key => notes[ key ] );
+
+		return notesArray.map( note => (
+			<ActivityCard
+				key={ note.id }
+				className="woocommerce-inbox-activity-card"
+				title={ note.title }
+				date={ note.date_created_gmt }
+				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
+				unread={
+					! lastRead ||
+					! note.date_created_gmt ||
+					new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
+				}
+				actions={ getButtonsFromActions( note.actions ) }
+			>
+				<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />
+			</ActivityCard>
+		) );
+	}
+
 	render() {
-		const { isError, isRequesting, lastRead, notes } = this.props;
+		const { isError, isRequesting } = this.props;
 
 		if ( isError ) {
 			const title = __(
@@ -58,19 +114,6 @@ class InboxPanel extends Component {
 			);
 		}
 
-		const getButtonsFromActions = actions => {
-			if ( ! actions ) {
-				return [];
-			}
-			return actions.map( action => (
-				<Button isDefault href={ action.url }>
-					{ action.label }
-				</Button>
-			) );
-		};
-
-		const notesArray = Object.keys( notes ).map( key => notes[ key ] );
-
 		return (
 			<Fragment>
 				<ActivityHeader title={ __( 'Inbox', 'woocommerce-admin' ) } />
@@ -83,23 +126,7 @@ class InboxPanel extends Component {
 							lines={ 2 }
 						/>
 					) : (
-						notesArray.map( note => (
-							<ActivityCard
-								key={ note.id }
-								className="woocommerce-inbox-activity-card"
-								title={ note.title }
-								date={ note.date_created_gmt }
-								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-								unread={
-									! lastRead ||
-									! note.date_created_gmt ||
-									new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
-								}
-								actions={ getButtonsFromActions( note.actions ) }
-							>
-								<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />
-							</ActivityCard>
-						) )
+						this.renderNotes()
 					) }
 				</Section>
 			</Fragment>

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -41,7 +41,7 @@ class InboxPanel extends Component {
 			>
 				{ __(
 					/* eslint-disable max-len */
-					"As things begin to happen in your store your inbox will start to fill up. You'll see things like achivements, new feature announcements, extension recommendations and more!",
+					"As things begin to happen in your store your inbox will start to fill up. You'll see things like achievements, new feature announcements, extension recommendations and more!",
 					/* eslint-enable */
 					'woocommerce-admin'
 				) }

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -40,9 +40,8 @@ class InboxPanel extends Component {
 				icon={ <Gridicon icon="checkmark" size={ 48 } /> }
 			>
 				{ __(
-					/* eslint-disable max-len */
-					"As things begin to happen in your store your inbox will start to fill up. You'll see things like achievements, new feature announcements, extension recommendations and more!",
-					/* eslint-enable */
+					'As things begin to happen in your store your inbox will start to fill up. ' +
+						"You'll see things like achievements, new feature announcements, extension recommendations and more!",
 					'woocommerce-admin'
 				) }
 			</ActivityCard>
@@ -52,7 +51,7 @@ class InboxPanel extends Component {
 	renderNotes() {
 		const { lastRead, notes } = this.props;
 
-		if ( Object.keys( notes ).length === 0 ) {
+		if ( 0 === Object.keys( notes ).length ) {
 			return this.renderEmptyCard();
 		}
 

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -4,8 +4,9 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 import interpolateComponents from 'interpolate-components';
@@ -35,173 +36,236 @@ import ActivityOutboundLink from '../activity-outbound-link';
 import { DEFAULT_ACTIONABLE_STATUSES, QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
-function OrdersPanel( { orders, isRequesting, isError, orderStatuses } ) {
-	if ( isError ) {
-		if ( ! orderStatuses.length ) {
+class OrdersPanel extends Component {
+	renderEmptyCard() {
+		const { hasNonActionableOrders } = this.props;
+		if ( hasNonActionableOrders ) {
 			return (
-				<EmptyContent
-					title={ __(
-						"You currently don't have any actionable statuses. " +
-							'To display orders here, select orders that require further review in settings.',
+				<ActivityCard
+					className="woocommerce-empty-review-activity-card"
+					title={ __( 'You have no orders to fulfill', 'woocommerce-admin' ) }
+					icon={ <Gridicon icon="checkmark" size={ 48 } /> }
+				>
+					{ __(
+						/* eslint-disable max-len */
+						"Good job, you've fullfilled all of your new orders!",
+						/* eslint-enable */
 						'woocommerce-admin'
 					) }
-					actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
-					actionURL={ getAdminLink( 'admin.php?page=wc-admin#/analytics/settings' ) }
-				/>
+				</ActivityCard>
 			);
 		}
 
-		const title = __(
-			'There was an error getting your orders. Please try again.',
-			'woocommerce-admin'
+		return (
+			<ActivityCard
+				className="woocommerce-empty-review-activity-card"
+				title={ __( 'You have no orders to fulfill', 'woocommerce-admin' ) }
+				icon={ <Gridicon icon="time" size={ 48 } /> }
+				actions={
+					<Button href="https://docs.woocommerce.com/document/managing-orders/" isDefault>
+						{ __( 'Learn more', 'woocommerce-admin' ) }
+					</Button>
+				}
+			>
+				{ __(
+					/* eslint-disable max-len */
+					"You're still waiting for your customers to make their first orders. While you wait why not learn how to manage orders?",
+					/* eslint-enable */
+					'woocommerce-admin'
+				) }
+			</ActivityCard>
 		);
-		const actionLabel = __( 'Reload', 'woocommerce-admin' );
-		const actionCallback = () => {
-			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
-			window.location.reload();
+	}
+
+	renderOrders() {
+		const { orders } = this.props;
+
+		if ( orders.length === 0 ) {
+			return this.renderEmptyCard();
+		}
+
+		const getCustomerString = order => {
+			const extended_info = order.extended_info || {};
+			const { first_name, last_name } = extended_info.customer || {};
+
+			if ( ! first_name && ! last_name ) {
+				return '';
+			}
+
+			const name = [ first_name, last_name ].join( ' ' );
+			return sprintf(
+				__(
+					/* translators: describes who placed an order, e.g. Order #123 placed by John Doe */
+					'placed by {{customerLink}}%(customerName)s{{/customerLink}}',
+					'woocommerce-admin'
+				),
+				{
+					customerName: name,
+				}
+			);
 		};
 
+		const orderCardTitle = order => {
+			const { extended_info, order_id } = order;
+			const { customer } = extended_info || {};
+			const customerUrl = customer.customer_id
+				? getNewPath( {}, '/analytics/customers', {
+						filter: 'single_customer',
+						customers: customer.customer_id,
+					} )
+				: null;
+
+			return (
+				<Fragment>
+					{ interpolateComponents( {
+						mixedString: sprintf(
+							__(
+								'Order {{orderLink}}#%(orderNumber)s{{/orderLink}} %(customerString)s {{destinationFlag/}}',
+								'woocommerce-admin'
+							),
+							{
+								orderNumber: order_id,
+								customerString: getCustomerString( order ),
+							}
+						),
+						components: {
+							orderLink: <Link href={ 'post.php?action=edit&post=' + order_id } type="wp-admin" />,
+							destinationFlag: customer.country ? (
+								<Flag code={ customer.country } round={ false } />
+							) : null,
+							customerLink: customerUrl ? <Link href={ customerUrl } type="wc-admin" /> : <span />,
+						},
+					} ) }
+				</Fragment>
+			);
+		};
+
+		const cards = [];
+		orders.forEach( order => {
+			const extended_info = order.extended_info || {};
+			const productsCount =
+				extended_info && extended_info.products ? extended_info.products.length : 0;
+
+			const total = order.gross_total;
+			const refundValue = order.refund_total;
+			const remainingTotal = getCurrencyFormatDecimal( total ) + refundValue;
+
+			cards.push(
+				<ActivityCard
+					key={ order.order_id }
+					className="woocommerce-order-activity-card"
+					title={ orderCardTitle( order ) }
+					date={ order.date_created_gmt }
+					subtitle={
+						<div>
+							<span>
+								{ sprintf(
+									_n( '%d product', '%d products', productsCount, 'woocommerce-admin' ),
+									productsCount
+								) }
+							</span>
+							{ refundValue ? (
+								<span>
+									<s>{ formatCurrency( total ) }</s> { formatCurrency( remainingTotal ) }
+								</span>
+							) : (
+								<span>{ formatCurrency( total ) }</span>
+							) }
+						</div>
+					}
+					actions={
+						<Button
+							isDefault
+							href={ getAdminLink( 'post.php?action=edit&post=' + order.order_id ) }
+						>
+							{ __( 'Begin fulfillment' ) }
+						</Button>
+					}
+				>
+					<OrderStatus order={ order } />
+				</ActivityCard>
+			);
+		} );
 		return (
 			<Fragment>
-				<EmptyContent
-					title={ title }
-					actionLabel={ actionLabel }
-					actionURL={ null }
-					actionCallback={ actionCallback }
-				/>
+				{ cards }
+				<ActivityOutboundLink href={ 'edit.php?post_type=shop_order' }>
+					{ __( 'Manage all orders', 'woocommerce-admin' ) }
+				</ActivityOutboundLink>
 			</Fragment>
 		);
 	}
 
-	const menu = (
-		<EllipsisMenu label="Demo Menu">
-			<MenuTitle>Test</MenuTitle>
-			<MenuItem onInvoke={ noop }>Test</MenuItem>
-		</EllipsisMenu>
-	);
+	render() {
+		const { orders, isRequesting, isError, orderStatuses } = this.props;
 
-	const getCustomerString = order => {
-		const extended_info = order.extended_info || {};
-		const { first_name, last_name } = extended_info.customer || {};
+		if ( isError ) {
+			if ( ! orderStatuses.length ) {
+				return (
+					<EmptyContent
+						title={ __(
+							"You currently don't have any actionable statuses. " +
+								'To display orders here, select orders that require further review in settings.',
+							'woocommerce-admin'
+						) }
+						actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
+						actionURL={ getAdminLink( 'admin.php?page=wc-admin#/analytics/settings' ) }
+					/>
+				);
+			}
 
-		if ( ! first_name && ! last_name ) {
-			return '';
+			const title = __(
+				'There was an error getting your orders. Please try again.',
+				'woocommerce-admin'
+			);
+			const actionLabel = __( 'Reload', 'woocommerce-admin' );
+			const actionCallback = () => {
+				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
+				window.location.reload();
+			};
+
+			return (
+				<Fragment>
+					<EmptyContent
+						title={ title }
+						actionLabel={ actionLabel }
+						actionURL={ null }
+						actionCallback={ actionCallback }
+					/>
+				</Fragment>
+			);
 		}
 
-		const name = [ first_name, last_name ].join( ' ' );
-		return sprintf(
-			__(
-				/* translators: describes who placed an order, e.g. Order #123 placed by John Doe */
-				'placed by {{customerLink}}%(customerName)s{{/customerLink}}',
-				'woocommerce-admin'
-			),
-			{
-				customerName: name,
-			}
+		const menu = (
+			<EllipsisMenu label="Demo Menu">
+				<MenuTitle>Test</MenuTitle>
+				<MenuItem onInvoke={ noop }>Test</MenuItem>
+			</EllipsisMenu>
 		);
-	};
 
-	const orderCardTitle = order => {
-		const { extended_info, order_id } = order;
-		const { customer } = extended_info || {};
-		const customerUrl = customer.customer_id
-			? getNewPath( {}, '/analytics/customers', {
-					filter: 'single_customer',
-					customers: customer.customer_id,
-				} )
-			: null;
+		const title =
+			isRequesting || orders.length
+				? __( 'Orders', 'woocommerce-admin' )
+				: __( 'No orders to ship', 'woocommerce-admin' );
 
 		return (
 			<Fragment>
-				{ interpolateComponents( {
-					mixedString: sprintf(
-						__(
-							'Order {{orderLink}}#%(orderNumber)s{{/orderLink}} %(customerString)s {{destinationFlag/}}',
-							'woocommerce-admin'
-						),
-						{
-							orderNumber: order_id,
-							customerString: getCustomerString( order ),
-						}
-					),
-					components: {
-						orderLink: <Link href={ 'post.php?action=edit&post=' + order_id } type="wp-admin" />,
-						destinationFlag: customer.country ? (
-							<Flag code={ customer.country } round={ false } />
-						) : null,
-						customerLink: customerUrl ? <Link href={ customerUrl } type="wc-admin" /> : <span />,
-					},
-				} ) }
+				<ActivityHeader title={ title } menu={ menu } />
+				<Section>
+					{ isRequesting ? (
+						<ActivityCardPlaceholder
+							className="woocommerce-order-activity-card"
+							hasAction
+							hasDate
+							lines={ 2 }
+						/>
+					) : (
+						this.renderOrders()
+					) }
+				</Section>
 			</Fragment>
 		);
-	};
-
-	const cards = [];
-	orders.forEach( order => {
-		const extended_info = order.extended_info || {};
-		const productsCount =
-			extended_info && extended_info.products ? extended_info.products.length : 0;
-
-		const total = order.gross_total;
-		const refundValue = order.refund_total;
-		const remainingTotal = getCurrencyFormatDecimal( total ) + refundValue;
-
-		cards.push(
-			<ActivityCard
-				key={ order.order_id }
-				className="woocommerce-order-activity-card"
-				title={ orderCardTitle( order ) }
-				date={ order.date_created_gmt }
-				subtitle={
-					<div>
-						<span>
-							{ sprintf(
-								_n( '%d product', '%d products', productsCount, 'woocommerce-admin' ),
-								productsCount
-							) }
-						</span>
-						{ refundValue ? (
-							<span>
-								<s>{ formatCurrency( total ) }</s> { formatCurrency( remainingTotal ) }
-							</span>
-						) : (
-							<span>{ formatCurrency( total ) }</span>
-						) }
-					</div>
-				}
-				actions={
-					<Button isDefault href={ getAdminLink( 'post.php?action=edit&post=' + order.order_id ) }>
-						{ __( 'Begin fulfillment' ) }
-					</Button>
-				}
-			>
-				<OrderStatus order={ order } />
-			</ActivityCard>
-		);
-	} );
-
-	return (
-		<Fragment>
-			<ActivityHeader title={ __( 'Orders', 'woocommerce-admin' ) } menu={ menu } />
-			<Section>
-				{ isRequesting ? (
-					<ActivityCardPlaceholder
-						className="woocommerce-order-activity-card"
-						hasAction
-						hasDate
-						lines={ 2 }
-					/>
-				) : (
-					<Fragment>
-						{ cards }
-						<ActivityOutboundLink href={ 'edit.php?post_type=shop_order' }>
-							{ __( 'Manage all orders' ) }
-						</ActivityOutboundLink>
-					</Fragment>
-				) }
-			</Section>
-		</Fragment>
-	);
+	}
 }
 
 OrdersPanel.propTypes = {
@@ -218,8 +282,8 @@ OrdersPanel.defaultProps = {
 
 export default compose(
 	withSelect( ( select, props ) => {
+		const { hasActionableOrders } = props;
 		const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
-		const { isEmpty } = props;
 		const orderStatuses =
 			wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses ||
 			DEFAULT_ACTIONABLE_STATUSES;
@@ -228,21 +292,35 @@ export default compose(
 			return { orders: [], isError: true, isRequesting: false, orderStatuses };
 		}
 
-		if ( isEmpty ) {
-			return { orders: [], isError: false, isRequesting: false, orderStatuses };
+		if ( hasActionableOrders ) {
+			const ordersQuery = {
+				page: 1,
+				per_page: QUERY_DEFAULTS.pageSize,
+				status_is: orderStatuses,
+				extended_info: true,
+			};
+
+			const orders = getReportItems( 'orders', ordersQuery ).data;
+			const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );
+			const isRequesting = isReportItemsRequesting( 'orders', ordersQuery );
+
+			return { orders, isError, isRequesting, orderStatuses };
 		}
 
-		const ordersQuery = {
+		const allOrdersQuery = {
 			page: 1,
-			per_page: QUERY_DEFAULTS.pageSize,
-			status_is: orderStatuses,
-			extended_info: true,
+			per_page: 0,
 		};
 
-		const orders = getReportItems( 'orders', ordersQuery ).data;
-		const isError = Boolean( getReportItemsError( 'orders', ordersQuery ) );
-		const isRequesting = isReportItemsRequesting( 'orders', ordersQuery );
+		const totalNonActionableOrders = getReportItems( 'orders', allOrdersQuery ).totalResults;
+		const isError = Boolean( getReportItemsError( 'orders', allOrdersQuery ) );
+		const isRequesting = isReportItemsRequesting( 'orders', allOrdersQuery );
 
-		return { orders, isError, isRequesting, orderStatuses };
+		return {
+			hasNonActionableOrders: totalNonActionableOrders > 0,
+			isError,
+			isRequesting,
+			orderStatuses,
+		};
 	} )
 )( OrdersPanel );

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -46,12 +46,7 @@ class OrdersPanel extends Component {
 					title={ __( 'You have no orders to fulfill', 'woocommerce-admin' ) }
 					icon={ <Gridicon icon="checkmark" size={ 48 } /> }
 				>
-					{ __(
-						/* eslint-disable max-len */
-						"Good job, you've fulfilled all of your new orders!",
-						/* eslint-enable */
-						'woocommerce-admin'
-					) }
+					{ __( "Good job, you've fulfilled all of your new orders!", 'woocommerce-admin' ) }
 				</ActivityCard>
 			);
 		}
@@ -62,15 +57,18 @@ class OrdersPanel extends Component {
 				title={ __( 'You have no orders to fulfill', 'woocommerce-admin' ) }
 				icon={ <Gridicon icon="time" size={ 48 } /> }
 				actions={
-					<Button href="https://docs.woocommerce.com/document/managing-orders/" isDefault>
+					<Button
+						href="https://docs.woocommerce.com/document/managing-orders/"
+						isDefault
+						target="_blank"
+					>
 						{ __( 'Learn more', 'woocommerce-admin' ) }
 					</Button>
 				}
 			>
 				{ __(
-					/* eslint-disable max-len */
-					"You're still waiting for your customers to make their first orders. While you wait why not learn how to manage orders?",
-					/* eslint-enable */
+					"You're still waiting for your customers to make their first orders. " +
+						'While you wait why not learn how to manage orders?',
 					'woocommerce-admin'
 				) }
 			</ActivityCard>

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -48,7 +48,7 @@ class OrdersPanel extends Component {
 				>
 					{ __(
 						/* eslint-disable max-len */
-						"Good job, you've fullfilled all of your new orders!",
+						"Good job, you've fulfilled all of your new orders!",
 						/* eslint-enable */
 						'woocommerce-admin'
 					) }

--- a/client/wc-api/notes/selectors.js
+++ b/client/wc-api/notes/selectors.js
@@ -30,11 +30,7 @@ const isGetNotesRequesting = getResource => ( query = {} ) => {
 	const resourceName = getResourceName( 'note-query', query );
 	const { lastRequested, lastReceived } = getResource( resourceName );
 
-	if ( isNil( lastRequested ) ) {
-		return false;
-	}
-
-	if ( isNil( lastReceived ) ) {
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #2025.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Detailed test instructions:
- Force the Activity Panel not to load any Inbox note. For example removing all notes from the database or replacing the `type` in [this line](https://github.com/woocommerce/woocommerce-admin/blob/master/client/header/activity-panel/panels/inbox.js#L119) to `error`.
- Open the _Inbox_ tab of the Activity Panel.
- Verify the empty card appears:
![image](https://user-images.githubusercontent.com/3616980/55889173-f25c0780-5bb0-11e9-99dd-9d6c25dab1b6.png)
- Remove all orders in your store.
- Open the _Orders_ tab of the activity panel.
- Verify the empty card appears:
![image](https://user-images.githubusercontent.com/3616980/55889249-1ae40180-5bb1-11e9-9fab-adea5efdd3ba.png)
- Create an _on hold_ or _processing_ order.
- Open the _Orders_ tab of the activity panel.
- Verify the empty card appears:
![image](https://user-images.githubusercontent.com/3616980/55890417-f426ca80-5bb2-11e9-843d-1c0f524143a7.png)
