### PR TITLE
Cast to float, to avoid performing arithmetic with strings

### DIFF
--- a/src/Overrides/OrderTraits.php
+++ b/src/Overrides/OrderTraits.php
@@ -31,7 +31,7 @@ trait OrderTraits {
 			return 0;
 		}
 
-		$total_shipping_amount = $this->get_shipping_total();
+		$total_shipping_amount = (float) $this->get_shipping_total();
 
 		return $total_shipping_amount / $order_items * $product_qty;
 	}


### PR DESCRIPTION
Casts a numeric string (ie, `'10.00'`) to a float, to avoid warnings/error log noise in more recent versions of PHP.

Currently:

* `$this->get_shipping_total()` returns a string such as `'10.00'`.
* This is used to perform a calculation (the other values are integers).
* While this works—the calculation is still performed correctly—modern PHPs complain about the use of strings in this situation _("PHP Warning: A non-numeric value encountered")._

This change:

* Casts the string to a float.
* This should avoid unwanted noise in the error logs.
