### PR TITLE
Tests: Prevent UnhandledPromiseRejectionWarning in tests

### DIFF
--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -10,18 +10,9 @@ import { Button } from '@wordpress/components';
 
 import { Plugins } from '../index.js';
 
-// This function will cause Jest to wait until all Promises have completed
-// See: https://stackoverflow.com/questions/37408834/testing-with-reacts-jest-and-enzyme-when-simulated-clicks-call-a-function-that
-function tick() {
-	return new Promise( ( resolve ) => {
-		setTimeout( resolve, 0 );
-	} );
-}
-
 describe( 'Rendering', () => {
 	it( 'should render nothing when autoInstalling', async () => {
-		const installPlugins = jest.fn().mockResolvedValue( { success: true } );
-		const activatePlugins = jest.fn().mockResolvedValue( {
+		const installAndActivatePlugins = jest.fn().mockResolvedValue( {
 			success: true,
 			data: {
 				activated: [ 'jetpack' ],
@@ -35,13 +26,10 @@ describe( 'Rendering', () => {
 				autoInstall
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ onComplete }
-				installPlugins={ installPlugins }
-				activatePlugins={ activatePlugins }
+				installAndActivatePlugins={ installAndActivatePlugins }
 				createNotice={ createNotice }
 			/>
 		);
-
-		await tick();
 
 		const buttons = pluginsWrapper.find( Button );
 		expect( buttons.length ).toBe( 0 );
@@ -52,8 +40,6 @@ describe( 'Rendering', () => {
 			<Plugins pluginSlugs={ [] } onComplete={ () => {} } />
 		);
 
-		await tick();
-
 		const continueButton = pluginsWrapper.find( Button );
 		expect( continueButton.length ).toBe( 1 );
 		expect( continueButton.text() ).toBe( 'Continue' );
@@ -63,8 +49,6 @@ describe( 'Rendering', () => {
 		const pluginsWrapper = shallow(
 			<Plugins pluginSlugs={ [ 'jetpack' ] } onComplete={ () => {} } />
 		);
-
-		await tick();
 
 		const buttons = pluginsWrapper.find( Button );
 		expect( buttons.length ).toBe( 2 );
@@ -84,9 +68,6 @@ describe( 'Installing and activating', () => {
 	const onComplete = jest.fn();
 
 	beforeEach( () => {
-		installPlugins.mockClear();
-		activatePlugins.mockClear();
-
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
@@ -127,9 +108,6 @@ describe( 'Installing and activating errors', () => {
 	const onError = jest.fn();
 
 	beforeEach( () => {
-		installPlugins.mockClear();
-		activatePlugins.mockClear();
-
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
@@ -150,8 +128,6 @@ describe( 'Installing and activating errors', () => {
 	it( 'should call the onError callback', async () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
-
-		await tick();
 
 		expect( onError ).toHaveBeenCalledWith( errors );
 	} );

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -10,33 +10,62 @@ import { Button } from '@wordpress/components';
 
 import { Plugins } from '../index.js';
 
+// This function will cause Jest to wait until all Promises have completed
+// See: https://stackoverflow.com/questions/37408834/testing-with-reacts-jest-and-enzyme-when-simulated-clicks-call-a-function-that
+function tick() {
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, 0 );
+	} );
+}
+
 describe( 'Rendering', () => {
-	it( 'should render nothing when autoInstalling', () => {
+	it( 'should render nothing when autoInstalling', async () => {
+		const installPlugins = jest.fn().mockResolvedValue( { success: true } );
+		const activatePlugins = jest.fn().mockResolvedValue( {
+			success: true,
+			data: {
+				activated: [ 'jetpack' ],
+			},
+		} );
+		const createNotice = jest.fn();
+		const onComplete = jest.fn();
+
 		const pluginsWrapper = shallow(
 			<Plugins
 				autoInstall
 				pluginSlugs={ [ 'jetpack' ] }
-				onComplete={ () => {} }
+				onComplete={ onComplete }
+				installPlugins={ installPlugins }
+				activatePlugins={ activatePlugins }
+				createNotice={ createNotice }
 			/>
 		);
-		const buttons = pluginsWrapper.find( Button );
 
+		await tick();
+
+		const buttons = pluginsWrapper.find( Button );
 		expect( buttons.length ).toBe( 0 );
 	} );
 
-	it( 'should render a continue button when no pluginSlugs are given', () => {
+	it( 'should render a continue button when no pluginSlugs are given', async () => {
 		const pluginsWrapper = shallow(
 			<Plugins pluginSlugs={ [] } onComplete={ () => {} } />
 		);
+
+		await tick();
+
 		const continueButton = pluginsWrapper.find( Button );
 		expect( continueButton.length ).toBe( 1 );
 		expect( continueButton.text() ).toBe( 'Continue' );
 	} );
 
-	it( 'should render install and no thanks buttons', () => {
+	it( 'should render install and no thanks buttons', async () => {
 		const pluginsWrapper = shallow(
 			<Plugins pluginSlugs={ [ 'jetpack' ] } onComplete={ () => {} } />
 		);
+
+		await tick();
+
 		const buttons = pluginsWrapper.find( Button );
 		expect( buttons.length ).toBe( 2 );
 		expect( buttons.at( 0 ).text() ).toBe( 'Install & enable' );
@@ -55,6 +84,9 @@ describe( 'Installing and activating', () => {
 	const onComplete = jest.fn();
 
 	beforeEach( () => {
+		installPlugins.mockClear();
+		activatePlugins.mockClear();
+
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
@@ -68,7 +100,9 @@ describe( 'Installing and activating', () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( installAndActivatePlugins ).toHaveBeenCalledWith( [ 'jetpack' ] );
+		expect( installAndActivatePlugins ).toHaveBeenCalledWith( [
+			'jetpack',
+		] );
 	} );
 
 	it( 'should call the onComplete callback', async () => {
@@ -93,6 +127,9 @@ describe( 'Installing and activating errors', () => {
 	const onError = jest.fn();
 
 	beforeEach( () => {
+		installPlugins.mockClear();
+		activatePlugins.mockClear();
+
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
@@ -113,6 +150,8 @@ describe( 'Installing and activating errors', () => {
 	it( 'should call the onError callback', async () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
+
+		await tick();
 
 		expect( onError ).toHaveBeenCalledWith( errors );
 	} );


### PR DESCRIPTION
Partially fixes #4534

This PR updates the JS unit tests for `plugins` outputting the `UnhandledPromiseRejectionWarning` warning.

### Detailed test instructions:

- Check out master
- Run `npm test`
- Note the following error is output:

```
(node:5668) UnhandledPromiseRejectionWarning: TypeError: installAndActivatePlugins is not a function
(node:5668) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:5668) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

- Check out this branch
- Run `npm tests`
- Verify that the above error is no longer output

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

No changelog required.