### PR TITLE
Fix up warnings in notes

### DIFF
--- a/src/Notes/WC_Admin_Notes_Choose_Niche.php
+++ b/src/Notes/WC_Admin_Notes_Choose_Niche.php
@@ -37,7 +37,10 @@ class WC_Admin_Notes_Choose_Niche {
 		}
 
 		// Make sure that the person who filled out the OBW was not setting up the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 
@@ -54,7 +57,6 @@ class WC_Admin_Notes_Choose_Niche {
 		$note->set_title( __( 'How to choose a niche for your online store', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Your niche defines the products and services you develop. It directs your marketing. It focuses your attention on specific problems facing your customers. It differentiates you from the competition. Learn more about the five guiding principles to define your niche.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Customize_Store_With_Blocks.php
+++ b/src/Notes/WC_Admin_Notes_Customize_Store_With_Blocks.php
@@ -38,7 +38,10 @@ class WC_Admin_Notes_Customize_Store_With_Blocks {
 
 		// Make sure that the person who filled out the OBW was not setting up
 		// the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_First_Product.php
+++ b/src/Notes/WC_Admin_Notes_First_Product.php
@@ -43,7 +43,10 @@ class WC_Admin_Notes_First_Product {
 
 		// Make sure that the person who filled out the OBW was not setting up
 		// the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Need_Some_Inspiration.php
+++ b/src/Notes/WC_Admin_Notes_Need_Some_Inspiration.php
@@ -48,7 +48,10 @@ class WC_Admin_Notes_Need_Some_Inspiration {
 
 		// Make sure that the person who filled out the OBW was not setting up
 		// the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Online_Clothing_Store.php
+++ b/src/Notes/WC_Admin_Notes_Online_Clothing_Store.php
@@ -61,7 +61,10 @@ class WC_Admin_Notes_Online_Clothing_Store {
 
 		// Make sure that the person who filled out the OBW was not setting up
 		// the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Start_Dropshipping_Business.php
+++ b/src/Notes/WC_Admin_Notes_Start_Dropshipping_Business.php
@@ -43,15 +43,22 @@ class WC_Admin_Notes_Start_Dropshipping_Business {
 		}
 
 		// Make sure that the person who filled out the OBW was not setting up the store for their customer/client.
-		if ( $onboarding_profile['setup_client'] ) {
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
 			return;
 		}
 
 		// We need to show the notification when product number is 0 or the revenue is 'none' or 'up to 2500'.
 		if (
-			0 !== (int) $onboarding_profile['product_count'] &&
-			'none' !== $onboarding_profile['revenue'] &&
-			'up-to-2500' !== $onboarding_profile['revenue']
+			! isset( $onboarding_profile['product_count'] ) ||
+			! isset( $onboarding_profile['revenue'] ) ||
+			(
+				0 !== (int) $onboarding_profile['product_count'] &&
+				'none' !== $onboarding_profile['revenue'] &&
+				'up-to-2500' !== $onboarding_profile['revenue']
+			)
 		) {
 			return;
 		}
@@ -60,7 +67,6 @@ class WC_Admin_Notes_Start_Dropshipping_Business {
 		$note->set_title( __( 'Are you considering starting a dropshipping business?', 'woocommerce-admin' ) );
 		$note->set_content( __( 'The ability to add inventory without having to deal with production, stocking, or fulfilling orders may seem like a dream. But is dropshipping worth it? Let’s explore some of the advantages and disadvantages to help you make the best decision for your business.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Subscriptions.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Subscriptions.php
@@ -45,7 +45,6 @@ class WC_Admin_Notes_WooCommerce_Subscriptions {
 		$note->set_title( __( 'Do you need more info about WooCommerce Subscriptions?', 'woocommerce-admin' ) );
 		$note->set_content( __( 'WooCommerce Subscriptions allows you to introduce a variety of subscriptions for physical or virtual products and services. Create product-of-the-month clubs, weekly service subscriptions or even yearly software billing packages. Add sign-up fees, offer free trials, or set expiration periods.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );


### PR DESCRIPTION
Fixes #4734 

Fixes a missing check in various notes and removes deprecated `set_icon()` calls.

### Detailed test instructions:

1. Delete `woocommerce_onboarding_profile`.
1. Enable the profiler.
1. Directly visit `wp-admin/admin.php?page=wc-admin&step=product-types` to bypass the first step and save some profiler data (to mimic not having `setup_client` like older stores)
1. Attempt to trigger various notes by running the `wc_admin_daily` cron event.  This should trigger most of them:
  * Make sure "I'm setting up a store for a client" is not checked in the profiler.
  * Active for > 14 && < 30 days.
  * Select clothing for industry in profiler
  * 0 products
  * 0 revenue and no products in Business Details step of profiler.
  * Select `subscriptions` for product types in profiler.
5. Check that no errors occur