### PR TITLE
Fix build check for core.

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -261,7 +261,9 @@ class FeaturePlugin {
 	 * @return bool
 	 */
 	protected function check_build() {
-		return file_exists( plugin_dir_path( __DIR__ ) . '/dist/app/index.js' );
+		$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		$suffix       = Loader::should_use_minified_js_file( $script_debug ) ? '.min' : '';
+		return file_exists( plugin_dir_path( __DIR__ ) . "/dist/app/index{$suffix}.js" );
 	}
 
 	/**


### PR DESCRIPTION
Core package doesn't have unminified JS..

### Detailed test instructions:

- Run a core build `WC_ADMIN_PHASE=core npm run build`
- Delete `dist/app/index.js` if it exists
- Verify the "running a development version" notice is not shown

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
