### PR TITLE
Fix wc-admin registered page breadcrumb path

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -170,7 +170,7 @@ class PageController {
 					$parent = $this->pages[ $parent_id ];
 
 					if ( 0 === strpos( $parent['path'], self::PAGE_ROOT ) ) {
-						$parent['path'] = 'admin.php?page=' . self::PAGE_ROOT . '&path=' . $parent['path'];
+						$parent['path'] = 'admin.php?page=' . $parent['path'];
 					}
 
 					array_unshift( $breadcrumbs, array( $parent['path'], reset( $parent['title'] ) ) );

--- a/tests/page-controller.php
+++ b/tests/page-controller.php
@@ -124,7 +124,7 @@ class WC_Admin_Tests_Page_Controller extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			array(
-				'admin.php?page=wc-admin&path=wc-admin&path=/marketing',
+				'admin.php?page=wc-admin&path=/marketing',
 				'Marketing',
 			),
 			$breadcrumbs[1],


### PR DESCRIPTION
I previously submitted https://github.com/woocommerce/woocommerce-admin/pull/4490

But it looks like I got a little muddled up with the urls (the issue was correct - just fix wasn't right).

For example

http://example.woo/wp-admin/admin.php?page=wc-admin&path=wc-admin&path=/marketing

Is incorrect - there is an extra **wc-admin&path=**

The wc-admin urls should look like...

http://example.woo/wp-admin/admin.php?page=wc-admin&path=/marketing
http://example.woo/wp-admin/admin.php?page=wc-admin&path=/analytics/revenue
http://example.woo/wp-admin/admin.php?page=wc-admin&path=/analytics/categories

**Detailed test instructions:**

Same as previously but double check the url.  For whatever reason I didn't pick it up because the link ends up redirecting if clicked anyway.

* Clone branch
* Set a parent for the coupons page - you can use woocommerce-marketing or any other wc-admin registered page e.g. woocommerce-analytics
* Go to the coupons admin page and check that the parent breadcrumb url is correct.
* Confirm other breadcrumbs are still ok by browsing to other admin pages like Reports.
* You can also set the parent to be another woocommerce connected page to confirm they still work e.g. woocommerce-orders
