### PR TITLE
Don't make an API call when there are no performance indicators

### DIFF
--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -177,14 +177,16 @@ class StorePerformance extends Component {
 	}
 
 	render() {
-		const { title } = this.props;
+		const { userIndicators, title } = this.props;
 		return (
 			<Fragment>
 				<SectionHeader
 					title={ title || __( 'Store Performance', 'woocommerce-admin' ) }
 					menu={ this.renderMenu() }
 				/>
-				<div className="woocommerce-dashboard__store-performance">{ this.renderList() }</div>
+				{ userIndicators.length > 0 && (
+					<div className="woocommerce-dashboard__store-performance">{ this.renderList() }</div>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -225,6 +225,14 @@ export default compose(
 		);
 		const statKeys = userIndicators.map( indicator => indicator.stat ).join( ',' );
 
+		if ( statKeys.length === 0 ) {
+			return {
+				hiddenIndicators,
+				userIndicators,
+				indicators,
+			};
+		}
+
 		const primaryQuery = {
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
 			before: appendTimestamp( endPrimary, endPrimary.isSame( moment(), 'day' ) ? 'now' : 'end' ),


### PR DESCRIPTION
Fixes #2153.

This will prevent error 500 from happening when querying the Rest API endpoint with no `stats` parameter.

### Detailed test instructions:
1. Open the _Network_ tab of your browser devtools.
2. Remove all _Store Performance_ blocks in the _Dashboard_.
3. Reload the page and verify there are no calls to the endpoint `/wc/v4/reports/performance-indicators`.