### PR TITLE
Use chunk id instead of generated name to reduce filename length.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,7 +101,7 @@ const webpackConfig = {
 				? `wp-admin-scripts/[name].min.js`
 				: `[name]/index.min.js`;
 		},
-		chunkFilename: `chunks/[name].[chunkhash].min.js`,
+		chunkFilename: `chunks/[id].[chunkhash].min.js`,
 		path: path.join( __dirname, 'dist' ),
 		library: [ 'wc', '[modulename]' ],
 		libraryTarget: 'this',
@@ -232,6 +232,7 @@ const webpackConfig = {
 		} ),
 		new MiniCssExtractPlugin( {
 			filename: './[name]/style.css',
+			chunkFilename: './chunks/[id].style.css',
 		} ),
 		new CopyWebpackPlugin(
 			wcAdminPackages.map( ( packageName ) => ( {
@@ -252,9 +253,7 @@ const webpackConfig = {
 	].filter( Boolean ),
 	optimization: {
 		minimize: NODE_ENV !== 'development',
-		minimizer: [
-			new TerserPlugin(),
-		],
+		minimizer: [ new TerserPlugin() ],
 	},
 };
 


### PR DESCRIPTION
Fixes #4512.
Fixes #4519.

This PR seeks to reduce the filename lengths by using chunk IDs instead of (long) generated chunk names.

There is still an issue with RTL stylesheets that I'll address in a follow up.

### Detailed test instructions:

- Remove the `dist` folder
- Build the app (`start` or `run build`)
- Smoke test all screens, verify function and styles

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: reduce asset filename length.