### PR TITLE
Add real time order alerts note for mobile app

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -23,6 +23,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Marketing;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Start_Dropshipping_Business;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Subscriptions;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Migrate_From_Shopify;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Real_Time_Order_Alerts;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Loader;
@@ -89,6 +90,7 @@ class Events {
 		WC_Admin_Notes_Learn_More_About_Product_Settings::possibly_add_note();
 		WC_Admin_Notes_Online_Clothing_Store::possibly_add_note();
 		WC_Admin_Notes_First_Product::possibly_add_note();
+		WC_Admin_Notes_Real_Time_Order_Alerts::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
+++ b/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
@@ -30,8 +30,8 @@ class WC_Admin_Notes_Real_Time_Order_Alerts {
 	 */
 	public static function get_note() {
 		// Only add this note if the store is 3 months old.
-		$nintey_days_in_seconds = 90 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $nintey_days_in_seconds ) ) {
+		$ninety_days_in_seconds = 90 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $ninety_days_in_seconds ) ) {
 			return;
 		}
 
@@ -45,7 +45,7 @@ class WC_Admin_Notes_Real_Time_Order_Alerts {
 			}
 		}
 
-		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app', 'woocommerce-admin' );
+		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app.', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Get real-time order alerts anywhere', 'woocommerce-admin' ) );

--- a/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
+++ b/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WooCommerce Admin Real Time Order Alerts Note.
+ *
+ * Adds a note to download the mobile app to monitor store activity.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Real_Time_Order_Alerts
+ */
+class WC_Admin_Notes_Real_Time_Order_Alerts {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-real-time-order-alerts';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		// Only add this note if the store is 3 months old.
+		$nintey_days_in_seconds = 90 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $nintey_days_in_seconds ) ) {
+			return;
+		}
+
+		// Check that the previous mobile app note was not actioned.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( WC_Admin_Notes_Mobile_App::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			$note = WC_Admin_Notes::get_note( $note_ids[0] );
+			if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
+				return;
+			}
+		}
+
+		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Get real-time order alerts anywhere', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/?utm_source=inbox' );
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4225 

Adds the real time order alerts note if the mobile app note was not previously actioned.

### Screenshots
<img width="477" alt="Screen Shot 2020-06-10 at 9 57 37 AM" src="https://user-images.githubusercontent.com/10561050/84236745-d4fe3280-ab00-11ea-9c5f-fb98d2d8d1e3.png">

### Detailed test instructions:

1. Make sure your install timestamp is >= 90 days.
1. Make sure the mobile app note status is `unactioned`.
1. Run `wc_admin_daily`.
1. Check that the note was added.
1. Try actioning the old mobile app note or a store that is not yet 90 days old.
1. No note should be added.