### PR TITLE
Usage of URLSearchParams breaks in IE11

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -65,23 +65,30 @@ class InboxNoteCard extends Component {
 		}
 	}
 
+	getUrlParams() {
+		return window.location.search
+			.substr( 1 )
+			.split( '&' )
+			.reduce( ( params, query ) => {
+				const chunks = query.split( '=' );
+				const key = chunks[ 0 ];
+				let value = decodeURIComponent( chunks[ 1 ] );
+				value = isNaN( Number( value ) ) ? value : Number( value );
+				return ( params[ key ] = value ), params;
+			}, {} );
+	}
+
 	getScreenName() {
 		let screenName = '';
-		const urlParams = new URLSearchParams( window.location.search );
-
-		if ( urlParams.has( 'page' ) ) {
+		const urlParams = this.getUrlParams();
+		if ( urlParams.page ) {
 			const currentPage =
-				urlParams.get( 'page' ) === 'wc-admin'
-					? 'home_screen'
-					: urlParams.get( 'page' );
-			screenName = urlParams.has( 'path' )
-				? urlParams
-						.get( 'path' )
-						.replace( /\//g, '_' )
-						.substring( 1 )
+				urlParams.page === 'wc-admin' ? 'home_screen' : urlParams.page;
+			screenName = urlParams.path
+				? urlParams.path.replace( /\//g, '_' ).substring( 1 )
 				: currentPage;
-		} else if ( urlParams.has( 'post_type' ) ) {
-			screenName = urlParams.get( 'post_type' );
+		} else if ( urlParams.post_type ) {
+			screenName = urlParams.post_type;
 		}
 		return screenName;
 	}

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -65,23 +65,29 @@ class InboxNoteCard extends Component {
 		}
 	}
 
+	getUrlParams() {
+		return window.location.search
+			.substr( 1 )
+			.split( '&' )
+			.reduce( ( params, query ) => {
+				const chunks = query.split( '=' );
+				const key = chunks[ 0 ];
+				let value = decodeURIComponent( chunks[ 1 ] );
+				value = isNaN( Number( value ) ) ? value : Number( value );
+				return ( params[ key ] = value ), params;
+			}, {} );
+	}
+
 	getScreenName() {
 		let screenName = '';
-		const urlParams = new URLSearchParams( window.location.search );
-
-		if ( urlParams.has( 'page' ) ) {
-			const currentPage =
-				urlParams.get( 'page' ) === 'wc-admin'
-					? 'home_screen'
-					: urlParams.get( 'page' );
-			screenName = urlParams.has( 'path' )
-				? urlParams
-						.get( 'path' )
-						.replace( /\//g, '_' )
-						.substring( 1 )
+		const { page, path, post_type: postType } = this.getUrlParams();
+		if ( page ) {
+			const currentPage = page === 'wc-admin' ? 'home_screen' : page;
+			screenName = path
+				? path.replace( /\//g, '_' ).substring( 1 )
 				: currentPage;
-		} else if ( urlParams.has( 'post_type' ) ) {
-			screenName = urlParams.get( 'post_type' );
+		} else if ( postType ) {
+			screenName = postType;
 		}
 		return screenName;
 	}

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -17,6 +17,7 @@ import classnames from 'classnames';
 import { recordEvent } from 'lib/tracks';
 import './style.scss';
 import { H, Section } from '@woocommerce/components';
+import { getUrlParams } from 'utils';
 
 class InboxNoteCard extends Component {
 	constructor( props ) {
@@ -65,22 +66,11 @@ class InboxNoteCard extends Component {
 		}
 	}
 
-	getUrlParams() {
-		return window.location.search
-			.substr( 1 )
-			.split( '&' )
-			.reduce( ( params, query ) => {
-				const chunks = query.split( '=' );
-				const key = chunks[ 0 ];
-				let value = decodeURIComponent( chunks[ 1 ] );
-				value = isNaN( Number( value ) ) ? value : Number( value );
-				return ( params[ key ] = value ), params;
-			}, {} );
-	}
-
 	getScreenName() {
 		let screenName = '';
-		const { page, path, post_type: postType } = this.getUrlParams();
+		const { page, path, post_type: postType } = getUrlParams(
+			window.location.search
+		);
 		if ( page ) {
 			const currentPage = page === 'wc-admin' ? 'home_screen' : page;
 			screenName = path

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -65,30 +65,23 @@ class InboxNoteCard extends Component {
 		}
 	}
 
-	getUrlParams() {
-		return window.location.search
-			.substr( 1 )
-			.split( '&' )
-			.reduce( ( params, query ) => {
-				const chunks = query.split( '=' );
-				const key = chunks[ 0 ];
-				let value = decodeURIComponent( chunks[ 1 ] );
-				value = isNaN( Number( value ) ) ? value : Number( value );
-				return ( params[ key ] = value ), params;
-			}, {} );
-	}
-
 	getScreenName() {
 		let screenName = '';
-		const urlParams = this.getUrlParams();
-		if ( urlParams.page ) {
+		const urlParams = new URLSearchParams( window.location.search );
+
+		if ( urlParams.has( 'page' ) ) {
 			const currentPage =
-				urlParams.page === 'wc-admin' ? 'home_screen' : urlParams.page;
-			screenName = urlParams.path
-				? urlParams.path.replace( /\//g, '_' ).substring( 1 )
+				urlParams.get( 'page' ) === 'wc-admin'
+					? 'home_screen'
+					: urlParams.get( 'page' );
+			screenName = urlParams.has( 'path' )
+				? urlParams
+						.get( 'path' )
+						.replace( /\//g, '_' )
+						.substring( 1 )
 				: currentPage;
-		} else if ( urlParams.post_type ) {
-			screenName = urlParams.post_type;
+		} else if ( urlParams.has( 'post_type' ) ) {
+			screenName = urlParams.get( 'post_type' );
 		}
 		return screenName;
 	}

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -21,6 +21,7 @@ import { Spinner } from '@woocommerce/components';
  * Internal dependencies
  */
 import { getSetting } from '@woocommerce/wc-admin-settings';
+import { getUrlParams } from 'utils';
 
 const AnalyticsReport = lazy( () =>
 	import( /* webpackChunkName: "analytics-report" */ 'analytics/report' )
@@ -49,18 +50,6 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 export const getPages = ( homepageEnabled ) => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
-
-	const getUrlParams = ( locationSearch ) =>
-		locationSearch
-			.substr( 1 )
-			.split( '&' )
-			.reduce( ( params, query ) => {
-				const chunks = query.split( '=' );
-				const key = chunks[ 0 ];
-				let value = decodeURIComponent( chunks[ 1 ] );
-				value = isNaN( Number( value ) ) ? value : Number( value );
-				return ( params[ key ] = value ), params;
-			}, {} );
 
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -50,13 +50,24 @@ export const getPages = ( homepageEnabled ) => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
+	const getUrlParams = ( locationSearch ) =>
+		locationSearch
+			.substr( 1 )
+			.split( '&' )
+			.reduce( ( params, query ) => {
+				const chunks = query.split( '=' );
+				const key = chunks[ 0 ];
+				let value = decodeURIComponent( chunks[ 1 ] );
+				value = isNaN( Number( value ) ) ? value : Number( value );
+				return ( params[ key ] = value ), params;
+			}, {} );
+
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {
 			container: DevDocs,
 			path: '/devdocs',
 			breadcrumbs: ( { location } ) => {
-				const searchParams = new URLSearchParams( location.search );
-				const component = searchParams.get( 'component' );
+				const { component } = getUrlParams( location.search );
 
 				if ( component ) {
 					return [

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -50,25 +50,13 @@ export const getPages = ( homepageEnabled ) => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
-	const getUrlParams = ( locationSearch ) =>
-		locationSearch
-			.substr( 1 )
-			.split( '&' )
-			.reduce( ( params, query ) => {
-				const chunks = query.split( '=' );
-				const key = chunks[ 0 ];
-				let value = decodeURIComponent( chunks[ 1 ] );
-				value = isNaN( Number( value ) ) ? value : Number( value );
-				return ( params[ key ] = value ), params;
-			}, {} );
-
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {
 			container: DevDocs,
 			path: '/devdocs',
 			breadcrumbs: ( { location } ) => {
-				const searchParams = getUrlParams( location.search );
-				const component = searchParams.component;
+				const searchParams = new URLSearchParams( location.search );
+				const component = searchParams.get( 'component' );
 
 				if ( component ) {
 					return [

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -50,13 +50,25 @@ export const getPages = ( homepageEnabled ) => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
+	const getUrlParams = ( locationSearch ) =>
+		locationSearch
+			.substr( 1 )
+			.split( '&' )
+			.reduce( ( params, query ) => {
+				const chunks = query.split( '=' );
+				const key = chunks[ 0 ];
+				let value = decodeURIComponent( chunks[ 1 ] );
+				value = isNaN( Number( value ) ) ? value : Number( value );
+				return ( params[ key ] = value ), params;
+			}, {} );
+
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {
 			container: DevDocs,
 			path: '/devdocs',
 			breadcrumbs: ( { location } ) => {
-				const searchParams = new URLSearchParams( location.search );
-				const component = searchParams.get( 'component' );
+				const searchParams = getUrlParams( location.search );
+				const component = searchParams.component;
 
 				if ( component ) {
 					return [

--- a/client/utils/README.md
+++ b/client/utils/README.md
@@ -1,0 +1,4 @@
+Utils
+=========
+
+This folder contains general utils.

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -1,0 +1,15 @@
+export function getUrlParams( locationSearch ) {
+	if ( locationSearch ) {
+		return locationSearch
+			.substr( 1 )
+			.split( '&' )
+			.reduce( ( params, query ) => {
+				const chunks = query.split( '=' );
+				const key = chunks[ 0 ];
+				let value = decodeURIComponent( chunks[ 1 ] );
+				value = isNaN( Number( value ) ) ? value : Number( value );
+				return ( params[ key ] = value ), params;
+			}, {} );
+	}
+	return {};
+}

--- a/client/utils/test/index.js
+++ b/client/utils/test/index.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { getUrlParams } from '../index';
+
+describe( 'getUrlParams', () => {
+	let locationSearch = '?param1=text1&param2=text2';
+
+	test( 'should return an object with sent params', () => {
+		const { param1, param2 } = getUrlParams( locationSearch );
+		expect( param1 ).toEqual( 'text1' );
+		expect( param2 ).toEqual( 'text2' );
+	} );
+
+	test( 'should return an object with 2 keys/params', () => {
+		const params = getUrlParams( locationSearch );
+		expect( Object.keys( params ).length ).toEqual( 2 );
+	} );
+
+	test( 'should return an empty object', () => {
+		locationSearch = '';
+		const params = getUrlParams( locationSearch );
+		expect( Object.keys( params ).length ).toEqual( 0 );
+	} );
+
+	test( 'should return an object with key "no_value" equal to "undefined"', () => {
+		locationSearch = 'no_value';
+		const { no_value: noValue } = getUrlParams( locationSearch );
+		expect( noValue ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Fixes #4497

This PR removes the method `URLSearchParams` (not compatible with IE 11) to use something compatible.
This method was used on the new `Inbox notes` and on the `layout controller`.

### Detailed test instructions:
- Using IE 11.
- Go to `WooCommerce`| `Documentation` | `search-list-control` (URL `/wp-admin/admin.php?page=wc-admin&path=%2Fdevdocs&component=search-list-control`)
- Verify the page loaded normally.
- Press the `Inbox` button that is in the header.
- Verify the error `'URLSearchParams' is undefined ` is not present in the console.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Removed URLSearchParams method
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
