### PR TITLE
Add JS unit tests to pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged",
+			"pre-commit": "lint-staged && npm run test",
 			"pre-push": "npm run -s install-if-no-packages && node bin/pre-push-hook.js"
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged && npm run test",
-			"pre-push": "npm run -s install-if-no-packages && node bin/pre-push-hook.js"
+			"pre-commit": "lint-staged",
+			"pre-push": "npm run test && npm run -s install-if-no-packages && node bin/pre-push-hook.js"
 		}
 	},
 	"lint-staged": {


### PR DESCRIPTION
This PR adds `npm run test` to the pre-push hook.

If we are going to have unit tests, it is important that they run before code is pushed, so that developers do not inadvertently commit code that breaks other parts of the system.

### Detailed test instructions:

- Create a new branch off of this branch
- Add a test somewhere that will fail, such as...

```
	it( 'should fail pre-push', () => {
		expect( true ).toBe( false );
	} );
```

- Commit this change
- Verify that unit tests are not run pre-commit
- Try to push the commit
- Verify that the pre-push hook fails

```
husky > pre-push hook failed (add --no-verify to bypass)
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Dev: Add JS unit tests to pre-push hook.
