### PR TITLE
Add education and travel to the onboarding industry types

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -310,6 +310,16 @@ class Onboarding {
 					'use_description'   => false,
 					'description_label' => '',
 				),
+				'education-and-learning'          => array(
+					'label'             => __( 'Education and learning', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'travel-and-tourism'              => array(
+					'label'             => __( 'Travel and tourism', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
 				'other'                           => array(
 					'label'             => __( 'Other', 'woocommerce-admin' ),
 					'use_description'   => true,


### PR DESCRIPTION
Fixes #4476

This adds:

- Education and learning
- Travel and tourism

industry options to the onboarding wizard.

Note that the new industries also need to be added to WooCommerce.com (pr TBA).

### Screenshots

![image](https://user-images.githubusercontent.com/224531/85643667-28af7500-b6d8-11ea-9b83-3b8ccb80c1d5.png)

### Detailed test instructions:

- Enable tracks debugging in the console: `localStorage.setItem( 'debug', 'wc-admin:tracks' )`
- Open the OBW and ensure that tracking is enabled
- On the industries step, make sure the new industries are displayed
- select the new industries and navigate next
- make sure the new industries are logged in the console:
![image](https://user-images.githubusercontent.com/224531/85644382-19312b80-b6da-11ea-8f74-8f931dca2339.png)
- finish the OBW then start it again
- when you get back to the industries step, the new industries should be selected
