### PR TITLE
Add support for List item tags and link types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3646,6 +3646,15 @@
         }
       }
     },
+    "@storybook/addon-console": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-console/-/addon-console-1.2.1.tgz",
+      "integrity": "sha512-2iDbDTipWonvRpIqLLntfhCGvawFFvoG1xyErpyL7K/HRdQ1zzIvR1Qm83S7TK8Vg+RzZWm4wcDbxx7WOsFCNg==",
+      "dev": true,
+      "requires": {
+        "global": "^4.3.2"
+      }
+    },
     "@storybook/addon-docs": {
       "version": "5.3.18",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-5.3.18.tgz",
@@ -5248,6 +5257,16 @@
             "@babel/runtime-corejs3": "^7.7.4"
           }
         },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5263,6 +5282,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "pretty-format": {
           "version": "25.4.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.4.0.tgz",
@@ -5273,6 +5298,15 @@
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -5349,8 +5383,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -5565,6 +5598,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5580,6 +5623,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "pretty-format": {
           "version": "25.4.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.4.0.tgz",
@@ -5590,6 +5639,15 @@
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -5642,6 +5700,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5657,6 +5725,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "pretty-format": {
           "version": "25.4.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.4.0.tgz",
@@ -5667,6 +5741,15 @@
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -16982,12 +17065,59 @@
       "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
       "integrity": "sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==",
       "requires": {
+        "chalk": "^3.0.0",
         "cwd": "^0.10.0",
         "find-process": "^1.4.3",
         "prompts": "^2.3.0",
         "spawnd": "^4.4.0",
         "tree-kill": "^1.2.2",
         "wait-on": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -17075,9 +17205,56 @@
       "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.4.0.tgz",
       "integrity": "sha512-iV8S8+6qkdTM6OBR/M9gKywEk8GDSOe05hspCs5D8qKSwtmlUfdtHfB4cakdc68lC6YfK3AUsLirpfgodCHjzQ==",
       "requires": {
+        "chalk": "^3.0.0",
         "cwd": "^0.10.0",
         "jest-dev-server": "^4.4.0",
         "merge-deep": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-get-type": {
@@ -19673,6 +19850,15 @@
             "semver": "^6.0.0"
           }
         },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -19681,6 +19867,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
@@ -21957,7 +22149,7 @@
       "dev": true
     },
     "prettier": {
-      "version": "npm:wp-prettier@1.19.1",
+      "version": "npm:prettier@1.19.1",
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
       "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
       "dev": true
@@ -26568,6 +26760,15 @@
             "semver": "^6.0.0"
           }
         },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -26576,6 +26777,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
@@ -28316,179 +28523,53 @@
       },
       "dependencies": {
         "@webassemblyjs/ast": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-          "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+          "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
           "dev": true,
           "requires": {
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5"
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0"
           }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-          "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-          "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-          "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-code-frame": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-          "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/helper-fsm": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-          "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
-          "dev": true
         },
         "@webassemblyjs/helper-module-context": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-          "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+          "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
           "dev": true,
           "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "mamacro": "^0.0.3"
+            "@webassemblyjs/ast": "1.9.0"
           }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-          "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-          "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-          "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
-          "dev": true,
-          "requires": {
-            "@xtuc/ieee754": "^1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-          "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-          "dev": true,
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-          "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
-          "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-          "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+          "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
           "dev": true,
           "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/helper-wasm-section": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-opt": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-          "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-          "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5"
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/helper-wasm-section": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-opt": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "@webassemblyjs/wast-printer": "1.9.0"
           }
         },
         "@webassemblyjs/wasm-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-          "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+          "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
           "dev": true,
           "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wast-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-          "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-code-frame": "1.8.5",
-            "@webassemblyjs/helper-fsm": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-          "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5",
-            "@xtuc/long": "4.2.2"
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
           }
         },
         "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5322,6 +5322,12 @@
         "@types/testing-library__react": "^10.0.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-10.1.0.tgz",
+      "integrity": "sha512-qutUm/2lWAD8IiKrss2Cg6Hf8AkcMeylKm09bSMtYC39Ug68aXWkcbc0H/NVD5R1zOHguTjkR/Ppuns6bWksGQ==",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
 		"@octokit/graphql": "4.3.1",
 		"@storybook/addon-a11y": "5.3.18",
 		"@storybook/addon-actions": "5.3.18",
+		"@storybook/addon-console": "1.2.1",
 		"@storybook/addon-docs": "5.3.18",
 		"@storybook/addon-knobs": "5.3.18",
 		"@storybook/addon-links": "5.3.18",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
 		"@storybook/addons": "5.3.18",
 		"@storybook/react": "5.3.18",
 		"@testing-library/react": "^10.0.3",
+		"@testing-library/user-event": "^10.1.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
 		"@wordpress/babel-plugin-makepot": "2.1.3",
 		"@wordpress/babel-preset-default": "3.0.2",

--- a/packages/components/src/link/stories/index.js
+++ b/packages/components/src/link/stories/index.js
@@ -1,17 +1,62 @@
-/*
+/**
+ * External dependencies
+ */
+import { withConsole } from '@storybook/addon-console';
+
+/**
  * Internal dependencies
  */
 import Link from '../';
 
+function logLinkClick( event ) {
+	const a = event.currentTarget;
+	const logMessage = `[${ a.textContent }](${ a.href }) ${ a.dataset.linkType } link clicked`;
+
+	// eslint-disable-next-line no-console
+	console.log( logMessage );
+
+	event.preventDefault();
+	return false;
+}
+
 export default {
 	title: 'WooCommerce Admin/components/Link',
 	component: Link,
+	decorators: [ ( storyFn, context ) => withConsole()( storyFn )( context ) ],
 };
 
 export const External = () => {
 	return (
-		<Link href="https://woocommerce.com" type="external">
+		<Link
+			href="https://woocommerce.com"
+			type="external"
+			onClick={ logLinkClick }
+		>
 			WooCommerce.com
+		</Link>
+	);
+};
+
+export const WCAdmin = () => {
+	return (
+		<Link
+			href="admin.php?page=wc-admin&path=%2Fanalytics%2Forders"
+			type="wc-admin"
+			onClick={ logLinkClick }
+		>
+			Analytics: Orders
+		</Link>
+	);
+};
+
+export const WPAdmin = () => {
+	return (
+		<Link
+			href="post-new.php?post_type=product"
+			type="wp-admin"
+			onClick={ logLinkClick }
+		>
+			New Product
 		</Link>
 	);
 };

--- a/packages/components/src/link/test/index.js
+++ b/packages/components/src/link/test/index.js
@@ -15,6 +15,7 @@ describe( 'Link', () => {
 				WooCommerce.com
 			</Link>
 		);
+
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
 			  data-link-type="external"
@@ -31,6 +32,7 @@ describe( 'Link', () => {
 				New Post
 			</Link>
 		);
+
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
 			  data-link-type="wp-admin"
@@ -50,6 +52,7 @@ describe( 'Link', () => {
 				Analytics: Orders
 			</Link>
 		);
+
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
 			  data-link-type="wc-admin"
@@ -66,6 +69,7 @@ describe( 'Link', () => {
 				Analytics: Orders
 			</Link>
 		);
+
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
 			  data-link-type="wc-admin"
@@ -87,6 +91,7 @@ describe( 'Link', () => {
 				WooCommerce.com
 			</Link>
 		);
+
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
 			  class="foo"
@@ -101,6 +106,7 @@ describe( 'Link', () => {
 
 	it( 'should support `onClick`', () => {
 		const clickHandler = jest.fn();
+
 		const { container } = render(
 			<Link
 				href="https://woocommerce.com"
@@ -110,7 +116,9 @@ describe( 'Link', () => {
 				WooCommerce.com
 			</Link>
 		);
+
 		fireEvent.click( container.firstChild );
+
 		expect( clickHandler ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/components/src/link/test/index.js
+++ b/packages/components/src/link/test/index.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Link from '../index';
+
+describe( 'Link', () => {
+	it( 'should render `external` links', () => {
+		const { container } = render(
+			<Link href="https://woocommerce.com" type="external">
+				WooCommerce.com
+			</Link>
+		);
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			<a
+			  data-link-type="external"
+			  href="https://woocommerce.com"
+			>
+			  WooCommerce.com
+			</a>
+		` );
+	} );
+
+	it( 'should render `wp-admin` links', () => {
+		const { container } = render(
+			<Link href="post-new.php?post_type=product" type="wp-admin">
+				New Post
+			</Link>
+		);
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			<a
+			  data-link-type="wp-admin"
+			  href="post-new.php?post_type=product"
+			>
+			  New Post
+			</a>
+		` );
+	} );
+
+	it( 'should render `wc-admin` links', () => {
+		const { container } = render(
+			<Link
+				href="admin.php?page=wc-admin&path=%2Fanalytics%2Forders"
+				type="wc-admin"
+			>
+				Analytics: Orders
+			</Link>
+		);
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			<a
+			  data-link-type="wc-admin"
+			  href="admin.php?page=wc-admin&path=%2Fanalytics%2Forders"
+			>
+			  Analytics: Orders
+			</a>
+		` );
+	} );
+
+	it( 'should render links without a type as `wc-admin`', () => {
+		const { container } = render(
+			<Link href="admin.php?page=wc-admin&path=%2Fanalytics%2Forders">
+				Analytics: Orders
+			</Link>
+		);
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			<a
+			  data-link-type="wc-admin"
+			  href="admin.php?page=wc-admin&path=%2Fanalytics%2Forders"
+			>
+			  Analytics: Orders
+			</a>
+		` );
+	} );
+
+	it( 'should allow custom props to be passed through', () => {
+		const { container } = render(
+			<Link
+				href="https://woocommerce.com"
+				type="external"
+				className="foo"
+				target="bar"
+			>
+				WooCommerce.com
+			</Link>
+		);
+		expect( container.firstChild ).toMatchInlineSnapshot( `
+			<a
+			  class="foo"
+			  data-link-type="external"
+			  href="https://woocommerce.com"
+			  target="bar"
+			>
+			  WooCommerce.com
+			</a>
+		` );
+	} );
+
+	it( 'should support `onClick`', () => {
+		const clickHandler = jest.fn();
+		const { container } = render(
+			<Link
+				href="https://woocommerce.com"
+				type="external"
+				onClick={ clickHandler }
+			>
+				WooCommerce.com
+			</Link>
+		);
+		fireEvent.click( container.firstChild );
+		expect( clickHandler ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -44,6 +44,7 @@ class List extends Component {
 						className: itemClasses,
 						content,
 						href,
+						listItemTag,
 						onClick,
 						target,
 						title,
@@ -69,6 +70,7 @@ class List extends Component {
 						target: href ? target : null,
 						type: this.getItemLinkType( item ),
 						href,
+						'data-list-item-tag': listItemTag,
 					};
 
 					return (

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -21,6 +21,16 @@ class List extends Component {
 		}
 	}
 
+	getItemLinkType( item ) {
+		const { href, linkType } = item;
+
+		if ( linkType ) {
+			return linkType;
+		}
+
+		return href ? 'external' : null;
+	}
+
 	render() {
 		const { className, items } = this.props;
 		const listClassName = classnames( 'woocommerce-list', className );
@@ -57,7 +67,7 @@ class List extends Component {
 						onKeyDown: ( e ) =>
 							hasAction ? this.handleKeyDown( e, onClick ) : null,
 						target: href ? target : null,
-						type: href ? 'external' : null,
+						type: this.getItemLinkType( item ),
 						href,
 					};
 

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -12,9 +12,13 @@ import './style.scss';
 
 function logItemClick( event ) {
 	const a = event.currentTarget;
-	const logMessage = a.href
-		? `[${ a.textContent }](${ a.href }) ${ a.dataset.linkType } item clicked`
-		: `[${ a.textContent }] item clicked`;
+	const itemDescription = a.href
+		? `[${ a.textContent }](${ a.href }) ${ a.dataset.linkType }`
+		: `[${ a.textContent }]`;
+	const itemTag = a.dataset.listItemTag
+		? `'${ a.dataset.listItemTag }'`
+		: 'not set';
+	const logMessage = `[${ itemDescription } item clicked (tag: ${ itemTag })`;
 
 	// eslint-disable-next-line no-console
 	console.log( logMessage );
@@ -94,7 +98,7 @@ export const BeforeAndAfter = () => {
 	return <List items={ listItems } />;
 };
 
-export const CustomStyle = () => {
+export const CustomStyleAndTags = () => {
 	const listItems = [
 		{
 			before: <Gridicon icon="cart" />,
@@ -102,6 +106,7 @@ export const CustomStyle = () => {
 			title: 'WooCommerce.com',
 			href: 'https://woocommerce.com',
 			onClick: logItemClick,
+			listItemTag: 'woocommerce.com-link',
 		},
 		{
 			before: <Gridicon icon="my-sites" />,
@@ -109,6 +114,7 @@ export const CustomStyle = () => {
 			title: 'WordPress.org',
 			href: 'https://wordpress.org',
 			onClick: logItemClick,
+			listItemTag: 'wordpress.org-link',
 		},
 		{
 			before: <Gridicon icon="link-break" />,
@@ -123,6 +129,7 @@ export const CustomStyle = () => {
 				window.alert( 'List item clicked' );
 				return logItemClick( event );
 			},
+			listItemTag: 'click-me',
 		},
 	];
 

--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Gridicon from 'gridicons';
+import { withConsole } from '@storybook/addon-console';
 
 /**
  * Internal dependencies
@@ -9,9 +10,23 @@ import Gridicon from 'gridicons';
 import List from '../';
 import './style.scss';
 
+function logItemClick( event ) {
+	const a = event.currentTarget;
+	const logMessage = a.href
+		? `[${ a.textContent }](${ a.href }) ${ a.dataset.linkType } item clicked`
+		: `[${ a.textContent }] item clicked`;
+
+	// eslint-disable-next-line no-console
+	console.log( logMessage );
+
+	event.preventDefault();
+	return false;
+}
+
 export default {
 	title: 'WooCommerce Admin/components/List',
 	component: List,
+	decorators: [ ( storyFn, context ) => withConsole()( storyFn )( context ) ],
 };
 
 export const Default = () => {
@@ -19,10 +34,12 @@ export const Default = () => {
 		{
 			title: 'WooCommerce.com',
 			href: 'https://woocommerce.com',
+			onClick: logItemClick,
 		},
 		{
 			title: 'WordPress.org',
 			href: 'https://wordpress.org',
+			onClick: logItemClick,
 		},
 		{
 			title: 'A list item with no action',
@@ -30,9 +47,10 @@ export const Default = () => {
 		{
 			title: 'Click me!',
 			content: 'An alert will be triggered.',
-			onClick: () => {
+			onClick: ( event ) => {
 				// eslint-disable-next-line no-alert
 				window.alert( 'List item clicked' );
+				return logItemClick( event );
 			},
 		},
 	];
@@ -47,12 +65,14 @@ export const BeforeAndAfter = () => {
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WooCommerce.com',
 			href: 'https://woocommerce.com',
+			onClick: logItemClick,
 		},
 		{
 			before: <Gridicon icon="my-sites" />,
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WordPress.org',
 			href: 'https://wordpress.org',
+			onClick: logItemClick,
 		},
 		{
 			before: <Gridicon icon="link-break" />,
@@ -63,9 +83,10 @@ export const BeforeAndAfter = () => {
 			before: <Gridicon icon="notice" />,
 			title: 'Click me!',
 			content: 'An alert will be triggered.',
-			onClick: () => {
+			onClick: ( event ) => {
 				// eslint-disable-next-line no-alert
 				window.alert( 'List item clicked' );
+				return logItemClick( event );
 			},
 		},
 	];
@@ -80,12 +101,14 @@ export const CustomStyle = () => {
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WooCommerce.com',
 			href: 'https://woocommerce.com',
+			onClick: logItemClick,
 		},
 		{
 			before: <Gridicon icon="my-sites" />,
 			after: <Gridicon icon="chevron-right" />,
 			title: 'WordPress.org',
 			href: 'https://wordpress.org',
+			onClick: logItemClick,
 		},
 		{
 			before: <Gridicon icon="link-break" />,
@@ -95,9 +118,10 @@ export const CustomStyle = () => {
 			before: <Gridicon icon="notice" />,
 			title: 'Click me!',
 			content: 'An alert will be triggered.',
-			onClick: () => {
+			onClick: ( event ) => {
 				// eslint-disable-next-line no-alert
 				window.alert( 'List item clicked' );
+				return logItemClick( event );
 			},
 		},
 	];

--- a/packages/components/src/list/test/index.js
+++ b/packages/components/src/list/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { fireEvent, getAllByRole, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -22,9 +23,9 @@ describe( 'List', () => {
 			},
 		];
 
-		const { container } = render( <List items={ listItems } /> );
+		render( <List items={ listItems } /> );
 
-		expect( getAllByRole( container, 'menuitem' ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'menuitem' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'should support `onClick` for items', () => {
@@ -40,9 +41,11 @@ describe( 'List', () => {
 			},
 		];
 
-		const { container } = render( <List items={ listItems } /> );
+		render( <List items={ listItems } /> );
 
-		fireEvent.click( getAllByRole( container, 'menuitem' )[ 1 ] );
+		userEvent.click(
+			screen.getByRole( 'menuitem', { name: 'Click me!' } )
+		);
 
 		expect( clickHandler ).toHaveBeenCalled();
 	} );
@@ -70,13 +73,24 @@ describe( 'List', () => {
 			},
 		];
 
-		const { container } = render( <List items={ listItems } /> );
-		const renderedItems = getAllByRole( container, 'menuitem' );
+		render( <List items={ listItems } /> );
 
-		expect( renderedItems[ 0 ].dataset.linkType ).toBe( 'wp-admin' );
-		expect( renderedItems[ 1 ].dataset.linkType ).toBe( 'wc-admin' );
-		expect( renderedItems[ 2 ].dataset.linkType ).toBe( 'external' );
-		expect( renderedItems[ 3 ].dataset.linkType ).toBe( 'external' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Add products' } ).dataset
+				.linkType
+		).toBe( 'wp-admin' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Market my store' } ).dataset
+				.linkType
+		).toBe( 'wc-admin' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'WooCommerce.com' } ).dataset
+				.linkType
+		).toBe( 'external' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'WordPress.org' } ).dataset
+				.linkType
+		).toBe( 'external' );
 	} );
 
 	it( 'should set `data-list-item-tag` on items', () => {
@@ -105,14 +119,23 @@ describe( 'List', () => {
 			},
 		];
 
-		const { container } = render( <List items={ listItems } /> );
-		const renderedItems = getAllByRole( container, 'menuitem' );
+		render( <List items={ listItems } /> );
 
-		expect( renderedItems[ 0 ].dataset.listItemTag ).toBe( 'add-product' );
-		expect( renderedItems[ 1 ].dataset.listItemTag ).toBe( 'marketing' );
-		expect( renderedItems[ 2 ].dataset.listItemTag ).toBe(
-			'woocommerce.com-site'
-		);
-		expect( renderedItems[ 3 ].dataset.listItemTag ).toBeUndefined();
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Add products' } ).dataset
+				.listItemTag
+		).toBe( 'add-product' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'Market my store' } ).dataset
+				.listItemTag
+		).toBe( 'marketing' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'WooCommerce.com' } ).dataset
+				.listItemTag
+		).toBe( 'woocommerce.com-site' );
+		expect(
+			screen.getByRole( 'menuitem', { name: 'WordPress.org' } ).dataset
+				.listItemTag
+		).toBeUndefined();
 	} );
 } );

--- a/packages/components/src/list/test/index.js
+++ b/packages/components/src/list/test/index.js
@@ -43,6 +43,39 @@ describe( 'List', () => {
 		const { container } = render( <List items={ listItems } /> );
 
 		fireEvent.click( getAllByRole( container, 'menuitem' )[ 1 ] );
+
 		expect( clickHandler ).toHaveBeenCalled();
+	} );
+
+	it( 'should set `data-link-type` on items', () => {
+		const listItems = [
+			{
+				title: 'Add products',
+				href: '/post-new.php?post_type=product',
+				linkType: 'wp-admin',
+			},
+			{
+				title: 'Market my store',
+				href: '/admin.php?page=wc-admin&path=%2Fmarketing',
+				linkType: 'wc-admin',
+			},
+			{
+				title: 'WooCommerce.com',
+				href: 'https://woocommerce.com',
+				linkType: 'external',
+			},
+			{
+				title: 'WordPress.org',
+				href: 'https://wordpress.org',
+			},
+		];
+
+		const { container } = render( <List items={ listItems } /> );
+		const renderedItems = getAllByRole( container, 'menuitem' );
+
+		expect( renderedItems[ 0 ].dataset.linkType ).toBe( 'wp-admin' );
+		expect( renderedItems[ 1 ].dataset.linkType ).toBe( 'wc-admin' );
+		expect( renderedItems[ 2 ].dataset.linkType ).toBe( 'external' );
+		expect( renderedItems[ 3 ].dataset.linkType ).toBe( 'external' );
 	} );
 } );

--- a/packages/components/src/list/test/index.js
+++ b/packages/components/src/list/test/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, getAllByRole, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import List from '../index';
+
+describe( 'List', () => {
+	it( 'should have aria roles for items', () => {
+		const clickHandler = jest.fn();
+		const listItems = [
+			{
+				title: 'WooCommerce.com',
+				href: 'https://woocommerce.com',
+			},
+			{
+				title: 'Click me!',
+				onClick: clickHandler,
+			},
+		];
+
+		const { container } = render( <List items={ listItems } /> );
+
+		expect( getAllByRole( container, 'menuitem' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'should support `onClick` for items', () => {
+		const clickHandler = jest.fn();
+		const listItems = [
+			{
+				title: 'WooCommerce.com',
+				href: 'https://woocommerce.com',
+			},
+			{
+				title: 'Click me!',
+				onClick: clickHandler,
+			},
+		];
+
+		const { container } = render( <List items={ listItems } /> );
+
+		fireEvent.click( getAllByRole( container, 'menuitem' )[ 1 ] );
+		expect( clickHandler ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/components/src/list/test/index.js
+++ b/packages/components/src/list/test/index.js
@@ -99,6 +99,10 @@ describe( 'List', () => {
 				linkType: 'external',
 				listItemTag: 'woocommerce.com-site',
 			},
+			{
+				title: 'WordPress.org',
+				href: 'https://wordpress.org',
+			},
 		];
 
 		const { container } = render( <List items={ listItems } /> );
@@ -109,5 +113,6 @@ describe( 'List', () => {
 		expect( renderedItems[ 2 ].dataset.listItemTag ).toBe(
 			'woocommerce.com-site'
 		);
+		expect( renderedItems[ 3 ].dataset.listItemTag ).toBeUndefined();
 	} );
 } );

--- a/packages/components/src/list/test/index.js
+++ b/packages/components/src/list/test/index.js
@@ -78,4 +78,36 @@ describe( 'List', () => {
 		expect( renderedItems[ 2 ].dataset.linkType ).toBe( 'external' );
 		expect( renderedItems[ 3 ].dataset.linkType ).toBe( 'external' );
 	} );
+
+	it( 'should set `data-list-item-tag` on items', () => {
+		const listItems = [
+			{
+				title: 'Add products',
+				href: '/post-new.php?post_type=product',
+				linkType: 'wp-admin',
+				listItemTag: 'add-product',
+			},
+			{
+				title: 'Market my store',
+				href: '/admin.php?page=wc-admin&path=%2Fmarketing',
+				linkType: 'wc-admin',
+				listItemTag: 'marketing',
+			},
+			{
+				title: 'WooCommerce.com',
+				href: 'https://woocommerce.com',
+				linkType: 'external',
+				listItemTag: 'woocommerce.com-site',
+			},
+		];
+
+		const { container } = render( <List items={ listItems } /> );
+		const renderedItems = getAllByRole( container, 'menuitem' );
+
+		expect( renderedItems[ 0 ].dataset.listItemTag ).toBe( 'add-product' );
+		expect( renderedItems[ 1 ].dataset.listItemTag ).toBe( 'marketing' );
+		expect( renderedItems[ 2 ].dataset.listItemTag ).toBe(
+			'woocommerce.com-site'
+		);
+	} );
 } );


### PR DESCRIPTION
Infrastructure work in preparation for #4082 (Quick Links)

- General
	- Adds support for showing console.log messages in Storybook, making it easy to verify interactions (added `@storybook/addon-console` as a dev dependency)
- Link component
	- Adds Storybook stories for all `Link` types (`wp-admin`, `wc-admin`, `external`)
	- Adds unit tests for `Link` component
- List component
	- Adds setting of `List` item link type
	- Adds `onListItemClick` prop
	- Adds `listItemTag` item prop
	- Adds item click and tag example to Storybook
	- Adds unit tests for `List` component

See draft PR #4292 for a look at how these changes to `List` will be used by the `QuickLinks` component in the new home screen. In particular, the item tagging and click support will be used to hook in Tracks events (not implemented yet in #4292).

### Screenshots

<img width="1138" alt="ScreenCapture at Tue May 5 15:14:29 EDT 2020" src="https://user-images.githubusercontent.com/2098816/81106459-a67aaf80-8ee3-11ea-8a7a-3bcd3925356c.png">

### Detailed test instructions:

#### Storybook
```
npm run storybook
```

#### Unit testing
```
npm test -- -i packages/components/src/link/test/index.js packages/components/src/list/test/index.js
```

#### Optional: Confidence check
- Make sure that `List` changes haven’t affected other use of `List` in `wc-admin`, such as task list

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

- Infrastructure work - no changelog note needed
