### PR TITLE
Update settings wc-api to accept multiple setting groups

### DIFF
--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -153,7 +153,7 @@ export default compose(
 	withSelect( select => {
 		const { getSettings, getSettingsError, isGetSettingsRequesting } = select( 'wc-api' );
 
-		const settings = getSettings();
+		const settings = getSettings( 'wc_admin' );
 		const isError = Boolean( getSettingsError() );
 		const isRequesting = isGetSettingsRequesting();
 

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -88,7 +88,7 @@ class Settings extends Component {
 	}
 
 	saveChanges = () => {
-		this.props.updateSettings( this.state.settings );
+		this.props.updateSettings( { wc_admin: this.state.settings } );
 		this.setState( { saving: true } );
 	};
 
@@ -154,8 +154,8 @@ export default compose(
 		const { getSettings, getSettingsError, isGetSettingsRequesting } = select( 'wc-api' );
 
 		const settings = getSettings( 'wc_admin' );
-		const isError = Boolean( getSettingsError() );
-		const isRequesting = isGetSettingsRequesting();
+		const isError = Boolean( getSettingsError( 'wc_admin' ) );
+		const isRequesting = isGetSettingsRequesting( 'wc_admin' );
 
 		return { getSettings, isError, isRequesting, settings };
 	} ),

--- a/client/wc-api/settings/mutations.js
+++ b/client/wc-api/settings/mutations.js
@@ -2,7 +2,11 @@
 
 const updateSettings = operations => settingFields => {
 	const resourceKey = 'settings';
-	operations.update( [ resourceKey ], { [ resourceKey ]: settingFields } );
+	Object.keys( settingFields ).map( group =>
+		operations.update( [ resourceKey + '/' + group ], {
+			[ resourceKey + '/' + group ]: settingFields[ group ],
+		} )
+	);
 };
 
 export default {

--- a/client/wc-api/settings/operations.js
+++ b/client/wc-api/settings/operations.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,31 +35,26 @@ function readSettings( resourceNames, fetch ) {
 }
 
 function updateSettings( resourceNames, data, fetch ) {
-	const resourceName = 'settings';
-	const settingsFields = [
-		'woocommerce_excluded_report_order_statuses',
-		'woocommerce_actionable_order_statuses',
-	];
+	const filteredNames = resourceNames.filter( name => {
+		return name.startsWith( 'settings/' );
+	} );
 
-	if ( resourceNames.includes( resourceName ) ) {
-		const url = NAMESPACE + '/settings/wc_admin/';
-		const settingsData = pick( data[ resourceName ], settingsFields );
-
-		const promises = Object.keys( settingsData ).map( setting => {
-			return fetch( {
-				path: url + setting,
-				method: 'POST',
-				data: { value: settingsData[ setting ] },
-			} )
-				.then( settingToSettingsResource.bind( null, data.settings ) )
-				.catch( error => {
-					return { [ resourceName ]: { error } };
-				} );
+	return filteredNames.map( async resourceName => {
+		const url = NAMESPACE + '/' + resourceName + '/batch';
+		const settingsData = Object.keys( data[ resourceName ] ).map( key => {
+			return { id: key, value: data[ resourceName ][ key ] };
 		} );
 
-		return promises;
-	}
-	return [];
+		return fetch( {
+			path: url,
+			method: 'POST',
+			data: { update: settingsData },
+		} )
+			.then( settingToSettingsResource.bind( null, resourceName ) )
+			.catch( error => {
+				return { [ resourceName ]: { error } };
+			} );
+	} );
 }
 
 function settingsToSettingsResource( resourceName, settings ) {
@@ -69,9 +63,17 @@ function settingsToSettingsResource( resourceName, settings ) {
 	return { [ resourceName ]: { data: settingsData } };
 }
 
-function settingToSettingsResource( settings, setting ) {
-	settings[ setting.id ] = setting.value;
-	return { [ 'settings' ]: { data: settings } };
+function settingToSettingsResource( resourceName, data ) {
+	const settings = {};
+	if ( 'undefined' === typeof data.update ) {
+		return '';
+	}
+
+	// @todo This will only return updated fields so fields
+	// not updated may be temporarily overwritten in the store.
+	data.update.forEach( setting => ( settings[ setting.id ] = setting.value ) );
+
+	return { [ resourceName ]: { data: settings } };
 }
 
 export default {

--- a/client/wc-api/settings/operations.js
+++ b/client/wc-api/settings/operations.js
@@ -20,18 +20,19 @@ function update( resourceNames, data, fetch = apiFetch ) {
 }
 
 function readSettings( resourceNames, fetch ) {
-	if ( resourceNames.includes( 'settings' ) ) {
-		const url = NAMESPACE + '/settings/wc_admin';
+	const filteredNames = resourceNames.filter( name => {
+		return name.startsWith( 'settings/' );
+	} );
 
-		return [
-			fetch( { path: url } )
-				.then( settingsToSettingsResource )
-				.catch( error => {
-					return { [ 'settings' ]: { error: String( error.message ) } };
-				} ),
-		];
-	}
-	return [];
+	return filteredNames.map( async resourceName => {
+		const url = NAMESPACE + '/' + resourceName;
+
+		return fetch( { path: url } )
+			.then( settingsToSettingsResource.bind( null, resourceName ) )
+			.catch( error => {
+				return { [ resourceName ]: { error: String( error.message ) } };
+			} );
+	} );
 }
 
 function updateSettings( resourceNames, data, fetch ) {
@@ -62,10 +63,10 @@ function updateSettings( resourceNames, data, fetch ) {
 	return [];
 }
 
-function settingsToSettingsResource( settings ) {
+function settingsToSettingsResource( resourceName, settings ) {
 	const settingsData = {};
 	settings.forEach( setting => ( settingsData[ setting.id ] = setting.value ) );
-	return { [ 'settings' ]: { data: settingsData } };
+	return { [ resourceName ]: { data: settingsData } };
 }
 
 function settingToSettingsResource( settings, setting ) {

--- a/client/wc-api/settings/selectors.js
+++ b/client/wc-api/settings/selectors.js
@@ -10,8 +10,11 @@ import { isNil } from 'lodash';
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
 
-const getSettings = ( getResource, requireResource ) => ( requirement = DEFAULT_REQUIREMENT ) => {
-	return requireResource( requirement, 'settings' ).data || {};
+const getSettings = ( getResource, requireResource ) => (
+	group,
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	return requireResource( requirement, `settings/${ group }` ).data || {};
 };
 
 const getSettingsError = getResource => () => {

--- a/client/wc-api/settings/selectors.js
+++ b/client/wc-api/settings/selectors.js
@@ -17,12 +17,12 @@ const getSettings = ( getResource, requireResource ) => (
 	return requireResource( requirement, `settings/${ group }` ).data || {};
 };
 
-const getSettingsError = getResource => () => {
-	return getResource( 'settings' ).error;
+const getSettingsError = getResource => group => {
+	return getResource( `settings/${ group }` ).error;
 };
 
-const isGetSettingsRequesting = getResource => () => {
-	const { lastRequested, lastReceived } = getResource( 'settings' );
+const isGetSettingsRequesting = getResource => group => {
+	const { lastReceived, lastRequested } = getResource( `settings/${ group }` );
 	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;
 	}


### PR DESCRIPTION
Fixes #2281 

Adds the ability to fetch and update all WC settings other than those in the `wc_admin` group.

### Detailed test instructions:

1.  Go to the Analytics settings page.
2.  Make sure the correct settings are shown.
3.  Save the data.
4.  Make sure data is persisted on refresh.