### PR TITLE
Show "Help" Activity Panel When Working Single Task List Item

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -17,7 +17,7 @@ import CrossIcon from 'gridicons/dist/cross-small';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { H, Section, Spinner } from '@woocommerce/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
-import { getHistory, getQuery } from '@woocommerce/navigation';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -126,12 +126,18 @@ class ActivityPanel extends Component {
 			hasUnapprovedReviews,
 			hasUnreadStock,
 			isEmbedded,
-			isPerformingSetupTask,
+			requestingTaskListOptions,
+			taskListComplete,
+			taskListHidden,
+			query,
 		} = this.props;
 
 		// Don't show the inbox on the Home screen.
 		const { location } = getHistory();
 		const showInbox = isEmbedded || ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
+		const isPerformingSetupTask = query.task && ( requestingTaskListOptions === true || (
+			taskListHidden === false && taskListComplete === false
+		) );
 
 		return [
 			! isPerformingSetupTask && showInbox
@@ -354,7 +360,6 @@ export default compose(
 		const hasUnreadOrders = getUnreadOrders( select );
 		const hasUnreadStock = getUnreadStock();
 		const hasUnapprovedReviews = getUnapprovedReviews( select );
-		const query = getQuery();
 		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
 
 		let requestingTaskListOptions, taskListComplete, taskListHidden;
@@ -371,16 +376,14 @@ export default compose(
 				] );
 		}
 
-		const isPerformingSetupTask = query.task && ( requestingTaskListOptions === true || (
-			taskListHidden === false && taskListComplete === false
-		) );
-
 		return {
 			hasUnreadNotes,
 			hasUnreadOrders,
 			hasUnreadStock,
 			hasUnapprovedReviews,
-			isPerformingSetupTask,
+			requestingTaskListOptions,
+			taskListComplete,
+			taskListHidden,
 		};
 	} ),
 	clickOutside

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -25,6 +25,11 @@ import {
 	getUnapprovedReviews,
 	getUnreadStock,
 } from './unread-indicators';
+
+const HelpPanel = lazy( () =>
+	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
+);
+
 const InboxPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-inbox" */ './panels/inbox' )
 );
@@ -158,6 +163,15 @@ class ActivityPanel extends Component {
 						unread: hasUnapprovedReviews,
 				  }
 				: null,
+			{
+				name: 'help',
+				title: __( 'Help', 'woocommerce-admin' ),
+				icon: (
+					<i className="material-icons-outlined">
+						support
+					</i>
+				),
+			},
 		].filter( Boolean );
 	}
 
@@ -177,6 +191,8 @@ class ActivityPanel extends Component {
 						hasUnapprovedReviews={ hasUnapprovedReviews }
 					/>
 				);
+			case 'help':
+				return <HelpPanel />;
 			default:
 				return null;
 		}

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -205,7 +205,9 @@ class ActivityPanel extends Component {
 					/>
 				);
 			case 'help':
-				return <HelpPanel />;
+				const { query } = this.props;
+				const { task } = query;
+				return <HelpPanel taskName={ task } />;
 			default:
 				return null;
 		}

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -135,9 +135,15 @@ class ActivityPanel extends Component {
 		// Don't show the inbox on the Home screen.
 		const { location } = getHistory();
 		const showInbox = isEmbedded || ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
-		const isPerformingSetupTask = query.task && ( requestingTaskListOptions === true || (
-			taskListHidden === false && taskListComplete === false
-		) );
+		const isPerformingSetupTask =
+			query.task &&
+			! query.path &&
+			( requestingTaskListOptions === true ||
+				(
+					taskListHidden === false &&
+					taskListComplete === false
+				)
+			);
 
 		return [
 			! isPerformingSetupTask && showInbox

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -55,7 +55,7 @@ import withSelect from 'wc-api/with-select';
 const manageStock = getSetting( 'manageStock', 'no' );
 const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
 
-class ActivityPanel extends Component {
+export class ActivityPanel extends Component {
 	constructor() {
 		super( ...arguments );
 		this.togglePanel = this.togglePanel.bind( this );
@@ -133,7 +133,7 @@ class ActivityPanel extends Component {
 		} = this.props;
 
 		// Don't show the inbox on the Home screen.
-		const { location } = getHistory();
+		const { location } = this.props.getHistory();
 		const showInbox = isEmbedded || ! window.wcAdminFeatures.homescreen || location.pathname !== '/';
 		const isPerformingSetupTask =
 			query.task &&
@@ -361,6 +361,10 @@ class ActivityPanel extends Component {
 		);
 	}
 }
+
+ActivityPanel.defaultProps = {
+	getHistory,
+};
 
 export default compose(
 	withSelect( ( select ) => {

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -11,6 +11,7 @@ import { partial } from 'lodash';
 /**
  * WooCommerce dependencies
  */
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import { List, Section } from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
@@ -26,7 +27,6 @@ import { getCountryCode } from 'dashboard/utils';
 import { recordEvent } from 'lib/tracks';
 import { getPaymentMethods } from 'task-list/tasks/payments/methods';
 import { compose } from 'redux';
-// import './style.scss';
 
 function getAppearanceItems() {
 	return [
@@ -132,11 +132,11 @@ function getProductsItems() {
 	];
 }
 
-function shouldShowWCS( { activePlugins, countryCode } ) {
-	return ( countryCode === 'US' && activePlugins.includes( 'woocommerce-services' ) );
-}
-
-function getShippingItems( props ) {
+function getShippingItems( { activePlugins, countryCode } ) {
+	const showWCS = (
+		countryCode === 'US' &&
+		! activePlugins.includes( 'woocommerce-services' )
+	);
 	return [
 		{
 			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
@@ -150,7 +150,7 @@ function getShippingItems( props ) {
 			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel',
 		},
-		shouldShowWCS( props ) && {
+		showWCS && {
 			title: __( 'WooCommerce Shipping setup and configuration', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel',
 		},
@@ -161,13 +161,23 @@ function getShippingItems( props ) {
 	].filter( Boolean );
 }
 
-function getTaxItems( props ) {
+function getTaxItems( { countryCode } ) {
+	const {
+		automatedTaxSupportedCountries = [],
+		taxJarActivated,
+	} = getSetting( 'onboarding', {} );
+
+	const showWCS = (
+		! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
+		automatedTaxSupportedCountries.includes( countryCode )
+	);
+
 	return [
 		{
 			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel',
 		},
-		shouldShowWCS( props ) && {
+		showWCS && {
 			title: __( 'Automated Tax calculation using WooCommerce Services', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10',
 		},

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -208,6 +208,11 @@ function getItems( props ) {
 function handleOnItemClick( props, event ) {
 	const { taskName } = props;
 
+	// event isn't initially set when triggering link with the keyboard.
+	if ( ! event ) {
+		return;
+	}
+
 	props.recordEvent( 'help_panel_click', {
 		task_name: taskName,
 		link: event.currentTarget.href,

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalText as Text } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 import { Icon, chevronRight, page } from '@wordpress/icons';
 // import { partial } from 'lodash';
 
@@ -15,6 +16,7 @@ import { List, Section } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import ActivityHeader from '../activity-header';
 import { recordEvent } from 'lib/tracks';
 // import './style.scss';
 
@@ -201,12 +203,15 @@ const HelpPanel = ( props ) => {
 	const listItems = getListItems( props );
 
 	return (
-		<Section>
-			<List
-				items={ listItems }
-				className="woocommerce-quick-links__list"
-			/>
-		</Section>
+		<Fragment>
+			<ActivityHeader title={ __( 'Documentation', 'woocommerce-admin' ) } />
+			<Section>
+				<List
+					items={ listItems }
+					className="woocommerce-quick-links__list"
+				/>
+			</Section>
+		</Fragment>
 	);
 };
 

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -18,7 +18,76 @@ import { List, Section } from '@woocommerce/components';
 import { recordEvent } from 'lib/tracks';
 // import './style.scss';
 
-function getProductItems() {
+function getAppearanceItems() {
+	return [
+		{
+			title: __( 'Showcase your products and tailor your shopping experience using Blocks', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Manage Store Notice, Catalog View and Product Images', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel',
+		},
+		{
+			title: __( 'How to choose and change a theme', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/choose-change-theme/?utm_source=help_panel',
+		},
+	];
+}
+
+function getPaymentsItems() {
+	return [
+		{
+			title: __( 'Which Payment Option is Right for Me?', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel',
+		},
+		// TODO: if WC Pay is an option.
+		{
+			title: __( 'WooCommerce Payments Start Up Guide', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/payments//?utm_source=help_panel',
+		},
+		// TODO: if WC Pay is an option.
+		{
+			title: __( 'WooCommerce Payments FAQs', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel',
+		},
+		// TODO: if Stripe is an option.
+		{
+			title: __( 'Stripe Setup and Configuration', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/stripe/?utm_source=help_panel',
+		},
+		// TODO: if PayPal is an option.
+		{
+			title: __( 'PayPal Checkout Setup and Configuration', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/paypal-express-checkout/?utm_source=help_panel',
+		},
+		// TODO: if Square is an option.
+		{
+			title: __( 'Square - Get started', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/woocommerce-square/?utm_source=help_panel',
+		},
+		// TODO: if Klarna is an option.
+		{
+			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/klarna-payments/?utm_source=help_panel',
+		},
+		// TODO: if Payfast is an option.
+		{
+			title: __( 'PayFast Setup and Configuration', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/bacs/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Cash on Delivery', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/cash-on-delivery/?utm_source=help_panel',
+		},
+	];
+}
+
+function getProductsItems() {
 	return [
 		{
 			title: __( 'Adding and Managing Products', 'woocommerce-admin' ),
@@ -39,11 +108,60 @@ function getProductItems() {
 	];
 }
 
+function getShippingItems() {
+	return [
+		{
+			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Core Shipping Options', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel',
+		},
+		// TODO: (if WCS is active)
+		{
+			title: __( 'WooCommerce Shipping setup and configuration', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Learn more about configuring your shipping settings', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel',
+		},
+	];
+}
+
+function getTaxItems() {
+	return [
+		{
+			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel',
+		},
+		// TODO: (if WCS is active)
+		{
+			title: __( 'Automated Tax calculation using WooCommerce Services', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10',
+		},
+	];
+}
+
 function getItems( taskName ) {
 	switch ( taskName ) {
 		case 'products':
+			return getProductsItems();
+		case 'appearance':
+			return getAppearanceItems();
+		case 'shipping':
+			return getShippingItems();
+		case 'tax':
+			return getTaxItems();
+		case 'payments':
+			return getPaymentsItems();
 		default:
-			return getProductItems();
+			return [];
 	}
 }
 
@@ -95,7 +213,7 @@ const HelpPanel = ( props ) => {
 HelpPanel.defaultProps = {
 	getSetting,
 	recordEvent,
-	taskName: 'products',
+	taskName: 'shipping',
 };
 
 export default HelpPanel;

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -213,7 +213,13 @@ function getItems( props ) {
 // }
 
 function getListItems( props ) {
-	return getItems( props ).map( ( item ) => ( {
+	const itemsByType = getItems( props );
+	itemsByType.push( {
+		title: __( 'WooCommerce Docs', 'woocommerce-admin' ),
+		link: 'https://docs.woocommerce.com/?utm_source=help_panel',
+	} );
+
+	return itemsByType.map( ( item ) => ( {
 		title: <Text as="div" variant="button">{ item.title }</Text>,
 		before: <Icon icon={ page } />,
 		after: <Icon icon={ chevronRight } />,

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -15,6 +15,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
 import { List, Section } from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
+	PLUGINS_STORE_NAME,
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 
@@ -132,7 +133,11 @@ function getProductsItems() {
 	];
 }
 
-function getShippingItems() {
+function shouldShowWCS( { activePlugins, countryCode } ) {
+	return ( countryCode === 'US' && activePlugins.includes( 'woocommerce-services' ) );
+}
+
+function getShippingItems( props ) {
 	return [
 		{
 			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
@@ -146,8 +151,7 @@ function getShippingItems() {
 			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel',
 		},
-		// TODO: (if WCS is active)
-		{
+		shouldShowWCS( props ) && {
 			title: __( 'WooCommerce Shipping setup and configuration', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel',
 		},
@@ -155,21 +159,20 @@ function getShippingItems() {
 			title: __( 'Learn more about configuring your shipping settings', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel',
 		},
-	];
+	].filter( Boolean );
 }
 
-function getTaxItems() {
+function getTaxItems( props ) {
 	return [
 		{
 			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel',
 		},
-		// TODO: (if WCS is active)
-		{
+		shouldShowWCS( props ) && {
 			title: __( 'Automated Tax calculation using WooCommerce Services', 'woocommerce-admin' ),
 			link: 'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10',
 		},
-	];
+	].filter( Boolean );
 }
 
 function getItems( props ) {
@@ -181,9 +184,9 @@ function getItems( props ) {
 		case 'appearance':
 			return getAppearanceItems();
 		case 'shipping':
-			return getShippingItems();
+			return getShippingItems( props );
 		case 'tax':
-			return getTaxItems();
+			return getTaxItems( props );
 		case 'payments':
 			return getPaymentsItems( props );
 		default:
@@ -246,8 +249,9 @@ export default compose(
 	withSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 		const { general: generalSettings = {} } = getSettings( 'general' );
-
+		const activePlugins = getActivePlugins();
 		const profileItems = getProfileItems();
 
 		const countryCode = getCountryCode(
@@ -255,6 +259,7 @@ export default compose(
 		);
 
 		return {
+			activePlugins,
 			countryCode,
 			profileItems,
 		};

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { __experimentalText as Text } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useEffect } from '@wordpress/element';
 import { Icon, chevronRight, page } from '@wordpress/icons';
 // import { partial } from 'lodash';
 
@@ -231,6 +231,13 @@ function getListItems( props ) {
 }
 
 const HelpPanel = ( props ) => {
+	const { taskName } = props;
+	useEffect( () => {
+		recordEvent( 'help_panel_open', {
+			task_name: taskName,
+		} );
+	}, [ taskName ] );
+
 	const listItems = getListItems( props );
 
 	return (

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { __experimentalText as Text } from '@wordpress/components';
+import { Icon, chevronRight, page } from '@wordpress/icons';
+// import { partial } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+import { List, Section } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+// import './style.scss';
+
+function getProductItems() {
+	return [
+		{
+			title: __( 'Adding and Managing Products', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/managing-products/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Import products using the CSV Importer and Exporter', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Migrate products using Cart2Cart', 'woocommerce-admin' ),
+			link: 'https://woocommerce.com/products/cart2cart/?utm_source=help_panel',
+		},
+		{
+			title: __( 'Learn more about setting up products', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel',
+		},
+	];
+}
+
+function getItems( taskName ) {
+	switch ( taskName ) {
+		case 'products':
+		default:
+			return getProductItems();
+	}
+}
+
+// function handleOnItemClick( props, event ) {
+// 	const a = event.currentTarget;
+
+// 	props.recordEvent( 'help_panel_click', {
+// 		task_name: 'GET TASK NAME HERE',
+// 		link: a.href,
+// 	} );
+
+// 	if ( typeof props.onItemClick !== 'function' ) {
+// 		return;
+// 	}
+
+// 	if ( ! props.onItemClick( listItemTag ) ) {
+// 		event.preventDefault();
+// 		return false;
+// 	}
+// }
+
+function getListItems( props ) {
+	const { taskName } = props;
+
+	return getItems( taskName ).map( ( item ) => ( {
+		title: <Text as="div" variant="button">{ item.title }</Text>,
+		before: <Icon icon={ page } />,
+		after: <Icon icon={ chevronRight } />,
+		linkType: 'external',
+		target: '_blank',
+		href: item.link,
+		// onClick: partial( handleOnItemClick, props ),
+	} ) );
+}
+
+const HelpPanel = ( props ) => {
+	const listItems = getListItems( props );
+
+	return (
+		<Section>
+			<List
+				items={ listItems }
+				className="woocommerce-quick-links__list"
+			/>
+		</Section>
+	);
+};
+
+HelpPanel.defaultProps = {
+	getSetting,
+	recordEvent,
+	taskName: 'products',
+};
+
+export default HelpPanel;

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -6,12 +6,11 @@ import { __experimentalText as Text } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
 import { Icon, chevronRight, page } from '@wordpress/icons';
-// import { partial } from 'lodash';
+import { partial } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings';
 import { List, Section } from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
@@ -194,23 +193,14 @@ function getItems( props ) {
 	}
 }
 
-// function handleOnItemClick( props, event ) {
-// 	const a = event.currentTarget;
+function handleOnItemClick( props, event ) {
+	const { taskName } = props;
 
-// 	props.recordEvent( 'help_panel_click', {
-// 		task_name: 'GET TASK NAME HERE',
-// 		link: a.href,
-// 	} );
-
-// 	if ( typeof props.onItemClick !== 'function' ) {
-// 		return;
-// 	}
-
-// 	if ( ! props.onItemClick( listItemTag ) ) {
-// 		event.preventDefault();
-// 		return false;
-// 	}
-// }
+	props.recordEvent( 'help_panel_click', {
+		task_name: taskName,
+		link: event.currentTarget.href,
+	} );
+}
 
 function getListItems( props ) {
 	const itemsByType = getItems( props );
@@ -219,6 +209,8 @@ function getListItems( props ) {
 		link: 'https://docs.woocommerce.com/?utm_source=help_panel',
 	} );
 
+	const onClick = partial( handleOnItemClick, props );
+
 	return itemsByType.map( ( item ) => ( {
 		title: <Text as="div" variant="button">{ item.title }</Text>,
 		before: <Icon icon={ page } />,
@@ -226,14 +218,14 @@ function getListItems( props ) {
 		linkType: 'external',
 		target: '_blank',
 		href: item.link,
-		// onClick: partial( handleOnItemClick, props ),
+		onClick,
 	} ) );
 }
 
 const HelpPanel = ( props ) => {
 	const { taskName } = props;
 	useEffect( () => {
-		recordEvent( 'help_panel_open', {
+		props.recordEvent( 'help_panel_open', {
 			task_name: taskName,
 		} );
 	}, [ taskName ] );
@@ -254,7 +246,6 @@ const HelpPanel = ( props ) => {
 };
 
 HelpPanel.defaultProps = {
-	getSetting,
 	recordEvent,
 };
 

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { __experimentalText as Text } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { Icon, chevronRight, page } from '@wordpress/icons';
 import { partial } from 'lodash';
 
@@ -28,19 +29,34 @@ import { recordEvent } from 'lib/tracks';
 import { getPaymentMethods } from 'task-list/tasks/payments/methods';
 import { compose } from 'redux';
 
+export const SETUP_TASK_HELP_ITEMS_FILTER =
+	'woocommerce_admin_setup_task_help_items';
+
 function getAppearanceItems() {
 	return [
 		{
-			title: __( 'Showcase your products and tailor your shopping experience using Blocks', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel',
+			title: __(
+				'Showcase your products and tailor your shopping experience using Blocks',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel',
 		},
 		{
-			title: __( 'Manage Store Notice, Catalog View and Product Images', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel',
+			title: __(
+				'Manage Store Notice, Catalog View and Product Images',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel',
 		},
 		{
-			title: __( 'How to choose and change a theme', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/choose-change-theme/?utm_source=help_panel',
+			title: __(
+				'How to choose and change a theme',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/choose-change-theme/?utm_source=help_panel',
 		},
 	];
 }
@@ -54,7 +70,10 @@ function getPaymentsItems( props ) {
 		profileItems,
 	} );
 
-	const methodIsVisible = ( methodKey ) => Boolean( paymentMethods.find( method => method.key === methodKey ) );
+	const methodIsVisible = ( methodKey ) =>
+		Boolean(
+			paymentMethods.find( ( method ) => method.key === methodKey )
+		);
 
 	const showWCPay = methodIsVisible( 'wcpay' );
 	const showStripe = methodIsVisible( 'stripe' );
@@ -66,48 +85,68 @@ function getPaymentsItems( props ) {
 
 	return [
 		{
-			title: __( 'Which Payment Option is Right for Me?', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel',
+			title: __(
+				'Which Payment Option is Right for Me?',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel',
 		},
 		showWCPay && {
-			title: __( 'WooCommerce Payments Start Up Guide', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/payments//?utm_source=help_panel',
+			title: __(
+				'WooCommerce Payments Start Up Guide',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/payments//?utm_source=help_panel',
 		},
 		showWCPay && {
 			title: __( 'WooCommerce Payments FAQs', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel',
 		},
 		showStripe && {
 			title: __( 'Stripe Setup and Configuration', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/stripe/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/stripe/?utm_source=help_panel',
 		},
 		showPayPal && {
-			title: __( 'PayPal Checkout Setup and Configuration', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/paypal-express-checkout/?utm_source=help_panel',
+			title: __(
+				'PayPal Checkout Setup and Configuration',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/paypal-express-checkout/?utm_source=help_panel',
 		},
 		showSquare && {
 			title: __( 'Square - Get started', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/woocommerce-square/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-square/?utm_source=help_panel',
 		},
 		showKlarnaCheckout && {
 			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/klarna-checkout/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/klarna-checkout/?utm_source=help_panel',
 		},
 		showKlarnaPayments && {
 			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/klarna-payments/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/klarna-payments/?utm_source=help_panel',
 		},
 		showPayFast && {
 			title: __( 'PayFast Setup and Configuration', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel',
 		},
 		{
 			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/bacs/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/bacs/?utm_source=help_panel',
 		},
 		{
 			title: __( 'Cash on Delivery', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/cash-on-delivery/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/cash-on-delivery/?utm_source=help_panel',
 		},
 	].filter( Boolean );
 }
@@ -116,48 +155,71 @@ function getProductsItems() {
 	return [
 		{
 			title: __( 'Adding and Managing Products', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/managing-products/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/managing-products/?utm_source=help_panel',
 		},
 		{
-			title: __( 'Import products using the CSV Importer and Exporter', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel',
+			title: __(
+				'Import products using the CSV Importer and Exporter',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel',
 		},
 		{
-			title: __( 'Migrate products using Cart2Cart', 'woocommerce-admin' ),
-			link: 'https://woocommerce.com/products/cart2cart/?utm_source=help_panel',
+			title: __(
+				'Migrate products using Cart2Cart',
+				'woocommerce-admin'
+			),
+			link:
+				'https://woocommerce.com/products/cart2cart/?utm_source=help_panel',
 		},
 		{
-			title: __( 'Learn more about setting up products', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel',
+			title: __(
+				'Learn more about setting up products',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel',
 		},
 	];
 }
 
 function getShippingItems( { activePlugins, countryCode } ) {
-	const showWCS = (
+	const showWCS =
 		countryCode === 'US' &&
-		! activePlugins.includes( 'woocommerce-services' )
-	);
+		! activePlugins.includes( 'woocommerce-services' );
 	return [
 		{
 			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel',
 		},
 		{
 			title: __( 'Core Shipping Options', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel',
 		},
 		{
 			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel',
 		},
 		showWCS && {
-			title: __( 'WooCommerce Shipping setup and configuration', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel',
+			title: __(
+				'WooCommerce Shipping setup and configuration',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel',
 		},
 		{
-			title: __( 'Learn more about configuring your shipping settings', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel',
+			title: __(
+				'Learn more about configuring your shipping settings',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel',
 		},
 	].filter( Boolean );
 }
@@ -169,19 +231,23 @@ function getTaxItems( props ) {
 		taxJarActivated,
 	} = props.getSetting( 'onboarding', {} );
 
-	const showWCS = (
+	const showWCS =
 		! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
-		automatedTaxSupportedCountries.includes( countryCode )
-	);
+		automatedTaxSupportedCountries.includes( countryCode );
 
 	return [
 		{
 			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel',
+			link:
+				'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel',
 		},
 		showWCS && {
-			title: __( 'Automated Tax calculation using WooCommerce Services', 'woocommerce-admin' ),
-			link: 'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10',
+			title: __(
+				'Automated Tax calculation using WooCommerce Services',
+				'woocommerce-admin'
+			),
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10',
 		},
 	].filter( Boolean );
 }
@@ -221,15 +287,39 @@ function handleOnItemClick( props, event ) {
 
 function getListItems( props ) {
 	const itemsByType = getItems( props );
-	itemsByType.push( {
+	const genericDocsLink = {
 		title: __( 'WooCommerce Docs', 'woocommerce-admin' ),
 		link: 'https://docs.woocommerce.com/?utm_source=help_panel',
-	} );
+	};
+	itemsByType.push( genericDocsLink );
+
+	const filteredItems = applyFilters(
+		SETUP_TASK_HELP_ITEMS_FILTER,
+		itemsByType,
+		props.taskName,
+		props
+	);
+
+	// Filter out items that aren't objects without `title` and `link` properties.
+	let validatedItems = Array.isArray( filteredItems )
+		? filteredItems.filter(
+				( item ) => item instanceof Object && item.title && item.link
+		  )
+		: [];
+
+	// Default empty array to the generic docs link.
+	if ( ! validatedItems.length ) {
+		validatedItems = [ genericDocsLink ];
+	}
 
 	const onClick = partial( handleOnItemClick, props );
 
-	return itemsByType.map( ( item ) => ( {
-		title: <Text as="div" variant="button">{ item.title }</Text>,
+	return validatedItems.map( ( item ) => ( {
+		title: (
+			<Text as="div" variant="button">
+				{ item.title }
+			</Text>
+		),
 		before: <Icon icon={ page } />,
 		after: <Icon icon={ chevronRight } />,
 		linkType: 'external',
@@ -251,7 +341,9 @@ export const HelpPanel = ( props ) => {
 
 	return (
 		<Fragment>
-			<ActivityHeader title={ __( 'Documentation', 'woocommerce-admin' ) } />
+			<ActivityHeader
+				title={ __( 'Documentation', 'woocommerce-admin' ) }
+			/>
 			<Section>
 				<List
 					items={ listItems }

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -218,7 +218,6 @@ const HelpPanel = ( props ) => {
 HelpPanel.defaultProps = {
 	getSetting,
 	recordEvent,
-	taskName: 'shipping',
 };
 
 export default HelpPanel;

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -45,8 +45,9 @@ function getAppearanceItems() {
 	];
 }
 
-function getPaymentsItems( { countryCode, profileItems } ) {
-	const paymentMethods = getPaymentMethods( {
+function getPaymentsItems( props ) {
+	const { countryCode, profileItems } = props;
+	const paymentMethods = props.getPaymentMethods( {
 		activePlugins: [],
 		countryCode,
 		options: {},
@@ -161,11 +162,12 @@ function getShippingItems( { activePlugins, countryCode } ) {
 	].filter( Boolean );
 }
 
-function getTaxItems( { countryCode } ) {
+function getTaxItems( props ) {
+	const { countryCode } = props;
 	const {
 		automatedTaxSupportedCountries = [],
 		taxJarActivated,
-	} = getSetting( 'onboarding', {} );
+	} = props.getSetting( 'onboarding', {} );
 
 	const showWCS = (
 		! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
@@ -232,7 +234,7 @@ function getListItems( props ) {
 	} ) );
 }
 
-const HelpPanel = ( props ) => {
+export const HelpPanel = ( props ) => {
 	const { taskName } = props;
 	useEffect( () => {
 		props.recordEvent( 'help_panel_open', {
@@ -256,6 +258,8 @@ const HelpPanel = ( props ) => {
 };
 
 HelpPanel.defaultProps = {
+	getPaymentMethods,
+	getSetting,
 	recordEvent,
 };
 

--- a/client/header/activity-panel/test/help-panel.js
+++ b/client/header/activity-panel/test/help-panel.js
@@ -2,138 +2,237 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { addFilter, removeAllFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { HelpPanel } from '../panels/help';
+import { HelpPanel, SETUP_TASK_HELP_ITEMS_FILTER } from '../panels/help';
 
-describe( 'Activity Panel > Help', () => {
-	it( 'only shows links for available payment methods', () => {
-		const fixtures = [
-			{
-				key: 'wcpay',
-				text: 'WooCommerce Payments',
-			},
-			{
-				key: 'stripe',
-				text: 'Stripe',
-			},
-			{
-				key: 'klarna_checkout',
-				text: 'Klarna',
-			},
-			{
-				key: 'klarna_payments',
-				text: 'Klarna',
-			},
-			{
-				key: 'paypal',
-				text: 'PayPal Checkout',
-			},
-			{
-				key: 'square',
-				text: 'Square',
-			},
-			{
-				key: 'payfast',
-				text: 'PayFast',
-			},
-		];
+describe( 'Activity Panels', () => {
+	describe( 'Help', () => {
+		it( 'only shows links for available payment methods', () => {
+			const fixtures = [
+				{
+					key: 'wcpay',
+					text: 'WooCommerce Payments',
+				},
+				{
+					key: 'stripe',
+					text: 'Stripe',
+				},
+				{
+					key: 'klarna_checkout',
+					text: 'Klarna',
+				},
+				{
+					key: 'klarna_payments',
+					text: 'Klarna',
+				},
+				{
+					key: 'paypal',
+					text: 'PayPal Checkout',
+				},
+				{
+					key: 'square',
+					text: 'Square',
+				},
+				{
+					key: 'payfast',
+					text: 'PayFast',
+				},
+			];
 
-		const noMethods = render(
-			<HelpPanel
-				getPaymentMethods={ () => ( [] ) }
-				taskName="payments"
-			/>
-		);
+			const noMethods = render(
+				<HelpPanel getPaymentMethods={ () => [] } taskName="payments" />
+			);
 
-		fixtures.forEach( method => {
-			expect( noMethods.queryAllByText( ( text ) => text.includes( method.text ) ) ).toHaveLength( 0 );
+			fixtures.forEach( ( method ) => {
+				expect(
+					noMethods.queryAllByText( ( text ) =>
+						text.includes( method.text )
+					)
+				).toHaveLength( 0 );
+			} );
+
+			fixtures.forEach( ( method ) => {
+				const { queryAllByText } = render(
+					<HelpPanel
+						getPaymentMethods={ () => [ method ] }
+						taskName="payments"
+					/>
+				);
+
+				expect(
+					queryAllByText( ( text ) => text.includes( method.text ) )
+						.length
+				).toBeGreaterThanOrEqual( 1 );
+			} );
 		} );
 
-		fixtures.forEach( method => {
-			const { queryAllByText } = render(
+		it( 'only shows links for automated tax when supported', () => {
+			const taxjarPluginEnabled = render(
 				<HelpPanel
-					getPaymentMethods={ () => ( [ method ] ) }
-					taskName="payments"
+					countryCode="US"
+					getSetting={ () => ( {
+						automatedTaxSupportedCountries: [ 'US' ],
+						taxJarActivated: true,
+					} ) }
+					taskName="tax"
 				/>
 			);
 
-			expect( queryAllByText( ( text ) => text.includes( method.text ) ).length ).toBeGreaterThanOrEqual( 1 );
+			expect(
+				taxjarPluginEnabled.queryByText( /WooCommerce Services/ )
+			).toBeNull();
+
+			const unSupportedCountry = render(
+				<HelpPanel
+					countryCode="NZ"
+					getSetting={ () => ( {
+						automatedTaxSupportedCountries: [ 'US' ],
+						taxJarActivated: false,
+					} ) }
+					taskName="tax"
+				/>
+			);
+
+			expect(
+				unSupportedCountry.queryByText( /WooCommerce Services/ )
+			).toBeNull();
+
+			const supportedCountry = render(
+				<HelpPanel
+					countryCode="US"
+					getSetting={ () => ( {
+						automatedTaxSupportedCountries: [ 'US' ],
+						taxJarActivated: false,
+					} ) }
+					taskName="tax"
+				/>
+			);
+
+			expect(
+				supportedCountry.getByText( /WooCommerce Services/ )
+			).toBeDefined();
 		} );
-	} );
 
-	it( 'only shows links for automated tax when supported', () => {
-		const taxjarPluginEnabled = render(
-			<HelpPanel
-				countryCode="US"
-				getSetting={ () => ( {
-					automatedTaxSupportedCountries: [ 'US' ],
-					taxJarActivated: true,
-				} ) }
-				taskName="tax"
-			/>
-		);
+		it( 'only shows links for WooCommerce Shipping when supported', () => {
+			const wcsActive = render(
+				<HelpPanel
+					activePlugins={ [ 'woocommerce-services' ] }
+					countryCode="US"
+					taskName="shipping"
+				/>
+			);
 
-		expect( taxjarPluginEnabled.queryByText( /WooCommerce Services/ ) ).toBeNull();
+			expect(
+				wcsActive.queryByText( /WooCommerce Shipping/ )
+			).toBeNull();
 
-		const unSupportedCountry = render(
-			<HelpPanel
-				countryCode="NZ"
-				getSetting={ () => ( {
-					automatedTaxSupportedCountries: [ 'US' ],
-					taxJarActivated: false,
-				} ) }
-				taskName="tax"
-			/>
-		);
+			const unSupportedCountry = render(
+				<HelpPanel
+					activePlugins={ [ 'woocommerce-services' ] }
+					countryCode="UK"
+					taskName="shipping"
+				/>
+			);
 
-		expect( unSupportedCountry.queryByText( /WooCommerce Services/ ) ).toBeNull();
+			expect(
+				unSupportedCountry.queryByText( /WooCommerce Shipping/ )
+			).toBeNull();
 
-		const supportedCountry = render(
-			<HelpPanel
-				countryCode="US"
-				getSetting={ () => ( {
-					automatedTaxSupportedCountries: [ 'US' ],
-					taxJarActivated: false,
-				} ) }
-				taskName="tax"
-			/>
-		);
+			const supportedCountry = render(
+				<HelpPanel
+					activePlugins={ [] }
+					countryCode="US"
+					taskName="shipping"
+				/>
+			);
 
-		expect( supportedCountry.getByText( /WooCommerce Services/ ) ).toBeDefined();
-	} );
+			expect(
+				supportedCountry.getByText( /WooCommerce Shipping/ )
+			).toBeDefined();
+		} );
 
-	it( 'only shows links for WooCommerce Shipping when supported', () => {
-		const wcsActive = render(
-			<HelpPanel
-				activePlugins={ [ 'woocommerce-services' ] }
-				countryCode="US"
-				taskName="shipping"
-			/>
-		);
+		describe( 'Filters', () => {
+			const testNamespace = 'wc/admin/tests';
 
-		expect( wcsActive.queryByText( /WooCommerce Shipping/ ) ).toBeNull();
+			afterEach( () => {
+				removeAllFilters( SETUP_TASK_HELP_ITEMS_FILTER, testNamespace );
+			} );
 
-		const unSupportedCountry = render(
-			<HelpPanel
-				activePlugins={ [ 'woocommerce-services' ] }
-				countryCode="UK"
-				taskName="shipping"
-			/>
-		);
+			it( 'defaults to generic link with non-arrays', () => {
+				// Return a non-array.
+				addFilter(
+					SETUP_TASK_HELP_ITEMS_FILTER,
+					testNamespace,
+					() => ( {} )
+				);
 
-		expect( unSupportedCountry.queryByText( /WooCommerce Shipping/ ) ).toBeNull();
+				const nonArray = render( <HelpPanel taskName="appearance" /> );
 
-		const supportedCountry = render(
-			<HelpPanel
-				activePlugins={ [] }
-				countryCode="US"
-				taskName="shipping"
-			/>
-		);
+				// Verify non-arrays default to generic docs link.
+				expect(
+					nonArray.getByText( 'WooCommerce Docs' )
+				).toBeDefined();
+			} );
 
-		expect( supportedCountry.getByText( /WooCommerce Shipping/ ) ).toBeDefined();
+			it( 'defaults to generic link with empty arrays', () => {
+				// Return an empty array.
+				addFilter(
+					SETUP_TASK_HELP_ITEMS_FILTER,
+					testNamespace,
+					() => []
+				);
+
+				const emptyArray = render(
+					<HelpPanel taskName="appearance" />
+				);
+
+				// Verify empty arrays default to generic docs link.
+				expect(
+					emptyArray.getByText( 'WooCommerce Docs' )
+				).toBeDefined();
+			} );
+
+			it( 'defaults to generic link with malformed arrays', () => {
+				// Return an malformed array.
+				addFilter( SETUP_TASK_HELP_ITEMS_FILTER, testNamespace, () => [
+					{
+						title: 'missing a link!',
+					},
+				] );
+
+				const badArray = render( <HelpPanel taskName="appearance" /> );
+
+				// Verify malformed arrays default to generic docs link.
+				expect(
+					badArray.getByText( 'WooCommerce Docs' )
+				).toBeDefined();
+			} );
+
+			it( 'allows help items to be replaced', () => {
+				// Replace all help items.
+				addFilter( SETUP_TASK_HELP_ITEMS_FILTER, testNamespace, () => [
+					{
+						title: 'There can only be one',
+						link: 'https://www.google.com/search?q=highlander',
+					},
+				] );
+
+				const replacedArray = render(
+					<HelpPanel taskName="appearance" />
+				);
+
+				// Verify filtered array.
+				expect(
+					replacedArray.queryByText( 'WooCommerce Docs' )
+				).toBeNull();
+				expect(
+					replacedArray.getByText( 'There can only be one' )
+				).toBeDefined();
+			} );
+		} );
 	} );
 } );

--- a/client/header/activity-panel/test/help-panel.js
+++ b/client/header/activity-panel/test/help-panel.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { HelpPanel } from '../panels/help';
+
+describe( 'Activity Panel > Help', () => {
+	it( 'only shows links for available payment methods', () => {
+		const fixtures = [
+			{
+				key: 'wcpay',
+				text: 'WooCommerce Payments',
+			},
+			{
+				key: 'stripe',
+				text: 'Stripe',
+			},
+			{
+				key: 'klarna_checkout',
+				text: 'Klarna',
+			},
+			{
+				key: 'klarna_payments',
+				text: 'Klarna',
+			},
+			{
+				key: 'paypal',
+				text: 'PayPal Checkout',
+			},
+			{
+				key: 'square',
+				text: 'Square',
+			},
+			{
+				key: 'payfast',
+				text: 'PayFast',
+			},
+		];
+
+		const noMethods = render(
+			<HelpPanel
+				getPaymentMethods={ () => ( [] ) }
+				taskName="payments"
+			/>
+		);
+
+		fixtures.forEach( method => {
+			expect( noMethods.queryAllByText( ( text ) => text.includes( method.text ) ) ).toHaveLength( 0 );
+		} );
+
+		fixtures.forEach( method => {
+			const { queryAllByText } = render(
+				<HelpPanel
+					getPaymentMethods={ () => ( [ method ] ) }
+					taskName="payments"
+				/>
+			);
+
+			expect( queryAllByText( ( text ) => text.includes( method.text ) ).length ).toBeGreaterThanOrEqual( 1 );
+		} );
+	} );
+
+	it( 'only shows links for automated tax when supported', () => {
+		const taxjarPluginEnabled = render(
+			<HelpPanel
+				countryCode="US"
+				getSetting={ () => ( {
+					automatedTaxSupportedCountries: [ 'US' ],
+					taxJarActivated: true,
+				} ) }
+				taskName="tax"
+			/>
+		);
+
+		expect( taxjarPluginEnabled.queryByText( /WooCommerce Services/ ) ).toBeNull();
+
+		const unSupportedCountry = render(
+			<HelpPanel
+				countryCode="NZ"
+				getSetting={ () => ( {
+					automatedTaxSupportedCountries: [ 'US' ],
+					taxJarActivated: false,
+				} ) }
+				taskName="tax"
+			/>
+		);
+
+		expect( unSupportedCountry.queryByText( /WooCommerce Services/ ) ).toBeNull();
+
+		const supportedCountry = render(
+			<HelpPanel
+				countryCode="US"
+				getSetting={ () => ( {
+					automatedTaxSupportedCountries: [ 'US' ],
+					taxJarActivated: false,
+				} ) }
+				taskName="tax"
+			/>
+		);
+
+		expect( supportedCountry.getByText( /WooCommerce Services/ ) ).toBeDefined();
+	} );
+
+	it( 'only shows links for WooCommerce Shipping when supported', () => {
+		const wcsActive = render(
+			<HelpPanel
+				activePlugins={ [ 'woocommerce-services' ] }
+				countryCode="US"
+				taskName="shipping"
+			/>
+		);
+
+		expect( wcsActive.queryByText( /WooCommerce Shipping/ ) ).toBeNull();
+
+		const unSupportedCountry = render(
+			<HelpPanel
+				activePlugins={ [ 'woocommerce-services' ] }
+				countryCode="UK"
+				taskName="shipping"
+			/>
+		);
+
+		expect( unSupportedCountry.queryByText( /WooCommerce Shipping/ ) ).toBeNull();
+
+		const supportedCountry = render(
+			<HelpPanel
+				activePlugins={ [] }
+				countryCode="US"
+				taskName="shipping"
+			/>
+		);
+
+		expect( supportedCountry.getByText( /WooCommerce Shipping/ ) ).toBeDefined();
+	} );
+} );

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ActivityPanel } from '../';
+
+describe( 'Activity Panel', () => {
+	it( 'should render inbox tab on embedded pages', () => {
+		render(
+			<ActivityPanel
+				isEmbedded
+				query={ {} }
+			/>
+		);
+
+		expect( screen.getByText( 'Inbox' ) ).toBeDefined();
+	} );
+
+	it( 'should render inbox tab if not on home screen', () => {
+		render(
+			<ActivityPanel
+				getHistory={ () => ( {
+					location: {
+						pathname: '/customers',
+					},
+				} ) }
+				query={ {} }
+			/>
+		);
+
+		expect( screen.getByText( 'Inbox' ) ).toBeDefined();
+	} );
+
+	it( 'should not render inbox tab on home screen', () => {
+		render(
+			<ActivityPanel
+				query={ {} }
+			/>
+		);
+
+		expect( screen.queryByText( 'Inbox' ) ).toBeNull();
+	} );
+
+	it ( 'should render help tab before options load', async () => {
+		render(
+			<ActivityPanel
+				requestingTaskListOptions
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		const tabs = await screen.findAllByRole( 'tab' );
+
+		// Expect that the only tab is "Help".
+		expect( tabs ).toHaveLength( 1 );
+		expect( screen.getByText( 'Help' ) ).toBeDefined();
+	} );
+
+	it ( 'should render help tab when on single task', async () => {
+		render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden={ false }
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		const tabs = await screen.findAllByRole( 'tab' );
+
+		// Expect that the only tab is "Help".
+		expect( tabs ).toHaveLength( 1 );
+		expect( screen.getByText( 'Help' ) ).toBeDefined();
+	} );
+
+	it ( 'should not render help tab when not on main route', () => {
+		render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden={ false }
+				query={ {
+					task: 'products',
+					path: '/customers',
+				} }
+			/>
+		);
+
+		// Expect that "Help" tab is absent.
+		expect( screen.queryByText( 'Help' ) ).toBeNull();
+	} );
+
+	it ( 'should not render help tab when TaskList is hidden', () => {
+		render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		// Expect that "Help" tab is absent.
+		expect( screen.queryByText( 'Help' ) ).toBeNull();
+	} );
+
+	it ( 'should not render help tab when TaskList is complete', () => {
+		render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete
+				taskListHidden={ false }
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		// Expect that "Help" tab is absent.
+		expect( screen.queryByText( 'Help' ) ).toBeNull();
+	} );
+} );

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -99,7 +99,7 @@ class Header extends Component {
 	}
 
 	render() {
-		const { sections, isEmbedded } = this.props;
+		const { sections, isEmbedded, query } = this.props;
 		const { isScrolled } = this.state;
 		const _sections = Array.isArray( sections ) ? sections : [ sections ];
 
@@ -136,7 +136,7 @@ class Header extends Component {
 					} ) }
 				</h1>
 				{ window.wcAdminFeatures[ 'activity-panels' ] && (
-					<ActivityPanel isEmbedded={ isEmbedded } />
+					<ActivityPanel isEmbedded={ isEmbedded } query={ query } />
 				) }
 			</div>
 		);

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -188,21 +188,20 @@ export class Controller extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const prevQuery = this.getQuery( prevProps.location.search );
 		const prevBaseQuery = omit(
-			this.getQuery( prevProps.location.search ),
+			prevProps.query,
 			'chartType',
 			'filter',
 			'paged'
 		);
 		const baseQuery = omit(
-			this.getQuery( this.props.location.search ),
+			this.props.query,
 			'chartType',
 			'filter',
 			'paged'
 		);
 
-		if ( prevQuery.paged > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
+		if ( prevProps.query.paged > 1 && ! isEqual( prevBaseQuery, baseQuery ) ) {
 			getHistory().replace( getNewPath( { paged: 1 } ) );
 		}
 
@@ -211,19 +210,9 @@ export class Controller extends Component {
 		}
 	}
 
-	getQuery( searchString ) {
-		if ( ! searchString ) {
-			return {};
-		}
-
-		const search = searchString.substring( 1 );
-		return parse( search );
-	}
-
 	render() {
-		const { page, match, location } = this.props;
+		const { page, match, query } = this.props;
 		const { url, params } = match;
-		const query = this.getQuery( location.search );
 
 		window.wpNavMenuUrlUpdate( query );
 		window.wpNavMenuClassChange( page, url );

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -120,9 +120,9 @@ class _Layout extends Component {
 
 	render() {
 		const { isEmbedded, ...restProps } = this.props;
-		const { breadcrumbs } = this.props.page;
-		const { search } = this.props.location;
-		const query = this.getQuery( search );
+		const { location, page } = this.props;
+		const { breadcrumbs } = page;
+		const query = this.getQuery( location && location.search );
 
 		return (
 			<div className="woocommerce-layout">

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -7,6 +7,7 @@ import { Component, lazy, Suspense } from '@wordpress/element';
 import { Router, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { get, isFunction, identity } from 'lodash';
+import { parse } from 'qs';
 
 /**
  * WooCommerce dependencies
@@ -108,9 +109,20 @@ class _Layout extends Component {
 		} );
 	}
 
+	getQuery( searchString ) {
+		if ( ! searchString ) {
+			return {};
+		}
+
+		const search = searchString.substring( 1 );
+		return parse( search );
+	}
+
 	render() {
 		const { isEmbedded, ...restProps } = this.props;
 		const { breadcrumbs } = this.props.page;
+		const { search } = this.props.location;
+		const query = this.getQuery( search );
 
 		return (
 			<div className="woocommerce-layout">
@@ -121,12 +133,13 @@ class _Layout extends Component {
 							: breadcrumbs
 					}
 					isEmbedded={ isEmbedded }
+					query={ query }
 				/>
 				<TransientNotices />
 				{ ! isEmbedded && (
 					<PrimaryLayout>
 						<div className="woocommerce-layout__main">
-							<Controller { ...restProps } />
+							<Controller { ...restProps } query={ query } />
 						</div>
 					</PrimaryLayout>
 				) }


### PR DESCRIPTION
Fixes #4593.

This PR seeks to implement most of the "nice to have" functionality described in #4539 

It does not include:
* Search box (it does include the "WooCommerce Docs" item on all help pages)
* Open a ticket button
* Start live chat button

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2020-07-08 at 4 03 25 PM](https://user-images.githubusercontent.com/63922/86965088-05071880-c135-11ea-8bbd-8eb071da4a13.png)

### Detailed test instructions:

- Ensure the Task List is shown
- Go to WooCommerce > Home
- Verify the "Help" tab is not shown
- Click a Task List item
- Verify only the "Help" tab is shown
- Click "Help"
- Verify the contents are relevant to the current task (use list in issue)
- Repeat for all tasks in issue
- Check conditional help items using issue as reference (e.g. WCS, specific payment gateways)
- Verify tracks event on Help tab open (in issue)
- Verify tracks event on help item click (in issue)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: show contextual help menu when working on store setup tasks.