### PR TITLE
Components: fix README url

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -185,7 +185,7 @@ install_deps() {
 
 	if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
 		BRANCH="$(sed 's/#/%23/' <<<$BRANCH)"
-		# Install wc-admin, the correct branch, if running from Travis CI.
+		# Install woocommerce-admin, the correct branch, if running from Travis CI.
 		php wp-cli.phar plugin install https://github.com/$REPO/archive/$BRANCH.zip --activate
 	fi
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,6 +1,6 @@
 # Feature Flags
 
-Features inside the `wc-admin` repository can be in various states of completeness. In addition to the development copy of `wc-admin`, feature plugin versions are bundled, and code is merged to WooCommerce core. To provide a way for improved control over how these features are released in these different environments, `wc-admin` has a system for feature flags.
+Features inside the `woocommerce-admin` repository can be in various states of completeness. In addition to the development copy of `woocommerce-admin`, feature plugin versions are bundled, and code is merged to WooCommerce core. To provide a way for improved control over how these features are released in these different environments, `woocommerce-admin` has a system for feature flags.
 
 We currently support the following environments:
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,4 +10,4 @@ Install the module
 npm install @woocommerce/components --save
 ```
 
-View [the full Component documentation](https://woocommerce.github.io/wc-admin/#/components/) for usage information.
+View [the full Component documentation](https://woocommerce.github.io/woocommerce-admin/#/components/) for usage information.


### PR DESCRIPTION
Link in components README updated to `woocommerce-admin` from `wc-admin`. 

I'm pretty sure this is the only instance.