### PR TITLE
Fix child theme upload error

### DIFF
--- a/src/API/Themes.php
+++ b/src/API/Themes.php
@@ -81,7 +81,11 @@ class Themes extends \WC_REST_Data_Controller {
 		}
 
 		include_once ABSPATH . 'wp-admin/includes/file.php';
-		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		include_once ABSPATH . '/wp-admin/includes/admin.php';
+		include_once ABSPATH . '/wp-admin/includes/theme-install.php';
+		include_once ABSPATH . '/wp-admin/includes/theme.php';
+		include_once ABSPATH . '/wp-admin/includes/class-wp-upgrader.php';
+		include_once ABSPATH . '/wp-admin/includes/class-theme-upgrader.php';
 
 		$_GET['package'] = true;
 		$file_upload     = new \File_Upload_Upgrader( 'pluginzip', 'package' );

--- a/src/Overrides/ThemeUpgraderSkin.php
+++ b/src/Overrides/ThemeUpgraderSkin.php
@@ -14,6 +14,13 @@ defined( 'ABSPATH' ) || exit;
  */
 class ThemeUpgraderSkin extends \Theme_Upgrader_Skin {
 	/**
+	 * Avoid undefined property error from \Theme_Upgrader::check_parent_theme_filter().
+	 *
+	 * @var array
+	 */
+	public $api;
+
+	/**
 	 * Hide the skin header display.
 	 */
 	public function header() {}

--- a/src/Overrides/ThemeUpgraderSkin.php
+++ b/src/Overrides/ThemeUpgraderSkin.php
@@ -27,8 +27,9 @@ class ThemeUpgraderSkin extends \Theme_Upgrader_Skin {
 	 * Hide the skin feedback display.
 	 *
 	 * @param string $string String to display.
+	 * @param mixed  ...$args Optional text replacements.
 	 */
-	public function feedback( $string ) {}
+	public function feedback( $string, ...$args ) {}
 
 	/**
 	 * Hide the skin after display.


### PR DESCRIPTION
Fixes #4188.

This PR seeks to fix the PHP Fatal error encountered when uploading a child theme through the OBW.

cc: @gglobalstep, @juliaamosova 

### Detailed test instructions:

- Go through the OBW to the theme step
- Upload a child theme .zip **that you do NOT have the parent theme installed for**
- Verify success and no PHP error log messages

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Installation of child theme zip files from the store setup wizard.