### PR TITLE
Cancel all scheduled actions on plugin deactivation

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -10,7 +10,4 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 require_once dirname( __FILE__ ) . '/woocommerce-admin.php';
 
 WC_Admin_Feature_Plugin::instance()->includes();
-WC_Admin_Reports_Sync::clear_queued_actions();
-WC_Admin_Notes::clear_queued_actions();
 WC_Admin_Install::delete_table_data();
-wp_clear_scheduled_hook( 'wc_admin_daily' );

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -56,6 +56,7 @@ class WC_Admin_Feature_Plugin {
 	public function init() {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
+		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
@@ -69,6 +70,16 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		WC_Admin_Install::create_tables();
 		WC_Admin_Install::create_events();
+	}
+
+	/**
+	 * Remove WooCommerce Admin related table data.
+	 *
+	 * @return void
+	 */
+	public function on_deactivation() {
+		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
+		WC_Admin_Install::delete_table_data();
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -56,6 +56,7 @@ class WC_Admin_Feature_Plugin {
 	public function init() {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
+		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
@@ -69,6 +70,18 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		WC_Admin_Install::create_tables();
 		WC_Admin_Install::create_events();
+	}
+
+	/**
+	 * Remove WooCommerce Admin scheduled actions on deactivate.
+	 *
+	 * @return void
+	 */
+	public function on_deactivation() {
+		$this->includes();
+		WC_Admin_Reports_Sync::clear_queued_actions();
+		WC_Admin_Notes::clear_queued_actions();
+		wp_clear_scheduled_hook( 'wc_admin_daily' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -56,7 +56,6 @@ class WC_Admin_Feature_Plugin {
 	public function init() {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
-		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
@@ -70,16 +69,6 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
 		WC_Admin_Install::create_tables();
 		WC_Admin_Install::create_events();
-	}
-
-	/**
-	 * Remove WooCommerce Admin related table data.
-	 *
-	 * @return void
-	 */
-	public function on_deactivation() {
-		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
-		WC_Admin_Install::delete_table_data();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2364 

Cancels all scheduled actions on plugin deactivation.

Note: Issue #2364 mentions to do this on uninstall, but I think deactivation might be the right place to do this since these functions would no longer be needed or available.

### Detailed test instructions:

1.  Make sure you have some scheduled actions (e.g., `wc_admin_unsnooze_admin_notes`) in your posts table.
2.  Deactivate the plugin.
3.  Note the actions are trashed in the posts table.

### Changelog Note:

Fix: Cancel all scheduled actions on plugin deactivation.