### PR TITLE
Set default values for onboarding select dropdowns

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -76,6 +76,12 @@ class BusinessDetails extends Component {
 		);
 	}
 
+	setDefaultValue( key, options ) {
+		if ( ! this.state[ key ].length ) {
+			this.setState( { [ key ]: options[ 0 ].value } );
+		}
+	}
+
 	render() {
 		const { other_platform, product_count, selling_venues } = this.state;
 
@@ -154,6 +160,7 @@ class BusinessDetails extends Component {
 					<SelectControl
 						label={ __( 'How many products will you add?', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { product_count: value } ) }
+						onClick={ this.setDefaultValue.bind( this, 'product_count', productCountOptions ) }
 						options={ productCountOptions }
 						value={ product_count }
 						required
@@ -162,6 +169,7 @@ class BusinessDetails extends Component {
 					<SelectControl
 						label={ __( 'Currently selling elsewhere?', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { selling_venues: value } ) }
+						onClick={ this.setDefaultValue.bind( this, 'selling_venues', sellingVenueOptions ) }
 						options={ sellingVenueOptions }
 						value={ selling_venues }
 						required
@@ -171,6 +179,7 @@ class BusinessDetails extends Component {
 						<SelectControl
 							label={ __( 'Which platform is the store using?', 'woocommerce-admin' ) }
 							onChange={ value => this.setState( { other_platform: value } ) }
+							onClick={ this.setDefaultValue.bind( this, 'other_platform', otherPlatformOptions ) }
 							options={ otherPlatformOptions }
 							value={ other_platform }
 							required

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -160,7 +160,7 @@ class BusinessDetails extends Component {
 					<SelectControl
 						label={ __( 'How many products will you add?', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { product_count: value } ) }
-						onClick={ this.setDefaultValue.bind( this, 'product_count', productCountOptions ) }
+						onFocus={ this.setDefaultValue.bind( this, 'product_count', productCountOptions ) }
 						options={ productCountOptions }
 						value={ product_count }
 						required
@@ -169,7 +169,7 @@ class BusinessDetails extends Component {
 					<SelectControl
 						label={ __( 'Currently selling elsewhere?', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { selling_venues: value } ) }
-						onClick={ this.setDefaultValue.bind( this, 'selling_venues', sellingVenueOptions ) }
+						onFocus={ this.setDefaultValue.bind( this, 'selling_venues', sellingVenueOptions ) }
 						options={ sellingVenueOptions }
 						value={ selling_venues }
 						required
@@ -179,7 +179,7 @@ class BusinessDetails extends Component {
 						<SelectControl
 							label={ __( 'Which platform is the store using?', 'woocommerce-admin' ) }
 							onChange={ value => this.setState( { other_platform: value } ) }
-							onClick={ this.setDefaultValue.bind( this, 'other_platform', otherPlatformOptions ) }
+							onFocus={ this.setDefaultValue.bind( this, 'other_platform', otherPlatformOptions ) }
 							options={ otherPlatformOptions }
 							value={ other_platform }
 							required


### PR DESCRIPTION
Fixes #2533

Selecting the first select dropdown doesn't trigger an `onChange` event which doesn't select the option.  This is a temporary workaround to set the first option as selected if no option is currently set.

A better long-term option would be to look at being able to trigger events from the select dropdown or adding disabled options in the component to create default unselectable values in https://github.com/WordPress/gutenberg/blob/master/packages/components/src/select-control/index.js but if we're migrating to Select2 dropdowns, this may no longer be an issue.

### Screenshots
<img width="566" alt="Screen Shot 2019-06-28 at 2 49 01 PM" src="https://user-images.githubusercontent.com/10561050/60323307-4efedf80-99b4-11e9-8a55-8e43720bab07.png">

### Detailed test instructions:

1. Go to `wp-admin/admin.php?page=wc-admin#/?step=business-details`
2. Select the first option from each select dropdown (or just open the select menu and close).
3. Make sure they get selected and the "Continue" button appears.

### Changelog Note:

Fix: Select first option in onboarding select dropdowns when clicked.