### PR TITLE
SelectControl: Select search result options by clicking on item text or icon in Firefox and Safari

### DIFF
--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -167,6 +167,7 @@ class List extends Component {
 				id={ listboxId }
 				role="listbox"
 				className={ listboxClasses }
+				tabIndex="-1"
 			>
 				{ options.map( ( option, index ) => (
 					<Button


### PR DESCRIPTION
This 

Fixes #4209

This PR fixes the issue where search results in the `SelectControl` could not be selected by clicking on the option text or icon in Firefox and Safari (it worked in Chrome).

I'm admittedly not 100% sure why setting `tabIndex="-1"` as I do in this PR is necessary for Firefox and Safari to work correctly. However, from testing, it appears that this doesn't cause any other side effects, so it appears to be a reasonable fix.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

#### Working correctly (how it should be now in all browsers)

![Selecting product from search dropdown in Chrome](https://user-images.githubusercontent.com/2098816/83274391-bceef080-a19b-11ea-9c0f-86489339a99d.gif)

#### Not working correctly (how it was before, in Firefox and Safari)

![Selecting product from search dropdown in Firefox](https://user-images.githubusercontent.com/2098816/83274404-c2e4d180-a19b-11ea-9dbf-4c5427b140e3.gif)

### Detailed test instructions:

- Run branch
- Verify that you can select items in places where the `SelectControl` is used to show search results, by clicking on the underlined text or icon, in Firefox, Safari, and Chrome. Some places:
    - WooCommerce / Analytics / Orders > Show > Advanced Filters > Add a Filter > Product
    - WooCommerce / Analytics / Products > Show > Single Product
    - WooCommerce / Analytics . Categories > Show > Single Category
    - Onboarding Wizard > Store Details > Country/Region

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Search results selectable by clicking on item text or icon.