### PR TITLE
Handle orphaned order statuses in analytics settings.

### DIFF
--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache;
 
 /**
  * API\Reports\Orders\DataStore.
@@ -430,6 +431,29 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 		return $coupons;
+	}
+
+	/**
+	 * Get all statuses that have been synced.
+	 *
+	 * @return array Unique order statuses.
+	 */
+	public static function get_all_statuses() {
+		global $wpdb;
+
+		$cache_key = 'orders-all-statuses';
+		$statuses  = Cache::get( $cache_key );
+
+		if ( false === $statuses ) {
+			$table_name = self::get_db_table_name();
+			$statuses   = $wpdb->get_col(
+				"SELECT DISTINCT status FROM {$table_name}"
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+
+			Cache::set( $cache_key, $statuses );
+		}
+
+		return $statuses;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -74,8 +74,6 @@ class Loader {
 		add_action( 'in_admin_header', array( __CLASS__, 'embed_page_header' ) );
 		add_filter( 'woocommerce_settings_groups', array( __CLASS__, 'add_settings_group' ) );
 		add_filter( 'woocommerce_settings-wc_admin', array( __CLASS__, 'add_settings' ) );
-		add_filter( 'option_woocommerce_actionable_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
-		add_filter( 'option_woocommerce_excluded_report_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
 		add_action( 'admin_head', array( __CLASS__, 'remove_notices' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );
@@ -832,21 +830,6 @@ class Loader {
 			'type'        => 'text',
 		);
 		return $settings;
-	}
-
-	/**
-	 * Filter invalid statuses from saved settings to avoid removed statuses throwing errors.
-	 *
-	 * @param array|null $value Saved order statuses.
-	 * @return array|null
-	 */
-	public static function filter_invalid_statuses( $value ) {
-		if ( is_array( $value ) ) {
-			$valid_statuses = array_keys( self::get_order_statuses( wc_get_order_statuses() ) );
-			$value          = array_intersect( $value, $valid_statuses );
-		}
-
-		return $value;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4050.

This PR seeks to represent all order statuses that have been synced to the order stats table in analytics settings. The current behavior is to filter out any status that isn't actively registered which becomes problematic when a custom status is excluded and then the extension registering the status is deactivated/uninstalled.

### Screenshots

![Screen Shot 2020-04-08 at 3 06 39 PM](https://user-images.githubusercontent.com/63922/78833793-ae116c00-79aa-11ea-963a-4eb0d88d5bf5.png)

### Detailed test instructions:

- Activate the WooCommerce Deposits extension (set up a store-wide partial payment)
- Place a partial payment order
- Go to Analytics > Settings
- Exclude the "Partially Paid" order status
- Go to Analytics > Orders
- Verify the partially paid order is not shown
- Deactivate the WooCommerce Deposits extension
- Go to Analytics > Settings
- Verify the `partial-payment` order status is shown under "Unregistered statuses" and is still selected
- Go to Analytics > Orders
- Verify the partially paid order is (still) not shown

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: Change Order Status setting to be inclusive instead of exclusive (fix unexpected orders in reports).