### PR TITLE
Use label tag for toggleable shipping zones

### DIFF
--- a/client/task-list/tasks/shipping/rates.js
+++ b/client/task-list/tasks/shipping/rates.js
@@ -263,16 +263,24 @@ class ShippingRates extends Component {
 											) }
 										</div>
 										<div className="woocommerce-shipping-rate__main">
-											<div className="woocommerce-shipping-rate__name">
-												{ zone.name }
-												{ zone.toggleable && (
+											{ zone.toggleable ? (
+												<label
+													htmlFor={ `woocommerce-shipping-rate__toggle-${ zone.id }` }
+													className="woocommerce-shipping-rate__name"
+												>
+													{ zone.name }
 													<FormToggle
+														id={ `woocommerce-shipping-rate__toggle-${ zone.id }` }
 														{ ...getInputProps(
 															`${ zone.id }_enabled`
 														) }
 													/>
-												) }
-											</div>
+												</label>
+											) : (
+												<div className="woocommerce-shipping-rate__name">
+													{ zone.name }
+												</div>
+											) }
 											{ ( ! zone.toggleable ||
 												values[
 													`${ zone.id }_enabled`


### PR DESCRIPTION
Fixes #4269 

Uses labels for toggleable zones to be more accessible and allow toggling via clicking the label (zone name).

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
<img width="751" alt="Screen Shot 2020-06-11 at 4 21 08 PM" src="https://user-images.githubusercontent.com/10561050/84390133-d2363700-abff-11ea-9b48-5a762ab343ca.png">

### Detailed test instructions:

1. Go to the shipping task in the task list.
1. Click on the "Rest of the world" text.
1. Make sure you are able to toggle on/off with this text.