### PR TITLE
Fix PHP warning when preloading scripts on WPEngine

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -556,12 +556,19 @@ class Loader {
 		}
 
 		foreach ( $dependencies_of_type->queue as $dependency_handle ) {
-			$dependency = $dependencies_of_type->registered[ $dependency_handle ];
+			$dependency = $dependencies_of_type->query( $dependency_handle, 'registered' );
+
+			if ( false === $dependency ) {
+				continue;
+			}
 
 			// Preload the subdependencies first.
 			foreach ( $dependency->deps as $sub_dependency_handle ) {
-				$sub_dependency = $dependencies_of_type->registered[ $sub_dependency_handle ];
-				self::maybe_output_preload_link_tag( $sub_dependency, $type, $whitelist );
+				$sub_dependency = $dependencies_of_type->query( $sub_dependency_handle, 'registered' );
+
+				if ( $sub_dependency ) {
+					self::maybe_output_preload_link_tag( $sub_dependency, $type, $whitelist );
+				}
 			}
 
 			self::maybe_output_preload_link_tag( $dependency, $type, $whitelist );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -519,16 +519,16 @@ class Loader {
 
 	/**
 	 * Render a preload link tag for a dependency, optionally
-	 * checked against a provided whitelist.
+	 * checked against a provided allowlist.
 	 *
 	 * See: https://macarthur.me/posts/preloading-javascript-in-wordpress
 	 *
 	 * @param WP_Dependency $dependency The WP_Dependency being preloaded.
 	 * @param string        $type Dependency type - 'script' or 'style'.
-	 * @param array         $whitelist Optional. List of allowed dependency handles.
+	 * @param array         $allowlist Optional. List of allowed dependency handles.
 	 */
-	public static function maybe_output_preload_link_tag( $dependency, $type, $whitelist = array() ) {
-		if ( ! empty( $whitelist ) && ! in_array( $dependency->handle, $whitelist, true ) ) {
+	public static function maybe_output_preload_link_tag( $dependency, $type, $allowlist = array() ) {
+		if ( ! empty( $allowlist ) && ! in_array( $dependency->handle, $allowlist, true ) ) {
 			return;
 		}
 
@@ -539,14 +539,14 @@ class Loader {
 
 	/**
 	 * Output a preload link tag for dependencies (and their sub dependencies)
-	 * with an optional whitelist.
+	 * with an optional allowlist.
 	 *
 	 * See: https://macarthur.me/posts/preloading-javascript-in-wordpress
 	 *
 	 * @param string $type Dependency type - 'script' or 'style'.
-	 * @param array  $whitelist Optional. List of allowed dependency handles.
+	 * @param array  $allowlist Optional. List of allowed dependency handles.
 	 */
-	public static function output_header_preload_tags_for_type( $type, $whitelist = array() ) {
+	public static function output_header_preload_tags_for_type( $type, $allowlist = array() ) {
 		if ( 'script' === $type ) {
 			$dependencies_of_type = wp_scripts();
 		} elseif ( 'style' === $type ) {
@@ -567,11 +567,11 @@ class Loader {
 				$sub_dependency = $dependencies_of_type->query( $sub_dependency_handle, 'registered' );
 
 				if ( $sub_dependency ) {
-					self::maybe_output_preload_link_tag( $sub_dependency, $type, $whitelist );
+					self::maybe_output_preload_link_tag( $sub_dependency, $type, $allowlist );
 				}
 			}
 
-			self::maybe_output_preload_link_tag( $dependency, $type, $whitelist );
+			self::maybe_output_preload_link_tag( $dependency, $type, $allowlist );
 		}
 	}
 


### PR DESCRIPTION
Fixes report from an HE:

```
Notice: Undefined index: heartbeat in /wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Loader.php on line 548

Notice: Trying to get property 'handle' of non-object in /wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Loader.php on line 516
```

WPEngine unregisters the `heartbeat` script which causes our "preload tag" logic to throw undefined index notices when trying to find `heartbeat` (a dependency of `wp-auth-check`) in the registered scripts array.

This PR seeks to make the preload logic more resilient by using the [`WP_Dependency::query()`](https://developer.wordpress.org/reference/classes/wp_dependencies/query/) method to access registered scripts. It also updates some terminology to not be racist. (whitelist -> allowlist)

### Detailed test instructions:

- Simulate missing heartbeat by adding `\wp_deregister_script( 'heartbeat' );` to `Loader::load_scripts()` before the call to `self::output_header_preload_tags()`
- Go to a WC Admin page
- Go to a core WC page
- Verify no errors in log

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: PHP notices when hosts block certain WP scripts.