### PR TITLE
Add import status endpoint and progress options

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -270,10 +270,11 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 	 */
 	public function get_import_status( $request ) {
 		$result = array(
+			'is_importing'    => WC_Admin_Reports_Sync::is_importing(),
 			'customers_total' => get_option( 'wc_admin_import_customers_total', 0 ),
 			'customers_count' => get_option( 'wc_admin_import_customers_count', 0 ),
 			'orders_total'    => get_option( 'wc_admin_import_orders_total', 0 ),
-			'orders_count'    => get_option( 'wc_admin_import_orders_total', 0 ),
+			'orders_count'    => get_option( 'wc_admin_import_orders_count', 0 ),
 			'imported_from'   => get_option( 'wc_admin_imported_from_date', false ),
 		);
 

--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -71,6 +71,18 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 				'schema' => array( $this, 'get_import_public_schema' ),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/status',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_import_status' ),
+					'permission_callback' => array( $this, 'import_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_import_public_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -243,6 +255,27 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 				'message' => $delete,
 			);
 		}
+
+		$response = $this->prepare_item_for_response( $result, $request );
+		$data     = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get the status of the current import.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_import_status( $request ) {
+		$result = array(
+			'customers_total' => get_option( 'wc_admin_import_customers_total', 0 ),
+			'customers_count' => get_option( 'wc_admin_import_customers_count', 0 ),
+			'orders_total'    => get_option( 'wc_admin_import_orders_total', 0 ),
+			'orders_count'    => get_option( 'wc_admin_import_orders_total', 0 ),
+			'imported_from'   => get_option( 'wc_admin_imported_from_date', false ),
+		);
 
 		$response = $this->prepare_item_for_response( $result, $request );
 		$data     = $this->prepare_response_for_collection( $response );

--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -83,6 +83,19 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 				'schema' => array( $this, 'get_import_public_schema' ),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/totals',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_import_totals' ),
+					'permission_callback' => array( $this, 'import_permissions_check' ),
+					'args'                => $this->get_import_collection_params(),
+				),
+				'schema' => array( $this, 'get_import_public_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -279,6 +292,22 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 		);
 
 		$response = $this->prepare_item_for_response( $result, $request );
+		$data     = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get the total orders and customers based on user supplied params.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_import_totals( $request ) {
+		$query_args = $this->prepare_objects_query( $request );
+		$totals     = WC_Admin_Reports_Sync::get_import_totals( $query_args['days'], $query_args['skip_existing'] );
+
+		$response = $this->prepare_item_for_response( $totals, $request );
 		$data     = $this->prepare_response_for_collection( $response );
 
 		return rest_ensure_response( $data );

--- a/includes/class-wc-admin-actionscheduler-wppoststore.php
+++ b/includes/class-wc-admin-actionscheduler-wppoststore.php
@@ -36,23 +36,15 @@ class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
 
 	/**
 	 * Forcefully delete all pending WC Admin scheduled actions.
-	 *
 	 * Directly trashes items from in database for performance.
+	 *
+	 * @param array $action_types Array of actions to delete.
 	 */
-	public function clear_pending_wcadmin_actions() {
+	public function clear_pending_wcadmin_actions( $action_types ) {
 		global $wpdb;
 
 		// Cancel all pending actions by trashing the posts.
 		// Action Scheduler will handle the cleanup.
-		$action_types = array(
-			WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-			WC_Admin_Reports_Sync::QUEUE_DEPEDENT_ACTION,
-			WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION,
-			WC_Admin_Reports_Sync::ORDERS_IMPORT_BATCH_ACTION,
-			WC_Admin_Reports_Sync::ORDERS_IMPORT_BATCH_INIT,
-			WC_Admin_Reports_Sync::SINGLE_ORDER_IMPORT_ACTION,
-		);
-
 		foreach ( $action_types as $action_type ) {
 			$wpdb->update(
 				$wpdb->posts,

--- a/includes/class-wc-admin-actionscheduler-wppoststore.php
+++ b/includes/class-wc-admin-actionscheduler-wppoststore.php
@@ -45,7 +45,7 @@ class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
 
 		// Cancel all pending actions by trashing the posts.
 		// Action Scheduler will handle the cleanup.
-		foreach ( $action_types as $action_type ) {
+		foreach ( (array) $action_types as $action_type ) {
 			$wpdb->update(
 				$wpdb->posts,
 				array(

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -202,7 +202,19 @@ class WC_Admin_Reports_Sync {
 
 		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.
-			$store->clear_pending_wcadmin_actions();
+			$action_types = array(
+				self::QUEUE_BATCH_ACTION,
+				self::QUEUE_DEPEDENT_ACTION,
+				self::CUSTOMERS_IMPORT_BATCH_ACTION,
+				self::CUSTOMERS_DELETE_BATCH_INIT,
+				self::CUSTOMERS_DELETE_BATCH_ACTION,
+				self::ORDERS_IMPORT_BATCH_ACTION,
+				self::ORDERS_IMPORT_BATCH_INIT,
+				self::ORDERS_DELETE_BATCH_INIT,
+				self::ORDERS_DELETE_BATCH_ACTION,
+				self::SINGLE_ORDER_IMPORT_ACTION,
+			);
+			$store->clear_pending_wcadmin_actions( $action_types );
 		} else {
 			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}

--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -18,6 +18,11 @@ class WC_Admin_Notes {
 	const UNSNOOZE_HOOK = 'wc_admin_unsnooze_admin_notes';
 
 	/**
+	 * Action scheduler group.
+	 */
+	const QUEUE_GROUP = 'wc-admin-notes';
+
+	/**
 	 * Hook appropriate actions.
 	 */
 	public static function init() {
@@ -131,7 +136,21 @@ class WC_Admin_Notes {
 		$next  = $queue->get_next( self::UNSNOOZE_HOOK );
 
 		if ( ! $next ) {
-			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), WC_Admin_Reports_Sync::QUEUE_GROUP );
+			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), self::QUEUE_GROUP );
+		}
+	}
+
+	/**
+	 * Clears all queued actions.
+	 */
+	public static function clear_queued_actions() {
+		$store = ActionScheduler::store();
+
+		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
+			// If we're using our data store, call our bespoke deletion method.
+			$store->clear_pending_wcadmin_actions();
+		} else {
+			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}
 	}
 }

--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -148,7 +148,8 @@ class WC_Admin_Notes {
 
 		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.
-			$store->clear_pending_wcadmin_actions();
+			$action_types = array( self::UNSNOOZE_HOOK );
+			$store->clear_pending_wcadmin_actions( $action_types );
 		} else {
 			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}

--- a/tests/framework/helpers/class-wc-helper-queue.php
+++ b/tests/framework/helpers/class-wc-helper-queue.php
@@ -40,4 +40,18 @@ class WC_Helper_Queue {
 			$job->execute();
 		}
 	}
+
+	/**
+	 * Run all pending queued actions.
+	 *
+	 * @return void
+	 */
+	public static function process_pending() {
+		$jobs = self::get_all_pending();
+
+		$queue_runner = new ActionScheduler_QueueRunner();
+		foreach ( $jobs as $job_id => $job ) {
+			$queue_runner->process_action( $job_id );
+		}
+	}
 }

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -190,6 +190,7 @@ function wc_admin_deactivate_wc_admin_plugin() {
 	if ( wc_admin_dependencies_satisfied() ) {
 		wp_clear_scheduled_hook( 'wc_admin_daily' );
 		WC_Admin_Reports_Sync::clear_queued_actions();
+		WC_Admin_Notes::clear_queued_actions();
 	}
 }
 register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_deactivate_wc_admin_plugin' );


### PR DESCRIPTION
Fixes #1850

Adds an endpoint to query the current import progress and oldest date of import.  The date will be set to `-1` if `days` are not specific initially.

Also adds an endpoint to query potential totals prior to import.

### Thoughts/notes
* Opted to use options here instead of attempting to query pending/completed batches.  The latter seems like it would get messy quickly and is prone to inaccurate results with completed results.
* Orders total is not calculated until after the customers batch is finished since it's a dependent action.  If we want to show orders total while customers are being processed, we will probably need to create both customer and order batches initially so that we can calculate totals and set the orders batch to pending until the customers batch is complete.
* Imports should still be limited to one import at a time.  Will outline a separate issue to tackle this.

### Screenshots
<img width="365" alt="Screen Shot 2019-05-08 at 3 56 39 PM" src="https://user-images.githubusercontent.com/10561050/57359381-2aec0280-71aa-11e9-84d0-30c8af330d64.png">

### Detailed test instructions:

1.  Start an import by posting to the `/wp-json/wc/v4/reports/import` endpoint.
2.  Send a get request to `/wp-json/wc/v4/reports/import/status`.
3.  Check that totals and progress count are reflected in the endpoint.
4.  Send a get request to `/wp-json/wc/v4/reports/import/totals` with `day` and `skip_existing` params.
5.  Make sure that total numbers returned are accurate.