### PR TITLE
Only show WCPay task in US based stores

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -26,6 +26,7 @@ import {
 	PLUGINS_STORE_NAME,
 	OPTIONS_STORE_NAME,
 	ONBOARDING_STORE_NAME,
+	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 
 /**
@@ -34,6 +35,7 @@ import {
 import './style.scss';
 import CartModal from 'dashboard/components/cart-modal';
 import { getAllTasks, recordTaskViewEvent } from './tasks';
+import { getCountryCode } from 'dashboard/utils';
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
 
@@ -142,6 +144,7 @@ class TaskDashboard extends Component {
 
 	getAllTasks() {
 		const {
+			countryCode,
 			profileItems,
 			query,
 			taskListPayments,
@@ -153,6 +156,7 @@ class TaskDashboard extends Component {
 		} = this.props;
 
 		return getAllTasks( {
+			countryCode,
 			profileItems,
 			taskListPayments,
 			query,
@@ -444,6 +448,7 @@ export default compose(
 	withSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		const { getOption } = select( OPTIONS_STORE_NAME );
+		const { getSettings } = select( SETTINGS_STORE_NAME );
 		const {
 			getActivePlugins,
 			getInstalledPlugins,
@@ -463,11 +468,17 @@ export default compose(
 		const dismissedTasks =
 			getOption( 'woocommerce_task_list_dismissed_tasks' ) || [];
 
+		const { general: generalSettings = {} } = getSettings( 'general' );
+		const countryCode = getCountryCode(
+			generalSettings.woocommerce_default_country
+		);
+
 		const activePlugins = getActivePlugins();
 		const installedPlugins = getInstalledPlugins();
 
 		return {
 			activePlugins,
+			countryCode,
 			dismissedTasks,
 			isJetpackConnected: isJetpackConnected(),
 			installedPlugins,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -45,6 +45,7 @@ export function recordTaskViewEvent(
 }
 
 export function getAllTasks( {
+	countryCode,
 	profileItems,
 	taskListPayments,
 	query,
@@ -166,7 +167,9 @@ export function getAllTasks( {
 				} );
 			},
 			visible:
-				window.wcAdminFeatures.wcpay && woocommercePaymentsInstalled,
+				window.wcAdminFeatures.wcpay &&
+				woocommercePaymentsInstalled &&
+				countryCode === 'US',
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 		{


### PR DESCRIPTION
Fixes #4885 

Hides the wcpay task if not in a US based store.

### Screenshots
<img width="537" alt="Screen Shot 2020-07-30 at 3 37 58 PM" src="https://user-images.githubusercontent.com/10561050/88923759-e64efa00-d27a-11ea-909d-f51da71001fb.png">


### Detailed test instructions:

1. Make sure the `wcpay` feature is enabled in your environment and wc pay is installed.
1. Set your store settings to a US based store.
1. View the task list and make sure the WC pay task exists.
1. Set your store to non-US.
1. Check that the task is not shown in the task list.