### PR TITLE
Don't directly import from React, use @wordpress/element.

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -4,8 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { escapeRegExp } from 'lodash';
-import { Fragment } from '@wordpress/element';
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/devdocs/example.js
+++ b/client/devdocs/example.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import React from 'react';
+import { Component, createElement } from '@wordpress/element';
 
 class Example extends Component {
 	state = {
@@ -28,7 +27,7 @@ class Example extends Component {
 		}
 
 		this.setState( {
-			example: React.createElement(
+			example: createElement(
 				exampleComponent.default || exampleComponent
 			),
 		} );

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { withDispatch, withSelect } from '@wordpress/data';
 


### PR DESCRIPTION
I noticed that some of our app files were directly importing from `react`, not `@wordpress/element`. This PR remedies that.

### Detailed test instructions:

- Verify that the DevDocs still work (full list and single component)
- Verify that the Stats Overview home screen widget Jetpack CTA still functions (should be hidden if you have the user preference)
- Verify that the store address step of the OBW still functions

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A