### PR TITLE
Added default value to the note icon

### DIFF
--- a/src/Install.php
+++ b/src/Install.php
@@ -260,6 +260,7 @@ class Install {
 			layout varchar(20) DEFAULT '' NOT NULL,
 			image varchar(200) NULL DEFAULT NULL,
 			is_deleted boolean DEFAULT 0 NOT NULL,
+			icon varchar(200) NOT NULL default 'info',
 			PRIMARY KEY (note_id)
 		) $collate;
 		CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (


### PR DESCRIPTION
Fixes #4736

This PR adds a default value to the note icon to fix the error:
````
PHP Fatal error: Uncaught WC_Data_Exception: The admin note icon prop cannot be empty.
````

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/7158648/86315128-ec41c300-bc5b-11ea-9843-860b097ba49c.png)

Now:
![screenshot-unlikely-seahorse jurassic ninja-2020 07 02-14_20_08](https://user-images.githubusercontent.com/1314156/86391030-7d6e6500-bc6f-11ea-9b5e-bb79e7b5ca94.png)


### Detailed test instructions:

**UPDATED**
- Create an ephemeral site (e.g. in jurassic.ninja).
- Go to the console and in this branch create a testing build `npm run test:zip`. 
- Install the `wc-admin` zip that the script created in the ephemeral site.
- Press `Activate` (it won't allow you to activate the plugin because it requires WooCommerce but it will create the table `wp_wc_admin_notes ` as if it were inside of `woocommerce.4.3.0-rc.2.zip`).
- Install and activate [WooCommerce 4.3.0 rc.2](https://downloads.wordpress.org/plugin/woocommerce.4.3.0-rc.2.zip).
- Go back to the plugin's page and activate `WooCommerce Admin` again (now it will work).
- Go to the `Home` screen and verify that everything looks normal.
- `Deactivate` WC-admin and the WooCommerce plugin.
- Delete the WooCommerce plugin.
- Now install and activate [WooCommerce 4.2.2](https://github.com/woocommerce/woocommerce/releases/download/4.2.2/woocommerce.zip).
- Verify the Inbox notifications are visible.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Added default value to the note icon
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
