### PR TITLE
Set active theme when OBW is shown via the task list

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -583,13 +583,9 @@ class Onboarding {
 			'profile'    => $profile,
 		);
 
-		// Only fetch if the onboarding wizard is incomplete.
-		if ( self::should_show_profiler() ) {
-			$settings['onboarding']['activeTheme'] = get_option( 'stylesheet' );
-		}
-
 		// Only fetch if the onboarding wizard OR the task list is incomplete.
 		if ( self::should_show_profiler() || self::should_show_tasks() ) {
+			$settings['onboarding']['activeTheme']              = get_option( 'stylesheet' );
 			$settings['onboarding']['stripeSupportedCountries'] = self::get_stripe_supported_countries();
 			$settings['onboarding']['euCountries']              = WC()->countries->get_european_union_countries();
 			$current_user                                       = wp_get_current_user();


### PR DESCRIPTION
Currently, using the OBW from the task list with the OBW previously complete doesn't load the `activeTheme` property, which means that the currently active theme isn't shown as active and there isn't a 'skip' link shown at the bottom of the theme step.

This PR moves where the `activeTheme` property is set so that it is loaded in this scenario.

*I'm not sure about this PR as it looks like not having the active theme was the intended behaviour, but it feels wrong and janky.*

### Detailed test instructions:

1. Make sure the OBW is complete and the task list is shown
2. Start the OBW via the task list
3. Go through to the theme selection step
4. Verify that the currently selected theme is shown as selected
5. "Continue with my active theme" and verify that it works as expected
6. Work through to get back to the theme selection step
7. "Skip this step" and verify that it works as expected
8. Work through to get back to the theme selection step
9. Select another theme and make sure it works as expected
