### PR TITLE
CSS fixes for Business Features popover.

### DIFF
--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -522,9 +522,8 @@
 	.woocommerce-business-extensions__benefits {
 		padding: 4px;
 		display: grid;
-		grid-template-columns: 1fr 1fr;
-		width: 600px;
-		max-width: 100%;
+		grid-template-columns: 1fr;
+		max-width: 592px;
 		font-size: 14px;
 
 		.woocommerce-business-extensions__benefit {


### PR DESCRIPTION
Fixes #4894

This branch adjusts some css to make the Features Popover on business details page for US-based fashion/apparel sites look a little less _wonky_.

@jameskoster I kind of eyeballed things for the width on the modal at various breakpoints, I'd be happy to update this with more precise widths if you happen to have some.

### Screenshots

__Before__

![popover](https://cldup.com/4c6Cf9KzNm-3000x3000.png)

__After__

![Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 14-55-54](https://user-images.githubusercontent.com/22080/88978973-8e61c480-d275-11ea-94a7-1d0b3314ca9c.png)

![Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 14-56-24](https://user-images.githubusercontent.com/22080/88978978-91f54b80-d275-11ea-9bd3-58443a18c4bf.png)

![Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 14-56-46](https://user-images.githubusercontent.com/22080/88978985-94f03c00-d275-11ea-870c-0711fcd2a4e9.png)


### Detailed test instructions:

- Enable the onboarding wizard via the Orders > Help menu
- Enter a US store address
- On industries select fashion/apparel
- Proceed to the Business Details step and interact with the popover at various breakpoints

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

NA unreleased feature
