### PR TITLE
Allow Jetpack plugin to be manipulated via API from the home screen.

### DIFF
--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -46,6 +46,10 @@ class AnalyticsDashboard {
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+
+		if ( Loader::is_feature_enabled( 'homescreen' ) ) {
+			add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ), 10, 2 );
+		}
 	}
 
 	/**
@@ -136,5 +140,20 @@ class AnalyticsDashboard {
 		// Move menu item to top of array.
 		unset( $submenu['woocommerce'][ $wc_admin_key ] );
 		array_unshift( $submenu['woocommerce'], $menu );
+	}
+
+	/**
+	 * Gets an array of plugins that can be installed & activated via the home screen.
+	 *
+	 * @param array $plugins Array of plugin slugs to be allowed.
+	 *
+	 * @return array
+	 */
+	public static function get_homescreen_allowed_plugins( $plugins ) {
+		$homescreen_plugins = array(
+			'jetpack' => 'jetpack/jetpack.php',
+		);
+
+		return array_merge( $plugins, $homescreen_plugins );
 	}
 }

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -48,7 +48,7 @@ class AnalyticsDashboard {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
 		if ( Loader::is_feature_enabled( 'homescreen' ) ) {
-			add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ), 10, 2 );
+			add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #4788.

cc: @pmcpinto @dougaitken 

Fixes issue where Jetpack's installation status wasn't visible if the OBW was skipped.

### Detailed test instructions:

- Spin up a new test store and skip the setup wizard
OR
- Delete the `woocommerce_onboarding_opt_in` option
- Enable the home screen feature if necessary
- Verify the Stats Overview widget correctly sees Jetpack's status
- If installed, but not active = "Activate" button
- If not installed = "Install" button
- If connected, no button

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: errant Jetpack activation prompt in Stats Overview home screen widget.