### PR TITLE
Refactor customer name retrieval

### DIFF
--- a/includes/class-wc-admin-order-refund.php
+++ b/includes/class-wc-admin-order-refund.php
@@ -49,6 +49,11 @@ class WC_Admin_Order_Refund extends WC_Order_Refund {
 	 */
 	public function get_report_customer_id() {
 		$parent_order = wc_get_order( $this->get_parent_id() );
+
+		if ( ! $parent_order ) {
+			return null;
+		}
+
 		return WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $parent_order );
 	}
 

--- a/includes/class-wc-admin-order.php
+++ b/includes/class-wc-admin-order.php
@@ -66,4 +66,34 @@ class WC_Admin_Order extends WC_Order {
 	public function is_returning_customer() {
 		return WC_Admin_Reports_Orders_Stats_Data_Store::is_returning_customer( $this );
 	}
+
+	/**
+	 * Get the customer's first name.
+	 */
+	public function get_customer_first_name() {
+		if ( $this->get_user_id() ) {
+			return get_user_meta( $this->get_user_id(), 'first_name', true );
+		}
+
+		if ( '' !== $this->get_billing_first_name( 'edit' ) ) {
+			return $this->get_billing_first_name( 'edit' );
+		} else {
+			return $this->get_shipping_first_name( 'edit' );
+		}
+	}
+
+	/**
+	 * Get the customer's last name.
+	 */
+	public function get_customer_last_name() {
+		if ( $this->get_user_id() ) {
+			return get_user_meta( $this->get_user_id(), 'last_name', true );
+		}
+
+		if ( '' !== $this->get_billing_last_name( 'edit' ) ) {
+			return $this->get_billing_last_name( 'edit' );
+		} else {
+			return $this->get_shipping_last_name( 'edit' );
+		}
+	}
 }

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -460,6 +460,10 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @return int|bool
 	 */
 	public static function get_or_create_customer_from_order( $order ) {
+		if ( ! $order ) {
+			return false;
+		}
+
 		global $wpdb;
 		$returning_customer_id = self::get_existing_customer_id_from_order( $order );
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -438,6 +438,10 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @return int|bool
 	 */
 	public static function get_existing_customer_id_from_order( $order ) {
+		if ( ! $order ) {
+			return false;
+		}
+
 		$user_id = $order->get_customer_id();
 
 		if ( 0 === $user_id ) {

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -471,17 +471,16 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			return $returning_customer_id;
 		}
 
-		$customer_name = self::get_customer_name( $order->get_user_id(), $order );
-		$data          = array(
-			'first_name'       => $customer_name[0],
-			'last_name'        => $customer_name[1],
+		$data   = array(
+			'first_name'       => $order->get_customer_first_name(),
+			'last_name'        => $order->get_customer_last_name(),
 			'email'            => $order->get_billing_email( 'edit' ),
 			'city'             => $order->get_billing_city( 'edit' ),
 			'postcode'         => $order->get_billing_postcode( 'edit' ),
 			'country'          => $order->get_billing_country( 'edit' ),
 			'date_last_active' => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 		);
-		$format        = array(
+		$format = array(
 			'%s',
 			'%s',
 			'%s',
@@ -514,42 +513,6 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		do_action( 'woocommerce_reports_new_customer', $customer_id );
 
 		return $result ? $customer_id : false;
-	}
-
-	/**
-	 * Try to get a customer name from user profile or order information.
-	 *
-	 * @param int      $user_id User ID.
-	 * @param WC_Order $order Order made by customer.
-	 * @return array
-	 */
-	public static function get_customer_name( $user_id = 0, $order = null ) {
-		$first_name = '';
-		$last_name  = '';
-
-		if (
-			$user_id &&
-			(
-				get_user_meta( $user_id, 'first_name', true ) ||
-				get_user_meta( $user_id, 'last_name', true )
-			)
-		) {
-			$first_name = get_user_meta( $user_id, 'first_name', true );
-			$last_name  = get_user_meta( $user_id, 'last_name', true );
-		} elseif ( $order ) {
-			if (
-				$order->get_billing_first_name( 'edit' ) ||
-				$order->get_billing_last_name( 'edit' )
-			) {
-				$first_name = $order->get_billing_first_name( 'edit' );
-				$last_name  = $order->get_billing_last_name( 'edit' );
-			} else {
-				$first_name = $order->get_shipping_first_name( 'edit' );
-				$last_name  = $order->get_shipping_last_name( 'edit' );
-			}
-		}
-
-		return apply_filters( 'woocommerce_reports_customer_name', array( $first_name, $last_name ), $order );
 	}
 
 	/**
@@ -631,13 +594,22 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			return false;
 		}
 
-		$customer_name = self::get_customer_name( $user_id, $customer->get_last_order() );
-		$last_active   = $customer->get_meta( 'wc_last_active', true, 'edit' );
-		$data          = array(
+		$last_order = $customer->get_last_order();
+
+		if ( ! $last_order ) {
+			$first_name = get_user_meta( $user_id, 'first_name', true );
+			$last_name  = get_user_meta( $user_id, 'last_name', true );
+		} else {
+			$first_name = $last_order->get_customer_first_name();
+			$last_name  = $last_order->get_customer_last_name();
+		}
+
+		$last_active = $customer->get_meta( 'wc_last_active', true, 'edit' );
+		$data        = array(
 			'user_id'          => $user_id,
 			'username'         => $customer->get_username( 'edit' ),
-			'first_name'       => $customer_name[0],
-			'last_name'        => $customer_name[1],
+			'first_name'       => $first_name,
+			'last_name'        => $last_name,
 			'email'            => $customer->get_email( 'edit' ),
 			'city'             => $customer->get_billing_city( 'edit' ),
 			'postcode'         => $customer->get_billing_postcode( 'edit' ),
@@ -645,7 +617,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			'date_registered'  => $customer->get_date_created( 'edit' )->date( WC_Admin_Reports_Interval::$sql_datetime_format ),
 			'date_last_active' => $last_active ? date( 'Y-m-d H:i:s', $last_active ) : null,
 		);
-		$format        = array(
+		$format      = array(
 			'%d',
 			'%s',
 			'%s',
@@ -686,7 +658,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	protected static function is_valid_customer( $user_id ) {
 		$customer = new WC_Customer( $user_id );
 
-		if ( $customer->get_id() != $user_id ) {
+		if ( $customer->get_id() !== $user_id ) {
 			return false;
 		}
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -658,7 +658,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	protected static function is_valid_customer( $user_id ) {
 		$customer = new WC_Customer( $user_id );
 
-		if ( $customer->get_id() !== $user_id ) {
+		if ( absint( $customer->get_id() ) !== absint( $user_id ) ) {
 			return false;
 		}
 

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -95,11 +95,11 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$product->set_regular_price( 25 );
 		$product->save();
 
-		$order_1 = WC_Helper_Order::create_order( 1, $product );
+		$order_1 = WC_Helper_Order::create_order( $this->customer, $product );
 		$order_1->set_status( 'completed' );
 		$order_1->set_date_created( time() - ( 3 * DAY_IN_SECONDS ) );
 		$order_1->save();
-		$order_2 = WC_Helper_Order::create_order( 1, $product );
+		$order_2 = WC_Helper_Order::create_order( $this->customer, $product );
 		$order_2->set_total( 100 );
 		$order_2->set_status( 'completed' );
 		$order_2->save();
@@ -127,7 +127,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$reports  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $reports );
+		$this->assertCount( 1, $reports );
 		$this->assertEquals( $this->customer, $reports[0]['user_id'] );
 
 		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports/orders' );
@@ -172,7 +172,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$reports  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $reports );
+		$this->assertCount( 1, $reports );
 		$this->assertEquals( 'Steve User', $reports[0]['name'] );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v4/reports/orders' );
@@ -303,7 +303,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Create 5 completed orders.
 		for ( $i = 0; $i < 5; $i++ ) {
-			$order = WC_Helper_Order::create_order( 1, $product );
+			$order = WC_Helper_Order::create_order( $this->customer, $product );
 			$order->set_status( 'completed' );
 			$order->set_date_created( time() - ( ( $i + 1 ) * DAY_IN_SECONDS ) );
 			$order->save();
@@ -314,7 +314,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$order->save();
 
 		// Create 1 draft order - to be excluded from totals.
-		$order = WC_Helper_Order::create_order( 1, $product );
+		$order = WC_Helper_Order::create_order( $this->customer, $product );
 		$order->set_date_created( time() - ( 5 * DAY_IN_SECONDS ) );
 		$order->save();
 		wp_update_post(


### PR DESCRIPTION
Fixes #1985

Refactors the customer name to make it more like the methods used in core.  Also separates out the logic for retrieving via order or customer ID.

### Detailed test instructions:

1.  Save an order with a guest billing/shipping names and make sure that the names are pulled from these fields (shipping if billing is marked optional and not filled in).
2.  Save an order with a customer and make sure the profile fields are favored over the billing/shipping fields.
3.  Make sure all tests pass and that imports continue to work.
4.  Check against the boolean order errors is difficult to reproduce, but optionally, throw in some `$order = false;` lines before some of the customer data store methods.

### Changelog Note:

Fix: Refactor customer name methods used in report creation and import.