### PR TITLE
Refactor task tax to use promise chain

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -696,11 +696,7 @@ BusinessDetails.contextType = CurrencyContext;
 
 export default compose(
 	withSelect( ( select ) => {
-		const {
-			getSettings,
-			getSettingsError,
-			isGetSettingsRequesting,
-		} = select( SETTINGS_STORE_NAME );
+		const { getSettings, getSettingsError } = select( SETTINGS_STORE_NAME );
 		const { getProfileItems, getOnboardingError } = select(
 			ONBOARDING_STORE_NAME
 		);
@@ -716,7 +712,6 @@ export default compose(
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),
 			profileItems: getProfileItems(),
 			isSettingsError: Boolean( getSettingsError( 'general' ) ),
-			isSettingsRequesting: isGetSettingsRequesting( 'general' ),
 			settings,
 			isInstallingActivating:
 				isPluginsRequesting( 'installPlugins' ) ||

--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -237,11 +237,7 @@ StoreDetails.contextType = CurrencyContext;
 
 export default compose(
 	withSelect( ( select ) => {
-		const {
-			getSettings,
-			getSettingsError,
-			isGetSettingsRequesting,
-		} = select( SETTINGS_STORE_NAME );
+		const { getSettings, getSettingsError } = select( SETTINGS_STORE_NAME );
 		const { getOnboardingError, getProfileItems } = select(
 			ONBOARDING_STORE_NAME
 		);
@@ -253,12 +249,10 @@ export default compose(
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );
-		const isSettingsRequesting = isGetSettingsRequesting( 'general' );
 
 		return {
 			isProfileItemsError,
 			isSettingsError,
-			isSettingsRequesting,
 			profileItems,
 			settings,
 		};

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -584,3 +584,8 @@
 		border-top-right-radius: 2px;
 	}
 }
+
+.woocommerce-task__caption {
+	color: $dark-gray-300;
+	margin-top: $gap;
+}

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -302,13 +302,13 @@ class Shipping extends Component {
 
 	render() {
 		const { isPending, step } = this.state;
-		const { isSettingsRequesting } = this.props;
+		const { isUpdateSettingsRequesting } = this.props;
 
 		return (
 			<div className="woocommerce-task-shipping">
 				<Card className="is-narrow">
 					<Stepper
-						isPending={ isPending || isSettingsRequesting }
+						isPending={ isPending || isUpdateSettingsRequesting }
 						isVertical
 						currentStep={ step }
 						steps={ this.getSteps() }
@@ -321,19 +321,14 @@ class Shipping extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const {
-			getSettings,
-			getSettingsError,
-			isGetSettingsRequesting,
-		} = select( SETTINGS_STORE_NAME );
+		const { getSettings, isUpdateSettingsRequesting } = select(
+			SETTINGS_STORE_NAME
+		);
 		const { getActivePlugins, isJetpackConnected } = select(
 			PLUGINS_STORE_NAME
 		);
 
 		const { general: settings = {} } = getSettings( 'general' );
-		const isSettingsError = Boolean( getSettingsError( 'general' ) );
-		const isSettingsRequesting = isGetSettingsRequesting( 'general' );
-
 		const countryCode = getCountryCode(
 			settings.woocommerce_default_country
 		);
@@ -348,8 +343,7 @@ export default compose(
 		return {
 			countryCode,
 			countryName,
-			isSettingsError,
-			isSettingsRequesting,
+			isUpdateSettingsRequesting: isUpdateSettingsRequesting( 'general' ),
 			settings,
 			activePlugins,
 			isJetpackConnected: isJetpackConnected(),

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -51,9 +51,6 @@ class Tax extends Component {
 		this.configureTaxRates = this.configureTaxRates.bind( this );
 		this.updateAutomatedTax = this.updateAutomatedTax.bind( this );
 		this.setIsPending = this.setIsPending.bind( this );
-		this.shouldShowSuccessScreen = this.shouldShowSuccessScreen.bind(
-			this
-		);
 	}
 
 	componentDidMount() {
@@ -65,7 +62,6 @@ class Tax extends Component {
 	}
 
 	shouldShowSuccessScreen() {
-		const { stepIndex } = this.state;
 		const {
 			isJetpackConnected,
 			pluginsToActivate,
@@ -80,7 +76,6 @@ class Tax extends Component {
 			storeAddress && defaultCountry && storePostCode
 		);
 		return (
-			stepIndex !== null &&
 			isCompleteAddress &&
 			! pluginsToActivate.length &&
 			isJetpackConnected &&
@@ -89,23 +84,7 @@ class Tax extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { generalSettings, isJetpackConnected, taxSettings } = this.props;
-		const {
-			woocommerce_calc_taxes: calcTaxes,
-			woocommerce_store_address: storeAddress,
-			woocommerce_default_country: defaultCountry,
-			woocommerce_store_postcode: storePostCode,
-		} = generalSettings;
-		const { stepIndex } = this.state;
-		const currentStep = this.getSteps()[ stepIndex ];
-		const currentStepKey = currentStep && currentStep.key;
-
-		if ( stepIndex !== null && this.shouldShowSuccessScreen() ) {
-			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { stepIndex: null } );
-			/* eslint-enable react/no-did-update-set-state */
-			return;
-		}
+		const { taxSettings } = this.props;
 
 		if (
 			taxSettings.wc_connect_taxes_enabled &&
@@ -120,27 +99,6 @@ class Tax extends Component {
 						: false,
 			} );
 			/* eslint-enable react/no-did-update-set-state */
-		}
-
-		if ( currentStepKey === 'connect' && isJetpackConnected ) {
-			this.completeStep();
-		}
-
-		const isCompleteAddress = Boolean(
-			storeAddress && defaultCountry && storePostCode
-		);
-
-		if ( currentStepKey === 'store_location' && isCompleteAddress ) {
-			this.completeStep();
-		}
-
-		const {
-			woocommerce_calc_taxes: prevCalcTaxes,
-		} = prevProps.generalSettings;
-		if ( prevCalcTaxes === 'no' && calcTaxes === 'yes' ) {
-			window.location = getAdminLink(
-				'admin.php?page=wc-settings&tab=tax&section=standard'
-			);
 		}
 	}
 
@@ -273,12 +231,7 @@ class Tax extends Component {
 							recordEvent( 'tasklist_tax_set_location', {
 								country,
 							} );
-							if ( this.shouldShowSuccessScreen() ) {
-								this.setState( { stepIndex: null } );
-								// Only complete step if another update hasn't already shown succes screen.
-							} else if ( this.state.stepIndex !== null ) {
-								this.completeStep();
-							}
+							this.completeStep();
 						} }
 						isSettingsRequesting={ false }
 						settings={ generalSettings }
@@ -412,14 +365,7 @@ class Tax extends Component {
 		return (
 			<div className="woocommerce-task-tax">
 				<Card className="is-narrow">
-					{ step ? (
-						<Stepper
-							isPending={ isPending || isTaxSettingsRequesting }
-							isVertical={ true }
-							currentStep={ step.key }
-							steps={ this.getSteps() }
-						/>
-					) : (
+					{ this.shouldShowSuccessScreen() ? (
 						<div className="woocommerce-task-tax__success">
 							<span
 								className="woocommerce-task-tax__success-icon"
@@ -484,6 +430,13 @@ class Tax extends Component {
 								) }
 							</Button>
 						</div>
+					) : (
+						<Stepper
+							isPending={ isPending || isTaxSettingsRequesting }
+							isVertical={ true }
+							currentStep={ step.key }
+							steps={ this.getSteps() }
+						/>
 					) }
 				</Card>
 			</div>

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -37,13 +37,14 @@ import { recordEvent, queueRecordEvent } from 'lib/tracks';
 class Tax extends Component {
 	constructor( props ) {
 		super( props );
+		const { hasCompleteAddress, pluginsToActivate } = props;
 
 		this.initialState = {
 			isPending: false,
-			stepIndex: 0,
+			stepIndex: hasCompleteAddress ? 1 : 0,
 			// Cache the value of pluginsToActivate so that we can
 			// show/hide tasks based on it, but not have them update mid task.
-			pluginsToActivate: props.pluginsToActivate,
+			pluginsToActivate,
 		};
 
 		this.state = this.initialState;
@@ -63,19 +64,12 @@ class Tax extends Component {
 	shouldShowSuccessScreen() {
 		const {
 			isJetpackConnected,
+			hasCompleteAddress,
 			pluginsToActivate,
-			generalSettings,
 		} = this.props;
-		const {
-			woocommerce_store_address: storeAddress,
-			woocommerce_default_country: defaultCountry,
-			woocommerce_store_postcode: storePostCode,
-		} = generalSettings;
-		const isCompleteAddress = Boolean(
-			storeAddress && defaultCountry && storePostCode
-		);
+
 		return (
-			isCompleteAddress &&
+			hasCompleteAddress &&
 			! pluginsToActivate.length &&
 			isJetpackConnected &&
 			this.isTaxJarSupported()
@@ -431,6 +425,14 @@ export default compose(
 		const countryCode = getCountryCode(
 			generalSettings.woocommerce_default_country
 		);
+		const {
+			woocommerce_store_address: storeAddress,
+			woocommerce_default_country: defaultCountry,
+			woocommerce_store_postcode: storePostCode,
+		} = generalSettings;
+		const hasCompleteAddress = Boolean(
+			storeAddress && defaultCountry && storePostCode
+		);
 
 		const { tax: taxSettings = {} } = getSettings( 'tax' );
 		const isTaxSettingsRequesting = isGetSettingsRequesting( 'tax' );
@@ -446,12 +448,13 @@ export default compose(
 			getOption( 'woocommerce_setup_jetpack_opted_in' );
 
 		return {
-			generalSettings,
 			countryCode,
-			taxSettings,
-			isTaxSettingsRequesting,
+			generalSettings,
+			hasCompleteAddress,
 			isJetpackConnected: isJetpackConnected(),
+			isTaxSettingsRequesting,
 			pluginsToActivate,
+			taxSettings,
 			tosAccepted,
 		};
 	} ),

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, __experimentalText as Text } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { difference, filter } from 'lodash';
@@ -253,7 +253,10 @@ class Tax extends Component {
 							) }
 						/>
 						{ ! tosAccepted && (
-							<p>
+							<Text
+								variant="caption"
+								className="woocommerce-task__caption"
+							>
 								{ interpolateComponents( {
 									mixedString: __(
 										'By installing Jetpack and WooCommerce Services you agree to the {{link}}Terms of Service{{/link}}.',
@@ -271,7 +274,7 @@ class Tax extends Component {
 										),
 									},
 								} ) }
-							</p>
+							</Text>
 						) }
 					</Fragment>
 				),

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -94,8 +94,6 @@ class Tax extends Component {
 
 		if ( nextStep ) {
 			this.setState( { stepIndex: stepIndex + 1 } );
-		} else {
-			getHistory().push( getNewPath( {}, '/', {} ) );
 		}
 	}
 

--- a/packages/data/src/settings/selectors.js
+++ b/packages/data/src/settings/selectors.js
@@ -3,9 +3,9 @@
  */
 import { getResourceName, getResourcePrefix } from '../utils';
 
-export const getSettingsGroupNames = state => {
+export const getSettingsGroupNames = ( state ) => {
 	const groupNames = new Set(
-		Object.keys( state ).map( resourceName => {
+		Object.keys( state ).map( ( resourceName ) => {
 			return getResourcePrefix( resourceName );
 		} )
 	);
@@ -14,11 +14,11 @@ export const getSettingsGroupNames = state => {
 
 export const getSettings = ( state, group ) => {
 	const settings = {};
-	const settingIds = state[ group ] && state[ group ].data || [];
+	const settingIds = ( state[ group ] && state[ group ].data ) || [];
 	if ( settingIds.length === 0 ) {
 		return settings;
 	}
-	settingIds.forEach( id => {
+	settingIds.forEach( ( id ) => {
 		settings[ id ] = state[ getResourceName( group, id ) ].data;
 	} );
 	return settings;
@@ -47,7 +47,7 @@ export const getSettingsForGroup = ( state, group, keys ) => {
 	}, {} );
 };
 
-export const isGetSettingsRequesting = ( state, group ) => {
+export const isUpdateSettingsRequesting = ( state, group ) => {
 	return state[ group ] && Boolean( state[ group ].isRequesting );
 };
 
@@ -70,9 +70,16 @@ export const isGetSettingsRequesting = ( state, group ) => {
  * @return {*}  The value present in the settings state for the given
  *                   name.
  */
-export function getSetting( state, group, name, fallback = false, filter = val => val ) {
+export function getSetting(
+	state,
+	group,
+	name,
+	fallback = false,
+	filter = ( val ) => val
+) {
 	const resourceName = getResourceName( group, name );
-	const value = ( state[ resourceName ] && state[ resourceName ].data ) || fallback;
+	const value =
+		( state[ resourceName ] && state[ resourceName ].data ) || fallback;
 	return filter( value, fallback );
 }
 
@@ -86,7 +93,7 @@ export const getLastSettingsErrorForGroup = ( state, group ) => {
 
 export const getSettingsError = ( state, group, id ) => {
 	if ( ! id ) {
-		return state[ group ] && state[ group ].error || false;
+		return ( state[ group ] && state[ group ].error ) || false;
 	}
 	return state[ getResourceName( group, id ) ].error || false;
 };

--- a/packages/data/src/settings/use-settings.js
+++ b/packages/data/src/settings/use-settings.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -7,18 +6,23 @@ import { STORE_NAME } from './constants';
 import { useCallback } from '@wordpress/element';
 
 export const useSettings = ( group, settingsKeys = [] ) => {
-	const { requestedSettings, settingsError, isRequesting, isDirty } = useSelect(
-		select => {
+	const {
+		requestedSettings,
+		settingsError,
+		isRequesting,
+		isDirty,
+	} = useSelect(
+		( select ) => {
 			const {
 				getLastSettingsErrorForGroup,
 				getSettingsForGroup,
 				getIsDirty,
-				isGetSettingsRequesting,
+				isUpdateSettingsRequesting,
 			} = select( STORE_NAME );
 			return {
 				requestedSettings: getSettingsForGroup( group, settingsKeys ),
 				settingsError: Boolean( getLastSettingsErrorForGroup( group ) ),
-				isRequesting: isGetSettingsRequesting( group ),
+				isRequesting: isUpdateSettingsRequesting( group ),
 				isDirty: getIsDirty( group, settingsKeys ),
 			};
 		},
@@ -35,14 +39,11 @@ export const useSettings = ( group, settingsKeys = [] ) => {
 		},
 		[ group ]
 	);
-	const persistSettings = useCallback(
-		() => {
-			// this action would simply persist all settings marked as dirty in the
-			// store state and then remove the dirty record in the isDirtyMap
-			persistSettingsForGroup( group );
-		},
-		[ group ]
-	);
+	const persistSettings = useCallback( () => {
+		// this action would simply persist all settings marked as dirty in the
+		// store state and then remove the dirty record in the isDirtyMap
+		persistSettingsForGroup( group );
+	}, [ group ] );
 	const updateAndPersistSettings = useCallback(
 		( name, data ) => {
 			updateAndPersistSettingsForGroup( group, { [ name ]: data } );


### PR DESCRIPTION
Fixes #4631
Fixes #4667

After the wp data transition, we now have access to async updates.  Since the `await` is now working, this caused some odd behavior on component update.

The logic in this component became tricky to follow and similar to other various updates around onboarding, this PR makes use of returned promises from wp data actions and attempts to minimize the state.

@pmcpinto @jameskoster It looks like with the current behavior, plugins only get installed on the tax step if TOS is already accepted, which currently will only occur if they opt in on the benefits screen from the profiler.  This seems redundant- should we remove the plugins step from here or is it possible to allow plugin installation and opt in to TOS from this step?

### Detailed test instructions:

1. On a fresh install, walk through the profiler, using a TaxJar supported country (e.g., US) and opting in at the benefits screen in the profiler.
1. Navigate to the tax task.
1. Make sure the "success" screen is shown and that click "Yes please" is successful and returns to the task list without redirecting to the tax configuration screen.
1. Deactivate WCS and/or Jetpack.
1. Go to the task tax again.
1. Check that you can manually configure taxes.
1. Go to General WC Settings and remove required pieces of your address.
1. Navigate back to the task tax.
1. Make sure you're able to fill in your address and complete the steps.
1. Also make sure that "skip" actions continue to work as expected.
1. Make sure busy states work as expected.