### PR TITLE
Only mark purchase task as complete when products exist

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -82,7 +82,7 @@ export function getAllTasks( {
 			onClick: () =>
 				remainingProductIds.length ? toggleCartModal() : null,
 			visible: productIds.length,
-			completed: ! remainingProductIds.length,
+			completed: productIds.length && ! remainingProductIds.length,
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 		{


### PR DESCRIPTION
Fixes the completion check for the purchase task and doesn't record this task as complete when no products ever existed to purchase.

### Detailed test instructions:

1. Delete the `woocommerce_task_list_tracked_completed_tasks` option if it exists in your options table.
1. Walk through the profiler, selecting product types that don't require purchase.
1. Complete the profiler and view the task list (dashboard).
1. Note in the option `woocommerce_task_list_tracked_completed_tasks` that `purchase` should not exist.
1. Re-enable the profiler, this time including purchaseable product types.
1. Complete the purchase flow, installing these products.
1. Note that `woocommerce_task_list_tracked_completed_tasks` does now contain `purchase`.