### PR TITLE
Added new note type

### DIFF
--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -22,5 +22,5 @@ export const QUERY_DEFAULTS = {
 	pageSize: 25,
 	period: 'month',
 	compare: 'previous_year',
-	noteTypes: 'info,warning,marketing',
+	noteTypes: 'info,warning,marketing,survey',
 };

--- a/src/API/NoteActions.php
+++ b/src/API/NoteActions.php
@@ -108,11 +108,6 @@ class NoteActions extends Notes {
 			$note->set_status( $triggered_action->status );
 		}
 
-		// Update note state depending on its type.
-		if ( WC_Admin_Note::E_WC_ADMIN_NOTE_SURVEY === $note->get_type() ) {
-			$note->set_is_deleted( 1 );
-		}
-
 		$note->save();
 
 		if ( in_array( $note->get_type(), array( 'error', 'update' ) ) ) {

--- a/src/API/NoteActions.php
+++ b/src/API/NoteActions.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
@@ -108,7 +109,7 @@ class NoteActions extends Notes {
 		}
 
 		// Update note state depending on its type.
-		if ( 'survey' === $note->get_type() ) {
+		if ( WC_Admin_Note::E_WC_ADMIN_NOTE_SURVEY === $note->get_type() ) {
 			$note->set_is_deleted( 1 );
 		}
 

--- a/src/API/NoteActions.php
+++ b/src/API/NoteActions.php
@@ -107,6 +107,11 @@ class NoteActions extends Notes {
 			$note->set_status( $triggered_action->status );
 		}
 
+		// Update note state depending on its type.
+		if ( 'survey' === $note->get_type() ) {
+			$note->set_is_deleted( 1 );
+		}
+
 		$note->save();
 
 		if ( in_array( $note->get_type(), array( 'error', 'update' ) ) ) {

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -22,6 +22,7 @@ class WC_Admin_Note extends \WC_Data {
 	const E_WC_ADMIN_NOTE_UPDATE        = 'update';    // i.e. used when a new version is available.
 	const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';      // used for presenting informational messages.
 	const E_WC_ADMIN_NOTE_MARKETING     = 'marketing'; // used for adding marketing messages.
+	const E_WC_ADMIN_NOTE_SURVEY        = 'survey';    // used for adding survey messages.
 
 	// Note status codes.
 	const E_WC_ADMIN_NOTE_PENDING    = 'pending';    // the note is pending - hidden but not actioned.
@@ -126,6 +127,7 @@ class WC_Admin_Note extends \WC_Data {
 			self::E_WC_ADMIN_NOTE_UPDATE,
 			self::E_WC_ADMIN_NOTE_INFORMATIONAL,
 			self::E_WC_ADMIN_NOTE_MARKETING,
+			self::E_WC_ADMIN_NOTE_SURVEY,
 		);
 
 		return apply_filters( 'woocommerce_note_types', $allowed_types );

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -164,7 +164,7 @@ class WC_Admin_Notes {
 				'orderby'    => 'date_created',
 				'per_page'   => 25,
 				'page'       => 1,
-				'type'       => array( 'info', 'marketing', 'warning' ),
+				'type'       => array( 'info', 'marketing', 'warning', 'survey' ),
 				'is_deleted' => 0,
 			)
 		);

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -24,6 +24,7 @@ class WC_Admin_Notes {
 	 */
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'schedule_unsnooze_notes' ) );
+		add_action( 'admin_init', array( __CLASS__, 'possibly_delete_survey_notes' ) );
 		add_action( 'update_option_woocommerce_show_marketplace_suggestions', array( __CLASS__, 'possibly_delete_marketing_notes' ), 10, 2 );
 	}
 
@@ -244,6 +245,25 @@ class WC_Admin_Notes {
 		foreach ( $notes as $note ) {
 			$note = new WC_Admin_Note( $note->note_id );
 			$note->delete();
+		}
+	}
+
+	/**
+	 * Delete actioned survey notes.
+	 */
+	public static function possibly_delete_survey_notes() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$notes      = $data_store->get_notes(
+			array(
+				'type'   => array( WC_Admin_Note::E_WC_ADMIN_NOTE_SURVEY ),
+				'status' => array( 'actioned' ),
+			)
+		);
+
+		foreach ( $notes as $note ) {
+			$note = new WC_Admin_Note( $note->note_id );
+			$note->set_is_deleted( 1 );
+			$note->save();
 		}
 	}
 }

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -164,7 +164,12 @@ class WC_Admin_Notes {
 				'orderby'    => 'date_created',
 				'per_page'   => 25,
 				'page'       => 1,
-				'type'       => array( 'info', 'marketing', 'warning', 'survey' ),
+				'type'       => array(
+					WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+					WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING,
+					WC_Admin_Note::E_WC_ADMIN_NOTE_WARNING,
+					WC_Admin_Note::E_WC_ADMIN_NOTE_SURVEY,
+				),
 				'is_deleted' => 0,
 			)
 		);

--- a/src/Notes/WC_Admin_Notes_Insight_First_Sale.php
+++ b/src/Notes/WC_Admin_Notes_Insight_First_Sale.php
@@ -35,9 +35,9 @@ class WC_Admin_Notes_Insight_First_Sale {
 		}
 
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Insight', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Did you know?', 'woocommerce-admin' ) );
 		$note->set_content( __( 'A WooCommerce powered store needs on average 31 days to get the first sale. You\'re on the right track! Do you find this type of insight useful?', 'woocommerce-admin' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_SURVEY );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );


### PR DESCRIPTION
Fixes #4656

_This is a follow up to the [PR 4621](https://github.com/woocommerce/woocommerce-admin/pull/4621)._

This PR adds a new note type `survey`. The survey note is deleted after calling its CTA.
Also, the note `WC_Admin_Notes_Insight_First_Sale.php` was modified since it belongs to this type of note. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-06-24 at 10-29-09](https://user-images.githubusercontent.com/1314156/85567094-f4b84f00-b606-11ea-8f56-cecc02623ada.gif)

### Detailed test instructions:

- Delete the notification `wc-admin-insight-first-sale`.
You can use a SQL sentence like:
````
DELETE FROM `wp_wc_admin_notes` WHERE `wp_wc_admin_notes`.`name` = 'wc-admin-insight-first-sale';
````
- Trigger the cron to add the note again. To do it you can use the plugin [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
- Verify that the note's title is: `Did you know?`.
- Select one of the note's options.
- The message `Thanks for your feedback` should be visible.
- The note should disappear.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: added new note type and modified the note `wc-admin-insight-first-sale` title.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
// cc: @pmcpinto