### PR TITLE
Add updateOptions prop to Layout tests

### DIFF
--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -27,7 +27,12 @@ jest.mock( 'quick-links', () => jest.fn().mockReturnValue( '[QuickLinks]' ) );
 describe( 'Homescreen Layout', () => {
 	it( 'should show TaskList placeholder when loading', () => {
 		const { container } = render(
-			<Layout requestingTaskList taskListHidden={ false } query={ {} } />
+			<Layout
+				requestingTaskList
+				taskListHidden={ false }
+				query={ {} }
+				updateOptions={ () => {} }
+			/>
 		);
 
 		const placeholder = container.querySelector(
@@ -42,6 +47,7 @@ describe( 'Homescreen Layout', () => {
 				requestingTaskList={ false }
 				taskListHidden={ false }
 				query={ {} }
+				updateOptions={ () => {} }
 			/>
 		);
 
@@ -64,6 +70,7 @@ describe( 'Homescreen Layout', () => {
 				query={ {
 					task: 'products',
 				} }
+				updateOptions={ () => {} }
 			/>
 		);
 
@@ -85,6 +92,7 @@ describe( 'Homescreen Layout', () => {
 				taskListComplete={ false }
 				taskListHidden
 				query={ {} }
+				updateOptions={ () => {} }
 			/>
 		);
 
@@ -99,6 +107,7 @@ describe( 'Homescreen Layout', () => {
 				taskListComplete
 				taskListHidden={ false }
 				query={ {} }
+				updateOptions={ () => {} }
 			/>
 		);
 
@@ -113,6 +122,7 @@ describe( 'Homescreen Layout', () => {
 				taskListComplete={ false }
 				taskListHidden
 				query={ {} }
+				updateOptions={ () => {} }
 			/>
 		);
 
@@ -127,6 +137,7 @@ describe( 'Homescreen Layout', () => {
 				taskListComplete
 				taskListHidden={ false }
 				query={ {} }
+				updateOptions={ () => {} }
 			/>
 		);
 


### PR DESCRIPTION
A `updateOptions` prop was added to `Layout` as a required prop, but it wasn't added to the `Layout` tests, which causes a warning. This just adds a noop property to each time `Layout` is instantiated.

### Testing
Run the tests (`npm test`), there shouldn't be any warnings.