### PR TITLE
Runtime feature config override

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -5,10 +5,6 @@ IS_CUSTOM_BUILD=false;
 SLUG='';
 
 while [ $# -gt 0 ]; do
-	if [[ $1 == '-f' || $1 == '--features' ]]; then
-		export WC_ADMIN_ADDITIONAL_FEATURES="$2"
-		IS_CUSTOM_BUILD=true
-	fi
 	if [[ $1 == '-s' || $1 == '--slug' ]]; then
 		IS_CUSTOM_BUILD=true
 		SLUG=$2
@@ -51,7 +47,6 @@ read -r VERSION
 if [ $IS_CUSTOM_BUILD = true ]; then
 	PLUGIN_TAG="${VERSION}-${SLUG}"
 
-	warning "You are building a custom build of wc-admin with these features ${GREEN_BOLD}$WC_ADMIN_ADDITIONAL_FEATURES${YELLOW_BOLD} applied."
 	warning "A release on Github will be made with the tag ${GREEN_BOLD}$PLUGIN_TAG${COLOR_RESET}"
 	warning "The resulting zip will be called ${GREEN_BOLD}$ZIP_FILE${COLOR_RESET}"
 else

--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -20,15 +20,6 @@ if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 $config_json = file_get_contents( 'config/' . $phase . '.json' );
 $config      = json_decode( $config_json );
 
-if ( ! empty( getenv( 'WC_ADMIN_ADDITIONAL_FEATURES' ) ) ) {
-	$additional_features = json_decode( getenv( 'WC_ADMIN_ADDITIONAL_FEATURES' ), true );
-	if ( is_array( $additional_features ) ) {
-		foreach ( $additional_features as $feature => $enabled ) {
-			$config->features->$feature = $enabled;
-		}
-	}
-}
-
 $write  = "<?php\n";
 $write .= "// WARNING: Do not directly edit this file.\n";
 $write .= "// This file is auto-generated as part of the build process and things may break.\n";

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -32,11 +32,11 @@ const ProfileWizard = lazy( () =>
 
 class Dashboard extends Component {
 	render() {
-		const { path, profileItems, query, homepageEnabled } = this.props;
+		const { path, profileItems, query } = this.props;
 		if (
 			isOnboardingEnabled() &&
 			! profileItems.completed &&
-			! homepageEnabled
+			! window.wcAdminFeatures.homepage
 		) {
 			return (
 				<Suspense fallback={ <Spinner /> }>

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -20,7 +20,6 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings';
 import { getUrlParams } from 'utils';
 
 const AnalyticsReport = lazy( () =>
@@ -47,7 +46,7 @@ const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
 
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
-export const getPages = ( homepageEnabled ) => {
+export const getPages = () => {
 	const pages = [];
 	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
@@ -74,7 +73,7 @@ export const getPages = ( homepageEnabled ) => {
 
 	if (
 		window.wcAdminFeatures[ 'analytics-dashboard' ] &&
-		! homepageEnabled
+		! window.wcAdminFeatures.homepage
 	) {
 		pages.push( {
 			container: Dashboard,
@@ -87,7 +86,7 @@ export const getPages = ( homepageEnabled ) => {
 		} );
 	}
 
-	if ( homepageEnabled ) {
+	if ( window.wcAdminFeatures.homepage ) {
 		pages.push( {
 			container: Homepage,
 			path: '/',
@@ -100,7 +99,7 @@ export const getPages = ( homepageEnabled ) => {
 	}
 
 	if ( window.wcAdminFeatures.analytics ) {
-		if ( homepageEnabled ) {
+		if ( window.wcAdminFeatures.homepage ) {
 			pages.push( {
 				container: Dashboard,
 				path: '/analytics/overview',
@@ -116,7 +115,7 @@ export const getPages = ( homepageEnabled ) => {
 			} );
 		}
 		const ReportWpOpenMenu = `toplevel_page_wc-admin-path--analytics-${
-			homepageEnabled ? 'overview' : 'revenue'
+			window.wcAdminFeatures.homepage ? 'overview' : 'revenue'
 		}`;
 
 		pages.push( {
@@ -218,7 +217,7 @@ export class Controller extends Component {
 	}
 
 	render() {
-		const { page, match, location, homepageEnabled } = this.props;
+		const { page, match, location } = this.props;
 		const { url, params } = match;
 		const query = this.getQuery( location.search );
 
@@ -231,7 +230,6 @@ export class Controller extends Component {
 					path={ url }
 					pathMatch={ page.path }
 					query={ query }
-					homepageEnabled={ homepageEnabled }
 				/>
 			</Suspense>
 		);
@@ -252,12 +250,8 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const { woocommerce_homescreen_enabled: homepageOption } = getSetting(
-			'preloadOptions',
-			{}
-		);
 		const defaultPath =
-			window.wcAdminFeatures.homepage && homepageOption === 'yes'
+			window.wcAdminFeatures.homepage
 				? 'homepage'
 				: 'dashboard';
 		const path = query.path || defaultPath;

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -15,7 +15,6 @@ import { useFilters, Spinner } from '@woocommerce/components';
 import { getHistory } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import {
-	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
 	withPluginsHydration,
 	withOptionsHydration,
@@ -97,7 +96,9 @@ class _Layout extends Component {
 
 		// When pathname is `/` we are on the dashboard
 		if ( path.length === 0 ) {
-			path = window.wcAdminFeatures.homepage ? 'home_screen' : 'dashboard';
+			path = window.wcAdminFeatures.homepage
+				? 'home_screen'
+				: 'dashboard';
 		}
 
 		recordPageView( path, {
@@ -213,7 +214,7 @@ export const PageLayout = compose(
 		? withOptionsHydration( {
 				...window.wcSettings.preloadOptions,
 		  } )
-		: identity,
+		: identity
 )( _PageLayout );
 
 export class EmbedLayout extends Component {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -79,7 +79,6 @@ class _Layout extends Component {
 			installedPlugins,
 			isEmbedded,
 			isJetpackConnected,
-			homepageEnabled,
 		} = this.props;
 
 		if ( isEmbedded ) {
@@ -98,7 +97,7 @@ class _Layout extends Component {
 
 		// When pathname is `/` we are on the dashboard
 		if ( path.length === 0 ) {
-			path = homepageEnabled ? 'home_screen' : 'dashboard';
+			path = window.wcAdminFeatures.homepage ? 'home_screen' : 'dashboard';
 		}
 
 		recordPageView( path, {
@@ -186,22 +185,17 @@ const Layout = compose(
 
 class _PageLayout extends Component {
 	render() {
-		const { homepageEnabled } = this.props;
 		return (
 			<Router history={ getHistory() }>
 				<Switch>
-					{ getPages( homepageEnabled ).map( ( page ) => {
+					{ getPages().map( ( page ) => {
 						return (
 							<Route
 								key={ page.path }
 								path={ page.path }
 								exact
 								render={ ( props ) => (
-									<Layout
-										page={ page }
-										homepageEnabled={ homepageEnabled }
-										{ ...props }
-									/>
+									<Layout page={ page } { ...props } />
 								) }
 							/>
 						);
@@ -220,13 +214,6 @@ export const PageLayout = compose(
 				...window.wcSettings.preloadOptions,
 		  } )
 		: identity,
-	withSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
-		const homepageEnabled =
-			window.wcAdminFeatures.homepage &&
-			getOption( 'woocommerce_homescreen_enabled' ) === 'yes';
-		return { homepageEnabled };
-	} )
 )( _PageLayout );
 
 export class EmbedLayout extends Component {

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -199,7 +199,7 @@ class FeaturePlugin {
 	 * Set up our admin hooks and plugin loader.
 	 */
 	protected function hooks() {
-		add_filter( 'woocommerce_admin_features', array( $this, 'replace_supported_features' ) );
+		add_filter( 'woocommerce_admin_features', array( $this, 'replace_supported_features' ), 0 );
 		add_action( 'admin_menu', array( $this, 'register_devdocs_page' ) );
 
 		new Loader();

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -77,8 +77,7 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
-		$features = wc_admin_get_feature_config();
-		$homepage_enabled = Loader::is_homepage_enabled( $features );
+		$homepage_enabled = Loader::is_feature_enabled( 'homepage' );
 		$report_pages = array(
 			array(
 				'id'       => 'woocommerce-analytics',

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -82,10 +82,8 @@ class AnalyticsDashboard {
 	 * Registers dashboard page.
 	 */
 	public function register_page() {
-		$features = wc_admin_get_feature_config();
-		$homepage_enabled = Loader::is_homepage_enabled( $features );
-		$id       = $homepage_enabled ? 'woocommerce-home' : 'woocommerce-dashboard';
-		$title    = $homepage_enabled ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
+		$id       = Loader::is_feature_enabled( 'homepage' ) ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$title    = Loader::is_feature_enabled( 'homepage' ) ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
 
 		wc_admin_register_page(
 			array(

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -491,6 +491,10 @@ class Loader {
 			return;
 		}
 
+		wp_add_inline_script( WC_ADMIN_APP,
+			'window.wcAdminFeatures = ' . json_encode( self::get_enabled_features() )
+		, 'before' );
+
 		wp_enqueue_script( WC_ADMIN_APP );
 		wp_enqueue_style( WC_ADMIN_APP );
 		wp_enqueue_style( 'wc-material-icons' );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -476,9 +476,12 @@ class Loader {
 			return;
 		}
 
-		wp_add_inline_script( WC_ADMIN_APP,
-			'window.paul = ' . json_encode( self::get_features() )
-		, 'before' );
+		$features        = self::get_features();
+		$features_object = array();
+		foreach ( $features as $key ) {
+			$features_object[ $key ] = true;
+		}
+		wp_add_inline_script( WC_ADMIN_APP, 'window.wcAdminFeatures = ' . wp_json_encode( $features_object ), 'before' );
 
 		wp_enqueue_script( WC_ADMIN_APP );
 		wp_enqueue_style( WC_ADMIN_APP );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -91,8 +91,6 @@ class Loader {
 		* Gutenberg has also disabled emojis. More on that here -> https://github.com/WordPress/gutenberg/pull/6151
 		*/
 		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
-
-		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 	}
 
 	/**
@@ -192,18 +190,6 @@ class Loader {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Preload options to prime state of the application.
-	 *
-	 * @param array $options Array of options to preload.
-	 * @return array
-	 */
-	public function preload_options( $options ) {
-		$options[] = 'woocommerce_homescreen_enabled';
-
-		return $options;
 	}
 
 	/**
@@ -474,11 +460,11 @@ class Loader {
 		}
 
 		$features        = self::get_features();
-		$features_object = array();
+		$enabled_features = array();
 		foreach ( $features as $key ) {
-			$features_object[ $key ] = true;
+			$enabled_features[ $key ] = self::is_feature_enabled( $key );
 		}
-		wp_add_inline_script( WC_ADMIN_APP, 'window.wcAdminFeatures = ' . wp_json_encode( $features_object ), 'before' );
+		wp_add_inline_script( WC_ADMIN_APP, 'window.wcAdminFeatures = ' . wp_json_encode( $enabled_features ), 'before' );
 
 		wp_enqueue_script( WC_ADMIN_APP );
 		wp_enqueue_style( WC_ADMIN_APP );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -164,11 +164,8 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
-		if ( 'homepage' === $feature ) {
-			$option = 'yes' === get_option( 'woocommerce_homescreen_enabled', 'no' );
-			if ( ! $option ) {
-				return false;
-			}
+		if ( 'homepage' === $feature && 'yes' !== get_option( 'woocommerce_homescreen_enabled', 'no' ) ) {
+			return false;
 		}
 
 		$features = self::get_features();
@@ -635,10 +632,8 @@ class Loader {
 	 * The initial contents here are meant as a place loader for when the PHP page initialy loads.
 	 */
 	public static function embed_page_header() {
-
-		$features = wc_admin_get_feature_config();
 		if (
-			$features['navigation'] &&
+			self::is_feature_enabled( 'navigation' ) &&
 			\Automattic\WooCommerce\Admin\Features\Navigation::instance()->is_woocommerce_page()
 		) {
 			self::embed_navigation_menu();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -132,21 +132,6 @@ class Loader {
 	}
 
 	/**
-	 * Gets a runtime array of enabled WooCommerce Admin features/sections.
-	 *
-	 * @return array Woocommerce Admin features/sections.
-	 */
-	protected static function get_enabled_features() {
-		$features_mask    = apply_filters( 'woocommerce_admin_features_to_enable_disable', array() );
-		$add_features     = array_filter( $features_mask );
-		$remove_features  = array_keys( array_diff_key( $features_mask, $add_features ) );
-
-		$enabled_features = self::get_features();
-		$enabled_features = array_diff( $enabled_features, $remove_features );
-		return array_merge( $enabled_features, array_keys( $add_features ) );
-	}
-
-	/**
 	 * Gets WordPress capability required to use analytics features.
 	 *
 	 * @return string
@@ -186,7 +171,7 @@ class Loader {
 			}
 		}
 
-		$features = self::get_enabled_features();
+		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}
 
@@ -269,7 +254,7 @@ class Loader {
 	 * Class loader for enabled WooCommerce Admin features/sections.
 	 */
 	public static function load_features() {
-		$features = self::get_enabled_features();
+		$features = self::get_features();
 		foreach ( $features as $feature ) {
 			$feature = str_replace( '-', '', ucwords( strtolower( $feature ), '-' ) );
 			$feature = 'Automattic\\WooCommerce\\Admin\\Features\\' . $feature;
@@ -492,7 +477,7 @@ class Loader {
 		}
 
 		wp_add_inline_script( WC_ADMIN_APP,
-			'window.wcAdminFeatures = ' . json_encode( self::get_enabled_features() )
+			'window.paul = ' . json_encode( self::get_features() )
 		, 'before' );
 
 		wp_enqueue_script( WC_ADMIN_APP );
@@ -725,7 +710,7 @@ class Loader {
 			$classes[] = 'woocommerce-admin-is-loading';
 		}
 
-		$features = self::get_enabled_features();
+		$features = self::get_features();
 		foreach ( $features as $feature_key ) {
 			$classes[] = sanitize_html_class( 'woocommerce-feature-enabled-' . $feature_key );
 		}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const MiniCssExtractPlugin = require( '@automattic/mini-css-extract-plugin-with-
 const { get } = require( 'lodash' );
 const path = require( 'path' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
-const { DefinePlugin } = require( 'webpack' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const FixStyleOnlyEntriesPlugin = require( 'webpack-fix-style-only-entries' );
 const BundleAnalyzerPlugin = require( 'webpack-bundle-analyzer' )
@@ -20,21 +19,6 @@ const UnminifyWebpackPlugin = require( './unminify' );
 const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
-
-// generate-feature-config.php defaults to 'plugin', so lets match that here.
-let WC_ADMIN_PHASE = process.env.WC_ADMIN_PHASE || 'plugin';
-if ( [ 'development', 'plugin', 'core' ].indexOf( WC_ADMIN_PHASE ) === -1 ) {
-	WC_ADMIN_PHASE = 'plugin';
-}
-const WC_ADMIN_CONFIG = require( path.join(
-	__dirname,
-	'config',
-	WC_ADMIN_PHASE + '.json'
-) );
-const WC_ADMIN_ADDITIONAL_FEATURES =
-	( process.env.WC_ADMIN_ADDITIONAL_FEATURES &&
-		JSON.parse( process.env.WC_ADMIN_ADDITIONAL_FEATURES ) ) ||
-	{};
 
 const externals = {
 	'@wordpress/api-fetch': { this: [ 'wp', 'apiFetch' ] },
@@ -200,13 +184,6 @@ const webpackConfig = {
 	},
 	plugins: [
 		new FixStyleOnlyEntriesPlugin(),
-		// Inject the current feature flags.
-		new DefinePlugin( {
-			'window.wcAdminFeatures': {
-				...WC_ADMIN_CONFIG.features,
-				...WC_ADMIN_ADDITIONAL_FEATURES,
-			},
-		} ),
 		new CustomTemplatedPathPlugin( {
 			modulename( outputPath, data ) {
 				const entryName = get( data, [ 'chunk', 'name' ] );


### PR DESCRIPTION
Fixes #4417

This supercedes https://github.com/woocommerce/woocommerce-admin/pull/4418 with some extra changes regarding dynamic creation of `window.wcAdminFeatures`.

### Background

Features configs were created via webpack for client side code. Now that we require a PHP filter to disable features, it needs to be created in PHP for analysis at runtime. This removes the ability to pass the cli arg `WC_ADMIN_ADDITIONAL_FEATURES` when building a release. I think this was a seldom used feature, so I'm ok with the tradeoff.

### Changes

* Removed usage of `is_homepage_enabled` in favor of `is_feature_enabled`.
* `window.wcAdminFeatures` is now created in PHP instead of webpack and reflects `is_feature_enabled` which takes into account the disable option in the case of homescreen.
* Now that the option value is baked into `window.wcAdminFeatures`, I removed the requirement of the option to be preloaded and evaluated client side, which cleans up the code quite a bit.

### Test

1. Try disabling features with a filter. The following example disables devdocs and homepage.

```php
add_filter( 'woocommerce_admin_features', function( $enabled_features ) {
	$features_to_turn_off = array( 'homepage', 'devdocs' );
	return array_diff( $enabled_features, $features_to_turn_off );
} );
```

2. Toggle the homescreen by changing the value of the option `woocommerce_homescreen_enabled`, which should be "yes" in order to view the homescreen.

3. In each case, make sure the menu items are correct, there are no errors, and the appropriate views render.

