### PR TITLE
Ignore *.swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ storybook-static/
 Thumbs.db
 wp-cli.local.yml
 *.sql
+*.swp
 *.tar.gz
 *.tgz
 *.zip


### PR DESCRIPTION
This PR adds `*.swp` (Vim temp files) to the list of files for git to ignore.

### Detailed test instructions:

1. Run branch
2. Add a `foo.swp` file somewhere in your `woocommerce-admin` directory tree
3. Run `git status` and verify that the `foo.swp` file isn't listed