### PR TITLE
New notification: Customize your online store with WooCommerce blocks

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -33,6 +33,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Need_Some_Inspiration;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Learn_More_About_Product_Settings;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Online_Clothing_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_First_Product;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Customize_Store_With_Blocks;
 
 /**
  * WC_Admin_Events Class.
@@ -97,6 +98,7 @@ class Events {
 		WC_Admin_Notes_First_Product::possibly_add_note();
 		WC_Admin_Notes_Choose_Niche::possibly_add_note();
 		WC_Admin_Notes_Real_Time_Order_Alerts::possibly_add_note();
+		WC_Admin_Notes_Customize_Store_With_Blocks::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/WC_Admin_Notes_Customize_Store_With_Blocks.php
+++ b/src/Notes/WC_Admin_Notes_Customize_Store_With_Blocks.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WooCommerce Admin: Customize your online store with WooCommerce blocks.
+ *
+ * Adds a note to customize the client online store with WooCommerce blocks.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Customize_Store_With_Blocks.
+ */
+class WC_Admin_Notes_Customize_Store_With_Blocks {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-customize-store-with-blocks';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Confirm that $onboarding_profile is set.
+		if ( empty( $onboarding_profile ) ) {
+			return;
+		}
+
+		// Make sure that the person who filled out the OBW was not setting up
+		// the store for their customer/client.
+		if ( $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// We want to show the note after fourteen days.
+		if ( ! self::wc_admin_active_for( 14 * DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		// Don't show if there aren't products.
+		$query    = new \WC_Product_Query(
+			array(
+				'limit'  => 1,
+				'return' => 'ids',
+				'status' => array( 'publish' ),
+			)
+		);
+		$products = $query->get_products();
+		if ( 0 === count( $products ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Customize your online store with WooCommerce blocks', 'woocommerce-admin' ) );
+		$note->set_content( __( 'With our blocks, you can select and display products, categories, filters, and more virtually anywhere on your site — no need to use shortcodes or edit lines of code. Learn more about how to use each one of them.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'customize-store-with-blocks',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/how-to-customize-your-online-store-with-woocommerce-blocks/?utm_source=inbox',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4212

This PR adds a new notification to customize the client store with WooCommerce blocks

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:
This notification should be visible for:
- New users with `setup_client: false` on `woocommerce_onboarding_profile `
- AND -> Has products.
- AND -> Timing: 14 days after registration

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Added new notification to customize the client store with blocks
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
