### PR TITLE
Prevent duplicate customer imports

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -442,9 +442,21 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			return false;
 		}
 
+		global $wpdb;
 		$user_id = $order->get_customer_id();
 
 		if ( 0 === $user_id ) {
+			$customer_id = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT customer_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d",
+					$order->get_id()
+				)
+			);
+
+			if ( $customer_id ) {
+				return $customer_id;
+			}
+
 			$email = $order->get_billing_email( 'edit' );
 
 			if ( $email ) {

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -436,13 +436,11 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		);
 
 		if ( 'shop_order_refund' === $order->get_type() ) {
-			$parent_order        = wc_get_order( $order->get_parent_id() );
-			$data['customer_id'] = WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $parent_order );
-			$data['parent_id']   = $parent_order->get_id();
-			$format[]            = '%d';
+			$parent_order      = wc_get_order( $order->get_parent_id() );
+			$data['parent_id'] = $parent_order->get_id();
+			$format[]          = '%d';
 		} else {
 			$data['returning_customer'] = self::is_returning_customer( $order );
-			$data['customer_id']        = WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $order );
 		}
 
 		// Update or add the information to the DB.


### PR DESCRIPTION
Fixes #2426

Gets the existing customer ID from order stats row in the event an order has already been saved or if an email is blank.

### Detailed test instructions:

1.  Make sure you have some guest orders (preferably without emails).
2. Delete all data and re-run the imports.
3. Make sure the import runs smoothly and customer accounts are connected with order stats.
4.  Save an existing guest order and make sure a duplicate customer is not created.

### Changelog Note:

Fix: Prevent duplicate guest customer entries when email is missing.