### PR TITLE
Refactor Jetpack connection flows

### DIFF
--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -24,21 +24,11 @@ class Connect extends Component {
 		props.setIsPending( true );
 	}
 
-	componentDidMount() {
-		const { autoConnect, jetpackConnectUrl } = this.props;
-
-		if ( autoConnect && jetpackConnectUrl ) {
-			this.connectJetpack();
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
 		const {
-			autoConnect,
 			createNotice,
 			error,
 			isRequesting,
-			jetpackConnectUrl,
 			onError,
 			setIsPending,
 		} = this.props;
@@ -53,37 +43,26 @@ class Connect extends Component {
 			}
 			createNotice( 'error', error );
 		}
-
-		if ( autoConnect && jetpackConnectUrl ) {
-			this.connectJetpack();
-		}
 	}
 
 	async connectJetpack() {
 		const { jetpackConnectUrl, onConnect } = this.props;
 
-		this.setState( {
-			isConnecting: true,
-		}, () => {
-			if ( onConnect ) {
-				onConnect();
+		this.setState(
+			{
+				isConnecting: true,
+			},
+			() => {
+				if ( onConnect ) {
+					onConnect();
+				}
+				window.location = jetpackConnectUrl;
 			}
-			window.location = jetpackConnectUrl;
-		} );
+		);
 	}
 
 	render() {
-		const {
-			autoConnect,
-			hasErrors,
-			isRequesting,
-			onSkip,
-			skipText,
-		} = this.props;
-
-		if ( autoConnect ) {
-			return null;
-		}
+		const { hasErrors, isRequesting, onSkip, skipText } = this.props;
 
 		return (
 			<Fragment>
@@ -115,10 +94,6 @@ class Connect extends Component {
 }
 
 Connect.propTypes = {
-	/**
-	 * If connection should happen automatically, or requires user confirmation.
-	 */
-	autoConnect: PropTypes.bool,
 	/**
 	 * Method to create a displayed notice.
 	 */
@@ -166,7 +141,6 @@ Connect.propTypes = {
 };
 
 Connect.defaultProps = {
-	autoConnect: false,
 	setIsPending: () => {},
 };
 

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -27,6 +27,7 @@ import { createNoticesFromResponse } from 'lib/notices';
 
 function InstallJetpackCta( {
 	getJetpackConnectUrl,
+	getPluginsError,
 	isJetpackInstalled,
 	isJetpackActivated,
 	isJetpackConnected,
@@ -56,7 +57,14 @@ function InstallJetpackCta( {
 
 		getJetpackConnectUrl( {
 			redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
-		} ).then( ( url ) => ( window.location = url ) );
+		} ).then( ( url ) => {
+			const error = getPluginsError( 'getJetpackConnectUrl' );
+			if ( error ) {
+				createNoticesFromResponse( error );
+				return;
+			}
+			window.location = url;
+		} );
 	}
 
 	function dismiss() {
@@ -139,14 +147,16 @@ export default compose(
 		const {
 			isJetpackConnected,
 			isPluginsRequesting,
-			getInstalledPlugins,
 			getActivePlugins,
+			getInstalledPlugins,
+			getPluginsError,
 		} = select( PLUGINS_STORE_NAME );
 
 		return {
 			getJetpackConnectUrl: __experimentalResolveSelect(
 				PLUGINS_STORE_NAME
 			).getJetpackConnectUrl,
+			getPluginsError,
 			isConnecting: isPluginsRequesting( 'getJetpackConnectUrl' ),
 			isInstalling:
 				isPluginsRequesting( 'installPlugins' ) ||

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -6,7 +6,11 @@ import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { withDispatch, withSelect } from '@wordpress/data';
+import {
+	withDispatch,
+	withSelect,
+	__experimentalResolveSelect,
+} from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -18,19 +22,19 @@ import { PLUGINS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import Connect from 'dashboard/components/connect';
 import { recordEvent } from 'lib/tracks';
 import { createNoticesFromResponse } from 'lib/notices';
 
 function InstallJetpackCta( {
+	getJetpackConnectUrl,
 	isJetpackInstalled,
 	isJetpackActivated,
 	isJetpackConnected,
 	installAndActivatePlugins,
+	isConnecting,
 	isInstalling,
 } ) {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
-	const [ isConnecting, setIsConnecting ] = useState( false );
 	const [ isDismissed, setIsDismissed ] = useState(
 		( userPrefs.homepage_stats || {} ).installJetpackDismissed
 	);
@@ -39,12 +43,20 @@ function InstallJetpackCta( {
 		recordEvent( 'statsoverview_install_jetpack' );
 
 		installAndActivatePlugins( [ 'jetpack' ] )
-			.then( () => {
-				setIsConnecting( ! isJetpackConnected );
-			} )
+			.then( connect )
 			.catch( ( error ) => {
 				createNoticesFromResponse( error );
 			} );
+	}
+
+	function connect() {
+		if ( isJetpackConnected ) {
+			return;
+		}
+
+		getJetpackConnectUrl( {
+			redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
+		} ).then( ( url ) => ( window.location = url ) );
 	}
 
 	function dismiss() {
@@ -60,16 +72,6 @@ function InstallJetpackCta( {
 
 		setIsDismissed( true );
 		recordEvent( 'statsoverview_dismiss_install_jetpack' );
-	}
-
-	function getConnector() {
-		return (
-			<Connect
-				autoConnect
-				onError={ () => setIsConnecting( false ) }
-				redirectUrl={ getAdminLink( 'admin.php?page=wc-admin' ) }
-			/>
-		);
 	}
 
 	const doNotShow =
@@ -121,8 +123,6 @@ function InstallJetpackCta( {
 					{ __( 'No thanks', 'woocommerce-admin' ) }
 				</Button>
 			</footer>
-
-			{ isConnecting && getConnector() }
 		</article>
 	);
 }
@@ -144,6 +144,10 @@ export default compose(
 		} = select( PLUGINS_STORE_NAME );
 
 		return {
+			getJetpackConnectUrl: __experimentalResolveSelect(
+				PLUGINS_STORE_NAME
+			).getJetpackConnectUrl,
+			isConnecting: isPluginsRequesting( 'getJetpackConnectUrl' ),
 			isInstalling:
 				isPluginsRequesting( 'installPlugins' ) ||
 				isPluginsRequesting( 'activatePlugins' ),


### PR DESCRIPTION
Fixes #4639 

To make the Jetpack connection flow easier to follow, this PR uses the experimental selector in wp data to resolve the connection URL instead of relying on a UI component to handle the connection.

It also removes the `autoConnect` feature to discourage use of this component when an interface is not part of the connection flow.

This will also be helpful for upcoming changes to the onboarding flow noted in https://github.com/woocommerce/woocommerce-admin/issues/4579

**Feedback:** I think that being able to catch errors from the resolver would be a great addition to this, but this would need to be something we handle upstream.

### Detailed test instructions:

1. Deactivate WCS and/or Jetpack.
1. Walk through the profiler, opting in at the benefits screen.
1. Make sure you are redirected to the Jetpack connection (note that you may need to be a non-local server to fully test the Jetpack connection flow).
1. Repeat this process with the install Jetpack CTA on the homescreen stats section.
1. Optionally throw a `WP_Error` in https://github.com/woocommerce/woocommerce-admin/blob/9213826b60d1255c72a8f5138a9e74cec2b662f0/src/API/Plugins.php#L440 and make sure its message is shown when attempting to connect in either of these places.