### PR TITLE
Highlight WooCommerce Payments task

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -33,7 +33,7 @@ import {
  */
 import './style.scss';
 import CartModal from 'dashboard/components/cart-modal';
-import { getAllTasks } from './tasks';
+import { getAllTasks, recordTaskViewEvent } from './tasks';
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
 
@@ -118,9 +118,11 @@ class TaskDashboard extends Component {
 			profileItems,
 			query,
 			taskListPayments,
+			activePlugins,
 			installedPlugins,
 			installAndActivatePlugins,
 			createNotice,
+			isJetpackConnected,
 		} = this.props;
 
 		return getAllTasks( {
@@ -128,40 +130,33 @@ class TaskDashboard extends Component {
 			taskListPayments,
 			query,
 			toggleCartModal: this.toggleCartModal.bind( this ),
+			activePlugins,
 			installedPlugins,
 			installAndActivatePlugins,
 			createNotice,
+			isJetpackConnected,
 		} ).filter( ( task ) => task.visible );
 	}
 
-	getPluginsInformation() {
+	recordTaskView() {
 		const {
 			isJetpackConnected,
 			activePlugins,
 			installedPlugins,
+			query,
 		} = this.props;
-		return {
-			wcs_installed: installedPlugins.includes( 'woocommerce-services' ),
-			wcs_active: activePlugins.includes( 'woocommerce-services' ),
-			jetpack_installed: installedPlugins.includes( 'jetpack' ),
-			jetpack_active: activePlugins.includes( 'jetpack' ),
-			jetpack_connected: isJetpackConnected,
-		};
-	}
+		const { task: taskName } = query;
 
-	recordTaskView() {
-		const { task } = this.props.query;
-		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const pluginsInformation = this.getPluginsInformation();
-
-		if ( ! task ) {
+		if ( ! taskName ) {
 			return;
 		}
 
-		recordEvent( 'task_view', {
-			task_name: task,
-			...pluginsInformation,
-		} );
+		recordTaskViewEvent(
+			taskName,
+			isJetpackConnected,
+			activePlugins,
+			installedPlugins
+		);
 	}
 
 	recordTaskListView() {
@@ -416,14 +411,17 @@ export default compose(
 			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 		const payments = getOption( 'woocommerce_task_list_payments' );
 
+		const activePlugins = getActivePlugins();
 		const installedPlugins = getInstalledPlugins();
 		const { createNotice } = props;
 		const tasks = getAllTasks( {
 			profileItems,
 			options: payments,
 			query: props.query,
+			activePlugins,
 			installedPlugins,
 			createNotice,
+			isJetpackConnected: isJetpackConnected(),
 		} );
 		const completedTaskKeys = tasks
 			.filter( ( task ) => task.completed )
@@ -431,7 +429,6 @@ export default compose(
 		const incompleteTasks = tasks.filter(
 			( task ) => task.visible && ! task.completed
 		);
-		const activePlugins = getActivePlugins();
 
 		return {
 			modalDismissed,

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -119,6 +119,8 @@ class TaskDashboard extends Component {
 			query,
 			taskListPayments,
 			installedPlugins,
+			installAndActivatePlugins,
+			createNotice,
 		} = this.props;
 
 		return getAllTasks( {
@@ -127,6 +129,8 @@ class TaskDashboard extends Component {
 			query,
 			toggleCartModal: this.toggleCartModal.bind( this ),
 			installedPlugins,
+			installAndActivatePlugins,
+			createNotice,
 		} ).filter( ( task ) => task.visible );
 	}
 
@@ -413,11 +417,13 @@ export default compose(
 		const payments = getOption( 'woocommerce_task_list_payments' );
 
 		const installedPlugins = getInstalledPlugins();
+		const { createNotice } = props;
 		const tasks = getAllTasks( {
 			profileItems,
 			options: payments,
 			query: props.query,
 			installedPlugins,
+			createNotice,
 		} );
 		const completedTaskKeys = tasks
 			.filter( ( task ) => task.completed )
@@ -441,8 +447,13 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
+		const { createNotice } = dispatch( 'core/notices' );
+
 		return {
 			updateOptions,
+			installAndActivatePlugins,
+			createNotice,
 		};
 	} )
 )( TaskDashboard );


### PR DESCRIPTION
Partially addresses #4597

If WooCommerce Payments is installed, this replaces the "Set up payments" task with a "Set up WooCommerce Payments" task which redirects straight to the WooCommerce Payments setup flow.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/87105412-40712680-c29e-11ea-9b61-b5c465431c21.png)

### Detailed test instructions:

1. Make sure the WooCommerce Payments plugin isn't installed
2. Go to the home page and make sure the "Set up payments" step is present and the "Set up WooCommerce Payments" step is not present
3. Install WooCommerce Payments - you can do this by going in to "Set up payments" and setting up WooCommerce Payments from that screen
4. Go back to the home page and make sure the "Set up WooCommerce Payments" step is present and the "Set up payments" step is not present
5. Select the "Set up WooCommerce Payments" step and verify that it takes you to the WooCommerce Payments setup flow
