### PR TITLE
Center the skip link on the theme selection step

### DIFF
--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -400,7 +400,7 @@ class Theme extends Component {
 					/>
 				) }
 				{ activeThemeSupportsWooCommerce && (
-					<p>
+					<p className="woocommerce-profile-wizard__themes-skip-this-step">
 						<Button
 							isLink
 							className="woocommerce-profile-wizard__skip"

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -40,6 +40,10 @@
 	}
 }
 
+p.woocommerce-profile-wizard__themes-skip-this-step {
+	text-align: center;
+}
+
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__theme.woocommerce-card {
 	overflow: hidden;
 


### PR DESCRIPTION
Fixes #4839 

This styles the `<p>` that the skip link lives in on the theme selection step of the OBW so that it is centred on screen.

### Detailed test instructions:

1. Start the OBW
2. Travel to the theme selection step
3. Scroll to the bottom. The skip link should be centred on the page.

### Changelog Note:

Fix: Center the skip link on the theme selection step