### PR TITLE
Allow revisiting of the payments task

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -178,12 +178,6 @@ export function getAllTasks( {
 				recordEvent( 'tasklist_click', {
 					task_name: 'payments',
 				} );
-				if ( paymentsCompleted || paymentsSkipped ) {
-					window.location = getAdminLink(
-						'admin.php?page=wc-settings&tab=checkout'
-					);
-					return;
-				}
 				updateQueryString( { task: 'payments' } );
 			},
 			visible: ! woocommercePaymentsInstalled,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -8,7 +8,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * WooCommerce dependencies
  */
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import {
 	getHistory,
 	getNewPath,


### PR DESCRIPTION
Fixes #4901  

Allow payments task to be revisited after completion.

### Screenshots
<img width="609" alt="Screen Shot 2020-08-03 at 11 47 51 AM" src="https://user-images.githubusercontent.com/10561050/89164001-2d8d0180-d57f-11ea-97e5-9762340241b3.png">


### Detailed test instructions:

1. Complete the payments task.
1. Try to revisit the payments task after completion.
1. Make sure you end up in the payments task and not the WC settings screen.
