### PR TITLE
Task List: dismiss and undo dismiss animation fixed

### DIFF
--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -42,13 +42,14 @@ class List extends Component {
 				className={ listClassName }
 				role="menu"
 			>
-				{ items.map( ( item, i ) => {
+				{ items.map( ( item ) => {
 					const {
 						after,
 						before,
 						className: itemClasses,
 						content,
 						href,
+						key,
 						listItemTag,
 						onClick,
 						target,
@@ -80,7 +81,7 @@ class List extends Component {
 
 					return (
 						<CSSTransition
-							key={ i }
+							key={ key }
 							timeout={ 500 }
 							classNames="woocommerce-list__item"
 						>


### PR DESCRIPTION
Fixes #4892

This PR replaces a prop we send to the component "CSSTransition" for `item key`.

We had a problem with the component "CSSTransition" since the animation was having an unexpected behavior.


### Screenshots
Before
![dismiss](https://cldup.com/6jOoqpcEjv.gif)

Now
![Screen Capture on 2020-08-04 at 18-48-25](https://user-images.githubusercontent.com/1314156/89348627-3bc44600-d683-11ea-9ef8-72cee600a766.gif)


### Detailed test instructions:

1. Go to the OBW and add a product that requires purchase (e.g. Bookings or Bundles).
2. Go to the task list.
3. Dismiss the task `Purchase & install extensions`.
4. Make sure that the animation works as expected and the item that disappears is the selected one.
5. A snack-bar will appear with the button `Undo`, press it.
6. Make sure the undo item animation works as expected. The undeleted item should appear with an animation.
7. Delete `woocommerce_task_list_dismissed_tasks` if you need all the tasks again.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
Fix: Task List: dismiss and undo dismiss animation fixed