### PR TITLE
Register wca pages with wc navigation

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -440,6 +440,17 @@ class PageController {
 				$options['icon'],
 				$options['position']
 			);
+
+			if ( method_exists( '\Automattic\WooCommerce\Navigation\Menu', 'add_category' ) ) {
+				\Automattic\WooCommerce\Navigation\Menu::add_category(
+					array(
+						'id'         => $options['id'],
+						'title'      => $options['title'],
+						'capability' => $options['capability'],
+						'url'        => $options['path'],
+					)
+				);
+			}
 		} else {
 			$parent_path = $this->get_path_from_id( $options['parent'] );
 			// @todo check for null path.
@@ -451,6 +462,18 @@ class PageController {
 				$options['path'],
 				array( __CLASS__, 'page_wrapper' )
 			);
+
+			if ( method_exists( '\Automattic\WooCommerce\Navigation\Menu', 'add_item' ) ) {
+				\Automattic\WooCommerce\Navigation\Menu::add_item(
+					array(
+						'id'         => $options['id'],
+						'parent'     => $options['parent'],
+						'title'      => $options['title'],
+						'capability' => $options['capability'],
+						'url'        => $options['path'],
+					)
+				);
+			}
 		}
 
 		$this->connect_page( $options );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/navigation/issues/3

Registers pages with the new nav project if the project methods exist.

### Screenshots
<img width="171" alt="Screen Shot 2020-07-22 at 4 13 28 PM" src="https://user-images.githubusercontent.com/10561050/88180612-4f5cbf00-cc36-11ea-9567-d25f1daab3b7.png">
<img width="194" alt="Screen Shot 2020-07-22 at 4 13 10 PM" src="https://user-images.githubusercontent.com/10561050/88180614-4ff55580-cc36-11ea-86b5-ee4a757800fc.png">


### Detailed test instructions:

1. Install and activate the nav project `https://github.com/woocommerce/navigation/` as a plugin.
1. Checkout the branch in this PR  `https://github.com/woocommerce/navigation/pull/43`
1. Check that analytics pages have been moved over with respective parent/child relationships.
1. Check that marketing pages have been moved over with respective parent/child relationships (just overview and coupons for the time being).
1. Optionally check that data looks good in `window.wcNavigation`.