### PR TITLE
Hook up API Historical Data screen to API endpoints

### DIFF
--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -11,6 +11,9 @@ function HistoricalDataActions( {
 	customersTotal,
 	hasImportedData,
 	inProgress,
+	onDeletePreviousData,
+	onStartImport,
+	onStopImport,
 	ordersProgress,
 	ordersTotal,
 } ) {
@@ -22,7 +25,7 @@ function HistoricalDataActions( {
 					<Button
 						className="woocommerce-settings-historical-data__action-button"
 						isPrimary
-						onClick={ () => null }
+						onClick={ onStopImport }
 					>
 						{ __( 'Stop Import', 'woocommerce-admin' ) }
 					</Button>
@@ -44,7 +47,7 @@ function HistoricalDataActions( {
 		// Has no imported data
 		if ( ! hasImportedData ) {
 			return (
-				<Button isPrimary onClick={ () => null }>
+				<Button isPrimary onClick={ onStartImport }>
 					{ __( 'Start', 'woocommerce-admin' ) }
 				</Button>
 			);
@@ -57,7 +60,7 @@ function HistoricalDataActions( {
 					<Button isDefault onClick={ () => null }>
 						{ __( 'Re-import Data', 'woocommerce-admin' ) }
 					</Button>
-					<Button isDefault onClick={ () => null }>
+					<Button isDefault onClick={ onDeletePreviousData }>
 						{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
 					</Button>
 				</Fragment>
@@ -67,10 +70,10 @@ function HistoricalDataActions( {
 		// It's not in progress and has some imported data
 		return (
 			<Fragment>
-				<Button isPrimary onClick={ () => null }>
+				<Button isPrimary onClick={ onStartImport }>
 					{ __( 'Start', 'woocommerce-admin' ) }
 				</Button>
-				<Button isDefault onClick={ () => null }>
+				<Button isDefault onClick={ onDeletePreviousData }>
 					{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
 				</Button>
 			</Fragment>

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -80,12 +80,12 @@ class HistoricalData extends Component {
 		}
 		if ( period.label !== 'all' ) {
 			if ( period.label === 'custom' ) {
-				const daysDifference = moment( period.date, this.dateFormat ).diff(
-					moment(),
+				const daysDifference = moment().diff(
+					moment( period.date, this.dateFormat ),
 					'days',
 					true
 				);
-				params.days = Math.ceil( Math.abs( daysDifference ) );
+				params.days = Math.ceil( daysDifference );
 			} else {
 				params.days = parseInt( period.label, 10 );
 			}

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -3,8 +3,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
 import moment from 'moment';
+
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -31,9 +37,74 @@ class HistoricalData extends Component {
 			skipChecked: true,
 		};
 
+		this.makeQuery = this.makeQuery.bind( this );
+		this.onDeletePreviousData = this.onDeletePreviousData.bind( this );
+		this.onStartImport = this.onStartImport.bind( this );
+		this.onStopImport = this.onStopImport.bind( this );
 		this.onDateChange = this.onDateChange.bind( this );
 		this.onPeriodChange = this.onPeriodChange.bind( this );
 		this.onSkipChange = this.onSkipChange.bind( this );
+	}
+
+	makeQuery( path, errorMessage ) {
+		const { addNotice } = this.props;
+		apiFetch( { path, method: 'POST' } )
+			.then( response => {
+				if ( 'success' === response.status ) {
+					addNotice( { status: 'success', message: response.message } );
+				} else {
+					addNotice( { status: 'error', message: errorMessage } );
+				}
+			} )
+			.catch( error => {
+				if ( error && error.message ) {
+					addNotice( { status: 'error', message: error.message } );
+				}
+			} );
+	}
+
+	onDeletePreviousData() {
+		const path = '/wc/v4/reports/import/delete';
+		const errorMessage = __(
+			'There was a problem deleting your previous data.',
+			'woocommerce-admin'
+		);
+		this.makeQuery( path, errorMessage );
+	}
+
+	onStartImport() {
+		const { period, skipChecked } = this.state;
+		const params = {};
+		if ( skipChecked ) {
+			params.skip_existing = true;
+		}
+		if ( period.label !== 'all' ) {
+			if ( period.label === 'custom' ) {
+				const daysDifference = moment( period.date, this.dateFormat ).diff(
+					moment(),
+					'days',
+					true
+				);
+				params.days = Math.ceil( Math.abs( daysDifference ) );
+			} else {
+				params.days = parseInt( period.label, 10 );
+			}
+		}
+		const path = '/wc/v4/reports/import' + stringifyQuery( params );
+		const errorMessage = __(
+			'There was a problem rebuilding your report data.',
+			'woocommerce-admin'
+		);
+		this.makeQuery( path, errorMessage );
+	}
+
+	onStopImport() {
+		const path = '/wc/v4/reports/import/cancel';
+		const errorMessage = __(
+			'There was a problem stopping your current import.',
+			'woocommerce-admin'
+		);
+		this.makeQuery( path, errorMessage );
 	}
 
 	onPeriodChange( val ) {
@@ -153,6 +224,9 @@ class HistoricalData extends Component {
 					customersTotal={ customersTotal }
 					hasImportedData={ hasImportedData }
 					inProgress={ inProgress }
+					onDeletePreviousData={ this.onDeletePreviousData }
+					onStartImport={ this.onStartImport }
+					onStopImport={ this.onStopImport }
 					ordersProgress={ ordersProgress }
 					ordersTotal={ ordersTotal }
 				/>

--- a/client/analytics/settings/historical-data/period-selector.js
+++ b/client/analytics/settings/historical-data/period-selector.js
@@ -68,11 +68,11 @@ function HistoricalDataPeriodSelector( {
 					onChange={ onSelectChange }
 					options={ [
 						{ label: 'All', value: 'all' },
-						{ label: 'Last 365 days', value: '365_days' },
-						{ label: 'Last 90 days', value: '90_days' },
-						{ label: 'Last 30 days', value: '30_days' },
-						{ label: 'Last 7 days', value: '7_days' },
-						{ label: 'Last 24 hours', value: '24_hours' },
+						{ label: 'Last 365 days', value: '365' },
+						{ label: 'Last 90 days', value: '90' },
+						{ label: 'Last 30 days', value: '30' },
+						{ label: 'Last 7 days', value: '7' },
+						{ label: 'Last 24 hours', value: '1' },
 						{ label: 'Custom', value: 'custom' },
 					] }
 				/>

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -110,6 +110,7 @@ class Settings extends Component {
 	}
 
 	render() {
+		const { addNotice } = this.props;
 		const { hasError } = this.state;
 		if ( hasError ) {
 			return null;
@@ -141,7 +142,7 @@ class Settings extends Component {
 							{ __( 'Save Changes', 'woocommerce-admin' ) }
 						</Button>
 					</div>
-					<HistoricalData />
+					<HistoricalData addNotice={ addNotice } />
 				</div>
 			</Fragment>
 		);


### PR DESCRIPTION
Part of #1851.

This PR hooks up the _Historical Data Import_ buttons to the REST API endpoints. Notice the endpoints to read the current state of the import are not available yet, so progress bars and the transition between pages don't work yet.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/56281614-6183af80-610d-11e9-8224-5362d9f216e9.png)

### Detailed test instructions:
- Go to the _Import Historical Data_ section of the _Settings_ page.
- Press _Start_ and verify a call to `/wc/v4/reports/import` is made.
- Try modifying the select box value (try with _Custom_, which will enable the date picker) and the _Skip_ checkbox and start the import again, verify the call to the endpoint has the correct parameters.
- Modify `<HistoricalData>` [props](https://github.com/woocommerce/woocommerce-admin/blob/master/client/analytics/settings/historical-data/index.js#L165) to:
```ES6
hasImportedData: true,
```
- Reload the page and press on _Delete Previously Imported Data_.
- Verify a call to `/wc/v4/reports/import/delete` is made.
- Modify `<HistoricalData>` props again to:
```ES6
inProgress: true,
```
- Press _Stop Import_ and verify a call to `/wc/v4/reports/import/cancel` is made.