### PR TITLE
Add Tool to Clear/Invalidate Analytics Cache

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -15,6 +15,11 @@ use Automattic\WooCommerce\Admin\Loader;
  */
 class Analytics {
 	/**
+	 * Clear cache tool identifier.
+	 */
+	const CACHE_TOOL_ID = 'clear_woocommerce_analytics_cache';
+
+	/**
 	 * Class instance.
 	 *
 	 * @var Analytics instance
@@ -38,6 +43,7 @@ class Analytics {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_pages' ) );
+		add_filter( 'woocommerce_debug_tools', array( $this, 'register_cache_clear_tool' ) );
 	}
 
 	/**
@@ -71,6 +77,35 @@ class Analytics {
 				'variations_report_columns',
 			)
 		);
+	}
+
+	/**
+	 * Register the cache clearing tool on the WooCommerce > Status > Tools page.
+	 *
+	 * @param array $debug_tools Available debug tool registrations.
+	 * @return array Filtered debug tool registrations.
+	 */
+	public function register_cache_clear_tool( $debug_tools ) {
+		$settings_url = add_query_arg(
+			array(
+				'page' => 'wc-admin',
+				'path' => '/analytics/settings',
+			),
+			get_admin_url( null, 'admin.php' )
+		);
+
+		$debug_tools[ self::CACHE_TOOL_ID ] = array(
+			'name'   => __( 'Clear analytics cache', 'woocommerce-admin' ),
+			'button' => __( 'Clear', 'woocommerce-admin' ),
+			'desc'   => sprintf(
+				/* translators: 1: opening link tag, 2: closing tag */
+				'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.',
+				'<a href="' . esc_url( $settings_url ) . '">',
+				'</a>'
+			),
+		);
+
+		return $debug_tools;
 	}
 
 	/**

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -206,5 +206,7 @@ class Analytics {
 	 */
 	public function run_clear_cache_tool() {
 		Cache::invalidate();
+
+		return __( 'Analytics cache cleared.', 'woocommerce-admin' );
 	}
 }

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -9,6 +9,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\API\Reports\Cache;
 
 /**
  * Contains backend logic for the Analytics feature.
@@ -95,14 +96,15 @@ class Analytics {
 		);
 
 		$debug_tools[ self::CACHE_TOOL_ID ] = array(
-			'name'   => __( 'Clear analytics cache', 'woocommerce-admin' ),
-			'button' => __( 'Clear', 'woocommerce-admin' ),
-			'desc'   => sprintf(
+			'name'     => __( 'Clear analytics cache', 'woocommerce-admin' ),
+			'button'   => __( 'Clear', 'woocommerce-admin' ),
+			'desc'     => sprintf(
 				/* translators: 1: opening link tag, 2: closing tag */
 				'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.',
 				'<a href="' . esc_url( $settings_url ) . '">',
 				'</a>'
 			),
+			'callback' => array( $this, 'run_clear_cache_tool' ),
 		);
 
 		return $debug_tools;
@@ -197,5 +199,12 @@ class Analytics {
 				wc_admin_register_page( $report_page );
 			}
 		}
+	}
+
+	/**
+	 * "Clear" analytics cache by invalidating it.
+	 */
+	public function run_clear_cache_tool() {
+		Cache::invalidate();
 	}
 }


### PR DESCRIPTION
Fixes #4251 

This PR adds a button to the WooCommerce > Status > Tools page that allows a self service clearing of the transient-based Analytics cache. It also includes a link to the Analytics Settings page with a note about the Historical Data Import.

### Screenshots

![Screen Shot 2020-06-15 at 12 31 09 PM](https://user-images.githubusercontent.com/63922/84683012-88ea2e00-af04-11ea-96b5-0d5bc3d353d8.png)

### Detailed test instructions:

- Visit an Analytics page so that cache is primed
- Note the value of the `_transient_woocommerce_reports-transient-version` option
- Go to WooCommerce > Status > Tools
- Run the "Clear analytics cache" tool
- Verify the value of the `_transient_woocommerce_reports-transient-version` option has changed

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add tool for user to clear Analytics cache.