### PR TITLE
 Add endpoint route to cancel all pending import actions

### DIFF
--- a/tests/framework/helpers/class-wc-helper-queue.php
+++ b/tests/framework/helpers/class-wc-helper-queue.php
@@ -12,11 +12,11 @@
  */
 class WC_Helper_Queue {
 	/**
-	 * Run all pending queued actions.
+	 * Get all pending queued actions.
 	 *
-	 * @return void
+	 * @return array Pending jobs.
 	 */
-	public static function run_all_pending() {
+	public static function get_all_pending() {
 		$jobs = WC()->queue()->search(
 			array(
 				'per_page' => -1,
@@ -24,6 +24,17 @@ class WC_Helper_Queue {
 				'claimed'  => false,
 			)
 		);
+
+		return $jobs;
+	}
+
+	/**
+	 * Run all pending queued actions.
+	 *
+	 * @return void
+	 */
+	public static function run_all_pending() {
+		$jobs = self::get_all_pending();
 
 		foreach ( $jobs as $job ) {
 			$job->execute();


### PR DESCRIPTION
Fixes (part of) #1850

Adds a cancel route to the import endpoint to cancel outstanding actions.

### Screenshots
<img width="648" alt="Screen Shot 2019-04-12 at 4 34 21 PM" src="https://user-images.githubusercontent.com/10561050/56024254-36cadd00-5d42-11e9-9da0-e66f2896bafc.png">

### Detailed test instructions:

1.  Begin an import by sending a POST request to `wp-json/wc/v4/reports/import/`.
2.  Send a request to `wp-json/wc/v4/reports/import/cancel`.
3.  Note the trashed `wc-admin_orders_lookup_batch_init` post in `wp_posts`.