### PR TITLE
Add option to automatically create a PayPal account

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -417,6 +417,11 @@
 	}
 }
 
+.woocommerce-task-payments__paypal-auto-create-account {
+	margin-top: $gap;
+	margin-bottom: $gap;
+}
+
 .woocommerce-task-payment-wcpay.woocommerce-task-payment-not-configured {
 	background-color: $studio-woocommerce-purple-80;
 

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -209,8 +209,14 @@ export function getPaymentMethods( {
 			container: <PayPal />,
 			isConfigured:
 				options.woocommerce_ppec_paypal_settings &&
-				options.woocommerce_ppec_paypal_settings.api_username &&
-				options.woocommerce_ppec_paypal_settings.api_password,
+				( (
+						options.woocommerce_ppec_paypal_settings.reroute_requests &&
+						options.woocommerce_ppec_paypal_settings.email
+				) ||
+				(
+						options.woocommerce_ppec_paypal_settings.api_username &&
+						options.woocommerce_ppec_paypal_settings.api_password
+				) ),
 			isEnabled:
 				options.woocommerce_ppec_paypal_settings &&
 				options.woocommerce_ppec_paypal_settings.enabled === 'yes',

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -102,6 +102,7 @@ export class PayPal extends Component {
 			if ( ! result || ! result.connectUrl ) {
 				this.setState( {
 					autoConnectFailed: true,
+					isPending: false,
 				} );
 				return;
 			}

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -18,7 +18,7 @@ import { getQuery } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import { PLUGINS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 
-class PayPal extends Component {
+export class PayPal extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -68,7 +68,6 @@ class PayPal extends Component {
 			activePlugins.includes(
 				'woocommerce-gateway-paypal-express-checkout'
 			)
-			// TODO: check for active WCS here?
 		) {
 			this.fetchOAuthConnectURL();
 		}
@@ -208,7 +207,6 @@ class PayPal extends Component {
 		const canAutoCreate = this.isWooCommerceServicesConnected();
 		const initialValues = this.getInitialConfigValues();
 
-		// TODO: break this up into multiple functions?
 		return (
 			<Form
 				initialValues={ initialValues }

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -191,67 +191,6 @@ class PayPal extends Component {
 		return errors;
 	}
 
-	renderManualConfig() {
-		const { isOptionsUpdating } = this.props;
-		const link = (
-			<Link
-				href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-8"
-				target="_blank"
-				type="external"
-			/>
-		);
-		const help = interpolateComponents( {
-			mixedString: __(
-				'Your API details can be obtained from your {{link}}PayPal account{{/link}}',
-				'woocommerce-admin'
-			),
-			components: {
-				link,
-			},
-		} );
-
-		return (
-			<Form
-				initialValues={ this.getInitialConfigValues() }
-				onSubmitCallback={ this.updateSettings }
-				validate={ this.validate }
-			>
-				{ ( { getInputProps, handleSubmit } ) => {
-					return (
-						<Fragment>
-							<TextControl
-								label={ __(
-									'API Username',
-									'woocommerce-admin'
-								) }
-								required
-								{ ...getInputProps( 'api_username' ) }
-							/>
-							<TextControl
-								label={ __(
-									'API Password',
-									'woocommerce-admin'
-								) }
-								required
-								{ ...getInputProps( 'api_password' ) }
-							/>
-
-							<Button
-								onClick={ handleSubmit }
-								isPrimary
-								isBusy={ isOptionsUpdating }
-							>
-								{ __( 'Proceed', 'woocommerce-admin' ) }
-							</Button>
-
-							<p>{ help }</p>
-						</Fragment>
-					);
-				} }
-			</Form>
-		);
-	}
-
 	renderAutomaticConfig() {
 		const { isOptionsUpdating } = this.props;
 		const { autoConnectFailed, connectURL, isPending } = this.state;

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -180,7 +180,6 @@ class PayPal extends Component {
 		if (
 			this.isWooCommerceServicesConnected() &&
 			values.create_account &&
-			values.account_email.length &&
 			! isEmail( values.account_email )
 		) {
 			errors.account_email = __(

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -74,10 +74,11 @@ export class PayPal extends Component {
 	}
 
 	isWooCommerceServicesConnected() {
-		const { activePlugins, isJetpackConnected } = this.props;
+		const { activePlugins, isJetpackConnected, wcsTosAccepted } = this.props;
 
 		return (
 			isJetpackConnected &&
+			wcsTosAccepted &&
 			activePlugins.includes( 'woocommerce-services' )
 		);
 	}
@@ -241,7 +242,7 @@ export class PayPal extends Component {
 
 							{ ! isPending &&
 								( autoConnectFailed || ! connectURL ) &&
-								! values.create_account && (
+								( ! canAutoCreate || ! values.create_account ) && (
 									<Fragment>
 										<TextControl
 											label={ __(
@@ -310,7 +311,7 @@ export class PayPal extends Component {
 
 							{ ! autoConnectFailed &&
 								connectURL &&
-								! values.create_account && (
+								( ! canAutoCreate || ! values.create_account ) && (
 									<Fragment>
 										<Button isPrimary href={ connectURL }>
 											{ __(
@@ -370,14 +371,16 @@ export default compose(
 		const { getActivePlugins, isJetpackConnected } = select(
 			PLUGINS_STORE_NAME
 		);
-		const options = getOption( 'woocommerce_ppec_paypal_settings' );
+		const paypalOptions = getOption( 'woocommerce_ppec_paypal_settings' );
+		const wcsOptions = getOption( 'wc_connect_options' );
 		const activePlugins = getActivePlugins();
 
 		return {
 			activePlugins,
 			isJetpackConnected: isJetpackConnected(),
 			isOptionsUpdating: isOptionsUpdating(),
-			options,
+			options: paypalOptions,
+			wcsTosAccepted: wcsOptions && wcsOptions.tos_accepted,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -164,13 +164,13 @@ class PayPal extends Component {
 	validate( values ) {
 		const errors = {};
 
-		if ( ! values.api_username ) {
+		if ( ! values.create_account && ! values.api_username ) {
 			errors.api_username = __(
 				'Please enter your API username',
 				'woocommerce-admin'
 			);
 		}
-		if ( ! values.api_password ) {
+		if ( ! values.create_account && ! values.api_password ) {
 			errors.api_password = __(
 				'Please enter your API password',
 				'woocommerce-admin'

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -126,13 +126,23 @@ class PayPal extends Component {
 			markConfigured,
 		} = this.props;
 
+		const optionValues = {
+			...options.woocommerce_ppec_paypal_settings,
+			enabled: 'yes',
+		};
+
+		if ( values.create_account ) {
+			// Tell WCS to proxy payment requests.
+			// See: https://github.com/Automattic/woocommerce-services/blob/29dfe0ba6fd3075afe08f917a6ff33c321502d9c/classes/class-wc-connect-paypal-ec.php#L53.
+			optionValues.reroute_requests = 'yes';
+			optionValues.email = values.account_email;
+		} else {
+			optionValues.api_username = values.api_username;
+			optionValues.api_password = values.api_password;
+		}
+
 		const update = await updateOptions( {
-			woocommerce_ppec_paypal_settings: {
-				...options.woocommerce_ppec_paypal_settings,
-				api_username: values.api_username,
-				api_password: values.api_password,
-				enabled: 'yes',
-			},
+			woocommerce_ppec_paypal_settings: optionValues,
 		} );
 
 		if ( update.success ) {

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -218,24 +218,25 @@ export class PayPal extends Component {
 					return (
 						<Fragment>
 							{ canAutoCreate && (
-								<CheckboxControl
-									label={ __(
-										'Create a PayPal account for me',
-										'woocommerce-admin'
+								<div className="woocommerce-task-payments__paypal-auto-create-account">
+									<CheckboxControl
+										label={ __(
+											'Create a PayPal account for me',
+											'woocommerce-admin'
+										) }
+										{ ...getInputProps( 'create_account' ) }
+									/>
+									{ values.create_account && (
+										<TextControl
+											label={ __(
+												'Email address',
+												'woocommerce-admin'
+											) }
+											type="email"
+											{ ...getInputProps( 'account_email' ) }
+										/>
 									) }
-									{ ...getInputProps( 'create_account' ) }
-								/>
-							) }
-
-							{ canAutoCreate && values.create_account && (
-								<TextControl
-									label={ __(
-										'Email address',
-										'woocommerce-admin'
-									) }
-									type="email"
-									{ ...getInputProps( 'account_email' ) }
-								/>
+								</div>
 							) }
 
 							{ ! isPending &&

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -1,16 +1,18 @@
 /**
  * External dependenices
  */
-import { render } from '@testing-library/react';
-import * as domMatchers from '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+// @todo: Figure out conflict with Enzyme for global config.
+import '@testing-library/jest-dom/extend-expect';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
 
 /**
  * Internal dependenices
  */
 import { PayPal } from '../tasks/payments/paypal';
-
-// @todo: Figure out conflict with Enzyme for global config.
-expect.extend( domMatchers );
 
 describe( 'TaskList > Payments', () => {
 	describe( 'PayPal', () => {
@@ -22,12 +24,13 @@ describe( 'TaskList > Payments', () => {
 			label: 'Install',
 		};
 
-		it( 'shows "create account" when Jetpack and WCS are connected', () => {
-			jest.mock( '@wordpress/api-fetch', () => jest.fn().mockResolvedValue( {
-				connectUrl: '#testing',
-			} ) );
+		it( 'shows "create account" when Jetpack and WCS are connected', async () => {
+			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
+			apiFetch.mockResolvedValue( {
+				connectUrl: mockConnectUrl,
+			} );
 
-			const { getByLabelText } = render(
+			render(
 				<PayPal
 					activePlugins={ [
 						'jetpack',
@@ -39,7 +42,154 @@ describe( 'TaskList > Payments', () => {
 				/>
 			);
 
-			expect( getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeChecked();
+			// By default, the "create account" is checked.
+			expect( screen.getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeChecked();
+			expect( screen.getByLabelText( 'Email address', { selector: 'input' } ) ).toBeDefined();
+			expect( screen.getByText( 'Create account', { selector: 'button' } ) ).toBeDefined();
+
+			// The email input should disappear when "create account" is unchecked.
+			user.click( screen.getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) );
+			expect( screen.queryByLabelText( 'Email address', { selector: 'input' } ) ).toBeNull();
+
+			// Since the oauth response was mocked, we should have a "connect" button.
+			const oauthButton = await screen.findByText( 'Connect', { selector: 'a' } );
+			expect( oauthButton ).toBeDefined();
+			expect( oauthButton.href ).toEqual( mockConnectUrl );
+		} );
+
+		it( 'validates "create account" form and persists PayPal options', async () => {
+			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
+			apiFetch.mockResolvedValue( {
+				connectUrl: mockConnectUrl,
+			} );
+
+			const mockUpdateOptions = jest.fn().mockResolvedValue( { success: true } );
+			const mockCreateNotice = jest.fn();
+			const mockMarkConfigured = jest.fn();
+			const mockOptions = {
+				woocommerce_ppec_paypal_settings: {
+					test: 'yes',
+				},
+			};
+
+			render(
+				<PayPal
+					activePlugins={ [
+						'jetpack',
+						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-services',
+					] }
+					installStep={ mockInstallStep }
+					isJetpackConnected
+					options={ mockOptions }
+					createNotice={ mockCreateNotice }
+					markConfigured={ mockMarkConfigured }
+					updateOptions={ mockUpdateOptions }
+				/>
+			);
+
+			const createButton = screen.getByText( 'Create account', { selector: 'button' } );
+			const emailInput = screen.getByLabelText( 'Email address', { selector: 'input' } );
+
+			// Verify empty emails are invalid.
+			user.click( createButton );
+			expect( await screen.findByText( 'Please enter a valid email address' ) ).toBeDefined();
+			expect( mockUpdateOptions ).not.toHaveBeenCalled();
+
+			// Verify non-empty email validation.
+			await user.type( emailInput, 'not an email' );
+			user.click( createButton );
+			expect( await screen.findByText( 'Please enter a valid email address' ) ).toBeDefined();
+			expect( mockUpdateOptions ).not.toHaveBeenCalled();
+
+			// Submit a good email.
+			user.clear( emailInput );
+			await user.type( emailInput, 'owner@store.com' );
+			user.click( createButton );
+			expect( screen.queryByText( 'Please enter a valid email address' ) ).toBeNull();
+
+			// Trick to wait for the async code to call updateOption().
+			await waitFor( () => expect( mockUpdateOptions ).toHaveBeenCalledTimes( 1 ) );
+
+			// Verify the persisted options.
+			expect( mockUpdateOptions ).toHaveBeenCalledWith( {
+				woocommerce_ppec_paypal_settings: {
+					email: 'owner@store.com',
+					enabled: 'yes',
+					reroute_requests: 'yes',
+					test: 'yes', // Makes sure we're extending the retrieved settings.
+				},
+			} );
+		} );
+
+		it( 'shows API credential inputs when "create account" opted out and OAuth fetch fails', async () => {
+			apiFetch.mockResolvedValue( false );
+
+			render(
+				<PayPal
+					activePlugins={ [
+						'jetpack',
+						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-services',
+					] }
+					installStep={ mockInstallStep }
+					isJetpackConnected
+				/>
+			);
+
+			// The email input should disappear when "create account" is unchecked.
+			user.click( screen.getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) );
+			expect( screen.queryByLabelText( 'Email address', { selector: 'input' } ) ).toBeNull();
+
+			// Since the oauth response failed, we should have the API credentials form.
+			expect( await screen.findByText( 'Proceed', { selector: 'button' } ) ).toBeDefined();
+			expect( screen.getByLabelText( 'API Username', { selector: 'input' } ) ).toBeDefined();
+			expect( screen.getByLabelText( 'API Password', { selector: 'input' } ) ).toBeDefined();
+		} );
+
+		it( 'shows OAuth connect button', async () => {
+			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
+			apiFetch.mockResolvedValue( {
+				connectUrl: mockConnectUrl,
+			} );
+
+			render(
+				<PayPal
+					activePlugins={ [
+						'woocommerce-gateway-paypal-express-checkout',
+					] }
+					installStep={ mockInstallStep }
+				/>
+			);
+
+			// Verify the "create account" option is absent.
+			expect( screen.queryByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeNull();
+
+			// Since the oauth response was mocked, we should have a "connect" button.
+			const oauthButton = await screen.findByText( 'Connect', { selector: 'a' } );
+			expect( oauthButton ).toBeDefined();
+			expect( oauthButton.href ).toEqual( mockConnectUrl );
+		} );
+
+		it( 'shows API credential inputs when OAuth fetch fails', async () => {
+			apiFetch.mockResolvedValue( false );
+
+			render(
+				<PayPal
+					activePlugins={ [
+						'woocommerce-gateway-paypal-express-checkout',
+					] }
+					installStep={ mockInstallStep }
+				/>
+			);
+
+			// Verify the "create account" option is absent.
+			expect( screen.queryByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeNull();
+
+			// Since the oauth response failed, we should have the API credentials form.
+			expect( await screen.findByText( 'Proceed', { selector: 'button' } ) ).toBeDefined();
+			expect( screen.getByLabelText( 'API Username', { selector: 'input' } ) ).toBeDefined();
+			expect( screen.getByLabelText( 'API Password', { selector: 'input' } ) ).toBeDefined();
 		} );
 	} );
 } );

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -1,0 +1,45 @@
+/**
+ * External dependenices
+ */
+import { render } from '@testing-library/react';
+import * as domMatchers from '@testing-library/jest-dom';
+
+/**
+ * Internal dependenices
+ */
+import { PayPal } from '../tasks/payments/paypal';
+
+// @todo: Figure out conflict with Enzyme for global config.
+expect.extend( domMatchers );
+
+describe( 'TaskList > Payments', () => {
+	describe( 'PayPal', () => {
+		afterEach( () => jest.clearAllMocks() );
+
+		const mockInstallStep = {
+			isComplete: true,
+			key: 'install',
+			label: 'Install',
+		};
+
+		it( 'shows "create account" when Jetpack and WCS are connected', () => {
+			jest.mock( '@wordpress/api-fetch', () => jest.fn().mockResolvedValue( {
+				connectUrl: '#testing',
+			} ) );
+
+			const { getByLabelText } = render(
+				<PayPal
+					activePlugins={ [
+						'jetpack',
+						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-services',
+					] }
+					installStep={ mockInstallStep }
+					isJetpackConnected
+				/>
+			);
+
+			expect( getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeChecked();
+		} );
+	} );
+} );

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -39,6 +39,7 @@ describe( 'TaskList > Payments', () => {
 					] }
 					installStep={ mockInstallStep }
 					isJetpackConnected
+					wcsTosAccepted
 				/>
 			);
 
@@ -50,6 +51,34 @@ describe( 'TaskList > Payments', () => {
 			// The email input should disappear when "create account" is unchecked.
 			user.click( screen.getByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) );
 			expect( screen.queryByLabelText( 'Email address', { selector: 'input' } ) ).toBeNull();
+
+			// Since the oauth response was mocked, we should have a "connect" button.
+			const oauthButton = await screen.findByText( 'Connect', { selector: 'a' } );
+			expect( oauthButton ).toBeDefined();
+			expect( oauthButton.href ).toEqual( mockConnectUrl );
+		} );
+
+		it( 'requires WCS to have TOS accepted to show "create account"', async () => {
+			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
+			apiFetch.mockResolvedValue( {
+				connectUrl: mockConnectUrl,
+			} );
+
+			render(
+				<PayPal
+					activePlugins={ [
+						'jetpack',
+						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-services',
+					] }
+					installStep={ mockInstallStep }
+					isJetpackConnected
+					wcsTosAccepted={ false }
+				/>
+			);
+
+			// Verify "create account" isn't shown.
+			expect( screen.queryByLabelText( 'Create a PayPal account for me', { selector: 'input' } ) ).toBeNull();
 
 			// Since the oauth response was mocked, we should have a "connect" button.
 			const oauthButton = await screen.findByText( 'Connect', { selector: 'a' } );
@@ -81,6 +110,7 @@ describe( 'TaskList > Payments', () => {
 					] }
 					installStep={ mockInstallStep }
 					isJetpackConnected
+					wcsTosAccepted
 					options={ mockOptions }
 					createNotice={ mockCreateNotice }
 					markConfigured={ mockMarkConfigured }
@@ -134,6 +164,7 @@ describe( 'TaskList > Payments', () => {
 					] }
 					installStep={ mockInstallStep }
 					isJetpackConnected
+					wcsTosAccepted
 				/>
 			);
 


### PR DESCRIPTION
Fixes #4310.

This PR seeks to implement the "create a PayPal account for me" behavior from the old core OBW.

The option is only displayed if Jetpack is connected, WooCommerce Services is active, and the WooCommerce Services TOS has been accepted.

If the user opts out of auto account creation, the form defaults to the OAuth flow and falls back to the API credentials form if needed.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

With JP + WCS, default opted in:

![Screen Shot 2020-07-14 at 11 19 17 AM](https://user-images.githubusercontent.com/63922/87444178-724afb80-c5c4-11ea-8a84-16c73dc41741.png)

Opted out, successful OAuth URL fetch:

![Screen Shot 2020-07-14 at 11 19 37 AM](https://user-images.githubusercontent.com/63922/87444159-6bbc8400-c5c4-11ea-89c8-c578aa8f12b7.png)

Opted out, failed OAuth fetch:

![Screen Shot 2020-07-14 at 11 20 07 AM](https://user-images.githubusercontent.com/63922/87444135-64957600-c5c4-11ea-970c-020d3845f76c.png)

### Detailed test instructions:

- Ensure Jetpack and WCS are not connected (or installed, either way)
- Ensure PayPal Checkout is not configured
- Go to WooCommerce > Home
- Click "set up payments" in the task list
- Click "set up" in PayPal Checkout
- Verify no "create an account for me" checkbox is shown
- Connect Jetpack and activate WCS
- Return to PayPal Checkout setup task
- Verify the "create an account for me" checkbox is shown and is checked by default
- Verify an email input is shown
- Uncheck the checkbox
- Verify the OAuth connect button is shown
- Check the checkbox
- Fill out a valid email address and click "Create account"
- Verify you are redirected to the payments task and PayPal is marked enabled
- Verify the `woocommerce_ppec_paypal_settings` option has the following values:
```
{ enabled: "yes", reroute_requests: "yes", email": [YOUR EMAIL] }
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add automatic PayPal account creation flow.