### PR TITLE
Await profile items update in skip

### DIFF
--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -37,7 +37,6 @@ class Benefits extends Component {
 		this.state = {
 			isConnecting: false,
 			isInstalling: false,
-			isActioned: false,
 		};
 
 		this.isJetpackActive = props.activePlugins.includes( 'jetpack' );
@@ -62,11 +61,9 @@ class Benefits extends Component {
 
 	componentDidUpdate( prevProps, prevState ) {
 		const { goToNextStep } = this.props;
-		const { isActioned } = this.state;
 
 		// No longer pending or updating profile items, go to next step.
 		if (
-			isActioned &&
 			! this.isPending() &&
 			( prevProps.isRequesting ||
 				prevState.isConnecting ||
@@ -77,21 +74,21 @@ class Benefits extends Component {
 	}
 
 	isPending() {
-		const { isActioned, isConnecting, isInstalling } = this.state;
+		const { isConnecting, isInstalling } = this.state;
 		const { isRequesting } = this.props;
-		return isActioned && ( isConnecting || isInstalling || isRequesting );
+		return isConnecting || isInstalling || isRequesting;
 	}
 
 	async skipPluginInstall() {
 		const {
 			createNotice,
+			goToNextStep,
 			isProfileItemsError,
 			updateProfileItems,
 		} = this.props;
 
 		const plugins = this.isJetpackActive ? 'skipped-wcs' : 'skipped';
 		await updateProfileItems( { plugins } );
-		this.setState( { isActioned: true } );
 
 		if ( isProfileItemsError ) {
 			createNotice(
@@ -107,12 +104,14 @@ class Benefits extends Component {
 				plugins,
 			} );
 		}
+
+		goToNextStep();
 	}
 
 	async startPluginInstall() {
 		const { updateProfileItems, updateOptions } = this.props;
 
-		this.setState( { isActioned: true, isInstalling: true } );
+		this.setState( { isInstalling: true } );
 
 		await updateOptions( {
 			woocommerce_setup_jetpack_opted_in: true,


### PR DESCRIPTION
Fixes #4467 

Fixes the broken skip button on the benefits page.

This was occurring because `updateProfileItems` now returns a promise so the `await` that was previously broken began working.

This is part of the problem described in https://github.com/woocommerce/woocommerce-admin/issues/2959.  The current logic is still messy, #2959 can finally be resolved once https://github.com/woocommerce/woocommerce-admin/pull/4144 is merged in. 🎉 

### Detailed test instructions:

1. Disable Jetpack and/or WCS.
1. Enable the profiler and visit the last step.
1. Attempt to continue by skipping with "No thanks"
1. Reset the profiler.
1. Attempt to continue by installing plugins with "Yes please"