### PR TITLE
Make sure product count and revenue items are set in choose niche note

### DIFF
--- a/src/Notes/WC_Admin_Notes_Choose_Niche.php
+++ b/src/Notes/WC_Admin_Notes_Choose_Niche.php
@@ -44,6 +44,16 @@ class WC_Admin_Notes_Choose_Niche {
 			return;
 		}
 
+		// Make sure that the product count is set in the onboarding profile.
+		if ( ! isset( $onboarding_profile['product_count'] ) ) {
+			return;
+		}
+
+		// Make sure that the revenue is set in the onboarding profile.
+		if ( ! isset( $onboarding_profile['revenue'] ) ) {
+			return;
+		}
+
 		// We need to show the notification when product number is 0 or the revenue is 'none' or 'up to 2500'.
 		if (
 			0 !== (int) $onboarding_profile['product_count'] &&


### PR DESCRIPTION
Somehow, I finished the OBW without having product count or revenue set in the onboarding profile. This caused an error in the Choose Niche note factory. This PR adds additional checks to the note factory.

### Detailed test instructions:

1. `DELETE FROM wp_wc_admin_notes` - this clears out the existing notes
1. Delete the option `woocommerce_onboarding_profile` - this resets the onboarding profile
1. Start the OBW
2. Navigate away from the OBW without selecting the product count or revenue
4. Run the `wc_admin_daily` cron task - this will run the Choose Niche note factory
5. Check the error log - there shouldn't be any errors
6. Check the inbox - the Choose Niche note shouldn't be present
