### PR TITLE
OBW: fix use of unbound this in business details step.

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -75,6 +75,8 @@ class BusinessDetails extends Component {
 
 		this.onContinue = this.onContinue.bind( this );
 		this.validate = this.validate.bind( this );
+		this.getNumberRangeString = this.getNumberRangeString.bind( this );
+		this.numberFormat = this.numberFormat.bind( this );
 	}
 
 	async onContinue( values ) {


### PR DESCRIPTION
Fixes this error on the Business Details step of the OBW:

`Uncaught TypeError: Cannot read property 'context' of undefined at numberFormat (business-details.js:248)`

### Detailed test instructions:

- Verify you can load the Business Details step of the OBW

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

None needed - unreleased bug.