### PR TITLE
Update no data message in table

### DIFF
--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -225,7 +225,7 @@ class Table extends Component {
 							: (
 								<tr>
 									<td className="woocommerce-table__empty-item" colSpan={ headers.length }>
-										{ __( 'No data for the selected date range', 'woocommerce-admin' ) }
+										{ __( 'No data to display', 'woocommerce-admin' ) }
 									</td>
 								</tr>
 							)


### PR DESCRIPTION
This small PR updates the default no data error message for tables. The existing message 

"No data for the selected date range"

has a problem on reports that don't feature date range pickers by default. 

The new message is date range agnostic:

"No data to display" 

Eventually we may want to create a method for individual reports to customize this message depending on their content. 