### PR TITLE
Dismiss dropdown styles fixed

### DIFF
--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -133,19 +133,12 @@
 
 		.components-popover__content {
 			min-width: 195px;
-			margin-top: 7px;
 			ul {
-				padding: 0 20px;
+				text-align: center;
 			}
 			li {
-				margin: 12px 0;
+				margin: 0;
 				cursor: pointer;
-			}
-			li:first-child {
-				padding-top: 5px;
-			}
-			li:last-child {
-				padding-bottom: 5px;
 			}
 		}
 	}

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -158,7 +158,7 @@
 .woocommerce-inbox-dismiss-confirmation_wrapper {
 	p {
 		font-size: 16px;
-		color: #50575e;
+		color: $medium-gray-text;
 	}
 	.woocommerce-inbox-dismiss-confirmation_buttons {
 		text-align: right;


### PR DESCRIPTION
Fixes #4544 partially

This PR fixes the "Dismiss" dropdown styles.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 06 12-12_15_00](https://user-images.githubusercontent.com/1314156/84518065-825e7b00-aca6-11ea-9c2c-35c041e5867e.png)


### Detailed test instructions:
- In the `Inbox Panel` press the `Dismiss` button of any of the present notes.
- Verify the styles in the dropdown are ok.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Dismiss dropdown styles fixed.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
