### PR TITLE
Inbox panel on the home screen

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -154,7 +154,7 @@ class ActivityPanel extends Component {
 	getPanelContent( tab ) {
 		switch ( tab ) {
 			case 'inbox':
-				return <InboxPanel context="header" />;
+				return <InboxPanel />;
 			case 'orders':
 				const { hasUnreadOrders } = this.props;
 				return <OrdersPanel hasActionableOrders={ hasUnreadOrders } />;

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -154,7 +154,7 @@ class ActivityPanel extends Component {
 	getPanelContent( tab ) {
 		switch ( tab ) {
 			case 'inbox':
-				return <InboxPanel />;
+				return <InboxPanel context="header" />;
 			case 'orders':
 				const { hasUnreadOrders } = this.props;
 				return <OrdersPanel hasActionableOrders={ hasUnreadOrders } />;

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -18,7 +17,6 @@ import { EmptyContent, Section } from '@woocommerce/components';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { getUnreadNotesCount, hasValidNotes } from './utils';
-import classnames from 'classnames';
 
 class InboxPanel extends Component {
 	constructor( props ) {
@@ -88,8 +86,8 @@ class InboxPanel extends Component {
 
 	render() {
 		const {
-			context,
 			isError,
+			isPanelEmpty,
 			isRequesting,
 			isUndoRequesting,
 			isDismissAllUndoRequesting,
@@ -122,51 +120,44 @@ class InboxPanel extends Component {
 
 		const hasNotes = hasValidNotes( notes );
 
-		const panelClassName = classnames( {
-			'woocommerce-homepage-column is-inbox': context === 'homepage',
-		} );
+		const isActivityHeaderVisible =
+			hasNotes || isRequesting || isUndoRequesting;
 
-		const isActivityHeaderVisible = hasNotes || isRequesting || isUndoRequesting;
+		if ( isPanelEmpty ) {
+			isPanelEmpty( ! hasNotes && ! isActivityHeaderVisible );
+		}
 
 		return (
 			<Fragment>
-				{ ( context !== 'homepage' || isActivityHeaderVisible ) && (
-					<div className={ panelClassName }>
-						{ isActivityHeaderVisible && (
-							<ActivityHeader
-								title={ __( 'Inbox', 'woocommerce-admin' ) }
-								subtitle={ __(
-									'Insights and growth tips for your business',
-									'woocommerce-admin'
-								) }
-								unreadMessages={ getUnreadNotesCount(
-									notes,
-									lastRead
-								) }
-							/>
+				{ isActivityHeaderVisible && (
+					<ActivityHeader
+						title={ __( 'Inbox', 'woocommerce-admin' ) }
+						subtitle={ __(
+							'Insights and growth tips for your business',
+							'woocommerce-admin'
 						) }
-						<div className="woocommerce-homepage-notes-wrapper">
-							{ ( isRequesting || isDismissAllUndoRequesting ) && (
-								<Section>
-									<InboxNotePlaceholder className="banner message-is-unread" />
-								</Section>
-							) }
-							<Section>
-								{ ! isRequesting &&
-									! isDismissAllUndoRequesting &&
-									this.renderNotes( hasNotes ) }
-							</Section>
-						</div>
-					</div>
+						unreadMessages={ getUnreadNotesCount(
+							notes,
+							lastRead
+						) }
+					/>
 				) }
+				<div className="woocommerce-homepage-notes-wrapper">
+					{ ( isRequesting || isDismissAllUndoRequesting ) && (
+						<Section>
+							<InboxNotePlaceholder className="banner message-is-unread" />
+						</Section>
+					) }
+					<Section>
+						{ ! isRequesting &&
+							! isDismissAllUndoRequesting &&
+							this.renderNotes( hasNotes ) }
+					</Section>
+				</div>
 			</Fragment>
 		);
 	}
 }
-
-InboxPanel.propTypes = {
-	context: PropTypes.oneOf( [ 'homepage', 'header' ] ).isRequired,
-};
 
 export default compose(
 	withSelect( ( select ) => {

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import { EmptyContent, Section } from '@woocommerce/components';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { getUnreadNotesCount, hasValidNotes } from './utils';
+import classnames from 'classnames';
 
 class InboxPanel extends Component {
 	constructor( props ) {
@@ -86,6 +88,7 @@ class InboxPanel extends Component {
 
 	render() {
 		const {
+			context,
 			isError,
 			isRequesting,
 			isUndoRequesting,
@@ -119,35 +122,51 @@ class InboxPanel extends Component {
 
 		const hasNotes = hasValidNotes( notes );
 
+		const panelClassName = classnames( {
+			'woocommerce-homepage-column is-inbox': context === 'homepage',
+		} );
+
+		const isActivityHeaderVisible = hasNotes || isRequesting || isUndoRequesting;
+
 		return (
 			<Fragment>
-				{ ( hasNotes || isRequesting || isUndoRequesting ) && (
-					<ActivityHeader
-						title={ __( 'Inbox', 'woocommerce-admin' ) }
-						subtitle={ __(
-							'Insights and growth tips for your business',
-							'woocommerce-admin'
+				{ ( context !== 'homepage' || isActivityHeaderVisible ) && (
+					<div className={ panelClassName }>
+						{ isActivityHeaderVisible && (
+							<ActivityHeader
+								title={ __( 'Inbox', 'woocommerce-admin' ) }
+								subtitle={ __(
+									'Insights and growth tips for your business',
+									'woocommerce-admin'
+								) }
+								unreadMessages={ getUnreadNotesCount(
+									notes,
+									lastRead
+								) }
+							/>
 						) }
-						unreadMessages={ getUnreadNotesCount(
-							notes,
-							lastRead
-						) }
-					/>
+						<div className="woocommerce-homepage-notes-wrapper">
+							{ ( isRequesting || isDismissAllUndoRequesting ) && (
+								<Section>
+									<InboxNotePlaceholder className="banner message-is-unread" />
+								</Section>
+							) }
+							<Section>
+								{ ! isRequesting &&
+									! isDismissAllUndoRequesting &&
+									this.renderNotes( hasNotes ) }
+							</Section>
+						</div>
+					</div>
 				) }
-				{ ( isRequesting || isDismissAllUndoRequesting ) && (
-					<Section>
-						<InboxNotePlaceholder className="banner message-is-unread" />
-					</Section>
-				) }
-				<Section>
-					{ ! isRequesting &&
-						! isDismissAllUndoRequesting &&
-						this.renderNotes( hasNotes ) }
-				</Section>
 			</Fragment>
 		);
 	}
 }
+
+InboxPanel.propTypes = {
+	context: PropTypes.oneOf( [ 'homepage', 'header' ] ).isRequired,
+};
 
 export default compose(
 	withSelect( ( select ) => {

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -6,6 +6,29 @@
 	background: $core-grey-light-200;
 	border-radius: 2px;
 	@include font-size( 13 );
+	margin: 20px;
+	-ms-box-orient: horizontal;
+	&.banner {
+		-webkit-flex-direction: column;
+		flex-direction: column;
+		img {
+			width: 100%;
+			height: 120px;
+		}
+	}
+	&.thumbnail {
+		display: flex;
+		-webkit-flex-direction: row-reverse;
+		flex-direction: row-reverse;
+		img {
+			width: 128px;
+			height: 100%;
+		}
+	}
+
+	.woocommerce-homepage-column & {
+		margin: 20px 0;
+	}
 
 	&:not(.is-placeholder) {
 		border: 1px solid $light-gray-secondary;
@@ -152,34 +175,6 @@
 	}
 }
 
-
-.woocommerce-inbox-message {
-	margin: 20px;
-	-ms-box-orient: horizontal;
-	display: -webkit-box;
-	display: -moz-box;
-	display: -ms-flexbox;
-	&.banner {
-		-webkit-flex-direction: column;
-		flex-direction: column;
-		img {
-			width: 100%;
-			height: 120px;
-		}
-	}
-	&.thumbnail {
-		display: -moz-flex;
-		display: -webkit-flex;
-		display: flex;
-		-webkit-flex-direction: row-reverse;
-		flex-direction: row-reverse;
-		img {
-			width: 128px;
-			height: 100%;
-		}
-	}
-}
-
 .woocommerce-inbox-message__wrapper > div {
 	padding: $gap $gap-large;
 	.is-placeholder & {
@@ -194,6 +189,21 @@
 			@include placeholder();
 			width: 100%;
 			height: 120px;
+		}
+	}
+}
+
+.woocommerce-layout__inbox-panel-header {
+	.woocommerce-homepage-column & {
+		padding: 0 24px;
+	}
+}
+
+.woocommerce-homepage-notes-wrapper {
+	.is-inbox & {
+		height: calc(100% - 30px);
+		& > div {
+			overflow: auto;
 		}
 	}
 }

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -52,15 +52,31 @@ export const Layout = ( props ) => {
 		};
 	}, [] );
 
-	const { query, requestingTaskList, taskListComplete, taskListHidden } = props;
+	const {
+		isUndoRequesting,
+		query,
+		requestingTaskList,
+		taskListComplete,
+		taskListHidden,
+	} = props;
 	const isTaskListEnabled = taskListHidden === false && ! taskListComplete;
 	const isDashboardShown = ! isTaskListEnabled || ! query.task;
+
+	const isInboxPanelEmpty = ( isEmpty ) => {
+		setShowInbox( ! isEmpty );
+	};
+
+	if ( isUndoRequesting && ! showInbox ) {
+		setShowInbox( true );
+	}
 
 	const renderColumns = () => {
 		return (
 			<Fragment>
 				{ showInbox && (
-					<InboxPanel context="homepage" />
+					<div className="woocommerce-homepage-column is-inbox">
+						<InboxPanel isPanelEmpty={ isInboxPanelEmpty } />
+					</div>
 				) }
 				<div
 					className="woocommerce-homepage-column"
@@ -97,8 +113,7 @@ export const Layout = ( props ) => {
 		>
 			{ isDashboardShown
 				? renderColumns()
-				: isTaskListEnabled && renderTaskList()
-			}
+				: isTaskListEnabled && renderTaskList() }
 		</div>
 	);
 };
@@ -126,6 +141,7 @@ export default compose(
 	withSelect( ( select ) => {
 		const {
 			getOptions,
+			getUndoDismissRequesting,
 			isGetOptionsRequesting,
 		} = select( 'wc-api' );
 
@@ -134,14 +150,19 @@ export default compose(
 				'woocommerce_task_list_complete',
 				'woocommerce_task_list_hidden',
 			] );
-			
+			const { isUndoRequesting } = getUndoDismissRequesting();
 			return {
+				isUndoRequesting,
 				requestingTaskList: isGetOptionsRequesting( [
 					'woocommerce_task_list_complete',
 					'woocommerce_task_list_hidden',
 				] ),
-				taskListComplete: get( options, [ 'woocommerce_task_list_complete' ] ),
-				taskListHidden: get( options, [ 'woocommerce_task_list_hidden' ] ) === 'yes',
+				taskListComplete: get( options, [
+					'woocommerce_task_list_complete',
+				] ),
+				taskListHidden:
+					get( options, [ 'woocommerce_task_list_hidden' ] ) ===
+					'yes',
 			};
 		}
 

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -9,7 +9,6 @@ import {
 	useRef,
 	useEffect,
 } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import classnames from 'classnames';
 import { get } from 'lodash';
@@ -24,6 +23,7 @@ import './style.scss';
 import { isOnboardingEnabled } from 'dashboard/utils';
 import withSelect from 'wc-api/with-select';
 import TaskListPlaceholder from '../task-list/placeholder';
+import InboxPanel from '../header/activity-panel/panels/inbox';
 
 const TaskList = lazy( () =>
 	import( /* webpackChunkName: "task-list" */ '../task-list' )
@@ -60,24 +60,7 @@ export const Layout = ( props ) => {
 		return (
 			<Fragment>
 				{ showInbox && (
-					<div className="woocommerce-homepage-column is-inbox">
-						<div className="temp-content">
-							<Button
-								isPrimary
-								onClick={ () => {
-									setShowInbox( false );
-								} }
-							>
-								Dismiss All
-							</Button>
-						</div>
-						<div className="temp-content" />
-						<div className="temp-content" />
-						<div className="temp-content" />
-						<div className="temp-content" />
-						<div className="temp-content" />
-						<div className="temp-content" />
-					</div>
+					<InboxPanel context="homepage" />
 				) }
 				<div
 					className="woocommerce-homepage-column"

--- a/client/homepage/test/index.js
+++ b/client/homepage/test/index.js
@@ -10,6 +10,9 @@ jest.mock( 'homepage/stats-overview', () => jest.fn().mockReturnValue( null ) );
 // We aren't testing the <TaskList /> component here.
 jest.mock( 'task-list', () => jest.fn().mockReturnValue( '[TaskList]' ) );
 
+// We aren't testing the <InboxPanel /> component here.
+jest.mock( 'header/activity-panel/panels/inbox', () => jest.fn().mockReturnValue( '[InboxPanel]' ) );
+
 describe( 'Homepage Layout', () => {
 	it( 'should show TaskList placeholder when loading', () => {
 		const { container } = render(


### PR DESCRIPTION
Fixes #4097

This PR adds the Inbox panel on the home screen.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-06-03 at 15-21-51](https://user-images.githubusercontent.com/1314156/83674198-47758c80-a5ae-11ea-8156-af5451dd2ea8.gif)


### Detailed test instructions:
- Go to the WooCommerce Home page (URL `/wp-admin/admin.php?page=wc-admin`).
- The list of inbox notifications should be visible.
- If you want to add some notification types: `banner` and `thumbnail`, execute this sentence in your DB. By default, the notes are type `plain`.
````
INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `icon`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`) VALUES
('wc-admin-task-list-complete', 'info', 'en_US', 'Congratulations - your store is ready for launch!', 'You’re ready to take your first order - may the sales roll in!', 'notice', '{}', 'unactioned', 'woocommerce-admin', '2020-03-10 18:38:10', NULL, 0, 'thumbnail', 'https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTlm2mX1h6GfMnT9sDD9GsJB7of3MZw3UDzCAQM9EBepiJzyxXH&usqp=CAU'),
('wc-admin-marketing-intro', 'info', 'en_US', 'Connect with your audience', 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'speaker', '{}', 'unactioned', 'woocommerce-admin', '2020-04-09 16:08:41', NULL, 0, 'banner', 'https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSAK9Xg4L6FGmDAW5UVtVEv1IXKtGV3-rxYLfAzOBF-fMUdmyWz&usqp=CAU');
````
- There are 3 types of messages: `banner`, `thumbnail` and `plain`. Verify that every type looks as expected. 
- Verify that the messages have the right style for `read` and `unread` messages. To do this it's necessary to add a new message or change the `woocommerce_admin_activity_panel_inbox_last_read` in the `wp_usermeta` table.
You can use a sentence like this to set the `last read` value:
````
UPDATE `wp_usermeta` SET `meta_value` = '1581364679000' WHERE meta_key = 'woocommerce_admin_activity_panel_inbox_last_read'
````
- Verify that a dropdown with the options: `Dismiss this message` and `Dismiss all messages` is visible after pressing `Dissmis` for all the messages.
- Verify that a confirmation modal is visible after pressing any of the two dropdown options.
- Verfy that the events described [here](https://github.com/woocommerce/woocommerce-admin/pull/4320#issue-415245702) are tracked.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Homepage InboxPanel integration
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
