### PR TITLE
Remove payment task actions

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -144,7 +144,6 @@ class TaskDashboard extends Component {
 			countryCode,
 			profileItems,
 			query,
-			taskListPayments,
 			activePlugins,
 			installedPlugins,
 			installAndActivatePlugins,
@@ -155,7 +154,6 @@ class TaskDashboard extends Component {
 		return getAllTasks( {
 			countryCode,
 			profileItems,
-			taskListPayments,
 			query,
 			toggleCartModal: this.toggleCartModal.bind( this ),
 			activePlugins,
@@ -390,11 +388,8 @@ export default compose(
 
 		const isTaskListComplete =
 			getOption( 'woocommerce_task_list_complete' ) || false;
-		const taskListPayments = getOption( 'woocommerce_task_list_payments' );
 		const trackedCompletedTasks =
 			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
-
-		const payments = getOption( 'woocommerce_task_list_payments' );
 		const dismissedTasks =
 			getOption( 'woocommerce_task_list_dismissed_tasks' ) || [];
 
@@ -413,9 +408,7 @@ export default compose(
 			isJetpackConnected: isJetpackConnected(),
 			installedPlugins,
 			isTaskListComplete,
-			payments,
 			profileItems,
-			taskListPayments,
 			trackedCompletedTasks,
 		};
 	} ),

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -345,10 +345,6 @@
 }
 
 .woocommerce-task-dashboard__container {
-	.woocommerce-task-payments .woocommerce-task-payments__actions {
-		text-align: center;
-	}
-
 	button.components-button.is-primary {
 		margin: 0;
 	}

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -47,7 +47,6 @@ export function recordTaskViewEvent(
 export function getAllTasks( {
 	countryCode,
 	profileItems,
-	taskListPayments,
 	query,
 	toggleCartModal,
 	activePlugins,
@@ -57,32 +56,28 @@ export function getAllTasks( {
 	isJetpackConnected,
 } ) {
 	const {
+		hasPaymentGateway,
 		hasPhysicalProducts,
 		hasProducts,
 		isAppearanceComplete,
 		isTaxComplete,
 		shippingZonesCount,
+		wcPayIsConnected,
 	} = getSetting( 'onboarding', {
+		hasPaymentGateway: false,
 		hasPhysicalProducts: false,
 		hasProducts: false,
 		isAppearanceComplete: false,
 		isTaxComplete: false,
 		shippingZonesCount: 0,
+		wcPayIsConnected: false,
 	} );
 
 	const groupedProducts = getCategorizedOnboardingProducts(
 		profileItems,
 		installedPlugins
 	);
-
 	const { products, remainingProducts, uniqueItemsList } = groupedProducts;
-
-	const paymentsCompleted = Boolean(
-		taskListPayments && taskListPayments.completed
-	);
-	const paymentsSkipped = Boolean(
-		taskListPayments && taskListPayments.skipped
-	);
 
 	const woocommercePaymentsInstalled =
 		installedPlugins.indexOf( 'woocommerce-payments' ) !== -1;
@@ -150,7 +145,7 @@ export function getAllTasks( {
 			key: 'woocommerce-payments',
 			title: __( 'Set up WooCommerce Payments', 'woocommerce-admin' ),
 			container: <Fragment />,
-			completed: paymentsCompleted || paymentsSkipped,
+			completed: wcPayIsConnected,
 			onClick: async () => {
 				await new Promise( ( resolve, reject ) => {
 					// This task doesn't have a view, so the recordEvent call
@@ -183,7 +178,7 @@ export function getAllTasks( {
 			key: 'payments',
 			title: __( 'Set up payments', 'woocommerce-admin' ),
 			container: <Payments />,
-			completed: paymentsCompleted || paymentsSkipped,
+			completed: hasPaymentGateway,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {
 					task_name: 'payments',

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -145,6 +145,8 @@ class Payments extends Component {
 
 		enabledMethods[ key ] = ! enabledMethods[ key ];
 		this.setState( { enabledMethods } );
+		const hasEnabledMethod =
+			Object.values( enabledMethods ).filter( Boolean ).length > 0;
 
 		recordEvent( 'tasklist_payment_toggle', {
 			enabled: ! method.isEnabled,
@@ -158,12 +160,10 @@ class Payments extends Component {
 			},
 		} );
 
-		if ( ! method.isEnabled ) {
-			setSetting( 'onboarding', {
-				...getSetting( 'onboarding', {} ),
-				hasPaymentGateway: true,
-			} );
-		}
+		setSetting( 'onboarding', {
+			...getSetting( 'onboarding', {} ),
+			hasPaymentGateway: hasEnabledMethod,
+		} );
 	}
 
 	async handleClick( method ) {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -48,9 +48,7 @@ class Payments extends Component {
 			recommendedMethod: this.getRecommendedMethod(),
 		};
 
-		this.completeTask = this.completeTask.bind( this );
 		this.markConfigured = this.markConfigured.bind( this );
-		this.skipTask = this.skipTask.bind( this );
 	}
 
 	componentDidUpdate() {
@@ -69,60 +67,6 @@ class Payments extends Component {
 		return methods.find( ( m ) => m.key === 'wcpay' && m.visible )
 			? 'wcpay'
 			: 'stripe';
-	}
-
-	async completeTask() {
-		const { createNotice, methods, updateOptions } = this.props;
-
-		const update = await updateOptions( {
-			woocommerce_task_list_payments: {
-				completed: 1,
-				timestamp: Math.floor( Date.now() / 1000 ),
-			},
-		} );
-
-		recordEvent( 'tasklist_payment_done', {
-			configured: methods
-				.filter( ( method ) => method.isConfigured )
-				.map( ( method ) => method.key ),
-		} );
-
-		if ( update.success ) {
-			createNotice(
-				'success',
-				__(
-					'💰 Ka-ching! Your store can now accept payments 💳',
-					'woocommerce-admin'
-				)
-			);
-
-			getHistory().push( getNewPath( {}, '/', {} ) );
-		} else {
-			createNotice(
-				'error',
-				__(
-					'There was a problem updating settings',
-					'woocommerce-admin'
-				)
-			);
-		}
-	}
-
-	skipTask() {
-		const { methods, updateOptions } = this.props;
-
-		updateOptions( {
-			woocommerce_task_list_payments: {
-				skipped: 1,
-				timestamp: Math.floor( Date.now() / 1000 ),
-			},
-		} );
-
-		recordEvent( 'tasklist_payment_skip_task', {
-			options: methods.map( ( method ) => method.key ),
-		} );
-
-		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 
 	markConfigured( method ) {
@@ -239,10 +183,7 @@ class Payments extends Component {
 	render() {
 		const currentMethod = this.getCurrentMethod();
 		const { busyMethod, enabledMethods, recommendedMethod } = this.state;
-		const { methods, query, requesting } = this.props;
-		const hasEnabledMethods = Object.keys( enabledMethods ).filter(
-			( method ) => enabledMethods[ method ]
-		).length;
+		const { methods, query } = this.props;
 
 		if ( currentMethod ) {
 			return (
@@ -348,24 +289,6 @@ class Payments extends Component {
 						</Card>
 					);
 				} ) }
-				<div className="woocommerce-task-payments__actions">
-					{ ! hasEnabledMethods ? (
-						<Button isLink onClick={ this.skipTask }>
-							{ __(
-								'My store doesn’t take payments',
-								'woocommerce-admin'
-							) }
-						</Button>
-					) : (
-						<Button
-							isPrimary
-							isBusy={ requesting }
-							onClick={ this.completeTask }
-						>
-							{ __( 'Done', 'woocommerce-admin' ) }
-						</Button>
-					) }
-				</div>
 			</div>
 		);
 	}

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -17,6 +17,7 @@ import {
 	getNewPath,
 	updateQueryString,
 } from '@woocommerce/navigation';
+import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 import {
 	ONBOARDING_STORE_NAME,
 	OPTIONS_STORE_NAME,
@@ -79,11 +80,16 @@ class Payments extends Component {
 			},
 		} );
 
-		getHistory().push( getNewPath( { task: 'payments' }, '/', {} ) );
+		setSetting( 'onboarding', {
+			...getSetting( 'onboarding', {} ),
+			hasPaymentGateway: true,
+		} );
 
 		recordEvent( 'tasklist_payment_connect_method', {
 			payment_method: method,
 		} );
+
+		getHistory().push( getNewPath( { task: 'payments' }, '/', {} ) );
 	}
 
 	getCurrentMethod() {
@@ -151,6 +157,13 @@ class Payments extends Component {
 				enabled: method.isEnabled ? 'no' : 'yes',
 			},
 		} );
+
+		if ( ! method.isEnabled ) {
+			setSetting( 'onboarding', {
+				...getSetting( 'onboarding', {} ),
+				hasPaymentGateway: true,
+			} );
+		}
 	}
 
 	async handleClick( method ) {
@@ -308,7 +321,7 @@ export default compose(
 	withSelect( ( select, props ) => {
 		const { createNotice, installAndActivatePlugins } = props;
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
-		const { getOption, isOptionsUpdating } = select( OPTIONS_STORE_NAME );
+		const { getOption } = select( OPTIONS_STORE_NAME );
 		const { getActivePlugins, isJetpackConnected } = select(
 			PLUGINS_STORE_NAME
 		);
@@ -351,15 +364,12 @@ export default compose(
 			profileItems,
 		} );
 
-		const requesting = isOptionsUpdating();
-
 		return {
 			countryCode,
 			profileItems,
 			activePlugins,
 			options,
 			methods,
-			requesting,
 		};
 	} )
 )( Payments );

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -50,7 +50,6 @@ A few new WordPress options have been introduced to store information and settin
 * `woocommerce_task_list_hidden`. This option is used to conditionally show the entire task list. The task list can be hidden by the user after they have completed all tasks. Hiding the wizard stops it from showing in both full screen mode, and the collapsed inline version that shows above the dashboard analytics cards.
 * `woocommerce_task_list_welcome_modal_dismissed`. This option is used to show a congratulations modal during the transition between the profile wizard and task list.
 * `woocommerce_task_list_prompt_shown`. This option is used to conditionally show the "Is this card useful?" snackbar notice, shown once right after a user completes all the task list tasks.
-* `woocommerce_task_list_payments`. Since the payments step requires multiple redirects to payment providers to setup accounts, we cache the current progress of the payments step in an option, so that we can quickly drop users back into the correct part of the task.
 
 We also use existing options from WooCommerce Core or extensions like WooCommerce Services or Stripe. The list below may not be complete, as new tasks are introduced, but you can generally find usage of these by searching for the [getOptions selector](https://github.com/woocommerce/woocommerce-admin/search?q=getOptions&unscoped_q=getOptions).
 

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -136,7 +136,6 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_ppec_paypal_settings'   => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_task_list_payments'     => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
 		);

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -652,7 +652,6 @@ class Onboarding {
 		$options[] = 'wc_connect_options';
 		$options[] = 'woocommerce_task_list_welcome_modal_dismissed';
 		$options[] = 'woocommerce_task_list_prompt_shown';
-		$options[] = 'woocommerce_task_list_payments';
 		$options[] = 'woocommerce_task_list_tracked_completed_tasks';
 		$options[] = 'woocommerce_task_list_dismissed_tasks';
 		$options[] = 'woocommerce_allow_tracking';

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -96,10 +96,19 @@ class OnboardingTasks {
 				: false;
 		}
 
+		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
+		$enabled_gateways = array_filter(
+			$gateways,
+			function( $gateway ) {
+				return 'yes' === $gateway->enabled;
+			}
+		);
+
 		// @todo We may want to consider caching some of these and use to check against
 		// task completion along with cache busting for active tasks.
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
 		$settings['onboarding']['hasHomepage']                    = self::check_task_completion( 'homepage' ) || 'classic' === get_option( 'classic-editor-replace' );
+		$settings['onboarding']['hasPaymentGateway']              = ! empty( $enabled_gateways );
 		$settings['onboarding']['hasPhysicalProducts']            = count(
 			wc_get_products(
 				array(

--- a/src/Notes/WC_Admin_Notes_Test_Checkout.php
+++ b/src/Notes/WC_Admin_Notes_Test_Checkout.php
@@ -25,14 +25,15 @@ class WC_Admin_Notes_Test_Checkout {
 	 */
 	const NOTE_NAME = 'wc-admin-test-checkout';
 
-	const TASK_LIST_PAYMENTS      = 'woocommerce_task_list_payments';
+	/**
+	 * Completed tasks option name.
+	 */
 	const TASK_LIST_TRACKED_TASKS = 'woocommerce_task_list_tracked_completed_tasks';
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'update_option_' . self::TASK_LIST_PAYMENTS, array( $this, 'possibly_add_note' ) );
 		add_action( 'update_option_' . self::TASK_LIST_TRACKED_TASKS, array( $this, 'possibly_add_note' ) );
 	}
 
@@ -57,8 +58,8 @@ class WC_Admin_Notes_Test_Checkout {
 		}
 
 		// Make sure payments task was completed.
-		$payments_task = get_option( self::TASK_LIST_PAYMENTS, array() );
-		if ( ! isset( $payments_task['completed'] ) ) {
+		$completed_tasks = get_option( self::TASK_LIST_TRACKED_TASKS, array() );
+		if ( ! in_array( 'payments', $completed_tasks, true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4638

Removes the done/skip buttons as well as any references to the tracked payments options.

### Screenshots
<img width="728" alt="Screen Shot 2020-08-03 at 11 25 03 AM" src="https://user-images.githubusercontent.com/10561050/89161951-fec15c00-d57b-11ea-8032-63435546416b.png">

### Detailed test instructions:

**Setting up payment gateways**
1. Disable any enabled payment gateways.
1. Go to the task list payments task.
1. Note that the done/skip buttons have been removed.
1. Attempt to set up a payment gateway and make sure the payments task is marked complete upon clicking `Home` without refreshing.
1. Make sure on refresh that the payment task completion persists.

**Toggling payment gateways**
1. Disable all payment gateways.
1. Attempt to toggle on a simple payment gateway (like COD).
1. Click `Home` and make sure the task is marked as complete.

**Checkout test note**
1. Make sure the payments task is complete.
1. Qualify for the checkout notes (1 product created < 30 min ago, no `setup_client`)
1. Run `wc_admin_daily` or complete the payment task after filling the above criteria.
1. Note the note in your inbox.