### PR TITLE
Onboarding: Fixed choose a theme from the Live demo

### DIFF
--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -191,10 +191,7 @@ class Theme extends Component {
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 
 		return (
-			<Card
-				className="woocommerce-profile-wizard__theme"
-				key={ theme.slug }
-			>
+			<Card className="woocommerce-profile-wizard__theme" key={ slug }>
 				{ image && (
 					<div
 						className="woocommerce-profile-wizard__theme-image"

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -397,7 +397,7 @@ class Theme extends Component {
 				{ demo && (
 					<ThemePreview
 						theme={ demo }
-						onChoose={ this.onChoose }
+						onChoose={ () => this.onChoose( demo, 'card' ) }
 						onClose={ this.onClosePreview }
 						isBusy={ chosen === demo.slug }
 					/>


### PR DESCRIPTION
Fixes #4556

This PR fixes a problem with the method `onChoose` in the last onboarding step.

### Screenshots
Before
![Screen Capture on 2020-06-11 at 13-12-32](https://user-images.githubusercontent.com/1314156/84412265-5dee9a00-abe5-11ea-9cf5-35517f729c2f.gif)


And now
![Screen Capture on 2020-06-15 at 17-59-10](https://user-images.githubusercontent.com/1314156/84705615-0d9f7100-af32-11ea-8643-1aed9a67b8d0.gif)

### Detailed test instructions:
1. Be sure you have the `New onboarding experience` and the `Profile Setup Wizard` enabled.
2. Go to the last step of the new onboarding (URL: `/wp-admin/admin.php?page=wc-admin&step=theme`).
3. Press the `Live Demo` button of any theme.
4. Now press the `Choose` button visible at the top right of the screen.
5. This should install the theme.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Solved a problem with the method `onChoose` in the last onboarding step.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
