### PR TITLE
Bundle @wordpress/data to avoid fatal exceptions

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -397,7 +397,6 @@ class Loader {
 			array(
 				'moment',
 				'wp-api-fetch',
-				'wp-data',
 				'wp-data-controls',
 				'wp-element',
 				'wp-hooks',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,6 @@ const WC_ADMIN_PHASE = process.env.WC_ADMIN_PHASE || 'development';
 const externals = {
 	'@wordpress/api-fetch': { this: [ 'wp', 'apiFetch' ] },
 	'@wordpress/blocks': { this: [ 'wp', 'blocks' ] },
-	'@wordpress/data': { this: [ 'wp', 'data' ] },
 	'@wordpress/editor': { this: [ 'wp', 'editor' ] },
 	'@wordpress/element': { this: [ 'wp', 'element' ] },
 	'@wordpress/hooks': { this: [ 'wp', 'hooks' ] },
@@ -220,10 +219,11 @@ const webpackConfig = {
 			startYear: 2000, // This strips out timezone data before the year 2000 to make a smaller file.
 		} ),
 		process.env.ANALYZE && new BundleAnalyzerPlugin(),
-		WC_ADMIN_PHASE !== 'core' && new UnminifyWebpackPlugin( {
-			test: /\.js($|\?)/i,
-			mainEntry: 'app/index.min.js',
-		} ),
+		WC_ADMIN_PHASE !== 'core' &&
+			new UnminifyWebpackPlugin( {
+				test: /\.js($|\?)/i,
+				mainEntry: 'app/index.min.js',
+			} ),
 	].filter( Boolean ),
 	optimization: {
 		minimize: NODE_ENV !== 'development',
@@ -231,10 +231,7 @@ const webpackConfig = {
 	},
 };
 
-if (
-	webpackConfig.mode !== 'production' &&
-	WC_ADMIN_PHASE !== 'core'
-) {
+if ( webpackConfig.mode !== 'production' && WC_ADMIN_PHASE !== 'core' ) {
 	webpackConfig.devtool = process.env.SOURCEMAP || 'source-map';
 }
 


### PR DESCRIPTION
Fixes #4710 

There was an issue where we depended on `__experimentalResolveSelect` from `@wordpress/data` but it is not available on some versions of `@wordpress/data` that are bundled with Wordpress. To solve this, we are bundling `@wordpress/data` for now.

### Detailed test instructions:

To test this you'll need an older version of Wordpress. Wordpress 5.3.2 was used in the original issue so I've used that to replicate it. I suggest using the WP Downgrade plugin to install a 5.3.2 in your development environment.

Also you'll need to make sure that your build assets are clean. run `npm run clean`, then `npm start`

Once you have an older version of Wordpress and your build assets are cleaned out and rebuilt, simply go to the WooCommerce home page and make sure it doesn't crash, do a quick smoke test of the home screen and the setup wizard to ensure nothing causes an exception.
