### PR TITLE
Fix industry args type in REST API

### DIFF
--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -249,7 +249,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
-					'type' => array( 'string', 'array' ),
+					'type' => 'object',
 				),
 			),
 			'product_types'       => array(

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -249,7 +249,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
-					'type' => 'json',
+					'type' => array( 'string', 'array' ),
 				),
 			),
 			'product_types'       => array(

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -59,7 +59,12 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		// Test updating 2 fields separately.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
 		$request->set_headers( array( 'content-type' => 'application/json' ) );
-		$request->set_body( wp_json_encode( array( 'industry' => 'health-beauty' ) ) );
+		$industry = array(
+			array(
+				'slug' => 'health-beauty',
+			),
+		);
+		$request->set_body( wp_json_encode( array( 'industry' => $industry ) ) );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -82,7 +87,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'health-beauty', $data['industry'][0] );
+		$this->assertEquals( 'health-beauty', $data['industry'][0]['slug'] );
 		$this->assertEquals( 'storefront', $data['theme'] );
 	}
 


### PR DESCRIPTION
Fixes a `type` argument error that causes failing tests in WP 5.5.0.

WP 5.5 introduced a number of deprecated properties in the REST API.  ( See https://github.com/WordPress/WordPress/blame/master/wp-includes/rest-api.php ).  One of these requires a valid `type` property.

### Detailed test instructions:

1. Make sure tests pass.
1. Navigate to the profiler.
1. Make sure industry data can be updated still and persists across refresh.