### PR TITLE
Fix RTL issues with `wc-admin` pages

### DIFF
--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -119,6 +119,12 @@
 
 	.components-button {
 		padding: 4px;
+
+		/*!rtl:ignore*/
+		.rtl & .dashicons-arrow-left-alt2,
+		.rtl & .dashicons-arrow-right-alt2 {
+			transform: scaleX(-1);
+		}
 	}
 
 	.woocommerce-store-alerts__pagination-label {

--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -112,6 +112,11 @@
 						border: solid $studio-white;
 						border-width: 0 2px 2px 0;
 						transform: rotate(45deg);
+
+						/*!rtl:ignore*/
+						.rtl & {
+							transform: rotate(45deg) scaleX(-1);
+						}
 					}
 				}
 			}

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -373,6 +373,11 @@ $inner-border: $core-grey-light-500;
 		margin-right: 3px;
 		fill: currentColor;
 
+		/*!rtl:ignore*/
+		.rtl &.gridicons-arrow-right {
+			transform: scaleX(-1);
+		}
+
 		&.gridicons-arrow-up {
 			transform: rotate(45deg);
 		}


### PR DESCRIPTION
Fixes #3811

This PR corrects three RTL issues with the `wc-admin` pages:

- Correct store alerts pagination arrows display
- Correct chart legend checkboxs display
- Correct summary item's delta arrow display when flat

The approach used is similar to that used in `wp-calypso` to correct elements that should/shouldn't be flipped when WordPress is in RTL mode ([example](https://github.com/Automattic/wp-calypso/blob/master/client/assets/stylesheets/_main.scss#L109)).

Styles are introduced that are only applied when in RTL mode. These CSS rules are annotated with `/*!rtl:ignore*/` so that when the RTL CSS files are built, `rtlcss` doesn't attempt to automatically 'fix' them.

### Screenshots

Before:

<img width="1292" alt="ScreenCapture at Thu Apr 2 13:57:51 EDT 2020" src="https://user-images.githubusercontent.com/2098816/78284160-f9c89f00-74ec-11ea-92f4-4ad513a58fbe.png">

After:

<img width="1292" alt="ScreenCapture at Thu Apr 2 14:02:10 EDT 2020" src="https://user-images.githubusercontent.com/2098816/78284190-0816bb00-74ed-11ea-8c96-feae3460ca8e.png">

_Note: The `of 2 1` label in the pagination control is okay. This text would be translated in a real RTL locale, and display properly. If this English string was to be shown in a RTL setting, it would be modified with BiDi directional control characters to be ordered properly. But, it is only shown in English in a test environment, so there is no need for that._

### Detailed test instructions:

1. Run branch.
2. Make sure you have two or more store alerts that always appear at the top of the `wc-admin` pages. You can easily force this by going into your DB and changing the `type` value for two `wp_wc_admin_notes` table rows to `error`.
3. Make sure you have some data in your store, so that you can see a variety of summary item delta arrows. You can use [WooCommerce Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) to quickly populate your store with test data.
4. Go to Analytics (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&period=last_week&compare=previous_period`) and verify that elements appear properly in LTR.
5. Switch your WordPress to RTL mode. The easiest way to do this for testing is to use the [RTL Tester plugin](https://wordpress.org/plugins/rtl-tester/).
6. Verify that elements appear properly in RTL.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Proper display of elements in `wc-admin` pages when in a RTL environment.