### PR TITLE
New notification: Don't forget to test your checkout

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -37,6 +37,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Online_Clothing_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_First_Product;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Customize_Store_With_Blocks;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Marketing_Expert;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Test_Checkout;
 
 /**
  * WC_Admin_Events Class.
@@ -105,6 +106,7 @@ class Events {
 		WC_Admin_Notes_Real_Time_Order_Alerts::possibly_add_note();
 		WC_Admin_Notes_Customize_Store_With_Blocks::possibly_add_note();
 		WC_Admin_Notes_Facebook_Marketing_Expert::possibly_add_note();
+		WC_Admin_Notes_Test_Checkout::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -21,6 +21,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Coupon_Page_Moved;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Home_Screen_Feedback;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Set_Up_Additional_Payment_Types;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Test_Checkout;
 
 /**
  * Feature plugin main class.
@@ -194,6 +195,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Draw_Attention();
 		new WC_Admin_Notes_Home_Screen_Feedback();
 		new WC_Admin_Notes_Set_Up_Additional_Payment_Types();
+		new WC_Admin_Notes_Test_Checkout();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -178,7 +178,7 @@ class OnboardingTasks {
 		switch ( $task ) {
 			case 'products':
 				$products = wp_count_posts( 'product' );
-				return (int) $products->publish > 0 || (int) $products->draft > 0;
+				return (int) $products->publish > 0;
 			case 'homepage':
 				$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
 				if ( ! $homepage_id ) {

--- a/src/Notes/WC_Admin_Notes_Test_Checkout.php
+++ b/src/Notes/WC_Admin_Notes_Test_Checkout.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WooCommerce Admin Test Checkout.
+ *
+ * Adds a note to remind the user to test their store checkout.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Test_Checkout
+ */
+class WC_Admin_Notes_Test_Checkout {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-test-checkout';
+
+	const PRODUCT_ADDED_OPTION_NAME = 'wc_admin_note_test_checkout_product_added';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'product_page_product_importer', array( $this, 'run_on_product_importer_done' ) );
+		add_action( 'transition_post_status', array( $this, 'run_on_transition_post_status_done' ), 10, 3 );
+	}
+
+	/**
+	 * Runs on product importer steps.
+	 */
+	public function run_on_product_importer_done() {
+		// We're only interested in when the importer completes.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_REQUEST['step'] ) ) {
+			return;
+		}
+		if ( 'done' !== $_REQUEST['step'] ) {
+			return;
+		}
+		// phpcs:enable
+
+		$this->update_product_added_and_possibly_add_note();
+	}
+
+	/**
+	 * Runs when a post status transitions, but we're only interested if it is
+	 * a product being published.
+	 *
+	 * @param string $new_status The new status.
+	 * @param string $old_status The old status.
+	 * @param Post   $post       The post.
+	 */
+	public function run_on_transition_post_status_done( $new_status, $old_status, $post ) {
+		if (
+			'product' !== $post->post_type ||
+			'publish' !== $new_status
+		) {
+			return;
+		}
+
+		$this->update_product_added_and_possibly_add_note();
+	}
+
+	/**
+	 * Updates "wc_admin_note_test_checkout_product_added" in the DB and calls "possibly_add_note" method.
+	 */
+	public function update_product_added_and_possibly_add_note() {
+		update_option( self::PRODUCT_ADDED_OPTION_NAME, true );
+		self::possibly_add_note();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		// Make sure a product was published or imported.
+		$product_added = get_option(
+			self::PRODUCT_ADDED_OPTION_NAME
+		);
+		if ( ! $product_added ) {
+			return;
+		}
+
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Confirm that $onboarding_profile is set.
+		if ( empty( $onboarding_profile ) ) {
+			return;
+		}
+
+		// Make sure that the person who filled out the OBW was not setting up
+		// the store for their customer/client.
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
+			return;
+		}
+
+		// Make sure payments task is completed.
+		$payments_task = get_option( 'woocommerce_task_list_payments', array() );
+		if ( ! isset( $payments_task['completed'] ) ) {
+			return;
+		}
+
+		$content = __( 'Make sure that your checkout is working properly before your launch your store. Go through your checkout process in its entirety: from adding a product to your cart, choosing a shipping location, and making a payment.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Don\'t forget to test your checkout', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'test-checkout', __( 'Test checkout', 'woocommerce-admin' ), site_url() );
+		return $note;
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Test_Checkout.php
+++ b/src/Notes/WC_Admin_Notes_Test_Checkout.php
@@ -122,7 +122,7 @@ class WC_Admin_Notes_Test_Checkout {
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'test-checkout', __( 'Test checkout', 'woocommerce-admin' ), site_url() );
+		$note->add_action( 'test-checkout', __( 'Test checkout', 'woocommerce-admin' ), wc_get_page_permalink( 'shop' ) );
 		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Test_Checkout.php
+++ b/src/Notes/WC_Admin_Notes_Test_Checkout.php
@@ -83,7 +83,7 @@ class WC_Admin_Notes_Test_Checkout {
 			return;
 		}
 
-		$content = __( 'Make sure that your checkout is working properly before your launch your store. Go through your checkout process in its entirety: from adding a product to your cart, choosing a shipping location, and making a payment.', 'woocommerce-admin' );
+		$content = __( 'Make sure that your checkout is working properly before you launch your store. Go through your checkout process in its entirety: from adding a product to your cart, choosing a shipping location, and making a payment.', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Don\'t forget to test your checkout', 'woocommerce-admin' ) );

--- a/src/Notes/WC_Admin_Notes_Test_Checkout.php
+++ b/src/Notes/WC_Admin_Notes_Test_Checkout.php
@@ -78,7 +78,7 @@ class WC_Admin_Notes_Test_Checkout {
 		}
 
 		$oldest_product_timestamp = $products[0]->get_date_created()->getTimestamp();
-		$half_hour_in_seconds     = 0.5 * HOUR_IN_SECONDS;
+		$half_hour_in_seconds     = 30 * MINUTE_IN_SECONDS;
 		if ( ( time() - $oldest_product_timestamp ) > $half_hour_in_seconds ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #4213

This PR adds a note to remind the user to test the checkout process.
This note should be triggered when the user has a payment method AND adds or imports products.

**Segmentation:**
New users with `setup_client`: `false` on `wcadmin_storeprofiler_store_details_continue`
**Timing:** 
"After triggering:
`wcadmin_product_add_publish` or `wcadmin_product_import_complete`
AND
`task_name: payments` on `wcadmin_tasklist_task_completed`
**Cadence:** Once


### Screenshots
![screenshot-one wordpress test-2020 07 14-12_54_00](https://user-images.githubusercontent.com/1314156/87447606-29e60a80-c5d1-11ea-9f6b-1612f7f826c0.png)

### Detailed test instructions:
- Execute the cron. To do it you can install [this plugin](https://wordpress.org/plugins/wp-crontrol/) and go to `/wp-admin/tools.php?page=crontrol_admin_manage_page`and press `wc_admin_daily`.
- Add a new product.
- At the end of the process, the note should be visible.
- Remove the note and the variable: `wc_admin_note_test_checkout_product_added` from the database with a sentence like this:
````
DELETE FROM `wp_options` WHERE `wp_options`.`option_name` = 'wc_admin_note_test_checkout_product_added';
DELETE FROM `wp_wc_admin_notes` WHERE `wp_wc_admin_notes`.`name` = 'wc-admin-test-checkout';
````
- Import products.
- At the end of the process, the note should be visible.

- Verify the call to action button in the note opens the store frontend in a new tab

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: New notification: Don't forget to test your checkout
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
