### PR TITLE
Prevent multiple imports from running simultaneously

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -123,6 +123,10 @@ class WC_Admin_Reports_Sync {
 	 * @return string
 	 */
 	public static function regenerate_report_data( $days, $skip_existing ) {
+		if ( self::is_importing() ) {
+			return new WP_Error( 'wc_admin_import_in_progress', __( 'An import is already in progress.  Please allow the previous import to complete before beginning a new one.', 'woocommerce-admin' ) );
+		}
+
 		self::reset_import_stats( $days, $skip_existing );
 		self::customer_lookup_import_batch_init( $days, $skip_existing );
 		self::queue_dependent_action( self::ORDERS_IMPORT_BATCH_INIT, array( $days, $skip_existing ), self::CUSTOMERS_IMPORT_BATCH_ACTION );

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -349,7 +349,14 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, $report['orders'] );
 
-		// Test import status.
+		// Cancel any pending imports, import, and check import status.
+		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/cancel' );
+		$response = $this->server->dispatch( $request );
+		$report   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $report['status'] );
+
 		$request  = new WP_REST_Request( 'POST', $this->endpoint );
 		$response = $this->server->dispatch( $request );
 		$report   = $response->get_data();


### PR DESCRIPTION
Fixes #2199

Prevents multiple imports from being run if the API is hit twice.

### Screenshots
<img width="931" alt="Screen Shot 2019-06-13 at 5 46 12 PM" src="https://user-images.githubusercontent.com/10561050/59422668-585c4980-8e03-11e9-8147-dd0130bd4af4.png">

### Detailed test instructions:

1. Hit the import endpoint with a POST request `/wp-json/wc/v4/reports/import/`
2. If no imports are being run, you should see a success message.
3. Hit the same endpoint again quickly.
4. Note the error and that no duplicate imports have started.
5. Cancel the import with a POST to `/wp-json/wc/v4/reports/import/cancel`
6. Attempt to import again, hopefully with a success message now that no imports are in progress.

### Changelog Note:

Dev: Prevent duplicate imports from occurring simultaneously.