### PR TITLE
Support IE11 in `wc-admin`

### DIFF
--- a/client/wp-admin-scripts/onboarding-menu-experience/index.js
+++ b/client/wp-admin-scripts/onboarding-menu-experience/index.js
@@ -32,7 +32,7 @@ setupAnchorLi.hidden = true;
 const topLevelPageWooCommerceLi = document.getElementById(
 	'toplevel_page_woocommerce'
 );
-topLevelPageWooCommerceLi.children[ 1 ].append( setupAnchorLi );
+topLevelPageWooCommerceLi.children[ 1 ].appendChild( setupAnchorLi );
 
 function hideOrShowMenuItemsForTaskList( show ) {
 	const allSubmenuItems = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -133,6 +133,7 @@ const webpackConfig = {
 						'|acorn-jsx' +
 						'|d3-array' +
 						'|debug' +
+						'|marked' +
 						'|regexpu-core' +
 						'|unicode-match-property-ecmascript' +
 						'|unicode-match-property-value-ecmascript)/'


### PR DESCRIPTION
Fixes #3972

This PR fixes the JS syntax errors that were preventing the `wc-admin` pages from loading in IE11.

It is probable that there are some errors that appear in IE11 now that the UI in general works. Any specific errors should be logged and addressed separately as they are uncovered.

### Detailed test instructions:

1. Ensure you do not have `define( 'SCRIPT_DEBUG', true );` in your `wp-config.php`, as that will cause debug versions of JS files to be sent to the browser, some of which are not compatible with IE11.
2. Run branch (`npm start`).
3. Go to `/wp-admin/admin.php?page=wc-admin` in IE11.
4. Verify that dashboard appears.

You should also run on a new store, and verify that the "Setup" option appears in the WooCommerce sidebar section (see #3796 for details, as it was introduced then).

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: wc-admin pages work in Internet Explorer 11.
