### PR TITLE
Add List and Link components to Storybook

### DIFF
--- a/packages/components/src/link/stories/index.js
+++ b/packages/components/src/link/stories/index.js
@@ -1,0 +1,17 @@
+/*
+ * Internal dependencies
+ */
+import Link from '../';
+
+export default {
+	title: 'WooCommerce Admin/components/Link',
+	component: Link,
+};
+
+export const External = () => {
+	return (
+		<Link href="https://woocommerce.com" type="external">
+			WooCommerce.com
+		</Link>
+	);
+};

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -17,17 +17,14 @@ export const Default = () => {
 	const listItems = [
 		{
 			title: 'WooCommerce.com',
-			description: 'List item description text',
 			href: 'https://woocommerce.com',
 		},
 		{
 			title: 'WordPress.org',
-			description: 'List item description text',
 			href: 'https://wordpress.org',
 		},
 		{
 			title: 'A list item with no action',
-			description: 'List item description text',
 		},
 		{
 			title: 'Click me!',
@@ -47,14 +44,12 @@ export const BeforeAndAfter = () => {
 			before: <Gridicon icon="cart" />,
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WooCommerce.com',
-			description: 'List item description text',
 			href: 'https://woocommerce.com',
 		},
 		{
 			before: <Gridicon icon="my-sites" />,
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WordPress.org',
-			description: 'List item description text',
 			href: 'https://wordpress.org',
 		},
 		{

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import List from '../';
+
+export default {
+	title: 'WooCommerce Admin/components/List',
+	component: List,
+};
+
+export const Default = () => {
+	const listItems = [
+		{
+			title: 'WooCommerce.com',
+			description: 'List item description text',
+			href: 'https://woocommerce.com',
+		},
+		{
+			title: 'WordPress.org',
+			description: 'List item description text',
+			href: 'https://wordpress.org',
+		},
+		{
+			title: 'A list item with no action',
+			description: 'List item description text',
+		},
+	];
+
+	return <List items={ listItems } />;
+};

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+
+/**
  * Internal dependencies
  */
 import List from '../';
@@ -23,6 +28,47 @@ export const Default = () => {
 		{
 			title: 'A list item with no action',
 			description: 'List item description text',
+		},
+		{
+			title: 'Click me!',
+			onClick: () => {
+				// eslint-disable-next-line no-alert
+				window.alert( 'List item clicked' );
+			},
+		},
+	];
+
+	return <List items={ listItems } />;
+};
+
+export const BeforeAndAfter = () => {
+	const listItems = [
+		{
+			before: <Gridicon icon="cart" />,
+			after: <Gridicon icon="chevron-right" />,
+			title: 'WooCommerce.com',
+			description: 'List item description text',
+			href: 'https://woocommerce.com',
+		},
+		{
+			before: <Gridicon icon="my-sites" />,
+			after: <Gridicon icon="chevron-right" />,
+			title: 'WordPress.org',
+			description: 'List item description text',
+			href: 'https://wordpress.org',
+		},
+		{
+			before: <Gridicon icon="link-break" />,
+			title: 'A list item with no action',
+			description: 'List item description text',
+		},
+		{
+			before: <Gridicon icon="notice" />,
+			title: 'Click me!',
+			onClick: () => {
+				// eslint-disable-next-line no-alert
+				window.alert( 'List item clicked' );
+			},
 		},
 	];
 

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -7,6 +7,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import List from '../';
+import './style.scss';
 
 export default {
 	title: 'WooCommerce Admin/components/List',
@@ -28,6 +29,7 @@ export const Default = () => {
 		},
 		{
 			title: 'Click me!',
+			content: 'An alert will be triggered.',
 			onClick: () => {
 				// eslint-disable-next-line no-alert
 				window.alert( 'List item clicked' );
@@ -60,6 +62,7 @@ export const BeforeAndAfter = () => {
 		{
 			before: <Gridicon icon="notice" />,
 			title: 'Click me!',
+			content: 'An alert will be triggered.',
 			onClick: () => {
 				// eslint-disable-next-line no-alert
 				window.alert( 'List item clicked' );
@@ -68,4 +71,36 @@ export const BeforeAndAfter = () => {
 	];
 
 	return <List items={ listItems } />;
+};
+
+export const CustomStyle = () => {
+	const listItems = [
+		{
+			before: <Gridicon icon="cart" />,
+			after: <Gridicon icon="chevron-right" />,
+			title: 'WooCommerce.com',
+			href: 'https://woocommerce.com',
+		},
+		{
+			before: <Gridicon icon="my-sites" />,
+			after: <Gridicon icon="chevron-right" />,
+			title: 'WordPress.org',
+			href: 'https://wordpress.org',
+		},
+		{
+			before: <Gridicon icon="link-break" />,
+			title: 'A list item with no action',
+		},
+		{
+			before: <Gridicon icon="notice" />,
+			title: 'Click me!',
+			content: 'An alert will be triggered.',
+			onClick: () => {
+				// eslint-disable-next-line no-alert
+				window.alert( 'List item clicked' );
+			},
+		},
+	];
+
+	return <List items={ listItems } className="storybook-custom-list" />;
 };

--- a/packages/components/src/list/stories/style.scss
+++ b/packages/components/src/list/stories/style.scss
@@ -1,0 +1,21 @@
+.storybook-custom-list {
+	border: 1px solid $core-grey-light-900;
+	border-radius: 2px;
+	padding: 0;
+
+	.woocommerce-list__item {
+		&:not(:first-child) {
+			border-top: 1px solid $core-grey-light-600;
+		}
+
+		.woocommerce-list__item-before {
+			.gridicon {
+				fill: $studio-pink;
+			}
+		}
+
+		.woocommerce-list__item-title {
+			color: $studio-pink;
+		}
+	}
+}

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -2,11 +2,22 @@
  * External dependencies
  */
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const path = require( 'path' );
 
 /**
  * External dependencies
  */
 const wcAdminWebpackConfig = require( '../webpack.config.js' );
+
+const wcAdminPackages = [
+	'components',
+	'csv-export',
+	'currency',
+	'date',
+	'navigation',
+	'number',
+	'data',
+];
 
 module.exports = ( { config: storybookConfig } ) => {
 	storybookConfig.module.rules.push(
@@ -19,6 +30,12 @@ module.exports = ( { config: storybookConfig } ) => {
 	);
 
 	storybookConfig.resolve.alias = wcAdminWebpackConfig.resolve.alias;
+
+	wcAdminPackages.forEach( ( name ) => {
+		storybookConfig.resolve.alias[
+			`@woocommerce/${ name }`
+		] = path.resolve( __dirname, `../packages/${ name }/src` );
+	} );
 
 	storybookConfig.plugins.push(
 		new MiniCssExtractPlugin( {


### PR DESCRIPTION
This PR adds the List and Link components to Storybook. It also, by necessity, updates the Storybook webpack configuration to resolve the WooCommerce Admin packages, so that common components are correctly in Storybook.

There are no changes to the actual components in this PR.

This PR is part of the groundwork for creating a QuickLinks component for #4082, which will make use of the List and Link components.

### Screenshots

<img width="838" alt="ScreenCapture at Tue Apr 28 15:01:37 EDT 2020" src="https://user-images.githubusercontent.com/2098816/80526834-60f93800-8961-11ea-902e-567ba57a28dd.png">

### Detailed test instructions:

- `npm run storybook`
- Open up `http://localhost:6007/` in your browser
- Confirm that the following stories are present and functional:
    - WooCommerce Admin / components / Link 
        - External
    - WooCommerce Admin / components / List
        - Default
        - Before And After
        - Custom Style