### PR TITLE
Post-Release: Sync readme changelog, bump versions to 1.4.0-dev.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "1.3.0-beta.1",
+	"version": "1.4.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "1.3.0-beta.1",
+	"version": "1.4.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.3.0
 Tested up to: 5.4.1
 Requires PHP: 5.6.20
-Stable tag: 1.3.0-beta.1
+Stable tag: 1.3.0
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 
@@ -71,7 +71,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
-= 1.3.0-beta.1 2020-06-15 =
+= 1.3.0 2020-07-08 =
 - Enhancement: Add Jetpack stats to performance indicatorts / homepage #4291
 - Enhancement: New "Store Management" quick links card on WooCommerce home screen. #4350
 - Enhancement: Inbox notifications layout updates #4218

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Migrate user store to wp.data #4505
 - Dev: Add options data store to wp.data #4144
 - Dev: Runtime feature config override #4523
+- Dev: Check that the possibly_add_note function exists before calling it #4680
+- Dev: Remove unnecessary rest API init action. #4691
+- Dev: Don't include sourcemaps or unminified JS for "core" builds. #4642
 - Fix: misaligned 'required' text on selects #4307
 - Fix: exception when opening dashboard after selecting extensions to purchase #4357
 - Fix: REST API collections schema #4377
@@ -102,6 +105,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Solved a problem with the method onChoose in the last onboarding step. #4583
 - Fix: Only mark purchase task as complete when products exist #4574
 - Fix: Remove unnecessary rest_api_init action that caused incompatibility issues with other plugins. #4691
+- Fix: Fix WCPay sometimes not appearing on the task list #4647
 - Tweak: make revenue report total sales column optional #4397
 - Tweak: Adjustments to WooCommerce Payments setup task #4373
 - Tweak: Handling of plugin installs in OBW #4411
@@ -112,6 +116,9 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Use single dash for country/state dropdown options #4553
 - Tweak: Use label tag for toggleable shipping zones #4554
 - Tweak: Tweak - Make it easier to add submenu items to the Marketing menu #4561
+- Tweak: Remove duplicate/redundant inbox note after first order received. #4659
+- Tweak: Fix the embed page CSS so the top content sits better #4622
+
 
 = 1.2.4 2020-06-11 =
 - Tweak: reduce asset filename length and remove tilde characters. #4535

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Check for enabled methods before payment task completion #4530
 - Fix: Solved a problem with the method onChoose in the last onboarding step. #4583
 - Fix: Only mark purchase task as complete when products exist #4574
+- Fix: Remove unnecessary rest_api_init action that caused incompatibility issues with other plugins. #4691
 - Tweak: make revenue report total sales column optional #4397
 - Tweak: Adjustments to WooCommerce Payments setup task #4373
 - Tweak: Handling of plugin installs in OBW #4411

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -155,7 +155,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.3.0-beta.1' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.4.0-dev' );
 	}
 
 	/**

--- a/src/Package.php
+++ b/src/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.3.0-beta.1';
+	const VERSION = '1.4.0-dev';
 
 	/**
 	 * Package active.

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,12 +7,12 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 1.3.0-beta.1
+ * Version: 1.4.0-dev
  * Requires at least: 5.3.0
  * Requires PHP: 5.6.20
  *
  * WC requires at least: 3.6.0
- * WC tested up to: 4.0.0
+ * WC tested up to: 4.3.0
  *
  * @package WC_Admin
  */


### PR DESCRIPTION
Few little cleanup items to get updated after the release of 1.3.0.

The one item to note here is I'm using the same versioning pattern taken by core and bumping `main` to 1.4.0-dev. I'm thinking this should probably happen once a beta release branch is created in the future. This would likely help avoid version number conflicts when doing db delta migrations in the future too.

But other changes beside version number:
- Synced the final changelog that was released to wporg to readme.txt, and updated the final release date.
- Bumped the stable tag and `WC tested up to` to 4.3