### PR TITLE
Delete associated customer analytics data when user is deleted from WordPress.

### DIFF
--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -85,7 +85,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function init() {
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
-		add_action( 'delete_user', array( __CLASS__, 'delete_customer_by_user_id' ) );
 	}
 
 	/**

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -85,6 +85,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function init() {
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
+		add_action( 'delete_user', array( __CLASS__, 'delete_customer_by_user_id' ) );
 	}
 
 	/**
@@ -675,16 +676,36 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function delete_customer( $customer_id ) {
 		global $wpdb;
+
 		$customer_id = (int) $customer_id;
+		$num_deleted = $wpdb->delete( self::get_db_table_name(), array( 'customer_id' => $customer_id ) );
 
-		$wpdb->delete( self::get_db_table_name(), array( 'customer_id' => $customer_id ) );
+		if ( $num_deleted ) {
+			/**
+			 * Fires when a customer is deleted.
+			 *
+			 * @param int $order_id Order ID.
+			 */
+			do_action( 'woocommerce_analytics_delete_customer', $customer_id );
 
-		/**
-		 * Fires when a customer is deleted.
-		 *
-		 * @param int $order_id Order ID.
-		 */
-		do_action( 'woocommerce_analytics_delete_customer', $customer_id );
+			ReportsCache::invalidate();
+		}
+	}
+
+	/**
+	 * Delete a customer lookup row by WordPress User ID.
+	 *
+	 * @param int $user_id WordPress User ID.
+	 */
+	public static function delete_customer_by_user_id( $user_id ) {
+		global $wpdb;
+
+		$user_id     = (int) $user_id;
+		$num_deleted = $wpdb->delete( self::get_db_table_name(), array( 'user_id' => $user_id ) );
+
+		if ( $num_deleted ) {
+			ReportsCache::invalidate();
+		}
 	}
 
 	/**

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -29,6 +29,7 @@ class CustomersScheduler extends ImportScheduler {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
+		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );
 
 		CustomersDataStore::init();
 		parent::init();
@@ -43,6 +44,7 @@ class CustomersScheduler extends ImportScheduler {
 		return array(
 			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' ),
 			'anonymize'         => self::get_action( 'import' ),
+			'delete_user'       => self::get_action( 'import' ),
 		);
 	}
 
@@ -118,8 +120,9 @@ class CustomersScheduler extends ImportScheduler {
 	 * @return array
 	 */
 	public static function get_scheduler_actions() {
-		$actions              = parent::get_scheduler_actions();
-		$actions['anonymize'] = 'wc-admin_anonymize_' . static::$name;
+		$actions                = parent::get_scheduler_actions();
+		$actions['anonymize']   = 'wc-admin_anonymize_' . static::$name;
+		$actions['delete_user'] = 'wc-admin_delete_user_' . static::$name;
 		return $actions;
 	}
 
@@ -143,6 +146,19 @@ class CustomersScheduler extends ImportScheduler {
 		if ( is_a( $order, 'WC_Order' ) ) {
 			// Postpone until any pending updates are completed.
 			self::schedule_action( 'anonymize', array( $order->get_id() ) );
+		}
+	}
+
+	/**
+	 * Schedule an action to delete a single User.
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public static function schedule_user_delete( $user_id ) {
+		if ( (int) $user_id > 0 ) {
+			// Postpone until any pending updates are completed.
+			self::schedule_action( 'delete_user', array( $user_id ) );
 		}
 	}
 
@@ -227,5 +243,15 @@ class CustomersScheduler extends ImportScheduler {
 		if ( $updated ) {
 			ReportsCache::invalidate();
 		}
+	}
+
+	/**
+	 * Delete the customer data for a single user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public static function delete_user( $user_id ) {
+		CustomersDataStore::delete_customer_by_user_id( $user_id );
 	}
 }

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -431,4 +431,47 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$this->assertFalse( CustomersDataStore::get_existing_customer_id_from_order( false ) );
 		$this->assertFalse( CustomersDataStore::get_or_create_customer_from_order( false ) );
 	}
+
+	/**
+	 * Test user deletion.
+	 */
+	public function test_user_deletion() {
+		wp_set_current_user( $this->user );
+
+		// Creating a customer should show up regardless of orders.
+		$customer = WC_Helper_Customer::create_customer( 'customer', 'password', 'customer@example.com' );
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'per_page' => 1,
+			)
+		);
+		$response  = $this->server->dispatch( $request );
+		$customers = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $customers );
+		$this->assertEquals( $customer->get_id(), $customers[0]['user_id'] );
+
+		// Delete the user associated with the customer.
+		wp_delete_user( $customer->get_id() );
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Verify they are gone.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'per_page' => 1,
+			)
+		);
+		$response  = $this->server->dispatch( $request );
+		$customers = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 0, $customers );
+	}
 }

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -439,7 +439,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// Creating a customer should show up regardless of orders.
-		$customer = WC_Helper_Customer::create_customer( 'customer', 'password', 'customer@example.com' );
+		$customer = WC_Helper_Customer::create_customer( 'deleteme', 'password', 'deleteme@example.com' );
 
 		WC_Helper_Queue::run_all_pending();
 
@@ -465,7 +465,8 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'per_page' => 1,
+				'per_page'  => 1,
+				'customers' => array( $customer->get_id() ),
 			)
 		);
 		$response  = $this->server->dispatch( $request );


### PR DESCRIPTION
Fixes #3810.

This PR seeks to delete rows from `wc_customer_lookup` when WordPress users are deleted.

### Detailed test instructions:

- Go to WooCommerce > Customers
- Choose any customer with a linked name column value and a "sign up" date
- Go to Users, search for the customer's name
- Delete user from results
- Go back to WooCommerce > Customers
- Verify the customer is no longer found

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: handle user deletion.