### PR TITLE
Add check that the order being queried is a valid order

### DIFF
--- a/src/API/Reports/Controller.php
+++ b/src/API/Reports/Controller.php
@@ -186,7 +186,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$order = wc_get_order( $order_id );
 
 		if ( ! $order instanceof \WC_Order ) {
-			return '';
+			return null;
 		}
 
 		if ( 'shop_order_refund' === $order->get_type() ) {

--- a/src/API/Reports/Controller.php
+++ b/src/API/Reports/Controller.php
@@ -185,6 +185,10 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_order_number( $order_id ) {
 		$order = wc_get_order( $order_id );
 
+		if ( ! $order instanceof \WC_Order ) {
+			return '';
+		}
+
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			$order = wc_get_order( $order->get_parent_id() );
 		}


### PR DESCRIPTION
Fixes #4447

This adds some defensive code when getting the order number within the report API controller.

### Detailed test instructions:

- Before switching to this PR's branch, fInd a recent order (`SELECT * FROM `wp_posts` where post_type = 'shop_order' order by post_date desc`) and delete it, taking note of the post date
- Go to Analytics/Orders, and see the 500 error when trying to load the orders table
- Switch to this PR's branch
- Reload Analytics/Orders, and see that the table now loads

### Changelog Note:

Fix: Fix an error in the Analytics/Orders table when there is an order deleted directly from the database