### PR TITLE
Rename "profile" to "store details".

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -32,7 +32,7 @@ class Dashboard extends Component {
 			! profileSkipped &&
 			! window.wcAdminFeatures.homescreen
 		) {
-			getHistory().push( getNewPath( {}, `/profiler`, {} ) );
+			getHistory().push( getNewPath( {}, '/store-details', {} ) );
 		}
 
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -32,7 +32,7 @@ class Dashboard extends Component {
 			! profileSkipped &&
 			! window.wcAdminFeatures.homescreen
 		) {
-			getHistory().push( getNewPath( {}, '/store-details', {} ) );
+			getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
 		}
 
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {

--- a/client/homescreen/index.js
+++ b/client/homescreen/index.js
@@ -20,7 +20,7 @@ const Homescreen = ( { profileItems, query } ) => {
 	const { completed: profilerCompleted, skipped: profilerSkipped } =
 		profileItems || {};
 	if ( ! profilerCompleted && ! profilerSkipped ) {
-		getHistory().push( getNewPath( {}, '/store-details', {} ) );
+		getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
 	}
 
 	return <Layout query={ query } />;

--- a/client/homescreen/index.js
+++ b/client/homescreen/index.js
@@ -20,7 +20,7 @@ const Homescreen = ( { profileItems, query } ) => {
 	const { completed: profilerCompleted, skipped: profilerSkipped } =
 		profileItems || {};
 	if ( ! profilerCompleted && ! profilerSkipped ) {
-		getHistory().push( getNewPath( {}, `/profiler`, {} ) );
+		getHistory().push( getNewPath( {}, '/store-details', {} ) );
 	}
 
 	return <Layout query={ query } />;

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -186,7 +186,10 @@ export const getPages = () => {
 			path: '/store-details',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[ '/store-details', __( 'Store details', 'woocommerce-admin' ) ],
+				[
+					'/store-details',
+					__( 'Store details', 'woocommerce-admin' ),
+				],
 			],
 		} );
 	}

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -183,10 +183,10 @@ export const getPages = () => {
 	if ( window.wcAdminFeatures.onboarding ) {
 		pages.push( {
 			container: ProfileWizard,
-			path: '/profiler',
+			path: '/store-details',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[ '/profiler', __( 'Profiler', 'woocommerce-admin' ) ],
+				[ '/store-details', __( 'Store details', 'woocommerce-admin' ) ],
 			],
 		} );
 	}

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -183,13 +183,10 @@ export const getPages = () => {
 	if ( window.wcAdminFeatures.onboarding ) {
 		pages.push( {
 			container: ProfileWizard,
-			path: '/store-details',
+			path: '/setup-wizard',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[
-					'/store-details',
-					__( 'Store details', 'woocommerce-admin' ),
-				],
+				[ '/setup-wizard', __( 'Setup Wizard', 'woocommerce-admin' ) ],
 			],
 		} );
 	}

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -103,7 +103,7 @@ export function getAllTasks( {
 				recordEvent( 'tasklist_click', {
 					task_name: 'store_details',
 				} );
-				getHistory().push( getNewPath( {}, '/store-details', {} ) );
+				getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
 			},
 			completed: profilerCompleted,
 			visible: true,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -103,7 +103,7 @@ export function getAllTasks( {
 				recordEvent( 'tasklist_click', {
 					task_name: 'store_details',
 				} );
-				getHistory().push( getNewPath( {}, `/profiler`, {} ) );
+				getHistory().push( getNewPath( {}, '/store-details', {} ) );
 			},
 			completed: profilerCompleted,
 			visible: true,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -97,7 +97,7 @@ export function getAllTasks( {
 	const tasks = [
 		{
 			key: 'store_details',
-			title: __( 'Store details', 'woocommerce-admin' ),
+			title: __( 'Setup wizard', 'woocommerce-admin' ),
 			container: null,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -770,7 +770,7 @@ class Onboarding {
 	public function is_loading( $is_loading ) {
 		$show_profiler = self::should_show_profiler();
 		$is_dashboard  = ! isset( $_GET['path'] ); // phpcs:ignore csrf ok.
-		$is_profiler   = isset( $_GET['path'] ) && '/store-details' === $_GET['path']; // phpcs:ignore csrf ok.
+		$is_profiler   = isset( $_GET['path'] ) && '/setup-wizard' === $_GET['path']; // phpcs:ignore csrf ok.
 
 		if ( $is_profiler ) {
 			return true;
@@ -915,7 +915,7 @@ class Onboarding {
 
 		$help_tab['content'] .= '<h3>' . __( 'Profile Setup Wizard', 'woocommerce-admin' ) . '</h3>';
 		$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-			'<p><a href="' . wc_admin_url( '&path=/store-details' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
+			'<p><a href="' . wc_admin_url( '&path=/setup-wizard' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
 
 		$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce-admin' ) . '</h3>';
 		$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task list, please click on the button below.', 'woocommerce-admin' ) . '</p>' .

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -770,7 +770,7 @@ class Onboarding {
 	public function is_loading( $is_loading ) {
 		$show_profiler = self::should_show_profiler();
 		$is_dashboard  = ! isset( $_GET['path'] ); // phpcs:ignore csrf ok.
-		$is_profiler   = isset( $_GET['path'] ) && '/profiler' === $_GET['path']; // phpcs:ignore csrf ok.
+		$is_profiler   = isset( $_GET['path'] ) && '/store-details' === $_GET['path']; // phpcs:ignore csrf ok.
 
 		if ( $is_profiler ) {
 			return true;
@@ -915,7 +915,7 @@ class Onboarding {
 
 		$help_tab['content'] .= '<h3>' . __( 'Profile Setup Wizard', 'woocommerce-admin' ) . '</h3>';
 		$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-			'<p><a href="' . wc_admin_url( '&path=/profiler' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
+			'<p><a href="' . wc_admin_url( '&path=/store-details' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
 
 		$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce-admin' ) . '</h3>';
 		$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task list, please click on the button below.', 'woocommerce-admin' ) . '</p>' .

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -270,9 +270,9 @@ class Loader {
 	public static function register_store_details_page() {
 		wc_admin_register_page(
 			array(
-				'title'  => __( 'Store details', 'woocommerce-admin' ),
+				'title'  => __( 'Setup Wizard', 'woocommerce-admin' ),
 				'parent' => '',
-				'path'   => '/store-details',
+				'path'   => '/setup-wizard',
 			)
 		);
 	}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -69,7 +69,7 @@ class Loader {
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'add_component_settings' ) );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'register_page_handler' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'register_profiler_page' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'register_store_details_page' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_user_data' ) );
 		add_action( 'in_admin_header', array( __CLASS__, 'embed_page_header' ) );
@@ -265,14 +265,14 @@ class Loader {
 	}
 
 	/**
-	 * Registers the profiler page.
+	 * Registers the store details (profiler) page.
 	 */
-	public static function register_profiler_page() {
+	public static function register_store_details_page() {
 		wc_admin_register_page(
 			array(
-				'title'  => 'Profiler',
+				'title'  => __( 'Store details', 'woocommerce-admin' ),
 				'parent' => '',
-				'path'   => '/profiler',
+				'path'   => '/store-details',
 			)
 		);
 	}


### PR DESCRIPTION
Follow up to https://github.com/woocommerce/woocommerce-admin/pull/4721.

This PR changes the labeling of "Profiler" to match the user-facing text of "Store details".

### Detailed test instructions:

- Verify that all `/profiler` links have been updated to `/store-details`
- Verify that for a new store with onboarding enabled (might have to Help > Setup Wizard > Enable new onboarding) the profiler is loaded when going to the homescreen
- Verify that the "store details" task in the task list works
- Verify that the Help > Setup Wizard > Profile setup wizard button works

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A