### PR TITLE
Release/0.11.0 take 2

### DIFF
--- a/docs/components/packages/animation-slider.md
+++ b/docs/components/packages/animation-slider.md
@@ -30,10 +30,10 @@ A unique identifier for each slideable page.
 
 null, 'left', 'right', to designate which direction to slide on a change.
 
-### `focusOnChange`
+### `onExited`
 
-- Type: Boolean
+- Type: Function
 - Default: null
 
-When set to true, the first focusable element will be focused after an animation has finished.
+A function to be executed after a transition is complete, passing the containing ref as the argument.
 

--- a/docs/components/packages/calendar.md
+++ b/docs/components/packages/calendar.md
@@ -107,13 +107,12 @@ The end date in human-readable format. Displayed in the text input.
 
 String identifying which is the currently focused input (start or end).
 
-### `invalidDays`
+### `isInvalidDate`
 
-- Type: One of type: enum, func
+- Type: Function
 - Default: null
 
-Optionally invalidate certain days. `past`, `future`, `none`, or function are accepted.
-A function will be passed to react-dates' `isOutsideRange` prop
+A function to determine if a day on the calendar is not valid
 
 ### `onUpdate`
 

--- a/docs/components/packages/search-list-control.md
+++ b/docs/components/packages/search-list-control.md
@@ -71,6 +71,13 @@ See `defaultMessages` above for examples.
 Callback fired when selected items change, whether added, cleared, or removed.
 Passed an array of item objects (as passed in via props.list).
 
+### `onSearch`
+
+- Type: Function
+- Default: null
+
+Callback fired when the search field is used.
+
 ### `renderItem`
 
 - Type: Function

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://woocommerce.github.io/woocommerce-admin/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ This plugin is under active development and, as such, we advise you to first ins
 WooCommerce Admin has a host of new reports that are optimized for speed and have advanced filters that allow you to dive into data about your store:
 
 - Revenue Report
-- Orders Report 
+- Orders Report
 - Products Report
 - Categories Report
 - Coupons Report
@@ -41,7 +41,7 @@ Once again: This plugin is under active development and, as such, we advise you 
 = Minimum Requirements =
 
 * WordPress 5.0
-* WooCommerce 3.5.1 or greater
+* WooCommerce 3.6.0 or greater
 * PHP version 5.2.4 or greater. PHP 7.2 or greater is recommended
 * MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended
 
@@ -49,10 +49,10 @@ Visit the [WooCommerce server requirements documentation](https://docs.woocommer
 
 = Automatic installation =
 
-Automatic installation is the easiest option, as WordPress handles the file transfers and you don't need to leave your web browser. To perform an automatic install: 
+Automatic installation is the easiest option, as WordPress handles the file transfers and you don't need to leave your web browser. To perform an automatic install:
 1. Log in to your WordPress dashboard.
 2. Go to: Plugins > Add New.
-3. Enter “WooCommerce Admin” in the Search field, and view details about its point release, the rating and description. 
+3. Enter “WooCommerce Admin” in the Search field, and view details about its point release, the rating and description.
 4. Select “Install Now” when you’re ready
 
 = Manual installation =
@@ -76,6 +76,41 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 3. Analytics
 
 == Changelog ==
+
+= 0.11.0 2019-04-17
+
+- Dev: Extend report submenu items #2033
+- Dev: Extension Examples #2018
+- Dev: Update admin notes readme #2043
+- Dev: Add profile wizard base page #1933
+- Dev: Method to publish core ready features #1863
+- Dev: Add PHP autofix to pre-commit hook #2022
+- Dev: PHP Lint fixes #2023
+- Dev: Update Link in readme to Proper Location #2026
+- Dev: Split D3Chart utils/axis file #2000
+- Dev: Remove coupon_total from order stats table #1975
+- Fix: Transpile acorn-jsx package #2064
+- Fix: Inbox: Giving Feedback Notice #2019 👏 @Mr-AjayM
+- Fix: Check if welcome message notice exists before creating it #2063
+- Fix: Respect manual offsets in default before/after params #2035
+- Fix: Fix wrong dates in Reviews and Orders panels of the Activity Panel #2013
+- Fix: Make customer name extendable #1976
+- Fix: center mobile icon vertically #1990 👏 @rrennick
+- Fix: search filter focus #1994
+- Fix: Fix date filter layout on Android #1996
+- Fix: Order Status filter: <select> is not vertically aligned #1971 👏 @dinhtungdu
+- Fix: add filter length condition to enable filter check #1983 👏 @rrennick
+- Fix: lookup product title in order meta if product has been deleted #1977 👏 @rrennick
+- Fix: Cast order totals as floats when calculating net total #1945
+- Enhancement: Add empty state in Stock panel #2049
+- Enhancement: Add empty state in Orders panel #2037
+- Enhancement: Hook up Stock panel #1998
+- Enhancement: Add order milestone notifications. #1872
+- Enhancement: Add leaderboard controller and endpoint #1995
+- Enhancement: Hook up leaderboards endpoint to dashboard #2004
+- Enhancement: Activity Panel: Add a mobile app note #2008
+- Enhancement: Scroll to top only when URL changes #1989
+- Enhancement: Allow negative values in charts #1979
 
 = 0.10.0 2019-04-02
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 0.10.0
+ * Version: 0.11.0
  *
  * WC requires at least: 3.5.0
  * WC tested up to: 3.5.7
@@ -40,7 +40,7 @@ if ( ! defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
-	define( 'WC_ADMIN_VERSION_NUMBER', '0.10.0' );
+	define( 'WC_ADMIN_VERSION_NUMBER', '0.11.0' );
 }
 
 /**
@@ -112,7 +112,7 @@ function wc_admin_build_notice() {
  * @return bool
  */
 function wc_admin_dependencies_satisfied() {
-	$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.5', '>' );
+	$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.6', '>=' );
 	if ( ! $woocommerce_minimum_met ) {
 		return false;
 	}


### PR DESCRIPTION
Release `0.11.0`

**Notable Change**
Minimum requirement for WooCommerce is now `3.6.0` due to changes with `wcSettings` now being applied by Woo instead of Woo-Blocks. See #2058 for more info.

Not too noticeable change: readme.txt whitespace changes. Append `?w=1` to the url to see actual changes.

Fixes https://github.com/woocommerce/woocommerce-admin/issues/2058
