### PR TITLE
Convert order status setting from blacklist to whitelist.

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -68,36 +68,6 @@ export const config = applyFilters( SETTINGS_FILTER, {
 		} ),
 		defaultValue: [ 'processing', 'on-hold', 'completed' ],
 	},
-	woocommerce_excluded_report_order_statuses: {
-		label: __( 'Excluded Statuses:', 'woocommerce-admin' ),
-		inputType: 'checkboxGroup',
-		options: [
-			{
-				key: 'defaultStatuses',
-				options: filteredOrderStatuses.filter( status =>
-					DEFAULT_ORDER_STATUSES.includes( status.value )
-				),
-			},
-			{
-				key: 'customStatuses',
-				label: __( 'Custom Statuses', 'woocommerce-admin' ),
-				options: filteredOrderStatuses.filter(
-					status => ! DEFAULT_ORDER_STATUSES.includes( status.value )
-				),
-			},
-		],
-		helpText: interpolateComponents( {
-			mixedString: __(
-				'Orders with these statuses are excluded from the totals in your reports. ' +
-					'The {{strong}}Refunded{{/strong}} status can not be excluded.',
-				'woocommerce-admin'
-			),
-			components: {
-				strong: <strong />,
-			},
-		} ),
-		defaultValue: [ 'pending', 'cancelled', 'failed' ],
-	},
 	woocommerce_actionable_order_statuses: {
 		label: __( 'Actionable Statuses:', 'woocommerce-admin' ),
 		inputType: 'checkboxGroup',

--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -31,13 +31,43 @@ const filteredOrderStatuses = Object.keys( ORDER_STATUSES )
 			value: key,
 			label: ORDER_STATUSES[ key ],
 			description: sprintf(
-				__( 'Exclude the %s status from reports', 'woocommerce-admin' ),
+				__( 'Include the %s status in reports', 'woocommerce-admin' ),
 				ORDER_STATUSES[ key ]
 			),
 		};
 	} );
 
 export const config = applyFilters( SETTINGS_FILTER, {
+	woocommerce_included_report_order_statuses: {
+		label: __( 'Included Statuses:', 'woocommerce-admin' ),
+		inputType: 'checkboxGroup',
+		options: [
+			{
+				key: 'defaultStatuses',
+				options: filteredOrderStatuses.filter( status =>
+					DEFAULT_ORDER_STATUSES.includes( status.value )
+				),
+			},
+			{
+				key: 'customStatuses',
+				label: __( 'Custom Statuses', 'woocommerce-admin' ),
+				options: filteredOrderStatuses.filter(
+					status => ! DEFAULT_ORDER_STATUSES.includes( status.value )
+				),
+			},
+		],
+		helpText: interpolateComponents( {
+			mixedString: __(
+				'Orders with these statuses are included in your reports totals. ' +
+					'The {{strong}}Refunded{{/strong}} status is always included.',
+				'woocommerce-admin'
+			),
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		defaultValue: [ 'processing', 'on-hold', 'completed' ],
+	},
 	woocommerce_excluded_report_order_statuses: {
 		label: __( 'Excluded Statuses:', 'woocommerce-admin' ),
 		inputType: 'checkboxGroup',

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -8,6 +8,7 @@
  */
 
 use \Automattic\WooCommerce\Admin\Install as Installer;
+use \Automattic\WooCommerce\Admin\Loader as Loader;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
@@ -75,4 +76,24 @@ function wc_admin_update_0251_remove_unsnooze_action() {
  */
 function wc_admin_update_0251_db_version() {
 	Installer::update_db_version( '0.25.1' );
+}
+
+/**
+ * Convert the "excluded" order status black list into an "included" white list.
+ * See: https://github.com/woocommerce/woocommerce-admin/issues/4050.
+ */
+function wc_admin_update_104_migration_excluded_order_status() {
+	$order_statuses = array_keys( Loader::get_order_statuses( wc_get_order_statuses() ) );
+	$black_list     = get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'cancelled', 'failed' ) );
+	$white_list     = array_values( array_diff( $order_statuses, $black_list ) );
+
+	update_option( 'woocommerce_included_report_order_statuses', $white_list );
+	delete_option( 'woocommerce_excluded_report_order_statuses' );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_104_db_version() {
+	Installer::update_db_version( '1.0.4' );
 }

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -85,7 +85,7 @@ function wc_admin_update_0251_db_version() {
 function wc_admin_update_104_migration_excluded_order_status() {
 	$order_statuses = array_keys( Loader::get_order_statuses( wc_get_order_statuses() ) );
 	$black_list     = get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'cancelled', 'failed' ) );
-	$white_list     = array_values( array_diff( $order_statuses, $black_list ) );
+	$white_list     = array_values( array_diff( $order_statuses, $black_list, array( 'refunded' ) ) );
 
 	update_option( 'woocommerce_included_report_order_statuses', $white_list );
 	delete_option( 'woocommerce_excluded_report_order_statuses' );

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -558,17 +558,17 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function get_oldest_orders( $customer_id ) {
 		global $wpdb;
 		$orders_table                = $wpdb->prefix . 'wc_order_stats';
-		$excluded_statuses           = array_map( array( __CLASS__, 'normalize_order_status' ), self::get_excluded_report_order_statuses() );
-		$excluded_statuses_condition = '';
-		if ( ! empty( $excluded_statuses ) ) {
-			$excluded_statuses_str       = implode( "','", $excluded_statuses );
-			$excluded_statuses_condition = "AND status NOT IN ('{$excluded_statuses_str}')";
+		$included_statuses           = array_map( array( __CLASS__, 'normalize_order_status' ), self::get_included_report_order_statuses() );
+		$included_statuses_condition = '';
+		if ( ! empty( $included_statuses ) ) {
+			$included_statuses_str       = implode( "','", $included_statuses );
+			$included_statuses_condition = "AND status IN ('{$included_statuses_str}')";
 		}
 
 		return $wpdb->get_results(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT order_id, date_created FROM {$orders_table} WHERE customer_id = %d {$excluded_statuses_condition} ORDER BY date_created, order_id ASC LIMIT 2",
+				"SELECT order_id, date_created FROM {$orders_table} WHERE customer_id = %d {$included_statuses_condition} ORDER BY date_created, order_id ASC LIMIT 2",
 				$customer_id
 			)
 		);

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -594,11 +594,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$first_order       = $oldest_orders[0];
 		$second_order      = isset( $oldest_orders[1] ) ? $oldest_orders[1] : false;
-		$excluded_statuses = self::get_excluded_report_order_statuses();
+		$included_statuses = self::get_included_report_order_statuses();
 
 		// Order is older than previous first order.
 		if ( $order->get_date_created() < wc_string_to_datetime( $first_order->date_created ) &&
-			! in_array( $order->get_status(), $excluded_statuses, true )
+			in_array( $order->get_status(), $included_statuses, true )
 		) {
 			self::set_customer_first_order( $customer_id, $order->get_id() );
 			return false;
@@ -610,9 +610,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$date_change = $second_order &&
 			$order->get_date_created() > wc_string_to_datetime( $first_order->date_created ) &&
 			wc_string_to_datetime( $second_order->date_created ) < $order->get_date_created();
-		// Status has changed to an excluded status and next oldest order is now the first order.
+		// Status has changed to a non-included status and next oldest order is now the first order.
 		$status_change = $second_order &&
-			in_array( $order->get_status(), $excluded_statuses, true );
+			! in_array( $order->get_status(), $included_statuses, true );
 		if ( $is_first_order && ( $date_change || $status_change ) ) {
 			self::set_customer_first_order( $customer_id, $second_order->order_id );
 			return true;

--- a/src/Install.php
+++ b/src/Install.php
@@ -40,6 +40,10 @@ class Install {
 			'wc_admin_update_0251_remove_unsnooze_action',
 			'wc_admin_update_0251_db_version',
 		),
+		'1.0.4'  => array(
+			'wc_admin_update_104_migration_excluded_order_status',
+			'wc_admin_update_104_db_version',
+		),
 	);
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -793,15 +793,6 @@ class Loader {
 			'options'     => $statuses,
 		);
 		$settings[] = array(
-			'id'          => 'woocommerce_excluded_report_order_statuses',
-			'option_key'  => 'woocommerce_excluded_report_order_statuses',
-			'label'       => __( 'Excluded report order statuses', 'woocommerce-admin' ),
-			'description' => __( 'Statuses that should not be included when calculating report totals.', 'woocommerce-admin' ),
-			'default'     => array( 'pending', 'cancelled', 'failed' ),
-			'type'        => 'multiselect',
-			'options'     => $statuses,
-		);
-		$settings[] = array(
 			'id'          => 'woocommerce_actionable_order_statuses',
 			'option_key'  => 'woocommerce_actionable_order_statuses',
 			'label'       => __( 'Actionable order statuses', 'woocommerce-admin' ),

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -74,7 +74,7 @@ class Loader {
 		add_filter( 'woocommerce_settings_groups', array( __CLASS__, 'add_settings_group' ) );
 		add_filter( 'woocommerce_settings-wc_admin', array( __CLASS__, 'add_settings' ) );
 		add_filter( 'option_woocommerce_actionable_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
-		add_filter( 'option_woocommerce_excluded_report_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
+		add_filter( 'option_woocommerce_included_report_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
 		add_action( 'admin_head', array( __CLASS__, 'remove_notices' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -784,6 +784,15 @@ class Loader {
 	public static function add_settings( $settings ) {
 		$statuses   = self::get_order_statuses( wc_get_order_statuses() );
 		$settings[] = array(
+			'id'          => 'woocommerce_included_report_order_statuses',
+			'option_key'  => 'woocommerce_included_report_order_statuses',
+			'label'       => __( 'Included report order statuses', 'woocommerce-admin' ),
+			'description' => __( 'Statuses that should be included when calculating report totals.', 'woocommerce-admin' ),
+			'default'     => array( 'processing', 'on-hold', 'completed' ),
+			'type'        => 'multiselect',
+			'options'     => $statuses,
+		);
+		$settings[] = array(
 			'id'          => 'woocommerce_excluded_report_order_statuses',
 			'option_key'  => 'woocommerce_excluded_report_order_statuses',
 			'label'       => __( 'Excluded report order statuses', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #4050.

This PR seeks to remove unexpected/defunct/unregistered statuses from Order stats queries. It accomplishes this by changing the "excluded order status" (black list) setting to "included order status" (whitelist). In turn, the query is changed from a `NOT IN` to an `IN` - making the results predictable.

The problem being solved is best illustrated by using an extension that adds custom order statuses. The test store I first saw this error produced had **previously** used WooCommerce Deposits, but no longer had the extension active. This left many orders with custom statuses (like `wc-partial-payment`) that polluted report data because they were included (with the existing black list behavior) in reports. Without the extension active, there was no way to exclude them in settings.

### Screenshots

![Screen Shot 2020-04-03 at 12 37 46 PM](https://user-images.githubusercontent.com/63922/78393973-05c56700-75a8-11ea-8034-4561d91aa2b5.png)

### Detailed test instructions:

- On `master` branch:
- Take note of your "Excluded Statuses" setting on Analytics > Settings
- Check out this branch
- Update https://github.com/woocommerce/woocommerce-admin/blob/b15748708f74270d9ca56d7f79a40af0a36b0eee/src/FeaturePlugin.php#L155 to `1.0.4`
- Load any admin page
- Verify the `woocommerce_excluded_report_order_statuses ` option has been removed
- Verify a new `woocommerce_included_report_order_statuses` option exists
- Go to Analytics > Settings
- Verify that a new "Included Statuses" setting is shown
- Verify the "Included Statuses" value is the inverse of the defunct "Excluded Statuses"
- Enable WooCommerce Deposits extension (set up a store-wide partial payment)
- Place a partial payment order
- Open WooCommerce > Reports
- Select just today for the date range
- In a new tab/window, open Analytics > Revenue
- Ensure the date range includes today
- Verify the numbers for today match between the two reports

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: Change Order Status setting to be inclusive instead of exclusive (fix unexpected orders in reports).