### PR TITLE
Fix deleted products breaking Downloads Report

### DIFF
--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -85,16 +85,31 @@ class CouponsReportTable extends Component {
 				product_id: productId,
 				username,
 			} = download;
-			const { name: productName } = _embedded.product[ 0 ];
 
-			const productLink = getNewPath(
-				persistedQuery,
-				'/analytics/products',
-				{
-					filter: 'single_product',
-					products: productId,
-				}
-			);
+			const { code: errorCode, name: productName } = _embedded.product[ 0 ];
+			let productDisplay, productValue;
+
+			// Handle deleted products.
+			if ( errorCode === 'woocommerce_rest_product_invalid_id' ) {
+				productDisplay = __( '(Deleted)', 'woocommerce-admin' );
+				productValue = __( '(Deleted)', 'woocommerce-admin' );
+			} else {
+				const productURL = getNewPath(
+					persistedQuery,
+					'/analytics/products',
+					{
+						filter: 'single_product',
+						products: productId,
+					}
+				);
+
+				productDisplay = (
+					<Link href={ productURL } type="wc-admin">
+						{ productName }
+					</Link>
+				);
+				productValue = productName;
+			}
 
 			return [
 				{
@@ -104,12 +119,8 @@ class CouponsReportTable extends Component {
 					value: date,
 				},
 				{
-					display: (
-						<Link href={ productLink } type="wc-admin">
-							{ productName }
-						</Link>
-					),
-					value: productName,
+					display: productDisplay,
+					value: productValue,
 				},
 				{
 					display: (

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -107,12 +107,20 @@ class Controller extends ReportsController implements ExportableInterface {
 
 		// Figure out file name.
 		// Matches https://github.com/woocommerce/woocommerce/blob/4be0018c092e617c5d2b8c46b800eb71ece9ddef/includes/class-wc-download-handler.php#L197.
-		$product_id                     = intval( $data['product_id'] );
-		$_product                       = wc_get_product( $product_id );
-		$file_path                      = $_product->get_file_download_path( $data['download_id'] );
-		$filename                       = basename( $file_path );
-		$response->data['file_name']    = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
-		$response->data['file_path']    = $file_path;
+		$product_id = intval( $data['product_id'] );
+		$_product   = wc_get_product( $product_id );
+
+		// Make sure the product hasn't been deleted.
+		if ( $_product ) {
+			$file_path                   = $_product->get_file_download_path( $data['download_id'] );
+			$filename                    = basename( $file_path );
+			$response->data['file_name'] = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
+			$response->data['file_path'] = $file_path;
+		} else {
+			$response->data['file_name'] = '';
+			$response->data['file_path'] = '';
+		}
+
 		$customer                       = new \WC_Customer( $data['user_id'] );
 		$response->data['username']     = $customer->get_username();
 		$response->data['order_number'] = $this->get_order_number( $data['order_id'] );

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -166,7 +166,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$object->set_permission_id( $download->get_id() );
 		$object->set_user_id( 2 );
 		$object->set_user_ip_address( '5.4.3.2.1' );
-		$object->set_timestamp( date( 'Y-m-d H:00:00', $time - ( 2 * DAY_IN_SECONDS ) ) );
+		$object->set_timestamp( gmdate( 'Y-m-d H:00:00', $time - ( 2 * DAY_IN_SECONDS ) ) );
 		$id = $object->save();
 
 		WC_Helper_Queue::run_all_pending();
@@ -196,8 +196,8 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'before' => date( 'Y-m-d H:00:00', $test_info['time'] + DAY_IN_SECONDS ),
-				'after'  => date( 'Y-m-d H:00:00', $test_info['time'] - DAY_IN_SECONDS ),
+				'before' => gmdate( 'Y-m-d H:00:00', $test_info['time'] + DAY_IN_SECONDS ),
+				'after'  => gmdate( 'Y-m-d H:00:00', $test_info['time'] - DAY_IN_SECONDS ),
 			)
 		);
 		$response        = $this->server->dispatch( $request );

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -380,6 +380,27 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test deleted product in report result set.
+	 */
+	public function test_get_report_with_deleted_product() {
+		$test_info = $this->filter_setup();
+
+		// Delete the first test product.
+		\WC_Helper_Product::delete_product( $test_info['product_1'] );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		// Verify the first product's download info is blank.
+		$this->assertEquals( '', $reports[0]['file_name'] );
+		$this->assertEquals( '', $reports[0]['file_path'] );
+		$this->assertEquals( 'test.png', $reports[1]['file_name'] );
+	}
+
+	/**
 	 * Test getting reports without valid permissions.
 	 */
 	public function test_get_reports_without_permission() {


### PR DESCRIPTION
Fixes #4421.

This PR seeks to fix the fatal errors thrown when viewing the Downloads Report where one of the products containing the download has been deleted. Deleted products will show as `(Deleted)` in the report table.

### Screenshots

![Screen Shot 2020-06-15 at 4 11 26 PM](https://user-images.githubusercontent.com/63922/84701602-497f0a00-af23-11ea-873c-dbe376209867.png)

### Detailed test instructions:

- Create a variable product with 1 variation that has a download attached.
- Add variation to cart, purchase, and then download file.
- Go back to product, switch to simple.
- This may not be needed, but I did it... Add download to simple product, add to cart, purchase, and download that file.
- Go to Analytics > Downloads
- Verify the report does load correctly and the row shows "(Deleted)"

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: deleted products breaking Downloads Report.