### PR TITLE
Fix column used to JOIN products to their categories.

### DIFF
--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -94,7 +94,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		// join wp_order_product_lookup_table with relationships and taxonomies
 		// @todo How to handle custom product tables?
 		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$wpdb->term_relationships} ON {$order_product_lookup_table}.product_id = {$wpdb->term_relationships}.object_id" );
-		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->wc_category_lookup}.category_id" );
+		// Adding this (inner) JOIN as a LEFT JOIN for ordering purposes. See comment in add_order_by_params().
+		$this->subquery->add_sql_clause( 'left_join', "JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.term_taxonomy_id = {$wpdb->term_relationships}.term_taxonomy_id" );
+		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_taxonomy}.term_id = {$wpdb->wc_category_lookup}.category_id" );
 
 		$included_categories = $this->get_included_categories( $query_args );
 		if ( $included_categories ) {

--- a/src/API/Reports/Coupons/Stats/Segmenter.php
+++ b/src/API/Reports/Coupons/Stats/Segmenter.php
@@ -308,8 +308,9 @@ class Segmenter extends ReportsSegmenter {
 			$this->report_columns      = array_merge( $product_level_columns, $order_level_columns );
 			$segmenting_from           = "
 			INNER JOIN $product_segmenting_table ON ($table_name.order_id = $product_segmenting_table.order_id)
-			LEFT JOIN {$wpdb->prefix}term_relationships ON {$product_segmenting_table}.product_id = {$wpdb->prefix}term_relationships.object_id
-			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->wc_category_lookup}.category_id
+			LEFT JOIN {$wpdb->term_relationships} ON {$product_segmenting_table}.product_id = {$wpdb->term_relationships}.object_id
+			JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.term_taxonomy_id = {$wpdb->term_relationships}.term_taxonomy_id
+			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_taxonomy}.term_id = {$wpdb->wc_category_lookup}.category_id
 			";
 			$segmenting_where          = " AND {$wpdb->wc_category_lookup}.category_tree_id IS NOT NULL";
 			$segmenting_groupby        = "{$wpdb->wc_category_lookup}.category_tree_id";

--- a/src/API/Reports/Orders/Stats/Segmenter.php
+++ b/src/API/Reports/Orders/Stats/Segmenter.php
@@ -404,7 +404,8 @@ class Segmenter extends ReportsSegmenter {
 			$segmenting_from          .= "
 			INNER JOIN $product_segmenting_table ON ($table_name.order_id = $product_segmenting_table.order_id)
 			LEFT JOIN {$wpdb->term_relationships} ON {$product_segmenting_table}.product_id = {$wpdb->term_relationships}.object_id
-			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->wc_category_lookup}.category_id
+			JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.term_taxonomy_id = {$wpdb->term_relationships}.term_taxonomy_id
+			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_taxonomy}.term_id = {$wpdb->wc_category_lookup}.category_id
 			";
 			$segmenting_where          = " AND {$wpdb->wc_category_lookup}.category_tree_id IS NOT NULL";
 			$segmenting_groupby        = "{$wpdb->wc_category_lookup}.category_tree_id";

--- a/src/API/Reports/Products/Stats/Segmenter.php
+++ b/src/API/Reports/Products/Stats/Segmenter.php
@@ -190,7 +190,8 @@ class Segmenter extends ReportsSegmenter {
 			$this->report_columns      = $product_level_columns;
 			$segmenting_from           = "
 			LEFT JOIN {$wpdb->term_relationships} ON {$product_segmenting_table}.product_id = {$wpdb->term_relationships}.object_id
-			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->wc_category_lookup}.category_id
+			JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.term_taxonomy_id = {$wpdb->term_relationships}.term_taxonomy_id
+			LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_taxonomy}.term_id = {$wpdb->wc_category_lookup}.category_id
 			";
 			$segmenting_where          = " AND {$wpdb->wc_category_lookup}.category_tree_id IS NOT NULL";
 			$segmenting_groupby        = "{$wpdb->wc_category_lookup}.category_tree_id";


### PR DESCRIPTION
Fixes #4492.

Match `term_id` to `category_id` after `JOIN`ing through the term taxonomy table.

Note: I'd like to add a test for this, but that's been proving time consuming. _(looks like I'll have to directed insert into the DB to create the proper test conditions)_

### Detailed test instructions:

- Verify the accuracy of the Categories report
- Verify the accuracy of the Categories report when comparing 2+ categories
- Verify the response of `/wp-json/wc-analytics/reports/products/stats` with `?segmentby=category`
- Verify the response of `/wp-json/wc-analytics/reports/orders/stats` with `?segmentby=category`
- Verify the response of `/wp-json/wc-analytics/reports/coupons/stats` with `?segmentby=category`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: category querying in legacy WordPress installs that still have shared terms.