### PR TITLE
Include Product Bundles and Product Add-ons as OBW product options

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -337,29 +337,37 @@ class Onboarding {
 	public static function get_allowed_product_types() {
 		$product_types = self::append_product_data(
 			array(
-				'physical'      => array(
+				'physical'        => array(
 					'label'       => __( 'Physical products', 'woocommerce-admin' ),
 					'description' => __( 'Products you ship to customers.', 'woocommerce-admin' ),
 				),
-				'downloads'     => array(
+				'downloads'       => array(
 					'label'       => __( 'Downloads', 'woocommerce-admin' ),
 					'description' => __( 'Virtual products that customers download.', 'woocommerce-admin' ),
 				),
-				'subscriptions' => array(
+				'subscriptions'   => array(
 					'label'   => __( 'Subscriptions', 'woocommerce-admin' ),
 					'product' => 27147,
 				),
-				'memberships'   => array(
+				'memberships'     => array(
 					'label'   => __( 'Memberships', 'woocommerce-admin' ),
 					'product' => 958589,
 				),
-				'composite'     => array(
+				'composite'       => array(
 					'label'   => __( 'Composite Products', 'woocommerce-admin' ),
 					'product' => 216836,
 				),
-				'bookings'      => array(
+				'bookings'        => array(
 					'label'   => __( 'Bookings', 'woocommerce-admin' ),
 					'product' => 390890,
+				),
+				'product-bundles' => array(
+					'label'   => __( 'Bundles', 'woocommerce-admin' ),
+					'product' => 18716,
+				),
+				'product-add-ons' => array(
+					'label'   => __( 'Customizable products', 'woocommerce-admin' ),
+					'product' => 18618,
 				),
 			)
 		);
@@ -512,7 +520,7 @@ class Onboarding {
 	public static function append_product_data( $product_types ) {
 		$woocommerce_products = get_transient( self::PRODUCT_DATA_TRANSIENT );
 		if ( false === $woocommerce_products ) {
-			$woocommerce_products = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type' );
+			$woocommerce_products = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search' );
 			if ( is_wp_error( $woocommerce_products ) ) {
 				return $product_types;
 			}


### PR DESCRIPTION
Partially addresses #4577

This adds Product Bundles and Product Add-ons as options on the OBW product selection step.

Note that to get the add-ons data, the product data query needed the category parameter to be removed as the required data wasn't being passed down from https://woocommerce.com/wp-json/wccom-extensions/1.0/search?category=product-type.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/85815767-a775e200-b7ac-11ea-80c6-dbcf672ce315.png)

### Detailed test instructions:

1. `delete from wp_options where option_name = 'woocommerce_onboarding_profile'` to reset the OBW
2. `delete from wp_options where option_name = '_transient_wc_onboarding_product_data'` to clear the product data transient and force the data to be reloaded from the woocommerce.com API
3. start the OBW and step through to the product step
4. note that the "Product bundle" and "Customizable products" (Product Add-ons) products are available
5. select the new products
6. finish off the OBW
7. the "Purchase & install extensions" step should be available in the "Finish setup" section
8. click "Purchase & install extensions". Both of the new products should be in the cart.
