### PR TITLE
Handle “all guests” when getting customers from orders.

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -337,24 +337,29 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	}
 
 	/**
-	 * Get customer data from order IDs.
+	 * Get customer data from Order data.
 	 *
-	 * @param array $orders Array of orders.
+	 * @param array $orders Array of orders data.
 	 * @return array
 	 */
 	protected function get_customers_by_orders( $orders ) {
 		global $wpdb;
-		$customer_lookup_table = $wpdb->prefix . 'wc_customer_lookup';
 
-		$customer_ids = array();
+		$customer_lookup_table = $wpdb->prefix . 'wc_customer_lookup';
+		$customer_ids          = array();
+
 		foreach ( $orders as $order ) {
 			if ( $order['customer_id'] ) {
 				$customer_ids[] = $order['customer_id'];
 			}
 		}
-		$customer_ids = implode( ',', $customer_ids );
 
-		$customers = $wpdb->get_results(
+		if ( empty( $customer_ids ) ) {
+			return array();
+		}
+
+		$customer_ids = implode( ',', $customer_ids );
+		$customers    = $wpdb->get_results(
 			"SELECT * FROM {$customer_lookup_table} WHERE customer_id IN ({$customer_ids})",
 			ARRAY_A
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -350,7 +350,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		foreach ( $orders as $order ) {
 			if ( $order['customer_id'] ) {
-				$customer_ids[] = $order['customer_id'];
+				$customer_ids[] = intval( $order['customer_id'] );
 			}
 		}
 


### PR DESCRIPTION
`WC_Admin_Reports_Orders_Data_Store::get_customers_by_orders()` issues a bad query when none of the orders have a non-guest (non-0) customer ID.

This PR introduces a `empty()` check before issuing an unnecessary (and broken) query for customers.

### Detailed test instructions:

- Create an order that will show in the Orders panel (has an actionable status) that has no customer information
- Go to the Dashboard and open the Orders panel
- Verify that the API request made returns without error
