### PR TITLE
Onboarding: Update theme order and sorting

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -103,13 +103,13 @@ class Theme extends Component {
 	}
 
 	getThemeStatus( theme ) {
-		const { installed, price, slug } = theme;
+		const { is_installed, price, slug } = theme;
 		const { activeTheme } = wcSettings.onboarding;
 
 		if ( activeTheme === slug ) {
 			return __( 'Currently active theme', 'woocommerce-admin' );
 		}
-		if ( installed ) {
+		if ( is_installed ) {
 			return __( 'Installed', 'woocommerce-admin' );
 		} else if ( this.getPriceValue( price ) <= 0 ) {
 			return __( 'Free', 'woocommerce-admin' );

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -29,9 +29,11 @@
 		border-bottom: 1px solid transparent;
 		color: $muriel-gray-500;
 		display: flex;
+		justify-content: center;
 		background: transparent;
 		height: 48px;
 		width: 100%;
+		cursor: pointer;
 		@include font-size(14);
 		font-weight: 500;
 		outline: none;

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -130,31 +130,31 @@ class WC_Admin_Onboarding {
 					$themes[ $slug ]['is_installed']            = false;
 					$themes[ $slug ]['has_woocommerce_support'] = true;
 				}
+			}
 
-				$installed_themes = wp_get_themes();
-				$active_theme     = get_option( 'stylesheet' );
+			$installed_themes = wp_get_themes();
+			$active_theme     = get_option( 'stylesheet' );
 
-				foreach ( $installed_themes as $slug => $theme ) {
-					$has_woocommerce_support = self::has_woocommerce_support( $theme );
+			foreach ( $installed_themes as $slug => $theme ) {
+				$has_woocommerce_support = self::has_woocommerce_support( $theme );
 
-					if ( ! $has_woocommerce_support && $active_theme !== $slug ) {
-						continue;
-					}
-
-					$themes[ $slug ] = array(
-						'slug'                    => sanitize_title( $slug ),
-						'title'                   => $theme->get( 'Name' ),
-						'price'                   => '0.00',
-						'is_installed'            => true,
-						'image'                   => $theme->get_screenshot(),
-						'has_woocommerce_support' => $has_woocommerce_support,
-					);
+				if ( ! $has_woocommerce_support && $active_theme !== $slug ) {
+					continue;
 				}
 
-				$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
-
-				set_transient( $themes_transient_name, $themes, DAY_IN_SECONDS );
+				$themes[ $slug ] = array(
+					'slug'                    => sanitize_title( $slug ),
+					'title'                   => $theme->get( 'Name' ),
+					'price'                   => '0.00',
+					'is_installed'            => true,
+					'image'                   => $theme->get_screenshot(),
+					'has_woocommerce_support' => $has_woocommerce_support,
+				);
 			}
+
+			$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
+
+			set_transient( $themes_transient_name, $themes, DAY_IN_SECONDS );
 		}
 
 		$themes = apply_filters( 'woocommerce_admin_onboarding_themes', $themes );

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -132,17 +132,26 @@ class WC_Admin_Onboarding {
 				}
 
 				$installed_themes = wp_get_themes();
+				$active_theme     = get_option( 'stylesheet' );
 
 				foreach ( $installed_themes as $slug => $theme ) {
+					$has_woocommerce_support = self::has_woocommerce_support( $theme );
+
+					if ( ! $has_woocommerce_support && $active_theme !== $slug ) {
+						continue;
+					}
+
 					$themes[ $slug ] = array(
 						'slug'                    => sanitize_title( $slug ),
 						'title'                   => $theme->get( 'Name' ),
 						'price'                   => '0.00',
 						'is_installed'            => true,
 						'image'                   => $theme->get_screenshot(),
-						'has_woocommerce_support' => self::has_woocommerce_support( $theme ),
+						'has_woocommerce_support' => $has_woocommerce_support,
 					);
 				}
+
+				$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
 
 				set_transient( $themes_transient_name, $themes, DAY_IN_SECONDS );
 			}


### PR DESCRIPTION
Fixes #2535

* Reorders the themes to:

1. Current active theme
2. Storefront
3. Marketplace suggestions
4. Installed themes that are WC compatible
5. Upload

* Fixes incorrect `is_installed` param for checking installation status.
* Centers text for tab panel buttons.

Side note- anyone else experiencing the weird issue in Figma where button text becomes left-aligned when an element is clicked?

### Screenshots

<img width="830" alt="Screen Shot 2019-07-02 at 11 40 38 AM" src="https://user-images.githubusercontent.com/10561050/60481066-790b1700-9cbe-11e9-8f27-0e09aff8d504.png">


### Detailed test instructions:

1.  Visit `wp-admin/admin.php?page=wc-admin#/?step=theme`.
2.  Delete the `wc_onboarding_themes` transient.
3. Check that the themes are in the above order and only show WC supported themes (and the currently active theme regardless of support)