### PR TITLE
Onboarding: Center continue buttons in profile wizard

### DIFF
--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -238,6 +238,7 @@ class Industry extends Component {
 						isPrimary
 						onClick={ this.onContinue }
 						disabled={ ! selected.length }
+						className="woocommerce-profile-wizard__continue"
 					>
 						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
@@ -249,7 +250,9 @@ class Industry extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getProfileItems, getOnboardingError } = select( ONBOARDING_STORE_NAME );
+		const { getProfileItems, getOnboardingError } = select(
+			ONBOARDING_STORE_NAME
+		);
 		const { getSettings } = select( SETTINGS_STORE_NAME );
 		const { general: locationSettings = {} } = getSettings( 'general' );
 

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -234,14 +234,15 @@ class Industry extends Component {
 						) }
 					</div>
 
-					<Button
-						isPrimary
-						onClick={ this.onContinue }
-						disabled={ ! selected.length }
-						className="woocommerce-profile-wizard__continue"
-					>
-						{ __( 'Continue', 'woocommerce-admin' ) }
-					</Button>
+					<div className="woocommerce-profile-wizard__card-actions">
+						<Button
+							isPrimary
+							onClick={ this.onContinue }
+							disabled={ ! selected.length }
+						>
+							{ __( 'Continue', 'woocommerce-admin' ) }
+						</Button>
+					</div>
 				</Card>
 			</Fragment>
 		);

--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -176,14 +176,15 @@ class ProductTypes extends Component {
 						) }
 					</div>
 
-					<Button
-						isPrimary
-						onClick={ this.onContinue }
-						disabled={ ! selected.length }
-						className="woocommerce-profile-wizard__continue"
-					>
-						{ __( 'Continue', 'woocommerce-admin' ) }
-					</Button>
+					<div className="woocommerce-profile-wizard__card-actions">
+						<Button
+							isPrimary
+							onClick={ this.onContinue }
+							disabled={ ! selected.length }
+						>
+							{ __( 'Continue', 'woocommerce-admin' ) }
+						</Button>
+					</div>
 				</Card>
 			</Fragment>
 		);

--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -27,8 +27,9 @@ class ProductTypes extends Component {
 		const profileItems = get( props, 'profileItems', {} );
 
 		const { productTypes = {} } = getSetting( 'onboarding', {} );
-		const defaultProductTypes = Object.keys( productTypes )
-			.filter( key => !! productTypes[ key ].default );
+		const defaultProductTypes = Object.keys( productTypes ).filter(
+			( key ) => !! productTypes[ key ].default
+		);
 
 		this.state = {
 			error: null,
@@ -137,19 +138,19 @@ class ProductTypes extends Component {
 											.more_url ? (
 												<Link
 													href={
-														productTypes[ slug ]
-															.more_url
-													}
+													productTypes[ slug ]
+														.more_url
+												}
 													target="_blank"
 													type="external"
 													onClick={ () =>
-														this.onLearnMore( slug )
-													}
-												>
+													this.onLearnMore( slug )
+												}
+											>
 													{ __(
-														'Learn more',
-														'woocommerce-admin'
-													) }
+													'Learn more',
+													'woocommerce-admin'
+												) }
 												</Link>
 										) : (
 											''
@@ -179,6 +180,7 @@ class ProductTypes extends Component {
 						isPrimary
 						onClick={ this.onContinue }
 						disabled={ ! selected.length }
+						className="woocommerce-profile-wizard__continue"
 					>
 						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
@@ -190,7 +192,9 @@ class ProductTypes extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getProfileItems, getOnboardingError } = select( ONBOARDING_STORE_NAME );
+		const { getProfileItems, getOnboardingError } = select(
+			ONBOARDING_STORE_NAME
+		);
 
 		return {
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),

--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -221,6 +221,7 @@ class StoreDetails extends Component {
 									isPrimary
 									onClick={ handleSubmit }
 									disabled={ ! isValidForm }
+									className="woocommerce-profile-wizard__continue"
 								>
 									{ __( 'Continue', 'woocommerce-admin' ) }
 								</Button>

--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -217,14 +217,18 @@ class StoreDetails extends Component {
 									/>
 								</div>
 
-								<Button
-									isPrimary
-									onClick={ handleSubmit }
-									disabled={ ! isValidForm }
-									className="woocommerce-profile-wizard__continue"
-								>
-									{ __( 'Continue', 'woocommerce-admin' ) }
-								</Button>
+								<div className="woocommerce-profile-wizard__card-actions">
+									<Button
+										isPrimary
+										onClick={ handleSubmit }
+										disabled={ ! isValidForm }
+									>
+										{ __(
+											'Continue',
+											'woocommerce-admin'
+										) }
+									</Button>
+								</div>
 							</Fragment>
 						) }
 					</Form>

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -3,11 +3,6 @@
 		color: $studio-pink-50;
 	}
 
-	.woocommerce-profile-wizard__continue {
-		display: block;
-		margin: 0 auto;
-	}
-
 	.woocommerce-card {
 		margin-top: $gap;
 

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -1,8 +1,11 @@
-
-
 .woocommerce-profile-wizard__body {
 	.woocommerce-profile-wizard__container a {
 		color: $studio-pink-50;
+	}
+
+	.woocommerce-profile-wizard__continue {
+		display: block;
+		margin: 0 auto;
 	}
 
 	.woocommerce-card {


### PR DESCRIPTION
Fixes #4635

This PR centers the continue buttons at the bottom of the onboarding profile wizard.

### Screenshots

#### Before

<img width="1318" alt="ScreenCapture at Mon Jul 13 19:56:21 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87365303-e5f8f400-c543-11ea-8f91-09007bd79c83.png">

<img width="1318" alt="ScreenCapture at Mon Jul 13 19:56:49 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87365300-e42f3080-c543-11ea-9c59-849a86bf4b76.png">

#### After

<img width="1318" alt="ScreenCapture at Mon Jul 13 19:59:08 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87365345-fe690e80-c543-11ea-996f-7f5ef9ce7f89.png">

<img width="1318" alt="ScreenCapture at Mon Jul 13 19:59:25 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87365343-fdd07800-c543-11ea-875f-3f71ca8676a3.png">


### Detailed test instructions:

- Run branch.
- Go through the onboarding profile wizard. If you need to, force the wizard to display by enabling it on the Orders page: (`/wp-admin/edit.php?post_type=shop_order`)

<img width="1159" alt="ScreenCapture at Mon Jul 13 20:05:52 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87365486-60297880-c544-11ea-8b38-42cc27dec5dc.png">

- Verify that the continue buttons at the bottom of the profile wizard are centered.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Center continue buttons in the onboarding profile wizard.