### PR TITLE
Remove use welcome message statement (merge fail)

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -12,7 +12,6 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
-use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;


### PR DESCRIPTION
I had a rebase fail that added an unused `use` statement. This just cleans that up.

### Detailed test instructions:

N/A