### PR TITLE
Added key to generic items in list without one

### DIFF
--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -42,7 +42,7 @@ class List extends Component {
 				className={ listClassName }
 				role="menu"
 			>
-				{ items.map( ( item ) => {
+				{ items.map( ( item, index ) => {
 					const {
 						after,
 						before,
@@ -81,7 +81,7 @@ class List extends Component {
 
 					return (
 						<CSSTransition
-							key={ key }
+							key={ key || index }
 							timeout={ 500 }
 							classNames="woocommerce-list__item"
 						>


### PR DESCRIPTION
Related to [PR 4924](https://github.com/woocommerce/woocommerce-admin/pull/4924)

This PR adds a key to generic items in a list that don't have one.

The [PR 4924](https://github.com/woocommerce/woocommerce-admin/pull/4924) introduced an error in the List component when the items don't have a defined key.
Now, if an item key is not defined, we set it with its map index.

### Detailed test instructions:
1. Go to the OBW and add one or more products that require purchase (e.g. Bookings or Bundles).
2. Go to the task list.
3. Press `Purchase & install extensions`. It will show a modal with the selected products like this:
![screenshot-one wordpress test-2020 08 05-12_21_21](https://user-images.githubusercontent.com/1314156/89431436-4f6cbc80-d716-11ea-9866-657830c31812.png)

4. Make sure that there aren't any errors in the console.

_If you have dismissed that task you can undismiss it deleting `woocommerce_task_list_dismissed_tasks` in `wp_options` table in your DB_.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
Fix: Added key to generic items in list without one