### PR TITLE
Add customizable dashboard feature flag, and base page.

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -1,0 +1,31 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import DashboardCharts from './dashboard-charts';
+import Leaderboards from './leaderboards';
+import { ReportFilters, H } from '@woocommerce/components';
+import StorePerformance from './store-performance';
+
+// @todo Replace dashboard-charts, leaderboards, and store-performance sections as neccessary with customizable equivalents.
+export default class CustomizableDashboard extends Component {
+	render() {
+		const { query, path } = this.props;
+		return (
+			<Fragment>
+				<H>{ __( 'Customizable Dashboard', 'woocommerce-admin' ) }</H>
+				<ReportFilters query={ query } path={ path } />
+				<StorePerformance query={ query } />
+				<DashboardCharts query={ query } path={ path } />
+				<Leaderboards query={ query } />
+			</Fragment>
+		);
+	}
+}

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -9,6 +9,7 @@ import { Component, Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import CustomizableDashboard from './customizable';
 import DashboardCharts from './dashboard-charts';
 import Header from 'header';
 import Leaderboards from './leaderboards';
@@ -17,23 +18,36 @@ import StorePerformance from './store-performance';
 import TaskList from './task-list';
 
 export default class Dashboard extends Component {
-	render() {
-		const { query, path } = this.props;
+	renderDashboardOutput() {
 		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
 		const requiredTasksComplete = true;
+		if ( window.wcAdminFeatures.onboarding && ! requiredTasksComplete ) {
+			return <TaskList />;
+		}
+
+		const { query, path } = this.props;
+
+		// @todo When the customizable dashboard is ready to be launched, we can pull `CustomizableDashboard`'s render
+		// method into `index.js`, and replace both this feature check, and the existing dashboard below.
+		if ( window.wcAdminFeatures[ 'dashboard/customizable' ] ) {
+			return <CustomizableDashboard query={ query } path={ path } />;
+		}
+
+		return (
+			<Fragment>
+				<ReportFilters query={ query } path={ path } />
+				<StorePerformance query={ query } />
+				<DashboardCharts query={ query } path={ path } />
+				<Leaderboards query={ query } />
+			</Fragment>
+		);
+	}
+
+	render() {
 		return (
 			<Fragment>
 				<Header sections={ [ __( 'Dashboard', 'woocommerce-admin' ) ] } />
-				{ window.wcAdminFeatures.onboarding && ! requiredTasksComplete ? (
-					<TaskList />
-				) : (
-					<Fragment>
-						<ReportFilters query={ query } path={ path } />
-						<StorePerformance query={ query } />
-						<DashboardCharts query={ query } path={ path } />
-						<Leaderboards query={ query } />
-					</Fragment>
-				) }
+				{ this.renderDashboardOutput() }
 			</Fragment>
 		);
 	}

--- a/config/core.json
+++ b/config/core.json
@@ -3,6 +3,7 @@
 		"activity-panels": false,
 		"analytics": false,
 		"dashboard": false,
+		"dashboard/customizable": false,
 		"devdocs": false,
 		"onboarding": false,
 		"store-alerts": false

--- a/config/development.json
+++ b/config/development.json
@@ -3,6 +3,7 @@
 		"activity-panels": true,
 		"analytics": true,
 		"dashboard": true,
+		"dashboard/customizable": true,
 		"devdocs": true,
 		"onboarding": true,
 		"store-alerts": true

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -3,6 +3,7 @@
 		"activity-panels": true,
 		"analytics": true,
 		"dashboard": true,
+		"dashboard/customizable": false,
 		"devdocs": false,
 		"onboarding": false,
 		"store-alerts": true


### PR DESCRIPTION
Fixes #2041.

This PR adds a new `dashboard/customizable` feature flag, that allows us to work on making the dashboard extendable, separate from the current dashboard experience shipped in the plugin. It also makes a small adjustment to the plugin build progress that broke when #1863 landed.

### Detailed test instructions:

* `npm start` to start the app in development mode. 
* Note the "Customizable Dashboard" header I added as an example of split code.
* Run `npm run build:release` to build a plugin release.
* Run the plugin on a test site, note the old dashboard (no header) is present.