### PR TITLE
Task List: Cleanup styles

### DIFF
--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -60,6 +60,7 @@
 		grid-template-columns: auto 24px;
 
 		// IE doesn't support `align-items` on grid container
+		
 		& > * {
 			align-self: center;
 		}

--- a/client/quick-links/index.js
+++ b/client/quick-links/index.js
@@ -157,7 +157,7 @@ function getLinkTypeAndHref( item ) {
 function getListItems( props ) {
 	return getItems( props ).map( ( item ) => {
 		return {
-			title: item.title,
+			title: <Text as="div" variant="button">{ item.title }</Text>,
 			before: <Icon icon={ item.icon } />,
 			after: <Icon icon={ chevronRight } />,
 			...getLinkTypeAndHref( item ),

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -313,6 +313,10 @@ class TaskDashboard extends Component {
 				</div>
 			);
 
+			task.title = (
+				<Text as="div" variant={ task.completed ? 'body.small' : 'button' }>{ task.title }</Text>
+			);
+
 			if ( ! task.completed ) {
 				task.after = task.time ? (
 					<span className="woocommerce-task-estimated-time">

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -15,6 +15,12 @@
 				}
 			}
 
+			.woocommerce-list__item.is-complete {
+				.woocommerce-list__item-title {
+					color: $medium-gray-text;
+				}
+			}
+
 			.woocommerce-list__item-before .woocommerce-task__icon {
 				border-radius: 50%;
 				width: 32px;
@@ -32,6 +38,10 @@
 				min-width: unset;
 			}
 		}
+	}
+
+	.woocommerce-task-estimated-time {
+		color: $medium-gray-text;
 	}
 
 	.woocommerce-card.is-narrow {

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -84,7 +84,7 @@ class List extends Component {
 								) }
 								<div className="woocommerce-list__item-text">
 									<span className="woocommerce-list__item-title">
-										<Text variant="button">{ title }</Text>
+										<Text as="div" variant="button">{ title }</Text>
 									</span>
 									{ content && (
 										<span className="woocommerce-list__item-content">

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
+import { __experimentalText as Text } from '@wordpress/components';
 
 /**
  * WooCommerce dependencies
@@ -83,7 +84,7 @@ class List extends Component {
 								) }
 								<div className="woocommerce-list__item-text">
 									<span className="woocommerce-list__item-title">
-										{ title }
+										<Text variant="button">{ title }</Text>
 									</span>
 									{ content && (
 										<span className="woocommerce-list__item-content">

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
-import { __experimentalText as Text } from '@wordpress/components';
 
 /**
  * WooCommerce dependencies
@@ -84,7 +83,7 @@ class List extends Component {
 								) }
 								<div className="woocommerce-list__item-text">
 									<span className="woocommerce-list__item-title">
-										<Text as="div" variant="button">{ title }</Text>
+										{ title }
 									</span>
 									{ content && (
 										<span className="woocommerce-list__item-content">
@@ -150,7 +149,10 @@ List.propTypes = {
 			/**
 			 * Title displayed for the list item.
 			 */
-			title: PropTypes.string.isRequired,
+			title: PropTypes.oneOfType( [
+				PropTypes.string,
+				PropTypes.node,
+			] ),
 		} )
 	).isRequired,
 };

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -17,7 +17,7 @@
 		width: 100%;
 		display: flex;
 		align-items: center;
-		padding: $gap;
+		padding: $gap $gap-large;
 
 		&:focus {
 			box-shadow: inset 0 0 0 1px $studio-wordpress-blue, inset 0 0 0 2px $studio-white;
@@ -25,9 +25,6 @@
 	}
 
 	.woocommerce-list__item-title {
-		display: block;
-		font-size: 16px;
-		line-height: 22px;
 		color: $studio-gray-90;
 	}
 


### PR DESCRIPTION
Depends on https://github.com/woocommerce/woocommerce-admin/pull/4625
Partial https://github.com/woocommerce/woocommerce-admin/issues/4603

- Padding on task rows should be 16px 24px. 
- Task label should use "button" [`Text`](https://wordpress.github.io/gutenberg/?path=/story/components-text--default) style.
- Time estimate color should be [$medium-gray-text](https://github.com/WordPress/gutenberg/blob/master/packages/base-styles/_colors.scss#L30)

Other items were fixed in the previous PR https://github.com/woocommerce/woocommerce-admin/pull/4625

### Screenshots

![Screen Shot 2020-06-18 at 3 40 17 PM](https://user-images.githubusercontent.com/1922453/84976196-63b32500-b17b-11ea-8df0-873e888ffeea.png)
![Screen Shot 2020-06-18 at 3 40 43 PM](https://user-images.githubusercontent.com/1922453/84976203-657ce880-b17b-11ea-8df7-96b2ee32fedc.png)

### Detailed test instructions:

Visit the Homescreen's Task List and Quick Links. Make sure changes appear as described above.

### Changelog Note:

None: fixes unreleased feature.
