### PR TITLE
Add filter to allow modification of report columns

### DIFF
--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -97,12 +97,15 @@ class DataStore extends SqlQuery {
 	public function __construct() {
 		self::set_db_table_name();
 		$this->assign_report_columns();
-		$this->report_columns = apply_filters(
-			'woocommerce_admin_report_columns',
-			$this->report_columns,
-			$this->context,
-			self::get_db_table_name()
-		);
+
+		if ( property_exists( $this, 'report_columns' ) ) {
+			$this->report_columns = apply_filters(
+				'woocommerce_admin_report_columns',
+				$this->report_columns,
+				$this->context,
+				self::get_db_table_name()
+			);
+		}
 	}
 
 	/**

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -97,6 +97,12 @@ class DataStore extends SqlQuery {
 	public function __construct() {
 		self::set_db_table_name();
 		$this->assign_report_columns();
+		$this->report_columns = apply_filters(
+			'woocommerce_admin_report_columns',
+			$this->report_columns,
+			$this->context,
+			self::get_db_table_name()
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4147

Adds a filter to all report columns to allow adding or modifying existing columns at the database level.

@daigo75 Could you let me know if this adequately covers your use case?

### Detailed test instructions:

Note that you may need to flush your transients cache if the report columns aren't updated in the response.

1. Add a filter and add or change existing columns:
```php
		add_filter( 'woocommerce_admin_report_columns', function( $columns, $context, $table_name ) {
			if ( 'orders' === $context ) {
				$columns['my_column'] = "RAND(2) as my_column";
				$columns['net_total'] = "({$table_name}.net_total * 2) as net_total";
			}
			return $columns;
		}, 10, 3 );
```
2. Note the API response includes your changes.  E.g., `wp-json/wc-analytics/reports/orders`.
3. If you modified an existing column or have filters in place for the reports table on the JS side, note the changes in your table.