### PR TITLE
Activity Panel - event tracking improved

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -73,6 +73,9 @@ class OrdersPanel extends Component {
 					<Button
 						href="https://docs.woocommerce.com/document/managing-orders/"
 						isSecondary
+						onClick={ () =>
+							this.recordOrderEvent( 'learn_more' )
+						}
 						target="_blank"
 					>
 						{ __( 'Learn more', 'woocommerce-admin' ) }

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -38,7 +38,7 @@ import { recordEvent } from 'lib/tracks';
 
 class OrdersPanel extends Component {
 	recordOrderEvent( eventName ) {
-		recordEvent( `activity_panel_${ eventName }`, {} );
+		recordEvent( `activity_panel_orders_${ eventName }`, {} );
 	}
 
 	renderEmptyCard() {

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -34,8 +34,13 @@ import { QUERY_DEFAULTS } from 'wc-api/constants';
 import { DEFAULT_ACTIONABLE_STATUSES } from 'analytics/settings/config';
 import withSelect from 'wc-api/with-select';
 import { CurrencyContext } from 'lib/currency-context';
+import { recordEvent } from 'lib/tracks';
 
 class OrdersPanel extends Component {
+	recordOrderEvent( eventName ) {
+		recordEvent( `activity_panel_${ eventName }`, {} );
+	}
+
 	renderEmptyCard() {
 		const { hasNonActionableOrders } = this.props;
 		if ( hasNonActionableOrders ) {
@@ -146,6 +151,9 @@ class OrdersPanel extends Component {
 									href={ getAdminLink(
 										'post.php?action=edit&post=' + orderId
 									) }
+									onClick={ () =>
+										this.recordOrderEvent( 'order_number' )
+									}
 									type="wp-admin"
 								/>
 							),
@@ -156,7 +164,13 @@ class OrdersPanel extends Component {
 								/>
 							) : null,
 							customerLink: customerUrl ? (
-								<Link href={ customerUrl } type="wc-admin" />
+								<Link
+									href={ customerUrl }
+									onClick={ () =>
+										this.recordOrderEvent( 'customer_name' )
+									}
+									type="wc-admin"
+								/>
 							) : (
 								<span />
 							),
@@ -204,6 +218,11 @@ class OrdersPanel extends Component {
 							href={ getAdminLink(
 								'post.php?action=edit&post=' + order.order_id
 							) }
+							onClick={ () =>
+								this.recordOrderEvent(
+									'orders_begin_fulfillment'
+								)
+							}
 						>
 							{ __( 'Begin fulfillment' ) }
 						</Button>
@@ -219,7 +238,10 @@ class OrdersPanel extends Component {
 		return (
 			<Fragment>
 				{ cards }
-				<ActivityOutboundLink href={ 'edit.php?post_type=shop_order' }>
+				<ActivityOutboundLink
+					href={ 'edit.php?post_type=shop_order' }
+					onClick={ () => this.recordOrderEvent( 'orders_manage' ) }
+				>
 					{ __( 'Manage all orders', 'woocommerce-admin' ) }
 				</ActivityOutboundLink>
 			</Fragment>

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -73,9 +73,7 @@ class OrdersPanel extends Component {
 					<Button
 						href="https://docs.woocommerce.com/document/managing-orders/"
 						isSecondary
-						onClick={ () =>
-							this.recordOrderEvent( 'learn_more' )
-						}
+						onClick={ () => this.recordOrderEvent( 'learn_more' ) }
 						target="_blank"
 					>
 						{ __( 'Learn more', 'woocommerce-admin' ) }

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -167,7 +167,7 @@ class ReviewsPanel extends Component {
 		let buttonTarget = '';
 		let buttonText = '';
 		let content = '';
-		let eventName = '';
+		let eventName = 'learn_more';
 
 		if ( lastApprovedReviewTime ) {
 			const now = new Date();
@@ -231,7 +231,6 @@ class ReviewsPanel extends Component {
 					</p>
 				</Fragment>
 			);
-			eventName = 'learn_more';
 		}
 
 		return (

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -40,6 +40,10 @@ class ReviewsPanel extends Component {
 		this.mountTime = new Date().getTime();
 	}
 
+	recordReviewEvent( eventName ) {
+		recordEvent( `activity_panel_reviews_${ eventName }`, {} );
+	}
+
 	renderReview( review, props ) {
 		const { lastRead } = props;
 		const product =
@@ -64,11 +68,16 @@ class ReviewsPanel extends Component {
 			),
 			components: {
 				productLink: (
-					<Link href={ product.permalink } type="external" />
+					<Link
+						href={ product.permalink }
+						onClick={ () => this.recordReviewEvent( 'product' ) }
+						type="external"
+					/>
 				),
 				authorLink: (
 					<Link
 						href={ 'mailto:' + review.reviewer_email }
+						onClick={ () => this.recordReviewEvent( 'customer' ) }
 						type="external"
 					/>
 				),
@@ -158,6 +167,7 @@ class ReviewsPanel extends Component {
 		let buttonTarget = '';
 		let buttonText = '';
 		let content = '';
+		let eventName = '';
 
 		if ( lastApprovedReviewTime ) {
 			const now = new Date();
@@ -198,6 +208,7 @@ class ReviewsPanel extends Component {
 						) }
 					</p>
 				);
+				eventName = 'view_reviews';
 			}
 		} else {
 			buttonUrl =
@@ -220,6 +231,7 @@ class ReviewsPanel extends Component {
 					</p>
 				</Fragment>
 			);
+			eventName = 'learn_more';
 		}
 
 		return (
@@ -232,6 +244,7 @@ class ReviewsPanel extends Component {
 						href={ buttonUrl }
 						target={ buttonTarget }
 						isSecondary
+						onClick={ () => this.recordReviewEvent( eventName ) }
 					>
 						{ buttonText }
 					</Button>

--- a/client/header/activity-panel/panels/stock/card.js
+++ b/client/header/activity-panel/panels/stock/card.js
@@ -20,6 +20,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
  * Internal dependencies
  */
 import { ActivityCard } from '../../activity-card';
+import { recordEvent } from 'lib/tracks';
 
 class ProductStockCard extends Component {
 	constructor( props ) {
@@ -37,6 +38,10 @@ class ProductStockCard extends Component {
 		this.onSubmit = this.onSubmit.bind( this );
 	}
 
+	recordStockEvent( eventName, eventProps = {} ) {
+		recordEvent( `activity_panel_stock_${ eventName }`, eventProps );
+	}
+
 	beginEdit() {
 		const { product } = this.props;
 
@@ -51,6 +56,7 @@ class ProductStockCard extends Component {
 				}
 			}
 		);
+		this.recordStockEvent( 'update_stock' );
 	}
 
 	cancelEdit() {
@@ -60,6 +66,7 @@ class ProductStockCard extends Component {
 			editing: false,
 			quantity: product.stock_quantity,
 		} );
+		this.recordStockEvent( 'cancel' );
 	}
 
 	handleKeyDown( event ) {
@@ -79,6 +86,9 @@ class ProductStockCard extends Component {
 		this.setState( { editing: false, edited: true } );
 
 		updateProductStock( product, quantity );
+		this.recordStockEvent( 'save', {
+			quantity,
+		} );
 	}
 
 	getActions() {
@@ -158,6 +168,7 @@ class ProductStockCard extends Component {
 					'post.php?action=edit&post=' +
 					( product.parent_id || product.id )
 				}
+				onClick={ () => this.recordStockEvent( 'product_name' ) }
 				type="wp-admin"
 			>
 				{ product.name }


### PR DESCRIPTION
Fixes #4432

This PR adds event recording to the `Orders`, `Stock`, and `Reviews` panels.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:

![screenshot-one wordpress test-2020 07 26-18_50_03](https://user-images.githubusercontent.com/1314156/88490321-3bd09180-cf71-11ea-8fe9-b30d8d5e4014.png)

- Open the order panel
- Verify the following events are tracked correctly.
- Executing this sentence in the browser console may help to verify it:
````
localStorage.setItem( 'debug', 'wc-admin:*' )
````

**Orders panel:** 

Event name: wcadmin_activity_panel_orders_begin_fulfillment
Event prop: NA
Description: when the user clicks in the "Begin fulfillment" button

Event name: wcadmin_activity_panel_orders_manage
Event prop: NA
Description: when the user clicks in the "Manage all orders" button

Event name: wcadmin_activity_panel_order_number
Event prop: NA
Description: when the user clicks in the order number link

Event name: wcadmin_activity_panel_customer_name
Event prop: NA
Description: when the user clicks in the customer name link


![screenshot-one wordpress test-2020 07 26-18_51_43 (1)](https://user-images.githubusercontent.com/1314156/88490356-7cc8a600-cf71-11ea-8c37-6a0b9eac3eb5.png)

- Open the stock panel
- Verify the following events are tracked correctly.

**Stock:** 

Event name: wcadmin_activity_panel_stock_product_name
Event prop: NA
Description: when the user clicks in the product name link

Event name: wcadmin_activity_panel_stock_update_stock
Event prop: NA
Description: when the user clicks in the "Update stock" button

Event name: wcadmin_activity_panel_stock_save
Event prop: `quantity`, the number of products added to the inventory
Description: when the user clicks in the "Save" button

Event name: wcadmin_activity_panel_stock_cancel
Event prop: NA
Description: when the user clicks in the "Cancel" button


![screenshot-one wordpress test-2020 07 26-18_51_43](https://user-images.githubusercontent.com/1314156/88490345-6589b880-cf71-11ea-9be8-a39201d3d586.png)

- Open the reviews panel
- Verify the following events are tracked correctly.

**Reviews:** 

Event name: wcadmin_activity_panel_reviews_learn_more
Event prop: NA
Description: when the user clicks in the "Learn More" button in the empty state

Event name: wcadmin_activity_panel_reviews_view_reviews
Event prop: NA
Description: when the user clicks in the "View reviews" button in the empty state

Event name: wcadmin_activity_panel_reviews_product
Event prop: NA
Description: when the user clicks in the product name

Event name: wcadmin_activity_panel_reviews_customer
Event prop: NA
Description: when the user clicks in the customer name


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Added event recording to `Orders`, `Stock`, and `Reviews` panels.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
