### PR TITLE
Add WooCommerce Payments Inbox note

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -17,6 +17,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 
 /**
  * WC_Admin_Events Class.
@@ -68,5 +69,6 @@ class Events {
 		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
 		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_onboarding_email_marketing_note();
 		WC_Admin_Notes_Personalize_Store::possibly_add_personalize_store_note();
+		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 	}
 }

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -16,6 +16,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 
 /**
  * Feature plugin main class.
@@ -186,6 +187,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Welcome_Message();
 		new WC_Admin_Notes_Facebook_Extension();
 		new WC_Admin_Notes_Tracking_Opt_In();
+		new WC_Admin_Notes_WooCommerce_Payments();
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -607,6 +607,7 @@ class Onboarding {
 				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',
 				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
 				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/gateway-payfast.php',
+				'woocommerce-payments'                => 'woocommerce-payments/woocommerce-payments.php',
 			)
 		);
 	}

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -64,7 +64,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 			$note    = WC_Admin_Notes::get_note( $note_id );
 
 			// If the WooCommerce Payments plugin was installed after the note was created, make sure it's marked as actioned.
-			if ( self::validate_plugin() && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+			if ( self::is_installed() && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
 				$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 				$note->save();
 			}
@@ -106,7 +106,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 		$note->add_action( 'install-now', __( 'Install now', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 
 		// Create the note as "actioned" if the plugin is already installed.
-		if ( self::validate_plugin() ) {
+		if ( self::is_installed() ) {
 			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 		}
 
@@ -115,9 +115,12 @@ class WC_Admin_Notes_WooCommerce_Payments {
 
 
 	/**
-	 * Add a note on WooCommerce Payments.
+	 * Check if the WooCommerce Payments plugin is active or installed.
 	 */
-	protected static function validate_plugin() {
+	protected static function is_installed() {
+		if ( defined( 'WC_Payments' ) ) {
+			return true;
+		}
 		include_once ABSPATH . '/wp-admin/includes/plugin.php';
 		return 0 === validate_plugin( self::PLUGIN_FILE );
 	}

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -103,7 +103,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/payments/', WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
-		$note->add_action( 'install-now', __( 'Install now', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED, true );
+		$note->add_action( 'install-now', __( 'Install now', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 
 		// Create the note as "actioned" if the plugin is already installed.
 		if ( self::validate_plugin() ) {
@@ -140,8 +140,6 @@ class WC_Admin_Notes_WooCommerce_Payments {
 
 			$activate_request = array( 'plugins' => self::PLUGIN_SLUG );
 			$installer->activate_plugins( $activate_request );
-
-			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4012

This PR adds a note to make merchants aware of WooCommerce Payments as a payment method. The note will appear on stores that:

* are in the US
* do not have the WooCommerce Payments plugin installed
* completed registration or the task list 7 days or more ago.

The note will only be added after April 14th - a week after the estimated WC 4.1 beta date, and a safe bet for the public beta date of WooCommerce Payments (the date the WooCommerce Payments plugin is published on WordPress.org).

**Please note**: this PR will have a merge conflict with SHA: 25f1124ffdb2160a6d, which is being submitted as part of #3978. I've committed the conflicting code separately in SHA: 66faccb to make that easier to address (that commit can be removed.)

### Screenshots

![Image upload on 2020-03-27 at 15-54-41](https://user-images.githubusercontent.com/235523/77750551-b7780b80-706f-11ea-92ed-1236d9bc2682.png)

### Detailed test instructions:

1. Checkout this branch
1. Trigger the `wc_admin_daily` hook scheduled in WP Cron 
1. Go to **Tools > Scheduled Actions**
1. Confirm the `wc-admin-woocommerce-payments_add_note` hook is scheduled for April 14
1. Trigger the `wc-admin-woocommerce-payments_add_note` hook
1. Go to a WooCommerce page
1. Click the Inbox icon in the Navbar
1. Observe the new **Try the new way to get paid** note
1. Click the **Install Now** button to test plugin installation

**Note:** if you want installation to work before the WC Pay plugin is published in April, you'll need to change the `WC_Admin_Notes_WooCommerce_Payments::PLUGIN_SLUG` and `WC_Admin_Notes_WooCommerce_Payments::PLUGIN_FILE` to link to a publicly available plugin that is already included in `Onboarding::get_allowed_plugins()`.

/cc @allendav @LevinMedia @claraclee