### PR TITLE
Fix inbox spacing

### DIFF
--- a/client/analytics/report/style.scss
+++ b/client/analytics/report/style.scss
@@ -20,6 +20,7 @@
 	border-radius: 0;
 	border: 1px solid $core-grey-light-700;
 	box-shadow: none;
+	margin-bottom: $gap-large;
 
 	&:hover {
 		box-shadow: none;

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -29,23 +29,11 @@
 }
 
 .woocommerce-layout__inbox-panel-header {
-	padding: $gap * 2 42px $gap;
-
+	h2.woocommerce-layout__activity-panel-header-title,
 	h3.woocommerce-layout__activity-panel-header-title {
 		margin: 0 0 $gap-small / 2;
 		font-size: 20px;
 		line-height: 28px;
 		font-weight: 400;
-	}
-	span {
-		margin-left: 7px;
-		background: #40464d;
-		border-radius: 0.8em;
-		color: $core-grey-light-200;
-		display: inline-block;
-		text-align: center;
-		width: 1.6em;
-		font-size: 14px;
-		vertical-align: top;
 	}
 }

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -29,10 +29,13 @@
 }
 
 .woocommerce-layout__inbox-panel-header {
-	padding: 15px 43px 10px;
-	h3 {
-		margin: 5px 0;
-		font-weight: 500;
+	padding: $gap * 2 42px $gap;
+
+	h3.woocommerce-layout__activity-panel-header-title {
+		margin: 0 0 $gap-small / 2;
+		font-size: 20px;
+		line-height: 28px;
+		font-weight: 400;
 	}
 	span {
 		margin-left: 7px;

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -6,7 +6,7 @@
 	background: $core-grey-light-200;
 	border-radius: 2px;
 	@include font-size( 13 );
-	margin: 20px;
+	margin: 0 0 $gap-large;
 	-ms-box-orient: horizontal;
 	&.banner {
 		-webkit-flex-direction: column;
@@ -186,7 +186,13 @@
 	}
 }
 
+#activity-panel-inbox {
+	margin: 0 $gap-large;
+}
+
 .woocommerce-layout__inbox-panel-header {
+	padding: $gap-large;
+
 	.woocommerce-homepage-column & {
 		padding: 0 24px;
 	}

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -11,6 +11,7 @@
 
 	.woocommerce-task-dashboard__container {
 		width: 100%;
+		margin-bottom: $gap-large;
 	}
 
 	&.hasInbox .woocommerce-homescreen-column {

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -70,3 +70,23 @@
 	height: 225px;
 	background-color: #6495ed;
 }
+
+
+.is-inbox {
+	.woocommerce-inbox-message {
+		margin: 0 0 $gap-large;
+	}
+
+	.woocommerce-layout__inbox-panel-header {
+		padding-left: $gap-large;
+		padding-right: $gap-large;
+		padding-top: 0;
+
+		h2.woocommerce-layout__activity-panel-header-title {
+			margin: 0 0 $gap-small / 2;
+			font-size: 20px;
+			line-height: 28px;
+			font-weight: 400;
+		}
+	}
+}

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -22,10 +22,6 @@
 			position: inherit;
 			top: auto;
 		}
-
-		& > * {
-			margin-bottom: 24px;
-		}
 	}
 
 	@include breakpoint( '<782px' ) {
@@ -69,24 +65,4 @@
 .is-inbox .temp-content {
 	height: 225px;
 	background-color: #6495ed;
-}
-
-
-.is-inbox {
-	.woocommerce-inbox-message {
-		margin: 0 0 $gap-large;
-	}
-
-	.woocommerce-layout__inbox-panel-header {
-		padding-left: $gap-large;
-		padding-right: $gap-large;
-		padding-top: 0;
-
-		h2.woocommerce-layout__activity-panel-header-title {
-			margin: 0 0 $gap-small / 2;
-			font-size: 20px;
-			line-height: 28px;
-			font-weight: 400;
-		}
-	}
 }


### PR DESCRIPTION
I noticed we added some margin around Inbox notices for when they appear in the side panel. However this was also being applied on the home screen and throwing the layout off:

![layoutbad](https://cldup.com/72P3VkTG4Y-3000x3000.png)

I fixed that, as well as the spacing and type styles on the Inbox header. Ideally we use the `Text` component for this in future, it took a bit of wrangling to get them appearing consistently, and duplicating the styles feelsbadman.jpg.

![layoutgood](https://cldup.com/0rH6WQIabf-2000x2000.png)