### PR TITLE
Onboarding: Fix alignment of container on benefits screen.

### DIFF
--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -288,6 +288,7 @@ class ProfileWizard extends Component {
 	render() {
 		const { query } = this.props;
 		const step = this.getCurrentStep();
+		const stepKey = step.key;
 
 		const container = createElement( step.container, {
 			query,
@@ -300,13 +301,12 @@ class ProfileWizard extends Component {
 		const steps = this.getSteps().map( ( _step ) =>
 			pick( _step, [ 'key', 'label', 'isComplete' ] )
 		);
+		const classNames = `woocommerce-profile-wizard__container ${ stepKey }`;
 
 		return (
 			<Fragment>
-				<ProfileWizardHeader currentStep={ step.key } steps={ steps } />
-				<div className="woocommerce-profile-wizard__container">
-					{ container }
-				</div>
+				<ProfileWizardHeader currentStep={ stepKey } steps={ steps } />
+				<div className={ classNames }>{ container }</div>
 			</Fragment>
 		);
 	}

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -85,6 +85,10 @@
 			margin-right: auto;
 		}
 
+		&.benefits {
+			text-align: center;
+		}
+
 		@include breakpoint( '<782px' ) {
 			padding-left: $gap;
 			padding-right: $gap;


### PR DESCRIPTION
While testing out another pr today, I noticed a regression on the benefits screen that resulted in the container being left-aligned instead of center aligned:

![benefits-before](https://user-images.githubusercontent.com/22080/88102927-2c0e1300-cb55-11ea-8217-56c5cd00dc33.png)

It looks like this was introduced as part of #4771 

This PR adds a class name specific to the onboarding step, and some code to center align the benefits screen.

### After

![benefits-after](https://user-images.githubusercontent.com/22080/88103047-552ea380-cb55-11ea-8660-718756899e50.png)

### Detailed test instructions:

- Enable the Setup Checklist via the Help menu on the Orders Page
- Proceed to the end of the profile wizard, or visit `wp-admin/admin.php?page=wc-admin&path=%2Fprofiler&step=benefits` directly
- Verify the container is center aligned like the after screenshot above

### Changelog Note:

NA: Unreleased bug
