### PR TITLE
Add empty state for the Reviews panels

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -101,6 +101,14 @@
 
 .woocommerce-activity-card__body {
 	grid-area: body;
+
+	& > p:first-child {
+		margin-top: 0;
+	}
+
+	& > p:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .woocommerce-activity-card__actions {
@@ -331,4 +339,8 @@
 		color: $core-grey-dark-500;
 		@include font-size( 12 );
 	}
+}
+
+.woocommerce-empty-review-activity-card {
+	grid-template-columns: 72px 1fr;
 }

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -19,7 +19,7 @@ import { H, Section } from '@woocommerce/components';
 import {
 	getUnreadNotes,
 	getUnreadOrders,
-	getUnreadReviews,
+	getUnapprovedReviews,
 	getUnreadStock,
 } from './unread-indicators';
 import InboxPanel from './panels/inbox';
@@ -98,7 +98,7 @@ class ActivityPanel extends Component {
 
 	// @todo Pull in dynamic unread status/count
 	getTabs() {
-		const { hasUnreadNotes, hasUnreadOrders, hasUnreadReviews, hasUnreadStock } = this.props;
+		const { hasUnreadNotes, hasUnreadOrders, hasUnapprovedReviews, hasUnreadStock } = this.props;
 		return [
 			{
 				name: 'inbox',
@@ -125,7 +125,7 @@ class ActivityPanel extends Component {
 						name: 'reviews',
 						title: __( 'Reviews', 'woocommerce-admin' ),
 						icon: <Gridicon icon="star" />,
-						unread: hasUnreadReviews,
+						unread: hasUnapprovedReviews,
 					}
 				: null,
 		].filter( Boolean );
@@ -141,8 +141,7 @@ class ActivityPanel extends Component {
 			case 'stock':
 				return <StockPanel />;
 			case 'reviews':
-				const { numberOfReviews } = this.props;
-				return <ReviewsPanel numberOfReviews={ numberOfReviews } />;
+				return <ReviewsPanel />;
 			default:
 				return null;
 		}
@@ -272,7 +271,7 @@ export default withSelect( select => {
 	const hasUnreadNotes = getUnreadNotes( select );
 	const hasUnreadOrders = getUnreadOrders( select );
 	const hasUnreadStock = getUnreadStock( select );
-	const { numberOfReviews, hasUnreadReviews } = getUnreadReviews( select );
+	const hasUnapprovedReviews = getUnapprovedReviews( select );
 
-	return { hasUnreadNotes, hasUnreadOrders, hasUnreadReviews, hasUnreadStock, numberOfReviews };
+	return { hasUnreadNotes, hasUnreadOrders, hasUnreadStock, hasUnapprovedReviews };
 } )( clickOutside( ActivityPanel ) );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -141,7 +141,8 @@ class ActivityPanel extends Component {
 			case 'stock':
 				return <StockPanel />;
 			case 'reviews':
-				return <ReviewsPanel />;
+				const { hasUnapprovedReviews } = this.props;
+				return <ReviewsPanel hasUnapprovedReviews={ hasUnapprovedReviews } />;
 			default:
 				return null;
 		}

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -5,6 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
+import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
@@ -165,6 +166,34 @@ class ReviewsPanel extends Component {
 			) );
 	}
 
+	renderEmptyMessage() {
+		return (
+			<ActivityCard
+				className="woocommerce-empty-review-activity-card"
+				title={ __( 'You have no reviews to moderate', 'woocommerce-admin' ) }
+				icon={ <Gridicon icon="time" size={ 48 } /> }
+				actions={
+					<Button
+						href="https://woocommerce.com/posts/reviews-woocommerce-best-practices/"
+						isDefault
+					>
+						{ __( 'Learn more', 'woocommerce-admin' ) }
+					</Button>
+				}
+			>
+				<p>
+					{ __( "Your customers haven't started reviewing your products.", 'woocommerce-admin' ) }
+				</p>
+				<p>
+					{ __(
+						'Take some time to learn about best practices for collecting and using your reviews.',
+						'woocommerce-admin'
+					) }
+				</p>
+			</ActivityCard>
+		);
+	}
+
 	render() {
 		const { isError, isRequesting, reviews } = this.props;
 
@@ -190,15 +219,22 @@ class ReviewsPanel extends Component {
 			);
 		}
 
+		const title =
+			isRequesting || reviews.length
+				? __( 'Reviews', 'woocommerce-admin' )
+				: __( 'No reviews to moderate', 'woocommerce-admin' );
+
 		return (
 			<Fragment>
-				<ActivityHeader title={ __( 'Reviews', 'woocommerce-admin' ) } />
+				<ActivityHeader title={ title } />
 				<Section>
 					{ isRequesting ? (
 						this.renderPlaceholders()
 					) : (
 						<Fragment>
-							{ reviews.map( review => this.renderReview( review, this.props ) ) }
+							{ reviews.length
+								? reviews.map( review => this.renderReview( review, this.props ) )
+								: this.renderEmptyMessage() }
 						</Fragment>
 					) }
 				</Section>

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -156,6 +156,7 @@ class ReviewsPanel extends Component {
 
 		const title = __( 'You have no reviews to moderate', 'woocommerce-admin' );
 		let buttonUrl = '';
+		let buttonTarget = '';
 		let buttonText = '';
 		let content = '';
 
@@ -164,6 +165,7 @@ class ReviewsPanel extends Component {
 			const DAY = 24 * 60 * 60 * 1000;
 			if ( ( now.getTime() - lastApprovedReviewTime ) / DAY > 30 ) {
 				buttonUrl = 'https://woocommerce.com/posts/reviews-woocommerce-best-practices/';
+				buttonTarget = '_blank';
 				buttonText = __( 'Learn more', 'woocommerce-admin' );
 				content = (
 					<Fragment>
@@ -197,6 +199,7 @@ class ReviewsPanel extends Component {
 			}
 		} else {
 			buttonUrl = 'https://woocommerce.com/posts/reviews-woocommerce-best-practices/';
+			buttonTarget = '_blank';
 			buttonText = __( 'Learn more', 'woocommerce-admin' );
 			content = (
 				<Fragment>
@@ -219,7 +222,7 @@ class ReviewsPanel extends Component {
 				title={ title }
 				icon={ <Gridicon icon="time" size={ 48 } /> }
 				actions={
-					<Button href={ buttonUrl } isDefault>
+					<Button href={ buttonUrl } target={ buttonTarget } isDefault>
 						{ buttonText }
 					</Button>
 				}

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -14,8 +14,6 @@ export const DEFAULT_REQUIREMENT = {
 // WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter
 export const MAX_PER_PAGE = 100;
 
-export const DEFAULT_REVIEW_STATUSES = 'approved,hold';
-
 export const DEFAULT_ACTIONABLE_STATUSES = [ 'processing', 'on-hold' ];
 
 export const QUERY_DEFAULTS = {

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -47,7 +47,6 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 		'dashboard_leaderboards',
 		'dashboard_leaderboard_rows',
 		'activity_panel_inbox_last_read',
-		'activity_panel_reviews_last_read',
 	];
 
 	if ( resourceNames.includes( resourceName ) ) {


### PR DESCRIPTION
Fixes #1869.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Detailed test instructions:
First of all, make sure your store accepts reviews, and they must be approved manually.

- Delete all reviews in your store and verify this message is shown in the _Reviews_ Activity Panel tab.
![image](https://user-images.githubusercontent.com/3616980/56863683-e0a09f80-69b9-11e9-9478-3ac4f4d6d7a9.png)
- Verify the button links to: `https://woocommerce.com/posts/reviews-woocommerce-best-practices/`.
- Create a review and verify an unread indicator appears in the tab and it doesn't disappear when you close/open the panel.
- Approve the review (notice the button in the Card is not working yet, so you have to go to the _Comments_ admin page) and verify the message in the panel becomes:
![image](https://user-images.githubusercontent.com/3616980/56863751-89e79580-69ba-11e9-9a1b-765ca633a9b3.png)
- Verify the button links to: `/wp-admin/edit-comments.php`.
- Modify the review's submission date to something older than 30 days and verify the message in the panel changes to:
![image](https://user-images.githubusercontent.com/3616980/56863772-c0251500-69ba-11e9-8c71-28b999259b09.png)
- Verify the button links to: `https://woocommerce.com/posts/reviews-woocommerce-best-practices/`.
