### PR TITLE
Add option to dismiss tasks

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -120,6 +120,8 @@ class TaskDashboard extends Component {
 			],
 		} );
 
+		recordEvent( 'tasklist_dismiss_task', { task_name: key } );
+
 		updateOptions( {
 			woocommerce_task_list_dismissed_tasks: [ ...dismissedTasks, key ],
 		} );

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -167,7 +167,9 @@ class TaskDashboard extends Component {
 			installAndActivatePlugins,
 			createNotice,
 			isJetpackConnected,
-		} ).filter( ( task ) => task.visible && ! dismissedTasks.includes( task.key ) );
+		} ).filter(
+			( task ) => task.visible && ! dismissedTasks.includes( task.key )
+		);
 	}
 
 	recordTaskView() {
@@ -492,13 +494,11 @@ export default compose(
 		const { createNotice } = dispatch( 'core/notices' );
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
-		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			createNotice,
 			updateOptions,
 			installAndActivatePlugins,
-			createNotice,
 		};
 	} )
 )( TaskDashboard );

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -108,6 +108,14 @@ class TaskDashboard extends Component {
 		}
 	}
 
+	dismissTask( key ) {
+		const { dismissedTasks, updateOptions } = this.props;
+
+		updateOptions( {
+			woocommerce_task_list_dismissed_tasks: [ ...dismissedTasks, key ],
+		} );
+	}
+
 	componentWillUnmount() {
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-task-dashboard__body' );
@@ -115,6 +123,7 @@ class TaskDashboard extends Component {
 
 	getTasks() {
 		const {
+			dismissedTasks,
 			profileItems,
 			query,
 			taskListPayments,
@@ -135,7 +144,7 @@ class TaskDashboard extends Component {
 			installAndActivatePlugins,
 			createNotice,
 			isJetpackConnected,
-		} ).filter( ( task ) => task.visible );
+		} ).filter( ( task ) => task.visible && ! dismissedTasks.includes( task.key ) );
 	}
 
 	recordTaskView() {
@@ -318,14 +327,24 @@ class TaskDashboard extends Component {
 					variant={ task.completed ? 'body.small' : 'button' }
 				>
 					{ task.title }
+					{ task.time && ! task.completed &&
+						<span className="woocommerce-task__estimated-time">
+							{ task.time }
+						</span> }
 				</Text>
 			);
 
 			if ( ! task.completed ) {
-				task.after = task.time ? (
-					<span className="woocommerce-task-estimated-time">
-						{ task.time }
-					</span>
+				task.after = task.isDismissable ? (
+					<Button
+						isTertiary
+						onClick={ ( event ) => {
+							event.stopPropagation();
+							this.dismissTask( task.key );
+						} }
+					>
+						{ __( 'Dismiss', 'woocommerce-admin' ) }
+					</Button>
 				) : (
 					<Icon icon={ chevronRight } />
 				);
@@ -410,6 +429,7 @@ export default compose(
 		const trackedCompletedTasks =
 			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 		const payments = getOption( 'woocommerce_task_list_payments' );
+		const dismissedTasks = getOption( 'woocommerce_task_list_dismissed_tasks' ) || [];
 
 		const activePlugins = getActivePlugins();
 		const installedPlugins = getInstalledPlugins();
@@ -431,6 +451,7 @@ export default compose(
 		);
 
 		return {
+			dismissedTasks,
 			modalDismissed,
 			profileItems,
 			taskListPayments,

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -109,10 +109,31 @@ class TaskDashboard extends Component {
 	}
 
 	dismissTask( key ) {
-		const { dismissedTasks, updateOptions } = this.props;
+		const { createNotice, dismissedTasks, updateOptions } = this.props;
+
+		createNotice( 'success', __( 'Task dismissed' ), {
+			actions: [
+				{
+					label: __( 'Undo', 'woocommerce-admin' ),
+					onClick: () => this.undoDismissTask( key ),
+				},
+			],
+		} );
 
 		updateOptions( {
 			woocommerce_task_list_dismissed_tasks: [ ...dismissedTasks, key ],
+		} );
+	}
+
+	undoDismissTask( key ) {
+		const { dismissedTasks, updateOptions } = this.props;
+
+		const updatedDismissedTasks = dismissedTasks.filter(
+			( task ) => task !== key
+		);
+
+		updateOptions( {
+			woocommerce_task_list_dismissed_tasks: updatedDismissedTasks,
 		} );
 	}
 
@@ -327,10 +348,11 @@ class TaskDashboard extends Component {
 					variant={ task.completed ? 'body.small' : 'button' }
 				>
 					{ task.title }
-					{ task.time && ! task.completed &&
+					{ task.time && ! task.completed && (
 						<span className="woocommerce-task__estimated-time">
 							{ task.time }
-						</span> }
+						</span>
+					) }
 				</Text>
 			);
 
@@ -429,7 +451,8 @@ export default compose(
 		const trackedCompletedTasks =
 			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 		const payments = getOption( 'woocommerce_task_list_payments' );
-		const dismissedTasks = getOption( 'woocommerce_task_list_dismissed_tasks' ) || [];
+		const dismissedTasks =
+			getOption( 'woocommerce_task_list_dismissed_tasks' ) || [];
 
 		const activePlugins = getActivePlugins();
 		const installedPlugins = getInstalledPlugins();
@@ -464,11 +487,13 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
+		const { createNotice } = dispatch( 'core/notices' );
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
+			createNotice,
 			updateOptions,
 			installAndActivatePlugins,
 			createNotice,

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -40,8 +40,11 @@
 		}
 	}
 
-	.woocommerce-task-estimated-time {
-		color: $medium-gray-text;
+	.woocommerce-task__estimated-time {
+		color: $core-grey-dark-300;
+		font-weight: 400;
+		font-size: 12px;
+		display: block;
 	}
 
 	.woocommerce-card.is-narrow {

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -110,6 +110,7 @@ export function getAllTasks( {
 			visible: productIds.length,
 			completed: productIds.length && ! remainingProductIds.length,
 			time: __( '2 minutes', 'woocommerce-admin' ),
+			isDismissable: true,
 		},
 		{
 			key: 'connect',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix `<SelectControl />` component to allow clicking anywhere on options in list to select.
 - Add support for `<List />` component item tags and link types.
 - Add `<List />` and `<Link />` components to Storybook.
+- Add `key` prop to `<List />` component items.
 
 ## Breaking Changes
 - Removed `SplitButton` because its not being used.

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 /**
  * WooCommerce dependencies
@@ -36,7 +37,11 @@ class List extends Component {
 		const listClassName = classnames( 'woocommerce-list', className );
 
 		return (
-			<ul className={ listClassName } role="menu">
+			<TransitionGroup
+				component="ul"
+				className={ listClassName }
+				role="menu"
+			>
 				{ items.map( ( item, i ) => {
 					const {
 						after,
@@ -74,33 +79,39 @@ class List extends Component {
 					};
 
 					return (
-						<li className={ itemClassName } key={ i }>
-							<InnerTag { ...innerTagProps }>
-								{ before && (
-									<div className="woocommerce-list__item-before">
-										{ before }
-									</div>
-								) }
-								<div className="woocommerce-list__item-text">
-									<span className="woocommerce-list__item-title">
-										{ title }
-									</span>
-									{ content && (
-										<span className="woocommerce-list__item-content">
-											{ content }
-										</span>
+						<CSSTransition
+							key={ i }
+							timeout={ 500 }
+							classNames="woocommerce-list__item"
+						>
+							<li className={ itemClassName } key={ i }>
+								<InnerTag { ...innerTagProps }>
+									{ before && (
+										<div className="woocommerce-list__item-before">
+											{ before }
+										</div>
 									) }
-								</div>
-								{ after && (
-									<div className="woocommerce-list__item-after">
-										{ after }
+									<div className="woocommerce-list__item-text">
+										<span className="woocommerce-list__item-title">
+											{ title }
+										</span>
+										{ content && (
+											<span className="woocommerce-list__item-content">
+												{ content }
+											</span>
+										) }
 									</div>
-								) }
-							</InnerTag>
-						</li>
+									{ after && (
+										<div className="woocommerce-list__item-after">
+											{ after }
+										</div>
+									) }
+								</InnerTag>
+							</li>
+						</CSSTransition>
 					);
 				} ) }
-			</ul>
+			</TransitionGroup>
 		);
 	}
 }
@@ -149,10 +160,7 @@ List.propTypes = {
 			/**
 			 * Title displayed for the list item.
 			 */
-			title: PropTypes.oneOfType( [
-				PropTypes.string,
-				PropTypes.node,
-			] ),
+			title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		} )
 	).isRequired,
 };

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -49,6 +49,7 @@ class List extends Component {
 						className: itemClasses,
 						content,
 						href,
+						key,
 						listItemTag,
 						onClick,
 						target,
@@ -80,7 +81,7 @@ class List extends Component {
 
 					return (
 						<CSSTransition
-							key={ i }
+							key={ key }
 							timeout={ 500 }
 							classNames="woocommerce-list__item"
 						>

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -108,3 +108,29 @@
 .woocommerce-list__item-content {
 	color: $studio-gray-50;
 }
+
+.woocommerce-list__item-enter {
+	opacity: 0;
+	max-height: 0;
+	transform: translateX(50%);
+}
+
+.woocommerce-list__item-enter-active {
+	opacity: 1;
+	max-height: 100vh;
+	transform: translateX(0%);
+	transition: opacity 500ms, transform 500ms, max-height 500ms;
+}
+
+.woocommerce-list__item-exit {
+	opacity: 1;
+	max-height: 100vh;
+	transform: translateX(0%);
+}
+
+.woocommerce-list__item-exit-active {
+	opacity: 0;
+	max-height: 0;
+	transform: translateX(50%);
+	transition: opacity 500ms, transform 500ms, max-height 500ms;
+}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -620,6 +620,7 @@ class Onboarding {
 		$options[] = 'woocommerce_task_list_prompt_shown';
 		$options[] = 'woocommerce_task_list_payments';
 		$options[] = 'woocommerce_task_list_tracked_completed_tasks';
+		$options[] = 'woocommerce_task_list_dismissed_tasks';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce_ppec_paypal_settings';


### PR DESCRIPTION
Fixes #4576 

Adds an option to persistently dismiss tasks from the task list and animate entry/exit.

### Screenshots
<img width="679" alt="Screen Shot 2020-07-01 at 3 11 30 PM" src="https://user-images.githubusercontent.com/10561050/86242694-c3fb8b00-bbad-11ea-9f26-29bb5756acd6.png">


### Detailed test instructions:

1. Add products that require purchase during the profiler.
1. Go to the task list.
1. Dismiss the task.
1. Make sure that the animation works as expected.
1. Make sure the "Undo" button undoes the dismissal.
1. Make sure dismissed tasks remain dismissed across refreshes.
1. Delete `woocommerce_task_list_dismissed_tasks` if you need to rinse and repeat.