### PR TITLE
Make SummaryListPlaceholder height match SummaryNumber height

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- Tweaks to `<SummaryListPlaceholder>` height in order to better match `<SummaryNumber>`.
+
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
 - Chart component now accepts data with negative values.

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -23,6 +23,12 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-prev-value {
 		display: block;
 	}
+
+	&.is-placeholder {
+		.woocommerce-summary__item-prev-label {
+			margin-right: calc( 100% - 80px );
+		}
+	}
 }
 
 @mixin reset-wrap() {
@@ -34,6 +40,12 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-prev-label,
 	.woocommerce-summary__item-prev-value {
 		display: inline;
+	}
+
+	&.is-placeholder {
+		.woocommerce-summary__item-prev-label {
+			margin-right: 0;
+		}
 	}
 }
 
@@ -97,7 +109,7 @@ $inner-border: $core-grey-light-500;
 		max-height: 100%;
 		margin-top: 0;
 		margin-bottom: 0;
-		overflow-y: scroll;
+		overflow-y: auto;
 		border: none;
 	}
 
@@ -215,10 +227,10 @@ $inner-border: $core-grey-light-500;
 	&.is-dropdown-button {
 		padding: 0;
 		list-style: none;
-		border-bottom: 1px solid $outer-border;
 		border-right: 1px solid $outer-border;
 
 		.components-button {
+			border-bottom: 1px solid $outer-border;
 			text-align: left;
 			display: block;
 		}
@@ -263,7 +275,6 @@ $inner-border: $core-grey-light-500;
 		}
 
 		.woocommerce-summary__item-prev-label {
-			margin-right: calc( 100% - 80px );
 			width: 80px;
 		}
 
@@ -279,6 +290,7 @@ $inner-border: $core-grey-light-500;
 	background-color: $core-grey-light-100;
 	border-bottom: 1px solid $outer-border;
 	border-right: 1px solid $inner-border;
+	line-height: 1.4em;
 	text-decoration: none;
 
 	&:hover {

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -233,6 +233,7 @@ $inner-border: $core-grey-light-500;
 			@include placeholder();
 			display: inline-block;
 			height: 16px;
+			margin-top: 2.2px;
 			max-width: 110px;
 			width: 70%;
 		}
@@ -242,19 +243,32 @@ $inner-border: $core-grey-light-500;
 		}
 
 		.woocommerce-summary__item-value,
+		.woocommerce-summary__item-delta-value,
+		.woocommerce-summary__item-prev-label,
 		.woocommerce-summary__item-prev-value {
 			@include placeholder();
 			display: inline-block;
 			height: 16px;
-			max-width: 140px;
-			width: 80%;
+			min-width: auto;
+		}
+
+		.woocommerce-summary__item-value {
+			margin-top: 2.2px;
+			max-width: 60px;
 		}
 
 		.woocommerce-summary__item-delta-value {
-			@include placeholder();
-			display: inline-block;
-			height: 16px;
-			width: 20px;
+			margin-top: 2.2px;
+			width: 50px;
+		}
+
+		.woocommerce-summary__item-prev-label {
+			margin-right: calc( 100% - 80px );
+			width: 80px;
+		}
+
+		.woocommerce-summary__item-prev-value {
+			width: 40px;
 		}
 	}
 }
@@ -359,6 +373,7 @@ $inner-border: $core-grey-light-500;
 	.woocommerce-summary__item-prev-value {
 		@include font-size( 13 );
 		color: $core-grey-dark-500;
+		display: inline-block;
 	}
 
 	.woocommerce-summary__toggle {


### PR DESCRIPTION
Fixes #2080.

Makes `<SummaryListPlaceholder>` have the same height as `<SummaryNumber>`, avoiding jumps when loading report data.

### Screenshots
_Before:_
![summary-number-placeholders](https://user-images.githubusercontent.com/3616980/56378566-bc043500-620d-11e9-9e6d-225631875596.gif)

_After:_
![placeholder2](https://user-images.githubusercontent.com/3616980/56425991-cd554c00-62b6-11e9-8ec0-ebb695617895.gif)

### Detailed test instructions:
- Go to any report.
- Verify content doesn't jump when the data finishes loading, because the placeholder already had the correct height.