### PR TITLE
Filters: Fix static query parameters

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -43,7 +43,7 @@ export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 export const filters = applyFilters( CATEGORY_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [],
+		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -34,7 +34,7 @@ export const charts = applyFilters( COUPON_REPORT_CHARTS_FILTER, [
 export const filters = applyFilters( COUPON_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [],
+		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -22,7 +22,7 @@ const CUSTOMERS_REPORT_ADVANCED_FILTERS_FILTER =
 export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [],
+		staticParams: [ 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -27,7 +27,7 @@ export const charts = applyFilters( DOWLOADS_REPORT_CHARTS_FILTER, [
 export const filters = applyFilters( DOWLOADS_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [],
+		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -49,7 +49,7 @@ export const charts = applyFilters( ORDERS_REPORT_CHARTS_FILTER, [
 export const filters = applyFilters( ORDERS_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [ 'chart' ],
+		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -42,7 +42,7 @@ export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 
 const filterConfig = {
 	label: __( 'Show', 'woocommerce-admin' ),
-	staticParams: [],
+	staticParams: [ 'chartType', 'paged', 'per_page' ],
 	param: 'filter',
 	showFilters: () => true,
 	filters: [
@@ -102,7 +102,7 @@ const variationsConfig = {
 		query.filter === 'single_product' &&
 		!! query.products &&
 		query[ 'is-variable' ],
-	staticParams: [ 'filter', 'products' ],
+	staticParams: [ 'filter', 'products', 'chartType', 'paged', 'per_page' ],
 	param: 'filter-variations',
 	filters: [
 		{

--- a/client/analytics/report/stock/config.js
+++ b/client/analytics/report/stock/config.js
@@ -13,7 +13,7 @@ export const showDatePicker = false;
 export const filters = applyFilters( STOCK_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [],
+		staticParams: [ 'paged', 'per_page' ],
 		param: 'type',
 		showFilters: () => true,
 		filters: [

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -50,7 +50,7 @@ export const charts = applyFilters( TAXES_REPORT_CHARTS_FILTER, [
 export const filters = applyFilters( TAXES_REPORT_FILTERS_FILTER, [
 	{
 		label: __( 'Show', 'woocommerce-admin' ),
-		staticParams: [ 'chart' ],
+		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -186,10 +186,14 @@ export class Controller extends Component {
 		const prevQuery = this.getQuery( prevProps.location.search );
 		const prevBaseQuery = omit(
 			this.getQuery( prevProps.location.search ),
+			'chartType',
+			'filter',
 			'paged'
 		);
 		const baseQuery = omit(
 			this.getQuery( this.props.location.search ),
+			'chartType',
+			'filter',
 			'paged'
 		);
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4422

Clicking on Filters changes query parameters and the Report updates to reflect new parameters. Certain query parameters should not change, such as `chartType`. For filters that do not create a new data query, `paged` and `per_page` should also remain in the url.

![Screen Shot 2020-05-28 at 3 53 23 PM](https://user-images.githubusercontent.com/1922453/83097186-97aaa580-a0fb-11ea-82dd-f15a5d8b28f3.png)

### Detailed test instructions:

1. Navigate to any report that has an `Advanced filters` option
2. Go to page 2 or select a non-default value for Rows per page.
3. Select Advanced filters.
4. The list should stay on page 2 before any filter selected or applied.
5. Now apply a filter. The page should now be at 1.

### Changelog Note:

Fix: Filters' static query parameters
