### PR TITLE
Add the experimental resolver to WCA data package

### DIFF
--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -6,18 +6,18 @@ import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-	withDispatch,
-	withSelect,
-	__experimentalResolveSelect,
-} from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
+import {
+	__experimentalResolveSelect,
+	PLUGINS_STORE_NAME,
+	useUserPreferences,
+} from '@woocommerce/data';
 import { H } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
-import { PLUGINS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
 
 /**
  * Internal dependencies

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, createElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { identity, pick } from 'lodash';
-import { withDispatch, __experimentalResolveSelect } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -17,6 +17,7 @@ import {
 	updateQueryString,
 } from '@woocommerce/navigation';
 import {
+	__experimentalResolveSelect,
 	ONBOARDING_STORE_NAME,
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
 		"history": "4.10.1",
 		"interpolate-components": "1.1.1",
 		"marked": "0.8.2",
+		"memize": "^1.1.0",
 		"memoize-one": "5.1.1",
 		"prismjs": "1.20.0",
 		"qs": "6.9.3",

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -15,3 +15,5 @@ export { useUserPreferences } from './user-preferences/use-user-preferences';
 
 export { OPTIONS_STORE_NAME } from './options';
 export { withOptionsHydration } from './options/with-options-hydration';
+
+export { __experimentalResolveSelect } from './registry';

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { omit, mapValues } from 'lodash';
+import memize from 'memize';
+import { select, subscribe } from '@wordpress/data';
+
+export function __experimentalResolveSelect( reducerKey ) {
+	return getResolveSelectors( select( reducerKey ) );
+}
+
+const getResolveSelectors = memize(
+	( selectors ) => {
+		return mapValues(
+			omit( selectors, [
+				'getIsResolving',
+				'hasStartedResolution',
+				'hasFinishedResolution',
+				'isResolving',
+				'getCachedResolvers',
+			] ),
+			( selector, selectorName ) => {
+				return ( ...args ) => {
+					return new Promise( ( resolve ) => {
+						const hasFinished = () =>
+							selectors.hasFinishedResolution(
+								selectorName,
+								args
+							);
+						const getResult = () => selector.apply( null, args );
+
+						// trigger the selector (to trigger the resolver)
+						const result = getResult();
+						if ( hasFinished() ) {
+							return resolve( result );
+						}
+
+						const unsubscribe = subscribe( () => {
+							if ( hasFinished() ) {
+								unsubscribe();
+								resolve( getResult() );
+							}
+						} );
+					} );
+				};
+			}
+		);
+	},
+	{ maxSize: 1 }
+);

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -9,6 +9,11 @@ export function __experimentalResolveSelect( reducerKey ) {
 	return getResolveSelectors( select( reducerKey ) );
 }
 
+/**
+ * Returns a promise that resolves once a selector has finished resolving.
+ * This is directly pulled from https://github.com/WordPress/gutenberg/blob/909c9274b2440de5f6049ffddfcc8e0e6158df2d/packages/data/src/registry.js#L91-L130
+ * and will be removed in favor of the @wordpress/data function.
+ */
 const getResolveSelectors = memize(
 	( selectors ) => {
 		return mapValues(


### PR DESCRIPTION
Fixes #4710 

This PR adds in the experimental resolution selector to WCA so that we can await the resolution of the Jetpack connection URL.

This selector is no longer being labeled "experimental" and appears safe to use, however, going forward we're going to have the same issue with this selector not being readily available in older versions of WP where we pull in the WP hosted version of `@wordpress/data`.  This should be considered a temporary fix and we may want to consider fixing the bundling of `@wordpress/data` in the next cycle.

### Detailed test instructions:

1. Install an older version of WordPress (e.g., 5.3.2) or use WP Downgrade.
1. Check that the profiler and homescreen feature are able to load.
1. Make sure that Jetpack is disconnected and attempt to walk through the profiler to the benefits screen.
1. Make sure that you are redirected to the Jetpack connection screen (or just Jetpack page if you are testing locally).
1. Check that the Install Jetpack CTA on the homescreen also works and redirects to the Jetpack connection screen.