### PR TITLE
Check for page suffix to fix blank pages with WC Branding

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -351,8 +351,8 @@ class WC_Admin_Loader {
 	 * Returns true if we are on a JS powered admin page.
 	 */
 	public static function is_admin_page() {
-		global $hook_suffix;
-		if ( in_array( $hook_suffix, array( 'woocommerce_page_wc-admin' ) ) ) {
+		$current_screen = get_current_screen();
+		if ( '_page_wc-admin' === substr( $current_screen->id, -14 ) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Fixes #2077

Checks for the page suffix `_page_wc_admin` instead of `woocommerce_page_wc_admin` since this is filtered by WooCommerce Branding.

This text is normally filtered for text under the `woocommerce` domain so this workaround won't be necessary after this is merged into core.

### Detailed test instructions:

1.  Install WooCommerce Branding.
2.  Check that wc-admin pages are still working.