### PR TITLE
Travis: Exit scripts with error when one occurs

### DIFF
--- a/bin/js_lint_test.sh
+++ b/bin/js_lint_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 if [[ ${RUN_JS} == 1 ]]; then
 	npm run lint
 	npm run build

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -199,7 +199,7 @@ export default compose(
 
 		if ( statKeys.length === 0 ) {
 			return {
-				hiddenIndicators,
+				hiddenIndicators: [],
 				userIndicators,
 				indicators,
 			};

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -199,7 +199,7 @@ export default compose(
 
 		if ( statKeys.length === 0 ) {
 			return {
-				hiddenIndicators: [],
+				hiddenBlocks,
 				userIndicators,
 				indicators,
 			};


### PR DESCRIPTION
If Travis has failing scripts like `npm run lint`, the builds still succeeds because the bash script doesn't persist the error.

This PR persists errors so that builds fail when they should.

### Testing Intructions

1. See the build failed on this PR's first commit. The build should fail because there is a linting error.
2. See the final build on this PR succeed because the linting error has been addressed.