### PR TITLE
Stock Report: Fix bad text domains

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
 		'@wordpress/i18n-translator-comments': 'warn',
 		'@wordpress/valid-sprintf': 'warn',
 		'react-hooks/rules-of-hooks': 'warn',
-		'@wordpress/i18n-text-domain': 'warn',
 		'jsdoc/check-param-names': 'warn',
 		'jsdoc/require-param': 'warn',
 		'jsdoc/require-property': 'warn',

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -155,19 +155,19 @@ class StockReportTable extends Component {
 				value: formatValue( currency, 'number', products ),
 			},
 			{
-				label: __( 'out of stock', outofstock, 'woocommerce-admin' ),
+				label: __( 'out of stock', 'woocommerce-admin' ),
 				value: formatValue( currency, 'number', outofstock ),
 			},
 			{
-				label: __( 'low stock', lowstock, 'woocommerce-admin' ),
+				label: __( 'low stock', 'woocommerce-admin' ),
 				value: formatValue( 'currency, number', lowstock ),
 			},
 			{
-				label: __( 'on backorder', onbackorder, 'woocommerce-admin' ),
+				label: __( 'on backorder', 'woocommerce-admin' ),
 				value: formatValue( currency, 'number', onbackorder ),
 			},
 			{
-				label: __( 'in stock', instock, 'woocommerce-admin' ),
+				label: __( 'in stock', 'woocommerce-admin' ),
 				value: formatValue( currency, 'number', instock ),
 			},
 		];

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -160,7 +160,7 @@ class StockReportTable extends Component {
 			},
 			{
 				label: __( 'low stock', 'woocommerce-admin' ),
-				value: formatValue( 'currency, number', lowstock ),
+				value: formatValue( currency, 'number', lowstock ),
 			},
 			{
 				label: __( 'on backorder', 'woocommerce-admin' ),

--- a/client/homescreen/index.js
+++ b/client/homescreen/index.js
@@ -4,7 +4,6 @@
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { identity } from 'lodash';
-
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import {
 	ONBOARDING_STORE_NAME,

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -12,7 +12,6 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { get, xor } from 'lodash';
-
 import {
 	EllipsisMenu,
 	MenuItem,


### PR DESCRIPTION
Fixes violations of `@wordpress/i18n-text-domain` and turns the rule back on.

### Detailed test instructions:

Visit the Stock Report and see labels in the status column appear as they should.

### Changelog Note:

Dev: Fix invalid text domains in Stock Report
