### PR TITLE
Add `jest-dom` eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
 		'prettier',
 		'plugin:testing-library/recommended',
 		'plugin:testing-library/react',
+		'plugin:jest-dom/recommended',
 	],
 	env: {
 		'jest/globals': true,
@@ -11,7 +12,7 @@ module.exports = {
 	globals: {
 		wcSettings: true,
 	},
-	plugins: [ 'jest', 'testing-library' ],
+	plugins: [ 'jest', 'jest-dom', 'testing-library' ],
 	rules: {
 		'@wordpress/dependency-group': 'off',
 		'valid-jsdoc': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12930,6 +12930,15 @@
         }
       }
     },
+    "eslint-plugin-jest-dom": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-2.1.0.tgz",
+      "integrity": "sha512-J9H75qqPro0TA5AQcEJtZmxG4Go0KYjZYXAiAmvQsNUOIP1EzCF6BTJSkB/7Sw8wmzgLwNSvhMUDXqDfHa1HqA==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.2.0"
+      }
+    },
     "eslint-plugin-jsdoc": {
       "version": "15.12.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.12.2.tgz",

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
 		"eslint-config-prettier": "6.11.0",
 		"eslint-loader": "3.0.4",
 		"eslint-plugin-jest": "23.8.2",
+		"eslint-plugin-jest-dom": "^2.1.0",
 		"eslint-plugin-jsx-a11y": "6.2.3",
 		"eslint-plugin-react": "7.19.0",
 		"eslint-plugin-testing-library": "^3.1.0",

--- a/packages/components/src/chart/d3chart/test/legend.js
+++ b/packages/components/src/chart/d3chart/test/legend.js
@@ -29,8 +29,10 @@ describe( 'Legend', () => {
 			<D3Legend colorScheme={ colorScheme } data={ data } />
 		);
 
+		/* eslint-disable jest-dom/prefer-enabled-disabled */
 		expect( legend.find( 'button' ).get( 0 ).props.disabled ).toBeFalsy();
 		expect( legend.find( 'button' ).get( 1 ).props.disabled ).toBeFalsy();
+		/* eslint-enable jest-dom/prefer-enabled-disabled */
 	} );
 
 	test( 'should disable the last active button', () => {
@@ -40,7 +42,9 @@ describe( 'Legend', () => {
 			<D3Legend colorScheme={ colorScheme } data={ data } />
 		);
 
+		/* eslint-disable jest-dom/prefer-enabled-disabled */
 		expect( legend.find( 'button' ).get( 0 ).props.disabled ).toBeTruthy();
 		expect( legend.find( 'button' ).get( 1 ).props.disabled ).toBeFalsy();
+		/* eslint-enable jest-dom/prefer-enabled-disabled */
 	} );
 } );


### PR DESCRIPTION
This PR adds the `jest-dom` eslint plugin to our configuration. This will help us ensure that our DOM-based tests are robust and readable.

`jest-dom/prefer-enabled-disabled` rule was disabled in our `d3chart` tests, which are enzyme-based, as (1) I believe this was a false positive (since my understanding of enzyme tests is that they are testing React components directly, not the DOM), and (2) that test should at some point be re-written to use React Testing Library instead of enzyme.

### Detailed test instructions:

- Check out branch
- Add an assert that is not allowed by `jest-dom` to a test file, such as...

```
	it( 'should trigger es-lint', () => {
		render( <button /> );

		expect( screen.getByRole( 'button' ).innerHTML ).toBe( '' ); // bad
		expect( screen.getByRole( 'button' ) ).toBeEmpty(); // good
	} );
```

- Verify that your editor shows the eslint error (if your editor is configured to do so, which it definitely should be!)

```
jest-dom/prefer-empty: Use toBeEmpty instead of checking inner html.
```

- Verify that pre-commit hook fails if you try to commit the offending code

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Dev: Add `jest-dom` eslint plugin.
