### PR TITLE
Added warning message when there isn't a payment method set up

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -12,7 +12,7 @@ import { get, isFunction, identity } from 'lodash';
  * WooCommerce dependencies
  */
 import { useFilters, Spinner } from '@woocommerce/components';
-import { getHistory } from '@woocommerce/navigation';
+import { getHistory, getQuery } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import {
 	PLUGINS_STORE_NAME,
@@ -47,7 +47,7 @@ export class PrimaryLayout extends Component {
 			>
 				{ window.wcAdminFeatures[ 'store-alerts' ] && (
 					<Suspense fallback={ <Spinner /> }>
-						<StoreWarnings queryString={ document.location.search } />
+						<StoreWarnings queryString={ getQuery() } />
 						<StoreAlerts />
 					</Suspense>
 				) }

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -29,6 +29,9 @@ import Header from 'header';
 import Notices from './notices';
 import { recordPageView } from 'lib/tracks';
 import TransientNotices from './transient-notices';
+const StoreWarnings = lazy( () =>
+	import( /* webpackChunkName: "store-notices" */ './store-notices' )
+);
 const StoreAlerts = lazy( () =>
 	import( /* webpackChunkName: "store-alerts" */ './store-alerts' )
 );
@@ -44,6 +47,7 @@ export class PrimaryLayout extends Component {
 			>
 				{ window.wcAdminFeatures[ 'store-alerts' ] && (
 					<Suspense fallback={ <Spinner /> }>
+						<StoreWarnings queryString={ document.location.search } />
 						<StoreAlerts />
 					</Suspense>
 				) }

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -28,10 +28,10 @@ class StoreWarnings extends Component {
 	}
 
 	render() {
-		const showMissingPaimentMethod = this.isVisibleMissingPaimentWarning();
+		const showMissingPaymentMethod = this.isVisibleMissingPaimentWarning();
 
 		return (
-			showMissingPaimentMethod && (
+			showMissingPaymentMethod && (
 				<Notice
 					className="woocommerce-store-warnings"
 					status="warning"

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -16,13 +16,13 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
  */
 import './style.scss';
 import withSelect from 'wc-api/with-select';
-import { getUrlParams } from 'utils';
 
 class StoreWarnings extends Component {
 	isVisibleMissingPaimentWarning() {
 		const { taskListPayments, queryString } = this.props;
-		const urlParams = getUrlParams( queryString );
-		const isPaymentPage = urlParams.task ? urlParams.task === 'payments' : false;
+		const isPaymentPage = queryString.task
+			? queryString.task === 'payments'
+			: false;
 		return ! taskListPayments.completed && isPaymentPage;
 	}
 
@@ -36,19 +36,21 @@ class StoreWarnings extends Component {
 					status="warning"
 					isDismissible={ false }
 				>
-					<p>Customers cannot place orders at your store until you setup and enable a payment method.</p>
+					<p>
+						Customers cannot place orders at your store until you
+						setup and enable a payment method.
+					</p>
 				</Notice>
 			)
-			
 		);
 	}
 }
 
 StoreWarnings.propTypes = {
 	/**
-	 * The current url query string.
+	 * The url query string.
 	 */
-	queryString: PropTypes.string,
+	queryString: PropTypes.object,
 };
 
 export default compose(
@@ -58,5 +60,5 @@ export default compose(
 		return {
 			taskListPayments,
 		};
-	} ),
+	} )
 )( StoreWarnings );

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import PropTypes from 'prop-types';
+import { Notice } from '@wordpress/components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import withSelect from 'wc-api/with-select';
+import { getUrlParams } from 'utils';
+
+class StoreWarnings extends Component {
+	isVisibleMissingPaimentWarning() {
+		const { taskListPayments, queryString } = this.props;
+		const urlParams = getUrlParams( queryString );
+		const isPaymentPage = urlParams.task ? urlParams.task === 'payments' : false;
+		return ! taskListPayments.completed && isPaymentPage;
+	}
+
+	render() {
+		const showMissingPaimentMethod = this.isVisibleMissingPaimentWarning();
+
+		return (
+			showMissingPaimentMethod && (
+				<Notice
+					className="woocommerce-store-warnings"
+					status="warning"
+					isDismissible={ false }
+				>
+					<p>Customers cannot place orders at your store until you setup and enable a payment method.</p>
+				</Notice>
+			)
+			
+		);
+	}
+}
+
+StoreWarnings.propTypes = {
+	/**
+	 * The current url query string.
+	 */
+	queryString: PropTypes.string,
+};
+
+export default compose(
+	withSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		const taskListPayments = getOption( 'woocommerce_task_list_payments' );
+		return {
+			taskListPayments,
+		};
+	} ),
+)( StoreWarnings );

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
@@ -37,8 +38,10 @@ class StoreWarnings extends Component {
 					isDismissible={ false }
 				>
 					<p>
-						Customers cannot place orders at your store until you
-						setup and enable a payment method.
+						{ __(
+							'Customers cannot place orders at your store until you setup and enable a payment method.',
+							'woocommerce-admin'
+						) }
 					</p>
 				</Notice>
 			)

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -19,16 +19,8 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import './style.scss';
 
 class StoreWarnings extends Component {
-	isVisibleMissingPaimentWarning() {
-		const { paymentMethods, queryString } = this.props;
-		const isPaymentPage = queryString.task
-			? queryString.task === 'payments'
-			: false;
-		return ! Object.keys( paymentMethods ).length && isPaymentPage;
-	}
-
 	render() {
-		const showMissingPaymentMethod = this.isVisibleMissingPaimentWarning();
+		const { showMissingPaymentMethod } = this.props;
 
 		return (
 			showMissingPaymentMethod && (
@@ -57,7 +49,8 @@ StoreWarnings.propTypes = {
 };
 
 export default compose(
-	withSelect( ( select ) => {
+	withSelect( ( select, props ) => {
+		const { queryString } = props;
 		const { getOption } = select( OPTIONS_STORE_NAME );
 
 		const optionNames = [
@@ -95,8 +88,15 @@ export default compose(
 			}
 		}
 
+		const isPaymentPage = queryString.task
+			? queryString.task === 'payments'
+			: false;
+		const showMissingPaymentMethod =
+			! Object.keys( paymentMethods ).length && isPaymentPage;
+
 		return {
 			paymentMethods,
+			showMissingPaymentMethod,
 		};
 	} )
 )( StoreWarnings );

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -6,6 +6,7 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { Notice } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -16,7 +17,6 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
  * Internal dependencies
  */
 import './style.scss';
-import withSelect from 'wc-api/with-select';
 
 class StoreWarnings extends Component {
 	isVisibleMissingPaimentWarning() {

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -19,11 +19,11 @@ import withSelect from 'wc-api/with-select';
 
 class StoreWarnings extends Component {
 	isVisibleMissingPaimentWarning() {
-		const { taskListPayments, queryString } = this.props;
+		const { paymentMethods, queryString } = this.props;
 		const isPaymentPage = queryString.task
 			? queryString.task === 'payments'
 			: false;
-		return ! taskListPayments.completed && isPaymentPage;
+		return ! Object.keys( paymentMethods ).length && isPaymentPage;
 	}
 
 	render() {
@@ -56,10 +56,44 @@ StoreWarnings.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		const { getOption } = select( OPTIONS_STORE_NAME );
-		const taskListPayments =
-			getOption( 'woocommerce_task_list_payments' ) || {};
+
+		const optionNames = [
+			'woocommerce_stripe_alipay_settings',
+			'woocommerce_cheque_settings',
+			'woocommerce_paypal_settings',
+			'woocommerce_stripe_sepa_settings',
+			'woocommerce_stripe_bancontact_settings',
+			'woocommerce_stripe_sofort_settings',
+			'woocommerce_stripe_giropay_settings',
+			'woocommerce_stripe_eps_settings',
+			'woocommerce_stripe_ideal_settings',
+			'woocommerce_stripe_p24_settings',
+			'woocommerce_stripe_multibanco_settings',
+			'woocommerce_stripe_settings',
+			'woocommerce_ppec_paypal_settings',
+			'woocommerce_payfast_settings',
+			'woocommerce_square_credit_card_settings',
+			'woocommerce_kco_settings',
+			'woocommerce_cod_settings',
+			'woocommerce_bacs_settings',
+			'woocommerce_woocommerce_payments_settings',
+			'woocommerce_klarna_payments_settings',
+		];
+
+		const options = optionNames.reduce( ( result, name ) => {
+			result[ name ] = getOption( name );
+			return result;
+		}, {} );
+
+		const paymentMethods = {};
+		for ( const prop in options ) {
+			if ( options[ prop ] && options[ prop ].enabled === 'yes' ) {
+				paymentMethods[ prop ] = options[ prop ];
+			}
+		}
+
 		return {
-			taskListPayments,
+			paymentMethods,
 		};
 	} )
 )( StoreWarnings );

--- a/client/layout/store-notices/index.js
+++ b/client/layout/store-notices/index.js
@@ -56,7 +56,8 @@ StoreWarnings.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		const { getOption } = select( OPTIONS_STORE_NAME );
-		const taskListPayments = getOption( 'woocommerce_task_list_payments' );
+		const taskListPayments =
+			getOption( 'woocommerce_task_list_payments' ) || {};
 		return {
 			taskListPayments,
 		};

--- a/client/layout/store-notices/style.scss
+++ b/client/layout/store-notices/style.scss
@@ -1,0 +1,13 @@
+
+div.woocommerce-store-warnings {
+	margin: -44px -40px $gap-largest;
+	padding: 0 $gap;
+
+	@media (max-width: 960px) {
+		margin: -23px -23px $gap-largest;
+	}
+
+	@media (max-width: 782px) {
+		margin: -3px -16px $gap-largest;
+	}
+}


### PR DESCRIPTION
Fixes #4596

This PR adds a warning message for each page of the Payments task if payment methods are incomplete


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 07 08-16_22_11](https://user-images.githubusercontent.com/1314156/86961383-85c71400-c137-11ea-8dd3-73a60b4ce39c.png)


### Detailed test instructions:

- Go to the page: `Payment methods` (URL `/wp-admin/admin.php?page=wc-settings&tab=checkout`).
- Be sure, there isn't any payment method selected.
- Go to `home screen` / `dashboard` and press `Set up payments`.
- Verify the warning `Customers cannot place orders at your store until you setup and enable a payment method.` is visible.

![Screen Capture on 2020-07-08 at 18-04-23](https://user-images.githubusercontent.com/1314156/86970404-b6ae4580-c145-11ea-881b-871d99a6902d.gif)

- Go back to `home screen` / `dashboard` and verify the message is not visible anymore.

- Go to the `Payment methods` again and select a payment method.

- Go to `home screen` / `dashboard` and press `Set up payments`.
- Verify the warning message is not visible.

- Verify the message continues to look as expected in different screen widths.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Added warning message when there isn't a payment method set up
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
