### PR TITLE
Added event recording to home/dashboard task list

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -103,6 +103,9 @@ export function getAllTasks( {
 			title: __( 'Store details', 'woocommerce-admin' ),
 			container: null,
 			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'store_details',
+				} );
 				getHistory().push( getNewPath( {}, `/profiler`, {} ) );
 			},
 			completed: profilerCompleted,
@@ -113,8 +116,12 @@ export function getAllTasks( {
 			key: 'purchase',
 			title: __( 'Purchase & install extensions', 'woocommerce-admin' ),
 			container: null,
-			onClick: () =>
-				remainingProductIds.length ? toggleCartModal() : null,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'purchase',
+				} );
+				return remainingProductIds.length ? toggleCartModal() : null;
+			},
 			visible: productIds.length,
 			completed: productIds.length && ! remainingProductIds.length,
 			time: __( '2 minutes', 'woocommerce-admin' ),
@@ -127,6 +134,12 @@ export function getAllTasks( {
 				'woocommerce-admin'
 			),
 			container: <Connect query={ query } />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'connect',
+				} );
+				updateQueryString( { task: 'connect' } );
+			},
 			visible: itemsPurchased && ! wccomConnected,
 			completed: wccomConnected,
 			time: __( '1 minute', 'woocommerce-admin' ),
@@ -135,6 +148,12 @@ export function getAllTasks( {
 			key: 'products',
 			title: __( 'Add my products', 'woocommerce-admin' ),
 			container: <Products />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'products',
+				} );
+				updateQueryString( { task: 'products' } );
+			},
 			completed: hasProducts,
 			visible: true,
 			time: __( '1 minute per product', 'woocommerce-admin' ),
@@ -155,6 +174,9 @@ export function getAllTasks( {
 						activePlugins,
 						installedPlugins
 					);
+					recordEvent( 'tasklist_click', {
+						task_name: 'woocommerce-payments',
+					} );
 					return installActivateAndConnectWcpay(
 						resolve,
 						reject,
@@ -171,6 +193,12 @@ export function getAllTasks( {
 			key: 'appearance',
 			title: __( 'Personalize my store', 'woocommerce-admin' ),
 			container: <Appearance />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'appearance',
+				} );
+				updateQueryString( { task: 'appearance' } );
+			},
 			completed: isAppearanceComplete,
 			visible: true,
 			time: __( '2 minutes', 'woocommerce-admin' ),
@@ -179,6 +207,12 @@ export function getAllTasks( {
 			key: 'shipping',
 			title: __( 'Set up shipping', 'woocommerce-admin' ),
 			container: <Shipping />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'shipping',
+				} );
+				updateQueryString( { task: 'shipping' } );
+			},
 			completed: shippingZonesCount > 0,
 			visible:
 				( productTypes && productTypes.includes( 'physical' ) ) ||
@@ -189,6 +223,12 @@ export function getAllTasks( {
 			key: 'tax',
 			title: __( 'Set up tax', 'woocommerce-admin' ),
 			container: <Tax />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'tax',
+				} );
+				updateQueryString( { task: 'tax' } );
+			},
 			completed: isTaxComplete,
 			visible: true,
 			time: __( '1 minute', 'woocommerce-admin' ),
@@ -199,6 +239,9 @@ export function getAllTasks( {
 			container: <Payments />,
 			completed: paymentsCompleted || paymentsSkipped,
 			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'payments',
+				} );
 				if ( paymentsCompleted || paymentsSkipped ) {
 					window.location = getAdminLink(
 						'admin.php?page=wc-settings&tab=checkout'


### PR DESCRIPTION
Fixes #4568-partially

_This PR will need a rebase after merging [PR 4721](https://github.com/woocommerce/woocommerce-admin/pull/4721) since it depends on it_.

This PR adds event recording to the `home screen`/`dashboard` task list.


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:

- Verify that all the tasks list elements are tracked with the event recording.
- Executing this sentence in the browser console may help to verify it:
````
localStorage.setItem( 'debug', 'wc-admin:*' )
````
- Verify that the buttons continue working as expected.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Add: Event recording was added to home/dashboard task list
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
