### PR TITLE
Jetpack stats on home page

### DIFF
--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -30,7 +30,7 @@ import withSelect from 'wc-api/with-select';
 import './style.scss';
 import { recordEvent } from 'lib/tracks';
 import { CurrencyContext } from 'lib/currency-context';
-import { getIndicatorData, getIndictorValues } from './utils';
+import { getIndicatorData, getIndicatorValues } from './utils';
 
 const { performanceIndicators: indicators } = getSetting( 'dataEndpoints', {
 	performanceIndicators: [],
@@ -146,7 +146,7 @@ class StorePerformance extends Component {
 							secondaryValue,
 							delta,
 							reportUrl,
-						} = getIndictorValues( {
+						} = getIndicatorValues( {
 							indicator,
 							primaryData,
 							secondaryData,

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -146,6 +146,7 @@ class StorePerformance extends Component {
 							secondaryValue,
 							delta,
 							reportUrl,
+							reportUrlType,
 						} = getIndicatorValues( {
 							indicator,
 							primaryData,
@@ -159,6 +160,7 @@ class StorePerformance extends Component {
 							<SummaryNumber
 								key={ i }
 								href={ reportUrl }
+								hrefType={ reportUrlType }
 								label={ indicator.label }
 								value={ primaryValue }
 								prevLabel={ prevLabel }

--- a/client/dashboard/store-performance/utils.js
+++ b/client/dashboard/store-performance/utils.js
@@ -11,8 +11,23 @@ import { getCurrentDates, appendTimestamp } from '@woocommerce/date';
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { calculateDelta, formatValue } from '@woocommerce/number';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
-export const getIndictorValues = ( {
+function getReportUrl( href, persistedQuery, primaryItem ) {
+	if ( ! href ) {
+		return '';
+	}
+
+	if ( href === '/jetpack' ) {
+		return getAdminLink( 'admin.php?page=jetpack#/dashboard' );
+	}
+
+	return getNewPath( persistedQuery, href, {
+		chart: primaryItem.chart,
+	} );
+}
+
+export const getIndicatorValues = ( {
 	indicator,
 	primaryData,
 	secondaryData,
@@ -38,12 +53,8 @@ export const getIndictorValues = ( {
 			primaryItem._links.report[ 0 ] &&
 			primaryItem._links.report[ 0 ].href ) ||
 		'';
-	const reportUrl =
-		( href &&
-			getNewPath( persistedQuery, href, {
-				chart: primaryItem.chart,
-			} ) ) ||
-		'';
+	const reportUrl = getReportUrl( href, persistedQuery, primaryItem );
+	const reportUrlType = href === '/jetpack' ? 'wp-admin' : 'wc-admin';
 	const isCurrency = primaryItem.format === 'currency';
 
 	const delta = calculateDelta( primaryItem.value, secondaryItem.value );
@@ -58,6 +69,7 @@ export const getIndictorValues = ( {
 		secondaryValue,
 		delta,
 		reportUrl,
+		reportUrlType,
 	};
 };
 

--- a/client/homepage/stats-overview/defaults.js
+++ b/client/homepage/stats-overview/defaults.js
@@ -10,10 +10,14 @@ export const DEFAULT_STATS = applyFilters(
 		'revenue/net_revenue',
 		'orders/orders_count',
 		'products/items_sold',
+		'jetpack/stats/visitors',
+		'jetpack/stats/views',
 	]
 );
 
 export const DEFAULT_HIDDEN_STATS = [
 	'revenue/net_revenue',
 	'products/items_sold',
+	'jetpack/stats/visitors',
+	'jetpack/stats/views',
 ];

--- a/client/homepage/stats-overview/defaults.js
+++ b/client/homepage/stats-overview/defaults.js
@@ -18,6 +18,4 @@ export const DEFAULT_STATS = applyFilters(
 export const DEFAULT_HIDDEN_STATS = [
 	'revenue/net_revenue',
 	'products/items_sold',
-	'jetpack/stats/visitors',
-	'jetpack/stats/views',
 ];

--- a/client/homepage/stats-overview/stats-list.js
+++ b/client/homepage/stats-overview/stats-list.js
@@ -22,7 +22,7 @@ import { recordEvent } from 'lib/tracks';
 import { CurrencyContext } from 'lib/currency-context';
 import {
 	getIndicatorData,
-	getIndictorValues,
+	getIndicatorValues,
 } from 'dashboard/store-performance/utils';
 
 export const StatsList = ( {
@@ -62,7 +62,8 @@ export const StatsList = ( {
 					secondaryValue,
 					delta,
 					reportUrl,
-				} = getIndictorValues( {
+					reportUrlType,
+				} = getIndicatorValues( {
 					indicator: item,
 					primaryData,
 					secondaryData,
@@ -76,6 +77,7 @@ export const StatsList = ( {
 						isHomepage
 						key={ item.stat }
 						href={ reportUrl }
+						hrefType={ reportUrlType }
 						label={ item.label }
 						value={ primaryValue }
 						prevLabel={ __(

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -102,6 +102,8 @@ describe( 'StatsOverview toggle and persist stat preference', () => {
 				hiddenStats: [
 					'revenue/net_revenue',
 					'products/items_sold',
+					'jetpack/stats/visitors',
+					'jetpack/stats/views',
 					'revenue/total_sales',
 				],
 			},

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -102,8 +102,6 @@ describe( 'StatsOverview toggle and persist stat preference', () => {
 				hiddenStats: [
 					'revenue/net_revenue',
 					'products/items_sold',
-					'jetpack/stats/visitors',
-					'jetpack/stats/views',
 					'revenue/total_sales',
 				],
 			},

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -21,6 +21,7 @@ import Link from '../link';
 const SummaryNumber = ( {
 	delta,
 	href,
+	hrefType,
 	isOpen,
 	label,
 	onToggle,
@@ -81,6 +82,7 @@ const SummaryNumber = ( {
 			containerProps.href = href;
 			containerProps.role = 'menuitem';
 			containerProps.onClick = onLinkClickCallback;
+			containerProps.type = hrefType;
 		}
 	} else {
 		Container = 'div';
@@ -155,6 +157,11 @@ SummaryNumber.propTypes = {
 	 */
 	href: PropTypes.string,
 	/**
+	 * The type of the link
+	 */
+	hrefType: PropTypes.oneOf( [ 'wp-admin', 'wc-admin', 'external' ] )
+		.isRequired,
+	/**
 	 * Boolean describing whether the menu list is open. Only applies in mobile view,
 	 * and only applies to the toggle-able item (first in the list).
 	 */
@@ -196,6 +203,7 @@ SummaryNumber.propTypes = {
 
 SummaryNumber.defaultProps = {
 	href: '',
+	hrefType: 'wc-admin',
 	isOpen: false,
 	prevLabel: __( 'Previous Period:', 'woocommerce-admin' ),
 	reverseTrend: false,

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -231,6 +231,8 @@ class Controller extends \WC_REST_Reports_Controller {
 			$this->endpoints[ $endpoint ] = '/jetpack/v4/module/' . $item['module'] . '/data';
 			$this->formats[ $stat ]       = $item['format'];
 		}
+
+		$this->urls['jetpack/stats'] = '/jetpack';
 	}
 
 	/**


### PR DESCRIPTION
Adds Jetpack stats to the home page per https://github.com/woocommerce/woocommerce-admin/issues/4084

### Screenshots

![image](https://user-images.githubusercontent.com/224531/83481001-057e1500-a4e0-11ea-9894-aa850c94956d.png)

### Detailed test instructions:

- With Jetpack not connected, the Jetpack stats should not be available from the ellipsis menu
- With Jetpack connected, the Jetpack stats should be displayed by default and available from the ellipsis menu
- Clicking on either of the Jetpack stats should navigate to the Jetpack home page

### Changelog Note:

Enhancement: Add Jetpack stats to the home page
