### PR TITLE
Use filtered headers array in onColumnsChange callback.

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -92,30 +92,6 @@ const ReportTable = ( props ) => {
 				: userPrefColumns;
 	}
 
-	const onColumnsChange = ( shownColumns, toggledColumn ) => {
-		const columns = getHeadersContent().map( ( header ) => header.key );
-		const hiddenColumns = columns.filter(
-			( column ) => ! shownColumns.includes( column )
-		);
-
-		if ( columnPrefsKey ) {
-			const userDataFields = {
-				[ columnPrefsKey ]: hiddenColumns,
-			};
-			updateUserPreferences( userDataFields );
-		}
-
-		if ( toggledColumn ) {
-			const eventProps = {
-				report: endpoint,
-				column: toggledColumn,
-				status: shownColumns.includes( toggledColumn ) ? 'on' : 'off',
-			};
-
-			recordEvent( 'analytics_table_header_toggle', eventProps );
-		}
-	};
-
 	const onPageChange = ( newPage, source ) => {
 		scrollPointRef.current.scrollIntoView();
 		const tableElement = scrollPointRef.current.nextSibling.querySelector(
@@ -328,6 +304,29 @@ const ReportTable = ( props ) => {
 	} );
 	let { headers, rows } = filteredTableProps;
 	const { summary } = filteredTableProps;
+
+	const onColumnsChange = ( shownColumns, toggledColumn ) => {
+		const columns = headers.map( ( header ) => header.key );
+		const hiddenColumns = columns.filter(
+			( column ) => ! shownColumns.includes( column )
+		);
+		if ( columnPrefsKey ) {
+			const userDataFields = {
+				[ columnPrefsKey ]: hiddenColumns,
+			};
+			updateUserPreferences( userDataFields );
+		}
+
+		if ( toggledColumn ) {
+			const eventProps = {
+				report: endpoint,
+				column: toggledColumn,
+				status: shownColumns.includes( toggledColumn ) ? 'on' : 'off',
+			};
+
+			recordEvent( 'analytics_table_header_toggle', eventProps );
+		}
+	};
 
 	// Add in selection for comparisons.
 	if ( compareBy ) {

--- a/docs/examples/extensions/table-column/js/index.js
+++ b/docs/examples/extensions/table-column/js/index.js
@@ -9,16 +9,11 @@ addFilter(
 	'woocommerce_admin_report_table',
 	'plugin-domain',
 	( reportTableData ) => {
-		if (
-			reportTableData.endpoint !== 'products' ||
-			! reportTableData.items ||
-			! reportTableData.items.data ||
-			! reportTableData.items.data.length
-		) {
+		if ( reportTableData.endpoint !== 'products' ) {
 			return reportTableData;
 		}
 
-		const newHeaders = [
+		reportTableData.headers = [
 			...reportTableData.headers,
 			{
 				label: 'ID',
@@ -29,6 +24,15 @@ addFilter(
 				key: 'product_rating',
 			},
 		];
+
+		if (
+			! reportTableData.items ||
+			! reportTableData.items.data ||
+			! reportTableData.items.data.length
+		) {
+			return reportTableData;
+		}
+
 		const newRows = reportTableData.rows.map( ( row, index ) => {
 			const product = reportTableData.items.data[ index ];
 			const newRow = [
@@ -54,7 +58,6 @@ addFilter(
 			return newRow;
 		} );
 
-		reportTableData.headers = newHeaders;
 		reportTableData.rows = newRows;
 
 		return reportTableData;


### PR DESCRIPTION
Fixes #4236.

This PR fixes the toggling behavior for custom columns added to report tables. (The filtered headers array wasn't being used in the `onColumnsChange()` callback)

### Detailed test instructions:

- Build the `table-column` example if you haven't already (`npm run example -- --ext=table-column`)
- Activate the "WooCommerce Admin Table Column Example" plugin
- Visit the Products report
- Verify you can toggle the "Product ID" and "Product Rating" columns, and that changes persist between page reloads

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: bug preventing toggling filtered report columns.