### PR TITLE
Tests: Prevent navigation warnings in tests

### DIFF
--- a/client/quick-links/test/index.js
+++ b/client/quick-links/test/index.js
@@ -56,7 +56,12 @@ describe( 'QuickLinks', () => {
 		const recordEvent = jest.fn();
 
 		render(
-			<QuickLinks getSetting={ () => {} } recordEvent={ recordEvent } />
+			<QuickLinks
+				getSetting={ () => {} }
+				recordEvent={ recordEvent }
+				// Prevent jsdom "Error: Not implemented: navigation" in test output
+				onItemClick={ () => false }
+			/>
 		);
 
 		userEvent.click(
@@ -76,7 +81,12 @@ describe( 'QuickLinks', () => {
 		const recordEvent = jest.fn();
 
 		render(
-			<QuickLinks getSetting={ () => {} } recordEvent={ recordEvent } />
+			<QuickLinks
+				getSetting={ () => {} }
+				recordEvent={ recordEvent }
+				// Prevent jsdom "Error: Not implemented: navigation" in test output
+				onItemClick={ () => false }
+			/>
 		);
 
 		userEvent.click(
@@ -96,7 +106,12 @@ describe( 'QuickLinks', () => {
 		const recordEvent = jest.fn();
 
 		render(
-			<QuickLinks getSetting={ () => {} } recordEvent={ recordEvent } />
+			<QuickLinks
+				getSetting={ () => {} }
+				recordEvent={ recordEvent }
+				// Prevent jsdom "Error: Not implemented: navigation" in test output
+				onItemClick={ () => false }
+			/>
 		);
 
 		userEvent.click(
@@ -118,7 +133,12 @@ describe( 'QuickLinks', () => {
 		const recordEvent = jest.fn();
 
 		render(
-			<QuickLinks getSetting={ () => {} } recordEvent={ recordEvent } />
+			<QuickLinks
+				getSetting={ () => {} }
+				recordEvent={ recordEvent }
+				// Prevent jsdom "Error: Not implemented: navigation" in test output
+				onItemClick={ () => false }
+			/>
 		);
 
 		userEvent.click(
@@ -139,10 +159,6 @@ describe( 'QuickLinks', () => {
 
 		render(
 			<QuickLinks getSetting={ getSetting } recordEvent={ () => {} } />
-		);
-
-		userEvent.click(
-			screen.getByRole( 'menuitem', { name: 'View my store' } )
 		);
 
 		expect( getSetting ).toHaveBeenCalledWith( 'siteUrl' );

--- a/packages/components/src/link/test/index.js
+++ b/packages/components/src/link/test/index.js
@@ -105,7 +105,11 @@ describe( 'Link', () => {
 	} );
 
 	it( 'should support `onClick`', () => {
-		const clickHandler = jest.fn();
+		// Prevent jsdom "Error: Not implemented: navigation" in test output
+		const clickHandler = jest.fn( ( event ) => {
+			event.preventDefault();
+			return false;
+		} );
 
 		const { container } = render(
 			<Link


### PR DESCRIPTION
Partially addresses #4534

This PR updates the JS unit tests for `QuickLinks` and `Link` to avoid outputing the `Not implemented: navigation (except hash changes)` error.

### Detailed test instructions:

- Check out master
- Run `npm test`
- Note the following error is output multiple times:

```
  console.error node_modules/jest-environment-jsdom-sixteen/node_modules/jsdom/lib/jsdom/virtual-console.js:29
    Error: Not implemented: navigation (except hash changes)
        at module.exports (/Users/matt/vagrant-local/www/woocommerce-dev/public_html/wp-content/plugins/woocommerce-admin/node_modules/jest-environment-jsdom-sixteen/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
        at navigateFetch (/Users/matt/vagrant-local/www/woocommerce-dev/public_html/wp-content/plugins/woocommerce-admin/node_modules/jest-environment-jsdom-sixteen/node_modules/jsdom/lib/jsdom/living/window/navigation.js:76:3)
        at exports.navigate (/Users/matt/vagrant-local/www/woocommerce-dev/public_html/wp-content/plugins/woocommerce-admin/node_modules/jest-environment-jsdom-sixteen/node_modules/jsdom/lib/jsdom/living/window/navigation.js:54:3)
        at Timeout.setTimeout (/Users/matt/vagrant-local/www/woocommerce-dev/public_html/wp-content/plugins/woocommerce-admin/node_modules/jest-environment-jsdom-sixteen/node_modules/jsdom/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js:81:7)
        at ontimeout (timers.js:436:11)
        at tryOnTimeout (timers.js:300:5)
        at listOnTimeout (timers.js:263:5)
        at Timer.processTimers (timers.js:223:10) undefined
```

- Check out this branch
- Run `npm tests`
- Verify that the above error is no longer output

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

No changelog entry needed, as this is part of the larger home page feature.