### PR TITLE
Inbox panel - Actioned inbox notifications now are visible

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -273,6 +273,7 @@ class InboxNoteCard extends Component {
 			image,
 			is_deleted: isDeleted,
 			layout,
+			status,
 			title,
 		} = note;
 
@@ -287,7 +288,7 @@ class InboxNoteCard extends Component {
 		const date = dateCreated;
 		const hasImage = layout !== 'plain' && layout !== '';
 		const cardClassName = classnames( 'woocommerce-inbox-message', layout, {
-			'message-is-unread': unread,
+			'message-is-unread': unread && status === 'unactioned',
 		} );
 
 		return (

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -70,7 +70,7 @@ const renderNotes = ( {
 			/>
 		);
 	} );
-}
+};
 
 const InboxPanel = ( props ) => {
 	const {
@@ -87,7 +87,7 @@ const InboxPanel = ( props ) => {
 
 	useEffect( () => {
 		const mountTime = Date.now();
-	
+
 		return () => {
 			const userDataFields = {
 				activity_panel_inbox_last_read: mountTime,
@@ -106,8 +106,6 @@ const InboxPanel = ( props ) => {
 			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 			window.location.reload();
 		};
-
-		
 
 		return (
 			<Fragment>
@@ -139,10 +137,7 @@ const InboxPanel = ( props ) => {
 						'Insights and growth tips for your business',
 						'woocommerce-admin'
 					) }
-					unreadMessages={ getUnreadNotesCount(
-						notes,
-						lastRead
-					) }
+					unreadMessages={ getUnreadNotesCount( notes, lastRead ) }
 				/>
 			) }
 			<div className="woocommerce-homepage-notes-wrapper">
@@ -165,7 +160,7 @@ const InboxPanel = ( props ) => {
 			</div>
 		</Fragment>
 	);
-}
+};
 
 export default compose(
 	withSelect( ( select ) => {
@@ -181,7 +176,6 @@ export default compose(
 			type: QUERY_DEFAULTS.noteTypes,
 			orderby: 'date',
 			order: 'desc',
-			status: 'unactioned',
 			_fields: [
 				'id',
 				'name',

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -128,6 +128,8 @@ const InboxPanel = ( props ) => {
 		isPanelEmpty( ! hasNotes && ! isActivityHeaderVisible );
 	}
 
+	// @todo After having a pagination implemented we should call the method "getNotes" with a different query since
+	// the current one is only getting 25 notes and the count of unread notes only will refer to this 25 and not all the existing ones.
 	return (
 		<Fragment>
 			{ isActivityHeaderVisible && (

--- a/client/header/activity-panel/panels/inbox/test/index.js
+++ b/client/header/activity-panel/panels/inbox/test/index.js
@@ -118,40 +118,56 @@ const notes = [
 		id: 1,
 		date_created_gmt: '2019-05-10T16:57:31',
 		is_deleted: false,
+		status: 'unactioned',
 	},
 	{
 		id: 2,
 		date_created_gmt: '2020-05-12T16:57:31',
 		is_deleted: false,
+		status: 'unactioned',
 	},
 	{
 		id: 3,
 		date_created_gmt: '2020-05-14T16:57:31',
 		is_deleted: false,
+		status: 'unactioned',
 	},
 	{
 		id: 4,
 		date_created_gmt: '2020-05-15T16:57:31',
 		is_deleted: false,
+		status: 'unactioned',
+	},
+	{
+		id: 5,
+		date_created_gmt: '2020-05-18T16:57:31',
+		is_deleted: false,
+		status: 'unactioned',
 	},
 ];
 
 describe( 'getUnreadNotesCount', () => {
 	const lastRead = 1589285995243;
 
-	test( 'should return 3, 1 of the notes was read', () => {
+	test( 'should return 4, 1 of the notes was read', () => {
+		const unreadCount = getUnreadNotesCount( notes, lastRead );
+		expect( unreadCount ).toEqual( 4 );
+	} );
+
+	test( 'should return 3, 1 of the notes was read and 1 is deleted', () => {
+		notes[ 3 ].is_deleted = true;
 		const unreadCount = getUnreadNotesCount( notes, lastRead );
 		expect( unreadCount ).toEqual( 3 );
 	} );
 
-	test( 'should return 2, 1 of the notes was read and 1 is deleted', () => {
-		notes[ 3 ].is_deleted = true;
+	test( 'should return 2, 2 of the notes were read and 1 is deleted', () => {
+		notes[ 1 ].date_created_gmt = '2020-05-05T16:57:31';
 		const unreadCount = getUnreadNotesCount( notes, lastRead );
 		expect( unreadCount ).toEqual( 2 );
 	} );
 
-	test( 'should return 1, 2 of the notes were read and 1 is deleted', () => {
-		notes[ 1 ].date_created_gmt = '2020-05-05T16:57:31';
+	test( 'should return 1, 2 of the notes were read, 1 was actioned and 1 is deleted', () => {
+		notes[ 4 ].status = 'actioned';
 		const unreadCount = getUnreadNotesCount( notes, lastRead );
 		expect( unreadCount ).toEqual( 1 );
 	} );

--- a/client/header/activity-panel/panels/inbox/utils.js
+++ b/client/header/activity-panel/panels/inbox/utils.js
@@ -15,13 +15,14 @@ export function getUnreadNotesCount( notes, lastRead ) {
 		const {
 			is_deleted: isDeleted,
 			date_created_gmt: dateCreatedGmt,
+			status,
 		} = note;
 		if ( ! isDeleted ) {
-			return (
+			const unread =
 				! lastRead ||
 				! dateCreatedGmt ||
-				new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead
-			);
+				new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead;
+			return unread && status === 'unactioned';
 		}
 	} );
 	return unreadNotes.length;

--- a/client/header/activity-panel/panels/inbox/utils.js
+++ b/client/header/activity-panel/panels/inbox/utils.js
@@ -4,7 +4,7 @@
 import { filter } from 'lodash';
 
 /**
- * Get the count of the unread notes.
+ * Get the count of the unread notes from the received list.
  *
  * @param {Array} notes - List of notes, contains read and unread notes.
  * @param {number} lastRead - The timestamp that the user read a note.

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -28,6 +28,9 @@ export function getUnreadNotes( select ) {
 	if ( ! lastRead ) {
 		return null;
 	}
+
+	// @todo This method would be more performant if we ask only for 1 item per page with status "unactioned".
+	// This change should be applied after having pagination implemented.
 	const notesQuery = {
 		page: 1,
 		per_page: QUERY_DEFAULTS.pageSize,

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -9,20 +9,19 @@ import { SETTINGS_STORE_NAME, USER_STORE_NAME } from '@woocommerce/data';
 import { DEFAULT_ACTIONABLE_STATUSES } from 'analytics/settings/config';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
+import { getUnreadNotesCount } from './panels/inbox/utils';
 
 export function getUnreadNotes( select ) {
-	const {
-		getNotes,
-		getNotesError,
-		isGetNotesRequesting,
-	} = select( 'wc-api' );
+	const { getNotes, getNotesError, isGetNotesRequesting } = select(
+		'wc-api'
+	);
 
 	const { getCurrentUser } = select( USER_STORE_NAME );
 	const userData = getCurrentUser();
 	const lastRead = parseInt(
 		userData &&
-		userData.woocommerce_meta &&
-		userData.woocommerce_meta.activity_panel_inbox_last_read,
+			userData.woocommerce_meta &&
+			userData.woocommerce_meta.activity_panel_inbox_last_read,
 		10
 	);
 
@@ -31,16 +30,16 @@ export function getUnreadNotes( select ) {
 	}
 	const notesQuery = {
 		page: 1,
-		per_page: 1,
+		per_page: QUERY_DEFAULTS.pageSize,
 		type: QUERY_DEFAULTS.noteTypes,
 		orderby: 'date',
 		order: 'desc',
 	};
 
-	// Disable eslint rule requiring `latestNote` to be defined below because the next two statements
+	// Disable eslint rule requiring `latestNotes` to be defined below because the next two statements
 	// depend on `getNotes` to have been called.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const latestNote = getNotes( notesQuery );
+	const latestNotes = getNotes( notesQuery );
 	const isError = Boolean( getNotesError( notesQuery ) );
 	const isRequesting = isGetNotesRequesting( notesQuery );
 
@@ -48,10 +47,9 @@ export function getUnreadNotes( select ) {
 		return null;
 	}
 
-	return (
-		latestNote[ 0 ] &&
-		new Date( latestNote[ 0 ].date_created_gmt + 'Z' ).getTime() > lastRead
-	);
+	const unreadNotesCount = getUnreadNotesCount( latestNotes, lastRead );
+
+	return unreadNotesCount > 0;
 }
 
 export function getUnreadOrders( select ) {

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -165,7 +165,6 @@ class WC_Admin_Notes {
 				'per_page'   => 25,
 				'page'       => 1,
 				'type'       => array( 'info', 'marketing', 'warning' ),
-				'status'     => array( 'unactioned' ),
 				'is_deleted' => 0,
 			)
 		);


### PR DESCRIPTION
Fixes #4602

This PR modifies the inbox notifications to make them not disappear after clicking on the call to action.
Additionally, the notifications that received a click on the call to action will be shown as `read`.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-06-17 at 13-10-10](https://user-images.githubusercontent.com/1314156/84922257-faa8b000-b09b-11ea-9a7b-8bae9113a7af.gif)


### Detailed test instructions:
#### Read Inbox notification call to action:
1. Open the Inbox panel, which should be located in the `Home` screen.
2. Choose an already read notification and press its call to action button.
3. Refresh the webpage.
4. The notification should be still there.

#### Unread Inbox notification call to action:

_Add some new inbox notifications with the [helper plugin](https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-4.3#helper-plugin)_.

1. Choose an unread notification and press its call to action button.
2. After a few seconds, the notification will appear as `read`.

#### New messages warning
1. If there are any `unread` inbox notification, a red dot should be visible on the `Inbox` button in the header.
![9-unread-dot](https://user-images.githubusercontent.com/1314156/84932578-e4562080-b0aa-11ea-8a25-de175b9d5fad.png)

2. Verify that it's working correctly.
3. Confirm that the unread number next to the `Inbox` title corresponds with the unread messages number.
![10-unread-count](https://user-images.githubusercontent.com/1314156/84932604-ed46f200-b0aa-11ea-86dd-64df7b9b1a67.png)


#### Dismiss
1. Dismiss an inbox message.
2. Undo the dismiss by pressing the `Undo` button in the `snackbar` (it will appear after dismissing the message).
3. Verify that the process works correctly.
4. Do the same with the `Dismiss all messages` option.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Inbox notifications now are visible after the call to action button has been pressed.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
