### PR TITLE
UserPrefs store: Introduce optimistic update

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Fragment, Suspense, lazy, useState } from '@wordpress/element';
+import { Fragment, Suspense, lazy } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { partial } from 'lodash';
 import { Dropdown, Button, Icon } from '@wordpress/components';
@@ -69,7 +69,7 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 	} );
 
 	return sections;
-}
+};
 
 const CustomizableDashboard = ( {
 	defaultDateRange,
@@ -79,29 +79,19 @@ const CustomizableDashboard = ( {
 	taskListComplete,
 	taskListHidden,
 } ) => {
-	const { isRequesting, updateUserPreferences, ...userPrefs } = useUserPreferences();
-	const [ dashSections, setSections ] = useState(
-		isRequesting
-			? false
-			: mergeSectionsWithDefaults( userPrefs.dashboard_sections )
-	);
+	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 
-	// Update sections when the request is finished (and they weren't hydrated).
-	if ( ! isRequesting && dashSections === false ) {
-		setSections( mergeSectionsWithDefaults( userPrefs.dashboard_sections ) );
-	}
+	const sections = mergeSectionsWithDefaults( userPrefs.dashboard_sections );
 
-	const sections = dashSections || defaultSections;
-
-	const isTaskListEnabled = ! homepageEnabled && isOnboardingEnabled() && ! taskListHidden;
+	const isTaskListEnabled =
+		! homepageEnabled && isOnboardingEnabled() && ! taskListHidden;
 
 	const isDashboardShown =
 		! isTaskListEnabled || ( ! query.task && taskListComplete );
 
 	const updateSections = ( newSections ) => {
-		setSections( newSections );
 		updateUserPreferences( { dashboard_sections: newSections } );
-	}
+	};
 
 	const updateSection = ( updatedKey, newSettings ) => {
 		const newSections = sections.map( ( section ) => {
@@ -114,7 +104,7 @@ const CustomizableDashboard = ( {
 			return section;
 		} );
 		updateSections( newSections );
-	}
+	};
 
 	const onChangeHiddenBlocks = ( updatedKey ) => {
 		return ( updatedHiddenBlocks ) => {
@@ -122,14 +112,14 @@ const CustomizableDashboard = ( {
 				hiddenBlocks: updatedHiddenBlocks,
 			} );
 		};
-	}
+	};
 
 	const onSectionTitleUpdate = ( updatedKey ) => {
 		return ( updatedTitle ) => {
 			recordEvent( 'dash_section_rename', { key: updatedKey } );
 			updateSection( updatedKey, { title: updatedTitle } );
 		};
-	}
+	};
 
 	const toggleVisibility = ( key, onToggle ) => {
 		return () => {
@@ -153,7 +143,7 @@ const CustomizableDashboard = ( {
 
 			updateSections( sections );
 		};
-	}
+	};
 
 	const onMove = ( index, change ) => {
 		const movedSection = sections.splice( index, 1 ).shift();
@@ -180,7 +170,7 @@ const CustomizableDashboard = ( {
 			// No, lets try the next one.
 			onMove( index, change + change );
 		}
-	}
+	};
 
 	const renderAddMore = () => {
 		const hiddenSections = sections.filter(
@@ -242,7 +232,7 @@ const CustomizableDashboard = ( {
 				) }
 			/>
 		);
-	}
+	};
 
 	const renderDashboardReports = () => {
 		const { period, compare, before, after } = getDateParamsFromQuery(
@@ -292,9 +282,7 @@ const CustomizableDashboard = ( {
 								query={ query }
 								title={ section.title }
 								onMove={ partial( onMove, index ) }
-								onRemove={ toggleVisibility(
-									section.key
-								) }
+								onRemove={ toggleVisibility( section.key ) }
 								isFirst={
 									section.key === visibleSectionKeys[ 0 ]
 								}
@@ -312,22 +300,19 @@ const CustomizableDashboard = ( {
 				{ renderAddMore() }
 			</Fragment>
 		);
-	}
+	};
 
 	return (
 		<Fragment>
 			{ isTaskListEnabled && (
 				<Suspense fallback={ <Spinner /> }>
-					<TaskList
-						query={ query }
-						inline={ isDashboardShown }
-					/>
+					<TaskList query={ query } inline={ isDashboardShown } />
 				</Suspense>
 			) }
 			{ isDashboardShown && renderDashboardReports() }
 		</Fragment>
 	);
-}
+};
 
 export default compose(
 	withSelect( ( select ) => {

--- a/packages/data/src/user-preferences/use-user-preferences.js
+++ b/packages/data/src/user-preferences/use-user-preferences.js
@@ -91,10 +91,13 @@ export const useUserPreferences = () => {
 					};
 				}
 
-				// Optimistically propagate the woocommerce_meta to the store for instant update.
+				// Optimistically propagate new woocommerce_meta to the store for instant update.
 				receiveCurrentUser( {
-					id: user.id,
-					woocommerce_meta: metaData,
+					...user,
+					woocommerce_meta: {
+						...user.woocommerce_meta,
+						...metaData,
+					},
 				} );
 
 				// Use saveUser() to update WooCommerce meta values.

--- a/packages/data/src/user-preferences/use-user-preferences.js
+++ b/packages/data/src/user-preferences/use-user-preferences.js
@@ -120,9 +120,6 @@ export const useUserPreferences = () => {
 					};
 				}
 
-				// Propagate the updated User object to the store.
-				receiveCurrentUser( updatedUser );
-
 				// Decode the WooCommerce meta after save.
 				const updatedUserResponse = {
 					...updatedUser,

--- a/packages/data/src/user-preferences/use-user-preferences.js
+++ b/packages/data/src/user-preferences/use-user-preferences.js
@@ -91,6 +91,12 @@ export const useUserPreferences = () => {
 					};
 				}
 
+				// Optimistically propagate the woocommerce_meta to the store for instant update.
+				receiveCurrentUser( {
+					id: user.id,
+					woocommerce_meta: metaData,
+				} );
+
 				// Use saveUser() to update WooCommerce meta values.
 				const updatedUser = await saveUser( {
 					id: user.id,


### PR DESCRIPTION
Partial fix of https://github.com/woocommerce/woocommerce-admin/issues/4603

>There's a lag when clicking the toggles in the "Display stats" dropdown which makes them feel very odd to use. We should apply a loading state if we can't make this instant.

This was happening because the store wasn't updating until data returned from the server. This PR uses the data already available to update the store immediately so the UI doesn't need to wait for a round trip to the server.

The Dashboard suffered the same affliction but got around that by keeping duplicate data in state. Now that the issue is solved, this PR also removes state from the Dashboard in favor of a single source of truth in the UserPrefs store.

### Detailed test instructions:

1. Go to Homescreen.
2. Toggle stats in the Stats overview section and see the UI update immediately.
3. Visit the Dashboard.
4. Edit titles, section order, chart type preference, and toggle stats on/off.
5. Be sure no regressions were introduced.

### Changelog Note:

none: unreleased change.
