### PR TITLE
Add bundle install UI to Business Details step

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -233,7 +233,14 @@ class BusinessDetails extends Component {
 
 	getBusinessExtensions( values ) {
 		if ( this.simpleInstall ) {
-			return values.install_extensions ? this.extensions : [];
+			return values.install_extensions
+				? [
+						'jetpack',
+						'woocommerce-services',
+						'woocommerce-payments',
+						...this.extensions,
+				  ]
+				: [];
 		}
 
 		return keys( pickBy( values ) ).filter( ( name ) =>
@@ -422,14 +429,18 @@ class BusinessDetails extends Component {
 						id="woocommerce-business-extensions__checkbox"
 						{ ...getInputProps( 'install_extensions' ) }
 					/>
-					{ __(
-						'Install recommended free business features',
-						'woocommerce-admin'
-					) }
-					<span className="woocommerce-profile-wizard__help-text">
-						{ __( 'Requires an account', 'woocommerce-admin' ) }
+					<span className="woocommerce-business-extensions__label-text">
+						{ __(
+							'Install recommended free business features',
+							'woocommerce-admin'
+						) }
+						<span className="woocommerce-business-extensions__help-text">
+							{ __( 'Requires an account', 'woocommerce-admin' ) }
+						</span>
 					</span>
+				</label>
 
+				<div className="woocommerce-business-extensions__popover-wrapper">
 					<Button
 						isTertiary
 						onMouseEnter={ () =>
@@ -446,91 +457,95 @@ class BusinessDetails extends Component {
 						}
 					>
 						<i className="material-icons-outlined">info</i>
-						{ isPopoverVisible && (
-							<Popover focusOnMount={ false }>
-								<Fragment>
-									<div className="woocommerce-business-extensions__benefits">
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Manage your store on the go with the WooCommerce mobile app',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Accept credit cards with WooCommerce Payments',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Speed & security enhancements',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Automatic sales taxes',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Market on Facebook',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Contact customers with Mailchimp',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Drive sales with Google Ads',
-												'woocommerce-admin'
-											) }
-										</div>
-										<div className="woocommerce-business-extensions__benefit">
-											<i className="material-icons-outlined">
-												check
-											</i>
-											{ __(
-												'Print shipping labels at home',
-												'woocommerce-admin'
-											) }
-										</div>
-									</div>
-									{ this.renderBusinessExtensionHelpText(
-										values
-									) }
-								</Fragment>
-							</Popover>
-						) }
 					</Button>
-				</label>
+					{ isPopoverVisible && (
+						<Popover
+							className="woocommerce-business-extensions__popover"
+							focusOnMount={ false }
+							position="top center"
+						>
+							<Fragment>
+								<div className="woocommerce-business-extensions__benefits">
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Manage your store on the go with the WooCommerce mobile app',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Accept credit cards with WooCommerce Payments',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Speed & security enhancements',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Automatic sales taxes',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Market on Facebook',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Contact customers with Mailchimp',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Drive sales with Google Ads',
+											'woocommerce-admin'
+										) }
+									</div>
+									<div className="woocommerce-business-extensions__benefit">
+										<i className="material-icons-outlined">
+											check
+										</i>
+										{ __(
+											'Print shipping labels at home',
+											'woocommerce-admin'
+										) }
+									</div>
+								</div>
+								{ this.renderBusinessExtensionHelpText(
+									values
+								) }
+							</Fragment>
+						</Popover>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -181,58 +181,55 @@ class BusinessDetails extends Component {
 	validate( values ) {
 		const errors = {};
 
-		Object.keys( values ).forEach( ( name ) => {
-			if ( name === 'other_platform' ) {
-				if (
-					! values.other_platform.length &&
-					[ 'other', 'brick-mortar-other' ].includes(
-						values.selling_venues
-					)
-				) {
-					errors.other_platform = __(
-						'This field is required',
-						'woocommerce-admin'
-					);
-				}
-			} else if ( name === 'other_platform_name' ) {
-				if (
-					! values.other_platform_name &&
-					values.other_platform === 'other' &&
-					[ 'other', 'brick-mortar-other' ].includes(
-						values.selling_venues
-					)
-				) {
-					errors.other_platform_name = __(
-						'This field is required',
-						'woocommerce-admin'
-					);
-				}
-			} else if ( name === 'revenue' ) {
-				if (
-					! values.revenue.length &&
-					[
-						'other',
-						'brick-mortar',
-						'brick-mortar-other',
-						'other-woocommerce',
-					].includes( values.selling_venues )
-				) {
-					errors.revenue = __(
-						'This field is required',
-						'woocommerce-admin'
-					);
-				}
-			} else if (
-				! this.bundleInstall &&
-				! this.extensions.includes( name ) &&
-				! values[ name ].length
-			) {
-				errors[ name ] = __(
-					'This field is required',
-					'woocommerce-admin'
-				);
-			}
-		} );
+		if ( ! values.product_count.length ) {
+			errors.product_count = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
+
+		if ( ! values.selling_venues.length ) {
+			errors.selling_venues = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
+
+		if (
+			! values.other_platform.length &&
+			[ 'other', 'brick-mortar-other' ].includes( values.selling_venues )
+		) {
+			errors.other_platform = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
+
+		if (
+			! values.other_platform_name &&
+			values.other_platform === 'other' &&
+			[ 'other', 'brick-mortar-other' ].includes( values.selling_venues )
+		) {
+			errors.other_platform_name = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
+
+		if (
+			! values.revenue.length &&
+			[
+				'other',
+				'brick-mortar',
+				'brick-mortar-other',
+				'other-woocommerce',
+			].includes( values.selling_venues )
+		) {
+			errors.revenue = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
 
 		return errors;
 	}

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -53,7 +53,6 @@ class BusinessDetails extends Component {
 		);
 
 		this.state = {
-			hasInstallActivateError: false,
 			isPopoverVisible: false,
 		};
 
@@ -158,9 +157,6 @@ class BusinessDetails extends Component {
 						createNoticesFromResponse( response );
 					} )
 					.catch( ( error ) => {
-						this.setState( {
-							hasInstallActivateError: true,
-						} );
 						createNoticesFromResponse( error );
 						throw new Error();
 					} )

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -10,6 +10,7 @@ import {
 	FormToggle,
 	Popover,
 } from '@wordpress/components';
+import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { keys, get, pickBy } from 'lodash';
 
@@ -452,10 +453,15 @@ class BusinessDetails extends Component {
 						{ ...getInputProps( 'install_extensions' ) }
 					/>
 					<span className="woocommerce-business-extensions__label-text">
-						{ __(
-							'Install recommended free business features',
-							'woocommerce-admin'
-						) }
+						{ interpolateComponents( {
+							mixedString: __(
+								'Install recommended {{strong}}free{{/strong}} business features',
+								'woocommerce-admin'
+							),
+							components: {
+								strong: <strong />,
+							},
+						} ) }
 						<span className="woocommerce-business-extensions__label-subtext">
 							{ __( 'Requires an account', 'woocommerce-admin' ) }
 						</span>

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -249,6 +249,10 @@ class BusinessDetails extends Component {
 				: [];
 		}
 
+		if ( values.selling_venues === '' ) {
+			return [];
+		}
+
 		return keys( pickBy( values ) ).filter( ( name ) =>
 			this.extensions.includes( name )
 		);
@@ -331,7 +335,7 @@ class BusinessDetails extends Component {
 
 		if ( isInstallingActivating ) {
 			return (
-				<p className="woocommerce-business-extensions__help-text">
+				<p>
 					{ sprintf(
 						_n(
 							'Installing the following plugin: %s',
@@ -346,21 +350,36 @@ class BusinessDetails extends Component {
 		}
 
 		return (
-			<p className="woocommerce-business-extensions__help-text">
-				{ sprintf(
-					_n(
-						'The following plugin will be installed for free: %s',
-						'The following plugins will be installed for free: %s',
-						extensions.length,
-						'woocommerce-admin'
-					),
-					extensionsList
+			<Fragment>
+				<p>
+					{ sprintf(
+						_n(
+							'The following plugin will be installed for free: %s',
+							'The following plugins will be installed for free: %s',
+							extensions.length,
+							'woocommerce-admin'
+						),
+						extensionsList
+					) }
+				</p>
+				{ this.bundleInstall && (
+					<p>
+						{ __(
+							'An account is required to use these features.',
+							'woocommerce-admin'
+						) }
+					</p>
 				) }
-			</p>
+			</Fragment>
 		);
 	}
 
 	renderBusinessExtensions( values, getInputProps ) {
+		// Show extensions when the currently selling elsewhere checkbox has been answered.
+		if ( values.selling_venues === '' ) {
+			return null;
+		}
+
 		const extensionBenefits = [
 			{
 				slug: 'facebook-for-woocommerce',
@@ -470,85 +489,80 @@ class BusinessDetails extends Component {
 							focusOnMount={ false }
 							position="top center"
 						>
-							<Fragment>
-								<div className="woocommerce-business-extensions__benefits">
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Manage your store on the go with the WooCommerce mobile app',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Accept credit cards with WooCommerce Payments',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Speed & security enhancements',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Automatic sales taxes',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Market on Facebook',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Contact customers with Mailchimp',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Drive sales with Google Ads',
-											'woocommerce-admin'
-										) }
-									</div>
-									<div className="woocommerce-business-extensions__benefit">
-										<i className="material-icons-outlined">
-											check
-										</i>
-										{ __(
-											'Print shipping labels at home',
-											'woocommerce-admin'
-										) }
-									</div>
+							<div className="woocommerce-business-extensions__benefits">
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Manage your store on the go with the WooCommerce mobile app',
+										'woocommerce-admin'
+									) }
 								</div>
-								{ this.renderBusinessExtensionHelpText(
-									values
-								) }
-							</Fragment>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Accept credit cards with WooCommerce Payments',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Speed & security enhancements',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Automatic sales taxes',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Market on Facebook',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Contact customers with Mailchimp',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Drive sales with Google Ads',
+										'woocommerce-admin'
+									) }
+								</div>
+								<div className="woocommerce-business-extensions__benefit">
+									<i className="material-icons-outlined">
+										check
+									</i>
+									{ __(
+										'Print shipping labels at home',
+										'woocommerce-admin'
+									) }
+								</div>
+							</div>
 						</Popover>
 					) }
 				</div>
@@ -718,9 +732,6 @@ class BusinessDetails extends Component {
 				validate={ this.validate }
 			>
 				{ ( { getInputProps, handleSubmit, values, isValidForm } ) => {
-					// Show extensions when the currently selling elsewhere checkbox has been answered.
-					const shouldShowExtensions =
-						values.selling_venues !== '' && ! this.bundleInstall;
 					return (
 						<Fragment>
 							<H className="woocommerce-profile-wizard__header-title">
@@ -810,17 +821,15 @@ class BusinessDetails extends Component {
 										</Fragment>
 									) }
 
-									{ shouldShowExtensions &&
-										this.renderBusinessExtensions(
-											values,
-											getInputProps
-										) }
-
-									{ this.bundleInstall &&
-										this.renderBusinessExtensionsBundle(
-											values,
-											getInputProps
-										) }
+									{ this.bundleInstall
+										? this.renderBusinessExtensionsBundle(
+												values,
+												getInputProps
+										  )
+										: this.renderBusinessExtensions(
+												values,
+												getInputProps
+										  ) }
 
 									<div className="woocommerce-profile-wizard__card-actions">
 										<Button
@@ -853,8 +862,7 @@ class BusinessDetails extends Component {
 								</Fragment>
 							</Card>
 
-							{ shouldShowExtensions &&
-								this.renderBusinessExtensionHelpText( values ) }
+							{ this.renderBusinessExtensionHelpText( values ) }
 						</Fragment>
 					);
 				} }

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -471,26 +471,22 @@ class BusinessDetails extends Component {
 				<div className="woocommerce-business-extensions__popover-wrapper">
 					<Button
 						isTertiary
-						onMouseEnter={ () =>
-							this.setState( { isPopoverVisible: true } )
-						}
-						onMouseLeave={ () =>
-							this.setState( { isPopoverVisible: false } )
-						}
-						onFocus={ () =>
-							this.setState( { isPopoverVisible: true } )
-						}
-						onBlur={ () =>
-							this.setState( { isPopoverVisible: false } )
-						}
+						onClick={ () => {
+							recordEvent(
+								'storeprofiler_store_business_details_popover'
+							);
+							this.setState( { isPopoverVisible: true } );
+						} }
 					>
 						<i className="material-icons-outlined">info</i>
 					</Button>
 					{ isPopoverVisible && (
 						<Popover
 							className="woocommerce-business-extensions__popover"
-							focusOnMount={ false }
 							position="top center"
+							onClose={ () =>
+								this.setState( { isPopoverVisible: false } )
+							}
 						>
 							<div className="woocommerce-business-extensions__benefits">
 								<div className="woocommerce-business-extensions__benefit">

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -80,7 +80,7 @@ class BusinessDetails extends Component {
 			'kliken-marketing-for-google',
 		];
 
-		this.simpleInstall = true;
+		this.bundleInstall = false;
 		this.onContinue = this.onContinue.bind( this );
 		this.validate = this.validate.bind( this );
 		this.getNumberRangeString = this.getNumberRangeString.bind( this );
@@ -112,11 +112,21 @@ class BusinessDetails extends Component {
 			revenue,
 			used_platform: otherPlatform,
 			used_platform_name: otherPlatformName,
-			install_facebook: values[ 'facebook-for-woocommerce' ],
-			install_mailchimp: values[ 'mailchimp-for-woocommerce' ],
-			install_google_ads: values[ 'kliken-marketing-for-google' ],
+			install_woocommerce_services: businessExtensions.includes(
+				'facebook-for-woocommerce'
+			),
+			install_jetpack: businessExtensions.includes( 'jetpack' ),
+			install_facebook: businessExtensions.includes(
+				'facebook-for-woocommerce'
+			),
+			install_mailchimp: businessExtensions.includes(
+				'mailchimp-for-woocommerce'
+			),
+			install_google_ads: businessExtensions.includes(
+				'kliken-marketing-for-google'
+			),
 			install_extensions: installExtensions,
-			simple_install: this.simpleInstall,
+			bundle_install: this.bundleInstall,
 		} );
 
 		const _updates = {
@@ -213,7 +223,7 @@ class BusinessDetails extends Component {
 					);
 				}
 			} else if (
-				! this.simpleInstall &&
+				! this.bundleInstall &&
 				! this.extensions.includes( name ) &&
 				! values[ name ].length
 			) {
@@ -228,7 +238,7 @@ class BusinessDetails extends Component {
 	}
 
 	getBusinessExtensions( values ) {
-		if ( this.simpleInstall ) {
+		if ( this.bundleInstall ) {
 			return values.install_extensions
 				? [
 						'jetpack',
@@ -415,7 +425,7 @@ class BusinessDetails extends Component {
 		);
 	}
 
-	renderBusinessExtensionsSimple( values, getInputProps ) {
+	renderBusinessExtensionsBundle( values, getInputProps ) {
 		const { isPopoverVisible } = this.state;
 
 		return (
@@ -710,7 +720,7 @@ class BusinessDetails extends Component {
 				{ ( { getInputProps, handleSubmit, values, isValidForm } ) => {
 					// Show extensions when the currently selling elsewhere checkbox has been answered.
 					const shouldShowExtensions =
-						values.selling_venues !== '' && ! this.simpleInstall;
+						values.selling_venues !== '' && ! this.bundleInstall;
 					return (
 						<Fragment>
 							<H className="woocommerce-profile-wizard__header-title">
@@ -806,10 +816,11 @@ class BusinessDetails extends Component {
 											getInputProps
 										) }
 
-									{ this.renderBusinessExtensionsSimple(
-										values,
-										getInputProps
-									) }
+									{ this.bundleInstall &&
+										this.renderBusinessExtensionsBundle(
+											values,
+											getInputProps
+										) }
 
 									<div className="woocommerce-profile-wizard__card-actions">
 										<Button

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -4,7 +4,7 @@
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { Button, FormToggle } from '@wordpress/components';
+import { Button, CheckboxControl, FormToggle } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { keys, get, pickBy } from 'lodash';
 
@@ -62,6 +62,7 @@ class BusinessDetails extends Component {
 			'kliken-marketing-for-google': businessExtensions
 				? businessExtensions.includes( 'kliken-marketing-for-google' )
 				: true,
+			install_extensions: true,
 		};
 
 		this.extensions = [
@@ -70,6 +71,7 @@ class BusinessDetails extends Component {
 			'kliken-marketing-for-google',
 		];
 
+		this.simpleInstall = true;
 		this.onContinue = this.onContinue.bind( this );
 		this.validate = this.validate.bind( this );
 		this.getNumberRangeString = this.getNumberRangeString.bind( this );
@@ -392,6 +394,26 @@ class BusinessDetails extends Component {
 		);
 	}
 
+	renderBusinessExtensionsSimple( values, getInputProps ) {
+		return (
+			<div className="woocommerce-profile-wizard__business-extensions-simple">
+				<label htmlFor="woocommerce-profile-wizard__business-extensions-checkbox">
+					<CheckboxControl
+						id="woocommerce-profile-wizard__business-extensions-checkbox"
+						{ ...getInputProps( 'install_extensions' ) }
+					/>
+					{ __(
+						'Install recommended free business features',
+						'woocommerce-admin'
+					) }
+					<span className="woocommerce-profile-wizard__help-text">
+						{ __( 'Requires an account', 'woocommerce-admin' ) }
+					</span>
+				</label>
+			</div>
+		);
+	}
+
 	render() {
 		const {
 			goToNextStep,
@@ -555,7 +577,8 @@ class BusinessDetails extends Component {
 			>
 				{ ( { getInputProps, handleSubmit, values, isValidForm } ) => {
 					// Show extensions when the currently selling elsewhere checkbox has been answered.
-					const showExtensions = values.selling_venues !== '';
+					const shouldShowExtensions =
+						values.selling_venues !== '' && ! this.simpleInstall;
 					return (
 						<Fragment>
 							<H className="woocommerce-profile-wizard__header-title">
@@ -645,11 +668,16 @@ class BusinessDetails extends Component {
 										</Fragment>
 									) }
 
-									{ showExtensions &&
+									{ shouldShowExtensions &&
 										this.renderBusinessExtensions(
 											values,
 											getInputProps
 										) }
+
+									{ this.renderBusinessExtensionsSimple(
+										values,
+										getInputProps
+									) }
 
 									<div className="woocommerce-profile-wizard__card-actions">
 										<Button
@@ -682,7 +710,7 @@ class BusinessDetails extends Component {
 								</Fragment>
 							</Card>
 
-							{ showExtensions &&
+							{ shouldShowExtensions &&
 								this.renderBusinessExtensionHelpText( values ) }
 						</Fragment>
 					);

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -321,7 +321,7 @@ class BusinessDetails extends Component {
 
 		if ( isInstallingActivating ) {
 			return (
-				<p>
+				<p className="woocommerce-business-extensions__help-text">
 					{ sprintf(
 						_n(
 							'Installing the following plugin: %s',
@@ -336,7 +336,7 @@ class BusinessDetails extends Component {
 		}
 
 		return (
-			<p>
+			<p className="woocommerce-business-extensions__help-text">
 				{ sprintf(
 					_n(
 						'The following plugin will be installed for free: %s',
@@ -430,7 +430,7 @@ class BusinessDetails extends Component {
 							'Install recommended free business features',
 							'woocommerce-admin'
 						) }
-						<span className="woocommerce-business-extensions__help-text">
+						<span className="woocommerce-business-extensions__label-subtext">
 							{ __( 'Requires an account', 'woocommerce-admin' ) }
 						</span>
 					</span>

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -86,6 +86,7 @@ class BusinessDetails extends Component {
 			updateProfileItems,
 		} = this.props;
 		const {
+			install_extensions: installExtensions,
 			other_platform: otherPlatform,
 			other_platform_name: otherPlatformName,
 			product_count: productCount,
@@ -105,6 +106,8 @@ class BusinessDetails extends Component {
 			install_facebook: values[ 'facebook-for-woocommerce' ],
 			install_mailchimp: values[ 'mailchimp-for-woocommerce' ],
 			install_google_ads: values[ 'kliken-marketing-for-google' ],
+			install_extensions: installExtensions,
+			simple_install: this.simpleInstall,
 		} );
 
 		const _updates = {
@@ -204,6 +207,7 @@ class BusinessDetails extends Component {
 					);
 				}
 			} else if (
+				! this.simpleInstall &&
 				! this.extensions.includes( name ) &&
 				! values[ name ].length
 			) {
@@ -218,6 +222,10 @@ class BusinessDetails extends Component {
 	}
 
 	getBusinessExtensions( values ) {
+		if ( this.simpleInstall ) {
+			return values.install_extensions ? this.extensions : [];
+		}
+
 		return keys( pickBy( values ) ).filter( ( name ) =>
 			this.extensions.includes( name )
 		);

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -4,7 +4,12 @@
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { Button, CheckboxControl, FormToggle } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+	FormToggle,
+	Popover,
+} from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { keys, get, pickBy } from 'lodash';
 
@@ -46,6 +51,11 @@ class BusinessDetails extends Component {
 			'business_extensions',
 			false
 		);
+
+		this.state = {
+			hasInstallActivateError: false,
+			isPopoverVisible: false,
+		};
 
 		this.initialValues = {
 			other_platform: profileItems.other_platform || '',
@@ -403,11 +413,13 @@ class BusinessDetails extends Component {
 	}
 
 	renderBusinessExtensionsSimple( values, getInputProps ) {
+		const { isPopoverVisible } = this.state;
+
 		return (
-			<div className="woocommerce-profile-wizard__business-extensions-simple">
-				<label htmlFor="woocommerce-profile-wizard__business-extensions-checkbox">
+			<div className="woocommerce-business-extensions">
+				<label htmlFor="woocommerce-business-extensions__checkbox">
 					<CheckboxControl
-						id="woocommerce-profile-wizard__business-extensions-checkbox"
+						id="woocommerce-business-extensions__checkbox"
 						{ ...getInputProps( 'install_extensions' ) }
 					/>
 					{ __(
@@ -417,6 +429,107 @@ class BusinessDetails extends Component {
 					<span className="woocommerce-profile-wizard__help-text">
 						{ __( 'Requires an account', 'woocommerce-admin' ) }
 					</span>
+
+					<Button
+						isTertiary
+						onMouseEnter={ () =>
+							this.setState( { isPopoverVisible: true } )
+						}
+						onMouseLeave={ () =>
+							this.setState( { isPopoverVisible: false } )
+						}
+						onFocus={ () =>
+							this.setState( { isPopoverVisible: true } )
+						}
+						onBlur={ () =>
+							this.setState( { isPopoverVisible: false } )
+						}
+					>
+						<i className="material-icons-outlined">info</i>
+						{ isPopoverVisible && (
+							<Popover focusOnMount={ false }>
+								<Fragment>
+									<div className="woocommerce-business-extensions__benefits">
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Manage your store on the go with the WooCommerce mobile app',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Accept credit cards with WooCommerce Payments',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Speed & security enhancements',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Automatic sales taxes',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Market on Facebook',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Contact customers with Mailchimp',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Drive sales with Google Ads',
+												'woocommerce-admin'
+											) }
+										</div>
+										<div className="woocommerce-business-extensions__benefit">
+											<i className="material-icons-outlined">
+												check
+											</i>
+											{ __(
+												'Print shipping labels at home',
+												'woocommerce-admin'
+											) }
+										</div>
+									</div>
+									{ this.renderBusinessExtensionHelpText(
+										values
+									) }
+								</Fragment>
+							</Popover>
+						) }
+					</Button>
 				</label>
 			</div>
 		);

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -468,7 +468,7 @@
 		margin-right: $gap;
 	}
 
-	.woocommerce-business-extensions__help-text {
+	.woocommerce-business-extensions__label-subtext {
 		display: block;
 		color: $core-grey-dark-150;
 		font-size: 14px;
@@ -489,6 +489,9 @@
 		padding: 4px;
 		display: grid;
 		grid-template-columns: 1fr 1fr;
+		width: 600px;
+		max-width: 100%;
+		font-size: 14px;
 
 		.woocommerce-business-extensions__benefit {
 			padding: 10px;
@@ -501,22 +504,12 @@
 			}
 		}
 	}
-}
 
-.woocommerce-business-extensions__popover {
-	width: 600px;
-	max-width: 100%;
-	font-size: 14px;
-
-	.components-popover__content {
-		width: 100%;
-
-		p {
-			border-top: 1px solid $light-gray-tertiary;
-			margin: 0;
-			padding: $gap $gap-large;
-			font-size: 12px;
-			color: $core-grey-dark-150;
-		}
+	p.woocommerce-business-extensions__help-text {
+		border-top: 1px solid $light-gray-tertiary;
+		margin: 0;
+		padding: $gap $gap-large;
+		font-size: 12px;
+		color: $core-grey-dark-150;
 	}
 }

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -94,7 +94,8 @@
 		}
 
 		.woocommerce-card ~ p {
-			font-size: 14px;
+			font-size: 12px;
+			color: $core-grey-dark-150;
 		}
 	}
 
@@ -503,13 +504,5 @@
 				margin-right: $gap;
 			}
 		}
-	}
-
-	p.woocommerce-business-extensions__help-text {
-		border-top: 1px solid $light-gray-tertiary;
-		margin: 0;
-		padding: $gap $gap-large;
-		font-size: 12px;
-		color: $core-grey-dark-150;
 	}
 }

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -479,13 +479,6 @@
 		margin-left: auto;
 	}
 
-	.components-button.is-tertiary {
-		&:hover,
-		&:focus {
-			box-shadow: none;
-		}
-	}
-
 	.woocommerce-business-extensions__benefits {
 		padding: 4px;
 		display: grid;

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -448,3 +448,75 @@
 		}
 	}
 }
+
+.woocommerce-business-extensions {
+	margin-left: -$gap;
+	margin-right: -$gap;
+	padding: $gap-large $gap;
+	border-top: 1px solid $light-gray-tertiary;
+	border-bottom: 1px solid $light-gray-tertiary;
+	display: flex;
+	align-items: center;
+
+	label {
+		display: flex;
+		color: $dark-gray-primary;
+		align-items: center;
+	}
+
+	.components-checkbox-control__input-container {
+		margin-right: $gap;
+	}
+
+	.woocommerce-business-extensions__help-text {
+		display: block;
+		color: $core-grey-dark-150;
+		font-size: 14px;
+	}
+
+	.woocommerce-business-extensions__popover-wrapper {
+		margin-left: auto;
+	}
+
+	.components-button.is-tertiary {
+		&:hover,
+		&:focus {
+			box-shadow: none;
+		}
+	}
+
+	.woocommerce-business-extensions__benefits {
+		padding: 4px;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+
+		.woocommerce-business-extensions__benefit {
+			padding: 10px;
+			font-size: 14px;
+			display: inline-flex;
+
+			i {
+				color: $blue-medium-focus;
+				margin-right: $gap;
+			}
+		}
+	}
+}
+
+.woocommerce-business-extensions__popover {
+	width: 600px;
+	max-width: 100%;
+	font-size: 14px;
+
+	.components-popover__content {
+		width: 100%;
+
+		p {
+			border-top: 1px solid $light-gray-tertiary;
+			margin: 0;
+			padding: $gap $gap-large;
+			font-size: 12px;
+			color: $core-grey-dark-150;
+		}
+	}
+}

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -15,6 +15,7 @@ $core-grey-light-700: #ccd0d4;
 $core-grey-light-800: #b5bcc2;
 $core-grey-light-900: #a2aab2;
 $core-grey-dark-100: #86909b;
+$core-grey-dark-150: #8d96a0;
 $core-grey-dark-200: #78848f;
 $core-grey-dark-300: #6c7781; // This & below have 4.5+ contrast against white
 $core-grey-dark-400: #606a73;

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -336,6 +336,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'enum' => array(
 						'jetpack',
 						'woocommerce-services',
+						'woocommerce-payments',
 						'mailchimp-for-woocommerce',
 						'facebook-for-woocommerce',
 						'kliken-marketing-for-google',

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -334,6 +334,8 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
 					'enum' => array(
+						'jetpack',
+						'woocommerce-services',
 						'mailchimp-for-woocommerce',
 						'facebook-for-woocommerce',
 						'kliken-marketing-for-google',


### PR DESCRIPTION
Fixes (partially) #4579 

* Adds the alternative for install UI.
* Installs all business extension plugins (including Jetpack and WCS) on opt in.
* Saves newly added data to tracks and onboarding profile.

Note that this new UI is behind a flag until we have the desired segment determined and a follow-up to address benefits and Jetpack connection flow is in place.

@pmcpinto I just noticed your updates in #4579 around events.  I think this PR covers most of those, but instead of splitting into multiple events, the same `storeprofiler_store_business_details_continue` now includes all plugins as well as a `bundle_install` property to determine if they used the new bundle UI and `install_extensions` to determine if they opted in or out.  It does not yet cover:

* Changes to `wcadmin_storeprofiler_step_view` to add properties around this view.  We'll have to give more thought into how we can hook into that event from this child component.
* Clicking the popover.  I noticed some discussion of events firing when the popover is clicked, but also noticed that it should only show on hovering the icon/button (as it does in this PR).  Could you clarify which events are supposed to happen.

Aside from those two, if you feel any of the other events aren't enough, let me know and we can adjust accordingly.

### Screenshots
<img width="879" alt="Screen Shot 2020-06-25 at 2 14 12 PM" src="https://user-images.githubusercontent.com/10561050/85712400-f8280500-b6f0-11ea-8b4a-a60ebdcb71a1.png">

### Detailed test instructions:

1. Go to the Business Details step of the profiler and make sure the old flow works as expected.
1. In `client/profile-wizard/steps/business-details.js` update line 83 to `this.bundleInstall = true;`.
1. Try toggling the install checkbox on/off.
1. Make sure all 5 plugins are installed and activated when toggled on.
1. Make sure recorded events match expectations.
1. Make sure profile data is updated with all installed extensions.