### PR TITLE
Use plugins store rather than getSettings

### DIFF
--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -84,8 +84,27 @@ function InstallJetpackCta( props ) {
 		);
 	}
 
-	if ( isDismissed || ( isJetpackInstalled && isJetpackActivated ) ) {
+	const doNotShow =
+		isDismissed ||
+		( isJetpackInstalled && isJetpackActivated && isJetpackConnected );
+	if ( doNotShow ) {
 		return null;
+	}
+
+	function getInstallJetpackText() {
+		if ( ! isJetpackInstalled ) {
+			return __( 'Get Jetpack', 'woocommerce-admin' );
+		}
+
+		if ( ! isJetpackActivated ) {
+			return __( 'Activate Jetpack', 'woocommerce-admin' );
+		}
+
+		if ( ! isJetpackConnected ) {
+			return __( 'Connect Jetpack', 'woocommerce-admin' );
+		}
+
+		return '';
 	}
 
 	return (
@@ -103,9 +122,7 @@ function InstallJetpackCta( props ) {
 			</p>
 			<footer>
 				<Button isPrimary onClick={ install } isBusy={ isInstalling }>
-					{ ! isJetpackInstalled
-						? __( 'Get Jetpack', 'woocommerce-admin' )
-						: __( 'Activate Jetpack', 'woocommerce-admin' ) }
+					{ getInstallJetpackText() }
 				</Button>
 				<Button onClick={ dismiss } isBusy={ isInstalling }>
 					{ __( 'No thanks', 'woocommerce-admin' ) }

--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
  * WooCommerce dependencies
  */
 import { H, Plugins } from '@woocommerce/components';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
 /**
@@ -24,6 +24,8 @@ import { recordEvent } from 'lib/tracks';
 
 function InstallJetpackCta( props ) {
 	const {
+		isJetpackInstalled,
+		isJetpackActivated,
 		isJetpackConnected,
 		getCurrentUserData,
 		updateCurrentUserData,
@@ -33,12 +35,6 @@ function InstallJetpackCta( props ) {
 	const [ isDismissed, setIsDismissed ] = useState(
 		( getCurrentUserData().homepage_stats || {} ).installJetpackDismissed
 	);
-	const plugins = getSetting( 'plugins', {
-		installedPlugins: [],
-		activePlugins: [],
-	} );
-	const isJetpackInstalled = plugins.installedPlugins.includes( 'jetpack' );
-	const isJetpackActivated = plugins.activePlugins.includes( 'jetpack' );
 
 	function install() {
 		setIsInstalling( true );
@@ -139,10 +135,16 @@ InstallJetpackCta.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { isJetpackConnected } = select( PLUGINS_STORE_NAME );
+		const {
+			isJetpackConnected,
+			getInstalledPlugins,
+			getActivePlugins,
+		} = select( PLUGINS_STORE_NAME );
 		const { getCurrentUserData } = select( 'wc-api' );
 
 		return {
+			isJetpackInstalled: getInstalledPlugins().includes( 'jetpack' ),
+			isJetpackActivated: getActivePlugins().includes( 'jetpack' ),
 			isJetpackConnected: isJetpackConnected(),
 			getCurrentUserData,
 		};

--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -77,9 +77,7 @@ function InstallJetpackCta( props ) {
 			<Connect
 				autoConnect
 				onError={ () => setIsConnecting( false ) }
-				redirectUrl={ getAdminLink(
-					'admin.php?page=wc-admin&reset-profiler=0'
-				) }
+				redirectUrl={ getAdminLink( 'admin.php?page=wc-admin' ) }
 			/>
 		);
 	}


### PR DESCRIPTION
Switch to the plugins store rather than `getSettings` in the Jetpack CTA.

### Detailed test instructions:

- Smoke test the Jetpack CTA, when the plugin is not installed, when it is installed but not activated, and when it is installed and activated (the CTA will disappear).
