### PR TITLE
Allow free input in the table pagination input field

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- Pagination no longer considers `0` a valid input and triggers `onPageValueChange` on the input blur event.
+- Pagination no longer considers `0` a valid input and triggers `onPageChange` on the input blur event.
 - Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
 
 # 2.0.0

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- Pagination no longer considers `0` a valid input.
+
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
 - Chart component now accepts data with negative values.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- Pagination no longer considers `0` a valid input.
+- Pagination no longer considers `0` a valid input and triggers `onPageValueChange` on the input blur event.
 - Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
 
 # 2.0.0

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -20,6 +20,10 @@ class Pagination extends Component {
 	constructor( props ) {
 		super( props );
 
+		this.state = {
+				inputValue: this.props.page,
+		};
+
 		this.previousPage = this.previousPage.bind( this );
 		this.nextPage = this.nextPage.bind( this );
 		this.onPageValueChange = this.onPageValueChange.bind( this );
@@ -59,7 +63,11 @@ class Pagination extends Component {
 		const { onPageChange } = this.props;
 		const newPage = parseInt( event.target.value, 10 );
 
-		if ( isFinite( newPage ) && this.pageCount && this.pageCount >= newPage ) {
+		this.setState( {
+				inputValue: event.target.value,
+		} );
+
+		if ( isFinite( newPage ) && newPage > 0 && this.pageCount && this.pageCount >= newPage ) {
 			onPageChange( newPage );
 		}
 	}
@@ -116,6 +124,7 @@ class Pagination extends Component {
 
 	renderPagePicker() {
 		const { page } = this.props;
+		const { inputValue } = this.state;
 		const isError = page < 1 || page > this.pageCount;
 		const inputClass = classNames( 'woocommerce-pagination__page-picker-input', {
 			'has-error': isError,
@@ -133,7 +142,7 @@ class Pagination extends Component {
 						type="number"
 						onClick={ this.selectInputValue }
 						onChange={ this.onPageValueChange }
-						value={ page }
+						value={ inputValue }
 						min={ 1 }
 						max={ this.pageCount }
 					/>

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -26,7 +26,8 @@ class Pagination extends Component {
 
 		this.previousPage = this.previousPage.bind( this );
 		this.nextPage = this.nextPage.bind( this );
-		this.onPageValueChange = this.onPageValueChange.bind( this );
+		this.onInputChange = this.onInputChange.bind( this );
+		this.onInputBlur = this.onInputBlur.bind( this );
 		this.perPageChange = this.perPageChange.bind( this );
 		this.selectInputValue = this.selectInputValue.bind( this );
 	}
@@ -59,13 +60,15 @@ class Pagination extends Component {
 		}
 	}
 
-	onPageValueChange( event ) {
-		const { onPageChange } = this.props;
-		const newPage = parseInt( event.target.value, 10 );
-
+	onInputChange( event ) {
 		this.setState( {
 				inputValue: event.target.value,
 		} );
+	}
+
+	onInputBlur( event ) {
+		const { onPageChange } = this.props;
+		const newPage = parseInt( event.target.value, 10 );
 
 		if ( isFinite( newPage ) && newPage > 0 && this.pageCount && this.pageCount >= newPage ) {
 			onPageChange( newPage );
@@ -141,7 +144,8 @@ class Pagination extends Component {
 						aria-invalid={ isError }
 						type="number"
 						onClick={ this.selectInputValue }
-						onChange={ this.onPageValueChange }
+						onChange={ this.onInputChange }
+						onBlur={ this.onInputBlur }
 						value={ inputValue }
 						min={ 1 }
 						max={ this.pageCount }

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -376,6 +376,7 @@ class TableCard extends Component {
 				) }
 
 				<Pagination
+					key={ parseInt( query.page ) || 1 }
 					page={ parseInt( query.page ) || 1 }
 					perPage={ rowsPerPage }
 					total={ totalRows }


### PR DESCRIPTION
Fixes #2050.
Fixes #2090.

Allows free input in the table pagination input field, which allows the user to remove the current number to write a new one. It also prevents `<Pagination>` considering `0` a valid page, which was causing a 400 error.

### Screenshots
![pagination](https://user-images.githubusercontent.com/3616980/56429579-b6692680-62c3-11e9-8e27-5641272e7f48.gif)


### Detailed test instructions:
- Go to any report.
- Try removing the number in the table pagination input field.
- Write 0 and make sure it doesn't try to load that page.
- Write any valid number and verify it loads correctly.