### PR TITLE
Show admin notices on legacy admin screens

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -419,7 +419,7 @@ class Loader {
 	 * Loads the required scripts on the correct pages.
 	 */
 	public static function load_scripts() {
-		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
+		if ( ! self::is_admin_or_embed_page() ) {
 			return;
 		}
 
@@ -442,6 +442,14 @@ class Loader {
 			wp_enqueue_style( 'wc-admin-ie' );
 		}
 
+	}
+
+	/**
+	 * Returns true if we are on a JS powered admin page or
+	 * a "classic" (non JS app) powered admin page (an embedded page).
+	 */
+	public static function is_admin_or_embed_page() {
+		return self::is_admin_page() || self::is_embed_page();
 	}
 
 	/**
@@ -523,7 +531,7 @@ class Loader {
 	 * @param string $admin_body_class Body class to add.
 	 */
 	public static function add_admin_body_classes( $admin_body_class = '' ) {
-		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
+		if ( ! self::is_admin_or_embed_page() ) {
 			return $admin_body_class;
 		}
 
@@ -553,7 +561,7 @@ class Loader {
 	 * Removes notices that should not be displayed on WC Admin pages.
 	 */
 	public static function remove_notices() {
-		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
+		if ( ! self::is_admin_or_embed_page() ) {
 			return;
 		}
 
@@ -567,20 +575,32 @@ class Loader {
 	 * Runs before admin notices action and hides them.
 	 */
 	public static function inject_before_notices() {
-		if ( ( ! self::is_admin_page() && ! self::is_embed_page() ) ) {
+		if ( ! self::is_admin_or_embed_page() ) {
 			return;
 		}
+
+		// Wrap the notices in a hidden div to prevent flickering before
+		// they are moved elsewhere in the page by WordPress Core.
 		echo '<div class="woocommerce-layout__notice-list-hide" id="wp__notice-list">';
-		echo '<div class="wp-header-end" id="woocommerce-layout__notice-catcher"></div>'; // https://github.com/WordPress/WordPress/blob/f6a37e7d39e2534d05b9e542045174498edfe536/wp-admin/js/common.js#L737.
+
+		if ( self::is_admin_page() ) {
+			// Capture all notices and hide them. WordPress Core looks for
+			// `.wp-header-end` and appends notices after it if found.
+			// https://github.com/WordPress/WordPress/blob/f6a37e7d39e2534d05b9e542045174498edfe536/wp-admin/js/common.js#L737 .
+			echo '<div class="wp-header-end" id="woocommerce-layout__notice-catcher"></div>';
+		}
 	}
 
 	/**
 	 * Runs after admin notices and closes div.
 	 */
 	public static function inject_after_notices() {
-		if ( ( ! self::is_admin_page() && ! self::is_embed_page() ) ) {
+		if ( ! self::is_admin_or_embed_page() ) {
 			return;
 		}
+
+		// Close the hidden div used to prevent notices from flickering before
+		// they are inserted elsewhere in the page.
 		echo '</div>';
 	}
 


### PR DESCRIPTION
Fixes #4005 

This PR restores the showing of admin notices on the following embedded pages:

- Reports
- Settings
- Status
- Extensions

Note that `woocommerce-admin` admin pages, such the following, will not show admin notices:

- Dashboard
- Analytics
- Customers

### Screenshots

Before:

<details>

<img width="1216" alt="Dashboard - Before" src="https://user-images.githubusercontent.com/2098816/77791971-eb3a3d80-703d-11ea-9112-b4d646309fbc.png">
<img width="1214" alt="Orders - Before" src="https://user-images.githubusercontent.com/2098816/77791974-ebd2d400-703d-11ea-9165-e00997a7d982.png">
<img width="1217" alt="Reports - Before" src="https://user-images.githubusercontent.com/2098816/77791976-ec6b6a80-703d-11ea-814b-21ca0c68dc5b.png">
<img width="1214" alt="Settings - Before" src="https://user-images.githubusercontent.com/2098816/77791979-ed040100-703d-11ea-9d59-9dc61576932d.png">
<img width="1215" alt="Status - Before" src="https://user-images.githubusercontent.com/2098816/77791980-ed040100-703d-11ea-8fb4-453ed67062b0.png">
<img width="1216" alt="Extensions - Before" src="https://user-images.githubusercontent.com/2098816/77791982-ed9c9780-703d-11ea-9cc0-76f786095b5d.png">


</details>

After:

<details>

<img width="1214" alt="Dashboard - After" src="https://user-images.githubusercontent.com/2098816/77792016-fe4d0d80-703d-11ea-98a4-3a59ac607e9f.png">
<img width="1214" alt="Orders - After" src="https://user-images.githubusercontent.com/2098816/77792017-fee5a400-703d-11ea-8c07-833b9b1be8a9.png">
<img width="1215" alt="Reports - After" src="https://user-images.githubusercontent.com/2098816/77792020-ff7e3a80-703d-11ea-88d4-d7e066302454.png">
<img width="1215" alt="Settings - After" src="https://user-images.githubusercontent.com/2098816/77792021-0016d100-703e-11ea-8314-75ff8d19fcea.png">
<img width="1215" alt="Status - After" src="https://user-images.githubusercontent.com/2098816/77792023-0016d100-703e-11ea-836c-819e6e34a13d.png">
<img width="1214" alt="Extensions - After" src="https://user-images.githubusercontent.com/2098816/77792024-00af6780-703e-11ea-9772-d9e647747f70.png">

</details>

### Detailed test instructions:

1. Run branch.
2. Make sure you have some admin notices on your site.
3. Verify that admin notices display on the embedded/legacy pages: Orders, Reports, Settings, Status, Extensions, etc.
4. Verify that admin notices do not display on `woocommerce-admin` pages: Dashboard, Analytics, etc.

### Changelog Note:

Fix: Show admin notices on legacy admin screens.