### PR TITLE
Add empty state in Stock panel

### DIFF
--- a/client/header/activity-panel/panels/stock/index.js
+++ b/client/header/activity-panel/panels/stock/index.js
@@ -72,7 +72,7 @@ class StockPanel extends Component {
 		}
 
 		const title =
-			products.length > 0
+			isRequesting || products.length > 0
 				? __( 'Stock', 'woocommerce-admin' )
 				: __( 'No products with low stock', 'woocommerce-admin' );
 		return (

--- a/client/header/activity-panel/panels/stock/index.js
+++ b/client/header/activity-panel/panels/stock/index.js
@@ -15,13 +15,36 @@ import { EmptyContent, Section } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { ActivityCardPlaceholder } from '../../activity-card';
+import { ActivityCard, ActivityCardPlaceholder } from '../../activity-card';
 import ActivityHeader from '../../activity-header';
+import Gridicon from 'gridicons';
 import ProductStockCard from './card';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
 class StockPanel extends Component {
+	renderEmptyCard() {
+		return (
+			<ActivityCard
+				className="woocommerce-empty-review-activity-card"
+				title={ __( 'Your stock is in good shape.', 'woocommerce-admin' ) }
+				icon={ <Gridicon icon="checkmark" size={ 48 } /> }
+			>
+				{ __( 'You currently have no products running low on stock.', 'woocommerce-admin' ) }
+			</ActivityCard>
+		);
+	}
+
+	renderProducts() {
+		const { products } = this.props;
+
+		if ( products.length === 0 ) {
+			return this.renderEmptyCard();
+		}
+
+		return products.map( product => <ProductStockCard key={ product.id } product={ product } /> );
+	}
+
 	render() {
 		const { isError, isRequesting, products } = this.props;
 
@@ -48,9 +71,13 @@ class StockPanel extends Component {
 			);
 		}
 
+		const title =
+			products.length > 0
+				? __( 'Stock', 'woocommerce-admin' )
+				: __( 'No products with low stock', 'woocommerce-admin' );
 		return (
 			<Fragment>
-				<ActivityHeader title={ __( 'Stock', 'woocommerce-admin' ) } />
+				<ActivityHeader title={ title } />
 				<Section>
 					{ isRequesting ? (
 						<ActivityCardPlaceholder
@@ -59,7 +86,7 @@ class StockPanel extends Component {
 							lines={ 1 }
 						/>
 					) : (
-						products.map( product => <ProductStockCard key={ product.id } product={ product } /> )
+						this.renderProducts()
 					) }
 				</Section>
 			</Fragment>


### PR DESCRIPTION
Fixes #2036.

### Screenshots
![Screenshot from 2019-04-12 10-47-01](https://user-images.githubusercontent.com/3616980/56027026-9eb6fe80-5d15-11e9-8055-ebec209f598f.png)

### Detailed test instructions:
- Make sure you don't have any product in low stock.
- Verify the empty card appears in the _Stock_ tab of the Activity Panel.
