### PR TITLE
Setup Checklist: Fix exception in shipping.

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -27,6 +27,11 @@ class ShippingRates extends Component {
 	}
 
 	getShippingMethods( zone, type = null ) {
+		// Sometimes the wc/v3/shipping/zones response does not include a methods attribute, return early if so.
+		if ( ! zone || ! zone.methods || ! Array.isArray( zone.methods ) ) {
+			return [];
+		}
+
 		if ( ! type ) {
 			return zone.methods;
 		}


### PR DESCRIPTION
Fixes #4047

It appears not all REST API responses to `wc/v3/shipping/zones` return the `methods` attribute always, which results in the exception detailed in #4047. This branch seeks to resolve the bug by sniffing out for the times when `methods` is not present, and returning an empty array shipping methods for zones.

### Screenshots

Example REST response with missing zones attribute that is causing the exception:

<img width="818" alt="Dashboard ‹ WooCommerce ‹ My WordPress Site — WooCommerce - (Private Browsing) 2020-04-07 11-42-09" src="https://user-images.githubusercontent.com/22080/78708199-9a8cd500-78c6-11ea-87c3-3eb57ae86c70.png">

### Detailed test instructions:

- On a new test site ( clean site is critical here to ensure the default zone is missing methods ), I used an ephemeral site and first verified the bug by:
- Go through the OBW
- On the Setup Checklist, visit the shipping step, the error should happen after the REST requests are finished.
- **apply this branch**
- Refresh the screen and verify the exception no longer occurs.

### Changelog Note:

Fix: Add null check for shipping zone methods.
