### PR TITLE
Fix advancedFilter filter order

### DIFF
--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -226,6 +226,18 @@ class AdvancedFilters extends Component {
 		onAdvancedFilterAction( 'filter', { ...updatedQuery, match } );
 	}
 
+	orderFilters( a, b ) {
+		const qs = window.location.search;
+		const aPos = qs.indexOf( a.key );
+		const bPos = qs.indexOf( b.key );
+		// If either isn't in the url, it means its just been added, so leave it as is.
+		if ( aPos === -1 || bPos === -1 ) {
+			return 0;
+		}
+		// Otherwise use the url to determine order in which filter was added.
+		return aPos - bPos;
+	}
+
 	render() {
 		const { config, query, currency } = this.props;
 		const { activeFilters, match } = this.state;
@@ -244,90 +256,102 @@ class AdvancedFilters extends Component {
 					className="woocommerce-filters-advanced__list"
 					ref={ this.filterListRef }
 				>
-					{ activeFilters.map( ( filter ) => {
-						const { key } = filter;
-						const { input, labels } = config.filters[ key ];
-						return (
-							<li
-								className="woocommerce-filters-advanced__list-item"
-								key={ key }
-							>
-								{ input.component === 'SelectControl' && (
-									<SelectFilter
-										className="woocommerce-filters-advanced__fieldset-item"
-										filter={ filter }
-										config={ config.filters[ key ] }
-										onFilterChange={ this.onFilterChange }
-										isEnglish={ isEnglish }
-									/>
-								) }
-								{ input.component === 'Search' && (
-									<SearchFilter
-										className="woocommerce-filters-advanced__fieldset-item"
-										filter={ filter }
-										config={ config.filters[ key ] }
-										onFilterChange={ this.onFilterChange }
-										isEnglish={ isEnglish }
-										query={ query }
-									/>
-								) }
-								{ input.component === 'Number' && (
-									<NumberFilter
-										className="woocommerce-filters-advanced__fieldset-item"
-										filter={ filter }
-										config={ config.filters[ key ] }
-										onFilterChange={ this.onFilterChange }
-										isEnglish={ isEnglish }
-										query={ query }
-										currency={ currency }
-									/>
-								) }
-								{ input.component === 'Currency' && (
-									<NumberFilter
-										className="woocommerce-filters-advanced__fieldset-item"
-										filter={ filter }
-										config={ {
-											...config.filters[ key ],
-											...{
-												input: {
-													type: 'currency',
-													component: 'Currency',
-												},
-											},
-										} }
-										onFilterChange={ this.onFilterChange }
-										isEnglish={ isEnglish }
-										query={ query }
-										currency={ currency }
-									/>
-								) }
-								{ input.component === 'Date' && (
-									<DateFilter
-										className="woocommerce-filters-advanced__fieldset-item"
-										filter={ filter }
-										config={ config.filters[ key ] }
-										onFilterChange={ this.onFilterChange }
-										isEnglish={ isEnglish }
-										query={ query }
-										updateFilter={ this.updateFilter }
-									/>
-								) }
-								<Button
-									className={ classnames(
-										'woocommerce-filters-advanced__line-item',
-										'woocommerce-filters-advanced__remove'
-									) }
-									label={ labels.remove }
-									onClick={ partial(
-										this.removeFilter,
-										key
-									) }
+					{ activeFilters
+						.sort( this.orderFilters )
+						.map( ( filter ) => {
+							const { key } = filter;
+							const { input, labels } = config.filters[ key ];
+							return (
+								<li
+									className="woocommerce-filters-advanced__list-item"
+									key={ key }
 								>
-									<Gridicon icon="cross-small" />
-								</Button>
-							</li>
-						);
-					} ) }
+									{ input.component === 'SelectControl' && (
+										<SelectFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ config.filters[ key ] }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+										/>
+									) }
+									{ input.component === 'Search' && (
+										<SearchFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ config.filters[ key ] }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+											query={ query }
+										/>
+									) }
+									{ input.component === 'Number' && (
+										<NumberFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ config.filters[ key ] }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+											query={ query }
+											currency={ currency }
+										/>
+									) }
+									{ input.component === 'Currency' && (
+										<NumberFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ {
+												...config.filters[ key ],
+												...{
+													input: {
+														type: 'currency',
+														component: 'Currency',
+													},
+												},
+											} }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+											query={ query }
+											currency={ currency }
+										/>
+									) }
+									{ input.component === 'Date' && (
+										<DateFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ config.filters[ key ] }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+											query={ query }
+											updateFilter={ this.updateFilter }
+										/>
+									) }
+									<Button
+										className={ classnames(
+											'woocommerce-filters-advanced__line-item',
+											'woocommerce-filters-advanced__remove'
+										) }
+										label={ labels.remove }
+										onClick={ partial(
+											this.removeFilter,
+											key
+										) }
+									>
+										<Gridicon icon="cross-small" />
+									</Button>
+								</li>
+							);
+						} ) }
 				</ul>
 				{ availableFilterKeys.length > 0 && (
 					<div className="woocommerce-filters-advanced__add-filter">


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4426

AdvancedFilters were being rendered in the order that the `query` object has. We want to show them in the order they were added. Luckily, the url is a good indicator because we add parameters to the query in order.

This PR introduces a `sort` function to reflect the order in which users add filters.

### Detailed test instructions:

1. Navigate to any report that has an Advanced filters option
2. Add some filters without following the dropdown order
3. Click on Filter
4. The filter list order should be unchanged.
5. Try playing around with adding and removing filters, clicking in "Filter" and seeing if the order stays as expected.

Note: the diff in the render function is mostly Prettier, I just added the sort call on the `activeFilters` array.

### Changelog Note:

Fix: AdvancedFilters filter order when filtering
