### PR TITLE
Fix customer name conditions on import

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -525,25 +525,21 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 
 		if (
 			$user_id &&
-			get_user_meta( $user_id, 'first_name', true ) ||
-			get_user_meta( $user_id, 'last_name', true )
+			(
+				get_user_meta( $user_id, 'first_name', true ) ||
+				get_user_meta( $user_id, 'last_name', true )
+			)
 		) {
 			$first_name = get_user_meta( $user_id, 'first_name', true );
 			$last_name  = get_user_meta( $user_id, 'last_name', true );
-		} elseif (
-			$order &&
-			$order->get_billing_first_name( 'edit' ) ||
-			$order->get_billing_last_name( 'edit' )
-		) {
-			$first_name = $order->get_billing_first_name( 'edit' );
-			$last_name  = $order->get_billing_last_name( 'edit' );
-		} elseif (
-			$order &&
-			$order->get_shipping_first_name( 'edit' ) ||
-			$order->get_shipping_last_name( 'edit' )
-		) {
-			$first_name = $order->get_shipping_first_name( 'edit' );
-			$last_name  = $order->get_shipping_last_name( 'edit' );
+		} elseif ( $order ) {
+			if ( $order->get_billing_first_name( 'edit' ) || $order->get_billing_last_name( 'edit' ) ) {
+				$first_name = $order->get_billing_first_name( 'edit' );
+				$last_name  = $order->get_billing_last_name( 'edit' );
+			} elseif ( $order->get_shipping_first_name( 'edit' ) || $order->get_shipping_last_name( 'edit' ) ) {
+				$first_name = $order->get_shipping_first_name( 'edit' );
+				$last_name  = $order->get_shipping_last_name( 'edit' );
+			}
 		}
 
 		return apply_filters( 'woocommerce_reports_customer_name', array( $first_name, $last_name ), $order );


### PR DESCRIPTION
Fixes #2196

Fixes a bug on customer name import due to conditional precedence.

### Detailed test instructions:

1.  Create a user with role `customer` and no orders.
2.  Attempt to import the user.
3.  Make sure no errors are thrown.
4.  Make sure all tests pass.