### PR TITLE
Onboarding profile rule

### DIFF
--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -46,6 +46,8 @@ class GetRuleProcessor {
 				return new WCAdminActiveForRuleProcessor();
 			case 'product_count':
 				return new ProductCountRuleProcessor();
+			case 'onboarding_profile':
+				return new OnboardingProfileRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/OnboardingProfileRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OnboardingProfileRuleProcessor.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Rule processor that performs a comparison operation against a value in the
+ * onboarding profile.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor that performs a comparison operation against a value in the
+ * onboarding profile.
+ */
+class OnboardingProfileRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Performs a comparison operation against a value in the onboarding
+	 * profile.
+	 *
+	 * @param object $rule         The rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile' );
+
+		if ( empty( $onboarding_profile ) ) {
+			return false;
+		}
+
+		if ( ! isset( $onboarding_profile[ $rule->index ] ) ) {
+			return false;
+		}
+
+		return ComparisonOperation::compare(
+			$onboarding_profile[ $rule->index ],
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->index ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/RemoteInboxNotifications/RuleEvaluator.php
+++ b/src/RemoteInboxNotifications/RuleEvaluator.php
@@ -30,12 +30,16 @@ class RuleEvaluator {
 	 * Evaluate the given rules as an AND operation - return false early if a
 	 * rule evaluates to false.
 	 *
-	 * @param array  $rules        The rules being processed.
-	 * @param object $stored_state Stored state.
+	 * @param array|object $rules        The rule or rules being processed.
+	 * @param object       $stored_state Stored state.
 	 *
 	 * @return bool The result of the operation.
 	 */
 	public function evaluate( $rules, $stored_state ) {
+		if ( ! is_array( $rules ) ) {
+			$rules = array( $rules );
+		}
+
 		if ( 0 === count( $rules ) ) {
 			return false;
 		}


### PR DESCRIPTION
Adds a rule that provides access to the onboarding profile.

### Detailed test instructions:

- Make sure you've downloaded the [latest test JSON file](https://gist.githubusercontent.com/becdetat/f17e9617e5ca1211d0579cf079862905/raw/1adef708c9bd16f928cde0e17383446c537f3bd9/rinds-specs.json) or just point the poller at that URL.
- Delete all of the admin notes (`DELETE FROM wp_wc_admin_notes`)
- Set up the onboarding to match PR #4455 
    - WCAdmin active for more than one day
    - setting up client false
    - product count zero
    - revenue none or up-to-2500 ($3000 in the dropdown)
- Run the `wc_admin_daily` cron task
- Check for the "Are you considering starting a dropshipping business?" notification


### Changelog Note:

Enhancement: Add onboarding profile remote inbox notification rule
