### PR TITLE
Fix a React warning in test that the key prop wasn't assigned in List

### DIFF
--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -49,7 +49,6 @@ class List extends Component {
 						className: itemClasses,
 						content,
 						href,
-						key,
 						listItemTag,
 						onClick,
 						target,
@@ -81,11 +80,11 @@ class List extends Component {
 
 					return (
 						<CSSTransition
-							key={ key }
+							key={ i }
 							timeout={ 500 }
 							classNames="woocommerce-list__item"
 						>
-							<li className={ itemClassName } key={ i }>
+							<li className={ itemClassName }>
 								<InnerTag { ...innerTagProps }>
 									{ before && (
 										<div className="woocommerce-list__item-before">


### PR DESCRIPTION
An alternative approach I considered was giving all the data used
in tests a `key` prop because that also would have solved it, but
it made me wonder if all these types of data even have key props
on them. Without any type information to validate something like that, I felt
the safer choice was just to use the array index as the key for the
top level node instead.

### Detailed test instructions:

1. run the tests via `npm test`. You should not see any warnings from React in the output.