### PR TITLE
Import pluginNames from `@woocommerce/data`

### DIFF
--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -11,8 +11,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
-import { pluginNames } from 'wc-api/onboarding/constants';
+import { pluginNames, PLUGINS_STORE_NAME } from '@woocommerce/data';
 
 export class Plugins extends Component {
 	constructor() {
@@ -108,12 +107,7 @@ export class Plugins extends Component {
 	}
 
 	render() {
-		const {
-			isRequesting,
-			skipText,
-			autoInstall,
-			pluginSlugs,
-		} = this.props;
+		const { isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
 		const { hasErrors } = this.state;
 
 		if ( hasErrors ) {


### PR DESCRIPTION
PR #4433 deleted the `client/wc-api/onboarding/constants.js` file. Unfortunately, `packages/components/src/plugins/index.js ` was still importing `pluginNames` from it. So, wc-admin pages wouldn't load (you'd get a blank page) and you would get the following error:

```
ERROR in ./packages/components/build-module/plugins/index.js
[0] Module not found: Error: Can't resolve 'wc-api/onboarding/constants' in 'woocommerce-admin/packages/components/build-module/plugins'
```

I'm not sure how this snuck in!

This PR updates the import of `pluginNames` to get it from `@woocommerce/data`.

### Detailed test instructions:

- Run branch
- Try to load various wc-admin pages
- Verify that pages load correctly, without error

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog entry required.
