### PR TITLE
Build: Don't Attempt to Load non-minified Assets in Core Build

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -11,6 +11,7 @@
 		"remote-inbox-notifications": false,
 	  	"shipping-label-banner": true,
 		"store-alerts": true,
+		"unminified-js": false,
 		"wcpay": true,
 		"homescreen": true
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -11,6 +11,7 @@
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,
 		"store-alerts": true,
+		"unminified-js": true,
 		"wcpay": true,
 		"homescreen": true
 	}

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -11,6 +11,7 @@
 		"remote-inbox-notifications": false,
 		"shipping-label-banner": true,
 		"store-alerts": true,
+		"unminified-js": true,
 		"wcpay": true,
 		"homescreen": true
 	}

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -204,7 +204,7 @@ class FeaturePlugin {
 		add_filter( 'woocommerce_admin_features', array( $this, 'replace_supported_features' ), 0 );
 		add_action( 'admin_menu', array( $this, 'register_devdocs_page' ) );
 
-		new Loader();
+		Loader::get_instance();
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -193,6 +193,22 @@ class Loader {
 	}
 
 	/**
+	 * Determines if a minified JS file should be served.
+	 *
+	 * @param  boolean $script_debug Only serve unminified files if script debug is on.
+	 * @return boolean If js asset should use minified version.
+	 */
+	public static function should_use_minified_js_file( $script_debug ) {
+		// un-minified files are only shipped in non-core versions of wc-admin, return true if unminified files are not available.
+		if ( ! self::is_feature_enabled( 'unminified-js' ) ) {
+			return true;
+		}
+
+		// Otherwise we will serve un-minified files if SCRIPT_DEBUG is on, or if anything truthy is passed in-lieu of SCRIPT_DEBUG.
+		return ! $script_debug;
+	}
+
+	/**
 	 * Gets the URL to an asset file.
 	 *
 	 * @param  string $file File name (without extension).
@@ -204,7 +220,8 @@ class Loader {
 
 		// Potentially enqueue minified JavaScript.
 		if ( 'js' === $ext ) {
-			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+			$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+			$suffix = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
 		}
 
 		return plugins_url( self::get_path( $ext ) . $file . $suffix . '.' . $ext, WC_ADMIN_PLUGIN_FILE );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -60,7 +60,7 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
 
 		// Set up WC-Admin config.
-		tests_add_filter( 'wc_admin_get_feature_config', array( $this, 'add_development_features' ) );
+		tests_add_filter( 'woocommerce_admin_get_feature_config', array( $this, 'add_development_features' ) );
 
 		// load the WP testing environment.
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
@@ -152,10 +152,12 @@ class WC_Admin_Unit_Tests_Bootstrap {
 
 	/**
 	 * Use the `development` features for testing.
+	 *
+	 * @param array $flags Existing feature flags.
+	 * @return array Filtered feature flags.
 	 */
-	public function add_development_features() {
+	public function add_development_features( $flags ) {
 		$config = json_decode( file_get_contents( $this->plugin_dir . '/config/development.json' ) ); // @codingStandardsIgnoreLine.
-		$flags  = array();
 		foreach ( $config->features as $feature => $bool ) {
 			$flags[ $feature ] = $bool;
 		}

--- a/tests/loader.php
+++ b/tests/loader.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Loader tests
+ *
+ * @package WooCommerce Admin\Tests\Loader
+ */
+
+use \Automattic\WooCommerce\Admin\Loader;
+
+/**
+ * WC_Admin_Tests_Page_Loader Class
+ *
+ * @package WooCommerce Admin\Tests\Loader
+ */
+class WC_Admin_Tests_Loader extends WP_UnitTestCase {
+	/**
+	 * Setup
+	 */
+	public static function setUpBeforeClass() {
+		add_filter( 'woocommerce_admin_features', array( 'WC_Admin_Tests_Loader', 'turn_on_unminified_js_feature' ), 10, 1 );
+	}
+
+	/**
+	 * Tear Down
+	 */
+	public static function tearDownAfterClass() {
+		remove_filter( 'woocommerce_admin_features', array( 'WC_Admin_Tests_Loader', 'turn_on_unminified_js_feature' ) );
+	}
+
+	/**
+	 * Fitler to enable unminified-js feature.
+	 *
+	 * @param  array $features Array of active features.
+	 */
+	public static function turn_on_unminified_js_feature( $features ) {
+		return array_merge( $features, array( 'unminified-js' ) );
+	}
+
+	/**
+	 * Test get_url()
+	 */
+	public function test_get_url() {
+		$loader = Loader::get_instance();
+		$result = $loader->get_url( 'flavortown', 'js' );
+
+		// All we are concerned about in this test is the js filename. Pop it off the end of the asset url.
+		$parts           = explode( '/', $result );
+		$final_file_name = array_pop( $parts );
+
+		// Since this can vary depending on the env the tests are running in, we will make this assertion based upon the SCRIPT_DEBUG value.
+		$expected_value = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? 'flavortown.js' : 'flavortown.min.js';
+
+		$this->assertEquals(
+			$expected_value,
+			$final_file_name,
+			'the anticipated js file name should use .min when SCRIPT_DEBUG is off, and have no .min when SCRIPT_DEBUG is on.'
+		);
+	}
+
+	/**
+	 * Tests for should_use_minified_js_file
+	 */
+	public function test_should_use_minified_js_file() {
+		$loader = Loader::get_instance();
+
+		// We will simulate a call with SCRIPT_DEBUG on.
+		$script_debug = true;
+
+		$this->assertFalse(
+			$loader->should_use_minified_js_file( $script_debug ),
+			'Since unminifed js feature is TRUE/on, and script_debug is true, should_use_minified_js_file should return false'
+		);
+
+		// Now we will simulate SCRIPT_DEBUG off/false.
+		$script_debug = false;
+		$this->assertTrue(
+			$loader->should_use_minified_js_file( $script_debug ),
+			'Since unminifed js feature is TRUE/on, and script_debug is false, should_use_minified_js_file should return true'
+		);
+	}
+}

--- a/tests/loader.php
+++ b/tests/loader.php
@@ -16,15 +16,15 @@ class WC_Admin_Tests_Loader extends WP_UnitTestCase {
 	/**
 	 * Setup
 	 */
-	public static function setUpBeforeClass() {
-		add_filter( 'woocommerce_admin_features', array( 'WC_Admin_Tests_Loader', 'turn_on_unminified_js_feature' ), 10, 1 );
+	public function setUp() {
+		add_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20, 1 );
 	}
 
 	/**
 	 * Tear Down
 	 */
-	public static function tearDownAfterClass() {
-		remove_filter( 'woocommerce_admin_features', array( 'WC_Admin_Tests_Loader', 'turn_on_unminified_js_feature' ) );
+	public function tearDown() {
+		remove_filter( 'woocommerce_admin_features', array( $this, 'turn_on_unminified_js_feature' ), 20 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4738

With the changes shipped in 1.3.0 for not including un-minified files in the production/core build, users could encounter a state where wc-admin attempts to load non-minified JS files when they are not present in the build. The existing logic that determines if `.min` should be included in the file name was only looking to the value of `SCRIPT_DEBUG` was set and truthy. This would result in no wc-admin JS assets being loaded on sites running core builds with `define( 'SCRIPT_DEBUG', 'true' );`

The proposed fix in this PR involves adding a new config feature for `unminified-js`, which is `true` in development and plugin envs, but `false` for core. I had initially considered using the existing [`is_dev`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L116) method in the `Loader` for this, but that would prevent non-minified files from being loaded on the plugin version via `SCRIPT_DEBUG`.

I also opted to create a new helper method here to determine if `.min` should be used or not called `should_use_minified_js_file` - I primarily did this to allow for writing some unit tests that are independent of the value of `SCRIPT_DEBUG` in the testing environment. I feel it is a pretty sound approach, but am totally open to other ideas/approaches here.

### Detailed test instructions:
This PR is probably best to test on a Jurassic Ninja site so you can use the beta tester plugin and easily install 4.3.0-rc.2. So to setup a test site, and re-create the bug:

- Launch a new JN site, tick the boxes to install woocommerce and woocommerce-beta-tester.
- Once the site launches, SSH into the instance and add `define( 'SCRIPT_DEBUG', true );` to your `wp-config.php`
- Next head to wp-admin/plugins.php and use the beta tester plugin to upgrade to 4.3.0-rc.2
- Once the latest version is installed and active, launch the Setup Wizard, and with the network tab open, you should see something like this ( note the missing `.min` from the JS chunk files ):

![4 3-rc 2-SCRIPT_DEBUGtrue](https://user-images.githubusercontent.com/22080/86406445-f79aeb80-bc67-11ea-8901-baed9544984a.png)

_Back on your local computer_

- Check out this branch of wc-admin
- Clear out your local `dist` folder: `rm -rf dist`
- Run a **core** build of wc-admin: `WC_ADMIN_PHASE=core npm run build`
- Then the next few steps are just borrowed from the test:zip job:  `composer install --no-dev`
- `rm woocommerce-admin.zip` might not be there, but just to be safe
- and finally `./bin/make-zip.sh woocommerce-admin.zip`

__Back on JN__

- Upload and activate the .zip file you just built
- Reload the onboarding wizard, and it should now work, and you should see `.min` files in the network tab for js even though SCRIPT_DEBUG is on.

![4 3-rc 2-with-fix-applied](https://user-images.githubusercontent.com/22080/86406669-67a97180-bc68-11ea-8cb8-1645c7758efa.png)

__Bonus Points__

- You can run the tests locally, or let CI do it for you: `composer test -- --filter="WC_Admin_Tests_Loader"`

### Changelog Note:

Dev: Only load non-minified js files when SCRIPT_DEBUG is on, and env is development or plugin
