### PR TITLE
Fix logic error that was stopping dismiss link from appearing on the inbox cards

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -151,7 +151,7 @@ class InboxNoteCard extends Component {
 	renderDismissButton() {
 		const { clickedActionText } = this.state;
 
-		if ( ! clickedActionText ) {
+		if ( clickedActionText ) {
 			return null;
 		}
 


### PR DESCRIPTION
### Detailed test instructions:

- The dismiss link should be shown on all inbox notes
- Clicking an action on the "Insight - first sale" should replace the actions and the dismiss link with the "Thanks for your feedback" text
