### PR TITLE
Toggle the “Physical products” checkbox on by default

### DIFF
--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -26,9 +26,13 @@ class ProductTypes extends Component {
 		super();
 		const profileItems = get( props, 'profileItems', {} );
 
+		const { productTypes = {} } = getSetting( 'onboarding', {} );
+		const preselectedProductTypes = Object.keys( productTypes )
+			.filter( key => !! productTypes[ key ].preselect );
+
 		this.state = {
 			error: null,
-			selected: profileItems.product_types || [],
+			selected: profileItems.product_types || preselectedProductTypes,
 		};
 
 		this.onContinue = this.onContinue.bind( this );
@@ -106,6 +110,7 @@ class ProductTypes extends Component {
 	render() {
 		const { productTypes = {} } = getSetting( 'onboarding', {} );
 		const { error, selected } = this.state;
+
 		return (
 			<Fragment>
 				<H className="woocommerce-profile-wizard__header-title">

--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -27,12 +27,12 @@ class ProductTypes extends Component {
 		const profileItems = get( props, 'profileItems', {} );
 
 		const { productTypes = {} } = getSetting( 'onboarding', {} );
-		const preselectedProductTypes = Object.keys( productTypes )
-			.filter( key => !! productTypes[ key ].preselect );
+		const defaultProductTypes = Object.keys( productTypes )
+			.filter( key => !! productTypes[ key ].default );
 
 		this.state = {
 			error: null,
-			selected: profileItems.product_types || preselectedProductTypes,
+			selected: profileItems.product_types || defaultProductTypes,
 		};
 
 		this.onContinue = this.onContinue.bind( this );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -340,7 +340,7 @@ class Onboarding {
 				'physical'      => array(
 					'label'       => __( 'Physical products', 'woocommerce-admin' ),
 					'description' => __( 'Products you ship to customers.', 'woocommerce-admin' ),
-					'preselect'   => true,
+					'default'     => true,
 				),
 				'downloads'     => array(
 					'label'       => __( 'Downloads', 'woocommerce-admin' ),

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -340,6 +340,7 @@ class Onboarding {
 				'physical'      => array(
 					'label'       => __( 'Physical products', 'woocommerce-admin' ),
 					'description' => __( 'Products you ship to customers.', 'woocommerce-admin' ),
+					'preselect'   => true,
 				),
 				'downloads'     => array(
 					'label'       => __( 'Downloads', 'woocommerce-admin' ),


### PR DESCRIPTION
Partially addresses #4577

This toggles the "Physical products" product type to be selected by default in the OBW.

### Detailed test instructions:

1. Reset the OBW by deleting this option: `woocommerce_onboarding_profile`
2. Start the OBW
3. Carry through to the product selection step
4. Note that the "Physical products" product type should be preselected
5. Select some different product types and carry through the rest of the OBW
6. Restart the OBW
7. Carry through to the product selection step
8. Note that the product types you selected in step 5 should be selected
