### PR TITLE
Fix PHP Fatals from Notes DataStore when columns are missing.

### DIFF
--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -124,7 +124,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			 */
 			do_action( 'woocommerce_note_loaded', $note );
 		} else {
-			throw new \Exception( __( 'Invalid data store for admin note.', 'woocommerce-admin' ) );
+			throw new \Exception( __( 'Invalid admin note', 'woocommerce-admin' ) );
 		}
 	}
 

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -73,7 +73,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		if ( 0 !== $note_id || '0' !== $note_id ) {
 			$note_row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT name, type, locale, title, content, content_data, status, source, date_created, date_reminder, is_snoozable, layout, image FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
+					"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
 					$note->get_id()
 				)
 			);
@@ -342,7 +342,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		$query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT note_id, title, content, layout, image FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
+			"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
 			$offset,
 			$args['per_page']
 		);

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -99,9 +99,11 @@ trait NoteTraits {
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 		foreach ( $note_ids as $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
+			$note = WC_Admin_Notes::get_note( $note_id );
 
-			$data_store->delete( $note );
+			if ( $note ) {
+				$data_store->delete( $note );
+			}
 		}
 	}
 }

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -77,6 +77,7 @@ class WC_Admin_Note extends \WC_Data {
 			$this->set_id( $data );
 		} elseif ( is_object( $data ) && ! empty( $data->note_id ) ) {
 			$this->set_id( $data->note_id );
+			unset( $data->icon ); // Icons are deprecated.
 			$this->set_props( (array) $data );
 			$this->set_object_read( true );
 		} else {

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -85,7 +85,13 @@ class WC_Admin_Note extends \WC_Data {
 
 		$this->data_store = \WC_Data_Store::load( 'admin-note' );
 		if ( $this->get_id() > 0 ) {
-			$this->data_store->read( $this );
+			try {
+				$this->data_store->read( $this );
+			} catch ( \Exception $e ) {
+				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $this->get_id() ) );
+				$this->set_id( 0 );
+				$this->set_object_read( true );
+			}
 		}
 	}
 

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -85,13 +85,7 @@ class WC_Admin_Note extends \WC_Data {
 
 		$this->data_store = \WC_Data_Store::load( 'admin-note' );
 		if ( $this->get_id() > 0 ) {
-			try {
-				$this->data_store->read( $this );
-			} catch ( \Exception $e ) {
-				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $this->get_id() ) );
-				$this->set_id( 0 );
-				$this->set_object_read( true );
-			}
+			$this->data_store->read( $this );
 		}
 	}
 

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -40,23 +40,27 @@ class WC_Admin_Notes {
 		$raw_notes  = $data_store->get_notes( $args );
 		$notes      = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
-			$note                               = new WC_Admin_Note( $raw_note );
-			$note_id                            = $note->get_id();
-			$notes[ $note_id ]                  = $note->get_data();
-			$notes[ $note_id ]['name']          = $note->get_name( $context );
-			$notes[ $note_id ]['type']          = $note->get_type( $context );
-			$notes[ $note_id ]['locale']        = $note->get_locale( $context );
-			$notes[ $note_id ]['title']         = $note->get_title( $context );
-			$notes[ $note_id ]['content']       = $note->get_content( $context );
-			$notes[ $note_id ]['content_data']  = $note->get_content_data( $context );
-			$notes[ $note_id ]['status']        = $note->get_status( $context );
-			$notes[ $note_id ]['source']        = $note->get_source( $context );
-			$notes[ $note_id ]['date_created']  = $note->get_date_created( $context );
-			$notes[ $note_id ]['date_reminder'] = $note->get_date_reminder( $context );
-			$notes[ $note_id ]['actions']       = $note->get_actions( $context );
-			$notes[ $note_id ]['layout']        = $note->get_layout( $context );
-			$notes[ $note_id ]['image']         = $note->get_image( $context );
-			$notes[ $note_id ]['is_deleted']    = $note->get_is_deleted( $context );
+			try {
+				$note                               = new WC_Admin_Note( $raw_note );
+				$note_id                            = $note->get_id();
+				$notes[ $note_id ]                  = $note->get_data();
+				$notes[ $note_id ]['name']          = $note->get_name( $context );
+				$notes[ $note_id ]['type']          = $note->get_type( $context );
+				$notes[ $note_id ]['locale']        = $note->get_locale( $context );
+				$notes[ $note_id ]['title']         = $note->get_title( $context );
+				$notes[ $note_id ]['content']       = $note->get_content( $context );
+				$notes[ $note_id ]['content_data']  = $note->get_content_data( $context );
+				$notes[ $note_id ]['status']        = $note->get_status( $context );
+				$notes[ $note_id ]['source']        = $note->get_source( $context );
+				$notes[ $note_id ]['date_created']  = $note->get_date_created( $context );
+				$notes[ $note_id ]['date_reminder'] = $note->get_date_reminder( $context );
+				$notes[ $note_id ]['actions']       = $note->get_actions( $context );
+				$notes[ $note_id ]['layout']        = $note->get_layout( $context );
+				$notes[ $note_id ]['image']         = $note->get_image( $context );
+				$notes[ $note_id ]['is_deleted']    = $note->get_is_deleted( $context );
+			} catch ( \Exception $e ) {
+				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $note_id ) );
+			}
 		}
 		return $notes;
 	}
@@ -69,10 +73,11 @@ class WC_Admin_Notes {
 	 */
 	public static function get_note( $note_id ) {
 		if ( false !== $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
-
-			if ( $note_id == $note->get_id() ) {
-				return $note;
+			try {
+				return new WC_Admin_Note( $note_id );
+			} catch ( \Exception $e ) {
+				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $note_id ) );
+				return false;
 			}
 		}
 

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -72,6 +72,7 @@ class WC_Admin_Notes {
 			try {
 				return new WC_Admin_Note( $note_id );
 			} catch ( \Exception $e ) {
+				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $note_id ) );
 				return false;
 			}
 		}

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -69,13 +69,13 @@ class WC_Admin_Notes {
 	 */
 	public static function get_note( $note_id ) {
 		if ( false !== $note_id ) {
-			try {
-				return new WC_Admin_Note( $note_id );
-			} catch ( \Exception $e ) {
-				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, array( $note_id ) );
-				return false;
+			$note = new WC_Admin_Note( $note_id );
+
+			if ( $note_id == $note->get_id() ) {
+				return $note;
 			}
 		}
+
 		return false;
 	}
 

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -113,8 +113,10 @@ class WC_Admin_Notes {
 		foreach ( $names as $name ) {
 			$note_ids = $data_store->get_notes_with_name( $name );
 			foreach ( (array) $note_ids as $note_id ) {
-				$note = new WC_Admin_Note( $note_id );
-				$note->delete();
+				$note = WC_Admin_Notes::get_note( $note_id );
+				if ( $note ) {
+					$note->delete();
+				}
 			}
 		}
 	}
@@ -183,9 +185,11 @@ class WC_Admin_Notes {
 
 		$notes = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
-			$note = new WC_Admin_Note( $raw_note );
-			self::delete_note( $note );
-			array_push( $notes, $note );
+			$note = WC_Admin_Notes::get_note( $raw_note->note_id );
+			if ( $note ) {
+				self::delete_note( $note );
+				array_push( $notes, $note );
+			}
 		}
 		return $notes;
 	}
@@ -203,7 +207,11 @@ class WC_Admin_Notes {
 		$now        = new \DateTime();
 
 		foreach ( $raw_notes as $raw_note ) {
-			$note          = new WC_Admin_Note( $raw_note );
+			$note = WC_Admin_Notes::get_note( $raw_note->note_id );
+			if ( false === $note ) {
+				continue;
+			}
+
 			$date_reminder = $note->get_date_reminder( 'edit' );
 
 			if ( $date_reminder < $now ) {
@@ -249,9 +257,12 @@ class WC_Admin_Notes {
 		);
 
 		foreach ( $notes as $note ) {
-			$note = new WC_Admin_Note( $note->note_id );
-			$note->delete();
+			$note = WC_Admin_Notes::get_note( $note->note_id );
+			if ( $note ) {
+				$note->delete();
+			}
 		}
+		
 	}
 
 	/**
@@ -267,9 +278,11 @@ class WC_Admin_Notes {
 		);
 
 		foreach ( $notes as $note ) {
-			$note = new WC_Admin_Note( $note->note_id );
-			$note->set_is_deleted( 1 );
-			$note->save();
+			$note = WC_Admin_Notes::get_note( $note->note_id );
+			if ( $note ) {
+				$note->set_is_deleted( 1 );
+				$note->save();
+			}
 		}
 	}
 }

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -113,7 +113,7 @@ class WC_Admin_Notes {
 		foreach ( $names as $name ) {
 			$note_ids = $data_store->get_notes_with_name( $name );
 			foreach ( (array) $note_ids as $note_id ) {
-				$note = WC_Admin_Notes::get_note( $note_id );
+				$note = self::get_note( $note_id );
 				if ( $note ) {
 					$note->delete();
 				}
@@ -185,7 +185,7 @@ class WC_Admin_Notes {
 
 		$notes = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
-			$note = WC_Admin_Notes::get_note( $raw_note->note_id );
+			$note = self::get_note( $raw_note->note_id );
 			if ( $note ) {
 				self::delete_note( $note );
 				array_push( $notes, $note );
@@ -207,7 +207,7 @@ class WC_Admin_Notes {
 		$now        = new \DateTime();
 
 		foreach ( $raw_notes as $raw_note ) {
-			$note = WC_Admin_Notes::get_note( $raw_note->note_id );
+			$note = self::get_note( $raw_note->note_id );
 			if ( false === $note ) {
 				continue;
 			}
@@ -257,12 +257,11 @@ class WC_Admin_Notes {
 		);
 
 		foreach ( $notes as $note ) {
-			$note = WC_Admin_Notes::get_note( $note->note_id );
+			$note = self::get_note( $note->note_id );
 			if ( $note ) {
 				$note->delete();
 			}
 		}
-		
 	}
 
 	/**
@@ -278,7 +277,7 @@ class WC_Admin_Notes {
 		);
 
 		foreach ( $notes as $note ) {
-			$note = WC_Admin_Notes::get_note( $note->note_id );
+			$note = self::get_note( $note->note_id );
 			if ( $note ) {
 				$note->set_is_deleted( 1 );
 				$note->save();

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -44,7 +44,11 @@ class WC_Admin_Notes_Historical_Data {
 			return;
 		}
 
-		$note = new WC_Admin_Note( $note_ids[0] );
+		$note = WC_Admin_Notes::get_note( $note_ids[0] );
+		if ( false === $note ) {
+			return;
+		}
+
 		$note->set_status( 'actioned' );
 		$note->save();
 	}

--- a/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
+++ b/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
@@ -80,10 +80,12 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 		foreach ( $note_ids as $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
+			$note = WC_Admin_Notes::get_note( $note_id );
 
-			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
-			$note->save();
+			if ( $note ) {
+				$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+				$note->save();
+			}
 		}
 	}
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -88,7 +88,12 @@ class WC_Admin_Notes_Onboarding_Profiler {
 			return;
 		}
 
-		$note = new WC_Admin_Note( $note_ids[0] );
+		$note = WC_Admin_Notes::get_note( $note_ids[0] );
+
+		if ( false === $note ) {
+			return;
+		}
+
 		$note->set_status( 'actioned' );
 		$note->save();
 	}

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -59,6 +59,9 @@ class WC_Admin_Notes_WooCommerce_Payments {
 
 			$note_id = array_pop( $note_ids );
 			$note    = WC_Admin_Notes::get_note( $note_id );
+			if ( false === $note ) {
+				return;
+			}
 
 			// If the WooCommerce Payments plugin was installed after the note was created, make sure it's marked as actioned.
 			if ( self::is_installed() && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {

--- a/src/RemoteInboxNotifications/SpecRunner.php
+++ b/src/RemoteInboxNotifications/SpecRunner.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
  * Runs a single spec.
@@ -30,7 +31,10 @@ class SpecRunner {
 			$note = new WC_Admin_Note();
 			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_PENDING );
 		} else {
-			$note = new WC_Admin_Note( $existing_note_ids[0] );
+			$note = WC_Admin_Notes::get_note( $existing_note_ids[0] );
+			if ( false === $note ) {
+				return;
+			}
 		}
 
 		// Evaluate the spec and get the new note status.

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -95,8 +95,13 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	public function test_get_invalid_note() {
 		wp_set_current_user( $this->user );
 
+		// Suppress deliberately caused errors.
+		$log_file = ini_set( 'error_log', '/dev/null' );
+
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint . '/999' ) );
 		$note     = $response->get_data();
+
+		ini_set( 'error_log', $log_file );
 
 		$this->assertEquals( 404, $response->get_status() );
 	}

--- a/tests/notes/class-wc-tests-notes-data-store.php
+++ b/tests/notes/class-wc-tests-notes-data-store.php
@@ -202,4 +202,43 @@ class WC_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 			count( $data_store->get_notes_with_name( $note_name_to_keep ) )
 		);
 	}
+
+	/**
+	 * Test that fatal errors aren't thrown when the Notes datastore read() throws an exception.
+	 */
+	public function test_read_throws_exception() {
+		// Create a test note.
+		$note = new WC_Admin_Note();
+		$note->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
+		$note->set_title( 'PHPUNIT_TEST_NOTE_TITLE' );
+		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
+		$note->save();
+
+		$note_id = $note->get_id();
+
+		// Sub in a mock datastore that throws an error on read().
+		$mock_datastore = $this->createMock( \Automattic\WooCommerce\Admin\Notes\DataStore::class );
+		$mock_datastore
+			->method( 'read' )
+			->will( $this->throwException( new \Exception() ) );
+
+		// Suppress deliberately caused errors.
+		$log_file = ini_set( 'error_log', '/dev/null' );
+
+		$filter_datastore = function() use ( $mock_datastore ) {
+			return $mock_datastore;
+		};
+
+		add_filter( 'woocommerce_admin-note_data_store', $filter_datastore );
+
+		// Attempt to retrieve the test note.
+		$note = new WC_Admin_Note( $note_id );
+
+		remove_filter( 'woocommerce_admin-note_data_store', $filter_datastore );
+
+		ini_set( 'error_log', $log_file );
+
+		$this->assertEquals( 0, $note->get_id() );
+		$this->assertEquals( 1, did_action( 'woocommerce_caught_exception' ) );
+	}
 }

--- a/tests/notes/class-wc-tests-notes-data-store.php
+++ b/tests/notes/class-wc-tests-notes-data-store.php
@@ -232,13 +232,13 @@ class WC_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_admin-note_data_store', $filter_datastore );
 
 		// Attempt to retrieve the test note.
-		$note = new WC_Admin_Note( $note_id );
+		$note = WC_Admin_Notes::get_note( $note_id );
 
 		remove_filter( 'woocommerce_admin-note_data_store', $filter_datastore );
 
 		ini_set( 'error_log', $log_file );
 
-		$this->assertEquals( 0, $note->get_id() );
+		$this->assertFalse( $note );
 		$this->assertEquals( 1, did_action( 'woocommerce_caught_exception' ) );
 	}
 }


### PR DESCRIPTION
Fixes #4823.

This PR seeks to avoid PHP Fatal Errors being thrown when `dbDelta()` fails adding new Notes columns.

While this can't avoid `WordPress database error` messages in the error log, it should stop the stores from completely breaking.

cc: @peterfabian 

### Detailed test instructions:

- If your test store isn't already experiencing this issue:
- Rename the `layout` and/or `image` and/or `is_deleted` columns in the `wc_admin_notes` table
- Load any admin page
- Verify no PHP Fatals

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: PHP Fatal errors when columns are missing from the Notes table.