### PR TITLE
Add a bottom border to the Install Jetpack CTA

### DIFF
--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -1,6 +1,7 @@
 // Set up some local color variables to make the CSS more clear
 $outer-border: $core-grey-light-700;
-$promo-actions-border: $core-grey-light-500;
+$promo-actions-border-top: $core-grey-light-500;
+$promo-actions-border-bottom: $light-gray-tertiary;
 
 .woocommerce-stats-overview {
 	.woocommerce-card__body {
@@ -73,7 +74,8 @@ article.woocommerce-stats-overview__install-jetpack-promo {
 		margin: 0 $gap-large $gap;
 	}
 	footer {
-		border-top: 1px solid $promo-actions-border;
+		border-top: 1px solid $promo-actions-border-top;
+		border-bottom: 1px solid $promo-actions-border-bottom;
 
 		.components-button {
 			margin: $gap $gap-smallest;


### PR DESCRIPTION
A border was forgotten when adding the Install Jetpack CTA to the stats overview. This PR just adds it.

### Detailed test instructions:

- Uninstall or deactivate Jetpack if you have it installed
- Visit the WC home page. There should be a border between the CTA buttons and the stats.

![image](https://user-images.githubusercontent.com/224531/84738338-16a14880-afed-11ea-86db-91c5cf8b7cc3.png)
