### PR TITLE
Transpile acorn-jsx package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,7 @@ const webpackConfig = {
 					},
 				},
 				include: new RegExp( '/node_modules\/(' +
+					'|acorn-jsx' +
 					'|d3-array' +
 					'|debug' +
 					'|regexpu-core' +


### PR DESCRIPTION
Adds `acorn-jsx` to the list of packages to transpile.

### Detailed test instructions:
- Open WooCommerce Admin in IE11.
- Verify it loads.