### PR TITLE
Fix customer type filter param in orders report

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -144,7 +144,7 @@ export const advancedFilters = {
 				getLabels: getCouponLabels,
 			},
 		},
-		customer: {
+		customer_type: {
 			labels: {
 				add: __( 'Customer Type', 'woocommerce-admin' ),
 				remove: __( 'Remove customer filter', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #2168 

Fixes the filtering for "Customer type" advanced filter in the orders report.

### Detailed test instructions:

1. Go to the orders report.
2. Add the customer type filter.
3. Make sure both "New" and "Returning" filters work and fetch the appropriate results.