### PR TITLE
Update wp-prettier to latest beta release to avoid a crash in Prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8427,6 +8427,12 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.0.5",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+					"dev": true
 				}
 			}
 		},
@@ -9132,12 +9138,6 @@
 						"enzyme-to-json": "^3.4.4"
 					}
 				},
-				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-					"dev": true
-				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -9546,16 +9546,6 @@
 					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
 					"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
 					"dev": true
-				},
-				"https-proxy-agent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-					"dev": true,
-					"requires": {
-						"agent-base": "5",
-						"debug": "4"
-					}
 				},
 				"import-lazy": {
 					"version": "4.0.0",
@@ -10057,25 +10047,11 @@
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 					"dev": true
 				},
-				"puppeteer": {
-					"version": "npm:puppeteer-core@3.0.0",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-					"dev": true,
-					"requires": {
-						"@types/mime-types": "^2.1.0",
-						"debug": "^4.1.0",
-						"extract-zip": "^2.0.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mime-types": "^2.1.25",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
-					}
+				"prettier": {
+					"version": "npm:wp-prettier@2.0.5",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+					"dev": true
 				},
 				"quick-lru": {
 					"version": "4.0.1",
@@ -10439,12 +10415,6 @@
 						"signal-exit": "^3.0.2",
 						"typedarray-to-buffer": "^3.1.5"
 					}
-				},
-				"ws": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-					"dev": true
 				},
 				"yargs-parser": {
 					"version": "18.1.3",
@@ -29674,9 +29644,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+			"version": "npm:wp-prettier@2.0.5-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5-beta-1.tgz",
+			"integrity": "sha512-/REeWcNW3tSE5Mh4WT9Q48WoDPmWmakF7QaEhbJTrIiCIjqPNu3onzTikSwnUUBMpwJSWqZNURe7m5UEnBCQBg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -30172,6 +30142,50 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"puppeteer": {
+			"version": "npm:puppeteer-core@3.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+			"dev": true,
+			"requires": {
+				"@types/mime-types": "^2.1.0",
+				"debug": "^4.1.0",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"mime": "^2.0.3",
+				"mime-types": "^2.1.25",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+					"dev": true
+				},
+				"https-proxy-agent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "5",
+						"debug": "4"
+					}
+				},
+				"ws": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+					"dev": true
+				}
+			}
 		},
 		"q": {
 			"version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
 		"node-watch": "0.6.4",
 		"postcss-color-function": "4.1.0",
 		"postcss-loader": "3.0.0",
-		"prettier": "npm:wp-prettier@2.0.5",
+		"prettier": "npm:wp-prettier@2.0.5-beta-1",
 		"promptly": "3.0.3",
 		"prop-types": "15.7.2",
 		"raw-loader": "4.0.1",

--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -109,7 +109,7 @@ export class SearchListControl extends Component {
 		const re = new RegExp( escapeRegExp( search ), 'i' );
 		this.props.debouncedSpeak( messages.updated );
 		const filteredList = list
-			.map( ( item ) => ( re.test( item.name ) ? item : false ) )
+			.map( ( item ) => ( re.test( item.name ) ? item : false)  )
 			.filter( Boolean );
 		return isHierarchical
 			? buildTermsTree( filteredList, list )

--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -109,7 +109,7 @@ export class SearchListControl extends Component {
 		const re = new RegExp( escapeRegExp( search ), 'i' );
 		this.props.debouncedSpeak( messages.updated );
 		const filteredList = list
-			.map( ( item ) => ( re.test( item.name ) ? item : false)  )
+			.map( ( item ) => ( re.test( item.name ) ? item : false ) )
 			.filter( Boolean );
 		return isHierarchical
 			? buildTermsTree( filteredList, list )


### PR DESCRIPTION
In the previous release Prettier did not work in VSCode (and I
suspect would fail in other editors too) with an error:

"Could not find module ./parser-babylon". Updating to the latest
version fixes it in my environment.

This bug interrupts a fairly crucial workflow for me, so I'd be keen to
get it fixed/merged.

Testing details:

* Ensure you have done a fresh npm install
* Edit a JS file (ideally in VSCode with a prettier plugin if you can)
* Save it (if your prettier plugin has format on save)

You should not see errors from the plugin (in VSCode the plugin reports
status in the bottom bar) and it should format the file correctly.