### PR TITLE
Tweak tag remove button style so it is properly centered

### DIFF
--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -60,7 +60,7 @@
 		grid-template-columns: auto 24px;
 
 		// IE doesn't support `align-items` on grid container
-		
+
 		& > * {
 			align-self: center;
 		}

--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -36,6 +36,7 @@
 		color: $core-grey-dark-500;
 		line-height: 10px;
 		text-indent: 0;
+		height: 24px;
 
 		&:hover {
 			color: $core-grey-dark-700;


### PR DESCRIPTION
Fixes #4648

This just tweaks the height of the remove tag button so it is properly centred.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/224531/85250414-da149780-b499-11ea-8938-c103e5480f92.png)

After:
![image](https://user-images.githubusercontent.com/224531/85250437-e698f000-b499-11ea-9836-645727fc0f36.png)

### Detailed test instructions:
- Open WooCommerce -> Customers and select Advanced Filters
- Add a country filter
- Add a country to the filter
- Witness the position of the button

