### PR TITLE
G2: Remove pink/purple from ActivityPanels and Header

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -45,11 +45,6 @@
 	display: flex;
 	flex-direction: column;
 
-	a {
-		color: $studio-woocommerce-purple;
-		text-decoration: none;
-	}
-
 	.woocommerce-activity-card__title {
 		margin: 0;
 		@include font-size( 13 );

--- a/client/header/activity-panel/activity-outbound-link/style.scss
+++ b/client/header/activity-panel/activity-outbound-link/style.scss
@@ -22,16 +22,13 @@
 
 	&:hover {
 		background: $studio-white;
-		color: $studio-woocommerce-purple;
 	}
 
 	&:active {
 		background: $core-grey-light-100;
-		color: $studio-woocommerce-purple-70;
 	}
 
 	&:focus {
-		color: $studio-woocommerce-purple;
 		background: $core-grey-light-200;
 		box-shadow: inset 0 0 0 1px $box-shadow-blue, inset 0 0 0 2px $studio-white;
 	}
@@ -40,14 +37,12 @@
 	&:focus {
 		.gridicon {
 			display: initial;
-			color: $studio-woocommerce-purple;
 		}
 	}
 
 	&:active {
 		.gridicon {
 			display: initial;
-			color: $studio-woocommerce-purple-70;
 		}
 	}
 }

--- a/client/header/activity-panel/activity-outbound-link/style.scss
+++ b/client/header/activity-panel/activity-outbound-link/style.scss
@@ -13,7 +13,6 @@
 	font-weight: 500;
 	line-height: 18px;
 	margin: 0;
-	color: $studio-woocommerce-purple;
 	text-decoration: none;
 
 	.gridicon {

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -109,7 +109,7 @@
 			content: ' ';
 			position: absolute;
 			padding: 1px;
-			background: $core-orange;
+			background: $alert-red;
 			border: 2px solid $studio-white;
 			width: 4px;
 			height: 4px;

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -38,10 +38,6 @@
 			color: $gray-text;
 			margin: 0 2px 0 2px;
 		}
-
-		a {
-			color: $studio-pink;
-		}
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -201,7 +201,6 @@
 		text-align: right;
 
 		button.is-link {
-			color: $studio-pink;
 			margin-right: $gap;
 			text-decoration: none;
 			font-weight: 600;

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -31,25 +31,6 @@
 }
 
 .woocommerce-layout {
-	a:link,
-	a:visited,
-	.components-button.is-link {
-		color: $studio-pink;
-	}
-
-	a:hover,
-	a:active,
-	a:focus,
-	.components-button.is-link:hover,
-	.components-button.is-link:active,
-	.components-button.is-link:focus {
-		color: $studio-pink;
-	}
-
-	a:focus {
-		box-shadow: 0 0 0 1px $studio-pink, 0 0 2px 1px rgba($studio-pink, 0.8);
-	}
-
 	select:hover {
 		color: $core-grey-dark-700;
 	}


### PR DESCRIPTION
For #3897

This PR removes pinks and purples from the Header and Activity Panel areas:

__To Test__
- Open up a screen with the Activity Panel / Header, verify no pink or purple is seen.

__Before__
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-43-22](https://user-images.githubusercontent.com/22080/84716323-a1b80b00-af27-11ea-9146-90f1b91fa172.png)
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-43-33](https://user-images.githubusercontent.com/22080/84716335-a7adec00-af27-11ea-8822-9fc4355fb25c.png)
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-43-40](https://user-images.githubusercontent.com/22080/84716339-aa104600-af27-11ea-9f5c-62c711fef1d2.png)
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-43-54](https://user-images.githubusercontent.com/22080/84716342-abda0980-af27-11ea-934c-de3779bca364.png)

__After__
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-42-04](https://user-images.githubusercontent.com/22080/84716353-b4cadb00-af27-11ea-8a67-561262e7c4f6.png)
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-41-49](https://user-images.githubusercontent.com/22080/84716355-b6949e80-af27-11ea-9ba5-bbd9e0f7f6fc.png)
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-06-15 16-41-38](https://user-images.githubusercontent.com/22080/84716365-b8f6f880-af27-11ea-9298-e84c4ad8a2d5.png)
