### PR TITLE
Add import delete endpoint and batch actions

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -59,6 +59,18 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 				'schema' => array( $this, 'get_import_public_schema' ),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/delete',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'delete_imported_items' ),
+					'permission_callback' => array( $this, 'import_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_import_public_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -204,6 +216,35 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 			'status'  => 'success',
 			'message' => __( 'All pending and in-progress import actions have been cancelled.', 'woocommerce-admin' ),
 		);
+
+		$response = $this->prepare_item_for_response( $result, $request );
+		$data     = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Delete all imported items.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	
+	public function delete_imported_items( $request ) {
+		$delete = WC_Admin_Reports_Sync::delete_report_data();
+
+		if ( is_wp_error( $delete ) ) {
+			$result = array(
+				'status'  => 'error',
+				'message' => $delete->get_error_message(),
+			);
+		} else {
+			$result = array(
+				'status'  => 'success',
+				'message' => $delete,
+			);
+		}
+
 		$response = $this->prepare_item_for_response( $result, $request );
 		$data     = $this->prepare_response_for_collection( $response );
 

--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -212,7 +212,7 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 	public function cancel_import( $request ) {
 		WC_Admin_Reports_Sync::clear_queued_actions();
 
-		$result   = array(
+		$result = array(
 			'status'  => 'success',
 			'message' => __( 'All pending and in-progress import actions have been cancelled.', 'woocommerce-admin' ),
 		);
@@ -229,7 +229,6 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 	 * @param  WP_REST_Request $request Request data.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	
 	public function delete_imported_items( $request ) {
 		$delete = WC_Admin_Reports_Sync::delete_report_data();
 

--- a/includes/class-wc-admin-actionscheduler-wppoststore.php
+++ b/includes/class-wc-admin-actionscheduler-wppoststore.php
@@ -47,10 +47,10 @@ class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
 		$action_types = array(
 			WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
 			WC_Admin_Reports_Sync::QUEUE_DEPEDENT_ACTION,
-			WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION,
-			WC_Admin_Reports_Sync::ORDERS_BATCH_ACTION,
-			WC_Admin_Reports_Sync::ORDERS_LOOKUP_BATCH_INIT,
-			WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION,
+			WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION,
+			WC_Admin_Reports_Sync::ORDERS_IMPORT_BATCH_ACTION,
+			WC_Admin_Reports_Sync::ORDERS_IMPORT_BATCH_INIT,
+			WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION,
 		);
 
 		foreach ( $action_types as $action_type ) {

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -22,24 +22,44 @@ class WC_Admin_Reports_Sync {
 	const QUEUE_DEPEDENT_ACTION = 'wc-admin_queue_dependent_action';
 
 	/**
-	 * Action hook for processing a batch of customers.
+	 * Action hook for importing a batch of customers.
 	 */
-	const CUSTOMERS_BATCH_ACTION = 'wc-admin_process_customers_batch';
-
-	/**
-	 * Action hook for processing a batch of orders.
-	 */
-	const ORDERS_BATCH_ACTION = 'wc-admin_process_orders_batch';
+	const CUSTOMERS_IMPORT_BATCH_ACTION = 'wc-admin_import_customers_batch';
 
 	/**
 	 * Action hook for initializing the orders lookup batch creation.
 	 */
-	const ORDERS_LOOKUP_BATCH_INIT = 'wc-admin_orders_lookup_batch_init';
+	const CUSTOMERS_DELETE_BATCH_INIT = 'wc-admin_delete_customers_batch_init';
 
 	/**
-	 * Action hook for processing a batch of orders.
+	 * Action hook for importing a batch of customers.
 	 */
-	const SINGLE_ORDER_ACTION = 'wc-admin_process_order';
+	const CUSTOMERS_DELETE_BATCH_ACTION = 'wc-admin_delete_customers_batch';
+
+	/**
+	 * Action hook for importing a batch of orders.
+	 */
+	const ORDERS_IMPORT_BATCH_ACTION = 'wc-admin_import_orders_batch';
+
+	/**
+	 * Action hook for initializing the orders lookup batch creation.
+	 */
+	const ORDERS_IMPORT_BATCH_INIT = 'wc-admin_orders_lookup_import_batch_init';
+
+	/**
+	 * Action hook for initializing the orders lookup batch deletion.
+	 */
+	const ORDERS_DELETE_BATCH_INIT = 'wc-admin_orders_lookup_delete_batch_init';
+
+	/**
+	 * Action hook for deleting a batch of orders.
+	 */
+	const ORDERS_DELETE_BATCH_ACTION = 'wc-admin_delete_orders_batch';
+
+	/**
+	 * Action hook for importing a batch of orders.
+	 */
+	const SINGLE_ORDER_IMPORT_ACTION = 'wc-admin_import_order';
 
 	/**
 	 * Action scheduler group.
@@ -85,22 +105,26 @@ class WC_Admin_Reports_Sync {
 		// Initialize scheduled action handlers.
 		add_action( self::QUEUE_BATCH_ACTION, array( __CLASS__, 'queue_batches' ), 10, 4 );
 		add_action( self::QUEUE_DEPEDENT_ACTION, array( __CLASS__, 'queue_dependent_action' ), 10, 3 );
-		add_action( self::CUSTOMERS_BATCH_ACTION, array( __CLASS__, 'customer_lookup_process_batch' ), 10, 3 );
-		add_action( self::ORDERS_BATCH_ACTION, array( __CLASS__, 'orders_lookup_process_batch' ), 10, 3 );
-		add_action( self::ORDERS_LOOKUP_BATCH_INIT, array( __CLASS__, 'orders_lookup_batch_init' ), 10, 2 );
-		add_action( self::SINGLE_ORDER_ACTION, array( __CLASS__, 'orders_lookup_process_order' ) );
+		add_action( self::CUSTOMERS_IMPORT_BATCH_ACTION, array( __CLASS__, 'customer_lookup_import_batch' ), 10, 3 );
+		add_action( self::CUSTOMERS_DELETE_BATCH_INIT, array( __CLASS__, 'customer_lookup_delete_batch_init' ) );
+		add_action( self::CUSTOMERS_DELETE_BATCH_ACTION, array( __CLASS__, 'customer_lookup_delete_batch' ) );
+		add_action( self::ORDERS_IMPORT_BATCH_ACTION, array( __CLASS__, 'orders_lookup_import_batch' ), 10, 4 );
+		add_action( self::ORDERS_IMPORT_BATCH_INIT, array( __CLASS__, 'orders_lookup_import_batch_init' ), 10, 3 );
+		add_action( self::ORDERS_DELETE_BATCH_ACTION, array( __CLASS__, 'orders_lookup_delete_batch' ), 10, 4 );
+		add_action( self::ORDERS_DELETE_BATCH_INIT, array( __CLASS__, 'orders_lookup_delete_batch_init' ), 10, 3 );
+		add_action( self::SINGLE_ORDER_IMPORT_ACTION, array( __CLASS__, 'orders_lookup_import_order' ) );
 	}
 
 	/**
 	 * Regenerate data for reports.
 	 *
-	 * @param int|bool $days Number of days to process.
+	 * @param int|bool $days Number of days to import.
 	 * @param bool     $skip_existing Skip exisiting records.
 	 * @return string
 	 */
 	public static function regenerate_report_data( $days, $skip_existing ) {
-		self::customer_lookup_batch_init( $days, $skip_existing );
-		self::queue_dependent_action( self::ORDERS_LOOKUP_BATCH_INIT, array( $days, $skip_existing ), self::CUSTOMERS_BATCH_ACTION );
+		self::customer_lookup_import_batch_init( $days, $skip_existing );
+		self::queue_dependent_action( self::ORDERS_IMPORT_BATCH_INIT, array( $days, $skip_existing ), self::CUSTOMERS_IMPORT_BATCH_ACTION );
 
 		return __( 'Report table data is being rebuilt.  Please allow some time for data to fully populate.', 'woocommerce-admin' );
 	}
@@ -120,18 +144,36 @@ class WC_Admin_Reports_Sync {
 	}
 
 	/**
-	 * Schedule an action to process a single Order.
+	 * Delete all data for reports.
+	 *
+	 * @return string
+	 */
+	public static function delete_report_data() {
+		// Cancel all pending import jobs.
+		self::clear_queued_actions();
+
+		// Delete orders in batches.
+		self::queue()->schedule_single( time() + 5, self::ORDERS_DELETE_BATCH_INIT, array(), self::QUEUE_GROUP );
+
+		// Delete customers after order data is deleted.
+		self::queue_dependent_action( self::CUSTOMERS_DELETE_BATCH_INIT, array(), self::ORDERS_DELETE_BATCH_INIT );
+
+		return __( 'Report table data is being deleted.', 'woocommerce-admin' );
+	}
+
+	/**
+	 * Schedule an action to import a single Order.
 	 *
 	 * @param int $order_id Order ID.
 	 * @return void
 	 */
-	public static function schedule_single_order_process( $order_id ) {
+	public static function schedule_single_order_import( $order_id ) {
 		if ( 'shop_order' !== get_post_type( $order_id ) ) {
 			return;
 		}
 
 		if ( apply_filters( 'woocommerce_disable_order_scheduling', false ) ) {
-			self::orders_lookup_process_order( $order_id );
+			self::orders_lookup_import_order( $order_id );
 			return;
 		}
 
@@ -152,10 +194,10 @@ class WC_Admin_Reports_Sync {
 
 			// Bail out if there's a pending single order action, or a pending dependent action.
 			if (
-				( self::SINGLE_ORDER_ACTION === $existing_job->get_hook() ) ||
+				( self::SINGLE_ORDER_IMPORT_ACTION === $existing_job->get_hook() ) ||
 				(
 					self::QUEUE_DEPEDENT_ACTION === $existing_job->get_hook() &&
-					in_array( self::SINGLE_ORDER_ACTION, $existing_job->get_args() )
+					in_array( self::SINGLE_ORDER_IMPORT_ACTION, $existing_job->get_args() )
 				)
 			) {
 				return;
@@ -163,7 +205,7 @@ class WC_Admin_Reports_Sync {
 		}
 
 		// We want to ensure that customer lookup updates are scheduled before order updates.
-		self::queue_dependent_action( self::SINGLE_ORDER_ACTION, array( $order_id ), self::CUSTOMERS_BATCH_ACTION );
+		self::queue_dependent_action( self::SINGLE_ORDER_IMPORT_ACTION, array( $order_id ), self::CUSTOMERS_IMPORT_BATCH_ACTION );
 	}
 
 	/**
@@ -173,8 +215,8 @@ class WC_Admin_Reports_Sync {
 		// Activate WC_Order extension.
 		WC_Admin_Order::add_filters();
 
-		add_action( 'save_post', array( __CLASS__, 'schedule_single_order_process' ) );
-		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'schedule_single_order_process' ) );
+		add_action( 'save_post', array( __CLASS__, 'schedule_single_order_import' ) );
+		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'schedule_single_order_import' ) );
 
 		WC_Admin_Reports_Orders_Stats_Data_Store::init();
 		WC_Admin_Reports_Customers_Data_Store::init();
@@ -186,11 +228,11 @@ class WC_Admin_Reports_Sync {
 	/**
 	 * Init order/product lookup tables update (in batches).
 	 *
-	 * @param integer|boolean $days Number of days to process.
+	 * @param integer|boolean $days Number of days to import.
 	 * @param boolean         $skip_existing Skip exisiting records.
 	 */
-	public static function orders_lookup_batch_init( $days, $skip_existing ) {
-		$batch_size = self::get_batch_size( self::ORDERS_BATCH_ACTION );
+	public static function orders_lookup_import_batch_init( $days, $skip_existing ) {
+		$batch_size = self::get_batch_size( self::ORDERS_IMPORT_BATCH_ACTION );
 		$orders     = self::get_orders( 1, 1, $days, $skip_existing );
 
 		if ( 0 === $orders->total ) {
@@ -199,7 +241,7 @@ class WC_Admin_Reports_Sync {
 
 		$num_batches = ceil( $orders->total / $batch_size );
 
-		self::queue_batches( 1, $num_batches, self::ORDERS_BATCH_ACTION, array( $days, $skip_existing ) );
+		self::queue_batches( 1, $num_batches, self::ORDERS_IMPORT_BATCH_ACTION, array( $days, $skip_existing ) );
 	}
 
 	/**
@@ -253,30 +295,30 @@ class WC_Admin_Reports_Sync {
 	}
 
 	/**
-	 * Process a batch of orders to update (stats and products).
+	 * Imports a batch of orders to update (stats and products).
 	 *
-	 * @param int      $batch_number Batch number to process (essentially a query page number).
-	 * @param int|bool $days Number of days to process.
+	 * @param int      $batch_number Batch number to import (essentially a query page number).
+	 * @param int|bool $days Number of days to import.
 	 * @param bool     $skip_existing Skip exisiting records.
 	 * @return void
 	 */
-	public static function orders_lookup_process_batch( $batch_number, $days, $skip_existing ) {
-		$batch_size = self::get_batch_size( self::ORDERS_BATCH_ACTION );
+	public static function orders_lookup_import_batch( $batch_number, $days, $skip_existing ) {
+		$batch_size = self::get_batch_size( self::ORDERS_IMPORT_BATCH_ACTION );
 		$orders     = self::get_orders( $batch_size, $batch_number, $days, $skip_existing );
 
 		foreach ( $orders->order_ids as $order_id ) {
-			self::orders_lookup_process_order( $order_id );
+			self::orders_lookup_import_order( $order_id );
 		}
 	}
 
 	/**
-	 * Process a single order to update lookup tables for.
+	 * Imports a single order to update lookup tables for.
 	 * If an error is encountered in one of the updates, a retry action is scheduled.
 	 *
 	 * @param int $order_id Order ID.
 	 * @return void
 	 */
-	public static function orders_lookup_process_order( $order_id ) {
+	public static function orders_lookup_import_order( $order_id ) {
 		$result = array_sum(
 			array(
 				WC_Admin_Reports_Orders_Stats_Data_Store::sync_order( $order_id ),
@@ -293,7 +335,7 @@ class WC_Admin_Reports_Sync {
 		}
 
 		// Otherwise assume an error occurred and reschedule.
-		self::schedule_single_order_process( $order_id );
+		self::schedule_single_order_import( $order_id );
 	}
 
 	/**
@@ -305,9 +347,11 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function get_batch_size( $action ) {
 		$batch_sizes = array(
-			self::QUEUE_BATCH_ACTION     => 100,
-			self::CUSTOMERS_BATCH_ACTION => 25,
-			self::ORDERS_BATCH_ACTION    => 10,
+			self::QUEUE_BATCH_ACTION            => 100,
+			self::CUSTOMERS_IMPORT_BATCH_ACTION => 25,
+			self::CUSTOMERS_DELETE_BATCH_ACTION => 25,
+			self::ORDERS_IMPORT_BATCH_ACTION    => 10,
+			self::ORDERS_DELETE_BATCH_ACTION    => 10,
 		);
 		$batch_size  = isset( $batch_sizes[ $action ] ) ? $batch_sizes[ $action ] : 25;
 
@@ -461,8 +505,8 @@ class WC_Admin_Reports_Sync {
 	 * @param int|bool $days Number of days to process.
 	 * @param bool     $skip_existing Skip exisiting records.
 	 */
-	public static function customer_lookup_batch_init( $days, $skip_existing ) {
-		$batch_size      = self::get_batch_size( self::CUSTOMERS_BATCH_ACTION );
+	public static function customer_lookup_import_batch_init( $days, $skip_existing ) {
+		$batch_size      = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );
 		$customer_query  = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
@@ -479,7 +523,7 @@ class WC_Admin_Reports_Sync {
 
 		$num_batches = ceil( $total_customers / $batch_size );
 
-		self::queue_batches( 1, $num_batches, self::CUSTOMERS_BATCH_ACTION, array( $days, $skip_existing ) );
+		self::queue_batches( 1, $num_batches, self::CUSTOMERS_IMPORT_BATCH_ACTION, array( $days, $skip_existing ) );
 	}
 
 	/**
@@ -490,8 +534,8 @@ class WC_Admin_Reports_Sync {
 	 * @param bool     $skip_existing Skip exisiting records.
 	 * @return void
 	 */
-	public static function customer_lookup_process_batch( $batch_number, $days, $skip_existing ) {
-		$batch_size     = self::get_batch_size( self::CUSTOMERS_BATCH_ACTION );
+	public static function customer_lookup_import_batch( $batch_number, $days, $skip_existing ) {
+		$batch_size     = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );
 		$customer_query = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
@@ -511,6 +555,82 @@ class WC_Admin_Reports_Sync {
 			WC_Admin_Reports_Customers_Data_Store::update_registered_customer( $customer_id );
 		}
 	}
+
+	/**
+	 * Delete customer lookup table rows (in batches).
+	 */
+	public static function customer_lookup_delete_batch_init() {
+		global $wpdb;
+		$batch_size = self::get_batch_size( self::CUSTOMERS_DELETE_BATCH_ACTION );
+		$count      = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_customer_lookup" );
+
+		if ( 0 === $count ) {
+			return;
+		}
+
+		$num_batches = ceil( $count / $batch_size );
+
+		self::queue_batches( 1, $num_batches, self::CUSTOMERS_DELETE_BATCH_ACTION );
+	}
+
+	/**
+	 * Delete a batch of customers.
+	 *
+	 * @param int $batch_number Batch number to import (essentially a query page number).
+	 * @return void
+	 */
+	public static function customer_lookup_delete_batch( $batch_number ) {
+		global $wpdb;
+		$batch_size   = self::get_batch_size( self::CUSTOMERS_DELETE_BATCH_ACTION );
+		$customer_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT customer_id FROM {$wpdb->prefix}wc_customer_lookup ORDER BY customer_id ASC LIMIT %d",
+				$batch_size
+			)
+		);
+
+		foreach ( $customer_ids as $customer_id ) {
+			WC_Admin_Reports_Customers_Data_Store::delete_customer( $customer_id );
+		}
+	}
+
+	/**
+	 * Delete orders lookup table rows (in batches).
+	 */
+	public static function orders_lookup_delete_batch_init() {
+		global $wpdb;
+		$batch_size = self::get_batch_size( self::ORDERS_DELETE_BATCH_ACTION );
+		$count      = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_order_stats" );
+
+		if ( 0 === $count ) {
+			return;
+		}
+
+		$num_batches = ceil( $count / $batch_size );
+
+		self::queue_batches( 1, $num_batches, self::ORDERS_DELETE_BATCH_ACTION );
+	}
+
+	/**
+	 * Delete a batch of orders.
+	 *
+	 * @return void
+	 */
+	public static function orders_lookup_delete_batch() {
+		global $wpdb;
+		$batch_size = self::get_batch_size( self::ORDERS_DELETE_BATCH_ACTION );
+		$order_ids  = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT order_id FROM {$wpdb->prefix}wc_order_stats ORDER BY order_id ASC LIMIT %d",
+				$batch_size
+			)
+		);
+
+		foreach ( $order_ids as $order_id ) {
+			WC_Admin_Reports_Orders_Stats_Data_Store::delete_order( $order_id );
+		}
+	}
+
 }
 
 WC_Admin_Reports_Sync::init();

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -32,7 +32,7 @@ class WC_Admin_Reports_Sync {
 	const CUSTOMERS_DELETE_BATCH_INIT = 'wc-admin_delete_customers_batch_init';
 
 	/**
-	 * Action hook for importing a batch of customers.
+	 * Action hook for deleting a batch of customers.
 	 */
 	const CUSTOMERS_DELETE_BATCH_ACTION = 'wc-admin_delete_customers_batch';
 
@@ -575,11 +575,8 @@ class WC_Admin_Reports_Sync {
 
 	/**
 	 * Delete a batch of customers.
-	 *
-	 * @param int $batch_number Batch number to import (essentially a query page number).
-	 * @return void
 	 */
-	public static function customer_lookup_delete_batch( $batch_number ) {
+	public static function customer_lookup_delete_batch() {
 		global $wpdb;
 		$batch_size   = self::get_batch_size( self::CUSTOMERS_DELETE_BATCH_ACTION );
 		$customer_ids = $wpdb->get_col(

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -689,6 +689,31 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	}
 
 	/**
+	 * Delete a customer lookup row.
+	 *
+	 * @param int $customer_id Customer ID.
+	 */
+	public static function delete_customer( $customer_id ) {
+		global $wpdb;
+		$customer_id = (int) $customer_id;
+		$table_name  = $wpdb->prefix . self::TABLE_NAME;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM ${table_name} WHERE customer_id = %d",
+				$customer_id
+			)
+		);
+
+		/**
+		 * Fires when a customer is deleted.
+		 *
+		 * @param int $order_id Order ID.
+		 */
+		do_action( 'woocommerce_reports_delete_customer', $customer_id );
+	}
+
+	/**
 	 * Returns string to be used as cache key for the data.
 	 *
 	 * @param array $params Query parameters.

--- a/tests/api-init.php
+++ b/tests/api-init.php
@@ -72,13 +72,13 @@ class WC_Tests_API_Init extends WC_REST_Unit_Test_Case {
 		add_filter( 'query', array( $this, 'filter_order_query' ) );
 
 		// Initiate sync.
-		WC_Admin_Reports_Sync::orders_lookup_process_order( $order->get_id() );
+		WC_Admin_Reports_Sync::orders_lookup_import_order( $order->get_id() );
 
 		// Verify that a retry job was scheduled.
 		$this->assertCount( 1, $this->queue->actions );
 		$this->assertArraySubset(
 			array(
-				'hook' => WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION,
+				'hook' => WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION,
 				'args' => array( $order->get_id() ),
 			),
 			$this->queue->actions[0]

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -218,4 +218,71 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$pending_actions = WC_Helper_Queue::get_all_pending();
 		$this->assertCount( 0, $pending_actions );
 	}
+
+	/**
+	 * Test import deletion.
+	 */
+	public function test_delete_stats() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		for ( $i = 0; $i < 25; $i++ ) {
+			$order = WC_Helper_Order::create_order( 1, $product );
+			$order->set_status( 'completed' );
+			$order->save();
+		}
+
+		// Check that stats exist before deleting.
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v4/reports/orders' );
+		$request->set_query_params( array( 'per_page' => 25 ) );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 25, $reports );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v4/reports/customers' );
+		$request->set_query_params( array( 'per_page' => 25 ) );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $reports );
+
+		// Delete all stats.
+		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/delete' );
+		$response = $this->server->dispatch( $request );
+		$report   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $report['status'] );
+
+		// Run pending three times to process batches and dependent actions.
+		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending();
+
+		// Check that stats have been deleted.
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports/orders' );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 0, $reports );
+
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports/customers' );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 0, $reports );
+	}
 }

--- a/tests/batch-queue.php
+++ b/tests/batch-queue.php
@@ -45,7 +45,7 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 		switch ( $action ) {
 			case WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION:
 				return $this->queue_batch_size;
-			case WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION:
+			case WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION:
 				return $this->customers_batch_size;
 			case WC_Admin_Reports_Sync::ORDERS_BATCH_ACTION:
 				return $this->orders_batch_size;
@@ -81,20 +81,20 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 		$num_customers = 1234; // 1234 / 5 = 247 batches
 		$num_batches   = ceil( $num_customers / $this->customers_batch_size );
 
-		WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION );
+		WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION );
 
 		$this->assertCount( $this->queue_batch_size, $this->queue->actions );
 		$this->assertArraySubset(
 			array(
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-				'args' => array( 1, 25, WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION ),
+				'args' => array( 1, 25, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
 			$this->queue->actions[0]
 		);
 		$this->assertArraySubset(
 			array(
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-				'args' => array( 226, 247, WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION ),
+				'args' => array( 226, 247, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
 			$this->queue->actions[ $this->queue_batch_size - 1 ]
 		);
@@ -107,19 +107,19 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 		$num_customers = 45; // 45 / 5 = 9 batches (which is less than the batch queue size)
 		$num_batches   = ceil( $num_customers / $this->customers_batch_size );
 
-		WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION );
+		WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION );
 
 		$this->assertCount( 9, $this->queue->actions );
 		$this->assertArraySubset(
 			array(
-				'hook' => WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION,
+				'hook' => WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION,
 				'args' => array( 1 ),
 			),
 			$this->queue->actions[0]
 		);
 		$this->assertArraySubset(
 			array(
-				'hook' => WC_Admin_Reports_Sync::CUSTOMERS_BATCH_ACTION,
+				'hook' => WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION,
 				'args' => array( 9 ),
 			),
 			$this->queue->actions[8]

--- a/tests/queue-priority.php
+++ b/tests/queue-priority.php
@@ -37,13 +37,13 @@ class WC_Tests_Reports_Queue_Prioritization extends WC_REST_Unit_Test_Case {
 	 * Test that we're setting a priority on our actions.
 	 */
 	public function test_queue_action_sets_priority() {
-		WC_Admin_Reports_Sync::queue()->schedule_single( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
+		WC_Admin_Reports_Sync::queue()->schedule_single( time(), WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION );
 
 		$actions = WC_Admin_Reports_Sync::queue()->search(
 			array(
 				'status'  => 'pending',
 				'claimed' => false,
-				'hook'    => WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION,
+				'hook'    => WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION,
 			)
 		);
 
@@ -55,7 +55,7 @@ class WC_Tests_Reports_Queue_Prioritization extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( WC_Admin_ActionScheduler_wpPostStore::JOB_PRIORITY, $action->menu_order );
 
-		WC_Admin_Reports_Sync::queue()->cancel_all( WC_Admin_Reports_Sync::SINGLE_ORDER_ACTION );
+		WC_Admin_Reports_Sync::queue()->cancel_all( WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION );
 	}
 }
 


### PR DESCRIPTION
Fixes (part of) #1850

* Renames existing batch functions with an `IMPORT_` prefix.
* Adds the delete endpoint to the import controller.
* Adds delete batch actions for orders and customers.
* Adds a customer data store deletion method.

### Screenshots
<img width="481" alt="Screen Shot 2019-04-15 at 4 08 07 PM" src="https://user-images.githubusercontent.com/10561050/56116648-f022f000-5f98-11e9-9ae0-e7957fb04219.png">

### Detailed test instructions:

1. Make a POST request to `/wp-json/wc/v4/reports/import/delete`
2. Check that batch actions are queued up and that all stats are deleted afterwards.