### PR TITLE
Tweak the embed page CSS so the top content sits better

### DIFF
--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -69,7 +69,7 @@
 
 .woocommerce-embed-page {
 	.woocommerce-store-alerts {
-		margin: 20px;
+		margin: 40px 20px 20px;
 		@include breakpoint( '<782px' ) {
 			margin-top: $gap-large;
 		}

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -1,6 +1,11 @@
 
 
 .woocommerce-embed-page {
+	#wpbody .woocommerce-layout,
+	.woocommerce-layout__notice-list-hide + .wrap {
+		padding-top: $header-height + 50;
+	}
+
 	#wpcontent,
 	#wpbody-content {
 		overflow-x: initial !important;
@@ -15,7 +20,7 @@
 	}
 
 	.wrap {
-		padding: $header-height 20px 0;
+		padding: 20px 20px 0;
 
 		@include breakpoint( '<782px' ) {
 			p.search-box {

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -6,12 +6,16 @@
 		overflow-x: initial !important;
 	}
 
+	#wpbody-content {
+		padding-top: 0;
+	}
+
 	#wpbody-content .notice {
 		margin-top: 15px;
 	}
 
 	.wrap {
-		padding: 20px 20px 0;
+		padding: $header-height 20px 0;
 
 		@include breakpoint( '<782px' ) {
 			p.search-box {
@@ -72,7 +76,6 @@
 
 	.woocommerce-layout__primary {
 		margin: 0;
-		padding-top: $header-height + 20;
 
 		@include breakpoint( '<782px' ) {
 			padding-top: 10px;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -3,7 +3,7 @@
 .woocommerce-embed-page {
 	#wpbody .woocommerce-layout,
 	.woocommerce-layout__notice-list-hide + .wrap {
-		padding-top: $header-height + 50;
+		padding-top: $header-height + 10;
 	}
 
 	#wpcontent,
@@ -20,7 +20,7 @@
 	}
 
 	.wrap {
-		padding: 20px 20px 0;
+		padding: 0 20px;
 
 		@include breakpoint( '<782px' ) {
 			p.search-box {


### PR DESCRIPTION
Fixes #4460

The ticket mentions the  Help and Screen Options buttons overlapping the terms screen elements. The problem was actually deeper than that - the entire page header was being obscured by the WooCommerce layout header (the white bar).

This tweaks the embed page styles so the elements fit correctly. A nice side effect of these changes for the terms screen was that many of the other WC screens sit more nicely as well - previously there was a large gap between the WooCommerce layout header and the page content.

### Screenshots

#### Product tags
Before:
![image](https://user-images.githubusercontent.com/224531/84965235-ae1fac00-b151-11ea-9317-d6a5ae12b882.png)

After:
![image](https://user-images.githubusercontent.com/224531/85372110-b40ff580-b574-11ea-918b-58ad006c74b4.png)

#### Reports
Before:
![image](https://user-images.githubusercontent.com/224531/84965255-c0014f00-b151-11ea-8a49-446d387cf3ac.png)

After:
![image](https://user-images.githubusercontent.com/224531/85372212-dbff5900-b574-11ea-9eb2-cf4b42926bf7.png)

### Detailed test instructions:

- Visit embed pages and verify that the layout is correct
- Try this with and without an `update` admin note present
