### PR TITLE
Change the "Deactivate plugin" admin note to be informational

### DIFF
--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -39,7 +39,7 @@ class WC_Admin_Notes_Deactivate_Plugin {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );


### PR DESCRIPTION
Refer to #4502

This just changes the "Deactivate plugin" admin note's type from UPDATE to INFORMATIONAL so that it will appear in the inbox. This means that the note will have the built-in "Dismiss" functionality, so it can be dismissed even if the plugin has already been deactivated.

### Screenshots

![image](https://user-images.githubusercontent.com/224531/84983376-fd7ad200-b17b-11ea-8295-a929e0992462.png)

### Detailed test instructions:

- Add this to `src/Events.php` in the `do_wc_admin_daily()` function: `\Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Deactivate_Plugin::possibly_add_note();`
- In `WC_Admin_Notes_Deactivate_Plugin.php` comment out the body of the `delete_note()` function
- run the `wc_admin_daily` cron task
- verify that the "Deactivate plugin" admin note was added to the inbox
