### PR TITLE
Home Screen: Update tests to account for QuickLinks

### DIFF
--- a/client/homepage/test/index.js
+++ b/client/homepage/test/index.js
@@ -11,19 +11,22 @@ jest.mock( 'homepage/stats-overview', () => jest.fn().mockReturnValue( null ) );
 jest.mock( 'task-list', () => jest.fn().mockReturnValue( '[TaskList]' ) );
 
 // We aren't testing the <InboxPanel /> component here.
-jest.mock( 'header/activity-panel/panels/inbox', () => jest.fn().mockReturnValue( '[InboxPanel]' ) );
+jest.mock( 'header/activity-panel/panels/inbox', () =>
+	jest.fn().mockReturnValue( '[InboxPanel]' )
+);
+
+// We aren't testing the <QuickLinks /> component here.
+jest.mock( 'quick-links', () => jest.fn().mockReturnValue( '[QuickLinks]' ) );
 
 describe( 'Homepage Layout', () => {
 	it( 'should show TaskList placeholder when loading', () => {
 		const { container } = render(
-			<Layout
-				requestingTaskList
-				taskListHidden={ false }
-				query={ {} }
-			/>
+			<Layout requestingTaskList taskListHidden={ false } query={ {} } />
 		);
 
-		const placeholder = container.querySelector( '.woocommerce-task-card.is-loading' );
+		const placeholder = container.querySelector(
+			'.woocommerce-task-card.is-loading'
+		);
 		expect( placeholder ).not.toBeNull();
 	} );
 
@@ -37,11 +40,13 @@ describe( 'Homepage Layout', () => {
 		);
 
 		// Expect that we're rendering the "full" home screen (with columns).
-		const columns = container.querySelector( '.woocommerce-homepage-column' );
+		const columns = container.querySelector(
+			'.woocommerce-homepage-column'
+		);
 		expect( columns ).not.toBeNull();
 
 		// Expect that the <TaskList /> is there too.
-		const taskList = await screen.findByText( '[TaskList]' )
+		const taskList = await screen.findByText( '[TaskList]' );
 		expect( taskList ).toBeDefined();
 	} );
 
@@ -57,11 +62,13 @@ describe( 'Homepage Layout', () => {
 		);
 
 		// Expect that we're NOT rendering the "full" home screen (with columns).
-		const columns = container.querySelector( '.woocommerce-homepage-column' );
+		const columns = container.querySelector(
+			'.woocommerce-homepage-column'
+		);
 		expect( columns ).toBeNull();
 
 		// Expect that the <TaskList /> is there though.
-		const taskList = await screen.findByText( '[TaskList]' )
+		const taskList = await screen.findByText( '[TaskList]' );
 		expect( taskList ).toBeDefined();
 	} );
 
@@ -75,7 +82,7 @@ describe( 'Homepage Layout', () => {
 			/>
 		);
 
-		const taskList = screen.queryByText( '[TaskList]' )
+		const taskList = screen.queryByText( '[TaskList]' );
 		expect( taskList ).toBeNull();
 	} );
 
@@ -89,7 +96,35 @@ describe( 'Homepage Layout', () => {
 			/>
 		);
 
-		const taskList = screen.queryByText( '[TaskList]' )
+		const taskList = screen.queryByText( '[TaskList]' );
 		expect( taskList ).toBeNull();
+	} );
+
+	it( 'should show QuickLinks when user has hidden TaskList', () => {
+		render(
+			<Layout
+				requestingTaskList={ false }
+				taskListComplete={ false }
+				taskListHidden
+				query={ {} }
+			/>
+		);
+
+		const quickLinks = screen.queryByText( '[QuickLinks]' );
+		expect( quickLinks ).toBeDefined();
+	} );
+
+	it( 'should show QuickLinks when TaskList is complete', () => {
+		render(
+			<Layout
+				requestingTaskList={ false }
+				taskListComplete
+				taskListHidden={ false }
+				query={ {} }
+			/>
+		);
+
+		const quickLinks = screen.queryByText( '[QuickLinks]' );
+		expect( quickLinks ).toBeDefined();
 	} );
 } );


### PR DESCRIPTION
Partially addresses #4534

This PR addresses the warning mentioned in #4534, by mocking `QuickLinks` in the homepage tests. It also adds two additional tests to verify that `QuickLinks` is shown when it should be.

### Screenshots

### Detailed test instructions:

- Check out master
- Run `npm test --config tests/js/jest.config.json -- -i client/homepage/test/index.js`
- Note the following warning is output:

```
  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `items[8].href` of type `boolean` supplied to `List`, expected `string`.
        in List (created by QuickLinks)
        in QuickLinks (created by Layout)
        in div (created by Layout)
        in div (created by Layout)
        in Layout

  console.error node_modules/react-dom/cjs/react-dom.development.js:88
    Warning: Received `false` for a non-boolean attribute `href`.

    If you want to write it to the DOM, pass a string instead: href="false" or href={value.toString()}.

    If you used to conditionally omit it with href={condition && value}, pass href={condition ? value : undefined} instead.
        in div (created by List)
        in li (created by List)
        in ul (created by List)
        in List (created by QuickLinks)
        in div (created by Context.Consumer)
        in BodyUI (created by CardBody)
        in CardBody (created by QuickLinks)
        in div (created by Context.Consumer)
        in CardUI (created by Card)
        in Card (created by QuickLinks)
        in QuickLinks (created by Layout)
        in div (created by Layout)
        in div (created by Layout)
        in Layout
```
- Check out this branch
- Run `npm test --config tests/js/jest.config.json -- -i client/homepage/test/index.js`
- Verify that the above warning is gone, and that all tests pass

### Changelog Note:

No changelog entry needed, as this is part of the larger home screen feature.