### PR TITLE
Fix use of Jetpack autoloader.

### DIFF
--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -76,9 +76,9 @@ npm --no-git-tag-version version $release || { error "ERROR: Invalid version num
 
 success "Version bumped successfully"
 
-status "Run prestart scripts to propagate version numbers and update dependencies."
+status "Run scripts to propagate version numbers and update dependencies."
 
-npm run prestart
+npm run bump-version
 
 status "Run docs script to make sure docs are updated."
 

--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -25,6 +25,9 @@ function replace_version( $filename, $package_json ) {
 		if ( stripos( $line, 'Stable tag: ' ) !== false ) {
 			$line = "Stable tag: {$package_json->version}\n";
 		}
+		if ( stripos( $line, '"name": "woocommerce/woocommerce-admin",' ) !== false ) {
+			$line .= "\t\"version\": \"{$package_json->version}\",\n";
+		}
 		$lines[] = $line;
 	}
 	file_put_contents( $filename, $lines );
@@ -34,3 +37,4 @@ replace_version( 'woocommerce-admin.php', $package );
 replace_version( 'src/FeaturePlugin.php', $package );
 replace_version( 'src/Package.php', $package );
 replace_version( 'readme.txt', $package );
+replace_version( 'composer.json', $package );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"license.txt"
 	],
 	"scripts": {
-		"prebuild": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
+		"prebuild": "npm run -s install-if-deps-outdated",
 		"build": "npm run build:feature-config && npm run build:packages && cross-env NODE_ENV=production webpack",
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",
 		"postbuild": "npm run -s i18n:pot && npm run -s i18n:build",
@@ -52,7 +52,7 @@
 		"publish-packages:check": "npm run build:packages && lerna updated",
 		"publish-packages:dev": "npm run build:packages && lerna publish from-package --npm-tag next",
 		"publish-packages:prod": "npm run build:packages && lerna publish from-package",
-		"prestart": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
+		"prestart": "npm run -s install-if-deps-outdated",
 		"start": "cross-env WC_ADMIN_PHASE=development npm run build:packages && cross-env WC_ADMIN_PHASE=development npm run build:feature-config && concurrently \"cross-env WC_ADMIN_PHASE=development webpack --watch\" \"node ./bin/packages/watch.js\"",
 		"pretest": "npm run -s install-if-no-packages",
 		"test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
@@ -65,7 +65,8 @@
 		"create-wc-extension": "node ./bin/starter-pack/starter-pack.js",
 		"storybook": "start-storybook  -c ./storybook -p 6007 --ci",
 		"build-storybook": "build-storybook  -c ./storybook",
-		"changelog": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'"
+		"changelog": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'",
+		"bump-version": "npm run -s install-if-deps-outdated && php ./bin/update-version.php"
 	},
 	"changelog": {
 		"labelPrefix": "[Type]",

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -138,10 +138,6 @@ class FeaturePlugin {
 			return;
 		}
 
-		if ( ! $this->check_build() ) {
-			add_action( 'admin_notices', array( $this, 'render_build_notice' ) );
-		}
-
 		$this->includes();
 		$this->hooks();
 	}
@@ -256,17 +252,6 @@ class FeaturePlugin {
 	}
 
 	/**
-	 * Returns true if build file exists.
-	 *
-	 * @return bool
-	 */
-	protected function check_build() {
-		$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$suffix       = Loader::should_use_minified_js_file( $script_debug ) ? '.min' : '';
-		return file_exists( plugin_dir_path( __DIR__ ) . "/dist/app/index{$suffix}.js" );
-	}
-
-	/**
 	 * Deactivates this plugin.
 	 */
 	public function deactivate_self() {
@@ -280,19 +265,6 @@ class FeaturePlugin {
 	public function render_dependencies_notice() {
 		$message = $this->get_dependency_errors();
 		printf( '<div class="error"><p>%s</p></div>', implode( ' ', $message ) ); /* phpcs:ignore xss ok. */
-	}
-
-	/**
-	 * Notify users that the plugin needs to be built.
-	 */
-	public function render_build_notice() {
-		$message_one = __( 'You have installed a development version of WooCommerce Admin which requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files.', 'woocommerce-admin' );
-		$message_two = sprintf(
-			/* translators: 1: URL of GitHub Repository build page */
-			__( 'Or you can download a pre-built version of the plugin by visiting <a href="%1$s">the releases page in the repository</a>.', 'woocommerce-admin' ),
-			'https://github.com/woocommerce/woocommerce-admin/releases'
-		);
-		printf( '<div class="error"><p>%s %s</p></div>', $message_one, $message_two ); /* phpcs:ignore xss ok. */
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -27,7 +27,7 @@ use \Automattic\WooCommerce\Admin\FeaturePlugin;
  * We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.
  * If the autoloader is not present, let's log the failure and display a nice admin notice.
  */
-$autoloader = __DIR__ . '/vendor/autoload.php';
+$autoloader = __DIR__ . '/vendor/autoload_packages.php';
 if ( is_readable( $autoloader ) ) {
 	require $autoloader;
 } else {

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -20,6 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\FeaturePlugin;
+use \Automattic\WooCommerce\Admin\Loader;
 
 /**
  * Autoload packages.
@@ -64,6 +65,79 @@ if ( is_readable( $autoloader ) ) {
 		}
 	);
 	return;
+}
+
+/**
+ * Returns whether the current version is a development version
+ * Note this relies on composer.json version, not plugin version.
+ * Development installs of the plugin don't have a version defined in
+ * composer json.
+ *
+ * @return bool True means the current version is a development version.
+ */
+function woocommerce_admin_is_development_version() {
+	$composer_file = __DIR__ . '/composer.json';
+	if ( ! is_readable( $composer_file ) ) {
+		return false;
+	}
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- including local file
+	$composer_config = json_decode( file_get_contents( $composer_file ), true );
+	return ! isset( $composer_config['version'] );
+}
+
+/**
+ * Returns true if build file exists.
+ *
+ * @return bool
+ */
+function woocommerce_admin_check_build_files() {
+	$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+	$suffix       = Loader::should_use_minified_js_file( $script_debug ) ? '.min' : '';
+	return file_exists( __DIR__ . "/dist/app/index{$suffix}.js" );
+}
+
+/**
+ * If development version is detected and the Jetpack constant is not defined, show a notice.
+ */
+if ( woocommerce_admin_is_development_version() && ! defined( 'JETPACK_AUTOLOAD_DEV' ) ) {
+	add_action(
+		'admin_notices',
+		function() {
+			echo '<div class="error"><p>';
+			printf(
+				/* Translators: %1$s is referring to a php constant name, %2$s is referring to the wp-config.php file. */
+				esc_html__( 'WooCommerce Admin development mode requires the %1$s constant to be defined and true in your %2$s file. Otherwise you are loading the admin package from WooCommerce core.', 'woocommerce-admin' ),
+				'<code>JETPACK_AUTOLOAD_DEV</code>',
+				'<code>wp-config.php</code>'
+			);
+			echo '</p></div>';
+		}
+	);
+}
+
+/**
+ * If we're missing expected files, notify users that the plugin needs to be built.
+ */
+if ( ! woocommerce_admin_check_build_files() ) {
+	add_action(
+		'admin_notices',
+		function() {
+			echo '<div class="error"><p>';
+			printf(
+				/* Translators: %1$s, %2$s, and %3$s are all build commands to be run in order.  */
+				esc_html__( 'You have installed a development version of WooCommerce Admin which requires files to be built. From the plugin directory, run %1$s and %2$s to install dependencies, then %3$s to build the files.', 'woocommerce-admin' ),
+				'<code>composer install</code>',
+				'<code>npm install</code>',
+				'<code>npm run build</code>'
+			);
+			printf(
+				/* translators: 1: URL of GitHub Repository build page */
+				esc_html__( 'Or you can download a pre-built version of the plugin by visiting <a href="%1$s">the releases page in the repository</a>.', 'woocommerce-admin' ),
+				'https://github.com/woocommerce/woocommerce-admin/releases'
+			);
+			echo '</p></div>';
+		}
+	);
 }
 
 FeaturePlugin::instance()->init();


### PR DESCRIPTION
Fixes #4910.

This PR seeks to fix our project's usage of the Jetpack autoloader so that the latest version of the package gets included. It also introduces a check to see if the necessary Jetpack constant is defined for local development.

Since the `composer.json` now receives a version for builds, this PR also makes a change to the `prestart` and `prebuild` scripts so they don't bump versions, and introduces a new `bump-version` script that is used by `pre-release`.

Note: We can probably remove the `WC_Admin_Notes_Deactivate_Plugin` class now, but I chose not to do so at this time.

### Detailed test instructions:

### Testing missing development constant notice

_This also tests the change to use the correct Jetpack autoloader file._

This will require a bit additional setup:

1. Make sure you are running WooCommerce 4.4 beta 1 (or checked out the built release branch for that version - it must be that version, not beta2).
2. Make sure you are running the latest WP 5.5 release candidate.
3. Without doing anything in this branch, you should a notice instructing you to set `JETPACK_AUTOLOAD_DEV`
4. Add `define( 'JETPACK_AUTOLOAD_DEV', true )` to your `wp-config.php` file (you'll want to leave it defined there when developing going forward). **Note:** You _may_ get a fatal error because your checked out version of Woo Core has the constant defined, in that case just comment out the constant definition in Woo Core (Woo core 4.4. will not be released with the defined constant as it's being removed).
5. Verify that the notice disappears in your wp-admin dashboard. 

### Testing version bump changes.

To verify things work as expected, you can run this script locally:

```bash
npm run pre-release
```

Base the test release on the current branch (`fix/4910-autoloader-version`), pick any valid version (e.g. `5.5.5-beta.1`)

After running that you should note the following:

- `composer.json`, `package.json`, `package-lock.json`, `readme.txt`, `src/Package.php`, `src/FeaturePlugin.php`, `woocommerce-admin.php` should be changed.
- The above files should only have a version bump to the specified version
- `composer.json`, should have the `version` property added by the script (otherwise it exists without a `version` property in development).



### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: defer to WooCommerce Admin version in WooCommerce core if it is newer.