### PR TITLE
Setup Payments: Add eWAY for AU/NZ Stores.

### DIFF
--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -82,7 +82,7 @@ function getPaymentsItems( props ) {
 	const showPayPal = methodIsVisible( 'paypal' );
 	const showSquare = methodIsVisible( 'square' );
 	const showPayFast = methodIsVisible( 'payfast' );
-	const showeWAY = methodIsVisible( 'eway' );
+	const showEway = methodIsVisible( 'eway' );
 
 	return [
 		{
@@ -139,7 +139,7 @@ function getPaymentsItems( props ) {
 			link:
 				'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel',
 		},
-		showeWAY && {
+		showEway && {
 			title: __( 'eWAY Setup and Configuration', 'woocommerce-admin' ),
 			link:
 				'https://docs.woocommerce.com/document/eway/?utm_source=help_panel',

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -82,6 +82,7 @@ function getPaymentsItems( props ) {
 	const showPayPal = methodIsVisible( 'paypal' );
 	const showSquare = methodIsVisible( 'square' );
 	const showPayFast = methodIsVisible( 'payfast' );
+	const showeWAY = methodIsVisible( 'eway' );
 
 	return [
 		{
@@ -137,6 +138,11 @@ function getPaymentsItems( props ) {
 			title: __( 'PayFast Setup and Configuration', 'woocommerce-admin' ),
 			link:
 				'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel',
+		},
+		showeWAY && {
+			title: __( 'eWAY Setup and Configuration', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/eway/?utm_source=help_panel',
 		},
 		{
 			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce-admin' ),

--- a/client/header/activity-panel/test/help-panel.js
+++ b/client/header/activity-panel/test/help-panel.js
@@ -41,6 +41,10 @@ describe( 'Activity Panels', () => {
 					key: 'payfast',
 					text: 'PayFast',
 				},
+				{
+					key: 'eway',
+					text: 'eWAY',
+				},
 			];
 
 			const noMethods = render(

--- a/client/task-list/tasks/payments/eway.js
+++ b/client/task-list/tasks/payments/eway.js
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import interpolateComponents from 'interpolate-components';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+class EWay extends Component {
+	getInitialConfigValues = () => {
+		return {
+			customer_api: '',
+			customer_password: '',
+		};
+	};
+
+	validate = ( values ) => {
+		const errors = {};
+
+		if ( ! values.customer_api ) {
+			errors.customer_api = __(
+				'Please enter your customer API key ',
+				'woocommerce-admin'
+			);
+		}
+
+		if ( ! values.customer_password ) {
+			errors.customer_password = __(
+				'Please enter your customer password',
+				'woocommerce-admin'
+			);
+		}
+
+		return errors;
+	};
+
+	updateSettings = async ( values ) => {
+        const { updateOptions, createNotice, markConfigured } = this.props;
+
+		const update = await updateOptions( {
+			woocommerce_eway_settings: {
+				customer_api: values.customer_api,
+				customer_password: values.customer_password,
+				enabled: 'yes',
+			},
+		} );
+
+		if ( update.success ) {
+			markConfigured( 'eway' );
+			createNotice(
+				'success',
+				__( 'eWAY connected successfully', 'woocommerce-admin' )
+			);
+		} else {
+			createNotice(
+				'error',
+				__(
+					'There was a problem saving your payment setings',
+					'woocommerce-admin'
+				)
+			);
+		}
+	};
+
+	renderConnectStep() {
+		const { isOptionsRequesting } = this.props;
+		const helpText = interpolateComponents( {
+			mixedString: __(
+				'Your API details can be obtained from your {{link}}eWAY account{{/link}}',
+				'woocommerce-admin'
+			),
+			components: {
+				link: (
+					<Link
+						href="https://www.eway.com.au/"
+						target="_blank"
+						type="external"
+					/>
+				),
+			},
+		} );
+
+		return (
+			<Form
+				initialValues={ this.getInitialConfigValues() }
+				onSubmitCallback={ this.updateSettings }
+				validate={ this.validate }
+			>
+				{ ( { getInputProps, handleSubmit } ) => {
+					return (
+						<Fragment>
+							<TextControl
+								label={ __(
+									'Customer API Key',
+									'woocommerce-admin'
+								) }
+								required
+								{ ...getInputProps( 'customer_api' ) }
+							/>
+							<TextControl
+								label={ __(
+									'Customer Password',
+									'woocommerce-admin'
+								) }
+								required
+								{ ...getInputProps( 'customer_password' ) }
+							/>
+							<Button
+								isPrimary
+								isBusy={ isOptionsRequesting }
+								onClick={ handleSubmit }
+							>
+								{ __( 'Proceed', 'woocommerce-admin' ) }
+							</Button>
+
+							<p>{ helpText }</p>
+						</Fragment>
+					);
+				} }
+			</Form>
+		);
+	}
+
+	render() {
+		const { installStep, isOptionsRequesting } = this.props;
+
+		return (
+			<Stepper
+				isVertical
+				isPending={ ! installStep.isComplete || isOptionsRequesting }
+				currentStep={ installStep.isComplete ? 'connect' : 'install' }
+				steps={ [
+					installStep,
+					{
+						key: 'connect',
+						label: __(
+							'Connect your eWAY account',
+							'woocommerce-admin'
+						),
+						content: this.renderConnectStep(),
+					},
+				] }
+			/>
+		);
+	}
+}
+
+export default compose(
+	withSelect( ( select ) => {
+		const { isOptionsUpdating } = select( OPTIONS_STORE_NAME );
+		const isOptionsRequesting = isOptionsUpdating();
+
+		return {
+			isOptionsRequesting,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( EWay );

--- a/client/task-list/tasks/payments/eway.js
+++ b/client/task-list/tasks/payments/eway.js
@@ -43,7 +43,7 @@ class EWay extends Component {
 	};
 
 	updateSettings = async ( values ) => {
-        const { updateOptions, createNotice, markConfigured } = this.props;
+		const { updateOptions, createNotice, markConfigured } = this.props;
 
 		const update = await updateOptions( {
 			woocommerce_eway_settings: {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -407,6 +407,7 @@ export default compose(
 			'woocommerce_cod_settings',
 			'woocommerce_bacs_settings',
 			'woocommerce_bacs_accounts',
+			'woocommerce_eway_settings',
 		];
 
 		const options = optionNames.reduce( ( result, name ) => {

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -33,6 +33,7 @@ import WCPayIcon from './images/wcpay';
 import PayPal from './paypal';
 import Klarna from './klarna';
 import PayFast from './payfast';
+import EWay from './eway';
 
 export function installActivateAndConnectWcpay(
 	resolve,
@@ -357,6 +358,35 @@ export function getPaymentMethods( {
 				options.woocommerce_payfast_settings &&
 				options.woocommerce_payfast_settings.enabled === 'yes',
 			optionName: 'woocommerce_payfast_settings',
+		},
+		{
+			key: 'eway',
+			title: __( 'eWAY', 'woocommerce-admin' ),
+			content: (
+				<Fragment>
+					{ __(
+						'The eWAY extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.',
+						'woocommerce-admin'
+					) }
+				</Fragment>
+			),
+			before: (
+				<img
+					src={ wcAssetUrl + 'images/eway-logo.jpg' }
+					alt="eWAY logo"
+				/>
+			),
+			visible: [ 'AU', 'NZ' ].includes( countryCode ) && ! hasCbdIndustry,
+			plugins: [ 'woocommerce-gateway-eway' ],
+			container: <EWay />,
+			isConfigured:
+				options.woocommerce_eway_settings &&
+				options.woocommerce_eway_settings.customer_api &&
+				options.woocommerce_eway_settings.customer_password,
+			isEnabled:
+				options.woocommerce_eway_settings &&
+				options.woocommerce_eway_settings.enabled === 'yes',
+			optionName: 'woocommerce_eway_settings',
 		},
 		{
 			key: 'cod',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -630,6 +630,7 @@ class Onboarding {
 		$options[] = 'woocommerce_bacs_settings';
 		$options[] = 'woocommerce_bacs_accounts';
 		$options[] = 'woocommerce_woocommerce_payments_settings';
+		$options[] = 'woocommerce_eway_settings';
 
 		return $options;
 	}
@@ -722,6 +723,7 @@ class Onboarding {
 				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
 				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/gateway-payfast.php',
 				'woocommerce-payments'                => 'woocommerce-payments/woocommerce-payments.php',
+				'woocommerce-gateway-eway'            => 'woocommerce-gateway-eway/woocommerce-gateway-eway.php',
 			)
 		);
 		return array_merge( $plugins, $onboarding_plugins );


### PR DESCRIPTION
Fixes #4822

This branch adds the eWAY gateway to the list of payment options in the Setup Checklist for stores that are in Australia or New Zealand.

### Screenshots

<img width="1517" alt="eway" src="https://user-images.githubusercontent.com/22080/89573160-0896c980-d7df-11ea-8a06-c76141e53e68.png">

<img width="1517" alt="eway-help(1)" src="https://user-images.githubusercontent.com/22080/89573175-10566e00-d7df-11ea-9ad3-6faefa8b5f91.png">

### Detailed test instructions:

To setup for this test, you need to do the following:

- Update your store's address to be in New Zealand or Australia
- Clear out some options to ensure the setup checklist is shown on the homescreen, and the payments task is shown:
- ` wp option delete woocommerce_task_list_complete`
- `wp option delete woocommerce_task_list_hidden`
- `wp option delete woocommerce_task_list_payments`

Also if you happen to have the eWAY extension installed, deactivate and delete it and ` wp option delete woocommerce_eway_settings`

Now you are ready to test!

- Visit the Woo Home screen, and click the payments task on the setup list
- You should see eWAY shown as an option
- Click 'Set Up'
- Verify that the plugin installs correctly, and a toast notif is shown when it is installed + active
- When step 2 is shown, enter in a value in the first field, but not the other. Verify the validation works as expected
- Enter any random strings in both fields, and verify the setup completes as expected.

![eway](https://user-images.githubusercontent.com/22080/89574903-bd31ea80-d7e1-11ea-9a54-d8dafec4fb9c.gif)

__BONUS TESTS__
- Note the new help panel item for eWAY in the screenshot above, click the link and verify it works

### Changelog Note:

Enhancement: Add eWAY to Payment Setup for AU/NZ Stores
