### PR TITLE
Prepare to publish packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9653,6 +9653,26 @@
 					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 					"dev": true
 				},
+				"puppeteer": {
+					"version": "npm:puppeteer-core@3.0.0",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+					"dev": true,
+					"requires": {
+						"@types/mime-types": "^2.1.0",
+						"debug": "^4.1.0",
+						"extract-zip": "^2.0.0",
+						"https-proxy-agent": "^4.0.0",
+						"mime": "^2.0.3",
+						"mime-types": "^2.1.25",
+						"progress": "^2.0.1",
+						"proxy-from-env": "^1.0.0",
+						"rimraf": "^3.0.2",
+						"tar-fs": "^2.0.0",
+						"unbzip2-stream": "^1.3.3",
+						"ws": "^7.2.3"
+					}
+				},
 				"read-pkg": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -9995,6 +10015,12 @@
 						"signal-exit": "^3.0.2",
 						"typedarray-to-buffer": "^3.1.5"
 					}
+				},
+				"ws": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+					"dev": true
 				},
 				"yargs-parser": {
 					"version": "18.1.3",
@@ -29705,40 +29731,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@3.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-			"dev": true,
-			"requires": {
-				"@types/mime-types": "^2.1.0",
-				"debug": "^4.1.0",
-				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
-				"mime": "^2.0.3",
-				"mime-types": "^2.1.25",
-				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^3.0.2",
-				"tar-fs": "^2.0.0",
-				"unbzip2-stream": "^1.3.3",
-				"ws": "^7.2.3"
-			},
-			"dependencies": {
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-					"dev": true
-				},
-				"ws": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-					"dev": true
-				}
-			}
 		},
 		"q": {
 			"version": "1.5.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,161 +1,175 @@
-# 5.0.0 (Unreleased)
-- Added `<Timeline />` component.
-- Added `<ImageUpload />` component.
-- Style form components for WordPress 5.3.
-- Fix CompareFilter options format (key prop vs. id).
-- Fix styling of `<Search />` component "clear all" button.
-- Add state classes to `<TextControlWithAffixes />` component.
-- Fix `<AnimationSlider />` example code.
-- Add `<Plugins />` component for installation of plugins.
-- Removed use of `IconButton` in favor of `Button` component.
-- Add custom autocompleter support to `<Search />` component.
-- Fix `<SelectControl />` component to allow clicking anywhere on options in list to select.
-- Add support for `<List />` component item tags and link types.
-- Add `<List />` and `<Link />` components to Storybook.
-- Add `<Pill />` component.
-- Add `key` prop to `<List />` component items.
-- Remove unused `ref` from `<DateRangeFilterPicker />`.
+# 5.0.0
+
+-   Added `<Timeline />` component.
+-   Added `<ImageUpload />` component.
+-   Style form components for WordPress 5.3.
+-   Fix CompareFilter options format (key prop vs. id).
+-   Fix styling of `<Search />` component "clear all" button.
+-   Add state classes to `<TextControlWithAffixes />` component.
+-   Fix `<AnimationSlider />` example code.
+-   Add `<Plugins />` component for installation of plugins.
+-   Removed use of `IconButton` in favor of `Button` component.
+-   Add custom autocompleter support to `<Search />` component.
+-   Fix `<SelectControl />` component to allow clicking anywhere on options in list to select.
+-   Add support for `<List />` component item tags and link types.
+-   Add `<List />` and `<Link />` components to Storybook.
+-   Add `<Pill />` component.
+-   Add `key` prop to `<List />` component items.
+-   Remove unused `ref` from `<DateRangeFilterPicker />`.
 
 ## Breaking Changes
-- Removed `SplitButton` because its not being used.
+
+-   Removed `SplitButton` because its not being used.
 
 # 4.0.0
 
 ## Breaking Changes
-- Added a new `<ScrollTo />` component.
-- Changed the `<List />` `description` prop to `content` and allowed content nodes to be passed in addition to strings.
-- Removed the `<SimpleSelectControl />` component.
+
+-   Added a new `<ScrollTo />` component.
+-   Changed the `<List />` `description` prop to `content` and allowed content nodes to be passed in addition to strings.
+-   Removed the `<SimpleSelectControl />` component.
 
 ### Decouple wcSettings from published packages (#3001)
-- `AdvancedFilters` component now receives `siteLocale` as a prop.
-- `ReportsFilters` component now receives `siteLocale` as a prop.
-- `NumberFilter` component now receives `currencySymbol` and `symbolPosition` as props.
-- `AdvancedFilters` and `ReportsFilters` receive `currency` as a prop, it is required and must be an instance of the new `Currency` object exported by `@woocommerce/currency`
-- `Chart` receives `currency` as a prop.
-- Add `storeDate` prop to `<ReportFilters />` and `<DateRangeFilterPicker />` components.
-- `AdvancedFilters` and `ReportFilters` now receive a required `storeDate` prop as a means to pass down date initialization values from client.
-- The `href` prop in the `<Link>` component must now receive the full url instead of relative.
+
+-   `AdvancedFilters` component now receives `siteLocale` as a prop.
+-   `ReportsFilters` component now receives `siteLocale` as a prop.
+-   `NumberFilter` component now receives `currencySymbol` and `symbolPosition` as props.
+-   `AdvancedFilters` and `ReportsFilters` receive `currency` as a prop, it is required and must be an instance of the new `Currency` object exported by `@woocommerce/currency`
+-   `Chart` receives `currency` as a prop.
+-   Add `storeDate` prop to `<ReportFilters />` and `<DateRangeFilterPicker />` components.
+-   `AdvancedFilters` and `ReportFilters` now receive a required `storeDate` prop as a means to pass down date initialization values from client.
+-   The `href` prop in the `<Link>` component must now receive the full url instead of relative.
 
 ## Other Changes
-- Renamed the `<Autocomplete />` component to `<SelectControl />`.
-- Added `isSearchable` prop to `<SelectControl />` to allow simple select dropdowns.
-- Removed WC-Admin specific actions from `<TableCard />` component.
-- Export the `<CompareButton />` component.
-- Add `<TextControl />` component.
-- Require `currency` prop in `<AdvancedFilters />` component.
-- Remove call to `getAdminLink()` inside the `<Link />` component.
-- Explicitly import component styles from `@wordpress/base-styles` (#3292)
-- Update various dependencies
+
+-   Renamed the `<Autocomplete />` component to `<SelectControl />`.
+-   Added `isSearchable` prop to `<SelectControl />` to allow simple select dropdowns.
+-   Removed WC-Admin specific actions from `<TableCard />` component.
+-   Export the `<CompareButton />` component.
+-   Add `<TextControl />` component.
+-   Require `currency` prop in `<AdvancedFilters />` component.
+-   Remove call to `getAdminLink()` inside the `<Link />` component.
+-   Explicitly import component styles from `@wordpress/base-styles` (#3292)
+-   Update various dependencies
 
 # 3.2.0
-- AdvancedFilters component: fire `onAdvancedFilterAction` for match changes.
-- TableCard component: add `onSearch` and `onSort` function props.
-- Add new component `<List />` for displaying interactive list items.
-- Fix z-index issue in `<Chart />` empty message.
-- Added a new `<SimpleSelectControl />` component.
-- Added a new `<WebPreview />` component.
-- SearchListItem component: fix long count values being cut-off in IE11.
-- Add `disabled` prop to CompareButton, Search, and TableCard components.
-- Table component: add empty table display.
+
+-   AdvancedFilters component: fire `onAdvancedFilterAction` for match changes.
+-   TableCard component: add `onSearch` and `onSort` function props.
+-   Add new component `<List />` for displaying interactive list items.
+-   Fix z-index issue in `<Chart />` empty message.
+-   Added a new `<SimpleSelectControl />` component.
+-   Added a new `<WebPreview />` component.
+-   SearchListItem component: fix long count values being cut-off in IE11.
+-   Add `disabled` prop to CompareButton, Search, and TableCard components.
+-   Table component: add empty table display.
 
 # 3.1.0
-- Added support for a `countLabel` prop on `SearchListItem` to allow custom counts.
+
+-   Added support for a `countLabel` prop on `SearchListItem` to allow custom counts.
 
 # 3.0.0
-- <DateInput> and <DatePicker> got a `disabled` prop.
-- TableCard component: new `onPageChange` prop.
-- TableCard now has a `defaultOrder` parameter to specify default sort column sort order.
-- Pagination no longer considers `0` a valid input and triggers `onPageChange` on the input blur event.
-- Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
-- EllipsisMenu component (breaking change): Remove `children` prop in favor of a render prop `renderContent` so that function arguments `isOpen`, `onToggle`, and `onClose` can be passed down.
-- Chart has a new prop named `yBelow1Format` which overrides the `yFormat` for values between -1 and 1 (not included).
-- Add a `totals` prop to Chart component that allows overwriting the total values shown in the legend.
-- Add new component `<Stepper />` for showing a list of steps and progress.
-- Add new `<Spinner />` component.
-- Card component: updated default Muriel design.
-- Card component: new `description` prop.
-- Card component: new `isInactive` prop.
-- DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
-- Update license to GPL-3.0-or-later.
+
+-   <DateInput> and <DatePicker> got a `disabled` prop.
+-   TableCard component: new `onPageChange` prop.
+-   TableCard now has a `defaultOrder` parameter to specify default sort column sort order.
+-   Pagination no longer considers `0` a valid input and triggers `onPageChange` on the input blur event.
+-   Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
+-   EllipsisMenu component (breaking change): Remove `children` prop in favor of a render prop `renderContent` so that function arguments `isOpen`, `onToggle`, and `onClose` can be passed down.
+-   Chart has a new prop named `yBelow1Format` which overrides the `yFormat` for values between -1 and 1 (not included).
+-   Add a `totals` prop to Chart component that allows overwriting the total values shown in the legend.
+-   Add new component `<Stepper />` for showing a list of steps and progress.
+-   Add new `<Spinner />` component.
+-   Card component: updated default Muriel design.
+-   Card component: new `description` prop.
+-   Card component: new `isInactive` prop.
+-   DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
+-   Update license to GPL-3.0-or-later.
 
 # 2.0.0
-- Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
-- Chart component now accepts data with negative values.
-- Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
-- Expand search results and allow searching when input is refocused in autocompleter.
-- Animation Slider: Remove `focusOnChange` in favor of `onExited` so consumers can pass a function to be executed after a transition has finished.
-- SearchListControl: Add `onSearch` callback prop to let the parent component know about search changes.
-- Calendar: Expose `isInvalidDate` prop to `DatePicker` to indicated invalid days that are not selectable.
-- Calendar: Expose `isInvalidDate` prop to `DateRange` and remove the `invalidDays` prop.
-- Bump dependency versions.
+
+-   Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.
+-   Chart component now accepts data with negative values.
+-   Chart component: new prop `filterParam` used to detect selected items in the current query. If there are, they will be displayed in the chart even if their values are 0.
+-   Expand search results and allow searching when input is refocused in autocompleter.
+-   Animation Slider: Remove `focusOnChange` in favor of `onExited` so consumers can pass a function to be executed after a transition has finished.
+-   SearchListControl: Add `onSearch` callback prop to let the parent component know about search changes.
+-   Calendar: Expose `isInvalidDate` prop to `DatePicker` to indicated invalid days that are not selectable.
+-   Calendar: Expose `isInvalidDate` prop to `DateRange` and remove the `invalidDays` prop.
+-   Bump dependency versions.
 
 # 1.6.0
-- Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.
-- Chart component: remove d3-array dependency.
-- Chart component: fix display when there is no data.
-- Chart component: change chart type query parameter to `chartType`.
-- Chart component: add `screenReaderFormat` prop that will be used to format dates for screen reader labels.
-- Bug fix for `<StockReportTable />` returning N/A instead of zero.
-- Add new component: SearchListControl for displaying and filtering a selectable list of items.
+
+-   Chart component: new props `emptyMessage` and `baseValue`. When an empty message is provided, it will be displayed on top of the chart if there are no values different than `baseValue`.
+-   Chart component: remove d3-array dependency.
+-   Chart component: fix display when there is no data.
+-   Chart component: change chart type query parameter to `chartType`.
+-   Chart component: add `screenReaderFormat` prop that will be used to format dates for screen reader labels.
+-   Bug fix for `<StockReportTable />` returning N/A instead of zero.
+-   Add new component: SearchListControl for displaying and filtering a selectable list of items.
 
 # 1.5.0
-- Improves display of charts where all values are 0.
-- Fix X-axis labels in hourly bar charts.
-- New `<Search>` prop named `showClearButton`, that will display a 'Clear' button when the search box contains one or more tags.
-- Number of selectable chart elements is now limited to 5.
-- Color scale logic for charts with lots of items has been fixed.
-- Update `@woocommerce/navigation` to v2.0.0
-- Bug fix for `<StockReportTable />` returning N/A instead of zero.
-- In `<Search>` use backspace key to remove tags from the search box.
+
+-   Improves display of charts where all values are 0.
+-   Fix X-axis labels in hourly bar charts.
+-   New `<Search>` prop named `showClearButton`, that will display a 'Clear' button when the search box contains one or more tags.
+-   Number of selectable chart elements is now limited to 5.
+-   Color scale logic for charts with lots of items has been fixed.
+-   Update `@woocommerce/navigation` to v2.0.0
+-   Bug fix for `<StockReportTable />` returning N/A instead of zero.
+-   In `<Search>` use backspace key to remove tags from the search box.
 
 # 1.4.2
-- Add emoji-flags dependency
+
+-   Add emoji-flags dependency
 
 # 1.4.1
-- Chart component: format numbers and prices using store currency settings.
-- Make `href`/linking optional in SummaryNumber.
-- Fix SummaryNumber example code.
+
+-   Chart component: format numbers and prices using store currency settings.
+-   Make `href`/linking optional in SummaryNumber.
+-   Fix SummaryNumber example code.
 
 # 1.4.0
-- Add download log ip address autocompleter to search component
-- Add order number autocompleter to search component
-- Add order number, username, and IP address filters to the downloads report.
-- Added `interactive` prop for `d3chart/legend` to signal if legend items are clickable or not.
-- Fix for undefined ref in `d3chart/legend`.
-- Added three news props to `<Chart>`:
-  - `interactiveLegend`: whether legend items are clickable or not. Defaults to true.
-  - `legendPosition`: can be `top`, `side` or `bottom`. If not specified, it's calculated based on `mode` and viewport width.
-  - `showHeaderControls`: whether the header controls must be visible. Defaults to true.
-- `getColor()` method in chart utils now requires `keys` and `colorScheme` to be passed as separate params.
-- Fix to avoid duplicated Y-axis ticks when the Y max value was 0.
-- Remove decimals from Y-axis when displaying currencies.
-- Fix date formatting on charts in Safari.
+
+-   Add download log ip address autocompleter to search component
+-   Add order number autocompleter to search component
+-   Add order number, username, and IP address filters to the downloads report.
+-   Added `interactive` prop for `d3chart/legend` to signal if legend items are clickable or not.
+-   Fix for undefined ref in `d3chart/legend`.
+-   Added three news props to `<Chart>`:
+    -   `interactiveLegend`: whether legend items are clickable or not. Defaults to true.
+    -   `legendPosition`: can be `top`, `side` or `bottom`. If not specified, it's calculated based on `mode` and viewport width.
+    -   `showHeaderControls`: whether the header controls must be visible. Defaults to true.
+-   `getColor()` method in chart utils now requires `keys` and `colorScheme` to be passed as separate params.
+-   Fix to avoid duplicated Y-axis ticks when the Y max value was 0.
+-   Remove decimals from Y-axis when displaying currencies.
+-   Fix date formatting on charts in Safari.
 
 # 1.3.0
 
-- Update `<Table />` to use header keys to denote which columns are shown
-- Add `onColumnsChange` property to `<Table />` which is called when columns are shown/hidden
-- Add country autocompleter to search component
-- Add customer email autocompleter to search component
-- Add customer username autocompleter to search component
-- Adding new `<Chart />` component.
-- Added new `showDatePicker` prop to `<Filters />` component which allows to use the filters component without the date picker.
-- Added new taxes and customers autocompleters, and added support for using them within `<Filters />`.
-- Bug fix for `<SummaryNumber />` returning N/A instead of zero.
-- Bug fix for screen reader label IDs in `<Table />` header.
-- Added new component `<TextControlWithAffixes />`.
+-   Update `<Table />` to use header keys to denote which columns are shown
+-   Add `onColumnsChange` property to `<Table />` which is called when columns are shown/hidden
+-   Add country autocompleter to search component
+-   Add customer email autocompleter to search component
+-   Add customer username autocompleter to search component
+-   Adding new `<Chart />` component.
+-   Added new `showDatePicker` prop to `<Filters />` component which allows to use the filters component without the date picker.
+-   Added new taxes and customers autocompleters, and added support for using them within `<Filters />`.
+-   Bug fix for `<SummaryNumber />` returning N/A instead of zero.
+-   Bug fix for screen reader label IDs in `<Table />` header.
+-   Added new component `<TextControlWithAffixes />`.
 
 # 1.2.0
 
-- Update `Search` to exclude already-selected items
-- Fix incorrectly loaded `proptype-validator`
-- Update focus style on `SummaryNumber`
-- Remove prefixes from order statuses
+-   Update `Search` to exclude already-selected items
+-   Fix incorrectly loaded `proptype-validator`
+-   Update focus style on `SummaryNumber`
+-   Remove prefixes from order statuses
 
 # 1.1.0
 
-- Add `interpolate-components` as an explicit dependency, fixes issue with
-- Update `<Popover />` usage to match core component updates
-- Chart component: Add `chartMode` prop to control display mode
-- Add Taxes autocompleter to Search
-- Improve test coverage with new tests
+-   Add `interpolate-components` as an explicit dependency, fixes issue with
+-   Update `<Popover />` usage to match core component updates
+-   Chart component: Add `chartMode` prop to control display mode
+-   Add Taxes autocompleter to Search
+-   Improve test coverage with new tests

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,20 +1,20 @@
 # 1.2.0
 
-- Properly escape values with double quotes.
-- Prevent CSV injection.
+-   Properly escape values with double quotes.
+-   Prevent CSV injection.
 
 # 1.1.2
 
-- Update dependencies.
+-   Update dependencies.
 
 # 1.1.1
 
-- Update license to GPL-3.0-or-later.
+-   Update license to GPL-3.0-or-later.
 
 # 1.1.0
 
-- Fix error in `getCSVRows` when there is a null or undefined column value.
-- Bump dependency versions.
+-   Fix error in `getCSVRows` when there is a null or undefined column value.
+-   Bump dependency versions.
 
 # 1.0.3
 
@@ -24,4 +24,4 @@
 
 # 1.0.0
 
-- Released package
+-   Released package

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+-   Update to @wordpress/eslint coding standards.
+
 # 1.2.0
 
 -   Properly escape values with double quotes.

--- a/packages/csv-export/package.json
+++ b/packages/csv-export/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/csv-export",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "WooCommerce utility library to convert data to CSV files.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,37 +1,42 @@
-# 3.0.0 (unreleased)
+# 3.0.0
 
 ## Breaking changes
-- Currency is now a factory function instead of a class.
 
-- Add getCurrencyConfig method to retrieve currency config.
+-   Currency is now a factory function instead of a class.
+
+-   Add getCurrencyConfig method to retrieve currency config.
+
+-   `formatCurrency` is deprecated in favor of `formatAmount`.
 
 # 2.0.0
 
 ## Breaking changes
-- Decouple from global `wcSettings` object.
-- The currency package has been rewritten to export a `Currency` class instead of several utility functions.
+
+-   Decouple from global `wcSettings` object.
+-   The currency package has been rewritten to export a `Currency` class instead of several utility functions.
 
 ## Other changes
-- Remove lodash dependency.
+
+-   Remove lodash dependency.
 
 # 1.1.3
 
-- Update dependencies.
+-   Update dependencies.
 
 # 1.1.2
 
-- Update license to GPL-3.0-or-later.
+-   Update license to GPL-3.0-or-later.
 
 # 1.1.1
 
-- Change text domain on i18n functions.
-- Bump dependency versions.
+-   Change text domain on i18n functions.
+-   Bump dependency versions.
 
 # 1.1.0
 
-- Format using store currency settings (instead of locale)
-- Add optional currency symbol parameter
+-   Format using store currency settings (instead of locale)
+-   Add optional currency symbol parameter
 
 # 1.0.0
 
-- Released package
+-   Released package

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/currency",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "WooCommerce currency utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+-   Released package

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+-   Update to @wordpress/eslint coding standards.
+
 # 2.0.0
 
 ## Breaking changes

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,40 +2,40 @@
 
 ## Breaking changes
 
-- Decouple from global wcSettings object (#3278)
-- Exported methods of the date package have been rewritten to accept a configuration object as their second parameter.
-- `loadLocaleData` is no longer called within the date package. Consuming code must take care of that themselves.
+-   Decouple from global wcSettings object (#3278)
+-   Exported methods of the date package have been rewritten to accept a configuration object as their second parameter.
+-   `loadLocaleData` is no longer called within the date package. Consuming code must take care of that themselves.
 
 # 1.2.1
 
-- Update dependencies.
+-   Update dependencies.
 
 # 1.2.0
 
-- Enhancement: gather default date settings from `wcSettings.wcAdminSettings.woocommerce_default_date_range` if they exist.
-- Update license to GPL-3.0-or-later.
+-   Enhancement: gather default date settings from `wcSettings.wcAdminSettings.woocommerce_default_date_range` if they exist.
+-   Update license to GPL-3.0-or-later.
 
 # 1.0.7
 
-- Change text domain on i18n functions.
-- Bump dependency versions.
+-   Change text domain on i18n functions.
+-   Bump dependency versions.
 
 # 1.0.6
 
-- Removed timezone from `appendTimestamp()` output.
+-   Removed timezone from `appendTimestamp()` output.
 
 # 1.0.5
 
-- Fixed bug in getAllowedIntervalsForQuery() to not return `hour` for default intervals
+-   Fixed bug in getAllowedIntervalsForQuery() to not return `hour` for default intervals
 
 # 1.0.4
 
-- Remove deprecated @wordpress/date::getSettings() usage.
+-   Remove deprecated @wordpress/date::getSettings() usage.
 
 # 1.0.3
 
-- Fix missing comma seperator in date inside tooltips.
+-   Fix missing comma seperator in date inside tooltips.
 
 # 1.0.2
 
-- Add `getChartTypeForQuery` function to ensure chart type is always `bar` or `line`
+-   Add `getChartTypeForQuery` function to ensure chart type is always `bar` or `line`

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/date",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "WooCommerce date utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+-   Released package

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,37 +1,36 @@
-# (unreleased)
+# 5.0.0
 
-- `getPersistedQuery` Add a filter for extensions to add a persisted query, `woocommerce_admin_persisted_queries`.
+-   `getPersistedQuery` Add a filter for extensions to add a persisted query, `woocommerce_admin_persisted_queries`.
 
 # 4.0.0
 
 ## Breaking Changes
 
-- decouples `wcSettings` from the package (#3294)
-- `getAdminLink` is no longer available from this package. It is exported on the `wcSettings` global via the woo-blocks plugin (v2.5 or WC 3.9) when enqueued via the `wc-settings` handle.
-
+-   decouples `wcSettings` from the package (#3294)
+-   `getAdminLink` is no longer available from this package. It is exported on the `wcSettings` global via the woo-blocks plugin (v2.5 or WC 3.9) when enqueued via the `wc-settings` handle.
 
 # 3.0.0
 
-- `getHistory` updated to reflect path parameters in url query.
-- `getNewPath` also updated to reflect path parameters in url query.
-- `stringifyQuery` method is no longer available, instead use `addQueryArgs` from `@wordpress/url` package.
-- Added a new `<Form />` component.
-- Stepper component: Add new `content` and `description` props.
-- Remove `getAdminLink()` and dependency on global settings object.
+-   `getHistory` updated to reflect path parameters in url query.
+-   `getNewPath` also updated to reflect path parameters in url query.
+-   `stringifyQuery` method is no longer available, instead use `addQueryArgs` from `@wordpress/url` package.
+-   Added a new `<Form />` component.
+-   Stepper component: Add new `content` and `description` props.
+-   Remove `getAdminLink()` and dependency on global settings object.
 
 # 2.1.1
 
-- Update license to GPL-3.0-or-later
+-   Update license to GPL-3.0-or-later
 
 # 2.1.0
 
-- New method `getSearchWords` that extracts search words given a query object.
-- Bump dependency versions.
+-   New method `getSearchWords` that extracts search words given a query object.
+-   Bump dependency versions.
 
 # 2.0.0
 
-- Replace `history` export with `getHistory` (allows for lazy-create of history)
+-   Replace `history` export with `getHistory` (allows for lazy-create of history)
 
 # 1.1.0
 
-- Rename `getTimeRelatedQuery` to `getPersistedQuery`
+-   Rename `getTimeRelatedQuery` to `getPersistedQuery`

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/navigation",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "WooCommerce navigation utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,25 +1,26 @@
 # 2.0.0
-## Breaking Changes
-- Decouple from global wcSettings object.
-- Exported methods of the number package have been rewritten to accept a configuration object as their first parameter.
 
-## Other Changes
-- Remove lodash dependency.
+-   Remove lodash dependency.
+
+## Breaking Changes
+
+-   Decouple from global wcSettings object.
+-   Exported methods of the number package have been rewritten to accept a configuration object as their first parameter.
 
 # 1.0.4
 
-- Update dependencies.
+-   Update dependencies.
 
 # 1.0.3
 
-- Update license to GPL-3.0-or-later.
+-   Update license to GPL-3.0-or-later.
 
 # 1.0.2
 
-- Bump dependency versions.
+-   Bump dependency versions.
 
 # 1.0.1
 
 # 1.0.0
 
-- Initial release exports `numberFormat`, `formatValue`, and `calculateDelta`
+-   Initial release exports `numberFormat`, `formatValue`, and `calculateDelta`

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+-   Update to @wordpress/eslint coding standards.
+
 # 2.0.0
 
 -   Remove lodash dependency.

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/number",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Number formatting utilities for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.3.0
 Tested up to: 5.4.2
 Requires PHP: 5.6.20
-Stable tag: 1.5.0-dev
+Stable tag: 1.4.0
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.3.0
 Tested up to: 5.4.2
 Requires PHP: 5.6.20
-Stable tag: 1.4.0
+Stable tag: 1.5.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 


### PR DESCRIPTION
Prepare packages for release.

See https://github.com/woocommerce/woocommerce-admin/blob/main/packages/README.md#publishing-packages for publishing instructions.

Changelogs are updated and package.json versions bumped where appropriate.

## Test instructions

See the changelogs make sense and versions bumped correctly.

# Components 5.0.0

-   Added `<Timeline />` component.
-   Added `<ImageUpload />` component.
-   Style form components for WordPress 5.3.
-   Fix CompareFilter options format (key prop vs. id).
-   Fix styling of `<Search />` component "clear all" button.
-   Add state classes to `<TextControlWithAffixes />` component.
-   Fix `<AnimationSlider />` example code.
-   Add `<Plugins />` component for installation of plugins.
-   Removed use of `IconButton` in favor of `Button` component.
-   Add custom autocompleter support to `<Search />` component.
-   Fix `<SelectControl />` component to allow clicking anywhere on options in list to select.
-   Add support for `<List />` component item tags and link types.
-   Add `<List />` and `<Link />` components to Storybook.
-   Add `<Pill />` component.
-   Add `key` prop to `<List />` component items.
-   Remove unused `ref` from `<DateRangeFilterPicker />`.

# CSV Export 1.3.0

-   Update to @wordpress/eslint coding standards.

# Currency 3.0.0

## Breaking changes

-   Currency is now a factory function instead of a class.
-   Add getCurrencyConfig method to retrieve currency config.
-   `formatCurrency` is deprecated in favor of `formatAmount`.

# Data 1.0.0

-   Released package

# Date 2.1.0

-   Update to @wordpress/eslint coding standards.

# ESLint Plugin 1.0.0

-   Released package

# Navigation 5.0.0

-   `getPersistedQuery` Add a filter for extensions to add a persisted query, `woocommerce_admin_persisted_queries`.

# Number 2.1.0

-   Update to @wordpress/eslint coding standards.