### PR TITLE
Persist chart interval in Dashboard

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -46,7 +46,7 @@ class DashboardCharts extends Component {
 				'order_tax',
 				'shipping_tax',
 			],
-			interval: props.userPrefIntervals || 'day',
+			interval: props.userPrefChartInterval || 'day',
 		};
 
 		this.toggle = this.toggle.bind( this );


### PR DESCRIPTION
Fixes #2155

There was a name mismatch of the prop used.

### Screenshots
![dashboard-chart-persist](https://user-images.githubusercontent.com/3616980/57125216-e0711d00-6d88-11e9-978c-aae20f6f760d.gif)

### Detailed test instructions:
1. Go to the _Dashboard_.
2. In the _Charts_ section, change the interval to _Quarter_, for example.
3. Reload the page and verify the interval is still _Quarter_.
