### PR TITLE
Admin note to install other payment providers

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -195,8 +195,27 @@ class TaskDashboard extends Component {
 	}
 
 	getCurrentTask() {
-		const { task } = this.props.query;
-		const currentTask = this.getTasks().find( ( s ) => s.key === task );
+		const {
+			query,
+			profileItems,
+			payments,
+			activePlugins,
+			installedPlugins,
+			createNotice,
+			isJetpackConnected,
+		} = this.props;
+		const allTasks = getAllTasks( {
+			profileItems,
+			options: payments,
+			query,
+			activePlugins,
+			installedPlugins,
+			createNotice,
+			isJetpackConnected,
+		} );
+		const { task } = query;
+		
+		const currentTask = allTasks.find( ( s ) => s.key === task );
 
 		if ( ! currentTask ) {
 			return null;
@@ -437,6 +456,7 @@ export default compose(
 			completedTaskKeys,
 			activePlugins,
 			installedPlugins,
+			payments,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -20,6 +20,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Draw_Attention;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Coupon_Page_Moved;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Home_Screen_Feedback;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Set_Up_Additional_Payment_Types;
 
 /**
  * Feature plugin main class.
@@ -192,6 +193,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Install_JP_And_WCS_Plugins();
 		new WC_Admin_Notes_Draw_Attention();
 		new WC_Admin_Notes_Home_Screen_Feedback();
+		new WC_Admin_Notes_Set_Up_Additional_Payment_Types();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -88,4 +88,20 @@ trait NoteTraits {
 	public static function add_note() {
 		self::possibly_add_note();
 	}
+
+	/**
+	 * Possibly delete the note, if it exists in the database. Note that this
+	 * is a hard delete, for where it doesn't make sense to soft delete or
+	 * action the note.
+	 */
+	public static function possibly_delete_note() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		foreach ( $note_ids as $note_id ) {
+			$note = new WC_Admin_Note( $note_id );
+
+			$data_store->delete( $note );
+		}
+	}
 }

--- a/src/Notes/WC_Admin_Notes_Set_Up_Additional_Payment_Types.php
+++ b/src/Notes/WC_Admin_Notes_Set_Up_Additional_Payment_Types.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Add a note to the merchant's inbox prompting them to set up additional
+ * payment types if they have WooCommerce Payments activated.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Set_Up_Additional_Payment_Types
+ */
+class WC_Admin_Notes_Set_Up_Additional_Payment_Types {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-set-up-additional-payment-types';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action(
+			'activate_woocommerce-payments/woocommerce-payments.php',
+			array(
+				$this,
+				'on_activate_wcpay',
+			)
+		);
+		add_action(
+			'deactivate_woocommerce-payments/woocommerce-payments.php',
+			array(
+				$this,
+				'on_deactivate_wcpay',
+			)
+		);
+	}
+
+	/**
+	 * Executes when the WooCommerce Payments plugin is activated. Possibly
+	 * adds the note if it isn't already in the database and if it matches any
+	 * criteria (see get_note()).
+	 */
+	public static function on_activate_wcpay() {
+		self::possibly_add_note();
+	}
+
+	/**
+	 * Executes when the WooCommerce Payments plugin is deactivated. Possibly
+	 * hard-deletes the note if it is in the database. Hard-delete is used
+	 * instead of soft-delete or actioning the note because we need to
+	 * show the note if the plugin is activated again.
+	 */
+	public static function on_deactivate_wcpay() {
+		self::possibly_delete_note();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$content = __( 'Set up additional payment providers, using third-party services or other methods.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+
+		$note->set_title( __( 'Set up additional payment providers', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'set-up-payments',
+			__( 'Set up payments', 'woocommerce-admin' ),
+			wc_admin_url( '&task=payments' ),
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4597

This creates a note when the WooCommerce Payments plugin is activated. After #4793 the "Set up payments" task is hidden when the WooCommerce Payments plugin is activated, so this gives a method of installing other payment providers.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/87129163-408c1900-c2d4-11ea-85e9-d73bf0e85c4e.png)

### Detailed test instructions:

1. Deactivate the WooCommerce Payments plugin if it is installed
2. Check that the "set up additional payment types" note isn't shown in the inbox
3. Activate the WooCommerce Payments plugin
4. Check that the "set up additional payment types" not is now shown in the inbox
5. Check that clicking the "Set up payments" action navigates to the Payments task screen
