### PR TITLE
OBW: fix product types step bugs

### DIFF
--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -32,19 +32,22 @@ function getLabel( description, yearlyPrice ) {
 		__( '$%f per month, billed annually', 'woocommerce-admin' ),
 		monthlyPrice
 	);
+	/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
+	const toolTipText = __(
+		"This product type requires a paid extension.\nWe'll add this to a cart so that\nyou can purchase and install it later.",
+		'woocommerce-admin'
+	);
+	/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
 	return (
 		<Fragment>
 			<span className="woocommerce-product-wizard__product-types__label">
 				{ description }
 			</span>
-			<Tooltip
-				text={ __(
-					"This product type requires a paid extension. We'll add this to a cart so that you can purchase and install it later.",
-					'woocommerce-admin'
-				) }
-			>
-				<Pill>{ priceDescription }</Pill>
+			<Tooltip text={ toolTipText } position="bottom center">
+				<span aria-label={ toolTipText }>
+					<Pill>{ priceDescription }</Pill>
+				</span>
 			</Tooltip>
 		</Fragment>
 	);

--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -45,8 +45,13 @@ function getLabel( description, yearlyPrice ) {
 				{ description }
 			</span>
 			<Tooltip text={ toolTipText } position="bottom center">
-				<span aria-label={ toolTipText }>
-					<Pill>{ priceDescription }</Pill>
+				<span>
+					<Pill>
+						<span className="screen-reader-text">
+							{ toolTipText }
+						</span>
+						{ priceDescription }
+					</Pill>
 				</span>
 			</Tooltip>
 		</Fragment>

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -339,7 +339,8 @@ class Onboarding {
 		$product_types = self::append_product_data(
 			array(
 				'physical'        => array(
-					'label' => __( 'Physical products', 'woocommerce-admin' ),
+					'label'   => __( 'Physical products', 'woocommerce-admin' ),
+					'default' => true,
 				),
 				'downloads'       => array(
 					'label' => __( 'Downloads', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #4876.

This PR fixes some small bugs on the Product Types step of the OBW. It restores "physical products" as the default, and also fixes the display of the tooltips (on the price description).

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2020-07-30 at 10 40 18 AM](https://user-images.githubusercontent.com/63922/88936622-18e3fd00-d251-11ea-9ee0-0b3d06941d7f.png)

### Detailed test instructions:

- Clear profiler data or start a new test store
- Go through the OBW
- Verify on the Product Types step that "Physical products" is checked by default
- Verify that the tooltip works when hovering over the price info

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
