### PR TITLE
Automatically add free local shipping zone on completing the profiler

### DIFF
--- a/client/lib/sanitize-html/index.js
+++ b/client/lib/sanitize-html/index.js
@@ -3,7 +3,7 @@
  */
 import { sanitize } from 'dompurify';
 
-export const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p' ];
+export const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br' ];
 export const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
 
 export default ( html ) => {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Admin\Features;
 use \Automattic\WooCommerce\Admin\Loader;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Profiler;
 use \Automattic\WooCommerce\Admin\PluginsHelper;
+use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
 
 /**
  * Contains backend logic for the onboarding profile and checklist feature.
@@ -78,6 +79,9 @@ class Onboarding {
 		// Add actions and filters.
 		$this->add_actions();
 		$this->add_filters();
+
+		// Hook up dependant classes.
+		new OnboardingSetUpShipping();
 	}
 
 	/**
@@ -105,6 +109,15 @@ class Onboarding {
 		// Rest API hooks need to run before is_admin() checks.
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
+		add_action(
+			'update_option_' . self::PROFILE_DATA_OPTION,
+			array(
+				$this,
+				'trigger_profile_completed_action',
+			),
+			10,
+			2
+		);
 
 		if ( ! is_admin() ) {
 			return;
@@ -118,6 +131,20 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
+	}
+
+	/**
+	 * Trigger the woocommerce_onboarding_profile_completed action
+	 *
+	 * @param array $old_value Previous value.
+	 * @param array $value Current value.
+	 */
+	public function trigger_profile_completed_action( $old_value, $value ) {
+		if ( ! isset( $value['completed'] ) || ! $value['completed'] ) {
+			return;
+		}
+
+		do_action( 'woocommerce_onboarding_profile_completed' );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -144,6 +144,12 @@ class Onboarding {
 			return;
 		}
 
+		/**
+		 * Action hook fired when the onboarding profile (or onboarding wizard,
+		 * or profiler) is completed.
+		 *
+		 * @since 1.5.0
+		 */
 		do_action( 'woocommerce_onboarding_profile_completed' );
 	}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -140,6 +140,10 @@ class Onboarding {
 	 * @param array $value Current value.
 	 */
 	public function trigger_profile_completed_action( $old_value, $value ) {
+		if ( isset( $old_value['completed'] ) && $old_value['completed'] ) {
+			return;
+		}
+
 		if ( ! isset( $value['completed'] ) || ! $value['completed'] ) {
 			return;
 		}

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -28,5 +28,37 @@ class OnboardingSetUpShipping {
 	 * Set up shipping.
 	 */
 	public static function on_onboarding_profile_completed() {
+		// Only do this if there are no existing shipping methods.
+
+		self::turn_on_printing_shipping_labels();
+		self::set_up_free_local_shipping();
+		self::disable_international_shipping();
+		self::trigger_review_shipping_settings_note();
+		self::track_shipping_automatically_set_up_event();
 	}
+
+	/**
+	 * Turn on printing of shipping labels.
+	 */
+	private static function turn_on_printing_shipping_labels() {}
+
+	/**
+	 * Set up free local shipping.
+	 */
+	private static function set_up_free_local_shipping() {}
+
+	/**
+	 * Disable international shipping.
+	 */
+	private static function disable_international_shipping() {}
+
+	/**
+	 * Trigger the "Review your shipping settings" admin note.
+	 */
+	private static function trigger_review_shipping_settings_note() {}
+
+	/**
+	 * Track the shipping_automatically_set_up event.
+	 */
+	private static function track_shipping_automatically_set_up_event() {}
 }

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -31,19 +31,11 @@ class OnboardingSetUpShipping {
 	 * Set up shipping.
 	 */
 	public static function on_onboarding_profile_completed() {
-		if ( ! self::is_jetpack_installed_and_connected() ) {
-			return;
-		}
-
-		if ( ! PluginsHelper::is_plugin_active( 'woocommerce-services' ) ) {
-			return;
-		}
-
 		if ( ! self::is_physical_selected_as_product_type() ) {
 			return;
 		}
 
-		if ( ! self::are_there_existing_shipping_zones() ) {
+		if ( self::are_there_existing_shipping_zones() ) {
 			return;
 		}
 
@@ -80,21 +72,6 @@ class OnboardingSetUpShipping {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Is Jetpack installed and connected?
-	 *
-	 * @return bool
-	 */
-	private static function is_jetpack_installed_and_connected() {
-		if ( ! class_exists( '\Jetpack_Data' ) ) {
-			return false;
-		}
-
-		$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-
-		return isset( $user_token->external_user_id );
 	}
 
 	/**

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -28,13 +28,34 @@ class OnboardingSetUpShipping {
 	 * Set up shipping.
 	 */
 	public static function on_onboarding_profile_completed() {
-		// Only do this if there are no existing shipping methods.
+		if ( ! self::is_jetpack_installed_and_connected() ) {
+			return;
+		}
+
+		// Return if WCS isn't installed and active.
+		// Return unless Physical is selected as a product type.
+		// Return if there are existing shipping methods.
 
 		self::turn_on_printing_shipping_labels();
 		self::set_up_free_local_shipping();
 		self::disable_international_shipping();
-		self::trigger_review_shipping_settings_note();
+		self::add_review_shipping_settings_note();
 		self::track_shipping_automatically_set_up_event();
+	}
+
+	/**
+	 * Is Jetpack installed and connected?
+	 *
+	 * @return bool
+	 */
+	private static function is_jetpack_installed_and_connected() {
+		if ( ! class_exists( '\Jetpack_Data' ) ) {
+			return false;
+		}
+
+		$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+
+		return isset( $user_token->external_user_id );
 	}
 
 	/**
@@ -53,9 +74,9 @@ class OnboardingSetUpShipping {
 	private static function disable_international_shipping() {}
 
 	/**
-	 * Trigger the "Review your shipping settings" admin note.
+	 * Add the "Review your shipping settings" admin note.
 	 */
-	private static function trigger_review_shipping_settings_note() {}
+	private static function add_review_shipping_settings_note() {}
 
 	/**
 	 * Track the shipping_automatically_set_up event.

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Onboarding - set up shipping.
+ *
+ * @package Woocommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Features;
+
+/**
+ * This contains logic for setting up shipping when the profiler completes.
+ */
+class OnboardingSetUpShipping {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action(
+			'woocommerce_onboarding_profile_completed',
+			array(
+				__CLASS__,
+				'on_onboarding_profile_completed',
+			)
+		);
+	}
+
+	/**
+	 * Set up shipping.
+	 */
+	public static function on_onboarding_profile_completed() {
+	}
+}

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -49,7 +49,7 @@ class OnboardingSetUpShipping {
 
 		self::set_up_free_local_shipping();
 		WC_Admin_Notes_Review_Shipping_Settings::possibly_add_note();
-		self::track_shipping_automatically_set_up_event();
+		wc_admin_record_tracks_event( 'shipping_automatically_set_up' );
 	}
 
 	/**
@@ -128,9 +128,4 @@ class OnboardingSetUpShipping {
 		$zone->save();
 		$zone->add_shipping_method( 'free_shipping' );
 	}
-
-	/**
-	 * Track the shipping_automatically_set_up event.
-	 */
-	private static function track_shipping_automatically_set_up_event() {}
 }

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\PluginsHelper;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Review_Shipping_Settings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -47,7 +48,7 @@ class OnboardingSetUpShipping {
 		}
 
 		self::set_up_free_local_shipping();
-		self::add_review_shipping_settings_note();
+		WC_Admin_Notes_Review_Shipping_Settings::possibly_add_note();
 		self::track_shipping_automatically_set_up_event();
 	}
 
@@ -127,11 +128,6 @@ class OnboardingSetUpShipping {
 		$zone->save();
 		$zone->add_shipping_method( 'free_shipping' );
 	}
-
-	/**
-	 * Add the "Review your shipping settings" admin note.
-	 */
-	private static function add_review_shipping_settings_note() {}
 
 	/**
 	 * Track the shipping_automatically_set_up event.

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -100,7 +100,34 @@ class OnboardingSetUpShipping {
 	/**
 	 * Set up free local shipping.
 	 */
-	private static function set_up_free_local_shipping() {}
+	private static function set_up_free_local_shipping() {
+		$default_country = apply_filters(
+			'woocommerce_get_base_location',
+			get_option( 'woocommerce_default_country' )
+		);
+
+		if ( ! $default_country ) {
+			return;
+		}
+
+		$country_code = explode( ':', $default_country )[0];
+		$zone         = new \WC_Shipping_Zone();
+
+		$zone->add_location( $country_code, 'country' );
+
+		$countries = apply_filters(
+			'woocommerce_countries',
+			include WC()->plugin_path() . '/i18n/countries.php'
+		);
+		$zone_name = isset( $countries[ $country_code ] )
+			? $countries[ $country_code ]
+			: null;
+
+		$zone->set_zone_name( $zone_name );
+
+		$zone->save();
+		$zone->add_shipping_method( 'free_shipping' );
+	}
 
 	/**
 	 * Disable international shipping.

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -47,7 +47,6 @@ class OnboardingSetUpShipping {
 		}
 
 		self::set_up_free_local_shipping();
-		self::disable_international_shipping();
 		self::add_review_shipping_settings_note();
 		self::track_shipping_automatically_set_up_event();
 	}
@@ -128,11 +127,6 @@ class OnboardingSetUpShipping {
 		$zone->save();
 		$zone->add_shipping_method( 'free_shipping' );
 	}
-
-	/**
-	 * Disable international shipping.
-	 */
-	private static function disable_international_shipping() {}
 
 	/**
 	 * Add the "Review your shipping settings" admin note.

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use \Automattic\WooCommerce\Admin\PluginsHelper;
+
 /**
  * This contains logic for setting up shipping when the profiler completes.
  */
@@ -32,7 +34,10 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		// Return if WCS isn't installed and active.
+		if ( ! PluginsHelper::is_plugin_active( 'woocommerce-services' ) ) {
+			return;
+		}
+
 		// Return unless Physical is selected as a product type.
 		// Return if there are existing shipping methods.
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -42,7 +42,9 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		// Return if there are existing shipping methods.
+		if ( ! self::are_there_existing_shipping_zones() ) {
+			return;
+		}
 
 		self::turn_on_printing_shipping_labels();
 		self::set_up_free_local_shipping();
@@ -52,7 +54,20 @@ class OnboardingSetUpShipping {
 	}
 
 	/**
+	 * Are there existing shipping zones?
+	 *
+	 * @return bool
+	 */
+	private static function are_there_existing_shipping_zones() {
+		$zone_count = count( \WC_Shipping_Zones::get_zones() );
+
+		return $zone_count > 0;
+	}
+
+	/**
 	 * Is 'physical' selected as a product type?
+	 *
+	 * @return bool
 	 */
 	private static function is_physical_selected_as_product_type() {
 		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION );

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -46,7 +46,6 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		self::turn_on_printing_shipping_labels();
 		self::set_up_free_local_shipping();
 		self::disable_international_shipping();
 		self::add_review_shipping_settings_note();
@@ -97,11 +96,6 @@ class OnboardingSetUpShipping {
 
 		return isset( $user_token->external_user_id );
 	}
-
-	/**
-	 * Turn on printing of shipping labels.
-	 */
-	private static function turn_on_printing_shipping_labels() {}
 
 	/**
 	 * Set up free local shipping.

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -38,7 +38,10 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		// Return unless Physical is selected as a product type.
+		if ( ! self::is_physical_selected_as_product_type() ) {
+			return;
+		}
+
 		// Return if there are existing shipping methods.
 
 		self::turn_on_printing_shipping_labels();
@@ -46,6 +49,23 @@ class OnboardingSetUpShipping {
 		self::disable_international_shipping();
 		self::add_review_shipping_settings_note();
 		self::track_shipping_automatically_set_up_event();
+	}
+
+	/**
+	 * Is 'physical' selected as a product type?
+	 */
+	private static function is_physical_selected_as_product_type() {
+		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION );
+
+		if ( ! isset( $onboarding_data['product_types'] ) ) {
+			return false;
+		}
+
+		if ( ! in_array( 'physical', $onboarding_data['product_types'], true ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -31,11 +31,11 @@ class OnboardingSetUpShipping {
 	 * Set up shipping.
 	 */
 	public static function on_onboarding_profile_completed() {
-		if ( ! self::is_physical_selected_as_product_type() ) {
+		if ( ! self::has_physical_products() ) {
 			return;
 		}
 
-		if ( self::are_there_existing_shipping_zones() ) {
+		if ( self::has_existing_shipping_zones() ) {
 			return;
 		}
 
@@ -49,7 +49,7 @@ class OnboardingSetUpShipping {
 	 *
 	 * @return bool
 	 */
-	private static function are_there_existing_shipping_zones() {
+	private static function has_existing_shipping_zones() {
 		$zone_count = count( \WC_Shipping_Zones::get_zones() );
 
 		return $zone_count > 0;
@@ -60,7 +60,7 @@ class OnboardingSetUpShipping {
 	 *
 	 * @return bool
 	 */
-	private static function is_physical_selected_as_product_type() {
+	private static function has_physical_products() {
 		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION );
 
 		if ( ! isset( $onboarding_data['product_types'] ) ) {

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -92,11 +92,9 @@ class OnboardingSetUpShipping {
 
 		$zone->add_location( $country_code, 'country' );
 
-		$countries = apply_filters(
-			'woocommerce_countries',
-			include WC()->plugin_path() . '/i18n/countries.php'
-		);
-		$zone_name = isset( $countries[ $country_code ] )
+		$countries_service = new \WC_Countries();
+		$countries         = $countries_service->get_countries();
+		$zone_name         = isset( $countries[ $country_code ] )
 			? $countries[ $country_code ]
 			: null;
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -77,7 +77,7 @@ class OnboardingSetUpShipping {
 	/**
 	 * Set up free local shipping.
 	 */
-	private static function set_up_free_local_shipping() {
+	public static function set_up_free_local_shipping() {
 		$default_country = apply_filters(
 			'woocommerce_get_base_location',
 			get_option( 'woocommerce_default_country' )

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -96,7 +96,7 @@ class OnboardingSetUpShipping {
 		$countries         = $countries_service->get_countries();
 		$zone_name         = isset( $countries[ $country_code ] )
 			? $countries[ $country_code ]
-			: null;
+			: $country_code;
 
 		$zone->set_zone_name( $zone_name );
 

--- a/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
+++ b/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WooCommerce Admin Review Shipping Settings Note Provider.
+ *
+ * Adds an admin note prompting the admin to review their shipping settings.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Review_Shipping_Settings
+ */
+class WC_Admin_Notes_Review_Shipping_Settings {
+	use NoteTraits;
+
+	const NOTE_NAME = 'wc-admin-review-shipping-settings';
+
+	/**
+	 * Possibly add note.
+	 */
+	public static function possibly_add_note() {
+		if ( ! self::can_be_added() ) {
+			return;
+		}
+
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return WC_Admin_Note
+	 */
+	public static function get_note() {
+		$note = new WC_Admin_Note();
+
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->set_title( __( 'Review your shipping settings', 'woocommerce-admin' ) );
+		$note->set_content(
+			__(
+				"Based on the information that you provided we've configured some shipping rates and options for your store:<br/><br/>
+				Domestic orders: free shipping<br/>
+				International orders: disabled<br/>
+				Label printing: enabled",
+				'woocommerce-admin'
+			)
+		);
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+
+		$note->add_action(
+			'edit-shipping-settings',
+			__( 'Edit shipping settings', 'woocommerce-admin' ),
+			'/wp-admin/admin.php?page=wc-settings&tab=shipping',
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
+++ b/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
@@ -45,7 +45,7 @@ class WC_Admin_Notes_Review_Shipping_Settings {
 		$note->add_action(
 			'edit-shipping-settings',
 			__( 'Edit shipping settings', 'woocommerce-admin' ),
-			'/wp-admin/admin.php?page=wc-settings&tab=shipping',
+			admin_url( 'admin.php?page=wc-settings&tab=shipping' ),
 			'unactioned',
 			true
 		);

--- a/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
+++ b/src/Notes/WC_Admin_Notes_Review_Shipping_Settings.php
@@ -20,18 +20,6 @@ class WC_Admin_Notes_Review_Shipping_Settings {
 	const NOTE_NAME = 'wc-admin-review-shipping-settings';
 
 	/**
-	 * Possibly add note.
-	 */
-	public static function possibly_add_note() {
-		if ( ! self::can_be_added() ) {
-			return;
-		}
-
-		$note = self::get_note();
-		$note->save();
-	}
-
-	/**
 	 * Get the note.
 	 *
 	 * @return WC_Admin_Note

--- a/tests/features/class-onboarding-set-up-shipping.php
+++ b/tests/features/class-onboarding-set-up-shipping.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Onboarding - set up shipping tests.
+ *
+ * @package WooCommerce\Tests\Onboarding-shipping-set-up
+ */
+
+use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
+
+/**
+ * Tests shipping set up during onboarding.
+ */
+class WC_Tests_OnboardingShippingSetUp extends WC_Unit_Test_Case {
+	/**
+	 * Verify that the zone gets created.
+	 */
+	public function test_zone_gets_created_when_setting_up_free_shipping() {
+		update_option( 'woocommerce_default_country', 'AU:QLD' );
+
+		OnboardingSetUpShipping::set_up_free_local_shipping();
+
+		$zones = \WC_Shipping_Zones::get_zones();
+
+		// There should be only one zone, with a zone name of 'Australia'.
+		$this->assertEquals( 1, count( $zones ) );
+		$zone = $zones[ array_keys( $zones )[0] ];
+		$this->assertEquals( 'Australia', $zone['zone_name'] );
+
+		// There should only be one zone location with a code of 'AU'.
+		$this->assertEquals( 1, count( $zone['zone_locations'] ) );
+		$zone_location = $zone['zone_locations'][0];
+		$this->assertEquals( 'AU', $zone_location->code );
+
+		// There should be only one shipping zone method, with a method ID of
+		// 'free_shipping'.
+		$data_store = WC_Data_Store::load( 'shipping-zone' );
+		$methods    = $data_store->get_methods( $zone['id'], true );
+		$this->assertEquals( 1, count( $methods ) );
+		$method = $methods[0];
+		$this->assertEquals( 'free_shipping', $method->method_id );
+	}
+
+	/**
+	 * Verify that the zone doesn't get created if there is no default
+	 * country.
+	 */
+	public function test_zone_does_not_get_created_with_no_default_country() {
+		add_filter(
+			'woocommerce_get_base_location',
+			array(
+				$this,
+				'get_empty_base_location',
+			)
+		);
+
+		OnboardingSetUpShipping::set_up_free_local_shipping();
+
+		$zones = \WC_Shipping_Zones::get_zones();
+
+		$this->assertEquals( 0, count( $zones ) );
+	}
+
+	/**
+	 * Get empty base location.
+	 */
+	public function get_empty_base_location() {
+		return null;
+	}
+}


### PR DESCRIPTION
Fixes #4595

This adds free local shipping as a shipping option at the end of the onboarding wizard if:

- "Physical" was selected as a product type
- No existing shipping zones (except for "Locations not covered by your other zones", which is a system shipping zone that can't be deleted)

### Screenshots

### Detailed test instructions:

1. Delete the profile data option - `wp option delete woocommerce_onboarding_profile` or `delete from wp_options where option_name = 'wp option delete woocommerce_onboarding_profile'`
1. Delete all your shipping zones (WooCommerce -> Settings -> Shipping) except for "Locations not covered by your other zones", which is a system shipping zone that can't be deleted
2. Start the OBW
3. Complete the OBW
4. Go to the WooCommerce home page
5. Check that there is an admin note titled "Review your shipping settings"
6. Check that the "Set up shipping" task is completed
7. Check that the free local shipping zone has been added

### Changelog Note:

Enhancement: Automatically add free local shipping zone on completing the profiler