### PR TITLE
Components: Add overlooked changes to CHANGELOG.md for SelectControl, List, and Link

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add `<Plugins />` component for installation of plugins.
 - Removed use of `IconButton` in favor of `Button` component.
 - Add custom autocompleter support to `<Search />` component.
+- Fix `<SelectControl />` component to allow clicking anywhere on options in list to select.
+- Add support for `<List />` component item tags and link types.
+- Add `<List />` and `<Link />` components to Storybook.
 
 ## Breaking Changes
 - Removed `SplitButton` because its not being used.


### PR DESCRIPTION
This PR just adds a couple of bullets to the `CHANGELOG.md` for previous changes I have made in `@woocommerce/components` that I failed to put in `CHANGELOG.md`.

### Detailed test instructions:

- Check out branch
- Make sure `CHANGELOG.md` changes are formatted properly and contain no spelling/grammar errors

### Changelog Note:

No need for a changelog entry about a changelog modification. :-) 