### PR TITLE
Encode and decode persited query as JSON string in the leaderboards controller

### DIFF
--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -35,7 +35,7 @@ export function getLeaderboard( options ) {
 		after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 		before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		per_page,
-		persisted_query,
+		persisted_query: JSON.stringify( persisted_query ),
 	};
 
 	const leaderboards = getItems( endpoint, leaderboardQuery );

--- a/includes/api/class-wc-admin-rest-leaderboards-controller.php
+++ b/includes/api/class-wc-admin-rest-leaderboards-controller.php
@@ -351,10 +351,9 @@ class WC_Admin_REST_Leaderboards_Controller extends WC_REST_Data_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		parse_str( $request['persisted_query'], $persisted_query );
-
-		$leaderboards = $this->get_leaderboards( $request['per_page'], $request['after'], $request['before'], $persisted_query );
-		$data         = array();
+		$persisted_query = json_decode( $request['persisted_query'], true );
+		$leaderboards    = $this->get_leaderboards( $request['per_page'], $request['after'], $request['before'], $persisted_query );
+		$data            = array();
 
 		if ( ! empty( $leaderboards ) ) {
 			foreach ( $leaderboards as $leaderboard ) {

--- a/tests/api/leaderboards.php
+++ b/tests/api/leaderboards.php
@@ -109,7 +109,7 @@ class WC_Tests_API_Leaderboards extends WC_REST_Unit_Test_Case {
 			5
 		);
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
-		$request->set_query_params( array( 'persisted_query' => 'persisted_param=1' ) );
+		$request->set_query_params( array( 'persisted_query' => '{ "persisted_param": 1 }' ) );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
Fixes #2098 

Fixes the `persisted_query` string passed to the leaderboards controller.

### Screenshots
<img width="383" alt="Screen Shot 2019-04-23 at 4 13 57 PM" src="https://user-images.githubusercontent.com/10561050/56565665-81badf00-65e3-11e9-86fe-7521a7e13a59.png">
<img width="1017" alt="Screen Shot 2019-04-23 at 4 13 52 PM" src="https://user-images.githubusercontent.com/10561050/56565668-81badf00-65e3-11e9-868e-1ef9821962d6.png">

### Detailed test instructions:

1. Change the date range on the dashboards page.
2. Make sure leaderboards endpoint doesn't throw any errors.
3.  Check that leaderboard links include the persisted query from the date.