### PR TITLE
Fix missing version update callback and add test

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -117,3 +117,10 @@ function wc_admin_update_140_change_deactivate_plugin_note_type() {
 
 	$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}wc_admin_notes SET type = 'info' WHERE name = %s", WC_Admin_Notes_Deactivate_Plugin::NOTE_NAME ) );
 }
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_140_db_version() {
+	Installer::update_db_version( '1.4.0' );
+}

--- a/src/Install.php
+++ b/src/Install.php
@@ -50,6 +50,7 @@ class Install {
 		),
 		'1.4.0'  => array(
 			'wc_admin_update_140_change_deactivate_plugin_note_type',
+			'wc_admin_update_140_db_version',
 		),
 	);
 

--- a/tests/plugin-version.php
+++ b/tests/plugin-version.php
@@ -31,4 +31,24 @@ class WC_Admin_Tests_Plugin_Version extends WP_UnitTestCase {
 		$this->assertEquals( $package->version, $plugin['Version'], 'Plugin header version does not match package.json' );
 		$this->assertEquals( $package->version, $db_version, 'DB version constant does not match package.json' );
 	}
+
+	/**
+	 * Ensure that a DB version callback is defined when there are updates.
+	 */
+	public function test_db_update_callbacks() {
+		$all_callbacks = \Automattic\WooCommerce\Admin\Install::get_db_update_callbacks();
+
+		foreach ( $all_callbacks as $version => $version_callbacks ) {
+			// Verify all callbacks have been defined.
+			foreach ( $version_callbacks as $version_callback ) {
+				$this->assertTrue( function_exists( $version_callback ), "Callback {$version_callback}() is not defined." );
+			}
+
+			// Verify there is a version update callback for each version.
+			$version_string = str_replace( '.', '', $version );
+			$expected_callback = "wc_admin_update_{$version_string}_db_version";
+
+			$this->assertContains( $expected_callback, $version_callbacks, "Expected DB update callback {$expected_callback}() was not found." );
+		}
+	}
 }


### PR DESCRIPTION
This PR adds the missing DB update for version `1.4.0` and introduces a test to verify that all DB update callbacks have been defined and the expected version number callback is present.

### Detailed test instructions:

- Check the code
- Verify the tests pass

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A