### PR TITLE
Preventing refresh after answering a survey note

### DIFF
--- a/client/header/activity-panel/panels/inbox/action.js
+++ b/client/header/activity-panel/panels/inbox/action.js
@@ -64,13 +64,20 @@ class InboxNoteAction extends Component {
 		const { action, dismiss, label } = this.props;
 		const isPrimary = dismiss || action.primary;
 
+		let actionHref;
+		if ( action ) {
+			if ( action.url ) {
+				actionHref = action.url;
+			}
+		}
+
 		return (
 			<Button
 				isPrimary={ isPrimary }
 				isSecondary={ ! isPrimary }
 				isBusy={ this.state.inAction }
 				disabled={ this.state.inAction }
-				href={ action ? action.url : undefined }
+				href={ actionHref }
 				onClick={ this.handleActionClick }
 			>
 				{ dismiss ? label : action.label }

--- a/client/header/activity-panel/panels/inbox/action.js
+++ b/client/header/activity-panel/panels/inbox/action.js
@@ -64,20 +64,17 @@ class InboxNoteAction extends Component {
 		const { action, dismiss, label } = this.props;
 		const isPrimary = dismiss || action.primary;
 
-		let actionHref;
-		if ( action ) {
-			if ( action.url ) {
-				actionHref = action.url;
-			}
-		}
-
 		return (
 			<Button
 				isPrimary={ isPrimary }
 				isSecondary={ ! isPrimary }
 				isBusy={ this.state.inAction }
 				disabled={ this.state.inAction }
-				href={ actionHref }
+				href={
+					action && action.url && action.url.length
+						? action.url
+						: undefined
+				}
 				onClick={ this.handleActionClick }
 			>
 				{ dismiss ? label : action.label }


### PR DESCRIPTION
Following up with [PR 4686](https://github.com/woocommerce/woocommerce-admin/pull/4686)

This PR adds the code necessary to prevent a webpage refresh after answering a survey note.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-06-26 at 15-26-20](https://user-images.githubusercontent.com/1314156/85889301-96839b80-b7c1-11ea-9c83-cfaf36c8d2f1.gif)


### Detailed test instructions:

- Be sure you have the note `wc-admin-insight-first-sale` (WC_Admin_Notes_Insight_First_Sale.php) available and that it is type: `survey`.

If you already have it but with type `info` or with status `actioned` or with is_deleted `1` you should execute this SQL sentence:
````
UPDATE `wp_wc_admin_notes` SET `type` = 'survey', `status` = 'unactioned', `is_deleted` = 0 WHERE `wp_wc_admin_notes`.`name` = 'wc-admin-insight-first-sale'; 
````

- Go to the `Home` screen or open the `Inbox panel` pressing `Inbox` in the header.
- Answer the survey (`yes` or `no`, it's the same).
- The note should change its status to `active`, and the message `Thanks for your feedback` should replace the options `yes` and `no`.
- The webpage shouldn't reload.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Preventing refresh after answering a survey note
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
