### PR TITLE
Add wcAdminAssetUrl property again in wcSettings

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -782,6 +782,9 @@ class WC_Admin_Loader {
 		$settings['reviewsEnabled']    = get_option( 'woocommerce_enable_reviews' );
 		$settings['manageStock']       = get_option( 'woocommerce_manage_stock' );
 		$settings['commentModeration'] = get_option( 'comment_moderation' );
+		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
+		// and `wcAssetUrl` can be used in its place throughout the codebase.
+		$settings['wcAdminAssetUrl']   = plugins_url( 'images/', plugin_dir_path( dirname( __FILE__ ) ) . 'woocommerce-admin.php' );
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {


### PR DESCRIPTION
Fixes #2074.

In #1863, the `wcSettings` property `wcAdminAssetUrl` disappeared and that broke the component `<ImageAsset>`. This PR adds the property back.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/56287281-36548c80-611c-11e9-8f7e-35b9c5f53775.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/56289384-107db680-6121-11e9-8c07-2d0d8d751ea6.png)

### Detailed test instructions:
- Force `<ReportChart>` to display the error image replacing [this line](https://github.com/woocommerce/woocommerce-admin/blob/master/client/analytics/components/report-chart/index.js#L157) and [this other one](https://github.com/woocommerce/woocommerce-admin/blob/master/client/analytics/components/report-chart/index.js#L170) with `if ( true )`.
- Visit any report.
- Verify the image is loaded correctly.