### PR TITLE
Update connection flow for Bundle UI

### DIFF
--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -5,24 +5,26 @@ import { __ } from '@wordpress/i18n';
 import { Component, createElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { identity, pick } from 'lodash';
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, __experimentalResolveSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
-import { updateQueryString } from '@woocommerce/navigation';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
 	ONBOARDING_STORE_NAME,
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
 	withPluginsHydration,
 } from '@woocommerce/data';
+import { updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import Benefits from './steps/benefits';
 import BusinessDetails from './steps/business-details';
+import { createNoticesFromResponse } from 'lib/notices';
 import Industry from './steps/industry';
 import ProductTypes from './steps/product-types';
 import ProfileWizardHeader from './header';
@@ -36,10 +38,6 @@ import './style.scss';
 class ProfileWizard extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = {
-			cartRedirectUrl: null,
-		};
-
 		this.activePlugins = props.activePlugins;
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
@@ -103,13 +101,6 @@ class ProfileWizard extends Component {
 	}
 
 	componentWillUnmount() {
-		const { cartRedirectUrl } = this.state;
-
-		if ( cartRedirectUrl ) {
-			document.body.classList.add( 'woocommerce-admin-is-loading' );
-			window.location = cartRedirectUrl;
-		}
-
 		document.documentElement.classList.add( 'wp-toolbar' );
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
@@ -211,8 +202,12 @@ class ProfileWizard extends Component {
 	}
 
 	completeProfiler() {
-		const { notes, updateNote, updateProfileItems } = this.props;
-		updateProfileItems( { completed: true } );
+		const {
+			isJetpackConnected,
+			notes,
+			updateNote,
+			updateProfileItems,
+		} = this.props;
 		recordEvent( 'storeprofiler_complete' );
 
 		const profilerNote = notes.find(
@@ -221,6 +216,37 @@ class ProfileWizard extends Component {
 		if ( profilerNote ) {
 			updateNote( profilerNote.id, { status: 'actioned' } );
 		}
+
+		updateProfileItems( { completed: true } ).then( () => {
+			if (
+				this.activePlugins.includes( 'jetpack' ) &&
+				! isJetpackConnected
+			) {
+				this.connectJetpack();
+			}
+		} );
+	}
+
+	connectJetpack() {
+		const { getJetpackConnectUrl, getPluginsError } = this.props;
+
+		document.body.classList.add( 'woocommerce-admin-is-loading' );
+
+		getJetpackConnectUrl( {
+			redirect_url: getAdminLink(
+				'admin.php?page=wc-admin&reset_profiler=0'
+			),
+		} ).then( ( url ) => {
+			const error = getPluginsError( 'getJetpackConnectUrl' );
+			if ( error ) {
+				createNoticesFromResponse( error );
+				document.body.classList.remove(
+					'woocommerce-admin-is-loading'
+				);
+				return;
+			}
+			window.location = url;
+		} );
 	}
 
 	render() {
@@ -254,7 +280,9 @@ export default compose(
 		const { getProfileItems, getOnboardingError } = select(
 			ONBOARDING_STORE_NAME
 		);
-		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins, getPluginsError } = select(
+			PLUGINS_STORE_NAME
+		);
 
 		const notesQuery = {
 			page: 1,
@@ -269,6 +297,10 @@ export default compose(
 
 		return {
 			dismissedTasks,
+			getJetpackConnectUrl: __experimentalResolveSelect(
+				PLUGINS_STORE_NAME
+			).getJetpackConnectUrl,
+			getPluginsError,
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),
 			notes,
 			profileItems: getProfileItems(),

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -38,7 +38,7 @@ import './style.scss';
 class ProfileWizard extends Component {
 	constructor( props ) {
 		super( props );
-		this.activePlugins = props.activePlugins;
+		this.cachedActivePlugins = props.activePlugins;
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
 
@@ -73,7 +73,7 @@ class ProfileWizard extends Component {
 	}
 
 	componentDidMount() {
-		const { profileItems, updateProfileItems } = this.props;
+		const { activePlugins, profileItems, updateProfileItems } = this.props;
 
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );
 		document.documentElement.classList.remove( 'wp-toolbar' );
@@ -87,8 +87,8 @@ class ProfileWizard extends Component {
 
 		// Track plugins if already installed.
 		if (
-			this.activePlugins.includes( 'woocommerce-services' ) &&
-			this.activePlugins.includes( 'jetpack' ) &&
+			activePlugins.includes( 'woocommerce-services' ) &&
+			activePlugins.includes( 'jetpack' ) &&
 			profileItems.plugins !== 'already-installed'
 		) {
 			recordEvent(
@@ -108,7 +108,8 @@ class ProfileWizard extends Component {
 	}
 
 	getSteps() {
-		const { profileItems } = this.props;
+		const { profileItems, query } = this.props;
+		const { step } = query;
 		const steps = [];
 
 		steps.push( {
@@ -153,8 +154,9 @@ class ProfileWizard extends Component {
 		} );
 
 		if (
-			! this.activePlugins.includes( 'woocommerce-services' ) ||
-			! this.activePlugins.includes( 'jetpack' )
+			! this.cachedActivePlugins.includes( 'woocommerce-services' ) ||
+			! this.cachedActivePlugins.includes( 'jetpack' ) ||
+			step === 'benefits'
 		) {
 			steps.push( {
 				key: 'benefits',
@@ -176,7 +178,7 @@ class ProfileWizard extends Component {
 	}
 
 	async goToNextStep() {
-		const { dismissedTasks, updateOptions } = this.props;
+		const { activePlugins, dismissedTasks, updateOptions } = this.props;
 		const currentStep = this.getCurrentStep();
 		const currentStepIndex = this.getSteps().findIndex(
 			( s ) => s.key === currentStep.key
@@ -192,6 +194,10 @@ class ProfileWizard extends Component {
 			} );
 		}
 
+		// Update the activePlugins cache in case plugins were installed
+		// in the current step that affect the visibility of the next step.
+		this.cachedActivePlugins = activePlugins;
+
 		const nextStep = this.getSteps()[ currentStepIndex + 1 ];
 		if ( typeof nextStep === 'undefined' ) {
 			this.completeProfiler();
@@ -203,6 +209,7 @@ class ProfileWizard extends Component {
 
 	completeProfiler() {
 		const {
+			activePlugins,
 			getJetpackConnectUrl,
 			getPluginsError,
 			isJetpackConnected,
@@ -212,7 +219,7 @@ class ProfileWizard extends Component {
 		} = this.props;
 		recordEvent( 'storeprofiler_complete' );
 		const shouldConnectJetpack =
-			this.activePlugins.includes( 'jetpack' ) && ! isJetpackConnected;
+			activePlugins.includes( 'jetpack' ) && ! isJetpackConnected;
 
 		const profilerNote = notes.find(
 			( note ) => note.name === 'wc-admin-onboarding-profiler-reminder'

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -5,18 +5,13 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import {
-	withDispatch,
-	withSelect,
-	__experimentalResolveSelect,
-} from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { filter } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
 import { Card, H } from '@woocommerce/components';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
 	pluginNames,
 	ONBOARDING_STORE_NAME,
@@ -110,7 +105,7 @@ class Benefits extends Component {
 				woocommerce_setup_jetpack_opted_in: true,
 			} ),
 		] )
-			.then( () => this.connectJetpack() )
+			.then( goToNextStep )
 			.catch( ( pluginError, profileError ) => {
 				if ( pluginError ) {
 					createNoticesFromResponse( pluginError );
@@ -126,33 +121,6 @@ class Benefits extends Component {
 				}
 				goToNextStep();
 			} );
-	}
-
-	connectJetpack() {
-		const {
-			getJetpackConnectUrl,
-			getPluginsError,
-			goToNextStep,
-			isJetpackConnected,
-		} = this.props;
-		if ( isJetpackConnected ) {
-			goToNextStep();
-			return;
-		}
-
-		getJetpackConnectUrl( {
-			redirect_url: getAdminLink(
-				'admin.php?page=wc-admin&reset_profiler=0'
-			),
-		} ).then( ( url ) => {
-			const error = getPluginsError( 'getJetpackConnectUrl' );
-			if ( error ) {
-				createNoticesFromResponse( error );
-				goToNextStep();
-				return;
-			}
-			window.location = url;
-		} );
 	}
 
 	renderBenefit( benefit ) {
@@ -305,24 +273,16 @@ export default compose(
 			isOnboardingRequesting,
 		} = select( ONBOARDING_STORE_NAME );
 
-		const {
-			getActivePlugins,
-			getPluginsError,
-			isJetpackConnected,
-			isPluginsRequesting,
-		} = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins, isPluginsRequesting } = select(
+			PLUGINS_STORE_NAME
+		);
 
 		return {
 			activePlugins: getActivePlugins(),
-			getJetpackConnectUrl: __experimentalResolveSelect(
-				PLUGINS_STORE_NAME
-			).getJetpackConnectUrl,
-			getPluginsError,
 			isProfileItemsError: Boolean(
 				getOnboardingError( 'updateProfileItems' )
 			),
 			profileItems: getProfileItems(),
-			isJetpackConnected: isJetpackConnected(),
 			isRequesting: isOnboardingRequesting( 'updateProfileItems' ),
 			isInstallingActivating:
 				isPluginsRequesting( 'installPlugins' ) ||

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -157,13 +157,6 @@ class BusinessDetails extends Component {
 
 		const promises = [
 			updateProfileItems( updates ).catch( () => {
-				createNotice(
-					'error',
-					__(
-						'There was a problem updating your business details.',
-						'woocommerce-admin'
-					)
-				);
 				throw new Error();
 			} ),
 		];
@@ -181,9 +174,19 @@ class BusinessDetails extends Component {
 			);
 		}
 
-		Promise.all( promises ).then( () => {
-			goToNextStep();
-		} );
+		Promise.all( promises )
+			.then( () => {
+				goToNextStep();
+			} )
+			.catch( () => {
+				createNotice(
+					'error',
+					__(
+						'There was a problem updating your business details.',
+						'woocommerce-admin'
+					)
+				);
+			} );
 	}
 
 	validate( values ) {

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -37,7 +37,7 @@ import {
 	TextControl,
 } from '@woocommerce/components';
 import { recordEvent } from 'lib/tracks';
-import { getCurrencyRegion } from 'dashboard/utils';
+import { getCountryCode, getCurrencyRegion } from 'dashboard/utils';
 import { CurrencyContext } from 'lib/currency-context';
 import { createNoticesFromResponse } from 'lib/notices';
 
@@ -46,7 +46,11 @@ const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
 class BusinessDetails extends Component {
 	constructor( props ) {
 		super();
+		const settings = get( props, 'settings', {} );
 		const profileItems = get( props, 'profileItems', {} );
+		const industrySlugs = get( profileItems, 'industry', [] ).map(
+			( industry ) => industry.slug
+		);
 		const businessExtensions = get(
 			profileItems,
 			'business_extensions',
@@ -81,7 +85,10 @@ class BusinessDetails extends Component {
 			'kliken-marketing-for-google',
 		];
 
-		this.bundleInstall = false;
+		this.bundleInstall =
+			getCountryCode( settings.woocommerce_default_country ) === 'US' &&
+			( industrySlugs.includes( 'fashion-apparel-accessories' ) ||
+				industrySlugs.includes( 'health-beauty' ) );
 		this.onContinue = this.onContinue.bind( this );
 		this.validate = this.validate.bind( this );
 		this.getNumberRangeString = this.getNumberRangeString.bind( this );

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -482,7 +482,8 @@ class BusinessDetails extends Component {
 					<Button
 						isTertiary
 						label={ __(
-							'Learn more about recommended free business features'
+							'Learn more about recommended free business features',
+							'woocommerce-admin'
 						) }
 						onClick={ () => {
 							recordEvent(

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -481,6 +481,9 @@ class BusinessDetails extends Component {
 				<div className="woocommerce-business-extensions__popover-wrapper">
 					<Button
 						isTertiary
+						label={ __(
+							'Learn more about recommended free business features'
+						) }
 						onClick={ () => {
 							recordEvent(
 								'storeprofiler_store_business_details_popover'
@@ -488,11 +491,17 @@ class BusinessDetails extends Component {
 							this.setState( { isPopoverVisible: true } );
 						} }
 					>
-						<i className="material-icons-outlined">info</i>
+						<i
+							className="material-icons-outlined"
+							aria-hidden="true"
+						>
+							info
+						</i>
 					</Button>
 					{ isPopoverVisible && (
 						<Popover
 							className="woocommerce-business-extensions__popover"
+							focusOnMount="container"
 							position="top center"
 							onClose={ () =>
 								this.setState( { isPopoverVisible: false } )
@@ -500,7 +509,10 @@ class BusinessDetails extends Component {
 						>
 							<div className="woocommerce-business-extensions__benefits">
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -509,7 +521,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -518,7 +533,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -527,7 +545,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -536,7 +557,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -545,7 +569,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -554,7 +581,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(
@@ -563,7 +593,10 @@ class BusinessDetails extends Component {
 									) }
 								</div>
 								<div className="woocommerce-business-extensions__benefit">
-									<i className="material-icons-outlined">
+									<i
+										className="material-icons-outlined"
+										aria-hidden="true"
+									>
 										check
 									</i>
 									{ __(


### PR DESCRIPTION
Fixes #4579 

* Triggers the Jetpack connection flow from any step on profiler completion if Jetpack is installed and not connected.  Based on slack discussion p1593073481360000-slack-woo-start-manage
* Shows the bundle install UI based on segment defined in #4579 
* Updates cached plugins store in profiler to show/hide benefits step.

One minor annoyance and possible update here or in a future PR is that updating the profile to `complete` throws the user into the dashboard, so if we're still trying to accomplish tasks (like connecting to Jetpack) we need to hide the UI to prevent the "flash" of screens.  One possible fix for this is to create a route or show the profiler when `step` is in the query.

### Screenshots
<img width="560" alt="Screen Shot 2020-06-29 at 3 09 10 PM" src="https://user-images.githubusercontent.com/10561050/86003560-a4802900-ba1a-11ea-8c89-71c1d2701afa.png">

### Detailed test instructions:

**Bundle UI Segmentation**
1. Walk through the profiler, selecting US as the store default country and "Health & Beauty" or "Fashion" for the store industry.
1. Make sure the new bundle UI is shown on the business details step.
1. Go back and update to not include one of those industries or change to a non-US country.
1. Make sure the old business extensions UI is now shown on the Business Details step.

**Benefits plugin caching**
1. Disable Jetpack and/or WCS.
1. Use a non-US store to trigger the old business extensions UI.
1. Walk through to the benefits step and complete.
1. Make sure this step completes and works as expected.
1. Disable Jetpack and/or WCS.
1. With the new bundle UI enabled walk through the profiler, installing extensions.
1. Make sure the benefits page is not shown on completion.

**Jetpack connection flow**
1. Use a non-US store to trigger the old business extensions UI.
1. With Jetpack installed (can be installed during profiler run) but not connected, walk through the profiler.
1. Make sure that you are redirected to the connection flow after completing the benefits step.
1. Disconnected Jetpack.
1. Use a US store and selected industry to trigger the bundle UI.
1. Make sure you're redirected the Jetpack connection flow after the theme step.