### PR TITLE
Add check for wp_set_script_translations.

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -150,8 +150,8 @@ class WC_Admin_Loader {
 			$feature = strtolower( $feature );
 			$file    = WC_ADMIN_FEATURES_PATH . $feature . '/class-wc-admin-' . $feature . '.php';
 			if ( file_exists( $file ) ) {
-				require_once( $file );
-				$feature = ucfirst( $feature );
+				require_once $file;
+				$feature         = ucfirst( $feature );
 				self::$classes[] = 'WC_Admin_' . $feature;
 			}
 		}
@@ -214,6 +214,10 @@ class WC_Admin_Loader {
 	 * Registers all the neccessary scripts and styles to show the admin experience.
 	 */
 	public static function register_scripts() {
+		if ( ! function_exists( 'wp_set_script_translations' ) ) {
+			return;
+		}
+
 		wp_register_script(
 			'wc-csv',
 			self::get_url( 'csv-export/index.js' ),
@@ -784,7 +788,7 @@ class WC_Admin_Loader {
 		$settings['commentModeration'] = get_option( 'comment_moderation' );
 		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
 		// and `wcAssetUrl` can be used in its place throughout the codebase.
-		$settings['wcAdminAssetUrl']   = plugins_url( 'images/', plugin_dir_path( dirname( __FILE__ ) ) . 'woocommerce-admin.php' );
+		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', plugin_dir_path( dirname( __FILE__ ) ) . 'woocommerce-admin.php' );
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -85,7 +85,7 @@ function wc_admin_plugins_notice() {
 	} else {
 		$message = sprintf(
 			/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> 5.0 or greater and <a href="%2$s">WooCommerce</a> 3.5 or greater to be installed and active.', 'woocommerce-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> 5.0 or greater and <a href="%2$s">WooCommerce</a> 3.6 or greater to be installed and active.', 'woocommerce-admin' ),
 			'https://wordpress.org/',
 			'https://wordpress.org/plugins/woocommerce/'
 		);

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -9,8 +9,8 @@
  * Domain Path: /languages
  * Version: 0.11.0
  *
- * WC requires at least: 3.5.0
- * WC tested up to: 3.5.7
+ * WC requires at least: 3.6.0
+ * WC tested up to: 3.6.2
  *
  * @package WC_Admin
  */
@@ -79,7 +79,7 @@ function wc_admin_plugins_notice() {
 	if ( $wordpress_includes_gutenberg ) {
 		$message = sprintf(
 			/* translators: URL of WooCommerce plugin */
-			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> 3.5 or greater to be installed and active.', 'woocommerce-admin' ),
+			__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> 3.6 or greater to be installed and active.', 'woocommerce-admin' ),
 			'https://wordpress.org/plugins/woocommerce/'
 		);
 	} else {


### PR DESCRIPTION
Fixes #2116
Fixes #2118 

This branch fixes the fatal that is thrown when you attempt to activate the plugin on WordPress 4.9.x or earlier. There is also a couple of PHPCS fixes that were magically done on my behalf.

I also updated the admin alert that is shown to message the required version of WooCommerce being 3.6 now

### Detailed test instructions:

- Install this branch on WordPress 4.9.x
- Attempt to activate the plugin
- Verify no fatal is thrown and you see the admin alert about WP 5.0 being required:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/22080/56755037-68c93f80-6743-11e9-9c34-e342c4e329f6.png">
