### PR TITLE
Task List: Modified "completed" control for `Set up WooCommerce payments`

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -406,6 +406,12 @@ export default compose(
 		const activePlugins = getActivePlugins();
 		const installedPlugins = getInstalledPlugins();
 
+		const wcPaySettings =
+			getOption( 'woocommerce_woocommerce_payments_settings' ) || false;
+
+		taskListPayments.wcPayCompleted =
+			wcPaySettings && wcPaySettings.enabled === 'yes';
+
 		return {
 			activePlugins,
 			countryCode,

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -390,7 +390,8 @@ export default compose(
 
 		const isTaskListComplete =
 			getOption( 'woocommerce_task_list_complete' ) || false;
-		const taskListPayments = getOption( 'woocommerce_task_list_payments' );
+		const taskListPayments =
+			getOption( 'woocommerce_task_list_payments' ) || {};
 		const trackedCompletedTasks =
 			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -84,6 +84,10 @@ export function getAllTasks( {
 		taskListPayments && taskListPayments.skipped
 	);
 
+	const wcPaymentCompleted = Boolean(
+		taskListPayments && taskListPayments.wcPayCompleted
+	);
+
 	const woocommercePaymentsInstalled =
 		installedPlugins.indexOf( 'woocommerce-payments' ) !== -1;
 	const {
@@ -150,7 +154,7 @@ export function getAllTasks( {
 			key: 'woocommerce-payments',
 			title: __( 'Set up WooCommerce Payments', 'woocommerce-admin' ),
 			container: <Fragment />,
-			completed: paymentsCompleted || paymentsSkipped,
+			completed: wcPaymentCompleted || paymentsSkipped,
 			onClick: async () => {
 				await new Promise( ( resolve, reject ) => {
 					// This task doesn't have a view, so the recordEvent call


### PR DESCRIPTION
Fixes #4884

This PR modifies the "completed" control for `Set up WooCommerce Payments` task list item.

We were showing the `Set up WooCommerce Payments` task item as complete even though it wasn't. Now we check that specific payment method in order to show it as completed.

### Screenshots
![done](https://user-images.githubusercontent.com/19143190/88846019-04512780-d1b3-11ea-9d44-41e9526e66b8.jpg)

### Detailed test instructions:

Set WooCommerce Payments
To create a `WCPay test account` you should enable the `Dev Mode` by adding the following code snippet to your site’s `wp-config.php` file:
````
define( 'WCPAY_DEV_MODE', true );
````
There is more documentation about `WCPay test account` configuration [here](https://docs.woocommerce.com/document/payments/testing/dev-mode/).

1. Go to the `Home` screen / `Dashboard`.
2. In the task list, press `Set up WooCommerce Payments`.
_It's necessary to have a US store and Jetpack connected_.
3. Follow the `WCPay test account` configuration process.
4. After finishing the process, it should take you back to the Home screen.
5. Verify the task list item `Set up WooCommerce Payments` is showed as completed.

Set any payment method other than `WooCommerce Payments`. E.g. Cash on delivery.
- Go to `/wp-admin/admin.php?page=wc-admin&task=payments`.
- Turn `WooCommerce Payments` off.
- Turn `Cash on delivery` on.
- Press `Done`.
- Verify the task list item `Set up WooCommerce Payments` is shown as not completed.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Task List: Modified "completed" control for `Set up WooCommerce payments`.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
