### PR TITLE
Avoid Jetpack REST API when retrieving active modules 

### DIFF
--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -15,6 +15,24 @@ use \Automattic\WooCommerce\Admin\Loader;
  * Init class.
  */
 class Init {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
 
 	/**
 	 * Boostrap REST API.

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -43,6 +43,13 @@ class Controller extends \WC_REST_Reports_Controller {
 	protected $endpoints = array();
 
 	/**
+	 * Contains a list active Jetpack module slugs.
+	 *
+	 * @var array
+	 */
+	protected $active_jetpack_modules = null;
+
+	/**
 	 * Contains a list of allowed stats.
 	 *
 	 * @var array
@@ -178,16 +185,42 @@ class Controller extends \WC_REST_Reports_Controller {
 	}
 
 	/**
+	 * Get active Jetpack modules.
+	 *
+	 * @return array List of active Jetpack module slugs.
+	 */
+	public function get_active_jetpack_modules() {
+		if ( is_null( $this->active_jetpack_modules ) ) {
+			if ( class_exists( '\Jetpack' ) ) {
+				$this->active_jetpack_modules = \Jetpack::get_active_modules();
+			} else {
+				$this->active_jetpack_modules = array();
+			}
+		}
+
+		return $this->active_jetpack_modules;
+	}
+
+	/**
+	 * Set active Jetpack modules.
+	 *
+	 * @param array $modules List of active Jetpack module slugs.
+	 */
+	public function set_active_jetpack_modules( $modules ) {
+		$this->active_jetpack_modules = $modules;
+	}
+
+	/**
 	 * Get active Jetpack modules and endpoints.
 	 */
 	public function get_jetpack_modules_data() {
-		if ( ! class_exists( '\Jetpack_Core_Json_Api_Endpoints' ) ) {
+		$active_modules = $this->get_active_jetpack_modules();
+
+		if ( empty( $active_modules ) ) {
 			return;
 		}
 
-		$request  = new \WP_REST_Request( 'GET', '/jetpack/v4/module/all' );
-		$response = rest_do_request( $request );
-		$items    = apply_filters(
+		$items = apply_filters(
 			'woocommerce_rest_performance_indicators_jetpack_items',
 			array(
 				'stats/visitors' => array(
@@ -205,18 +238,8 @@ class Controller extends \WC_REST_Reports_Controller {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		if ( 200 !== $response->get_status() || empty( $items ) ) {
-			return;
-		}
-
-		$data = $response->get_data();
-
 		foreach ( $items as $item_key => $item ) {
-			if ( ! $data[ $item['module'] ] || ! $data[ $item['module'] ]['activated'] ) {
+			if ( ! in_array( $item['module'], $active_modules, true ) ) {
 				return;
 			}
 

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -43,7 +43,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	protected $endpoints = array();
 
 	/**
-	 * Contains a list active Jetpack module slugs.
+	 * Contains a list of active Jetpack module slugs.
 	 *
 	 * @var array
 	 */
@@ -192,7 +192,8 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_active_jetpack_modules() {
 		if ( is_null( $this->active_jetpack_modules ) ) {
 			if ( class_exists( '\Jetpack' ) && method_exists( '\Jetpack', 'get_active_modules' ) ) {
-				$this->active_jetpack_modules = \Jetpack::get_active_modules();
+				$active_modules               = \Jetpack::get_active_modules();
+				$this->active_jetpack_modules = is_array( $active_modules ) ? $active_modules : array();
 			} else {
 				$this->active_jetpack_modules = array();
 			}

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -191,7 +191,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	 */
 	public function get_active_jetpack_modules() {
 		if ( is_null( $this->active_jetpack_modules ) ) {
-			if ( class_exists( '\Jetpack' ) ) {
+			if ( class_exists( '\Jetpack' ) && method_exists( '\Jetpack', 'get_active_modules' ) ) {
 				$this->active_jetpack_modules = \Jetpack::get_active_modules();
 			} else {
 				$this->active_jetpack_modules = array();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -173,7 +173,7 @@ class FeaturePlugin {
 		ReportsSync::init();
 		Install::init();
 		Events::instance()->init();
-		new API\Init();
+		API\Init::instance();
 		ReportExporter::init();
 
 		// CRUD classes.

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -32,7 +32,8 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		// Mock the Jetpack endpoints and permissions.
 		$wp_user = get_userdata( $this->user );
 		$wp_user->add_cap( 'view_stats' );
-		$this->getMockBuilder( 'Jetpack_Core_Json_Api_Endpoints' )->getMock();
+		$this->mock_jetpack_modules();
+
 		add_filter( 'rest_post_dispatch', array( $this, 'mock_rest_responses' ), 10, 3 );
 	}
 
@@ -273,17 +274,6 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 	 * @return WP_Rest_Response
 	 */
 	public function mock_rest_responses( $response, $rest_server, $request ) {
-		if ( 'GET' === $request->get_method() && '/jetpack/v4/module/all' === $request->get_route() ) {
-			$response->set_status( 200 );
-			$response->set_data(
-				array(
-					'stats' => array(
-						'activated' => 1,
-					),
-				)
-			);
-		}
-
 		if ( 'GET' === $request->get_method() && '/jetpack/v4/module/stats/data' === $request->get_route() ) {
 			$general                 = new \stdClass();
 			$general->visits         = new \stdClass();
@@ -331,5 +321,15 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Mock the Jetpack stats module as active.
+	 */
+	public function mock_jetpack_modules() {
+		$api_init        = \Automattic\WooCommerce\Admin\API\Init::instance();
+		$controller_name = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
+
+		$api_init->$controller_name->set_active_jetpack_modules( array( 'stats' ) );
 	}
 }


### PR DESCRIPTION
Fixes #4751. Alternative to https://github.com/woocommerce/woocommerce-admin/pull/4752.

This PR seeks to avoid using the Jetpack REST API to retrieve active modules instead of selectively loading the Performance Indicators endpoint controller (as https://github.com/woocommerce/woocommerce-admin/pull/4752 does).

### Detailed test instructions:

- Install WC & Jetpack.
- Apply changes
- Test that performance indicators are still working in the admin area:
- WooCommerce > Home (if you have the home screen feature enabled), and
- Analytics > Overview
- Disable Jetpack
- Test that performance indicators are still working in the admin area (but missing "views", "visitors"):
- WooCommerce > Home (if you have the home screen feature enabled), and
- Analytics > Overview
<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: unnecessary REST API usage leading to potential overflow of Jetpack option sizes.