### PR TITLE
Inbox: Remove (duplicate) dismiss button on tracking opt-in note

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -91,3 +91,12 @@ function wc_admin_update_110_remove_facebook_note() {
 function wc_admin_update_110_db_version() {
 	Installer::update_db_version( '1.1.0' );
 }
+
+/**
+ * Remove Dismiss action from tracking opt-in admin note.
+ */
+function wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note() {
+	global $wpdb;
+
+	$wpdb->query( "DELETE actions FROM {$wpdb->prefix}wc_admin_note_actions actions INNER JOIN {$wpdb->prefix}wc_admin_notes notes USING (note_id) WHERE actions.name = 'tracking-dismiss' AND notes.name = 'wc-admin-usage-tracking-opt-in'" );
+}

--- a/src/Install.php
+++ b/src/Install.php
@@ -44,6 +44,9 @@ class Install {
 			'wc_admin_update_110_remove_facebook_note',
 			'wc_admin_update_110_db_version',
 		),
+		'1.3.0'  => array(
+			'wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note',
+		),
 	);
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -66,7 +66,6 @@ class WC_Admin_Notes_Tracking_Opt_In {
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'tracking-dismiss', __( 'Dismiss', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, false );
 		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 		return $note;
 	}


### PR DESCRIPTION
Fixes #4176

With the new inbox notification layout (#4099), every inbox note has a "Dismiss" button, so the "Help WooCommerce improve with usage tracking" note now has two "Dismiss" buttons. This PR removes the "Dismiss" button added explicitly for the tracking opt-in note, so that it only has the common "Dismiss" button as every other note does.

### Screenshots

#### Before

<img width="493" alt="ScreenCapture at Wed Jun 3 16:01:54 EDT 2020" src="https://user-images.githubusercontent.com/2098816/83776158-d5588280-a655-11ea-9188-ce49d7365391.png">

#### After

<img width="493" alt="ScreenCapture at Thu Jun 4 11:14:55 EDT 2020" src="https://user-images.githubusercontent.com/2098816/83776170-db4e6380-a655-11ea-8919-980026031083.png">

### Detailed test instructions

#### Scenarios
- New installation: opt-in note will be created after one week, with a single "Dismiss" button.
- Upgrade less than one week after initial installation: opt-in note will be created after one week, with a single "Dimiss" button.
- Upgrade greater than one week after initial installation: opt-in note, if currently in the inbox, will be modified to ensure only a single "Dismiss" button.

#### Steps
- Ensure your store is at least 1 week old (you can modify the `wc_admin_install_timestamp` option)
- Run branch
- Ensure you are opted *out of* tracking (WooCommerce > Settings > Advanced > WooCommerce.com)
- Use Crontrol plugin to run the `wc_admin_daily` job
- Verify that only the common "Dismiss" button exists on the opt-in note

Note: If you want to re-run the DB upgrade code for this PR, you will need to make sure any pending or completed actions for `wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note` are deleted (WooCommerce > Status > Scheduled Actions).

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note

No changelog note needed, as it is part of the new inbox layout, which should get its own changelog entry.
