### PR TITLE
Center all descriptive text on OBW steps.

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -783,12 +783,12 @@ class BusinessDetails extends Component {
 									'woocommerce-admin'
 								) }
 							</H>
-							<p>
+							<H className="woocommerce-profile-wizard__header-subtitle">
 								{ __(
 									"We'd love to know if you are just getting started or you already have a business in place.",
 									'woocommerce-admin'
 								) }
-							</p>
+							</H>
 							<Card>
 								<Fragment>
 									<SelectControl

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -180,9 +180,9 @@ class Industry extends Component {
 						'woocommerce-admin'
 					) }
 				</H>
-				<p className="woocommerce-profile-wizard__intro-paragraph">
+				<H className="woocommerce-profile-wizard__header-subtitle">
 					{ __( 'Choose any that apply' ) }
-				</p>
+				</H>
 				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ filteredIndustryKeys.map( ( slug ) => {

--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -157,7 +157,9 @@ class ProductTypes extends Component {
 						'woocommerce-admin'
 					) }
 				</H>
-				<p>{ __( 'Choose any that apply' ) }</p>
+				<H className="woocommerce-profile-wizard__header-subtitle">
+					{ __( 'Choose any that apply' ) }
+				</H>
 
 				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">


### PR DESCRIPTION
Fixes #4875.

This PR centers all subheading text on OBW steps.

### Detailed test instructions:

- Go through the OBW
- Verify all title/subheader text is centered

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
