### PR TITLE
DateRangeFilterPicker: Fix unused ref

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `<List />` and `<Link />` components to Storybook.
 - Add `<Pill />` component.
 - Add `key` prop to `<List />` component items.
+- Remove unused `ref` from `<DateRangeFilterPicker />`.
 
 ## Breaking Changes
 - Removed `SplitButton` because its not being used.

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component, createRef } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Dropdown } from '@wordpress/components';
 import PropTypes from 'prop-types';
@@ -21,8 +21,6 @@ class DateRangeFilterPicker extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = this.getResetState();
-
-		this.dropdownRef = createRef();
 
 		this.update = this.update.bind( this );
 		this.onSelect = this.onSelect.bind( this );
@@ -130,7 +128,6 @@ class DateRangeFilterPicker extends Component {
 					{ __( 'Date Range', 'woocommerce-admin' ) }:
 				</span>
 				<Dropdown
-					ref={ this.dropdownRef }
 					contentClassName="woocommerce-filters-date__content"
 					position="bottom"
 					expandOnMobile


### PR DESCRIPTION
A `ref` that wasn't being used started to cause a warning.

![Screen Shot 2020-07-24 at 4 03 31 PM](https://user-images.githubusercontent.com/1922453/88359711-cd9c9b00-cdc7-11ea-92dc-de299a09caf9.png)

### Detailed test instructions:

1. Visit any page with the datepicker.
2. See that there is no warning.
3. Bonus: Use the test instructions from the original PR and see the problem has been resolved elsewhere, https://github.com/woocommerce/woocommerce-admin/pull/294

### Changelog Note:

Remove unused `ref` from `<DateRangeFilterPicker />`
