### PR TITLE
Variation Names: Allow long names to be shown

### DIFF
--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -131,9 +131,12 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 
 		if ( false === $data ) {
 			// Ensure full variation titles are queried.
-			add_filter( 'woocommerce_product_variation_title_include_attributes', function() {
-				return true;
-			} );
+			add_filter(
+				'woocommerce_product_variation_title_include_attributes',
+				function() {
+					return true;
+				}
+			);
 
 			$this->initialize_queries();
 

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -130,6 +130,11 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
+			// Ensure full variation titles are queried.
+			add_filter( 'woocommerce_product_variation_title_include_attributes', function() {
+				return true;
+			} );
+
 			$this->initialize_queries();
 
 			$selections = $this->selected_columns( $query_args );

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -175,9 +175,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function include_extended_info( &$products_data, $query_args ) {
 		// Ensure full variation titles are queried.
-		add_filter( 'woocommerce_product_variation_title_include_attributes', function() {
-			return true;
-		} );
+		add_filter(
+			'woocommerce_product_variation_title_include_attributes',
+			function() {
+				return true;
+			}
+		);
 
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new \ArrayObject();

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -174,6 +174,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array $query_args Query parameters.
 	 */
 	protected function include_extended_info( &$products_data, $query_args ) {
+		// Ensure full variation titles are queried.
+		add_filter( 'woocommerce_product_variation_title_include_attributes', function() {
+			return true;
+		} );
+
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new \ArrayObject();
 			if ( $query_args['extended_info'] ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4336
Depends on https://github.com/woocommerce/woocommerce-admin/pull/4704

Variation names not were shown when attributes are more than one word. This PR uses the `woocommerce_product_variation_title_include_attributes` filter to make sure long names are shown.

### Before

![Screen Shot 2020-05-11 at 2 41 16 PM](https://user-images.githubusercontent.com/1922453/81526812-d1b24280-93ac-11ea-8ef2-4153b120b7f3.png)

### After

![Screen Shot 2020-06-29 at 11 17 22 AM](https://user-images.githubusercontent.com/1922453/85960770-3592d800-b9fa-11ea-8dcf-53980cb68bfc.png)

### Detailed test instructions:

**To Reproduce**

1. Create a variable product or use an existing one.
2. Change one attribute t be more than one word.
3. Create an order.
3. Be sure to clear cache if you've recently visited this report `wp transient delete woocommerce_reports-transient-version`
4. Visit the Product Report > Single Product and search for the variable product.
4. See the Product Report's variation names shown in full.

### Changelog Note:

tweak - Force full variation names to be shown on reports.
