### PR TITLE
Load chunked translation data from language packs.

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -480,6 +480,126 @@ class Loader {
 	}
 
 	/**
+	 * Generate a filename to cache translations from JS chunks.
+	 *
+	 * @param string $domain Text domain.
+	 * @param string $locale Locale being retrieved.
+	 * @return string Filename.
+	 */
+	public static function get_combined_translation_filename( $domain, $locale ) {
+		$version  = self::get_file_version( 'js' );
+		$filename = implode( '-', array( $domain, $locale, WC_ADMIN_APP, $version ) ) . '.json';
+
+		return $filename;
+	}
+
+	/**
+	 * Find and combine translation chunk files.
+	 * 
+	 * Only targets files that aren't represented by a registered script (e.g. not passed to wp_register_script()).
+	 *
+	 * @param string $lang_dir Path to language files.
+	 * @param string $domain Text domain.
+	 * @param string $locale Locale being retrieved.
+	 * @return array Combined translation chunk data.
+	 */
+	public static function get_translation_chunk_data( $lang_dir, $domain, $locale ) {
+		// Grab all JSON files in the current language pack.
+		$json_i18n_filenames = glob( $lang_dir . $domain . '-' . $locale . '-*.json' );
+		$combined_translation_data = array();
+
+		foreach ( $json_i18n_filenames as $json_filename ) {
+			if ( ! is_readable( $json_filename ) ) {
+				continue;
+			}
+
+			$file_contents = \file_get_contents( $json_filename );
+			$chunk_data    = \json_decode( $file_contents, true );
+
+			if ( empty( $chunk_data ) ) {
+				continue;
+			}
+
+			if ( ! isset( $chunk_data['comment']['reference'] ) ) {
+				continue;
+			}
+
+			$reference_file = $chunk_data['comment']['reference'];
+
+			// Only combine "app" files (not scripts registered with WP).
+			if (
+				false === strpos( $reference_file, 'dist/chunks/' ) &&
+				false === strpos( $reference_file, 'dist/app/index.js' )
+			) {
+				continue;
+			}
+
+			if ( empty( $combined_translation_data ) ) {
+				// Use the first translation file as the base structure.
+				$combined_translation_data = $chunk_data;
+			} else {
+				// Combine all messages from all chunk files.
+				$combined_translation_data['locale_data']['messages'] = array_merge(
+					$combined_translation_data['locale_data']['messages'],
+					$chunk_data['locale_data']['messages']
+				);
+			}
+		}
+
+		// Remove inaccurate reference comment.
+		unset( $combined_translation_data['comment'] );
+		
+		return $combined_translation_data;
+	}
+
+	/**
+	 * Load translation strings from language packs for dynamic imports.
+	 * 
+	 * This function combines JSON translation data auto-extracted by GlotPress
+	 * from Webpack-generated JS chunks into a single file that can be used in
+	 * subsequent requests. This is necessary since the JS chunks are not known
+	 * to WordPress via wp_register_script() and wp_set_script_translations().
+	 *
+	 * @param string $original_translations JSON encoded translations object.
+	 * @param string $file File location for the script being translated.
+	 * @param string $handle Script handle.
+	 * @param string $domain Text domain.
+	 *
+	 * @return string JSON encoded translations object.
+	 */
+	public static function load_script_translations( $original_translations, $file, $handle, $domain ) {
+		if ( 'woocommerce-admin' !== $domain || WC_ADMIN_APP !== $handle ) {
+			return $original_translations;
+		}
+
+		$locale         = determine_locale();
+		$cache_filename = self::get_combined_translation_filename( $domain, $locale );
+		$lang_dir       = WP_LANG_DIR . '/plugins/';
+
+		// First attempt to get a previously generated combined translation file.
+		if (
+			is_file( $lang_dir . $cache_filename ) &&
+			is_readable( $lang_dir . $cache_filename )
+		) {
+			return file_get_contents( $lang_dir . $cache_filename );
+		}
+
+		// Get all translation chunk data combined into a single object.
+		$translations_from_chunks = self::get_translation_chunk_data( $lang_dir, $domain, $locale );
+
+		if ( empty( $translations_from_chunks ) ) {
+			return $original_translations;
+		}
+
+		$chunk_translations_json = json_encode( $translations_from_chunks );
+
+		// Cache combined translations strings to a file.
+		file_put_contents( $lang_dir . $cache_filename, $chunk_translations_json );
+
+		return $chunk_translations_json;
+	}
+
+	/**
 	 * Loads the required scripts on the correct pages.
 	 */
 	public static function load_scripts() {
@@ -490,6 +610,9 @@ class Loader {
 		if ( ! static::user_can_analytics() ) {
 			return;
 		}
+
+		// Grab translation strings from Webpack-generated chunks.
+		add_filter( 'pre_load_script_translations', array( __CLASS__, 'load_script_translations' ), 10, 4 );
 
 		$features         = self::get_features();
 		$enabled_features = array();

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -570,7 +570,14 @@ class Loader {
 	 * @return string JSON encoded translations object.
 	 */
 	public static function load_script_translations( $original_translations, $file, $handle, $domain ) {
-		if ( 'woocommerce-admin' !== $domain || WC_ADMIN_APP !== $handle ) {
+		// Make sure the main app script is being loaded.
+		if ( WC_ADMIN_APP !== $handle ) {
+			return $original_translations;
+		}
+
+		// Make sure we're handing the correct domain (could be woocommerce or woocommerce-admin).
+		$plugin_domain = explode( '/', plugin_basename( __FILE__ ) )[0];
+		if ( $plugin_domain !== $domain ) {
 			return $original_translations;
 		}
 


### PR DESCRIPTION
Fixes #2336. (Again)

The introduction of code splitting broke translations for strings that ended up in JS chunk files. When translate.wordpress.org generates files, it automatically scans all JS in the project. Because the split code chunks aren't registered with WordPress via 
`wp_register_script()` and `wp_set_script_translations()`, the corresponding JSON translation files weren't being loaded.

I think the ideal solution would be to handle this all in JS, but it would require copying some code from Calypso (a Webpack plugin to subscribe to chunk loading, and an i18n context component) and some seemingly major application refactoring.

This PR seeks to provide an all-PHP solution to the problem. When loading the "main" application script (identified by the `WC_ADMIN_APP` handle) the JSON translation files are parsed, the "chunk" specific ones are combined into a single file (and written to the filesystem as a cache for subsequent loads) and served in place of the single JSON file representing just the `dist/app/index.js` file.

The code can handle being loaded as a package within WooCommerce core as well.

### Detailed test instructions:

- On `main`:
- Set your store language to German (or some other language we have a language pack for (>85%))
- Go to the updates screen, click "update translations" (should be very last button on screen)
- Go to Analytics > Revenue
- Verify that "Gross Sales" is **not** translated
- Check out this branch
- Go to Analytics > Revenue
- Verify that "Gross Sales" **is** translated
- Copy `src/Loader.php` to your local WooCommerce plugin (`/packages/woocommerce-admin/src/`)
- Deactivate WooCommerce Admin plugin
- Go to Analytics > Revenue
- Verify that "Gross Sales" **is** translated

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: translation loading from JavaScript files.