### PR TITLE
Fix Plugin release build zip structure

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -72,10 +72,8 @@ build_files=$(ls dist/*/*.{js,css})
 status "Creating archive... 🎁"
 zip -r woocommerce-admin.zip \
 	woocommerce-admin.php \
-	lib/*.php \
-	includes/*.php \
-	includes/**/*.php \
-	images/* \
+	includes/ \
+	images/ \
 	$build_files \
 	languages/woocommerce-admin.pot \
 	languages/woocommerce-admin.php \


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-admin/pull/1863, the folder structure in `/includes` changed to be a few layers deep. Our build script wasn't grabbing all the relevant files, creating a broken release.

This PR simply grabs the folder in its entirety.

### Testing instructions

1. `npm run build:release`.
2. Install the resulting zipped plugin on a test site and make sure its working.