### PR TITLE
Home Screen: Only show "Store management" (Quick Links) card if "Store setup" (Task List) card is not shown.

### DIFF
--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -87,7 +87,7 @@ export const Layout = ( props ) => {
 				>
 					{ isTaskListEnabled && renderTaskList() }
 					<StatsOverview />
-					<QuickLinks />
+					{ ! isTaskListEnabled && <QuickLinks /> }
 				</div>
 			</Fragment>
 		);
@@ -151,6 +151,7 @@ export default compose(
 				'woocommerce_task_list_hidden',
 			] );
 			const { isUndoRequesting } = getUndoDismissRequesting();
+
 			return {
 				isUndoRequesting,
 				requestingTaskList: isGetOptionsRequesting( [


### PR DESCRIPTION
This PR updates the home screen to only show the "Store management"  (Quick Links) card if the "Store setup" (Task List) card is not shown. This is how things were intended in the design (pbIJXs-4Z-p2):

> The quick links card is revealed when one of the following two conditions are met:
> 1. The task list has been completed and consequently removed from the home screen
> 2. The task list has been dismissed manually, via the ellipsis menu

### Screenshots

"Store setup" shown, "Store managment" hidden:

<img width="980" alt="ScreenCapture at Fri Jun 5 12:14:25 EDT 2020" src="https://user-images.githubusercontent.com/2098816/83899645-ce4d7500-a726-11ea-9406-60eb9ef75be2.png">

"Store setup" hidden, "Store management" shown:

<img width="977" alt="ScreenCapture at Fri Jun 5 12:14:39 EDT 2020" src="https://user-images.githubusercontent.com/2098816/83899659-d3122900-a726-11ea-87ef-b48492cf2f73.png">

### Detailed test instructions:

- Run branch
- Make sure home screen is enabled
```
wp option update woocommerce_homescreen_enabled yes
```
- Verify that "Store management" is only shown when "Store setup" is not shown.
    - Note: New onboarding experience needs to be enabled for the "Store setup" to be possibly shown.
    - Note: To quickly toggle the "Store setup" card to be visible again, you can set options:

```
wp option delete woocommerce_task_list_complete
wp option update woocommerce_task_list_hidden no
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog entry needed, as this is part of the broader new home screen feature.