### PR TITLE
Disable task list on analytics dashboard when homepage is enabled.

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -73,6 +73,7 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 
 const CustomizableDashboard = ( {
 	defaultDateRange,
+	homepageEnabled,
 	path,
 	query,
 	taskListComplete,
@@ -92,7 +93,7 @@ const CustomizableDashboard = ( {
 
 	const sections = dashSections || defaultSections;
 
-	const isTaskListEnabled = isOnboardingEnabled() && ! taskListHidden;
+	const isTaskListEnabled = ! homepageEnabled && isOnboardingEnabled() && ! taskListHidden;
 
 	const isDashboardShown =
 		! isTaskListEnabled || ( ! query.task && taskListComplete );

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -45,6 +45,7 @@ class AnalyticsDashboard {
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 	}
 
 	/**
@@ -76,6 +77,18 @@ class AnalyticsDashboard {
 				'homepage_stats',
 			)
 		);
+	}
+
+	/**
+	 * Preload options to prime state of the application.
+	 *
+	 * @param array $options Array of options to preload.
+	 * @return array
+	 */
+	public function preload_options( $options ) {
+		$options[] = 'woocommerce_homescreen_enabled';
+
+		return $options;
 	}
 
 	/**


### PR DESCRIPTION
Regression from 5b88ee0b82282a168d62fb8128375828a72ad2a1.

Fixes #4601.

### Detailed test instructions:

- Ensure that your test store has the new homepage enabled
- Ensure that your test store has the task list enabled
- Visit the Analytics Overview page
- Verify the task list is NOT displayed

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A (unreleased bug)