### PR TITLE
Fix/beta styles

### DIFF
--- a/client/analytics/settings/setting.scss
+++ b/client/analytics/settings/setting.scss
@@ -40,7 +40,7 @@
 		margin-bottom: 0;
 	}
 
-	button {
+	button:not(.components-tab-panel__tabs-item) {
 		margin-bottom: $gap-small;
 		align-self: flex-start;
 	}

--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -3,14 +3,15 @@
 .woocommerce-transient-notices {
 	position: fixed;
 	bottom: $gap-small;
-	left: 176px;
+	left: 0;
 	z-index: 99999;
 
-	@media (max-width: 960px) {
-		left: 50px;
+	.components-snackbar-list__notice-container {
+		margin-left: $gap-small;
+		margin-right: $gap-small;
 	}
 
-	@media (max-width: 782px) {
-		left: $gap;
+	.components-snackbar {
+		margin: 0 auto;
 	}
 }

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -98,24 +98,9 @@
 			margin: 13px auto 0 auto;
 			display: block;
 			width: auto;
-			min-width: 106px;
-			height: 40px;
-			line-height: 1;
-			box-shadow: none;
-
-			&.is-default {
-				border-color: $studio-pink-50;
-				color: $studio-pink-50;
-				background: transparent;
-			}
 
 			&.is-primary {
 				color: $studio-white;
-			}
-
-			&.is-tertiary {
-				font-size: 14px;
-				font-weight: 500;
 			}
 		}
 	}

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -498,6 +498,10 @@
 
 .woocommerce-task-card__section-controls {
 	text-align: center;
+
+	.components-button {
+		margin: 16px;
+	}
 }
 
 .woocommerce-task-dashboard__container {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -24,17 +24,31 @@
 	}
 
 	.CalendarDay__selected_span {
-		background: $studio-woocommerce-purple;
+		background: $blue-medium-focus;
 		border: 1px solid $core-grey-light-700;
 	}
 
+	.CalendarDay__hovered_span,
+	.CalendarDay__hovered_span:hover,
+	.CalendarDay__selected_span:hover {
+		background: lighten($blue-medium-focus, 10%);
+		border: 1px solid $core-grey-light-700;
+		color: $studio-white;
+	}
+
 	.CalendarDay__selected {
-		background: $studio-woocommerce-purple-70;
+		background: darken($blue-medium-focus, 10%);
+		border: 1px solid $core-grey-light-700;
+	}
+
+	.CalendarDay__selected:active,
+	.CalendarDay__selected:hover {
+		background: darken($blue-medium-focus, 20%);
 		border: 1px solid $core-grey-light-700;
 	}
 
 	.CalendarDay__hovered_span {
-		background: $studio-woocommerce-purple;
+		background: $blue-medium-focus;
 		border: 1px solid $core-grey-light-500;
 		color: $studio-white;
 	}


### PR DESCRIPTION
Partially solves https://github.com/woocommerce/woocommerce-admin/issues/4588

Fix some 1.3.0-beta.1 styling issues. See https://github.com/woocommerce/woocommerce-admin/issues/4588 for "before" screenshots

#### OBW theme button styles

![Screen Shot 2020-06-17 at 1 48 29 PM](https://user-images.githubusercontent.com/1922453/84845712-59bcf380-b0a1-11ea-8485-09c63b447846.png)

#### Centered Notifications

I reverted changes so that all notices are centered. Since `<TransientNotices />` are at the root node, the only way to differentiate is to have the Task List and OBW add a class to the root node. Since 95% of our notices are in the Task List and OBW, I made them all centered. I think we can revisit whether or not the added cost of implementing this is worth it for the next release.

#### "Hide this" on the Task List

![Screen Shot 2020-06-17 at 2 03 11 PM](https://user-images.githubusercontent.com/1922453/84846637-5460a880-b0a3-11ea-80ee-0a89cff68e6a.png)

#### Date Range Picker Colors

https://github.com/woocommerce/woocommerce-admin/issues/3897 says selected dates should be `$blue-medium-focus` so I went with that and lightened/darkened for selected and hover states.

![Screen Shot 2020-06-17 at 1 39 51 PM](https://user-images.githubusercontent.com/1922453/84846002-f8495480-b0a1-11ea-8cd9-ad3cfea9a9fc.png)

### Detailed test instructions:

1. Go to the Themes section of the OBW, notice "Choose"  button now has a border.
2. Disable the Task List by with the "Hide this" button from the ellipsis menu. Note the new spacing.
3. Interact with the Date Range Picker on any report, note the date selection colors.
4. Fire off a notice, the appearance task in the Task List is good, and see the notice centered

### Changelog Note:

none - fix unreleased change.
