### PR TITLE
Update profiler reference links and loading state

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -760,10 +760,16 @@ class Onboarding {
 	public function is_loading( $is_loading ) {
 		$show_profiler = self::should_show_profiler();
 		$is_dashboard  = ! isset( $_GET['path'] ); // phpcs:ignore csrf ok.
+		$is_profiler   = isset( $_GET['path'] ) && '/profiler' === $_GET['path']; // phpcs:ignore csrf ok.
+
+		if ( $is_profiler ) {
+			return true;
+		}
 
 		if ( ! $show_profiler || ! $is_dashboard ) {
 			return $is_loading;
 		}
+
 		return true;
 	}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -934,16 +934,12 @@ class Onboarding {
 			$screen->remove_help_tab( 'woocommerce_onboard_tab' );
 
 			$task_list_hidden = get_option( 'woocommerce_task_list_hidden', 'no' );
-			$is_enabled       = self::should_show_profiler();
 
 			$help_tab['content'] = '<h2>' . __( 'WooCommerce Onboarding', 'woocommerce-admin' ) . '</h2>';
 
 			$help_tab['content'] .= '<h3>' . __( 'Profile Setup Wizard', 'woocommerce-admin' ) . '</h3>';
-			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-			( $is_enabled
-				? '<p><a href="' . wc_admin_url( '&reset_profiler=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
-				: '<p><a href="' . wc_admin_url( '&reset_profiler=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
-			);
+			$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
+				'<p><a href="' . wc_admin_url( '&path=/profiler' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
 
 			$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce-admin' ) . '</h3>';
 			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task list, please click on the button below.', 'woocommerce-admin' ) . '</p>' .


### PR DESCRIPTION
Fixes #4821

* Updates the links to revisit the profiler.
* Hides the wp admin UI when loading profiler routes.

### Screenshots
<img width="406" alt="Screen Shot 2020-07-16 at 4 00 23 PM" src="https://user-images.githubusercontent.com/10561050/87673860-d5cc5900-c77d-11ea-95e5-709f85431229.png">

### Detailed test instructions:

1. Go to the WC Products page.
1. Click the "Help" tab and click "Setup wizard."
1. Click the setup wizard and make sure you are able to visit the profiler.
1. Make sure when loading this page or refreshing, the wp admin menu is not shown.