### PR TITLE
Adjust renovate to automerge devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,11 @@
 	"schedule": [ "before 3am on wednesday" ],
 	"composer": {
 		"enabled": false
-	}
+	},
+	"packageRules": [
+		{
+			"depTypeList": [ "devDependencies" ],
+			"automerge": true
+		}
+	]
 }


### PR DESCRIPTION
To lessen the burden of addressing renovate PRs, this automerges all renovate PRs for `devDependencies` (of which a significant amount of renovate PRs are.) Note that the PR checks must still pass before renovate merges them.

Currently we check out renovate PRs for dev dependencies locally and basically just run tests anyway, so we can rely on the PR builds passing for this instead. This is always something we can change again in future if we run into trouble, but this should save some time for developers.