### PR TITLE
Update task list title

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -355,7 +355,7 @@ class TaskDashboard extends Component {
 								<CardHeader>
 									<H>
 										{ __(
-											'Store setup',
+											'Finish setup',
 											'woocommerce-admin'
 										) }
 									</H>


### PR DESCRIPTION
Updates the title of the task list card on the home screen to read "Finish setup" rather than "Store setup".

This makes it feel like more of a continuation from the OBW.