### PR TITLE
Update store management links

### DIFF
--- a/client/quick-links/index.js
+++ b/client/quick-links/index.js
@@ -13,13 +13,13 @@ import {
 	megaphone,
 	box,
 	brush,
+	home,
 	shipping,
 	percent,
 	payment,
 	pencil,
 	lifesaver,
 	external,
-	chevronRight,
 } from '@wordpress/icons';
 import { partial } from 'lodash';
 
@@ -91,13 +91,15 @@ function getItems( props ) {
 			type: 'external',
 			href: 'https://woocommerce.com/my-account/create-a-ticket/',
 			icon: lifesaver,
+			after: <Icon icon={ external } />,
 			listItemTag: 'support',
 		},
 		{
 			title: __( 'View my store', 'woocommerce-admin' ),
 			type: 'external',
 			href: props.getSetting( 'siteUrl' ),
-			icon: external,
+			icon: home,
+			after: <Icon icon={ external } />,
 			listItemTag: 'view-store',
 		},
 	];
@@ -157,9 +159,13 @@ function getLinkTypeAndHref( item ) {
 function getListItems( props ) {
 	return getItems( props ).map( ( item ) => {
 		return {
-			title: <Text as="div" variant="button">{ item.title }</Text>,
+			title: (
+				<Text as="div" variant="button">
+					{ item.title }
+				</Text>
+			),
 			before: <Icon icon={ item.icon } />,
-			after: <Icon icon={ chevronRight } />,
+			after: item.after,
 			...getLinkTypeAndHref( item ),
 			listItemTag: item.listItemTag,
 			onClick: partial( handleOnItemClick, props ),


### PR DESCRIPTION
In our new WooCommerce navigation designs we're using the chevron icon to indicate when a menu item will reveal another panel via our "waterfall" pattern.

To promote consistency across our UX we should only use the chevron icon alongside that pattern moving forwards. Seeing as the items in the Store management card do not employ the waterfall pattern, we should remove the chevrons there so that we're ready for when the new navigation lands.

Before:
![before](https://cldup.com/8QSMzxKrYR-3000x3000.png)

After:
![after](https://cldup.com/hoqSdpgLiU-3000x3000.png)

Apologies if I butchered the code here but I replaced the chevrons with external icons for both of the `type: 'external'` links, and removed them for all other links.

I did notice however that those external links don't actually open new tabs currently. I'm not sure if that's something we should fix here or in the primitive component. Happy to open a new issue for that if necessary.
