### PR TITLE
Stats Overview: Cleanup styles

### DIFF
--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -3,14 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { TabPanel } from '@wordpress/components';
+import {
+	TabPanel,
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { get, xor } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
 import {
-	Card,
 	EllipsisMenu,
 	MenuItem,
 	MenuTitle,
@@ -38,7 +44,11 @@ const stats = performanceIndicators.filter( ( indicator ) => {
 
 export const StatsOverview = () => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
-	const hiddenStats = get( userPrefs, [ 'homepage_stats', 'hiddenStats' ], DEFAULT_HIDDEN_STATS );
+	const hiddenStats = get(
+		userPrefs,
+		[ 'homepage_stats', 'hiddenStats' ],
+		DEFAULT_HIDDEN_STATS
+	);
 
 	const toggleStat = ( stat ) => {
 		const nextHiddenStats = xor( hiddenStats, [ stat ] );
@@ -57,9 +67,13 @@ export const StatsOverview = () => {
 
 	return (
 		<Card
-			className="woocommerce-analytics__card woocommerce-stats-overview"
-			title={ __( 'Stats overview', 'woocommerce-admin' ) }
-			menu={
+			size="large"
+			className="woocommerce-stats-overview woocommerce-homescreen-card"
+		>
+			<CardHeader size="medium">
+				<Text variant="title.small">
+					{ __( 'Stats overview', 'woocommerce-admin' ) }
+				</Text>
 				<EllipsisMenu
 					label={ __(
 						'Choose which values to display',
@@ -92,44 +106,45 @@ export const StatsOverview = () => {
 						</Fragment>
 					) }
 				/>
-			}
-		>
-			<TabPanel
-				className="woocommerce-stats-overview__tabs"
-				onSelect={ ( period ) => {
-					recordEvent( 'statsoverview_date_picker_update', {
-						period,
-					} );
-				} }
-				tabs={ [
-					{
-						title: __( 'Today', 'woocommerce-admin' ),
-						name: 'today',
-					},
-					{
-						title: __( 'Week to date', 'woocommerce-admin' ),
-						name: 'week',
-					},
-					{
-						title: __( 'Month to date', 'woocommerce-admin' ),
-						name: 'month',
-					},
-				] }
-			>
-				{ ( tab ) => (
-					<Fragment>
-						<InstallJetpackCta />
-						<StatsList
-							query={ {
-								period: tab.name,
-								compare: 'previous_period',
-							} }
-							stats={ activeStats }
-						/>
-					</Fragment>
-				) }
-			</TabPanel>
-			<div className="woocommerce-stats-overview__footer">
+			</CardHeader>
+			<CardBody>
+				<TabPanel
+					className="woocommerce-stats-overview__tabs"
+					onSelect={ ( period ) => {
+						recordEvent( 'statsoverview_date_picker_update', {
+							period,
+						} );
+					} }
+					tabs={ [
+						{
+							title: __( 'Today', 'woocommerce-admin' ),
+							name: 'today',
+						},
+						{
+							title: __( 'Week to date', 'woocommerce-admin' ),
+							name: 'week',
+						},
+						{
+							title: __( 'Month to date', 'woocommerce-admin' ),
+							name: 'month',
+						},
+					] }
+				>
+					{ ( tab ) => (
+						<Fragment>
+							<InstallJetpackCta />
+							<StatsList
+								query={ {
+									period: tab.name,
+									compare: 'previous_period',
+								} }
+								stats={ activeStats }
+							/>
+						</Fragment>
+					) }
+				</TabPanel>
+			</CardBody>
+			<CardFooter>
 				<Link
 					className="woocommerce-stats-overview__more-btn"
 					href={ getNewPath( {}, '/analytics/overview' ) }
@@ -142,7 +157,7 @@ export const StatsOverview = () => {
 				>
 					{ __( 'View detailed stats' ) }
 				</Link>
-			</div>
+			</CardFooter>
 		</Card>
 	);
 };

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -97,17 +97,22 @@ function InstallJetpackCta( {
 
 	return (
 		<article className="woocommerce-stats-overview__install-jetpack-promo">
-			<H>
-				{ __( 'Get traffic stats with Jetpack', 'woocommerce-admin' ) }
-			</H>
-			<p>
-				{ __(
-					'Keep an eye on your views and visitors metrics with ' +
-						'Jetpack. Requires Jetpack plugin and a WordPress.com ' +
-						'account.',
-					'woocommerce-admin'
-				) }
-			</p>
+			<div className="woocommerce-stats-overview__install-jetpack-promo__content">
+				<H>
+					{ __(
+						'Get traffic stats with Jetpack',
+						'woocommerce-admin'
+					) }
+				</H>
+				<p>
+					{ __(
+						'Keep an eye on your views and visitors metrics with ' +
+							'Jetpack. Requires Jetpack plugin and a WordPress.com ' +
+							'account.',
+						'woocommerce-admin'
+					) }
+				</p>
+			</div>
 			<footer>
 				<Button isSecondary onClick={ install } isBusy={ isInstalling }>
 					{ getInstallJetpackText() }

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -117,7 +117,7 @@ function InstallJetpackCta( {
 				<Button isSecondary onClick={ install } isBusy={ isInstalling }>
 					{ getInstallJetpackText() }
 				</Button>
-				<Button onClick={ dismiss } isBusy={ isInstalling }>
+				<Button isTertiary onClick={ dismiss } isBusy={ isInstalling }>
 					{ __( 'No thanks', 'woocommerce-admin' ) }
 				</Button>
 			</footer>

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -67,7 +67,7 @@ $promo-actions-border-bottom: $light-gray-tertiary;
 }
 
 article.woocommerce-stats-overview__install-jetpack-promo {
-	h3 {
+	h2 {
 		margin: $gap $gap-large $gap-smaller;
 	}
 	p {

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -64,17 +64,6 @@ $promo-actions-border-bottom: $light-gray-tertiary;
 	}
 }
 
-
-.woocommerce-homescreen-card.woocommerce-stats-overview {
-	.woocommerce-summary__item {
-		padding: $gap-large;
-	}
-
-	.components-card__footer.is-size-large {
-		padding-left: $gap-smaller;
-	}
-}
-
 article.woocommerce-stats-overview__install-jetpack-promo {
 	.woocommerce-stats-overview__install-jetpack-promo__content {
 		padding: $gap $gap-large;

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -74,15 +74,8 @@ article.woocommerce-stats-overview__install-jetpack-promo {
 		margin: 0 $gap-large $gap;
 	}
 	footer {
+		padding: $gap $gap-large;
 		border-top: 1px solid $promo-actions-border-top;
 		border-bottom: 1px solid $promo-actions-border-bottom;
-
-		.components-button {
-			margin: $gap $gap-smallest;
-		}
-
-		.woocommerce-layout & button.components-button.is-secondary {
-			margin-left: $gap-large;
-		}
 	}
 }

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -94,6 +94,7 @@ article.woocommerce-stats-overview__install-jetpack-promo {
 		font-weight: normal;
 		@include font-size( 14 );
 		line-height: 20px;
+		margin: $gap-smaller 0;
 	}
 	footer {
 		padding: $gap $gap-large;

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -12,10 +12,6 @@ $promo-actions-border-bottom: $light-gray-tertiary;
 	}
 }
 
-.woocommerce-stats-overview__footer {
-	border-top: 1px solid $outer-border;
-}
-
 .woocommerce-stats-overview__more-btn {
 	display: inline-block;
 	padding: $gap;

--- a/client/homescreen/stats-overview/style.scss
+++ b/client/homescreen/stats-overview/style.scss
@@ -25,6 +25,8 @@ $promo-actions-border-bottom: $light-gray-tertiary;
 
 		.components-button {
 			width: 33.33%;
+			padding-right: $gap-large;
+			padding-left: $gap-large;
 		}
 	}
 }
@@ -62,16 +64,48 @@ $promo-actions-border-bottom: $light-gray-tertiary;
 	}
 }
 
+
+.woocommerce-homescreen-card.woocommerce-stats-overview {
+	.woocommerce-summary__item {
+		padding: $gap-large;
+	}
+
+	.components-card__footer.is-size-large {
+		padding-left: $gap-smaller;
+	}
+}
+
 article.woocommerce-stats-overview__install-jetpack-promo {
+	.woocommerce-stats-overview__install-jetpack-promo__content {
+		padding: $gap $gap-large;
+	}
+
 	h2 {
-		margin: $gap $gap-large $gap-smaller;
+		color: $dark-gray-primary;
+		@include font-size( 16 );
+		font-style: normal;
+		line-height: 1.5;
+		font-weight: normal;
+		margin: $gap-smaller 0;
 	}
 	p {
-		margin: 0 $gap-large $gap;
+		color: $medium-gray-text;
+		font-style: normal;
+		font-weight: normal;
+		@include font-size( 14 );
+		line-height: 20px;
 	}
 	footer {
 		padding: $gap $gap-large;
 		border-top: 1px solid $promo-actions-border-top;
 		border-bottom: 1px solid $promo-actions-border-bottom;
+
+		button {
+			margin-left: $gap-smaller;
+
+			&:first-child {
+				margin-left: 0;
+			}
+		}
 	}
 }

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -65,9 +65,12 @@
 		}
 	}
 
-	.components-card__body.is-size-large,
-	.components-card__footer.is-size-large {
+	.components-card__body.is-size-large {
 		padding: 0;
+	}
+
+	.components-card__footer.is-size-large {
+		padding: 0 $gap-smaller;
 	}
 }
 

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -33,26 +33,6 @@
 		margin-right: -16px;
 		flex-direction: column-reverse;
 	}
-
-	.components-card {
-		.components-card__header.is-size-large {
-			display: grid;
-			// to maintain consistent height with or without an ellipsis menu
-			min-height: 63px;
-			// to match alignment of `Card` from `@woocommerce/components`
-			padding: $gap-small $gap;
-
-			// IE doesn't support `align-items` on grid container
-			& > * {
-				align-self: center;
-			}
-
-			h2 {
-				// to match height of `Card` from `@woocommerce/components`
-				margin: 0;
-			}
-		}
-	}
 }
 .woocommerce-homescreen-column {
 	width: 50%;
@@ -70,3 +50,24 @@
 	height: 225px;
 	background-color: #6495ed;
 }
+
+.woocommerce-homescreen-card {
+	.components-card__header.is-size-large,
+	.components-card__header.is-size-medium {
+		min-height: 63px;
+		min-height: unset;
+		display: grid;
+		grid-template-columns: auto 24px;
+
+		// IE doesn't support `align-items` on grid container
+		& > * {
+			align-self: center;
+		}
+	}
+
+	.components-card__body.is-size-large,
+	.components-card__footer.is-size-large {
+		padding: 0;
+	}
+}
+

--- a/client/quick-links/index.js
+++ b/client/quick-links/index.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '@wordpress/components';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import {
 	Icon,
 	megaphone,
@@ -22,7 +27,7 @@ import { partial } from 'lodash';
  * WooCommerce dependencies
  */
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { H, List } from '@woocommerce/components';
+import { List } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -167,8 +172,10 @@ const QuickLinks = ( props ) => {
 
 	return (
 		<Card size="large" className="woocommerce-quick-links">
-			<CardHeader>
-				<H>{ __( 'Store management', 'woocommerce-admin' ) }</H>
+			<CardHeader size="medium">
+				<Text variant="title.small">
+					{ __( 'Store management', 'woocommerce-admin' ) }
+				</Text>
 			</CardHeader>
 			<CardBody>
 				<List

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -12,6 +12,7 @@ import {
 	CardBody,
 	CardHeader,
 	Modal,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { Icon, check, chevronRight } from '@wordpress/icons';
@@ -19,7 +20,7 @@ import { Icon, check, chevronRight } from '@wordpress/icons';
 /**
  * WooCommerce dependencies
  */
-import { H, List, EllipsisMenu } from '@woocommerce/components';
+import { List, EllipsisMenu } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import {
 	PLUGINS_STORE_NAME,
@@ -348,20 +349,20 @@ class TaskDashboard extends Component {
 						<Fragment>
 							<Card
 								size="large"
-								className="woocommerce-task-card"
+								className="woocommerce-task-card woocommerce-homescreen-card"
 							>
 								<progress
 									className={ progressBarClass }
 									max={ listTasks.length }
 									value={ numCompleteTasks }
 								/>
-								<CardHeader>
-									<H>
+								<CardHeader size="medium">
+									<Text variant="title.small">
 										{ __(
 											'Finish setup',
 											'woocommerce-admin'
 										) }
-									</H>
+									</Text>
 									{ this.renderMenu() }
 								</CardHeader>
 								<CardBody>

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -5,17 +5,9 @@
 
 	.woocommerce-task-dashboard__container {
 		.woocommerce-task-card {
-			.components-card__header.is-size-large {
-				min-height: unset;
+			.components-card__header.is-size-medium {
 				padding-top: 0;
-				display: grid;
-				grid-template-columns: auto 24px;
 			}
-
-			.components-card__body.is-size-large {
-				padding: 0;
-			}
-
 			.woocommerce-list__item:not(.is-complete) {
 				.woocommerce-task__icon {
 					border: 1px solid $core-grey-light-500;

--- a/packages/components/src/ellipsis-menu/index.js
+++ b/packages/components/src/ellipsis-menu/index.js
@@ -4,7 +4,7 @@
 import { Component } from '@wordpress/element';
 import classnames from 'classnames';
 import { Button, Dropdown, NavigableMenu } from '@wordpress/components';
-import { Icon, moreVertical } from '@wordpress/icons';
+import { Icon, more } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 
 /**
@@ -33,7 +33,7 @@ class EllipsisMenu extends Component {
 					title={ label }
 					aria-expanded={ isOpen }
 				>
-					<Icon icon={ moreVertical } />
+					<Icon icon={ more } />
 				</Button>
 			);
 		};

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -260,7 +260,7 @@ $border: $light-gray-tertiary;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: $spacing;
+	padding: $gap-large;
 	background-color: $core-grey-light-100;
 	border-bottom: 1px solid $border;
 	border-right: 1px solid $border;


### PR DESCRIPTION
Partial https://github.com/woocommerce/woocommerce-admin/issues/4603

Fix Stats Overview in the Homescreen styles. I reused some styles across all cards on the Homescreen and place `<Text />` component in headers for Quick Links and Task List.

### Points addressed in this PR

- Card header should use "Title Small" [`Text`](https://wordpress.github.io/gutenberg/?path=/story/components-text--default) style
- Card header padding should match the "medium" size in the core [`Card`](https://wordpress.github.io/gutenberg/?path=/story/components-card-header--default) component. 16px 24px.
- Text color in tabs should match the core [`TabPanel`](https://wordpress.github.io/gutenberg/?path=/story/components-tabpanel--default) component
- Text styles and colors of the Jetpack banner should match the Inbox notifications, as should the spacing in the actions buttons.
- "Connect Jetpack" button should be secondary instead of primary
- "View detailed stats" link should not be pink.
- Ellipsis icon should use the [core "more" icon](https://github.com/WordPress/gutenberg/blob/master/packages/icons/src/library/more.js).

### Points not addressed in this PR

- There's a lag when clicking the toggles in the "Display stats" dropdown which makes them feel very odd to use. We should apply a loading state if we can't make this instant.

This is a known issue with the dataStore. I'd like to introduce optimistic results in a follow up PR. Issue here https://github.com/woocommerce/woocommerce-admin/issues/4626

- Spacing in the "Display stats" dropdown should match the [dismiss menu on Inbox notifications](https://cloudup.com/cMQPPF1A5NY), and the toggles should be blue

I'm reusing an often used component for this one, so it will be best implemented in a separate PR.

- Tabs should include comparison label - https://cloudup.com/ctRMMoD_UW7

Core tab-panel component only accepts strings at this time. An upstream PR will need to be made to make this happen.

### Screenshots

![Screen Shot 2020-06-18 at 3 10 29 PM](https://user-images.githubusercontent.com/1922453/84973726-e2a55f00-b175-11ea-9bd4-4d4fff13cead.png)

### Detailed test instructions:

1. Visit the Homepage. 
2. Ensure the points addressed in this PR are satisfied.

### Changelog Note:

none: unreleased feature.
