### PR TITLE
Check if welcome message notice exists before creating it

### DIFF
--- a/includes/notes/class-wc-admin-notes-welcome-message.php
+++ b/includes/notes/class-wc-admin-notes-welcome-message.php
@@ -18,10 +18,16 @@ class WC_Admin_Notes_Welcome_Message {
 	 * Creates a note for welcome message.
 	 */
 	public static function add_welcome_note() {
-
 		// Check if plugin is upgrading if yes then don't create this note.
 		$is_upgrading = get_option( WC_Admin_Install::VERSION_OPTION );
 		if ( $is_upgrading ) {
+			return;
+		}
+
+		// See if we've already created this kind of note so we don't do it again.
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
 			return;
 		}
 


### PR DESCRIPTION
In a [previous code review](https://github.com/woocommerce/woocommerce-admin/pull/2005#discussion_r274380615) I completely missed a message and by mistake we removed the check that was preventing the welcome notice to appear several times. This PR fixes that.

Kudos to @ronakganatra9.

### Detailed test instructions:
In some way you need to force `WC_Admin_Notes_Welcome_Message::add_welcome_note();` to be called. One way is: in `class-wc-admin-install.php` comment out L43-L46, L56-L63 and in `includes/notes/class-wc-admin-notes-welcome-message.php` L21-L25.
- Clear your `wp_wc_admin_notes` table in the database, so you don't have any old notice there.
- Visit any WooCommerce Admin page.
- Make sure a Welcome Notice is added the first time.
- After reloading the page, make sure the Welcome Notice is not added a second time.