### PR TITLE
Prevent chart type buttons breaking in two lines

### DIFF
--- a/packages/components/src/chart/style.scss
+++ b/packages/components/src/chart/style.scss
@@ -97,6 +97,7 @@
 
 .woocommerce-chart__types {
 	padding: 0 8px;
+	white-space: nowrap;
 }
 
 .woocommerce-chart__type-button {


### PR DESCRIPTION
Fixes #2133.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/56957810-94379a00-6b48-11e9-9479-9572f2feaf2a.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/56957780-7ec27000-6b48-11e9-9978-59acbed61b10.png)

### Detailed test instructions:
- Go to the _Dashboard_, scroll to _Charts_ with the viewport width between 7880px and 960px.
- Verify the chart type buttons don't break in two lines.
