### PR TITLE
Added personalization to purchase extension task

### DIFF
--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -50,13 +50,81 @@ export function getProductIdsForCart(
 	includeInstalledItems = false,
 	installedPlugins
 ) {
+	const productList = getProductList(
+		profileItems,
+		includeInstalledItems,
+		installedPlugins
+	);
+	const productIds = productList.map(
+		( product ) => product.id || product.product
+	);
+	return productIds;
+}
+
+/**
+ * Gets the grouped product names and types for items based on the product types and theme selected in the onboarding profiler.
+ *
+ * @param {Object} profileItems Onboarding profile.
+ * @param {Array} installedPlugins Installed plugins.
+ * @return {Array} Objects with grouped product names and types.
+ */
+export function getGroupedOnboardingProducts( profileItems, installedPlugins ) {
+	const productList = {};
+	productList.products = getProductList(
+		profileItems,
+		true,
+		installedPlugins
+	);
+	productList.remainingProducts = getProductList(
+		profileItems,
+		false,
+		installedPlugins
+	);
+
+	const uniqueItemsList = [
+		...new Set( [
+			...productList.products,
+			...productList.remainingProducts,
+		] ),
+	];
+
+	productList.uniqueItemsList = uniqueItemsList.map( ( product ) => {
+		let cleanedProduct;
+		if ( product.label ) {
+			const splittedLabel = product.label.split( ' — ' );
+			if ( Array.isArray( splittedLabel ) ) {
+				product.label = splittedLabel[ 0 ];
+			}
+			cleanedProduct = { type: 'extension', name: product.label };
+		} else {
+			cleanedProduct = { type: 'theme', name: product.title };
+		}
+		return cleanedProduct;
+	} );
+
+	return productList;
+}
+
+/**
+ * Gets a product list for items based on the product types and theme selected in the onboarding profiler.
+ *
+ * @param {Object} profileItems Onboarding profile.
+ * @param {boolean} includeInstalledItems Include installed items in returned product IDs.
+ * @param {Array} installedPlugins Installed plugins.
+ * @return {Array} Products.
+ */
+export function getProductList(
+	profileItems,
+	includeInstalledItems = false,
+	installedPlugins
+) {
 	const onboarding = getSetting( 'onboarding', {} );
-	const productIds = [];
+	const productList = [];
 
 	// The population of onboarding.productTypes only happens if the task list should be shown
 	// so bail early if it isn't present.
 	if ( ! onboarding.productTypes ) {
-		return productIds;
+		return productList;
 	}
 
 	const productTypes = profileItems.product_types || [];
@@ -70,7 +138,7 @@ export function getProductIdsForCart(
 					onboarding.productTypes[ productType ].slug
 				) )
 		) {
-			productIds.push( onboarding.productTypes[ productType ].product );
+			productList.push( onboarding.productTypes[ productType ] );
 		}
 	} );
 
@@ -84,10 +152,10 @@ export function getProductIdsForCart(
 		getPriceValue( theme.price ) > 0 &&
 		( includeInstalledItems || ! theme.is_installed )
 	) {
-		productIds.push( theme.id );
+		productList.push( theme );
 	}
 
-	return productIds;
+	return productList;
 }
 
 /**

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -62,13 +62,16 @@ export function getProductIdsForCart(
 }
 
 /**
- * Gets the grouped product names and types for items based on the product types and theme selected in the onboarding profiler.
+ * Gets the labeled/categorized product names and types for items based on the product types and theme selected in the onboarding profiler.
  *
  * @param {Object} profileItems Onboarding profile.
  * @param {Array} installedPlugins Installed plugins.
- * @return {Array} Objects with grouped product names and types.
+ * @return {Array} Objects with labeled/categorized product names and types.
  */
-export function getGroupedOnboardingProducts( profileItems, installedPlugins ) {
+export function getCategorizedOnboardingProducts(
+	profileItems,
+	installedPlugins
+) {
 	const productList = {};
 	productList.products = getProductList(
 		profileItems,

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -91,10 +91,6 @@ export function getGroupedOnboardingProducts( profileItems, installedPlugins ) {
 	productList.uniqueItemsList = uniqueItemsList.map( ( product ) => {
 		let cleanedProduct;
 		if ( product.label ) {
-			const splittedLabel = product.label.split( ' — ' );
-			if ( Array.isArray( splittedLabel ) ) {
-				product.label = splittedLabel[ 0 ];
-			}
 			cleanedProduct = { type: 'extension', name: product.label };
 		} else {
 			cleanedProduct = { type: 'theme', name: product.title };

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -105,7 +105,7 @@ export function getGroupedOnboardingProducts( profileItems, installedPlugins ) {
  * Gets a product list for items based on the product types and theme selected in the onboarding profiler.
  *
  * @param {Object} profileItems Onboarding profile.
- * @param {boolean} includeInstalledItems Include installed items in returned product IDs.
+ * @param {boolean} includeInstalledItems Include installed items in returned product list.
  * @param {Array} installedPlugins Installed plugins.
  * @return {Array} Products.
  */

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -90,10 +90,20 @@ export function getAllTasks( {
 		product_types: productTypes,
 	} = profileItems;
 
-	const purchaseAndInstallText =
-		uniqueItemsList.length === 1
-			? `Purchase & install ${ uniqueItemsList[ 0 ].name } ${ uniqueItemsList[ 0 ].type }`
-			: 'Purchase & install extensions';
+	let purchaseAndInstallText = __( 'Purchase & install extensions' );
+
+	if ( uniqueItemsList.length === 1 ) {
+		const { name: itemName, type: itemType } = uniqueItemsList[ 0 ];
+		const type =
+			itemType === 'theme'
+				? __( 'theme', 'woocommerce-admin' )
+				: __( 'extension', 'woocommerce-admin' );
+		purchaseAndInstallText = sprintf(
+			__( 'Purchase & install %s %s', 'woocommerce-admin' ),
+			itemName,
+			type
+		);
+	}
 
 	const tasks = [
 		{
@@ -112,10 +122,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'purchase',
-			title: sprintf(
-				__( '%s', 'woocommerce-admin' ),
-				purchaseAndInstallText
-			),
+			title: purchaseAndInstallText,
 			container: null,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -94,15 +94,11 @@ export function getAllTasks( {
 
 	if ( uniqueItemsList.length === 1 ) {
 		const { name: itemName, type: itemType } = uniqueItemsList[ 0 ];
-		const type =
+		const purchaseAndInstallFormat =
 			itemType === 'theme'
-				? __( 'theme', 'woocommerce-admin' )
-				: __( 'extension', 'woocommerce-admin' );
-		purchaseAndInstallText = sprintf(
-			__( 'Purchase & install %s %s', 'woocommerce-admin' ),
-			itemName,
-			type
-		);
+				? __( 'Purchase & install %s theme', 'woocommerce-admin' )
+				: __( 'Purchase & install %s extension', 'woocommerce-admin' );
+		purchaseAndInstallText = sprintf( purchaseAndInstallFormat, itemName );
 	}
 
 	const tasks = [

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -20,7 +20,7 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import Appearance from './tasks/appearance';
-import { getGroupedOnboardingProducts } from 'dashboard/utils';
+import { getCategorizedOnboardingProducts } from 'dashboard/utils';
 import Products from './tasks/products';
 import Shipping from './tasks/shipping';
 import Tax from './tasks/tax';
@@ -69,7 +69,7 @@ export function getAllTasks( {
 		shippingZonesCount: 0,
 	} );
 
-	const groupedProducts = getGroupedOnboardingProducts(
+	const groupedProducts = getCategorizedOnboardingProducts(
 		profileItems,
 		installedPlugins
 	);


### PR DESCRIPTION
Fixes #4578

This PR adds personalization to the `Purchase extension` task list item.

It should:
- Display the extension name if the user selected one extension: Purchase and install [extension_name] extension
- Apply the same for themes: Purchase and install [theme_name] theme
- Keep the task description generic if the user selected more than one product

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-2020-06-02-at-12.34.18.png](https://images.zenhubusercontent.com/5d84fe8e1201de0001b6ab61/a414c7f8-77c2-41f9-bcfc-4ce30a915de1)

### Detailed test instructions:

#### Extensions
- Go to the 3rd step of the OBW (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fprofiler&step=product-types`).
- Select only one paid extension. Be sure you don't have a paid theme selected too. 
- Go back to the `Dashboard` or `Home` screen (URL: `/wp-admin/admin.php?page=wc-admin`).
- Now the item `Purchase and install [extension_name] extension` should be visible in the task list.

#### Themes
- Now unselect the paid extension, choose a free one and go to the 5th step of the OBW and select a paid theme.
- Go back to the `Dashboard` or `Home` screen (URL: `/wp-admin/admin.php?page=wc-admin`).
- Now the item `Purchase and install [theme_name] theme` should be visible in the task list.

#### More than one item
- Try adding a paid extension and a paid theme, or two paid extensions.
- The message `Purchase & install extensions` should be visible.


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Added personalization to purchase extension task
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
