### PR TITLE
Onboarding: only validate other platform name for 'other' selling venues

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -168,7 +168,10 @@ class BusinessDetails extends Component {
 			} else if ( name === 'other_platform_name' ) {
 				if (
 					! values.other_platform_name &&
-					values.other_platform === 'other'
+					values.other_platform === 'other' &&
+					[ 'other', 'brick-mortar-other' ].includes(
+						values.selling_venues
+					)
 				) {
 					errors.other_platform_name = __(
 						'This field is required',
@@ -685,7 +688,7 @@ class BusinessDetails extends Component {
 }
 
 export default compose(
-	withWCApiSelect( select => {
+	withWCApiSelect( ( select ) => {
 		const { getProfileItems, getProfileItemsError } = select( 'wc-api' );
 
 		return {
@@ -693,10 +696,12 @@ export default compose(
 			profileItems: getProfileItems(),
 		};
 	} ),
-	withSelect( select => {
-		const { getSettings, getSettingsError, isGetSettingsRequesting } = select(
-			SETTINGS_STORE_NAME
-		);
+	withSelect( ( select ) => {
+		const {
+			getSettings,
+			getSettingsError,
+			isGetSettingsRequesting,
+		} = select( SETTINGS_STORE_NAME );
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );


### PR DESCRIPTION
Minor fix to omit validation error (and resulting disabled "Continue" button) on the other platform name text field (introduced in https://github.com/woocommerce/woocommerce-admin/pull/3812/commits/8b052b1068ae9099eddbaf760da212893c9f1e22), in an edge case where the field is first required but value is missing, and then no longer required (e.g. see test instructions below).

(Looks like the coding standards changes got tacked onto the commit via some hook.)

### Screenshots

`master` | this branch
-- | --
<img width="523" src="https://user-images.githubusercontent.com/1867547/77723371-a626f480-6fc6-11ea-8029-5669edbad90e.png"> | <img width="525" src="https://user-images.githubusercontent.com/1867547/77723981-39145e80-6fc8-11ea-9dec-fe12c8485c0e.png">

### Detailed test instructions:

- Open onboarding wizard "Business Details" screen
- Select "Yes, on another platform" for "selling elsewhere"
- Select "Other" for which platform the store is currently using
- Leave the platform name text field blank, and verify that "Continue" button is disabled
- Select "No" for "selling elsewhere", and verify that **"Continue" button is enabled** 😌 

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->