### PR TITLE
Reordered home screen tasks

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -20,7 +20,6 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import Appearance from './tasks/appearance';
-import Connect from './tasks/connect';
 import { getProductIdsForCart } from 'dashboard/utils';
 import Products from './tasks/products';
 import Shipping from './tasks/shipping';
@@ -92,9 +91,7 @@ export function getAllTasks( {
 		installedPlugins.indexOf( 'woocommerce-payments' ) !== -1;
 	const {
 		completed: profilerCompleted,
-		items_purchased: itemsPurchased,
 		product_types: productTypes,
-		wccom_connected: wccomConnected,
 	} = profileItems;
 
 	const tasks = [
@@ -126,23 +123,6 @@ export function getAllTasks( {
 			completed: productIds.length && ! remainingProductIds.length,
 			time: __( '2 minutes', 'woocommerce-admin' ),
 			isDismissable: true,
-		},
-		{
-			key: 'connect',
-			title: __(
-				'Connect your store to WooCommerce.com',
-				'woocommerce-admin'
-			),
-			container: <Connect query={ query } />,
-			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'connect',
-				} );
-				updateQueryString( { task: 'connect' } );
-			},
-			visible: itemsPurchased && ! wccomConnected,
-			completed: wccomConnected,
-			time: __( '1 minute', 'woocommerce-admin' ),
 		},
 		{
 			key: 'products',

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -170,18 +170,38 @@ export function getAllTasks( {
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 		{
-			key: 'appearance',
-			title: __( 'Personalize my store', 'woocommerce-admin' ),
-			container: <Appearance />,
+			key: 'payments',
+			title: __( 'Set up payments', 'woocommerce-admin' ),
+			container: <Payments />,
+			completed: paymentsCompleted || paymentsSkipped,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {
-					task_name: 'appearance',
+					task_name: 'payments',
 				} );
-				updateQueryString( { task: 'appearance' } );
+				if ( paymentsCompleted || paymentsSkipped ) {
+					window.location = getAdminLink(
+						'admin.php?page=wc-settings&tab=checkout'
+					);
+					return;
+				}
+				updateQueryString( { task: 'payments' } );
 			},
-			completed: isAppearanceComplete,
-			visible: true,
+			visible: ! woocommercePaymentsInstalled,
 			time: __( '2 minutes', 'woocommerce-admin' ),
+		},
+		{
+			key: 'tax',
+			title: __( 'Set up tax', 'woocommerce-admin' ),
+			container: <Tax />,
+			onClick: () => {
+				recordEvent( 'tasklist_click', {
+					task_name: 'tax',
+				} );
+				updateQueryString( { task: 'tax' } );
+			},
+			completed: isTaxComplete,
+			visible: true,
+			time: __( '1 minute', 'woocommerce-admin' ),
 		},
 		{
 			key: 'shipping',
@@ -200,37 +220,17 @@ export function getAllTasks( {
 			time: __( '1 minute', 'woocommerce-admin' ),
 		},
 		{
-			key: 'tax',
-			title: __( 'Set up tax', 'woocommerce-admin' ),
-			container: <Tax />,
+			key: 'appearance',
+			title: __( 'Personalize my store', 'woocommerce-admin' ),
+			container: <Appearance />,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {
-					task_name: 'tax',
+					task_name: 'appearance',
 				} );
-				updateQueryString( { task: 'tax' } );
+				updateQueryString( { task: 'appearance' } );
 			},
-			completed: isTaxComplete,
+			completed: isAppearanceComplete,
 			visible: true,
-			time: __( '1 minute', 'woocommerce-admin' ),
-		},
-		{
-			key: 'payments',
-			title: __( 'Set up payments', 'woocommerce-admin' ),
-			container: <Payments />,
-			completed: paymentsCompleted || paymentsSkipped,
-			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'payments',
-				} );
-				if ( paymentsCompleted || paymentsSkipped ) {
-					window.location = getAdminLink(
-						'admin.php?page=wc-settings&tab=checkout'
-					);
-					return;
-				}
-				updateQueryString( { task: 'payments' } );
-			},
-			visible: ! woocommercePaymentsInstalled,
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 	];


### PR DESCRIPTION
Fixes #4591

_This PR will need a rebase after merging [PR 4743](https://github.com/woocommerce/woocommerce-admin/pull/4743)_.

This PR reorders the task list on the `home screen` / `dashboard`.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 07 06-15_22_00](https://user-images.githubusercontent.com/1314156/86626470-161d2180-bf9d-11ea-91a2-63bf29ec1f7f.png)


### Detailed test instructions:

- Go to the home screen.
- Verify the task list order is correct.
- The order is:
        Store details
        Purchase extensions
        Add products
        Set up payments
        Set up tax
        Set up shipping
        Personalize store

- Verify the task item `Connect your store to WooCommerce.com` was removed.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Reordered home screen tasks
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
