### PR TITLE
Check that the possibly_add_note function exists before calling it

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -53,7 +53,9 @@ class Package {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
 			$update_version       = new WC_Admin_Notes_Deactivate_Plugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
-				$update_version::possibly_add_note();
+				if ( method_exists( $update_version, 'possibly_add_note' ) ) {
+					$update_version::possibly_add_note();
+				}
 			} else {
 				$update_version::delete_note();
 			}


### PR DESCRIPTION
Fixes #4658

So if you:

1. spin up a fresh JN site
2. open an SSH session to the site, because you're going to break it
3. install & activate woocommerce-4.3.0-beta.1
4. install & activate WooCommerce Admin from the plugins screen

the site will crash:

![image](https://user-images.githubusercontent.com/224531/85504289-0d3c5f80-b62f-11ea-971b-75f59c5acc9d.png)

What's happening is that `Package.php` that is bundled in WC 4.3.0-beta.1 is trying to call the `possibly_add_note` function on a note however it's using the WCA plugin installed in step 4, which is an older version (1.2.4) that doesn't have the `possibly_add_note` function defined (it's in `NoteTraits.php`).

To fix it, in the SSH session:

```
vim /apps/user________/public/wp-content/plugins/woocommerce-4.3.0-beta.1/packages/woocommerce-admin/src/Package.php
```

find line 56 and change the call to `possibly_add_note` to the following:

```
if ( method_exists ( $update_version, 'possibly_add_note' ) ) {
    $update_version::possibly_add_note();
}
```

Save that and the site should magically start working - the note still won't appear unfortunately and I don't know if that's a dealbreaker or not.