### PR TITLE
Use single dash for country/state dropdown options

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -30,7 +30,10 @@ export function validateStoreAddress( values ) {
 		);
 	}
 	if ( ! values.countryState.length ) {
-		errors.countryState = __( 'Please select a country / region', 'woocommerce-admin' );
+		errors.countryState = __(
+			'Please select a country / region',
+			'woocommerce-admin'
+		);
 	}
 	if ( ! values.city.length ) {
 		errors.city = __( 'Please add a city', 'woocommerce-admin' );
@@ -63,7 +66,7 @@ export function getCountryStateOptions() {
 				key: country.code + ':' + state.code,
 				label:
 					decodeEntities( country.name ) +
-					' -- ' +
+					' — ' +
 					decodeEntities( state.name ),
 			};
 		} );


### PR DESCRIPTION
Fixes #4257

Change store address dropdowns to use a single dash between country and state.

### Screenshots
<img width="492" alt="Screen Shot 2020-06-11 at 3 56 21 PM" src="https://user-images.githubusercontent.com/10561050/84388232-e462a600-abfc-11ea-989b-85876fa1d9e7.png">


### Detailed test instructions:

1. Open anywhere the store address is being used (e.g., first step of the profiler).
1. Note the single dash between country and state.