### PR TITLE
Enable tax calculation before redirecting to standard tax rates page.

### DIFF
--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -245,7 +245,7 @@ class Tax extends Component {
 										install_extensions: false,
 									}
 								);
-								this.redirectToTaxSettings();
+								this.manuallyConfigureTaxRates();
 							} }
 							skipText={ __(
 								'Set up tax rates manually',


### PR DESCRIPTION
Fixes #4631. Follow up to https://github.com/woocommerce/woocommerce-admin/pull/4683

This PR seeks to remedy one missed redirection from https://github.com/woocommerce/woocommerce-admin/pull/4683 where tax calculations weren't enabled before redirecting to the standard rates settings page.

### Detailed test instructions:

- Enable the home screen and task list
- Turn off tax calculations for the store (WooCommerce > Settings > General - uncheck "Enable tax rates and calculations")
- Ensure the "install" step will be shown for the Tax setup task (be in a [TaxJar supported country](https://github.com/woocommerce/woocommerce-admin/blob/5e04841d26157795d58ec194a2bf3b6185144816/client/task-list/tasks/tax.js#L77))
- Click "Set up tax rates manually" on the install step
- Verify that you are redirected to the Tax settings tab

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

