### PR TITLE
Prep for 1.2.0 release.

### DIFF
--- a/docs/components/_sidebar.md
+++ b/docs/components/_sidebar.md
@@ -30,6 +30,7 @@
     * [List](components/packages/list/README.md)
     * [OrderStatus](components/packages/order-status/README.md)
     * [Pagination](components/packages/pagination/README.md)
+    * [Plugins](components/packages/plugins/README.md)
     * [ProductImage](components/packages/product-image/README.md)
     * [Rating](components/packages/rating/README.md)
     * [ScrollTo](components/packages/scroll-to/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22218,7 +22218,7 @@
       "dev": true
     },
     "prettier": {
-      "version": "npm:prettier@1.19.1",
+      "version": "npm:wp-prettier@1.19.1",
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
       "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.3.0
 Tested up to: 5.3.2
 Requires PHP: 5.6.20
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/master/license.txt
 
@@ -75,6 +75,34 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Storefront should show at top of theme options in onboarding wizard. #4187
 - Tweak: Remove Stripe auto-connect from payment task. #4164
 - Tweak: Hide suggested extensions in Marketing Tab if opted out of "Marketplace Suggestions"
+
+= 1.2.0 2020-05-05 =
+- Fix: Cast Shipping Total to float #4042 🎉barryhughes
+- Tweak: Dynamic Currency with Context API #4027
+- Fix: Remove Duplicate array entry #4049 🎉 tivnet
+- Fix: Proper display of elements in wc-admin pages when in a RTL environment. #4051
+- Enhancement: Marketing Inbox Note #4030
+- Tweak: Enable the default homepage template to be filtered #4072 🎉 stevegrunwell
+- Tweak: Create admin note if Jetpack or WooCommerce Services plugin doesn't get installed due to an error during OBW #3888
+- Fix: Update UX when knowledge base articles fail to retrieve #4133
+- Tweak: Decouple Plugins DataStore from onboarding feature #4048
+- Tweak: Move API out of Onboarding #4093
+- Dev: Add Profiler Step View Tracks #4141
+- Fix: Updated messaging after last step in OBW. #4148
+- Performance: trim down inbox note API request. #3977
+- Tweak: Update Email Marketing note. #4167
+- Fix: Reset profiler when visiting old OBW URL #4166.
+- Tweak: Adjust "demo products" verbiage to "Sample Products" #4184 🎉 jobthomas
+- Dev: Add React Testing Library #4221
+- Enhancement: New Link Component #4219
+- Performance: Use Route based code splitting to reduce bundle size #4094
+- Tweak: Use PAGE_ROOT constant to reduce redundant strings #4238 🎉 codemascot
+- Enhancement: Add onboarding payments note #4157 
+- Tweak: Don't reschedule imports on failed imports #4263
+- Tweak: Remove obsolete inbox messages #4182
+- Fix: Dashboard flash before OBW chunk loads #4259
+- Fix: Make query selector for admin alerts more specific #4289 🎉pauloiankoski 
+- Fix: Guard against null themes in OBW #4244
 
 = 1.1.0 2020-04-20 =
 - Tweak: Added link to "go shopping" button #3712

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -151,7 +151,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.1.1' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.2.0' );
 	}
 
 	/**

--- a/src/Package.php
+++ b/src/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.1.1';
+	const VERSION = '1.2.0';
 
 	/**
 	 * Package active.

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 1.1.1
+ * Version: 1.2.0
  * Requires at least: 5.3.0
  * Requires PHP: 5.6.20
  *


### PR DESCRIPTION
The code freeze for WooCommerce 4.2.0 is today! As such, I'm rolling a new release for inclusion that includes a few odds and ends that have been merged in, and not cherry-picked as part of the release efforts around 4.1


