### PR TITLE
Check for enabled methods before payment task completion

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -239,8 +239,8 @@ class Payments extends Component {
 		const currentMethod = this.getCurrentMethod();
 		const { busyMethod, enabledMethods, recommendedMethod } = this.state;
 		const { methods, query, requesting } = this.props;
-		const configuredMethods = methods.filter(
-			( method ) => method.isConfigured
+		const hasEnabledMethods = Object.keys( enabledMethods ).filter(
+			( method ) => enabledMethods[ method ]
 		).length;
 
 		if ( currentMethod ) {
@@ -348,7 +348,7 @@ class Payments extends Component {
 					);
 				} ) }
 				<div className="woocommerce-task-payments__actions">
-					{ configuredMethods.length === 0 ? (
+					{ ! hasEnabledMethods ? (
 						<Button isLink onClick={ this.skipTask }>
 							{ __(
 								'My store doesn’t take payments',


### PR DESCRIPTION
Fixes #4241 

Previously having any configured methods (but not enabled) would allow you to click "Done," resulting in a notice that stated your store is now ready to accept payments.

This PR updates this task to require at least one enabled payment before "Done" can be clicked, otherwise only the "skip" option is shown.

Note that at least one payment gateway (wc-pay) may not be fully configured and ready to accept payments so the notice that the store is ready to accept payments may not be entirely accurate.  More discussion on this in #4241 but feedback is welcome here as well.

### Screenshots
<img width="729" alt="Screen Shot 2020-06-09 at 1 24 13 PM" src="https://user-images.githubusercontent.com/10561050/84137143-edb10e80-aa54-11ea-8016-51790477da5c.png">


### Detailed test instructions:

1. Configure at least one payment method.
1. Disable all configured payment options.
1. Make sure the skip option is shown in the payment task.
1. Re-enable at least one of the payment methods.
1. Make sure the "Done" button is shown.