### PR TITLE
New home screen pageview tracking

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -13,7 +13,7 @@ import { applyFilters } from '@wordpress/hooks';
  * WooCommerce dependencies
  */
 import { H } from '@woocommerce/components';
-import { SETTINGS_STORE_NAME, withPluginsHydration } from '@woocommerce/data';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -32,12 +32,6 @@ import {
 } from 'lib/date';
 import ReportFilters from 'analytics/components/report-filters';
 
-const HydratedTaskList = withPluginsHydration( {
-	...window.wcSettings.plugins,
-	jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
-} )(
-	TaskList
-);
 const DASHBOARD_FILTERS_FILTER = 'woocommerce_admin_dashboard_filters';
 const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
 
@@ -313,7 +307,7 @@ class CustomizableDashboard extends Component {
 		return (
 			<Fragment>
 				{ isTaskListEnabled && (
-					<HydratedTaskList
+					<TaskList
 						query={ query }
 						inline={ isDashboardShown }
 					/>

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -12,7 +12,7 @@ import CustomizableDashboard from './customizable';
 import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
 import { isOnboardingEnabled } from 'dashboard/utils';
-import { withSettingsHydration, withPluginsHydration } from '@woocommerce/data';
+import { withSettingsHydration } from '@woocommerce/data';
 
 let PossiblyHydratedProfileWizard = ProfileWizard;
 
@@ -23,15 +23,6 @@ if (
 	PossiblyHydratedProfileWizard = withSettingsHydration( 'general', {
 		general: window.wcSettings.preloadSettings.general,
 	} )( PossiblyHydratedProfileWizard );
-}
-
-if ( window.wcSettings.plugins ) {
-	PossiblyHydratedProfileWizard = withPluginsHydration(
-		{
-			...window.wcSettings.plugins,
-			jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
-		}
-	)( PossiblyHydratedProfileWizard );
 }
 
 class Dashboard extends Component {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import { useFilters } from '@woocommerce/components';
 import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { Component } from '@wordpress/element';
 import { Router, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { get, isFunction } from 'lodash';
@@ -11,6 +11,7 @@ import { get, isFunction } from 'lodash';
 /**
  * WooCommerce dependencies
  */
+import { useFilters } from '@woocommerce/components';
 import { getHistory } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { PLUGINS_STORE_NAME, withPluginsHydration } from '@woocommerce/data';
@@ -26,7 +27,6 @@ import { recordPageView } from 'lib/tracks';
 import TransientNotices from './transient-notices';
 import StoreAlerts from './store-alerts';
 import { REPORTS_FILTER } from 'analytics/report';
-import withSelect from 'wc-api/with-select';
 
 export class PrimaryLayout extends Component {
 	render() {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -145,6 +145,10 @@ _Layout.propTypes = {
 };
 
 const Layout = compose(
+	withPluginsHydration( {
+		...window.wcSettings.plugins,
+		jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
+	} ),
 	withSelect( ( select, { isEmbedded } ) => {
 		// Embedded pages don't send plugin info to Tracks.
 		if ( isEmbedded ) {
@@ -165,11 +169,6 @@ const Layout = compose(
 	} )
 )( _Layout );
 
-const HydratedLayout = withPluginsHydration( {
-	...window.wcSettings.plugins,
-	jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
-} )( Layout );
-
 class _PageLayout extends Component {
 	render() {
 		return (
@@ -182,7 +181,7 @@ class _PageLayout extends Component {
 								path={ page.path }
 								exact
 								render={ ( props ) => (
-									<HydratedLayout
+									<Layout
 										page={ page }
 										{ ...props }
 									/>
@@ -203,7 +202,7 @@ export const PageLayout = useFilters( [ PAGES_FILTER, REPORTS_FILTER ] )(
 export class EmbedLayout extends Component {
 	render() {
 		return (
-			<HydratedLayout
+			<Layout
 				page={ {
 					breadcrumbs: getSetting( 'embedBreadcrumbs', [] ),
 				} }

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -146,8 +146,10 @@ _Layout.propTypes = {
 
 const Layout = compose(
 	withPluginsHydration( {
-		...window.wcSettings.plugins,
-		jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
+		...( window.wcSettings.plugins || {} ),
+		jetpackStatus:
+			window.wcSettings.dataEndpoints &&
+			window.wcSettings.dataEndpoints.jetpackStatus || false,
 	} ),
 	withSelect( ( select, { isEmbedded } ) => {
 		// Embedded pages don't send plugin info to Tracks.

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -78,7 +78,9 @@ class Layout extends Component {
 
 		// When pathname is `/` we are on the dashboard
 		if ( path.length === 0 ) {
-			path = 'dashboard';
+			path = window.wcAdminFeatures.homepage
+				? 'home_screen'
+				: 'dashboard';
 		}
 
 		recordPageView( path );


### PR DESCRIPTION
Fixes #4083.

This PR seeks to implement "Option 1" of #4083.

It changes `wcadmin_page_view`'s `path` Tracks event prop to `home_screen` and adds the Jetpack info.

### Detailed test instructions:

- Use `npm start` to ensure a development build with the new home screen feature enabled
- Enable tracks debugging by entering `localStorage.setItem( 'debug', 'wc-admin:*' )` in console
- Go to WooCommerce > Home
- Verify the tracks event is correct

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
