### PR TITLE
Drop 'sold' from 'products sold' in products report

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -216,7 +216,7 @@ class ProductsReportTable extends Component {
 		const { products_count = 0, items_sold = 0, net_revenue = 0, orders_count = 0 } = totals;
 		return [
 			{
-				label: _n( 'product sold', 'products sold', products_count, 'woocommerce-admin' ),
+				label: _n( 'product', 'products', products_count, 'woocommerce-admin' ),
 				value: numberFormat( products_count ),
 			},
 			{


### PR DESCRIPTION
Fixes #2239

Replaces `products sold` with `products` since this refers to the number of unique products and not the total products sold count.

### Before
<img width="452" alt="Screen Shot 2019-05-15 at 2 22 48 PM" src="https://user-images.githubusercontent.com/10561050/57753083-b0793080-771d-11e9-91a9-43e938ccaef4.png">

### After
<img width="414" alt="Screen Shot 2019-05-15 at 2 27 28 PM" src="https://user-images.githubusercontent.com/10561050/57753077-aeaf6d00-771d-11e9-9516-89b72bdd2dc2.png">


### Detailed test instructions:

1. Go to the products report.
2. Make sure the text is updated.
3.  ...
4. Profit!