### PR TITLE
Don't show the inbox panel on the new home screen.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -4,8 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
+import { withRouter } from 'react-router';
 import { Component, lazy, Suspense } from '@wordpress/element';
 import { Button, NavigableMenu } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { partial, uniqueId, find } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import PagesIcon from 'gridicons/dist/pages';
@@ -112,14 +114,21 @@ class ActivityPanel extends Component {
 			hasUnreadOrders,
 			hasUnapprovedReviews,
 			hasUnreadStock,
+			location,
 		} = this.props;
+
+		// Don't show the inbox on the Home screen.
+		const showInbox = ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
+
 		return [
-			{
-				name: 'inbox',
-				title: __( 'Inbox', 'woocommerce-admin' ),
-				icon: <i className="material-icons-outlined">inbox</i>,
-				unread: hasUnreadNotes,
-			},
+			showInbox
+				? {
+					name: 'inbox',
+					title: __( 'Inbox', 'woocommerce-admin' ),
+					icon: <i className="material-icons-outlined">inbox</i>,
+					unread: hasUnreadNotes,
+				}
+				: null,
 			{
 				name: 'orders',
 				title: __( 'Orders', 'woocommerce-admin' ),
@@ -315,16 +324,20 @@ class ActivityPanel extends Component {
 	}
 }
 
-export default withSelect( ( select ) => {
-	const hasUnreadNotes = getUnreadNotes( select );
-	const hasUnreadOrders = getUnreadOrders( select );
-	const hasUnreadStock = getUnreadStock();
-	const hasUnapprovedReviews = getUnapprovedReviews( select );
-
-	return {
-		hasUnreadNotes,
-		hasUnreadOrders,
-		hasUnreadStock,
-		hasUnapprovedReviews,
-	};
-} )( clickOutside( ActivityPanel ) );
+export default compose(
+	withSelect( ( select ) => {
+		const hasUnreadNotes = getUnreadNotes( select );
+		const hasUnreadOrders = getUnreadOrders( select );
+		const hasUnreadStock = getUnreadStock();
+		const hasUnapprovedReviews = getUnapprovedReviews( select );
+	
+		return {
+			hasUnreadNotes,
+			hasUnreadOrders,
+			hasUnreadStock,
+			hasUnapprovedReviews,
+		};
+	} ),
+	withRouter,
+	clickOutside
+)( ActivityPanel );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
-import { withRouter } from 'react-router';
 import { Component, lazy, Suspense } from '@wordpress/element';
 import { Button, NavigableMenu } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
@@ -19,6 +18,7 @@ import CrossIcon from 'gridicons/dist/cross-small';
 import './style.scss';
 import ActivityPanelToggleBubble from './toggle-bubble';
 import { H, Section, Spinner } from '@woocommerce/components';
+import { getHistory } from '@woocommerce/navigation';
 import {
 	getUnreadNotes,
 	getUnreadOrders,
@@ -114,11 +114,12 @@ class ActivityPanel extends Component {
 			hasUnreadOrders,
 			hasUnapprovedReviews,
 			hasUnreadStock,
-			location,
+			isEmbedded,
 		} = this.props;
 
 		// Don't show the inbox on the Home screen.
-		const showInbox = ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
+		const { location } = getHistory();
+		const showInbox = isEmbedded || ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
 
 		return [
 			showInbox
@@ -338,6 +339,5 @@ export default compose(
 			hasUnapprovedReviews,
 		};
 	} ),
-	withRouter,
 	clickOutside
 )( ActivityPanel );

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -136,7 +136,7 @@ class Header extends Component {
 					} ) }
 				</h1>
 				{ window.wcAdminFeatures[ 'activity-panels' ] && (
-					<ActivityPanel />
+					<ActivityPanel isEmbedded={ isEmbedded } />
 				) }
 			</div>
 		);


### PR DESCRIPTION
This PR seeks to address an issue highlighted in the demo of the new home screen.

If the homescreen feature is enabled, and we're on the homescreen, don't show the (redundant) Inbox Panel.

### Screenshots

![Screen Shot 2020-06-25 at 1 30 52 PM](https://user-images.githubusercontent.com/63922/85770097-906dbc00-b6e8-11ea-8759-8ec319d56213.png)

![Screen Shot 2020-06-25 at 1 31 23 PM](https://user-images.githubusercontent.com/63922/85770167-a0859b80-b6e8-11ea-8d5f-419cdc1bc20d.png)

### Detailed test instructions:

- Ensure your build has the new homescreen enabled
- Go to the homescreen
- Verify there is no Inbox tab
- Go to any other WooCommerce page
- Verify the Inbox tab is shown

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased change.