### PR TITLE
Fix Dashboard flash before OBW chunk loads.

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -53,7 +53,6 @@ export class PrimaryLayout extends Component {
 class _Layout extends Component {
 	componentDidMount() {
 		this.recordPageViewTrack();
-		document.body.classList.remove( 'woocommerce-admin-is-loading' );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -76,6 +76,7 @@ class ProfileWizard extends Component {
 	componentDidMount() {
 		const { profileItems, updateProfileItems } = this.props;
 
+		document.body.classList.remove( 'woocommerce-admin-is-loading' );
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -678,6 +678,9 @@ class Loader {
 
 		if ( self::is_admin_page() && $is_loading ) {
 			$classes[] = 'woocommerce-admin-is-loading';
+			// Include the full screen class now to prevent the dashboard
+			// from being shown while the <ProfileWizard /> chunk loads.
+			$classes[] = 'woocommerce-admin-full-screen';
 		}
 
 		$features = self::get_features();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -678,9 +678,6 @@ class Loader {
 
 		if ( self::is_admin_page() && $is_loading ) {
 			$classes[] = 'woocommerce-admin-is-loading';
-			// Include the full screen class now to prevent the dashboard
-			// from being shown while the <ProfileWizard /> chunk loads.
-			$classes[] = 'woocommerce-admin-full-screen';
 		}
 
 		$features = self::get_features();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -670,7 +670,8 @@ class Loader {
 		/**
 		 * Some routes or features like onboarding hide the wp-admin navigation and masterbar.
 		 * Setting `woocommerce_admin_is_loading` to true allows us to premeptively hide these
-		 * elements while the JS app loads. This class is removed when `<Layout />` is rendered.
+		 * elements while the JS app loads.
+		 * This class needs to be removed by those feature components (like <ProfileWizard />).
 		 *
 		 * @param bool $is_loading If WooCommerce Admin is loading a fullscreen view.
 		 */

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -667,9 +667,16 @@ class Loader {
 			$classes[] = 'woocommerce-embed-page';
 		}
 
-		// Some routes or features like onboarding hide the wp-admin navigation and masterbar. Setting `woocommerce_admin_is_loading` to true allows us
-		// to premeptively hide these elements while the JS app loads. This class is removed when `<Layout />` is rendered.
-		if ( self::is_admin_page() && apply_filters( 'woocommerce_admin_is_loading', false ) ) {
+		/**
+		 * Some routes or features like onboarding hide the wp-admin navigation and masterbar.
+		 * Setting `woocommerce_admin_is_loading` to true allows us to premeptively hide these
+		 * elements while the JS app loads. This class is removed when `<Layout />` is rendered.
+		 *
+		 * @param bool $is_loading If WooCommerce Admin is loading a fullscreen view.
+		 */
+		$is_loading = apply_filters( 'woocommerce_admin_is_loading', false );
+
+		if ( self::is_admin_page() && $is_loading ) {
 			$classes[] = 'woocommerce-admin-is-loading';
 		}
 


### PR DESCRIPTION
Fixes #4252.

This PR seeks to fix the flash of Dashboard seen before the OBW chunk loads (introduced in the code splitting PR).

It accomplishes this by applying the `woocommerce-admin-full-screen` class to the body at the same time as the `woocommerce-admin-is-loading` class.

### Detailed test instructions:

1. Enable the profile wizard in the help tab
2. Go to WooCommerce > Home (or Dashboard)
3. Turn on network throttling - Fast 3G or slower
4. Refresh
5. Verify that the dashboard is NOT seen during load
