### PR TITLE
Summary Numbers: Fix background

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -56,7 +56,6 @@ export class ReportSummary extends Component {
 	render() {
 		const {
 			charts,
-			isRequesting,
 			query,
 			selectedChart,
 			summaryData,
@@ -64,13 +63,13 @@ export class ReportSummary extends Component {
 			report,
 			defaultDateRange,
 		} = this.props;
-		const { isError, isRequesting: isSummaryDataRequesting } = summaryData;
+		const { isError, isRequesting } = summaryData;
 
 		if ( isError ) {
 			return <ReportError isError />;
 		}
 
-		if ( isRequesting || isSummaryDataRequesting ) {
+		if ( isRequesting ) {
 			return <SummaryListPlaceholder numberOfItems={ charts.length } />;
 		}
 
@@ -144,10 +143,6 @@ ReportSummary.propTypes = {
 	 */
 	query: PropTypes.object.isRequired,
 	/**
-	 * Whether there is an API call running.
-	 */
-	isRequesting: PropTypes.bool,
-	/**
 	 * Properties of the selected chart.
 	 */
 	selectedChart: PropTypes.shape( {
@@ -189,7 +184,6 @@ ReportSummary.defaultProps = {
 			secondary: {},
 		},
 		isError: false,
-		isRequesting: false,
 	},
 };
 
@@ -200,17 +194,12 @@ export default compose(
 		const {
 			charts,
 			endpoint,
-			isRequesting,
 			limitProperties,
 			query,
 			filters,
 			advancedFilters,
 		} = props;
 		const limitBy = limitProperties || [ endpoint ];
-
-		if ( isRequesting ) {
-			return {};
-		}
 
 		const hasLimitByParam = limitBy.some(
 			( item ) => query[ item ] && query[ item ].length

--- a/client/dashboard/store-performance/style.scss
+++ b/client/dashboard/store-performance/style.scss
@@ -23,16 +23,4 @@
 			}
 		}
 	}
-
-	.woocommerce-summary__item {
-		background-color: $studio-white;
-
-		&:hover {
-			background-color: $gray-100;
-		}
-
-		&:active {
-			background-color: $gray-100;
-		}
-	}
 }

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -259,7 +259,7 @@ $border: $gray-200;
 	flex-direction: column;
 	height: 100%;
 	padding: $gap-large;
-	background-color: $gray-100;
+	background-color: $studio-white;
 	border-bottom: 1px solid $border;
 	border-right: 1px solid $border;
 	line-height: 1.4em;


### PR DESCRIPTION
The background for Summary Numbers was only applied in the Dashboard. This PR moves that CSS to the component itself for consistency.

I also removed an unused prop `isRequesting` from the analytics component ReportSummary. It does not appear to be used anywhere.

### Before

![Screen Shot 2020-07-23 at 11 49 27 AM](https://user-images.githubusercontent.com/1922453/88358901-e35c9100-cdc4-11ea-8c20-c0a757a52491.png)
![Screen Shot 2020-07-24 at 3 35 38 PM](https://user-images.githubusercontent.com/1922453/88358908-e6f01800-cdc4-11ea-93b6-343031860826.png)

### After

![Screen Shot 2020-07-24 at 3 47 19 PM](https://user-images.githubusercontent.com/1922453/88358942-0129f600-cdc5-11ea-8d71-2736a9e06334.png)
![Screen Shot 2020-07-24 at 3 47 45 PM](https://user-images.githubusercontent.com/1922453/88358950-0ab35e00-cdc5-11ea-9684-4084694df1b8.png)

### Detailed test instructions:

1. Visit pages with Summary Numbers (Homescreen, any Report, and Overview page).
2. See the placeholders render.
3. See the background white.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Summary Numbers placeholder and background styles.
