### PR TITLE
Add is_ecommerce remote inbox notifications rule

### DIFF
--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DataSourcePoller {
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom//inbox-notifications/1.0/notifications.json',
+		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
 	);
 
 	/**

--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -48,6 +48,8 @@ class GetRuleProcessor {
 				return new ProductCountRuleProcessor();
 			case 'onboarding_profile':
 				return new OnboardingProfileRuleProcessor();
+			case 'is_ecommerce':
+				return new IsEcommerceRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/IsEcommerceRuleProcessor.php
+++ b/src/RemoteInboxNotifications/IsEcommerceRuleProcessor.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Rule processor that passes (or fails) when the site is on the eCommerce
+ * plan.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor that passes (or fails) when the site is on the eCommerce
+ * plan.
+ */
+class IsEcommerceRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Passes (or fails) based on whether the site is on the eCommerce plan or
+	 * not.
+	 *
+	 * @param object $rule         The rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		if ( ! function_exists( 'wc_calypso_bridge_is_ecommerce_plan' ) ) {
+			return false === $rule->value;
+		}
+
+		return (bool) wc_calypso_bridge_is_ecommerce_plan() === $rule->value;
+	}
+
+	/**
+	 * Validate the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/wc-calypso-bridge/issues/559

This adds a rule that passes (or fails, depending on the rule value) if the site is an eCommerce site.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/86877847-10eddd00-c12b-11ea-94df-0319e388d1f1.png)

### Detailed test instructions:

1. Clone [the Calypso bridge](https://github.com/Automattic/wc-calypso-bridge) into your `plugins` directory
2. Activate the plugin
3. Add `https://gist.githubusercontent.com/becdetat/f17e9617e5ca1211d0579cf079862905/raw/fc16ebaf98ac8dae8075b5be6145827892be5502/rinds-specs.json` to the `DATA_SOURCES` array in `src/RemoteInboxNotifications/DataSourcePoller.php`
4. `DELETE FROM wp_wc_admin_notes`
5. Run the `wc_admin_daily` cron task
6. The note about the eCommerce plan should _not_ appear in the inbox, but it should be a pending note in the `wp_wc_admin_notes` table
7. Execute this SQL: `INSERT INTO wp_options(option_name, option_value, autoload) VALUES('at_options', 'a:1:{s:9:"plan_slug";s:9:"ecommerce";}', 'yes')` - this flags the system as being on the eCommerce plan
8. Run the `wc_admin_daily` cron task again
9. The note about the eCommerce plan should now appear in the inbox
