### PR TITLE
Remove unnecessary rest API init action.

### DIFF
--- a/src/ReportCSVExporter.php
+++ b/src/ReportCSVExporter.php
@@ -121,10 +121,6 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 
 		if ( isset( $controller_map[ $this->report_type ] ) ) {
 			// Load the controllers if accessing outside the REST API.
-			if ( ! did_action( 'rest_api_init' ) ) {
-				do_action( 'rest_api_init' );
-			}
-
 			return new $controller_map[ $this->report_type ]();
 		}
 


### PR DESCRIPTION
Fixes #4604.

This PR seeks to remove a seemingly unnecessary firing of the `rest_api_init` action, which mistakenly omits the expected `WP_REST_Server` instance in the action arguments.

### Detailed test instructions:

- Test several report exports that require an email be sent
- Verify no PHP notices/warnings/errors in your log

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Remove unnecessary `rest_api_init` action that caused incompatibility issues with other plugins.