### PR TITLE
Add order date filter to customers data store

### DIFF
--- a/includes/api/class-wc-admin-rest-leaderboards-controller.php
+++ b/includes/api/class-wc-admin-rest-leaderboards-controller.php
@@ -206,9 +206,11 @@ class WC_Admin_REST_Leaderboards_Controller extends WC_REST_Data_Controller {
 		$customers_data_store = new WC_Admin_Reports_Customers_Data_Store();
 		$customers_data       = $per_page > 0 ? $customers_data_store->get_data(
 			array(
-				'orderby'  => 'total_spend',
-				'order'    => 'desc',
-				'per_page' => $per_page,
+				'orderby'      => 'total_spend',
+				'order'        => 'desc',
+				'order_after'  => $after,
+				'order_before' => $before,
+				'per_page'     => $per_page,
 			)
 		)->data : array();
 

--- a/includes/api/class-wc-admin-rest-reports-customers-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-customers-controller.php
@@ -41,6 +41,8 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		$args                        = array();
 		$args['registered_before']   = $request['registered_before'];
 		$args['registered_after']    = $request['registered_after'];
+		$args['order_before']        = $request['before'];
+		$args['order_after']         = $request['after'];
 		$args['page']                = $request['page'];
 		$args['per_page']            = $request['per_page'];
 		$args['order']               = $request['order'];
@@ -284,6 +286,18 @@ class WC_Admin_REST_Reports_Customers_Controller extends WC_REST_Reports_Control
 		);
 		$params['registered_after']        = array(
 			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['after']                   = array(
+			'description'       => __( 'Limit response to resources with orders published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['before']                  = array(
+			'description'       => __( 'Limit response to resources with orders published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -144,6 +144,10 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 				'clause' => 'where',
 				'column' => $table_name . '.date_registered',
 			),
+			'order'       => array(
+				'clause' => 'where',
+				'column' => $wpdb->prefix . 'wc_order_stats.date_created',
+			),
 			'last_active' => array(
 				'clause' => 'where',
 				'column' => $table_name . '.date_last_active',
@@ -338,11 +342,13 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
 		$defaults   = array(
-			'per_page' => get_option( 'posts_per_page' ),
-			'page'     => 1,
-			'order'    => 'DESC',
-			'orderby'  => 'date_registered',
-			'fields'   => '*',
+			'per_page'     => get_option( 'posts_per_page' ),
+			'page'         => 1,
+			'order'        => 'DESC',
+			'orderby'      => 'date_registered',
+			'order_before' => WC_Admin_Reports_Interval::default_before(),
+			'order_after'  => WC_Admin_Reports_Interval::default_after(),
+			'fields'       => '*',
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );


### PR DESCRIPTION
Fixes #2017

Allows customers to be filtered by order date `before` and `after` params.  Also hooks up the leaderboard to provide date based stats on customers.

### Screenshots
<img width="709" alt="Screen Shot 2019-04-22 at 5 29 18 PM" src="https://user-images.githubusercontent.com/10561050/56494299-5de49400-6524-11e9-9dbc-5bfb61d62a6e.png">

### Detailed test instructions:

1.  Make a request to `/wp-json/wc/v4/reports/customers` with `before` and `after` params.
2. Verify that returned stats are filtered by the order dates.
3.  Check that the dashboard customer's leaderboard now changes based on queried date. 