### PR TITLE
Inbox panel: Added styles to the unread notes counter

### DIFF
--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -35,5 +35,16 @@
 		font-size: 20px;
 		line-height: 28px;
 		font-weight: 400;
+		span {
+			margin-left: $gap-small / 2;
+			background: $core-grey-dark-600;
+			border-radius: 13px;
+			color: $core-grey-light-200;
+			display: inline-block;
+			text-align: center;
+			width: 27px;
+			font-size: 16px;
+			vertical-align: top;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4689

This PR adds styles to the `unread` notes counter.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
The unread notes counter looked like this:
![screenshot-smart-thrush jurassic ninja-2020 06 24-12_14_26](https://user-images.githubusercontent.com/1314156/85591282-9053ba80-b61b-11ea-8b9f-c4053102e6fc.png)

And now:
![screenshot-one wordpress test-2020 06 24-14_09_15](https://user-images.githubusercontent.com/1314156/85602742-0bba6980-b626-11ea-8c91-561c746a39dc.png)


### Detailed test instructions:
- You can see the inbox panel on the home screen (or through the `Inbox` button in the header).
- Be sure you have some unread notes.
- If you don't have any you can add them using [this plugin](https://gist.github.com/octaedro/864315edaf9c6a2a6de71d297be1ed88).
- Verify that next to the title: `Inbox`, a circle appears with the unread notes count.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Added styles to the unread notes counter in the inbox panel.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
