### PR TITLE
Restore unread indicator styling

### DIFF
--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -47,4 +47,17 @@
 			vertical-align: top;
 		}
 	}
+
+	span {
+		margin: 6px 0 0 7px;
+		background: #40464d;
+		border-radius: 0.8em;
+		color: $core-grey-light-200;
+		display: inline-block;
+		text-align: center;
+		width: 1.6em;
+		font-size: 14px;
+		vertical-align: top;
+		line-height: normal;
+	}
 }


### PR DESCRIPTION
The unread admin notes count indicator's style seem to have been lost at some point recently. This restores it.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/224531/85375059-1834b880-b579-11ea-8334-9d2ab88b2f35.png)

After:
![image](https://user-images.githubusercontent.com/224531/85375175-44503980-b579-11ea-9020-f2a5fa42bea7.png)

### Detailed test instructions:

- Look at the home page with some unread messages. The unread count indicator should be styled like a pill.
