### PR TITLE
Use lifesaver icon instead of gridicon for help panel.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -10,6 +10,7 @@ import { compose } from '@wordpress/compose';
 import { partial, uniqueId, find } from 'lodash';
 import PagesIcon from 'gridicons/dist/pages';
 import CrossIcon from 'gridicons/dist/cross-small';
+import { Icon, lifesaver } from '@wordpress/icons';
 
 /**
  * WooCommerce dependencies
@@ -184,7 +185,7 @@ export class ActivityPanel extends Component {
 			isPerformingSetupTask && {
 				name: 'help',
 				title: __( 'Help', 'woocommerce-admin' ),
-				icon: <i className="material-icons-outlined">support</i>,
+				icon: <Icon icon={ lifesaver } />,
 			},
 		].filter( Boolean );
 	}


### PR DESCRIPTION
Fixes #4893

Per @jameskoster 's request, this branch swaps out the usage of the support Gridicon for the new Help activity panel, with the `lifesaver` G2 icon.

__Before__
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 14-23-18](https://user-images.githubusercontent.com/22080/88976317-af73e680-d270-11ea-8193-5160075e4260.png)

__After__
![Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 14-25-36](https://user-images.githubusercontent.com/22080/88976327-b4389a80-d270-11ea-9627-868680297890.png)

### Detailed test instructions:

- Enable the setup checklist
- Visit `/wp-admin/admin.php?page=wc-admin&task=products`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

NA unreleased feature
