### PR TITLE
Remove lodash from bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "history": "4.9.0",
     "html-to-react": "1.3.4",
     "interpolate-components": "1.1.1",
-    "lodash": "^4.17.11",
     "marked": "0.6.2",
     "memoize-one": "5.0.2",
     "prismjs": "^1.15.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ const externals = {
 	tinymce: 'tinymce',
 	moment: 'moment',
 	react: 'React',
+	lodash: 'lodash',
 	'react-dom': 'ReactDOM',
 };
 


### PR DESCRIPTION
While looking at https://github.com/Prospress/action-scheduler-admin/pull/2 for @rrennick, it occurred to me that since lodash is already on window, we can exclude it from our build.

### Before

5.67 MB

![Screen Shot 2019-04-12 at 2 20 11 PM](https://user-images.githubusercontent.com/1922453/56009150-e8621200-5d32-11e9-8703-a61ebca0ca07.png)

### After

5.16 MB

![Screen Shot 2019-04-12 at 2 22 36 PM](https://user-images.githubusercontent.com/1922453/56009156-ed26c600-5d32-11e9-8718-f50f22f745c9.png)

### Detailed test instructions:

1. `npm start`
2. Check that nothing is broken
