### PR TITLE
Homescreen: Add option to disable

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -22,12 +22,11 @@ const ProfileWizard = lazy( () =>
 
 class Dashboard extends Component {
 	render() {
-		const { path, profileItems, query } = this.props;
-
+		const { path, profileItems, query, homepageEnabled } = this.props;
 		if (
 			isOnboardingEnabled() &&
 			! profileItems.completed &&
-			! window.wcAdminFeatures.homepage
+			! homepageEnabled
 		) {
 			return (
 				<Suspense fallback={ <Spinner /> }>

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -248,7 +248,7 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const { woocommerce_homepage_enabled: homepageOption } = getSetting(
+		const { woocommerce_homescreen_enabled: homepageOption } = getSetting(
 			'preloadOptions',
 			{}
 		);

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -20,6 +20,8 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
 const AnalyticsReport = lazy( () =>
 	import( /* webpackChunkName: "analytics-report" */ 'analytics/report' )
 );
@@ -44,7 +46,7 @@ const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
 
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
-export const getPages = () => {
+export const getPages = ( homepageEnabled ) => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
@@ -72,7 +74,7 @@ export const getPages = () => {
 
 	if (
 		window.wcAdminFeatures[ 'analytics-dashboard' ] &&
-		! window.wcAdminFeatures.homepage
+		! homepageEnabled
 	) {
 		pages.push( {
 			container: Dashboard,
@@ -85,7 +87,7 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures.homepage ) {
+	if ( homepageEnabled ) {
 		pages.push( {
 			container: Homepage,
 			path: '/',
@@ -98,7 +100,7 @@ export const getPages = () => {
 	}
 
 	if ( window.wcAdminFeatures.analytics ) {
-		if ( window.wcAdminFeatures.homepage ) {
+		if ( homepageEnabled ) {
 			pages.push( {
 				container: Dashboard,
 				path: '/analytics/overview',
@@ -114,7 +116,7 @@ export const getPages = () => {
 			} );
 		}
 		const ReportWpOpenMenu = `toplevel_page_wc-admin-path--analytics-${
-			window.wcAdminFeatures.homepage ? 'overview' : 'revenue'
+			homepageEnabled ? 'overview' : 'revenue'
 		}`;
 
 		pages.push( {
@@ -212,7 +214,7 @@ export class Controller extends Component {
 	}
 
 	render() {
-		const { page, match, location } = this.props;
+		const { page, match, location, homepageEnabled } = this.props;
 		const { url, params } = match;
 		const query = this.getQuery( location.search );
 
@@ -225,6 +227,7 @@ export class Controller extends Component {
 					path={ url }
 					pathMatch={ page.path }
 					query={ query }
+					homepageEnabled={ homepageEnabled }
 				/>
 			</Suspense>
 		);
@@ -245,9 +248,14 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const defaultPath = window.wcAdminFeatures.homepage
-			? 'homepage'
-			: 'dashboard';
+		const { woocommerce_homepage_enabled: homepageOption } = getSetting(
+			'preloadOptions',
+			{}
+		);
+		const defaultPath =
+			window.wcAdminFeatures.homepage && homepageOption === 'yes'
+				? 'homepage'
+				: 'dashboard';
 		const path = query.path || defaultPath;
 		const screen = path.replace( '/analytics', '' ).replace( '/', '' );
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -25,6 +25,7 @@ import Header from 'header';
 import Notices from './notices';
 import { recordPageView } from 'lib/tracks';
 import TransientNotices from './transient-notices';
+import withWCApiSelect from 'wc-api/with-select';
 const StoreAlerts = lazy( () =>
 	import( /* webpackChunkName: "store-alerts" */ './store-alerts' )
 );
@@ -74,6 +75,7 @@ class _Layout extends Component {
 			installedPlugins,
 			isEmbedded,
 			isJetpackConnected,
+			homepageEnabled,
 		} = this.props;
 
 		if ( isEmbedded ) {
@@ -92,9 +94,7 @@ class _Layout extends Component {
 
 		// When pathname is `/` we are on the dashboard
 		if ( path.length === 0 ) {
-			path = window.wcAdminFeatures.homepage
-				? 'home_screen'
-				: 'dashboard';
+			path = homepageEnabled ? 'home_screen' : 'dashboard';
 		}
 
 		recordPageView( path, {
@@ -156,8 +156,9 @@ const Layout = compose(
 	withPluginsHydration( {
 		...( window.wcSettings.plugins || {} ),
 		jetpackStatus:
-			window.wcSettings.dataEndpoints &&
-			window.wcSettings.dataEndpoints.jetpackStatus || false,
+			( window.wcSettings.dataEndpoints &&
+				window.wcSettings.dataEndpoints.jetpackStatus ) ||
+			false,
 	} ),
 	withSelect( ( select, { isEmbedded } ) => {
 		// Embedded pages don't send plugin info to Tracks.
@@ -181,20 +182,18 @@ const Layout = compose(
 
 class _PageLayout extends Component {
 	render() {
+		const { homepageEnabled } = this.props;
 		return (
 			<Router history={ getHistory() }>
 				<Switch>
-					{ getPages().map( ( page ) => {
+					{ getPages( homepageEnabled ).map( ( page ) => {
 						return (
 							<Route
 								key={ page.path }
 								path={ page.path }
 								exact
 								render={ ( props ) => (
-									<Layout
-										page={ page }
-										{ ...props }
-									/>
+									<Layout page={ page } homepageEnabled={ homepageEnabled } { ...props } />
 								) }
 							/>
 						);
@@ -204,10 +203,19 @@ class _PageLayout extends Component {
 		);
 	}
 }
-// Use the useFilters HoC so PageLayout is re-rendered when filters are used to add new pages or reports
-export const PageLayout = useFilters( [ PAGES_FILTER, REPORTS_FILTER ] )(
-	_PageLayout
-);
+
+export const PageLayout = compose(
+	// Use the useFilters HoC so PageLayout is re-rendered when filters are used to add new pages or reports
+	useFilters( [ PAGES_FILTER, REPORTS_FILTER ] ),
+	withWCApiSelect( ( select ) => {
+		const { getOptions } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_homepage_enabled' ] );
+		const homepageEnabled =
+			window.wcAdminFeatures.homepage &&
+			get( options, [ 'woocommerce_homepage_enabled' ], false ) === 'yes';
+		return { homepageEnabled };
+	} )
+)( _PageLayout );
 
 export class EmbedLayout extends Component {
 	render() {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -209,10 +209,10 @@ export const PageLayout = compose(
 	useFilters( [ PAGES_FILTER, REPORTS_FILTER ] ),
 	withWCApiSelect( ( select ) => {
 		const { getOptions } = select( 'wc-api' );
-		const options = getOptions( [ 'woocommerce_homepage_enabled' ] );
+		const options = getOptions( [ 'woocommerce_homescreen_enabled' ] );
 		const homepageEnabled =
 			window.wcAdminFeatures.homepage &&
-			get( options, [ 'woocommerce_homepage_enabled' ], false ) === 'yes';
+			get( options, [ 'woocommerce_homescreen_enabled' ], false ) === 'yes';
 		return { homepageEnabled };
 	} )
 )( _PageLayout );

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Loader;
+
 /**
  * Contains backend logic for the Analytics feature.
  */
@@ -76,17 +78,17 @@ class Analytics {
 	 */
 	public function register_pages() {
 		$features = wc_admin_get_feature_config();
-
+		$homepage_enabled = Loader::is_homepage_enabled( $features );
 		$report_pages = array(
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
 				'path'     => '/analytics/overview',
-				'path'     => $features['homepage'] ? '/analytics/overview' : '/analytics/revenue',
+				'path'     => $homepage_enabled ? '/analytics/overview' : '/analytics/revenue',
 				'icon'     => 'dashicons-chart-bar',
 				'position' => 56, // After WooCommerce & Product menu items.
 			),
-			$features['homepage'] ? array(
+			$homepage_enabled ? array(
 				'id'       => 'woocommerce-analytics-overview',
 				'title'    => __( 'Overview', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Loader;
+
 /**
  * Contains backend logic for the dashboard feature.
  */
@@ -81,8 +83,9 @@ class AnalyticsDashboard {
 	 */
 	public function register_page() {
 		$features = wc_admin_get_feature_config();
-		$id       = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
-		$title    = $features['homepage'] ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
+		$homepage_enabled = Loader::is_homepage_enabled( $features );
+		$id       = $homepage_enabled ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$title    = $homepage_enabled ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
 
 		wc_admin_register_page(
 			array(

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -91,6 +91,8 @@ class Loader {
 		* Gutenberg has also disabled emojis. More on that here -> https://github.com/WordPress/gutenberg/pull/6151
 		*/
 		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 	}
 
 	/**
@@ -189,6 +191,29 @@ class Loader {
 	}
 
 	/**
+	 * Preload options to prime state of the application.
+	 *
+	 * @param array $options Array of options to preload.
+	 * @return array
+	 */
+	public function preload_options( $options ) {
+		$options[] = 'woocommerce_homepage_enabled';
+
+		return $options;
+	}
+
+	/**
+	 * Determine if homescreen is enabled.
+	 *
+	 * @param array $features Array of features returned from wc_admin_get_feature_config.
+	 * @return bool
+	 */
+	public static function is_homepage_enabled( $features ) {
+		$option = get_option( 'woocommerce_homepage_enabled', 'no' );
+		return $features['homepage'] && 'yes' === $option;
+	}
+
+	/**
 	 * Gets the URL to an asset file.
 	 *
 	 * @param  string $file File name (without extension).
@@ -251,7 +276,7 @@ class Loader {
 	 */
 	public static function register_page_handler() {
 		$features = wc_admin_get_feature_config();
-		$id = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$id = self::is_homepage_enabled( $features ) ? 'woocommerce-home' : 'woocommerce-dashboard';
 
 		wc_admin_register_page(
 			array(

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -197,7 +197,7 @@ class Loader {
 	 * @return array
 	 */
 	public function preload_options( $options ) {
-		$options[] = 'woocommerce_homepage_enabled';
+		$options[] = 'woocommerce_homescreen_enabled';
 
 		return $options;
 	}
@@ -209,7 +209,7 @@ class Loader {
 	 * @return bool
 	 */
 	public static function is_homepage_enabled( $features ) {
-		$option = get_option( 'woocommerce_homepage_enabled', 'no' );
+		$option = get_option( 'woocommerce_homescreen_enabled', 'no' );
 		return $features['homepage'] && 'yes' === $option;
 	}
 


### PR DESCRIPTION
Fix partially https://github.com/woocommerce/woocommerce-admin/issues/4303

https://github.com/woocommerce/woocommerce-admin/issues/4303 requires the homescreen to be turned off for old users and on for new users, so this PR adds an option to control homescreen display beyond just the feature flag.

The new option is `woocommerce_homescreen_enabled`

Here is the corresponding Core pull request, which is not required to test this PR.

https://github.com/woocommerce/woocommerce/pull/26625

### Detailed test instructions:

1. Visit the app and see there is no Home screen.
2. The sidebar links should be correct.
3. Set the `woocommerce_homescreen_enabled` option to `yes` and repeat 1, 2 but now the Homescreen should be accessible.

### Changelog Note:

Add a flag to optionally remove Homescreen
