### PR TITLE
Onboarding: Don't show tracking modal if site is already opted in

### DIFF
--- a/client/profile-wizard/steps/usage-modal.js
+++ b/client/profile-wizard/steps/usage-modal.js
@@ -94,6 +94,14 @@ class UsageModal extends Component {
 	}
 
 	render() {
+		// Bail if site has already opted in to tracking
+		if ( this.props.allowTracking ) {
+			const { onClose, onContinue } = this.props;
+			onClose();
+			onContinue();
+			return null;
+		}
+
 		const { allowTracking } = this.state;
 		const { isRequesting } = this.props;
 		const trackingMessage = interpolateComponents( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/574

This branch adds some logic to not show the usage tracking modal if a site has already opted into usage tracking. While this use-case might not happen often ( sites likely don't run through the onboarding wizard more than once ) - it will be immediately useful in the context of the eCommerce Plan where users have already opted into usage tracking.

### Screenshots

__Flow With Usage Not Opted In ( DEFAULT )__
This is pretty much unchanged...

![usage-tracking-ff](https://user-images.githubusercontent.com/22080/86852406-90b37300-c069-11ea-96e2-3d94469a3be0.gif)

__Flow With Usage already opted in (NEW)__
![usge-opted-in](https://user-images.githubusercontent.com/22080/86852638-fbfd4500-c069-11ea-8869-61fd65d4fb07.gif)

### Detailed test instructions:
Two parts of testing fun on this one. For the first, verify the existing flow ( not opted in ) works as expected. To do so:

- Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`, and un-check the usage tracking checkbox there, and save settings.
- Open up the OBW via `/wp-admin/admin.php?page=wc-admin&reset_profiler=1` 
- Complete the first store details step, verify the usage modal is shown, and operates as expected.

Next up, revisit the same settings page, and opt-in/ turn on usage tracking.

- Visit `/wp-admin/admin.php?page=wc-admin&reset_profiler=1` again
- Verify after completing the step, the usage modal is not shown.

Worth noting, there is a react warning being shown on the store details step for me. This exists on `main` currently also:

<img width="1271" alt="Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-07 15-55-35" src="https://user-images.githubusercontent.com/22080/86856960-50a4be00-c072-11ea-8cee-9e9f5c001ef2.png">

### Changelog Note:

Tweak: Only show usage tracking modal once in OBW.
