### PR TITLE
Fix note data actions and consolidate query constants

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -7,7 +7,7 @@ import { Button, Dashicon, SelectControl } from '@wordpress/components';
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
 import { compose } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import moment from 'moment';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { Card } from '@woocommerce/components';
@@ -17,7 +17,6 @@ import { NOTES_STORE_NAME } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import withSelect from '../../wc-api/with-select';
 import { QUERY_DEFAULTS } from '../../wc-api/constants';
 import sanitizeHTML from '../../lib/sanitize-html';
 import StoreAlertsPlaceholder from './placeholder';
@@ -288,7 +287,7 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { triggerNoteAction, updateNote } = dispatch( 'wc-api' );
+		const { triggerNoteAction, updateNote } = dispatch( NOTES_STORE_NAME );
 
 		return {
 			triggerNoteAction,

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -30,4 +30,6 @@ export {
 	getTooltipValueFormat,
 } from './reports/utils';
 
+export { MAX_PER_PAGE, QUERY_DEFAULTS } from './constants';
+
 export { __experimentalResolveSelect } from './registry';

--- a/packages/data/src/reports/constants.js
+++ b/packages/data/src/reports/constants.js
@@ -2,12 +2,3 @@
  * Internal dependencies
  */
 export const STORE_NAME = 'wc/admin/reports';
-
-// WordPress & WooCommerce both set a hard limit of 100 for the per_page parameter
-export const MAX_PER_PAGE = 100;
-
-export const QUERY_DEFAULTS = {
-	pageSize: 25,
-	period: 'month',
-	compare: 'previous_year',
-};

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -18,7 +18,8 @@ import {
  * Internal dependencies
  */
 import * as reportsUtils from './utils';
-import { MAX_PER_PAGE, QUERY_DEFAULTS, STORE_NAME } from './constants';
+import { MAX_PER_PAGE, QUERY_DEFAULTS } from '../constants';
+import { STORE_NAME } from './constants';
 
 /**
  * Add filters and advanced filters values to a query object.


### PR DESCRIPTION
Fixes actions that were imported from `wc-api` instead of the data package.  Also consolidates constants into a single file.

### Detailed test instructions:

1. Make sure no warnings are shown in the console.
1. Make sure you have some store alerts.
1. Trigger the action on the alert and make sure no errors occur.