### PR TITLE
Don't show store location in the tax and shipping tasks if it's already been provided

### DIFF
--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -111,7 +111,12 @@ class Shipping extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { countryCode } = this.props;
+		const { countryCode, settings } = this.props;
+		const {
+			woocommerce_store_address: storeAddress,
+			woocommerce_default_country: defaultCountry,
+			woocommerce_store_postcode: storePostCode,
+		} = settings;
 		const { step } = this.state;
 
 		if (
@@ -120,6 +125,14 @@ class Shipping extends Component {
 				prevState.step !== 'rates' )
 		) {
 			this.fetchShippingZones();
+		}
+
+		const isCompleteAddress = Boolean(
+			storeAddress && defaultCountry && storePostCode
+		);
+
+		if ( step === 'store_location' && isCompleteAddress ) {
+			this.completeStep();
 		}
 	}
 

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -92,7 +92,12 @@ class Tax extends Component {
 			taxSettings,
 			isGeneralSettingsRequesting,
 		} = this.props;
-		const { woocommerce_calc_taxes: calcTaxes } = generalSettings;
+		const {
+			woocommerce_calc_taxes: calcTaxes,
+			woocommerce_store_address: storeAddress,
+			woocommerce_default_country: defaultCountry,
+			woocommerce_store_postcode: storePostCode,
+		} = generalSettings;
 		const { stepIndex } = this.state;
 		const currentStep = this.getSteps()[ stepIndex ];
 		const currentStepKey = currentStep && currentStep.key;
@@ -126,6 +131,14 @@ class Tax extends Component {
 		}
 
 		if ( currentStepKey === 'connect' && isJetpackConnected ) {
+			this.completeStep();
+		}
+
+		const isCompleteAddress = Boolean(
+			storeAddress && defaultCountry && storePostCode
+		);
+
+		if ( currentStepKey === 'store_location' && isCompleteAddress ) {
 			this.completeStep();
 		}
 


### PR DESCRIPTION
Fixes #4186

This skips the store location step in the tax and shipping tasks if the address has already been provided in the OBW.

The change to _not_ skip the step was made [here](https://github.com/woocommerce/woocommerce-admin/commit/d2f180f3b8835106ed4b4a3d309762ab56fb3f49) but that decision has been reversed (see discussion in #4186).

### Detailed test instructions:

- I had to hardcode `isTasklListEnabled` to `true` in `client/dashboard/customizable.js:307` to be able to see the task list, not sure if that's a bug or just the current expected experience
- Don't run through the OBW, or if you already have, execute `delete from wp_options where option_name = 'woocommerce_store_address'` to clear the address 1 value.
- Open the tax and shipping tasks and verify that the store location step is not skipped
- Rerun the OBW and set the address
- Open the tax and shipping tasks. The store location step should be skipped.

### Changelog Note:

Improvement: Don't show store location step in tax and shipping tasks if the address has already been provided