### PR TITLE
Fix inbox note deletion test cases.

### DIFF
--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -384,7 +384,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$notes    = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( 4, count( $notes ) );
 	}
 
 	/**
@@ -405,7 +405,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'DELETE', $this->endpoint . '/delete/all' ) );
 		$notes    = $response->get_data();
-		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( 4, count( $notes ) );
 
 		$request = new WP_REST_Request( 'PUT', $this->endpoint . '/undoremove' );
 		$request->set_body_params(


### PR DESCRIPTION
Counts were incorrect - 4 notes get created in the setup: https://github.com/woocommerce/woocommerce-admin/blob/e959ef474ec8c0a9ea6cea11d9ce944796c158a0/tests/framework/helpers/class-wc-helper-admin-notes.php#L29