### PR TITLE
Onboarding: Pull dynamic prices for product types

### DIFF
--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -145,11 +145,18 @@ class WC_Admin_Onboarding {
 	 * @param array $settings Component settings.
 	 */
 	public function component_settings( $settings ) {
+		$profile = get_option( 'wc_onboarding_profile', array() );
+
 		$settings['onboarding'] = array(
-			'industries'   => self::get_allowed_industries(),
-			'productTypes' => self::get_allowed_product_types(),
-			'profile'      => get_option( 'wc_onboarding_profile', array() ),
+			'industries' => self::get_allowed_industries(),
+			'profile'    => $profile,
 		);
+
+		// Only fetch if the onboarding wizard is incomplete.
+		if ( $this->should_show_profiler() ) {
+			$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
+		}
+
 		return $settings;
 	}
 

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -117,9 +117,14 @@ class WC_Admin_Onboarding {
 	 * @return array
 	 */
 	public static function append_product_data( $product_types ) {
-		$woocommerce_product_types = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type' );
-		$product_data              = json_decode( $woocommerce_product_types['body'] );
-		$products                  = array();
+		$product_data_transient_name = 'wc_onboarding_product_data';
+		$woocommerce_products        = get_transient( $product_data_transient_name );
+		if ( false === $woocommerce_products ) {
+			$woocommerce_products = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type' );
+			set_transient( $product_data_transient_name, $woocommerce_products, DAY_IN_SECONDS );
+		}
+		$product_data = json_decode( $woocommerce_products['body'] );
+		$products     = array();
 
 		// Map product data by slug.
 		foreach ( $product_data->products as $product_datum ) {

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -78,8 +78,7 @@ class WC_Admin_Onboarding {
 	 * @return array
 	 */
 	public static function get_allowed_product_types() {
-		return apply_filters(
-			'woocommerce_admin_onboarding_product_types',
+		$product_types = self::append_product_data(
 			array(
 				'physical'      => array(
 					'label'       => __( 'Physical products', 'woocommerce-admin' ),
@@ -90,32 +89,68 @@ class WC_Admin_Onboarding {
 					'description' => __( 'Virtual products that customers download.', 'woocommerce-admin' ),
 				),
 				'subscriptions' => array(
-					'label'       => __( 'Subscriptions — $199 per year', 'woocommerce-admin' ),
+					'label'       => __( 'Subscriptions', 'woocommerce-admin' ),
 					'description' => __( 'Products with recurring payment.', 'woocommerce-admin' ),
 					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-subscriptions/', 'woocommerce-admin' ),
+					'product'     => 'woocommerce-subscriptions',
 				),
 				'memberships'   => array(
-					'label'       => __( 'Memberships — $149 per year', 'woocommerce-admin' ),
+					'label'       => __( 'Memberships', 'woocommerce-admin' ),
 					'description' => __( 'Restrict content to customer groups.', 'woocommerce-admin' ),
 					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-memberships/', 'woocommerce-admin' ),
+					'product'     => 'woocommerce-memberships',
 				),
 				'composite'     => array(
-					'label'       => __( 'Composite Products — $79 per year', 'woocommerce-admin' ),
+					'label'       => __( 'Composite Products', 'woocommerce-admin' ),
 					'description' => __( 'Kits with configurable components.', 'woocommerce-admin' ),
 					'more_url'    => __( 'https://woocommerce.com/products/composite-products/', 'woocommerce-admin' ),
+					'product'     => 'woocommerce-composite-products',
 				),
 				'spaces'        => array(
-					'label'       => __( 'Spaces — $249 per year', 'woocommerce-admin' ),
+					'label'       => __( 'Spaces', 'woocommerce-admin' ),
 					'description' => __( 'Sell access to spaces, e.g. hotel rooms.', 'woocommerce-admin' ),
 					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-accommodation-bookings/', 'woocommerce-admin' ),
+					'product'     => 'WooCommerce Bookings',
 				),
 				'rentals'       => array(
-					'label'       => __( 'Rentals — $249 per year', 'woocommerce-admin' ),
+					'label'       => __( 'Rentals', 'woocommerce-admin' ),
 					'description' => __( 'Sell access to rental items, e.g. cars.', 'woocommerce-admin' ),
 					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-bookings/', 'woocommerce-admin' ),
+					'product'     => 'WooCommerce Bookings',
 				),
 			)
 		);
+
+		return apply_filters( 'woocommerce_admin_onboarding_product_types', $product_types );
+	}
+
+	/**
+	 * Append dynamic product data from API.
+	 *
+	 * @param array $product_types Array of product types.
+	 * @return array
+	 */
+	public static function append_product_data( $product_types ) {
+		$woocommerce_product_types = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type' );
+		$product_data              = json_decode( $woocommerce_product_types['body'] );
+		$products                  = array();
+
+		// Map product data by slug.
+		foreach ( $product_data->products as $product_datum ) {
+			$products[ $product_datum->slug ] = $product_datum;
+		}
+
+		// Loop over product types and append data.
+		foreach ( $product_types as $key => $product_type ) {
+			if ( isset( $product_type['product'] ) ) {
+				/* translators: Amount of product per year (e.g. Bookings - $240.00 per year) */
+				$product_types[ $key ]['label']      .= sprintf( __( ' — %s per year', 'woocommerce-admin' ), html_entity_decode( $products[ $product_type['product'] ]->price ) );
+				$product_types[ $key ]['description'] = $products[ $product_type['product'] ]->excerpt;
+				$product_types[ $key ]['more_url']    = $products[ $product_type['product'] ]->link;
+			}
+		}
+
+		return $product_types;
 	}
 
 	/**

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -89,34 +89,20 @@ class WC_Admin_Onboarding {
 					'description' => __( 'Virtual products that customers download.', 'woocommerce-admin' ),
 				),
 				'subscriptions' => array(
-					'label'       => __( 'Subscriptions', 'woocommerce-admin' ),
-					'description' => __( 'Products with recurring payment.', 'woocommerce-admin' ),
-					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-subscriptions/', 'woocommerce-admin' ),
-					'product'     => 'woocommerce-subscriptions',
+					'label'   => __( 'Subscriptions', 'woocommerce-admin' ),
+					'product' => 'woocommerce-subscriptions',
 				),
 				'memberships'   => array(
-					'label'       => __( 'Memberships', 'woocommerce-admin' ),
-					'description' => __( 'Restrict content to customer groups.', 'woocommerce-admin' ),
-					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-memberships/', 'woocommerce-admin' ),
-					'product'     => 'woocommerce-memberships',
+					'label'   => __( 'Memberships', 'woocommerce-admin' ),
+					'product' => 'woocommerce-memberships',
 				),
 				'composite'     => array(
-					'label'       => __( 'Composite Products', 'woocommerce-admin' ),
-					'description' => __( 'Kits with configurable components.', 'woocommerce-admin' ),
-					'more_url'    => __( 'https://woocommerce.com/products/composite-products/', 'woocommerce-admin' ),
-					'product'     => 'woocommerce-composite-products',
+					'label'   => __( 'Composite Products', 'woocommerce-admin' ),
+					'product' => 'woocommerce-composite-products',
 				),
-				'spaces'        => array(
-					'label'       => __( 'Spaces', 'woocommerce-admin' ),
-					'description' => __( 'Sell access to spaces, e.g. hotel rooms.', 'woocommerce-admin' ),
-					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-accommodation-bookings/', 'woocommerce-admin' ),
-					'product'     => 'WooCommerce Bookings',
-				),
-				'rentals'       => array(
-					'label'       => __( 'Rentals', 'woocommerce-admin' ),
-					'description' => __( 'Sell access to rental items, e.g. cars.', 'woocommerce-admin' ),
-					'more_url'    => __( 'https://woocommerce.com/products/woocommerce-bookings/', 'woocommerce-admin' ),
-					'product'     => 'WooCommerce Bookings',
+				'bookings'      => array(
+					'label'   => __( 'Bookings', 'woocommerce-admin' ),
+					'product' => 'WooCommerce Bookings',
 				),
 			)
 		);


### PR DESCRIPTION
Fixes #2341

Adds prices for each product dynamically.

### Questions
* Do we need any caching here?  I think for such a small, one-time use request it’s probably okay to leave uncached.
* We had some discussion about removing the 2nd bookings item.  Renamed this “Bookings” to cover both “spaces” and “rentals.”  Also opted to use the WCCOM excerpts to keep things consistent.  Do we need a design review on this or should we revert descriptions?

### Screenshots
<img width="560" alt="Screen Shot 2019-06-20 at 5 24 24 PM" src="https://user-images.githubusercontent.com/10561050/59837716-4721b880-9380-11e9-95f4-f2f823819b85.png">

### Detailed test instructions:

1.  Visit `wp-admin/admin.php?page=wc-admin#/?step=product-types`
2. Make sure product prices, descriptions, and “Learn More” URLs are all pulled in dynamically based on a. Product types “product” key.

### Changelog Note:

Enhancement: Pull dynamic prices for product types during onboarding
