### PR TITLE
Fix dashboard task list menu placement

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -99,3 +99,28 @@
 		}
 	}
 }
+
+
+.woocommerce-dashboard-card {
+	.components-card__header.is-size-large,
+	.components-card__header.is-size-medium {
+		min-height: 63px;
+		min-height: unset;
+		display: grid;
+		grid-template-columns: auto 24px;
+
+		// IE doesn't support `align-items` on grid container
+
+		& > * {
+			align-self: center;
+		}
+	}
+
+	.components-card__body.is-size-large {
+		padding: 0;
+	}
+
+	.components-card__footer.is-size-large {
+		padding: 0 $gap-smaller;
+	}
+}

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -32,7 +32,6 @@ import {
  * Internal dependencies
  */
 import './style.scss';
-import '../homescreen/style.scss';
 import CartModal from 'dashboard/components/cart-modal';
 import { getAllTasks } from './tasks';
 import { recordEvent } from 'lib/tracks';
@@ -359,7 +358,7 @@ class TaskDashboard extends Component {
 						<Fragment>
 							<Card
 								size="large"
-								className="woocommerce-task-card woocommerce-homescreen-card"
+								className="woocommerce-task-card woocommerce-dashboard-card"
 							>
 								<progress
 									className={ progressBarClass }

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -32,6 +32,7 @@ import {
  * Internal dependencies
  */
 import './style.scss';
+import '../homescreen/style.scss';
 import CartModal from 'dashboard/components/cart-modal';
 import { getAllTasks } from './tasks';
 import { recordEvent } from 'lib/tracks';
@@ -314,7 +315,12 @@ class TaskDashboard extends Component {
 			);
 
 			task.title = (
-				<Text as="div" variant={ task.completed ? 'body.small' : 'button' }>{ task.title }</Text>
+				<Text
+					as="div"
+					variant={ task.completed ? 'body.small' : 'button' }
+				>
+					{ task.title }
+				</Text>
 			);
 
 			if ( ! task.completed ) {

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -584,27 +584,3 @@
 		border-top-right-radius: 2px;
 	}
 }
-
-.woocommerce-dashboard-card {
-	.components-card__header.is-size-large,
-	.components-card__header.is-size-medium {
-		min-height: 63px;
-		min-height: unset;
-		display: grid;
-		grid-template-columns: auto 24px;
-
-		// IE doesn't support `align-items` on grid container
-
-		& > * {
-			align-self: center;
-		}
-	}
-
-	.components-card__body.is-size-large {
-		padding: 0;
-	}
-
-	.components-card__footer.is-size-large {
-		padding: 0 $gap-smaller;
-	}
-}

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -584,3 +584,27 @@
 		border-top-right-radius: 2px;
 	}
 }
+
+.woocommerce-dashboard-card {
+	.components-card__header.is-size-large,
+	.components-card__header.is-size-medium {
+		min-height: 63px;
+		min-height: unset;
+		display: grid;
+		grid-template-columns: auto 24px;
+
+		// IE doesn't support `align-items` on grid container
+
+		& > * {
+			align-self: center;
+		}
+	}
+
+	.components-card__body.is-size-large {
+		padding: 0;
+	}
+
+	.components-card__footer.is-size-large {
+		padding: 0 $gap-smaller;
+	}
+}


### PR DESCRIPTION
 so it is styled correctly in the dashboard view.

Fixes #4663
Fixes #4675

The ellipsis menu on the task list in dashboard view is misaligned. This is because the new home screen styles weren't imported to the task list on the dashboard view.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/224531/85365741-4e6a3c00-b569-11ea-8932-141a82269348.png)

After:
![image](https://user-images.githubusercontent.com/224531/85365787-5f1ab200-b569-11ea-89d2-2893313929c7.png)

### Detailed test instructions:

- Configure the home screen off in `/config/development.json` and restart `npm start`, or just build a zip from this branch and upload it to a fresh ephemeral site with the `woocommerce_task_list_hidden` option set to `no`
- Check the dashboard task menu style

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
