### PR TITLE
Onboarding: Fix "Set store location" in Shipping and Tax tasks on Dashboard

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -38,13 +38,7 @@ class Shipping extends Component {
 		};
 
 		// Cache active plugins to prevent removal mid-step.
-<<<<<<< HEAD
 		this.activePlugins = props.activePlugins;
-		this.state = this.initialState;
-=======
-		const { activePlugins = [] } = getSetting( 'onboarding', {} );
-		this.activePlugins = activePlugins;
->>>>>>> 1db398d3... Move most state handling to mapSelectToProps in Shipping component.
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
 

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -249,7 +249,6 @@ class Shipping extends Component {
 					/>
 				),
 				visible: true,
-				isComplete: false,
 			},
 			{
 				key: 'label_printing',
@@ -303,7 +302,6 @@ class Shipping extends Component {
 					/>
 				),
 				visible: pluginsToActivate.length,
-				isComplete: false,
 			},
 			{
 				key: 'connect',

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -357,9 +357,13 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
+		const { updateAndPersistSettingsForGroup } = dispatch(
+			SETTINGS_STORE_NAME
+		);
 
 		return {
 			createNotice,
+			updateAndPersistSettingsForGroup,
 		};
 	} )
 )( Shipping );

--- a/client/dashboard/task-list/tasks/steps/location.js
+++ b/client/dashboard/task-list/tasks/steps/location.js
@@ -29,10 +29,10 @@ export default class StoreLocation extends Component {
 			onComplete,
 			createNotice,
 			isSettingsError,
-			updateSettings,
+			updateAndPersistSettingsForGroup,
 		} = this.props;
 
-		await updateSettings( {
+		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
 				woocommerce_store_address: values.addressLine1,
 				woocommerce_store_address_2: values.addressLine2,

--- a/client/dashboard/task-list/tasks/steps/location.js
+++ b/client/dashboard/task-list/tasks/steps/location.js
@@ -28,7 +28,6 @@ export default class StoreLocation extends Component {
 		const {
 			onComplete,
 			createNotice,
-			isSettingsError,
 			updateAndPersistSettingsForGroup,
 		} = this.props;
 
@@ -42,7 +41,7 @@ export default class StoreLocation extends Component {
 			},
 		} );
 
-		if ( ! isSettingsError ) {
+		if ( ! this.props.isSettingsError ) {
 			onComplete( values );
 		} else {
 			createNotice(

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -331,8 +331,6 @@ class Tax extends Component {
 					</Fragment>
 				),
 				visible: ! isTaxJarSupported,
-				// TODO: Should this step ever be considered complete?
-				isComplete: false,
 			},
 		];
 

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -34,15 +34,13 @@ class Tax extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.initialState = {
+		this.state = {
 			isPending: false,
 			stepIndex: null,
 			automatedTaxEnabled: true,
 			// Cache the value of pluginsToActivate so that we can show/hide tasks based on it, but not have them update mid task.
 			pluginsToActivate: props.pluginsToActivate,
 		};
-
-		this.state = this.initialState;
 
 		this.goToNextStep = this.goToNextStep.bind( this );
 		this.configureTaxRates = this.configureTaxRates.bind( this );

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -71,7 +71,7 @@ class Tax extends Component {
 			return;
 		}
 
-		this.goToFirstStep();
+		this.goToFirstStepOrSuccessScreen();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -83,8 +83,8 @@ class Tax extends Component {
 			! this.isWaitingForSettings()
 		) {
 			// We have the settings, so we can proceed with going to the
-			// first step.
-			this.goToFirstStep();
+			// first step, or the success screen.
+			this.goToFirstStepOrSuccessScreen();
 		}
 
 		if (
@@ -126,10 +126,22 @@ class Tax extends Component {
 		);
 	}
 
-	goToFirstStep() {
+	goToFirstStepOrSuccessScreen() {
 		this.setState( {
 			waitForSettingsBeforeInitialStepSet: false,
 		} );
+
+		// Show the success screen if all requirements are satisfied.
+		if (
+			this.props.pluginsToActivate.length === 0 &&
+			this.isStoreLocationComplete() &&
+			this.props.isJetpackConnected &&
+			this.isTaxJarSupported()
+		) {
+			this.setState( { stepIndex: null } );
+			return;
+		}
+
 		this.goToNextStep( 0 );
 	}
 
@@ -147,13 +159,9 @@ class Tax extends Component {
 				this.goToNextStep( nextStepIndex + 1 );
 				return;
 			}
-
 			this.setState( { stepIndex: nextStepIndex } );
-		} else if ( this.isTaxJarSupported() ) {
-			// Show success screen
-			this.setState( { stepIndex: null } );
 		} else {
-			// TODO: what does this do?
+			// Return to the Dashboard
 			getHistory().push( getNewPath( {}, '/', {} ) );
 		}
 	}
@@ -401,6 +409,7 @@ class Tax extends Component {
 					</Fragment>
 				),
 				visible: ! this.isTaxJarSupported(),
+				// TODO: Should this step ever be considered complete?
 				isComplete: false,
 			},
 		];

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -75,28 +75,8 @@ class Tax extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const {
-			generalSettings,
-			isJetpackConnected,
-			pluginsToActivate,
-			taxSettings,
-		} = this.props;
+		const { generalSettings, taxSettings } = this.props;
 		const { woocommerce_calc_taxes: calcTaxes } = generalSettings;
-		const { stepIndex } = this.state;
-
-		// Show the success screen if all requirements are satisfied from the beginning.
-		if (
-			stepIndex !== null &&
-			! pluginsToActivate.length &&
-			this.isStoreLocationComplete() &&
-			isJetpackConnected &&
-			this.isTaxJarSupported()
-		) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { stepIndex: null } );
-			/* eslint-enable react/no-did-update-set-state */
-			return;
-		}
 
 		if (
 			this.state.waitForSettingsBeforeInitialStepSet &&
@@ -169,7 +149,11 @@ class Tax extends Component {
 			}
 
 			this.setState( { stepIndex: nextStepIndex } );
+		} else if ( this.isTaxJarSupported() ) {
+			// Show success screen
+			this.setState( { stepIndex: null } );
 		} else {
+			// TODO: what does this do?
 			getHistory().push( getNewPath( {}, '/', {} ) );
 		}
 	}
@@ -339,7 +323,7 @@ class Tax extends Component {
 					/>
 				),
 				visible: pluginsToActivate.length && this.isTaxJarSupported(),
-				isComplete: false,
+				isComplete: ! pluginsToActivate.length,
 			},
 			{
 				key: 'connect',


### PR DESCRIPTION
Fixes #4031

This PR allows the store location to be properly set in the "Set up shipping" and "Set up tax" tasks on the WooCommerce Dashboard.

This issue is encountered when you do not have your store address set in `/wp-admin/admin.php?page=wc-settings`. So, either do not use the “new and improved setup experience" after activating the WooCommerce plugin (pick “Not right now”), or delete your store address after completing the setup wizard.

### Detailed test instructions:

- Run branch. Make sure WooCommerce Admin plugin is activated.

- Go to `/wp-admin/edit.php?post_type=shop_order` to make sure the new onboarding experience is enabled. Skip the setup wizard.



- Add a physical product to your store (“Add your first product”) so that the "Set up shipping" task is available.

- Then, go through both “Set up shipping” and “Set up tax” tasks on the Dashboard.

<img width="1131" alt="ScreenCapture at Fri Apr 17 17:54:20 EDT 2020" src="https://user-images.githubusercontent.com/2098816/79617145-cd0fac80-80d4-11ea-9217-1ed11eef2b17.png">

- Make sure both tasks correctly step through all available steps.
    - Try with both Jetpack not installed, and Jetpack installed and connected to your store, as different steps are presented in those different scenarios.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: "Set store location" step now works in "Set up shipping" and "Set up tax" tasks on the WooCommerce Dashboard.