### PR TITLE
Don't redirect to connect Jetpack if "no thanks!" selected.

### DIFF
--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -219,12 +219,17 @@ class ProfileWizard extends Component {
 			getPluginsError,
 			isJetpackConnected,
 			notes,
+			profileItems,
 			updateNote,
 			updateProfileItems,
 		} = this.props;
 		recordEvent( 'storeprofiler_complete' );
+
+		const { plugins } = profileItems;
 		const shouldConnectJetpack =
-			activePlugins.includes( 'jetpack' ) && ! isJetpackConnected;
+			( plugins === 'installed' || plugins === 'installed-wcs' ) &&
+			activePlugins.includes( 'jetpack' ) &&
+			! isJetpackConnected;
 
 		const profilerNote = notes.find(
 			( note ) => note.name === 'wc-admin-onboarding-profiler-reminder'


### PR DESCRIPTION
Fixes #4939

This PR checks whether or not the user opted in to install Jetpack before redirecting to the connection flow.

### Detailed test instructions:

- Install and activate (but do not connect) Jetpack
- Go through the OBW
- Select "no thanks!" on the Jetpack step
- Verify that you are redirected to the WooCommerce Home screen, not a Jetpack screen

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug.