### PR TITLE
Remove table data on plugin uninstall

### DIFF
--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -89,13 +89,6 @@ class WC_Admin_Api_Init {
 		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-reports-customers-data-store.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-reports-customers-stats-data-store.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php';
-
-		// Data triggers.
-		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-notes-data-store.php';
-
-		// CRUD classes.
-		require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-note.php';
-		require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-notes.php';
 	}
 
 	/**

--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -272,6 +272,19 @@ class WC_Admin_Install {
 		WC_Admin_Notes_Historical_Data::add_note();
 		WC_Admin_Notes_Welcome_Message::add_welcome_note();
 	}
+
+	/**
+	 * Delete all data from tables.
+	 */
+	public static function delete_table_data() {
+		global $wpdb;
+
+		$tables = self::get_tables();
+
+		foreach ( $tables as $table ) {
+			$wpdb->query( "TRUNCATE TABLE {$table}" ); // WPCS: unprepared SQL ok.
+		}
+	}
 }
 
 WC_Admin_Install::init();

--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -23,6 +23,26 @@ class WC_Admin_Notes {
 	const QUEUE_GROUP = 'wc-admin-notes';
 
 	/**
+	 * Queue instance.
+	 *
+	 * @var WC_Queue_Interface
+	 */
+	protected static $queue = null;
+
+	/**
+	 * Get queue instance.
+	 *
+	 * @return WC_Queue_Interface
+	 */
+	public static function queue() {
+		if ( is_null( self::$queue ) ) {
+			self::$queue = WC()->queue();
+		}
+
+		return self::$queue;
+	}
+
+	/**
 	 * Hook appropriate actions.
 	 */
 	public static function init() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,10 @@
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
-WC_Admin::instance()->includes();
+require_once dirname( __FILE__ ) . '/woocommerce-admin.php';
+
+WC_Admin_Feature_Plugin::instance()->includes();
 WC_Admin_Reports_Sync::clear_queued_actions();
 WC_Admin_Notes::clear_queued_actions();
+WC_Admin_Install::delete_table_data();
 wp_clear_scheduled_hook( 'wc_admin_daily' );

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -56,7 +56,6 @@ class WC_Admin_Feature_Plugin {
 	public function init() {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
-		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
@@ -70,16 +69,6 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		WC_Admin_Install::create_tables();
 		WC_Admin_Install::create_events();
-	}
-
-	/**
-	 * Remove WooCommerce Admin related table data.
-	 *
-	 * @return void
-	 */
-	public function on_deactivation() {
-		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
-		WC_Admin_Install::delete_table_data();
 	}
 
 	/**
@@ -135,6 +124,13 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-events.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-api-init.php';
+
+		// Data triggers.
+		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-notes-data-store.php';
+
+		// CRUD classes.
+		require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-note.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-notes.php';
 
 		// Admin note providers.
 		// @todo These should be bundled in the features/ folder, but loading them from there currently has a load order issue.

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -56,12 +56,13 @@ class WC_Admin_Feature_Plugin {
 	public function init() {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
+		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
 
 	/**
-	 * Install DB and create cron events when activated,
+	 * Install DB and create cron events when activated.
 	 *
 	 * @return void
 	 */
@@ -69,6 +70,16 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		WC_Admin_Install::create_tables();
 		WC_Admin_Install::create_events();
+	}
+
+	/**
+	 * Remove WooCommerce Admin related table data.
+	 *
+	 * @return void
+	 */
+	public function on_deactivation() {
+		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
+		WC_Admin_Install::delete_table_data();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2361 

Removes all wc-admin table data when the plugin is uninstalled.

### Detailed test instructions:

1. Activate wc-admin if not already active.
2. Make sure you have some table data.
3. Uninstall (delete) the plugin.
4. Note the tables are empty.

### Changelog Note:

Fix: Remove all WooCommerce Admin table data on plugin deactivation