### PR TITLE
Trigger a remote inbox notifications engine run when the OBW completes

### DIFF
--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -75,7 +75,7 @@ class WC_Admin_Notes_Onboarding_Profiler {
 	 */
 	public static function update_status_on_complete( $old_value, $new_value ) {
 		if (
-			( isset( $old_value['complete'] ) && $old_value['completed'] ) ||
+			( isset( $old_value['completed'] ) && $old_value['completed'] ) ||
 			! isset( $new_value['completed'] ) ||
 			! $new_value['completed']
 		) {

--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DataSourcePoller {
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom//inbox-notifications/1.0/notifications.json',
+		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
 	);
 
 	/**

--- a/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -48,7 +48,7 @@ class RemoteInboxNotificationsEngine {
 	public static function update_profile_option( $old_value, $new_value ) {
 		// Return early if we're not completing the profiler.
 		if (
-			( isset( $old_value['complete'] ) && $old_value['completed'] ) ||
+			( isset( $old_value['completed'] ) && $old_value['completed'] ) ||
 			! isset( $new_value['completed'] ) ||
 			! $new_value['completed']
 		) {

--- a/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\PluginsProvider\PluginsProvider;
 use \Automattic\WooCommerce\Admin\Loader;
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
 
 /**
  * Remote Inbox Notifications engine.
@@ -27,6 +28,34 @@ class RemoteInboxNotificationsEngine {
 	public static function init() {
 		// Continue init via admin_init.
 		add_action( 'admin_init', array( __CLASS__, 'on_admin_init' ) );
+
+		// Trigger when the profile data option is updated (during onboarding).
+		add_action(
+			'update_option_' . Onboarding::PROFILE_DATA_OPTION,
+			array( __CLASS__, 'update_profile_option' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * This is triggered when the profile option is updated and if the
+	 * profiler is being completed, triggers a run of the engine.
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param mixed $new_value New value.
+	 */
+	public static function update_profile_option( $old_value, $new_value ) {
+		// Return early if we're not completing the profiler.
+		if (
+			( isset( $old_value['complete'] ) && $old_value['completed'] ) ||
+			! isset( $new_value['completed'] ) ||
+			! $new_value['completed']
+		) {
+			return;
+		}
+
+		self::run();
 	}
 
 	/**


### PR DESCRIPTION
This is required for https://github.com/Automattic/wc-calypso-bridge/issues/559

A requirement of the admin note to be created is that it is created when the store is created. This may as well be when the OBW completes. So this triggers an engine run when the OBW completes.

### Detailed test instructions:

1. Add a test data source to `DataSourcePoller::DATA_SOURCES`: `https://gist.githubusercontent.com/becdetat/f17e9617e5ca1211d0579cf079862905/raw/1adef708c9bd16f928cde0e17383446c537f3bd9/rinds-specs.json`
2. `DELETE FROM wp_wc_admin_notes` - this sets an initial state with the notes
3. Start the OBW
4. Check that the `wp_wc_admin_notes` table doesn't contain any pending notes
5. Complete the OBW
6. Check that the `wp_wc_admin_notes` table now contains pending and unactioned notes with a source of `'woocommerce.com'`
