### PR TITLE
Fix warnings in travis: CSS lint error & phpunit warning

### DIFF
--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -26,7 +26,7 @@ $inner-border: $core-grey-light-500;
 
 	&.is-placeholder {
 		.woocommerce-summary__item-prev-label {
-			margin-right: calc( 100% - 80px );
+			margin-right: calc(100% - 80px);
 		}
 	}
 }

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -3403,7 +3403,7 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		$coupon->save();
 
 		// Create order.
-		$order = new WC_Order();
+		$order = WC_Helper_Order::create_order();
 		$order->add_product( $product, 1 );
 		$order->set_status( 'completed' );
 		$order->set_shipping_total( 10 );


### PR DESCRIPTION
There are a few issues coming up in the travis tests, but nothing that errors out the entire test. It's still distracting when looking over the result though, so this PR cleans up some things.

The issues in travis now are (see [an example log here](https://travis-ci.org/woocommerce/woocommerce-admin/jobs/523776041))

- Some CSS flagged with stylelint
- Running phpunit triggers "WordPress database error Column 'first_name' cannot be null for query"
- Warning with `php bin/generate-feature-config.php`

This PR fixes the first two, as the feature-config issue is fixed with #2060 

**To test**

- Run `npm run lint:css`, there should be no error
- Run `phpunit`, there should be no warning thrown during the execution of tests
- Check the travis log of this PR once it's complete, there should only be the feature-config warning