### PR TITLE
Inbox notification: fixed Dismiss dropdowns for IE 11

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -150,6 +150,7 @@ class InboxNoteCard extends Component {
 	renderDismissButton() {
 		return (
 			<Dropdown
+				contentClassName="woocommerce-admin-dismiss-dropdown"
 				position="bottom right"
 				renderToggle={ ( { onClose, onToggle } ) => (
 					<Button

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -131,9 +131,13 @@ class InboxNoteCard extends Component {
 			'woocommerce-admin-dismiss-notification',
 			'components-popover__content',
 		];
-		const isClickOutsideDropdown = event.relatedTarget
+		// This line is for IE compatibility.
+		const relatedTarget = event.relatedTarget
+			? event.relatedTarget
+			: document.activeElement;
+		const isClickOutsideDropdown = relatedTarget
 			? dropdownClasses.some( ( className ) =>
-					event.relatedTarget.className.includes( className )
+					relatedTarget.className.includes( className )
 			  )
 			: false;
 		if ( isClickOutsideDropdown ) {

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -197,3 +197,16 @@
 		}
 	}
 }
+
+// Tweak to fix dropdown and placeholder in IE 11
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+	.woocommerce-admin-dismiss-dropdown {
+		margin-top: 0;
+	}
+
+	.woocommerce-inbox-message__wrapper {
+		.is-placeholder & {
+			padding-bottom: 10px;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4503

This PR adds a refactor in the method "handleBlur" for IE compatibility.

### Screenshots
![Screen Capture on 2020-06-04 at 17-44-52](https://user-images.githubusercontent.com/1314156/83811921-0a35fb00-a691-11ea-8c1d-30d0aaba2dc0.gif)

### Detailed test instructions:
- Using IE 11, open the Inbox panel, pressing Inbox.
- Click on `Dismiss`.
- Choose one of the two options.
- A confirmation dialog should be visible.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Inbox notification: fixed Dismiss dropdowns for IE 11
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
