### PR TITLE
Add a theme REST API to allow uploading themes

### DIFF
--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -56,8 +56,8 @@ class WC_Admin_REST_Themes_Controller extends WC_REST_Data_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function upload_theme_permissions_check( $request ) {
-		if ( ! current_user_can( 'upload_plugins' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you are not allowed to install plugins on this site.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		if ( ! current_user_can( 'upload_themes' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you are not allowed to install themes on this site.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -85,11 +85,10 @@ class WC_Admin_REST_Themes_Controller extends WC_REST_Data_Controller {
 		}
 
 		if ( ! is_wp_error( $install ) && isset( $install['destination_name'] ) ) {
-			$theme  = wp_get_theme( $install['destination_name'] );
 			$result = array(
 				'status'  => 'success',
 				'message' => $upgrader->strings['process_success'],
-				'theme'   => $theme,
+				'theme'   => $install['destination_name'],
 			);
 		} else {
 			if ( is_wp_error( $install ) && $install->get_error_code() ) {

--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -70,6 +70,10 @@ class WC_Admin_REST_Themes_Controller extends WC_REST_Data_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function upload_theme( $request ) {
+		if ( ! isset( $_FILES['pluginzip'] ) || ! is_uploaded_file( $_FILES['pluginzip']['tmp_name'] ) || ! is_file( $_FILES['pluginzip']['tmp_name'] ) ) { // WPCS: sanitization ok.
+			return new WP_Error( 'woocommerce_rest_invalid_file', __( 'Specified file failed upload test.', 'woocommerce-admin' ) );
+		}
+
 		include_once ABSPATH . 'wp-admin/includes/file.php';
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		include_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-theme-upgrader.php';

--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * REST API Themes Controller
+ *
+ * Handles requests to /themes
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Themes controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class WC_Admin_REST_Themes_Controller extends WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'themes';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'upload_theme' ),
+					'permission_callback' => array( $this, 'upload_theme_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check whether a given request has permission to edit upload plugins/themes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function upload_theme_permissions_check( $request ) {
+		if ( ! current_user_can( 'upload_plugins' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you are not allowed to install plugins on this site.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Upload and install a theme.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function upload_theme( $request ) {
+		include_once ABSPATH . 'wp-admin/includes/file.php';
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		include_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-theme-upgrader.php';
+		include_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-theme-upgrader-skin.php';
+
+		$_GET['package'] = true;
+		$file_upload     = new File_Upload_Upgrader( 'pluginzip', 'package' );
+		$upgrader        = new WC_Admin_Theme_Upgrader( new WC_Admin_Theme_Upgrader_Skin() );
+		$install         = $upgrader->install( $file_upload->package );
+
+		if ( $install || is_wp_error( $install ) ) {
+			$file_upload->cleanup();
+		}
+
+		if ( ! is_wp_error( $install ) && isset( $install['destination_name'] ) ) {
+			$theme  = wp_get_theme( $install['destination_name'] );
+			$result = array(
+				'status'  => 'success',
+				'message' => $upgrader->strings['process_success'],
+				'theme'   => $theme,
+			);
+		} else {
+			if ( is_wp_error( $install ) && $install->get_error_code() ) {
+				$error_message = isset( $upgrader->strings[ $install->get_error_code() ] ) ? $upgrader->strings[ $install->get_error_code() ] : $install->get_error_data();
+			} else {
+				$error_message = $upgrader->strings['process_failed'];
+			}
+
+			$result = array(
+				'status'  => 'error',
+				'message' => $error_message,
+			);
+		}
+
+		$response = $this->prepare_item_for_response( $result, $request );
+		$data     = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter the list returned from the API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original item.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_themes', $response, $item, $request );
+	}
+
+
+	/**
+	 * Get the schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'upload_theme',
+			'type'       => 'object',
+			'properties' => array(
+				'status'  => array(
+					'description' => __( 'Theme installation status.', 'woocommerce-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'message' => array(
+					'description' => __( 'Theme installation message.', 'woocommerce-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'theme'   => array(
+					'description' => __( 'Uploaded theme.', 'woocommerce-admin' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['pluginzip'] = array(
+			'description'       => __( 'A zip file of the theme to be uploaded.', 'woocommerce-admin' ),
+			'type'              => 'file',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return apply_filters( 'woocommerce_rest_themes_collection_params', $params );
+	}
+}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -131,6 +131,7 @@ class WC_Admin_Api_Init {
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-reports-stock-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-reports-stock-stats-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-taxes-controller.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-themes-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-customers-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-reports-export-controller.php';
 
@@ -171,6 +172,7 @@ class WC_Admin_Api_Init {
 			'WC_Admin_REST_Reports_Customers_Controller',
 			'WC_Admin_REST_Reports_Customers_Stats_Controller',
 			'WC_Admin_REST_Taxes_Controller',
+			'WC_Admin_REST_Themes_Controller',
 		);
 
 		if ( WC_Admin_Loader::is_feature_enabled( 'onboarding' ) ) {

--- a/includes/class-wc-admin-theme-upgrader-skin.php
+++ b/includes/class-wc-admin-theme-upgrader-skin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Theme upgrader skin used in REST API response.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Theme_Upgrader_Skin Class.
+ */
+class WC_Admin_Theme_Upgrader_Skin extends Theme_Upgrader_Skin {
+	/**
+	 * Hide the skin header display.
+	 */
+	public function header() {}
+
+	/**
+	 * Hide the skin footer display.
+	 */
+	public function footer() {}
+
+	/**
+	 * Hide the skin feedback display.
+	 *
+	 * @param string $string String to display.
+	 */
+	public function feedback( $string ) {}
+
+	/**
+	 * Hide the skin after display.
+	 */
+	public function after() {}
+}

--- a/includes/class-wc-admin-theme-upgrader.php
+++ b/includes/class-wc-admin-theme-upgrader.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Theme upgrader used in REST API response.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Theme_Upgrader Class.
+ */
+class WC_Admin_Theme_Upgrader extends Theme_Upgrader {
+	/**
+	 * Install a theme package.
+	 *
+	 * @param string $package The full local path or URI of the package.
+	 * @param array  $args {
+	 *     Optional. Other arguments for installing a theme package. Default empty array.
+	 *
+	 *     @type bool $clear_update_cache Whether to clear the updates cache if successful.
+	 *                                    Default true.
+	 * }
+	 *
+	 * @return bool|WP_Error True if the installation was successful, false or a WP_Error object otherwise.
+	 */
+	public function install( $package, $args = array() ) {
+		$defaults    = array(
+			'clear_update_cache' => true,
+		);
+		$parsed_args = wp_parse_args( $args, $defaults );
+
+		$this->init();
+		$this->install_strings();
+
+		add_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
+		add_filter( 'upgrader_post_install', array( $this, 'check_parent_theme_filter' ), 10, 3 );
+		if ( $parsed_args['clear_update_cache'] ) {
+			// Clear cache so wp_update_themes() knows about the new theme.
+			add_action( 'upgrader_process_complete', 'wp_clean_themes_cache', 9, 0 );
+		}
+
+		$result = $this->run(
+			array(
+				'package'           => $package,
+				'destination'       => get_theme_root(),
+				'clear_destination' => false, // Do not overwrite files.
+				'clear_working'     => true,
+				'hook_extra'        => array(
+					'type'   => 'theme',
+					'action' => 'install',
+				),
+			)
+		);
+
+		remove_action( 'upgrader_process_complete', 'wp_clean_themes_cache', 9 );
+		remove_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
+		remove_filter( 'upgrader_post_install', array( $this, 'check_parent_theme_filter' ) );
+
+		if ( $result && ! is_wp_error( $result ) ) {
+			// Refresh the Theme Update information.
+			wp_clean_themes_cache( $parsed_args['clear_update_cache'] );
+		}
+
+		return $result;
+	}
+}

--- a/tests/api/themes.php
+++ b/tests/api/themes.php
@@ -28,6 +28,13 @@ class WC_Tests_API_Themes extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+
+		// Editor does not have theme capabilities.
+		$this->editor = $this->factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
 	}
 
 	/**
@@ -43,6 +50,21 @@ class WC_Tests_API_Themes extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 500, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_invalid_file', $data['code'] );
 	}
+
+	/**
+	 * Test that a user without capabilities receives a forbidden response error.
+	 */
+	public function test_capabilities() {
+		wp_set_current_user( $this->editor );
+
+		$request  = new WP_REST_Request( 'POST', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_cannot_view', $data['code'] );
+	}
+
 
 	/**
 	 * Test schema.

--- a/tests/api/themes.php
+++ b/tests/api/themes.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Themes REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Themes
+ */
+class WC_Tests_API_Themes extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-admin/v1/themes';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that an error is thrown if the file is missing.
+	 */
+	public function test_missing_upload() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'POST', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_file', $data['code'] );
+	}
+
+	/**
+	 * Test schema.
+	 */
+	public function test_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 3, $properties );
+		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertArrayHasKey( 'message', $properties );
+		$this->assertArrayHasKey( 'theme', $properties );
+	}
+}


### PR DESCRIPTION
Fixes (part of) #2470

Adds a theme rest api so we can upload themes from a theme uploader component in onboarding.

### Screenshots
<img width="768" alt="Screen Shot 2019-07-03 at 3 49 56 PM" src="https://user-images.githubusercontent.com/10561050/60573742-dd0b0980-9daa-11e9-8e8f-e7e1ba077770.png">

### Detailed test instructions:

1. Using the body/form-data params, send a POST request to `/wp-json/wc-admin/v1/themes` with the `pluginzip` param set to a theme file.
2. Make sure that you can upload a valid zipped theme.
3. Make sure the theme data needed for the profiler is filtered into the response.
3. Try also uploading a theme that already exists or invalid zip to ensure errors are returned.

### Changelog Note:

Enhancement: Add a themes REST API for uploading themes.