### PR TITLE
Fix/extension examples

### DIFF
--- a/docs/examples/extensions/add-report/js/index.js
+++ b/docs/examples/extensions/add-report/js/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+
 import { addFilter } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -8,16 +9,43 @@ import { __ } from '@wordpress/i18n';
 /**
  * WooCommerce dependencies
  */
-import { ReportFilters } from '@woocommerce/components';
+import { ReportFilters, TableCard } from '@woocommerce/components';
 
 const Report = ( { path, query } ) => {
 	return (
 		<Fragment>
-			<ReportFilters
-				query={ query }
-				path={ path }
-				filters={ [] }
-				advancedFilters={ {} }
+			<ReportFilters query={ query } path={ path } filters={ [] } advancedFilters={ {} } />
+			<TableCard
+				title="Apples"
+				headers={ [
+					{ label: 'Type', key: 'type' },
+					{ label: 'Color', key: 'color' },
+					{ label: 'Taste', key: 'taste' },
+				] }
+				rows={ [
+					[
+						{ display: 'Granny Smith', value: 'type' },
+						{ display: 'Green', value: 'color' },
+						{ display: 'Tangy and sweet', value: 'taste' },
+					],
+					[
+						{ display: 'Golden Delicious', value: 'type' },
+						{ display: 'Gold', value: 'color' },
+						{ display: 'Sweet and cheery', value: 'taste' },
+					],
+					[
+						{ display: 'Gala', value: 'type' },
+						{ display: 'Red', value: 'color' },
+						{ display: 'Mild, sweet and crisp', value: 'taste' },
+					],
+					[
+						{ display: 'Braeburn', value: 'type' },
+						{ display: 'Red', value: 'color' },
+						{ display: 'Firm, crisp and pleasing', value: 'taste' },
+					],
+				] }
+				rowsPerPage={ 100 }
+				totalRows={ 1 }
 			/>
 		</Fragment>
 	);

--- a/docs/examples/extensions/examples.config.js
+++ b/docs/examples/extensions/examples.config.js
@@ -5,6 +5,7 @@
 const path = require( 'path' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const fs = require( 'fs' );
+const woocommerceAdminConfig = require( path.resolve( __dirname, '../../../webpack.config.js' ) );
 
 const extArg = process.argv.find( arg => arg.startsWith( '--ext=' ) );
 
@@ -19,31 +20,6 @@ if ( ! fs.existsSync( extensionPath ) ) {
 	throw new Error( 'Extension example does not exist.' );
 }
 
-const externals = {
-	'@wordpress/api-fetch': 'window.wp.apiFetch',
-	'@wordpress/blocks': 'window.wp.blocks',
-	'@wordpress/components': 'window.wp.components',
-	'@wordpress/compose': 'window.wp.compose',
-	'@wordpress/data': 'window.wp.data',
-	'@wordpress/editor': 'window.wp.editor',
-	'@wordpress/element': 'window.wp.element',
-	'@wordpress/hooks': 'window.wp.hooks',
-	'@wordpress/html-entities': 'window.wp.htmlEntities',
-	'@wordpress/i18n': 'window.wp.i18n',
-	'@wordpress/keycodes': 'window.wp.keycodes',
-	tinymce: 'tinymce',
-	moment: 'moment',
-	react: 'React',
-	lodash: 'lodash',
-	'react-dom': 'ReactDOM',
-	'@woocommerce/components': 'window.wc.components',
-	'@woocommerce/csv-export': 'window.wc.csvExport',
-	'@woocommerce/currency': 'window.wc.currency',
-	'@woocommerce/date': 'window.wc.date',
-	'@woocommerce/navigation': 'window.wc.navigation',
-	'@woocommerce/number': 'window.wc.number',
-};
-
 const webpackConfig = {
 	mode: 'development',
 	entry: {
@@ -52,8 +28,9 @@ const webpackConfig = {
 	output: {
 		filename: '[name]/dist/index.js',
 		path: path.resolve( __dirname ),
+		libraryTarget: 'this',
 	},
-	externals,
+	externals: woocommerceAdminConfig.externals,
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
This is a clean up of comments in https://github.com/woocommerce/woocommerce-admin/pull/2018 suggesting to add a table to the example report and re-use the externals object from the main app's webpack config.

### Screenshots

I added a basic table with some apples 🍏 🍎. I'd love to get a unifying theme going on these examples that is more interesting than apples, so I'm open to suggestions.

![Screen Shot 2019-04-30 at 7 59 00 AM](https://user-images.githubusercontent.com/1922453/56923169-fc24bb00-6b1d-11e9-8d29-e297343ba019.png)

### Detailed test instructions:

1. `npm run example -- --ext=add-report`.
2. Activate the WooCommerce Admin Add Report Example plugin.
3. Visit /wp-admin/admin.php?page=wc-admin#/analytics/example to see the report and its new table.

