### PR TITLE
Setup Checklist: Fix Homepage Template

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -264,27 +264,19 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'New In', 'woocommerce-admin' ) . '</h2>
 				<!-- /wp:heading -->
-				<!-- wp:woocommerce/product-new {"columns":4} -->
-				<div class="wp-block-woocommerce-product-new">[products limit="4" columns="4" orderby="date" order="DESC"]</div>
-				<!-- /wp:woocommerce/product-new -->
+				<!-- wp:woocommerce/product-new {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'Fan Favorites', 'woocommerce-admin' ) . '</h2>
 				<!-- /wp:heading -->
-				<!-- wp:woocommerce/product-top-rated {"columns":4} -->
-				<div class="wp-block-woocommerce-product-top-rated">[products limit="4" columns="4" orderby="rating"]</div>
-				<!-- /wp:woocommerce/product-top-rated -->
+				<!-- wp:woocommerce/product-top-rated {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'On Sale', 'woocommerce-admin' ) . '</h2>
 				<!-- /wp:heading -->
-				<!-- wp:woocommerce/product-on-sale {"columns":4} -->
-				<div class="wp-block-woocommerce-product-on-sale">[products limit="4" columns="4" orderby="date" order="DESC" on_sale="1"]</div>
-				<!-- /wp:woocommerce/product-on-sale -->
+				<!-- wp:woocommerce/product-on-sale {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'Best Sellers', 'woocommerce-admin' ) . '</h2>
 				<!-- /wp:heading -->
-				<!-- wp:woocommerce/product-best-sellers {"columns":4} -->
-				<div class="wp-block-woocommerce-product-best-sellers">[products limit="4" columns="4" best_selling="1"]</div>
-				<!-- /wp:woocommerce/product-best-sellers -->
+				<!-- wp:woocommerce/product-best-sellers {"columns":4} /-->
 			';
 
 			/**

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -259,7 +259,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				<h2 style="text-align:center">' . __( 'Shop by Category', 'woocommerce-admin' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:shortcode -->
-				[product_categories limit="3" columns="3" orderby="menu_order"]
+				[product_categories number="0" parent="0"]
 				<!-- /wp:shortcode -->
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'New In', 'woocommerce-admin' ) . '</h2>


### PR DESCRIPTION
Fixes a bug reported by @LevinMedia in [slack today](https://a8c.slack.com/archives/C9K5T0XSP/p1594745851055700)

The template code used to create the homepage during the Setup Checklist is currently resulting in some sub-optimal output:

__Before__

<img width="1129" alt="Screen Shot 2020-07-14 at 10 07 55 AM" src="https://user-images.githubusercontent.com/22080/87475539-d5935880-c5d9-11ea-8abb-3746da8513fd.png">

This branch implements a fix that is being used in Storefront to correct the bug: https://github.com/woocommerce/storefront/pull/1422

__After__

![image](https://user-images.githubusercontent.com/22080/87475783-3ae74980-c5da-11ea-952e-c2901f2e68c3.png)

### Test Instructions

To prep for this test you will need to reset your setup checklist to a clean slate mode - the following commands should get you poised for testing success. Some might be needed, but it could save you some steps.

```
wp option delete woocommerce_task_list_complete
wp option delete woocommerce_task_list_hidden
wp option delete woocommerce_onboarding_homepage_post_id
```

And now you can then do the following test passes, the first time with less than 4 products present on the site, and the second time with 4 or more products as the template changes for those two. You will have to `wp option delete woocommerce_onboarding_homepage_post_id` between the tests.

- Visit `/wp-admin/admin.php?page=wc-admin&task=appearance`
- Click 'Create homepage' button on the step:

![image](https://user-images.githubusercontent.com/22080/87476462-45eea980-c5db-11ea-906a-039329598d51.png)

- Then visit `/wp-admin/edit.php?post_type=page&orderby=date&order=desc` and your freshly created home page should be at the top of the list. Edit it and verify all looks good ( like the after screenie above )

### Changelog Note:

Fix: Homepage template used in setup checklist customization task.
