### PR TITLE
eslint-plugin: Fix dependency rule to allow WooCommerce block

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 1.0.0
+# 1.0.0-beta.1
+
+-   Fix eslint-plugin dependency rule to allow WooCommerce block.
+
+# 1.0.0-beta.0
 
 -   Released package

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0-beta.1
+# 1.0.0-beta.1 (unreleased)
 
 -   Fix eslint-plugin dependency rule to allow WooCommerce block.
 

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -4,7 +4,7 @@ Ensures that all top-level package imports adhere to dependencies grouping conve
 
 Specifically, this ensures that:
 
-- An import is preceded by "External dependencies" or "Internal dependencies" as appropriate by the import source.
+-   An import is preceded by "External dependencies" or "Internal dependencies" as appropriate by the import source.
 
 ## Rule details
 
@@ -13,6 +13,7 @@ Examples of **incorrect** code for this rule:
 ```js
 import { get } from 'lodash';
 import { Component } from '@wordpress/element';
+import { withPluginsHydration } from '@woocommerce/data';
 import edit from './edit';
 ```
 
@@ -24,6 +25,11 @@ Examples of **correct** code for this rule:
  */
 import { get } from 'lodash';
 import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+import { withPluginsHydration } from '@woocommerce/data';
 
 /*
  * Internal dependencies

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -4,7 +4,7 @@ Ensures that all top-level package imports adhere to dependencies grouping conve
 
 Specifically, this ensures that:
 
--   An import is preceded by "External dependencies" or "Internal dependencies" as appropriate by the import source.
+-   An import is preceded by "External dependencies", "WooCommerce dependencies" or "Internal dependencies" as appropriate by the import source.
 
 ## Rule details
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/eslint-plugin",
-	"version": "1.0.0-beta.0",
+	"version": "1.0.0-beta.1",
 	"description": "ESLint plugin for WooCommerce development.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
@@ -30,7 +30,7 @@
 		"eslint": "^7",
 		"eslint-plugin-react-hooks": "^4.0.4",
 		"eslint-plugin-testing-library": "^3.3.1",
-		"requireindex":"^1.2.0"
+		"requireindex": "^1.2.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -26,9 +26,9 @@ import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
+ * WooCommerce dependencies
  */
-import { Component } from '@wordpress/element';
+import { withPluginsHydration } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -44,9 +44,9 @@ const { get } = require( 'lodash' );
 const classnames = require( 'classnames' );
 
 /**
- * WordPress dependencies
+ * WooCommerce dependencies
  */
-const { Component } = require( '@wordpress/element' );
+import { withPluginsHydration } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -60,9 +60,9 @@ const edit = require( './edit' );`,
 import { get } from 'lodash';
 import classnames from 'classnames';
 /*
- * wordpress dependencies.
+ * woocommerce dependencies.
  */
-import { Component } from '@wordpress/element';
+import { withPluginsHydration } from '@woocommerce/data';
 import edit from './edit';`,
 			errors: [
 				{
@@ -71,7 +71,7 @@ import edit from './edit';`,
 				},
 				{
 					message:
-						'Expected preceding "WordPress dependencies" comment block',
+						'Expected preceding "WooCommerce dependencies" comment block',
 				},
 				{
 					message:
@@ -85,9 +85,9 @@ import edit from './edit';`,
 import { get } from 'lodash';
 import classnames from 'classnames';
 /**
- * WordPress dependencies
+ * WooCommerce dependencies
  */
-import { Component } from '@wordpress/element';
+import { withPluginsHydration } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
@@ -98,9 +98,9 @@ import edit from './edit';`,
 const { get } = require( 'lodash' );
 const classnames = require( 'classnames' );
 /*
- * wordpress dependencies.
+ * woocommerce dependencies.
  */
-const { Component } = require( '@wordpress/element' );
+const { withPluginsHydration } = require( '@woocommerce/element' );
 const edit = require( './edit' );`,
 			errors: [
 				{
@@ -109,7 +109,7 @@ const edit = require( './edit' );`,
 				},
 				{
 					message:
-						'Expected preceding "WordPress dependencies" comment block',
+						'Expected preceding "WooCommerce dependencies" comment block',
 				},
 				{
 					message:
@@ -123,9 +123,9 @@ const edit = require( './edit' );`,
 const { get } = require( 'lodash' );
 const classnames = require( 'classnames' );
 /**
- * WordPress dependencies
+ * WooCommerce dependencies
  */
-const { Component } = require( '@wordpress/element' );
+const { withPluginsHydration } = require( '@woocommerce/element' );
 /**
  * Internal dependencies
  */

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -24,73 +24,112 @@ ruleTester.run( 'dependency-group', rule, {
  */
 import { get } from 'lodash';
 import classnames from 'classnames';
-import { Component } from '@wordpress/element';
+
 /**
- * WooCommerce dependencies
+ * WordPress dependencies
  */
-import { SearchListControl } from '@woocommerce/components';
-import { withProductVariations } from '@woocommerce/block-hocs';
+import { Component } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
-import edit from './edit';
-import './style.scss';`,
+import edit from './edit';`,
 		},
-	],
-	invalid: [
 		{
 			code: `
 /**
  * External dependencies
  */
-import { get } from 'lodash';
-import './style.scss';
-import { withProductVariations } from '@woocommerce/block-hocs';
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+
+/**
+ * WordPress dependencies
+ */
+const { Component } = require( '@wordpress/element' );
+
 /**
  * Internal dependencies
  */
-import edit from './edit';
+const edit = require( './edit' );`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+import { get } from 'lodash';
 import classnames from 'classnames';
-import { Component } from '@wordpress/element';
-import { SearchListControl } from '@woocommerce/components';
-/**
- * WooCommerce dependencies
+/*
+ * wordpress dependencies.
  */
-import PropTypes from 'prop-types';`,
+import { Component } from '@wordpress/element';
+import edit from './edit';`,
 			errors: [
 				{
 					message:
-						'Expected preceding "WooCommerce dependencies" comment block',
+						'Expected preceding "External dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "WordPress dependencies" comment block',
 				},
 				{
 					message:
 						'Expected preceding "Internal dependencies" comment block',
 				},
+			],
+			output: `
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import classnames from 'classnames';
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import edit from './edit';`,
+		},
+		{
+			code: `
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+/*
+ * wordpress dependencies.
+ */
+const { Component } = require( '@wordpress/element' );
+const edit = require( './edit' );`,
+			errors: [
 				{
 					message:
-						'Expected "WooCommerce dependencies" to be defined before Internal',
+						'Expected preceding "External dependencies" comment block',
 				},
 				{
 					message:
-						'Expected preceding "WooCommerce dependencies" comment block',
+						'Expected preceding "WordPress dependencies" comment block',
 				},
 				{
 					message:
-						'Expected "WooCommerce dependencies" to be defined before Internal',
-				},
-				{
-					message:
-						'Expected preceding "WooCommerce dependencies" comment block',
-				},
-				{
-					message:
-						'Expected preceding "WooCommerce dependencies" comment block',
-				},
-				{
-					message:
-						'Expected preceding "WooCommerce dependencies" comment block',
+						'Expected preceding "Internal dependencies" comment block',
 				},
 			],
+			output: `
+/**
+ * External dependencies
+ */
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+/**
+ * WordPress dependencies
+ */
+const { Component } = require( '@wordpress/element' );
+/**
+ * Internal dependencies
+ */
+const edit = require( './edit' );`,
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -25,6 +25,9 @@ ruleTester.run( 'dependency-group', rule, {
 import { get } from 'lodash';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
+/**
+ * WooCommerce dependencies
+ */
 import { SearchListControl } from '@woocommerce/components';
 import { withProductVariations } from '@woocommerce/block-hocs';
 /**
@@ -49,31 +52,43 @@ import { withProductVariations } from '@woocommerce/block-hocs';
 import edit from './edit';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { SearchListControl } from '@woocommerce/components';`,
+import { SearchListControl } from '@woocommerce/components';
+/**
+ * WooCommerce dependencies
+ */
+import PropTypes from 'prop-types';`,
 			errors: [
+				{
+					message:
+						'Expected preceding "WooCommerce dependencies" comment block',
+				},
 				{
 					message:
 						'Expected preceding "Internal dependencies" comment block',
 				},
 				{
 					message:
-						'Expected "External dependencies" to be defined before Internal',
+						'Expected "WooCommerce dependencies" to be defined before Internal',
 				},
 				{
 					message:
-						'Expected "External dependencies" to be defined before Internal',
+						'Expected preceding "WooCommerce dependencies" comment block',
 				},
 				{
 					message:
-						'Expected preceding "External dependencies" comment block',
+						'Expected "WooCommerce dependencies" to be defined before Internal',
 				},
 				{
 					message:
-						'Expected preceding "External dependencies" comment block',
+						'Expected preceding "WooCommerce dependencies" comment block',
 				},
 				{
 					message:
-						'Expected preceding "External dependencies" comment block',
+						'Expected preceding "WooCommerce dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "WooCommerce dependencies" comment block',
 				},
 			],
 		},

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -55,7 +55,7 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 		function getPackageLocality( source ) {
 			if ( source.startsWith( '.' ) ) {
 				return 'Internal';
-			} else if ( source.startsWith( '@WooCommerce/' ) ) {
+			} else if ( source.startsWith( '@woocommerce/' ) ) {
 				return 'WooCommerce';
 			}
 

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -36,6 +36,9 @@ module.exports = {
 			if ( source.startsWith( '.' ) ) {
 				return 'Internal';
 			}
+			if ( '@woocommerce' ) {
+				return 'WooCommerce';
+			}
 			return 'External';
 		}
 
@@ -62,6 +65,10 @@ module.exports = {
 
 			if ( locality === 'External' ) {
 				locality = '(External|Node)';
+			}
+
+			if ( locality === 'WooCommerce' ) {
+				locality = '(WooCommerce|Node)';
 			}
 
 			const pattern = new RegExp(
@@ -145,10 +152,21 @@ module.exports = {
 		function checkLocalityOrder( child, locality, previousLocality ) {
 			switch ( locality ) {
 				case 'External':
-					if ( previousLocality === 'Internal' ) {
+					if (
+						previousLocality === 'Internal' ||
+						previousLocality === 'WooCommerce'
+					) {
 						context.report( {
 							node: child,
 							message: `Expected "External dependencies" to be defined before ${ previousLocality }`,
+						} );
+					}
+					break;
+				case 'WooCommerce':
+					if ( previousLocality === 'Internal' ) {
+						context.report( {
+							node: child,
+							message: `Expected "WooCommerce dependencies" to be defined before ${ previousLocality }`,
 						} );
 					}
 					break;

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -1,22 +1,42 @@
-module.exports = {
+/** @typedef {import('estree').Comment} Comment */
+/** @typedef {import('estree').Node} Node */
+
+module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 	meta: {
 		type: 'layout',
+		docs: {
+			description: 'Enforce dependencies docblocks formatting',
+			url:
+				'https://github.com/WooCommerce/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md',
+		},
 		schema: [],
+		fixable: 'code',
 	},
 	create( context ) {
 		const comments = context.getSourceCode().getAllComments();
 
 		/**
-		 * Locality classification of an import, "External" or "Internal".
+		 * Locality classification of an import, one of "External",
+		 * "WooCommerce", "Internal".
 		 *
-		 * @typedef {string} WCPackageLocality
+		 * @typedef {string} WPPackageLocality
+		 */
+
+		/**
+		 * Object describing a dependency block correction to be made.
+		 *
+		 * @typedef WPDependencyBlockCorrection
+		 *
+		 * @property {Comment} [comment] Comment node on which to replace value,
+		 *                               if one can be salvaged.
+		 * @property {string}  value     Expected comment node value.
 		 */
 
 		/**
 		 * Given a desired locality, generates the expected comment node value
 		 * property.
 		 *
-		 * @param {WCPackageLocality} locality Desired package locality.
+		 * @param {WPPackageLocality} locality Desired package locality.
 		 *
 		 * @return {string} Expected comment node value.
 		 */
@@ -30,15 +50,15 @@ module.exports = {
 		 *
 		 * @param {string} source Import source string.
 		 *
-		 * @return {WCPackageLocality} Package locality.
+		 * @return {WPPackageLocality} Package locality.
 		 */
 		function getPackageLocality( source ) {
 			if ( source.startsWith( '.' ) ) {
 				return 'Internal';
-			}
-			if ( '@woocommerce' ) {
+			} else if ( source.startsWith( '@WooCommerce/' ) ) {
 				return 'WooCommerce';
 			}
+
 			return 'External';
 		}
 
@@ -46,8 +66,8 @@ module.exports = {
 		 * Returns true if the given comment node satisfies a desired locality,
 		 * or false otherwise.
 		 *
-		 * @param {espree.Node}       node     Comment node to check.
-		 * @param {WCPackageLocality} locality Desired package locality.
+		 * @param {Comment}           node     Comment node to check.
+		 * @param {WPPackageLocality} locality Desired package locality.
 		 *
 		 * @return {boolean} Whether comment node satisfies locality.
 		 */
@@ -67,10 +87,6 @@ module.exports = {
 				locality = '(External|Node)';
 			}
 
-			if ( locality === 'WooCommerce' ) {
-				locality = '(WooCommerce|Node)';
-			}
-
 			const pattern = new RegExp(
 				`^\\*?\\n \\* ${ locality } dependencies\\.?\\n $`,
 				'i'
@@ -82,8 +98,8 @@ module.exports = {
 		 * Returns true if the given node occurs prior in code to a reference,
 		 * or false otherwise.
 		 *
-		 * @param {espree.Node} node      Node to test being before reference.
-		 * @param {espree.Node} reference Node against which to compare.
+		 * @param {Comment} node      Node to test being before reference.
+		 * @param {Node}    reference Node against which to compare.
 		 *
 		 * @return {boolean} Whether node occurs before reference.
 		 */
@@ -91,33 +107,27 @@ module.exports = {
 			if ( ! node.range || ! reference.range ) {
 				return false;
 			}
+
 			return node.range[ 0 ] < reference.range[ 0 ];
 		}
 
 		/**
 		 * Tests source comments to determine whether a comment exists which
 		 * satisfies the desired locality. If a match is found and requires no
-		 * updates, the function returns false. Otherwise, it will return true.
+		 * updates, the function returns undefined. Otherwise, it will return
+		 * a WPDependencyBlockCorrection object describing a correction.
 		 *
-		 * @param {espree.Node}       node     Node to test.
-		 * @param {WCPackageLocality} locality Desired package locality.
+		 * @param {Node}              node     Node to test.
+		 * @param {WPPackageLocality} locality Desired package locality.
 		 *
-		 * @return {boolean} Whether the node is in the correct locality.
+		 * @return {WPDependencyBlockCorrection=} Correction, if applicable.
 		 */
-		function isNodeInLocality( node, locality ) {
+		function getDependencyBlockCorrection( node, locality ) {
 			const value = getCommentValue( locality );
 
 			let comment;
-			let nextComment;
 			for ( let i = 0; i < comments.length; i++ ) {
 				comment = comments[ i ];
-				nextComment =
-					i < comments.length - 1 ? comments[ i + 1 ] : null;
-
-				if ( nextComment && isBefore( nextComment, node ) ) {
-					// If it's not the immediately previous comment, continue.
-					continue;
-				}
 
 				if ( ! isBefore( comment, node ) ) {
 					// Exhausted options.
@@ -132,94 +142,116 @@ module.exports = {
 
 				if ( comment.value === value ) {
 					// No change needed. (OK)
-					return true;
+					return;
 				}
 
 				// Found a comment needing correction.
-				return false;
+				return { comment, value };
 			}
 
-			return false;
-		}
-
-		/**
-		 * Tests if the locality is defined in the correct order (External, WooCommerce, Internal).
-		 *
-		 * @param {espree.Node}       child    Node to test.
-		 * @param {WCPackageLocality} locality Package locality.
-		 * @param {WCPackageLocality} previousLocality Previous package locality.
-		 */
-		function checkLocalityOrder( child, locality, previousLocality ) {
-			switch ( locality ) {
-				case 'External':
-					if (
-						previousLocality === 'Internal' ||
-						previousLocality === 'WooCommerce'
-					) {
-						context.report( {
-							node: child,
-							message: `Expected "External dependencies" to be defined before ${ previousLocality }`,
-						} );
-					}
-					break;
-				case 'WooCommerce':
-					if ( previousLocality === 'Internal' ) {
-						context.report( {
-							node: child,
-							message: `Expected "WooCommerce dependencies" to be defined before ${ previousLocality }`,
-						} );
-					}
-					break;
-			}
+			return { value };
 		}
 
 		return {
+			/**
+			 * @param {import('estree').Program} node Program node.
+			 */
 			Program( node ) {
-				let previousLocality = null;
+				/**
+				 * The set of package localities which have been reported for
+				 * the current program. Each locality is reported at most one
+				 * time, since otherwise the fixer would insert a comment
+				 * block for each individual import statement.
+				 *
+				 * @type {Set<WPPackageLocality>}
+				 */
+				const verified = new Set();
+
+				/**
+				 * Nodes to check for violations associated with module import,
+				 * an array of tuples of the node and its import source string.
+				 *
+				 * @type {Array<[Node,string]>}
+				 */
+				const candidates = [];
 
 				// Since we only care to enforce imports which occur at the
 				// top-level scope, match on Program and test its children,
 				// rather than matching the import nodes directly.
 				node.body.forEach( ( child ) => {
+					/** @type {string} */
 					let source;
 					switch ( child.type ) {
 						case 'ImportDeclaration':
-							source = child.source.value;
+							source = /** @type {string} */ ( child.source
+								.value );
+							candidates.push( [ child, source ] );
 							break;
 
-						case 'CallExpression':
-							const { callee, arguments: args } = child;
-							if (
-								callee.name === 'require' &&
-								args.length === 1 &&
-								args[ 0 ].type === 'Literal' &&
-								typeof args[ 0 ].value === 'string'
-							) {
-								source = args[ 0 ].value;
-							}
-							break;
-					}
+						case 'VariableDeclaration':
+							child.declarations.forEach( ( declaration ) => {
+								const { init } = declaration;
+								if (
+									! init ||
+									init.type !== 'CallExpression' ||
+									/** @type {import('estree').CallExpression} */ ( init )
+										.callee.type !== 'Identifier' ||
+									/** @type {import('estree').Identifier} */ ( init.callee )
+										.name !== 'require'
+								) {
+									return;
+								}
 
-					if ( ! source ) {
-						return;
+								const { arguments: args } = init;
+								if (
+									args.length === 1 &&
+									args[ 0 ].type === 'Literal' &&
+									typeof args[ 0 ].value === 'string'
+								) {
+									source = args[ 0 ].value;
+									candidates.push( [ child, source ] );
+								}
+							} );
 					}
+				} );
 
+				for ( const [ child, source ] of candidates ) {
 					const locality = getPackageLocality( source );
+					if ( verified.has( locality ) ) {
+						continue;
+					}
 
-					checkLocalityOrder( child, locality, previousLocality );
+					// Avoid verifying any other imports for the locality,
+					// regardless whether a correction must be made.
+					verified.add( locality );
 
-					previousLocality = locality;
-
-					if ( isNodeInLocality( child, locality ) ) {
-						return;
+					// Determine whether a correction must be made.
+					const correction = getDependencyBlockCorrection(
+						child,
+						locality
+					);
+					if ( ! correction ) {
+						continue;
 					}
 
 					context.report( {
 						node: child,
 						message: `Expected preceding "${ locality } dependencies" comment block`,
+						fix( fixer ) {
+							const { comment, value } = correction;
+							const text = `/*${ value }*/`;
+							if ( comment && comment.range ) {
+								return fixer.replaceTextRange(
+									comment.range,
+									text
+								);
+							}
+
+							return fixer.insertTextBefore( child, text + '\n' );
+						},
 					} );
-				} );
+				}
 			},
 		};
 	},
-};
+} );

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -7,7 +7,7 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 		docs: {
 			description: 'Enforce dependencies docblocks formatting',
 			url:
-				'https://github.com/WooCommerce/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md',
+				'https://github.com/woocommerce/woocommerce-admin/blob/main/packages/eslint-plugin/docs/rules/dependency-group.md',
 		},
 		schema: [],
 		fixable: 'code',


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/4714 added an eslint plugin package for distribution for all WooCommerce applications. It modified the `dependency-group.js` such that "External" and "Internal" dependencies are allowed only. There was some discussion on whether or not to include "WooCommerce" as well. For instance:

```js
/**
 * WooCommerce dependencies
 */
import { withPluginsHydration } from '@woocommerce/data';
```
Considering we used Gutenberg as a model for distributing packages and following patterns of documenting internal packages v. internal files, I think we should have the `WooCommerce dependencies` rule.

This PR simply copies Gutenberg's logic for [dependency-group.js](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/rules/dependency-group.js) and replaces `WordPress` with `WooCommerce`.

### Detailed test instructions:

1. npm install
2. npm run lint
3. See only 347 warnings, instead of the 891 on `main`

cc @nerrad 

### Changelog Note:

- dev: Fix eslint-plugin dependency rule to allow WooCommerce block