### PR TITLE
Fix missing leaderboard schema options

### DIFF
--- a/includes/api/class-wc-admin-rest-leaderboards-controller.php
+++ b/includes/api/class-wc-admin-rest-leaderboards-controller.php
@@ -476,7 +476,13 @@ class WC_Admin_REST_Leaderboards_Controller extends WC_REST_Data_Controller {
 			'properties' => array(
 				'id'      => array(
 					'type'        => 'string',
-					'description' => __( 'Leaderboard Name.', 'woocommerce-admin' ),
+					'description' => __( 'Leaderboard ID.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'label'   => array(
+					'type'        => 'string',
+					'description' => __( 'Displayed title for the leaderboard.', 'woocommerce-admin' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
@@ -524,5 +530,16 @@ class WC_Admin_REST_Leaderboards_Controller extends WC_REST_Data_Controller {
 		);
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get schema for the list of allowed leaderboards.
+	 *
+	 * @return array $schema
+	 */
+	public function get_public_allowed_item_schema() {
+		$schema = $this->get_public_item_schema();
+		unset( $schema['properties']['rows'] );
+		return $schema;
 	}
 }


### PR DESCRIPTION
Fixes #2054

Adds in missing schema properties for the leaderboard and allowed leaderboard endpoints.

### Detailed test instructions:

1.  Make an `OPTIONS` request to `/wp-json/wc/v4/leaderboards/` and `/wp-json/wc/v4/leaderboards/allowed`.
2.  Make sure the schema properties match those expected.
3.  Make sure all tests pass.