### PR TITLE
Vertically center Dashboard 'Add more' button

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -32,8 +32,7 @@
 .woocommerce-dashboard-section__add-more {
 	margin: 0 auto;
 	width: 84px;
-	padding: $gap-large;
-	margin-top: -$gap-large;
+	padding: 0 $gap-large $gap-large;
 
 	.components-popover__content {
 		padding: 0 $gap $gap-smaller;

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -33,6 +33,7 @@
 	margin: 0 auto;
 	width: 84px;
 	padding: $gap-large;
+	margin-top: -$gap-large;
 
 	.components-popover__content {
 		padding: 0 $gap $gap-smaller;


### PR DESCRIPTION
Fixes #2170.

Tiny PR that aligns the _Add more_ button in the Dashboard.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/57220612-4addc380-6ffc-11e9-9066-396c623880c4.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/57220784-ef600580-6ffc-11e9-8fa3-cd72bd7c8a0f.png)

### Detailed test instructions:

1. Go to the _Dashboard_ and hide one section.
2. Scroll to the bottom.
3. Verify the _Add more_ button is vertically centered between the bottom of the page and the cards above.
