### PR TITLE
Changed logic of "Set up payments" reminder

### DIFF
--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -11,8 +11,6 @@ namespace Automattic\WooCommerce\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Features\Onboarding;
-
 /**
  * WC_Admin_Notes_Onboarding_Payments.
  */
@@ -31,11 +29,6 @@ class WC_Admin_Notes_Onboarding_Payments {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		// This note should only be added if the task list is still shown.
-		if ( ! Onboarding::should_show_tasks() ) {
-			return;
-		}
-
 		// We want to show the note after five days.
 		if ( ! self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
 			return;

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -36,14 +36,8 @@ class WC_Admin_Notes_Onboarding_Payments {
 			return;
 		}
 
-		// Make sure payments task was skipped at least 3 days ago.
-		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
-		$payments_task         = get_option( 'woocommerce_task_list_payments', array() );
-		if (
-			! isset( $payments_task['skipped'] ) ||
-			! isset( $payments_task['timestamp'] ) ||
-			( time() - $payments_task['timestamp'] ) < $three_days_in_seconds
-		) {
+		// We want to show the note after five days.
+		if ( ! self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4653

This PR removes the use of `woocommerce_task_list_payments` from the note `Set up payments`.


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 07 09-15_48_27](https://user-images.githubusercontent.com/1314156/87078932-b6708180-c1fb-11ea-9ccf-6f9507e0c57a.png)


### Detailed test instructions:
1. Disable all payment methods. You can do it here: `/wp-admin/admin.php?page=wc-settings&tab=checkout`
1. The note will be triggered after 5 days of the store creation without having a payment method enabled.
1. Check that a note is added.
1.  Click on the "Learn more" button in the note and make sure the note is actioned and you are taken to the wc payment extensions page.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix Removed "woocommerce_task_list_payments" from the note "Set up payments".
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
