### PR TITLE
Add custom autocompleter support to Search component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `<AnimationSlider />` example code.
 - Add `<Plugins />` component for installation of plugins.
 - Removed use of `IconButton` in favor of `Button` component.
+- Add custom autocompleter support to `<Search />` component.
 
 ## Breaking Changes
 - Removed `SplitButton` because its not being used.

--- a/packages/components/src/search/README.md
+++ b/packages/components/src/search/README.md
@@ -23,7 +23,7 @@ Name | Type | Default | Description
 `className` | String | `null` | Class name applied to parent div
 `onChange` | Function | `noop` | Function called when selected results change, passed result list
 `type` | One of: 'categories', 'countries', 'coupons', 'customers', 'downloadIps', 'emails', 'orders', 'products', 'taxes', 'usernames', 'variations', 'custom' | `null` | (required) The object type to be used in searching
-`autocompleter` | Completer | `{}` | Custom [completer](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface) to be used in searching when `type` is 'custom'
+`autocompleter` | Completer | `null` | Custom [completer](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface) to be used in searching. Required when `type` is 'custom'
 `placeholder` | String | `null` | A placeholder for the search input
 `selected` | Array | `[]` | An array of objects describing selected values. If the label of the selected value is omitted, the Tag of that value will not be rendered inside the search box.
 `inlineTags` | Boolean | `false` | Render tags inside input, otherwise render below input

--- a/packages/components/src/search/README.md
+++ b/packages/components/src/search/README.md
@@ -22,7 +22,8 @@ Name | Type | Default | Description
 `allowFreeTextSearch` | Boolean | `false` | Render additional options in the autocompleter to allow free text entering depending on the type
 `className` | String | `null` | Class name applied to parent div
 `onChange` | Function | `noop` | Function called when selected results change, passed result list
-`type` | One of: 'categories', 'countries', 'coupons', 'customers', 'downloadIps', 'emails', 'orders', 'products', 'taxes', 'usernames', 'variations' | `null` | (required) The object type to be used in searching
+`type` | One of: 'categories', 'countries', 'coupons', 'customers', 'downloadIps', 'emails', 'orders', 'products', 'taxes', 'usernames', 'variations', 'custom' | `null` | (required) The object type to be used in searching
+`autocompleter` | Completer | `{}` | Custom [completer](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface) to be used in searching when `type` is 'custom'
 `placeholder` | String | `null` | A placeholder for the search input
 `selected` | Array | `[]` | An array of objects describing selected values. If the label of the selected value is omitted, the Tag of that value will not be rendered inside the search box.
 `inlineTags` | Boolean | `false` | Render tags inside input, otherwise render below input

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -64,6 +64,14 @@ export class Search extends Component {
 			case 'variations':
 				return variations;
 			case 'custom':
+				if (
+					! this.props.autocompleter ||
+					typeof this.props.autocompleter !== 'object'
+				) {
+					throw new Error(
+						"Invalid autocompleter provided to Search component, it requires a completer object when using 'custom' type."
+					);
+				}
 				return this.props.autocompleter;
 			default:
 				return {};

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -250,7 +250,6 @@ Search.defaultProps = {
 	showClearButton: false,
 	staticResults: false,
 	disabled: false,
-	autocompleter: {},
 };
 
 export default Search;

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -63,6 +63,8 @@ export class Search extends Component {
 				return usernames;
 			case 'variations':
 				return variations;
+			case 'custom':
+				return this.props.autocompleter;
 			default:
 				return {};
 		}
@@ -200,7 +202,12 @@ Search.propTypes = {
 		'taxes',
 		'usernames',
 		'variations',
+		'custom',
 	] ).isRequired,
+	/**
+	 * The custom autocompleter to be used in searching when type is 'custom'
+	 */
+	autocompleter: PropTypes.object,
 	/**
 	 * A placeholder for the search input.
 	 */
@@ -243,6 +250,7 @@ Search.defaultProps = {
 	showClearButton: false,
 	staticResults: false,
 	disabled: false,
+	autocompleter: {},
 };
 
 export default Search;


### PR DESCRIPTION
This PR updates the Search component to allow for custom autocompleters, so it can be extended further than the default ones. This is needed for some WCPay reports that rely on other APIs.

### Detailed test instructions:

- Include the Search component with `type="custom"` and provide a custom `autocompleter` ([see default ones](https://github.com/woocommerce/woocommerce-admin/tree/master/packages/components/src/search/autocompleters))
- Results should be suggested when something is typed in the search field, based on the custom autocompleter provided

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
Tweak - Add custom autocompleter support to Search component
