### PR TITLE
Reduce queries in Inbox Panel.

### DIFF
--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -126,6 +126,18 @@ export default compose(
 			orderby: 'date',
 			order: 'desc',
 			status: 'unactioned',
+			_fields: [
+				'id',
+				'name',
+				'title',
+				'content',
+				'type',
+				'icon',
+				'status',
+				'actions',
+				'date_created',
+				'date_created_gmt',
+			],
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -152,6 +152,18 @@ class WC_Admin_Note extends \WC_Data {
 	*/
 
 	/**
+	 * Returns all data for this object.
+	 *
+	 * Override \WC_Data::get_data() to avoid errantly including meta data
+	 * from ID collisions with the posts table.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		return array_merge( array( 'id' => $this->get_id() ), $this->data );
+	}
+
+	/**
 	 * Get note name.
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.


### PR DESCRIPTION
This PR seeks to improve the performance of the Inbox Panel by:
* Only requesting fields necessary for the component render/behavior
* Avoid `WC_Data`'s meta retrieval since it's errant anyhow (collisions with post table object IDs)

## Detailed test instructions:
- Verify the Inbox displays properly
- Verify that note actions work as expected - including simple links and actions (like installing plugins)

## Changelog Note:

Performance: trim down inbox note API request.

