### PR TITLE
Add First product admin note

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -25,6 +25,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Migrate_From_Shopify;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Loader;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_First_Product;
 
 /**
  * WC_Admin_Events Class.
@@ -81,6 +82,7 @@ class Events {
 		WC_Admin_Notes_Giving_Feedback_Notes::possibly_add_note();
 		WC_Admin_Notes_WooCommerce_Subscriptions::possibly_add_note();
 		WC_Admin_Notes_Migrate_From_Shopify::possibly_add_note();
+		WC_Admin_Notes_First_Product::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/WC_Admin_Notes_First_Product.php
+++ b/src/Notes/WC_Admin_Notes_First_Product.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WooCommerce Admin: Do you need help with adding your first product?
+ *
+ * Adds a note to ask the client if they need help adding their first product.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_First_Product.
+ */
+class WC_Admin_Notes_First_Product {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-first-product';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		// We want to show the note after seven days.
+		if ( ! self::wc_admin_active_for( 7 * DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		// Don't show if there are products.
+		$query    = new \WC_Product_Query(
+			array(
+				'limit'    => 1,
+				'paginate' => true,
+				'return'   => 'ids',
+				'status'   => array( 'publish' ),
+			)
+		);
+		$products = $query->get_products();
+		$count    = $products->total;
+		if ( 0 !== $count ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Do you need help with adding your first product?', 'woocommerce-admin' ) );
+		$note->set_content( __( 'This video tutorial will help you go through the process of adding your first product in WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'first-product-watch-tutorial',
+			__( 'Watch tutorial', 'woocommerce-admin' ),
+			'https://www.youtube.com/watch?v=sFtXa00Jf_o&list=PLHdG8zvZd0E575Ia8Mu3w1h750YLXNfsC&index=24'
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/WC_Admin_Notes_First_Product.php
+++ b/src/Notes/WC_Admin_Notes_First_Product.php
@@ -34,6 +34,19 @@ class WC_Admin_Notes_First_Product {
 			return;
 		}
 
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Confirm that $onboarding_profile is set.
+		if ( empty( $onboarding_profile ) ) {
+			return;
+		}
+
+		// Make sure that the person who filled out the OBW was not setting up
+		// the store for their customer/client.
+		if ( $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
 		// Don't show if there are products.
 		$query    = new \WC_Product_Query(
 			array(


### PR DESCRIPTION
Fixes #4214

This adds a "First product" admin note under these conditions:

- not set up for a client
- at least seven days after wc-admin install
- no products in the system

### Screenshots

![image](https://user-images.githubusercontent.com/224531/84107339-b9434f80-aa60-11ea-8cb2-6ae030f054ab.png)

### Detailed test instructions:

- With no products in the system, run the `wc_admin_daily` cron task and confirm that the admin note was not generated
- Add a product
- Run the `wc_admin_daily_ cron task again and confirm that the admin note is now present

### Changelog Note:

Enhancement: Add First product admin note