### PR TITLE
Currency: re-add deprecated formatCurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7758,7 +7758,8 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs2": "7.10.5",
-				"@woocommerce/number": "2.0.0"
+				"@woocommerce/number": "2.0.0",
+				"@wordpress/deprecated": "^2.9.0"
 			}
 		},
 		"@woocommerce/data": {

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -22,7 +22,8 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.10.5",
-		"@woocommerce/number": "2.0.0"
+		"@woocommerce/number": "2.0.0",
+		"@wordpress/deprecated": "^2.9.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -59,8 +59,9 @@ const CurrencyFactory = ( currencySetting ) => {
 	 */
 	function formatCurrency( number ) {
 		deprecated( 'Currency().formatCurrency', {
-			version: '1.3.0',
+			version: '4.3.0',
 			alternative: 'Currency().formatAmount',
+			plugin: 'WooCommerce',
 			hint: '`formatAmount` accepts the same arguments as formatCurrency',
 		} );
 		return formatAmount( number );

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -3,6 +3,7 @@
  */
 import { sprintf } from '@wordpress/i18n';
 import { numberFormat } from '@woocommerce/number';
+import deprecated from '@wordpress/deprecated';
 
 const CurrencyFactory = ( currencySetting ) => {
 	let currency;
@@ -49,6 +50,23 @@ const CurrencyFactory = ( currencySetting ) => {
 	}
 
 	/**
+	 * Formats money value.
+	 *
+	 * @deprecated
+	 *
+	 * @param   {number|string} number number to format
+	 * @return {?string} A formatted string.
+	 */
+	function formatCurrency( number ) {
+		deprecated( 'Currency().formatCurrency', {
+			version: '1.3.0',
+			alternative: 'Currency().formatAmount',
+			hint: '`formatAmount` accepts the same arguments as formatCurrency',
+		} );
+		return formatAmount( number );
+	}
+
+	/**
 	 * Get the default price format from a currency.
 	 *
 	 * @param {Object} config Currency configuration.
@@ -79,6 +97,7 @@ const CurrencyFactory = ( currencySetting ) => {
 		},
 		setCurrency,
 		formatAmount,
+		formatCurrency,
 		getPriceFormat,
 
 		/**

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -59,7 +59,7 @@ const CurrencyFactory = ( currencySetting ) => {
 	 */
 	function formatCurrency( number ) {
 		deprecated( 'Currency().formatCurrency', {
-			version: '4.3.0',
+			version: '5.0.0',
 			alternative: 'Currency().formatAmount',
 			plugin: 'WooCommerce',
 			hint: '`formatAmount` accepts the same arguments as formatCurrency',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4860

`woocommerce/currency`'s `formatCurrency` was changed to `formatAmount` in version 1.3.0. This causes problems for plugins using the package as part of Core.

This PR adds the deprecated function back in with a warning.

### Detailed test instructions:

1. Go to a file that uses `formatAmount` and change it to `formatCurrency`. ie: 

https://github.com/woocommerce/woocommerce-admin/blob/330677bc72b46a38121f2b091e6e26c571b5671e/client/analytics/components/report-chart/index.js#L173

2. Go to the page in question. If using the above example, visit any report.
3. See the deprecation warning in the console.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- dev: Re-introduce `@woocommerce/currency` function `formatCurrency` with deprecation warning.
