### PR TITLE
Use CSS variables in the Activity Panel and breadcrumbs CSS

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 	position: fixed;
 	right: 0;
-	height: $large-header-height;
+	height: $medium-header-height;
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
@@ -15,16 +15,15 @@
 		padding: 0;
 		width: 100vw;
 		display: none;
-		height: #{$medium-header-height};
 		flex: 1 100%;
 	}
 
 	@include breakpoint( '782px-960px' ) {
 		max-width: 280px;
-		height: $medium-header-height;
 	}
 
 	@include breakpoint( '>960px' ) {
+		height: $large-header-height;
 		max-width: 400px;
 	}
 
@@ -41,10 +40,6 @@
 
 	@include breakpoint( '>960px' ) {
 		height: $large-header-height;
-	}
-
-	@include breakpoint( '<782px' ) {
-		height: $medium-header-height;
 	}
 
 	.dashicon,

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -6,23 +6,22 @@
 	align-items: center;
 	position: fixed;
 	right: 0;
-	height: 80px;
+	height: $large-header-height;
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
 		background: $white;
 		margin: 0;
 		padding: 0;
-		top: -3px;
 		width: 100vw;
 		display: none;
-		height: 60px;
+		height: #{$medium-header-height};
 		flex: 1 100%;
 	}
 
 	@include breakpoint( '782px-960px' ) {
 		max-width: 280px;
-		height: 60px;
+		height: $medium-header-height;
 	}
 
 	@include breakpoint( '>960px' ) {
@@ -37,11 +36,15 @@
 .woocommerce-layout__activity-panel-tabs {
 	width: 100%;
 	display: flex;
-	height: 60px;
+	height: $medium-header-height;
 	justify-content: flex-end;
 
 	@include breakpoint( '>960px' ) {
-		height: 80px;
+		height: $large-header-height;
+	}
+
+	@include breakpoint( '<782px' ) {
+		height: $medium-header-height;
 	}
 
 	.dashicon,
@@ -78,10 +81,10 @@
 		min-width: 80px;
 		width: 100%;
 		font-size: 11px;
-		height: 60px;
+		height: $medium-header-height;
 		@include breakpoint( '>960px' ) {
 			font-size: 13px;
-			height: 80px;
+			height: $large-header-height;
 		}
 
 		&.is-active {
@@ -149,9 +152,9 @@
 .woocommerce-layout__activity-panel-mobile-toggle {
 	margin-right: 10px;
 	max-width: 48px;
-	height: 46px;
+	height: $small-header-height;
 	position: fixed;
-	top: 50px;
+	top: $adminbar-height-mobile;
 	right: 0;
 	@include breakpoint( '>782px' ) {
 		display: none;
@@ -194,31 +197,26 @@
 }
 
 .woocommerce-layout__activity-panel-wrapper {
-	height: calc(100vh - 80px);
-	min-height: calc(100vh - 80px);
+	height: calc(100vh - #{$medium-header-height + $small-header-height + $adminbar-height-mobile});
 	background: $core-grey-light-200;
 	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	width: 0;
 	@include activity-panel-slide();
 	position: fixed;
 	right: 0;
-	top: 92px;
+	top: #{$medium-header-height + $small-header-height + $adminbar-height-mobile};
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	// Extra padding is needed at the bottom of the wrapper because of our positioning, height, and overflow rules. Otherwise, some content can get cut off.
-	padding-bottom: $gap-small * 6;
 	@include breakpoint( '782px-960px' ) {
-		padding-bottom: $gap-small;
-	}
-	@include breakpoint( '>960px' ) {
-		top: 112px;
-		padding-bottom: $gap * 2;
+		height: calc(100vh - #{$medium-header-height + $adminbar-height});
+		top: #{$medium-header-height + $adminbar-height};
 	}
 
-	@include breakpoint( '<782px' ) {
-		top: 153px;
+	@include breakpoint( '>960px' ) {
+		height: calc(100vh - #{$large-header-height + $adminbar-height});
+		top: #{$large-header-height + $adminbar-height};
 	}
 
 	&.is-open {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -34,18 +34,18 @@
 		padding: 0 0 0 $fallback-gutter-large;
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
-		height: 50px;
-		line-height: 50px;
+		height: $small-header-height;
+		line-height: $small-header-height;
 		background: $white;
 
 		@include breakpoint( '782px-960px' ) {
-			height: 60px;
-			line-height: 60px;
+			height: $medium-header-height;
+			line-height: $medium-header-height;
 		}
 
 		@include breakpoint( '>960px' ) {
-			height: 80px;
-			line-height: 80px;
+			height: $large-header-height;
+			line-height: $large-header-height;
 		}
 
 		span + span::before {


### PR DESCRIPTION
Fixes #2095.

As discussed in https://github.com/woocommerce/woocommerce-admin/pull/2051#discussion_r277198663, we want to use the new header height CSS variables in the activity panel and breadcrumbs styles. This PR updates that and fixes #2095.

### Screenshots
_Before:_
![Screen Shot 2019-04-22 at 15 52 11](https://user-images.githubusercontent.com/3616980/56503711-99786180-6516-11e9-99a2-1f3c30fe3cce.png)
_(:point_up_2: notice it's scrolled to the bottom but the last item is cut-off)_

_After:_
![Screen Shot 2019-04-22 at 15 51 16](https://user-images.githubusercontent.com/3616980/56503680-7c439300-6516-11e9-9ad8-2973975117c1.png)

### Detailed test instructions:
- Open an activity panel tab with a small viewport.
- Scroll to the bottom.
- Verify the last element is completely visible.
- Verify there are no regressions anywhere else.
