### PR TITLE
Focus date popover container on click

### DIFF
--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -79,7 +79,6 @@ class DatePicker extends Component {
 		return (
 			<Dropdown
 				position="bottom center"
-				focusOnMount="container"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<DateInput
 						disabled={ disabled }

--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -79,7 +79,7 @@ class DatePicker extends Component {
 		return (
 			<Dropdown
 				position="bottom center"
-				focusOnMount={ false }
+				focusOnMount="container"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<DateInput
 						disabled={ disabled }


### PR DESCRIPTION
Fixes #4425 

Focuses the popover container on click so clicking outside closes the popover/dropdown.

There is also a `focused` prop in the react dates component that wp components uses under the hood - https://github.com/airbnb/react-dates/blob/480b9902d69e64e62a2ef5c2d3b5fc3adef94444/src/components/DayPickerSingleDateController.jsx#L110

If this prop is meant to actually gain focus and not describe it, it does not appear to be working.

Also worth noting that the solution in this PR only sometimes works in Safari.  I think that this is due to the actual HTML input grabbing focus, but this is probably something we'll need to handle upstream in `@wordpress/components`.

/cc @psealock for any thoughts or additional reasoning I missed on focus around these elements.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
<img width="702" alt="Screen Shot 2020-06-12 at 4 48 28 PM" src="https://user-images.githubusercontent.com/10561050/84509748-d5e3bf80-accc-11ea-838f-10d1d0e8b619.png">

### Detailed test instructions:

1. Open a filter with a dropdown (e.g., Customers - Registered filter).
1. Click on the input box to open the calendar popover.
1. Click anywhere outside of the calendar/input.
1. Note that the input is closed.
1. Retest this using a screen reader.