### PR TITLE
Onboarding: Change account required text on biz step.

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -356,28 +356,26 @@ class BusinessDetails extends Component {
 				</p>
 			);
 		}
-
+		const accountRequiredText = this.bundleInstall
+			? __(
+					'User accounts are required to use these features.',
+					'woocommerce-admin'
+			  )
+			: '';
 		return (
 			<Fragment>
 				<p>
 					{ sprintf(
 						_n(
-							'The following plugin will be installed for free: %s',
-							'The following plugins will be installed for free: %s',
+							'The following plugin will be installed for free: %s. %s',
+							'The following plugins will be installed for free: %s. %s',
 							extensions.length,
 							'woocommerce-admin'
 						),
-						extensionsList
+						extensionsList,
+						accountRequiredText
 					) }
 				</p>
-				{ this.bundleInstall && (
-					<p>
-						{ __(
-							'An account is required to use these features.',
-							'woocommerce-admin'
-						) }
-					</p>
-				) }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
Fixes #4881

This branch adjusts the text that is shown when users are going to install the recommended bundled extensions.

__Before__

![Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 16-15-04](https://user-images.githubusercontent.com/22080/88983660-80fe0780-d280-11ea-99c0-835e564fd6cb.png)

__After__

![Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-07-30 16-10-26](https://user-images.githubusercontent.com/22080/88983670-865b5200-d280-11ea-9f35-9dfdf1866ca6.png)

### Detailed test instructions:

- Enable the onboarding wizard via Orders > Help
- Enter a US address on the first step, and select fashion/apparel as an industry
- On the biz details step, note the text shown in the footer has changed per the decision made in #4881 

### Changelog Note:

NA unreleased feature
