### PR TITLE
Respect manual offsets in default before/after params

### DIFF
--- a/includes/class-wc-admin-reports-interval.php
+++ b/includes/class-wc-admin-reports-interval.php
@@ -44,8 +44,13 @@ class WC_Admin_Reports_Interval {
 	 * @return DateTime
 	 */
 	public static function default_before() {
-		$datetime = new DateTime();
-		$datetime->setTimezone( new DateTimeZone( wc_timezone_string() ) );
+		$datetime = new WC_DateTime();
+		// Set local timezone or offset.
+		if ( get_option( 'timezone_string' ) ) {
+			$datetime->setTimezone( new DateTimeZone( wc_timezone_string() ) );
+		} else {
+			$datetime->set_utc_offset( wc_timezone_offset() );
+		}
 		return $datetime;
 	}
 
@@ -58,9 +63,14 @@ class WC_Admin_Reports_Interval {
 		$now       = time();
 		$week_back = $now - WEEK_IN_SECONDS;
 
-		$datetime = new DateTime();
+		$datetime = new WC_DateTime();
 		$datetime->setTimestamp( $week_back );
-		$datetime->setTimezone( new DateTimeZone( wc_timezone_string() ) );
+		// Set local timezone or offset.
+		if ( get_option( 'timezone_string' ) ) {
+			$datetime->setTimezone( new DateTimeZone( wc_timezone_string() ) );
+		} else {
+			$datetime->set_utc_offset( wc_timezone_offset() );
+		}
 		return $datetime;
 	}
 

--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -572,13 +572,21 @@ class WC_Admin_Reports_Data_Store {
 		);
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
-			$datetime_str                    = $query_args['before']->format( WC_Admin_Reports_Interval::$sql_datetime_format );
+			if ( is_a( $query_args['before'], 'WC_DateTime' ) ) {
+				$datetime_str = $query_args['before']->date( WC_Admin_Reports_Interval::$sql_datetime_format );
+			} else {
+				$datetime_str = $query_args['before']->format( WC_Admin_Reports_Interval::$sql_datetime_format );
+			}
 			$sql_query['where_time_clause'] .= " AND {$table_name}.date_created <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
-			$datetime_str                    = $query_args['after']->format( WC_Admin_Reports_Interval::$sql_datetime_format );
+			if ( is_a( $query_args['after'], 'WC_DateTime' ) ) {
+				$datetime_str = $query_args['after']->date( WC_Admin_Reports_Interval::$sql_datetime_format );
+			} else {
+				$datetime_str = $query_args['after']->format( WC_Admin_Reports_Interval::$sql_datetime_format );
+			}
 			$sql_query['where_time_clause'] .= " AND {$table_name}.date_created >= '$datetime_str'";
 		}
 


### PR DESCRIPTION
Fixes #2035.

Default values for before/after params did not respect manual offsets which are not recognized by `wc_timezone_string()`, so setting your store timezone to _UTC+14_, for example, might give unexpected results. This PR applies a solution used in WooCommerce that handles the case when the timezone is not one of the recognized ones:
https://docs.woocommerce.com/wc-apidocs/source-function-wc_timezone_string.html#654-659

### Detailed test instructions:
1. Set your store timezone to _UTC+14_, for example.
2. Create an _on hold_ order and rebuild tables.
3. Verify the order appears in the _Orders_ tab of the Activity Panel.
4. Verify there are no regressions in other queries.
