### PR TITLE
Style cleanup from components update

### DIFF
--- a/client/analytics/settings/setting.scss
+++ b/client/analytics/settings/setting.scss
@@ -40,13 +40,17 @@
 		margin-bottom: 0;
 	}
 
-	button {
+	button:not(.components-tab-panel__tabs-item) {
 		margin-bottom: $gap-small;
 		align-self: flex-start;
 	}
 
 	.components-base-control__field {
 		display: flex;
+	}
+
+	.woocommerce-filters-date__content-controls {
+		padding-bottom: 0;
 	}
 }
 

--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -16,6 +16,9 @@ import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 class Connect extends Component {
 	constructor( props ) {
 		super( props );
+		this.state = {
+			isConnecting: false,
+		};
 
 		this.connectJetpack = this.connectJetpack.bind( this );
 		props.setIsPending( true );
@@ -59,10 +62,14 @@ class Connect extends Component {
 	async connectJetpack() {
 		const { jetpackConnectUrl, onConnect } = this.props;
 
-		if ( onConnect ) {
-			onConnect();
-		}
-		window.location = jetpackConnectUrl;
+		this.setState( {
+			isConnecting: true,
+		}, () => {
+			if ( onConnect ) {
+				onConnect();
+			}
+			window.location = jetpackConnectUrl;
+		} );
 	}
 
 	render() {
@@ -90,6 +97,7 @@ class Connect extends Component {
 				) : (
 					<Button
 						disabled={ isRequesting }
+						isBusy={ this.state.isConnecting }
 						isPrimary
 						onClick={ this.connectJetpack }
 					>

--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -3,7 +3,6 @@
 .woocommerce-transient-notices {
 	position: fixed;
 	bottom: $gap-small;
-	left: 176px;
 	z-index: 99999;
 
 	@media (max-width: 960px) {
@@ -12,5 +11,10 @@
 
 	@media (max-width: 782px) {
 		left: $gap;
+	}
+
+	.components-snackbar {
+		margin-left: auto;
+		margin-right: auto;
 	}
 }

--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -3,6 +3,7 @@
 .woocommerce-transient-notices {
 	position: fixed;
 	bottom: $gap-small;
+	left: 176px;
 	z-index: 99999;
 
 	@media (max-width: 960px) {
@@ -13,8 +14,12 @@
 		left: $gap;
 	}
 
-	.components-snackbar {
-		margin-left: auto;
-		margin-right: auto;
+	.woocommerce-profile-wizard__body & {
+		left: unset;
+
+		.components-snackbar {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 }

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -101,13 +101,6 @@
 			min-width: 106px;
 			height: 40px;
 			line-height: 1;
-			box-shadow: none;
-
-			&.is-default {
-				border-color: $studio-pink-50;
-				color: $studio-pink-50;
-				background: transparent;
-			}
 
 			&.is-primary {
 				color: $studio-white;

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -6,6 +6,8 @@
 	.woocommerce-task-dashboard__container {
 		.woocommerce-task-card {
 			.components-card__header.is-size-large {
+				min-height: unset;
+				padding-top: 0;
 				display: grid;
 				grid-template-columns: auto 24px;
 			}

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -24,19 +24,34 @@
 	}
 
 	.CalendarDay__selected_span {
-		background: $studio-woocommerce-purple;
+		background: theme(primary);
 		border: 1px solid $core-grey-light-700;
+
+		&:hover {
+			background: theme(secondary);
+			border: 1px solid $core-grey-light-500;
+		}
 	}
 
 	.CalendarDay__selected {
-		background: $studio-woocommerce-purple-70;
+		background: color(theme(primary) shade(20%));
 		border: 1px solid $core-grey-light-700;
+
+		&:hover {
+			background: theme(secondary);
+			border: 1px solid $core-grey-light-500;
+		}
 	}
 
 	.CalendarDay__hovered_span {
-		background: $studio-woocommerce-purple;
+		background: color(theme(primary) shade(15%));
 		border: 1px solid $core-grey-light-500;
 		color: $studio-white;
+
+		&:hover {
+			color: $studio-white;
+			background: theme(primary);
+		}
 	}
 
 	.CalendarDay__blocked_out_of_range {

--- a/packages/components/src/date-range-filter-picker/style.scss
+++ b/packages/components/src/date-range-filter-picker/style.scss
@@ -20,6 +20,7 @@
 
 .woocommerce-filters-date__tabs {
 	height: calc(100% - 42px);
+	border-top: 1px solid $core-grey-light-700;
 
 	.components-tab-panel__tabs {
 		display: flex;
@@ -37,9 +38,7 @@
 		flex-direction: column;
 		align-items: center;
 	}
-}
 
-.woocommerce-filters-date__tab {
 	@include set-grid-item-position( 2, 2 );
 }
 
@@ -74,7 +73,7 @@
 	justify-content: center;
 	width: 100%;
 
-	.woocommerce-filters-date__button.is-button {
+	.woocommerce-filters-date__button {
 		justify-content: center;
 		width: 40%;
 		height: 34px;

--- a/packages/components/src/dropdown-button/style.scss
+++ b/packages/components/src/dropdown-button/style.scss
@@ -32,11 +32,6 @@
 		background-color: $core-grey-light-100;
 	}
 
-	&.components-button:focus:not(:disabled) {
-		border-color: $studio-woocommerce-purple-60;
-		box-shadow: 0 0 2px rgba($studio-woocommerce-purple-60, 0.8);
-	}
-
 	&.is-multi-line .woocommerce-dropdown-button__labels {
 		flex-direction: column;
 	}

--- a/packages/components/src/ellipsis-menu/index.js
+++ b/packages/components/src/ellipsis-menu/index.js
@@ -48,6 +48,7 @@ class EllipsisMenu extends Component {
 			<div className="woocommerce-ellipsis-menu">
 				<Dropdown
 					contentClassName="woocommerce-ellipsis-menu__popover"
+					focusOnMount="container"
 					position="bottom left"
 					renderToggle={ renderEllipsis }
 					renderContent={ renderMenu }

--- a/packages/components/src/ellipsis-menu/index.js
+++ b/packages/components/src/ellipsis-menu/index.js
@@ -48,7 +48,6 @@ class EllipsisMenu extends Component {
 			<div className="woocommerce-ellipsis-menu">
 				<Dropdown
 					contentClassName="woocommerce-ellipsis-menu__popover"
-					focusOnMount="container"
 					position="bottom left"
 					renderToggle={ renderEllipsis }
 					renderContent={ renderMenu }

--- a/packages/components/src/ellipsis-menu/style.scss
+++ b/packages/components/src/ellipsis-menu/style.scss
@@ -26,10 +26,6 @@
 		padding: 2px;
 	}
 
-	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: $studio-woocommerce-purple;
-	}
-
 	.woocommerce-ellipsis-menu__content {
 		width: 100%;
 	}

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -89,8 +89,18 @@
 		fill: $chevron-color;
 	}
 
-	&.is-complete .woocommerce-task__icon {
-		background-color: $theme-color;
+	&.is-complete {
+		.woocommerce-task__icon {
+			background-color: $theme-color;
+		}
+
+		.woocommerce-list__item-title {
+			color: $dark-gray-500;
+		}
+
+		.woocommerce-list__item-content {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4588.

This PR fixes the styling problems pointed out in the linked issue. It also restores the new styling of the `<TaskList />` components that was somehow lost (diff between complete and incomplete tasks).

### Screenshots

![Screen Shot 2020-06-16 at 4 25 50 PM](https://user-images.githubusercontent.com/63922/84824791-7a784100-afee-11ea-8ede-94be68dfd2cc.png)

![Screen Shot 2020-06-16 at 4 10 30 PM](https://user-images.githubusercontent.com/63922/84824809-7f3cf500-afee-11ea-9376-8d377938ddf2.png)

![Screen Shot 2020-06-16 at 4 10 49 PM](https://user-images.githubusercontent.com/63922/84824816-819f4f00-afee-11ea-9c8b-d38cf5bfc6de.png)

![Screen Shot 2020-06-16 at 4 11 28 PM](https://user-images.githubusercontent.com/63922/84824838-86640300-afee-11ea-96c7-34a34adbf7e4.png)

![Screen Shot 2020-06-16 at 4 12 06 PM](https://user-images.githubusercontent.com/63922/84824844-89f78a00-afee-11ea-9163-0ea21b8117c4.png)

