### PR TITLE
Added filters for `DataStore` columns

### DIFF
--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -72,12 +72,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'items_sold'     => 'SUM(product_qty) as items_sold',
 			'net_revenue'    => 'SUM(product_net_revenue) AS net_revenue',
 			'orders_count'   => "COUNT(DISTINCT {$table_name}.order_id) as orders_count",
 			'products_count' => "COUNT(DISTINCT {$table_name}.product_id) as products_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -57,11 +57,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'coupon_id'    => 'coupon_id',
 			'amount'       => 'SUM(discount_amount) as amount',
 			'orders_count' => "COUNT(DISTINCT {$table_name}.order_id) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Coupons/Stats/DataStore.php
+++ b/src/API/Reports/Coupons/Stats/DataStore.php
@@ -58,11 +58,11 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'amount'        => 'SUM(discount_amount) as amount',
 			'coupons_count' => 'COUNT(DISTINCT coupon_id) as coupons_count',
 			'orders_count'  => "COUNT(DISTINCT {$table_name}.order_id) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -62,7 +62,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$table_name           = self::get_db_table_name();
 		$orders_count         = 'SUM( CASE WHEN parent_id = 0 THEN 1 ELSE 0 END )';
 		$total_spend          = 'SUM( total_sales )';
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'id'               => "{$table_name}.customer_id as id",
 			'user_id'          => 'user_id',
 			'username'         => 'username',
@@ -78,7 +78,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'orders_count'     => "{$orders_count} as orders_count",
 			'total_spend'      => "{$total_spend} as total_spend",
 			'avg_order_value'  => "CASE WHEN {$orders_count} = 0 THEN NULL ELSE {$total_spend} / {$orders_count} END AS avg_order_value",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Customers/Stats/DataStore.php
+++ b/src/API/Reports/Customers/Stats/DataStore.php
@@ -46,12 +46,12 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'customers_count'     => 'COUNT( * ) as customers_count',
 			'avg_orders_count'    => 'AVG( orders_count ) as avg_orders_count',
 			'avg_total_spend'     => 'AVG( total_spend ) as avg_total_spend',
 			'avg_avg_order_value' => 'AVG( avg_order_value ) as avg_avg_order_value',
-		);
+		), self::get_db_table_name(), $this);
 	}
 
 	/**

--- a/src/API/Reports/Downloads/DataStore.php
+++ b/src/API/Reports/Downloads/DataStore.php
@@ -61,7 +61,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'id'          => 'download_log_id as id',
 			'date'        => 'timestamp as date_gmt',
 			'download_id' => 'product_permissions.download_id',
@@ -69,7 +69,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'order_id'    => 'product_permissions.order_id',
 			'user_id'     => 'product_permissions.user_id',
 			'ip_address'  => 'user_ip_address as ip_address',
-		);
+		), self::get_db_table_name(), $this);
 	}
 
 	/**

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -46,9 +46,9 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'download_count' => 'COUNT(DISTINCT download_log_id) as download_count',
-		);
+		), self::get_db_table_name(), $this);
 	}
 
 	/**

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -64,7 +64,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	protected function assign_report_columns() {
 		$table_name = self::get_db_table_name();
 		// Avoid ambigious columns in SQL query.
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'order_id'         => "{$table_name}.order_id",
 			'parent_id'        => "{$table_name}.parent_id",
 			'date_created'     => "{$table_name}.date_created",
@@ -75,7 +75,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'total_sales'      => "{$table_name}.total_sales",
 			'num_items_sold'   => "{$table_name}.num_items_sold",
 			'customer_type'    => "(CASE WHEN {$table_name}.returning_customer = 1 THEN 'returning' WHEN {$table_name}.returning_customer = 0 THEN 'new' ELSE '' END) as customer_type",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -85,7 +85,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			" + {$refunds}" .
 			' ) as gross_sales';
 
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'orders_count'            => "SUM( CASE WHEN {$table_name}.parent_id = 0 THEN 1 ELSE 0 END ) as orders_count",
 			'num_items_sold'          => "SUM({$table_name}.num_items_sold) as num_items_sold",
 			'gross_sales'             => $gross_sales,
@@ -101,7 +101,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			// Count returning customers as ( total_customers - new_customers ) to get an accurate number and count customers in with both new and old statuses as new.
 			'num_returning_customers' => "( COUNT( DISTINCT( {$table_name}.customer_id ) ) -  COUNT( DISTINCT( CASE WHEN {$table_name}.returning_customer = 0 THEN {$table_name}.customer_id END ) ) ) AS num_returning_customers",
 			'num_new_customers'       => "COUNT( DISTINCT( CASE WHEN {$table_name}.returning_customer = 0 THEN {$table_name}.customer_id END ) ) AS num_new_customers",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -90,12 +90,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'product_id'   => 'product_id',
 			'items_sold'   => 'SUM(product_qty) as items_sold',
 			'net_revenue'  => 'SUM(product_net_revenue) AS net_revenue',
 			'orders_count' => "COUNT( DISTINCT ( CASE WHEN product_gross_revenue >= 0 THEN {$table_name}.order_id END ) ) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -47,13 +47,13 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'items_sold'       => 'SUM(product_qty) as items_sold',
 			'net_revenue'      => 'SUM(product_net_revenue) AS net_revenue',
 			'orders_count'     => "COUNT( DISTINCT ( CASE WHEN product_gross_revenue >= 0 THEN {$table_name}.order_id END ) ) as orders_count",
 			'products_count'   => 'COUNT(DISTINCT product_id) as products_count',
 			'variations_count' => 'COUNT(DISTINCT variation_id) as variations_count',
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -64,7 +64,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'tax_rate_id'  => "{$table_name}.tax_rate_id",
 			'name'         => 'tax_rate_name as name',
 			'tax_rate'     => 'tax_rate',
@@ -75,7 +75,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'order_tax'    => 'SUM(order_tax) as order_tax',
 			'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
 			'orders_count' => "COUNT( DISTINCT ( CASE WHEN total_tax >= 0 THEN {$table_name}.order_id END ) ) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -58,13 +58,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'tax_codes'    => 'COUNT(DISTINCT tax_rate_id) as tax_codes',
 			'total_tax'    => 'SUM(total_tax) AS total_tax',
 			'order_tax'    => 'SUM(order_tax) as order_tax',
 			'shipping_tax' => 'SUM(shipping_tax) as shipping_tax',
 			'orders_count' => "COUNT( DISTINCT ( CASE WHEN parent_id = 0 THEN {$table_name}.order_id END ) ) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**
@@ -104,12 +104,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function get_taxes( $args ) {
 		global $wpdb;
 		$query = "
-			SELECT 
-				tax_rate_id, 
-				tax_rate_country, 
-				tax_rate_state, 
-				tax_rate_name, 
-				tax_rate_priority 
+			SELECT
+				tax_rate_id,
+				tax_rate_country,
+				tax_rate_state,
+				tax_rate_name,
+				tax_rate_priority
 			FROM {$wpdb->prefix}woocommerce_tax_rates
 		";
 		if ( ! empty( $args['include'] ) ) {

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -81,13 +81,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		$table_name           = self::get_db_table_name();
-		$this->report_columns = array(
+		$this->report_columns =  apply_filters('wc_analytics_' . $this->context . '_report_columns', array(
 			'product_id'   => 'product_id',
 			'variation_id' => 'variation_id',
 			'items_sold'   => 'SUM(product_qty) as items_sold',
 			'net_revenue'  => 'SUM(product_net_revenue) AS net_revenue',
 			'orders_count' => "COUNT(DISTINCT {$table_name}.order_id) as orders_count",
-		);
+		), $table_name, $this);
 	}
 
 	/**


### PR DESCRIPTION
Fixes
* Implements the changes suggested at https://github.com/woocommerce/woocommerce-admin/issues/4147

### Changelog Note:

Tweak - Added filter `wc_analytics_<CONTEXT>_report_columns`, to allow 3rd parties to alter the columns of a report.