### PR TITLE
Fix loading of RTL styles in chunks.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,18 @@
       "integrity": "sha512-GRMV4PMtn2iE+30+RP33LyJSe4Qp8oILFNvk+iF8zd0LzUUaErZu86rk8YpEcLvFJzOU2BTXSewSdwyGc/sa1g==",
       "dev": true
     },
+    "@automattic/mini-css-extract-plugin-with-rtl": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@automattic/mini-css-extract-plugin-with-rtl/-/mini-css-extract-plugin-with-rtl-0.8.0.tgz",
+      "integrity": "sha512-HEGnZjw4hpR3axUO8e3v7Is38VKrkrizdwianNCaEP3KW8Kx4z0fzc1DyiiLTptIrHy4VaoyHnfkA3+js5N7JQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      }
+    },
     "@babel/cli": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
@@ -18012,6 +18024,28 @@
             "lolex": "^5.0.0"
           }
         },
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
         "acorn": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -18137,6 +18171,12 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
@@ -21180,18 +21220,6 @@
         "@babel/runtime": "^7.4.0",
         "gud": "^1.0.0",
         "tiny-warning": "^1.0.2"
-      }
-    },
-    "mini-css-extract-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "normalize-url": "1.9.1",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
       }
     },
     "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "2.3.0",
+		"@automattic/mini-css-extract-plugin-with-rtl": "^0.8.0",
 		"@babel/cli": "7.8.4",
 		"@babel/core": "7.9.6",
 		"@babel/plugin-transform-async-to-generator": "7.8.3",
@@ -202,7 +203,6 @@
 		"lint-staged": "10.1.7",
 		"locutus": "2.0.11",
 		"merge-config": "2.0.0",
-		"mini-css-extract-plugin": "0.9.0",
 		"moment-timezone-data-webpack-plugin": "1.2.0",
 		"node-sass": "4.13.1",
 		"node-watch": "0.6.3",

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -142,7 +142,7 @@ class ShippingLabelBanner {
 	 * @param string $hook current page hook.
 	 */
 	public function add_print_shipping_label_script( $hook ) {
-		$rtl = is_rtl() ? '-rtl' : '';
+		$rtl = is_rtl() ? '.rtl' : '';
 		wp_enqueue_style(
 			'print-shipping-label-banner-style',
 			Loader::get_url( "print-shipping-label-banner/style{$rtl}", 'css' ),

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -276,7 +276,7 @@ class Loader {
 	 */
 	public static function register_page_handler() {
 		$features = wc_admin_get_feature_config();
-		$id = self::is_homepage_enabled( $features ) ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$id       = self::is_homepage_enabled( $features ) ? 'woocommerce-home' : 'woocommerce-dashboard';
 
 		wc_admin_register_page(
 			array(
@@ -444,21 +444,22 @@ class Loader {
 
 		wp_set_script_translations( WC_ADMIN_APP, 'woocommerce-admin' );
 
+		// The "app" RTL files are in a different format than the components.
+		$rtl = is_rtl() ? '.rtl' : '';
+
 		wp_register_style(
 			WC_ADMIN_APP,
-			self::get_url( 'app/style', 'css' ),
+			self::get_url( "app/style{$rtl}", 'css' ),
 			array( 'wc-components' ),
 			$css_file_version
 		);
-		wp_style_add_data( WC_ADMIN_APP, 'rtl', 'replace' );
 
 		wp_register_style(
 			'wc-admin-ie',
-			self::get_url( 'ie/style', 'css' ),
+			self::get_url( "ie/style{$rtl}", 'css' ),
 			array( WC_ADMIN_APP ),
 			$css_file_version
 		);
-		wp_style_add_data( 'wc-admin-ie', 'rtl', 'replace' );
 
 		wp_register_style(
 			'wc-material-icons',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const MiniCssExtractPlugin = require( '@automattic/mini-css-extract-plugin-with-rtl' );
 const { get } = require( 'lodash' );
 const path = require( 'path' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
@@ -219,7 +219,6 @@ const webpackConfig = {
 			},
 		} ),
 		new WebpackRTLPlugin( {
-			filename: './[name]/style-rtl.css',
 			minify: {
 				safe: true,
 			},
@@ -227,6 +226,7 @@ const webpackConfig = {
 		new MiniCssExtractPlugin( {
 			filename: './[name]/style.css',
 			chunkFilename: './chunks/[id].style.css',
+			rtlEnabled: true,
 		} ),
 		new CopyWebpackPlugin(
 			wcAdminPackages.map( ( packageName ) => ( {


### PR DESCRIPTION
This PR seeks to restore RTL styles for chunks generated as a result of code splitting.

It does change the filename format (due to the Webpack plugin used) from `style-rtl.css` to `style.rtl.css`.

### Detailed test instructions:

- Verify styles load properly in the app (I like using the network tab filtered by CSS)
- Switch to a RTL language like Arabic or Hebrew
- Verify RTL styles load properly in the app (network tab)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: RTL stylesheet loading for split code chunks.