### PR TITLE
Documentation: Fix Add Report 

### DIFF
--- a/client/analytics/report/README.md
+++ b/client/analytics/report/README.md
@@ -1,36 +1,55 @@
-Reports
-=======
+# Reports
 
 The core reports offered by WooCommerce live in this folder. The Header is added automatically by the parent Report component, each individual component should contain just the report contents.
 
 ## Extending Reports
 
-New reports can be added by third-parties without altering `woocommerce-admin`, by hooking into the reports filter, `woocommerce_admin_reports_list`. For example:
+New reports can be added by third-parties without altering `woocommerce-admin`. First, a page will need to be registered in PHP to populate menu items.
+
+```php
+function register_page( $report_pages ) {
+	$report_pages[] = array(
+		'id'     => 'extension-example',
+		'title'  => __( 'Example', 'plugin-domain' ),
+		'parent' => 'woocommerce-analytics',
+		'path'   => '/analytics/example',
+	);
+	return $report_pages;
+}
+
+add_filter( 'woocommerce_analytics_report_menu_items', 'register_page' );
+```
+
+Next, hook into the reports filter, `woocommerce_admin_reports_list`, to add a report component.
 
 ```js
-addFilter( 'woocommerce_admin_reports_list', 'analytics/my-report', pages => {
-	return [
-		...pages,
-		{
-			report: 'example',
-			title: 'My Example Extension',
-			component: Report,
-		},
-	];
-} );
+addFilter(
+	'woocommerce_admin_reports_list',
+	'analytics/my-report',
+	( pages ) => {
+		return [
+			...pages,
+			{
+				report: 'example',
+				title: 'My Example Extension',
+				component: Report,
+			},
+		];
+	}
+);
 ```
 
 Each report is defined by an object containing `report`, `title`, `component`.
 
-- `report` (string): The path used to show the report, ex: `/analytics/example`
-- `title` (string): The title shown in the breadcrumbs & document title.
-- `component` (react component): The component containing the report content- everything on the page under the breadcrumbs header.
+-   `report` (string): The path used to show the report, ex: `/analytics/example`
+-   `title` (string): The title shown in the breadcrumbs & document title.
+-   `component` (react component): The component containing the report content- everything on the page under the breadcrumbs header.
 
 The component will get the following props:
 
-- `query` (object): The query string for the current view, can be used to paginate reports, or sort/filter report data.
-- `path` (string): The exact path for this view.
-- `pathMatch` (string): The route matched for this view, should always be `/analytics/:report`.
-- `params` (object): This will contain the `report` from the path, which should match `report` in the page object.
+-   `query` (object): The query string for the current view, can be used to paginate reports, or sort/filter report data.
+-   `path` (string): The exact path for this view.
+-   `pathMatch` (string): The route matched for this view, should always be `/analytics/:report`.
+-   `params` (object): This will contain the `report` from the path, which should match `report` in the page object.
 
 **Note:** Adding your page to `woocommerce_admin_reports_list` does not add the item to the admin menu, you'll need to do that in PHP with the `woocommerce_admin_report_menu_items` filter.

--- a/client/analytics/report/README.md
+++ b/client/analytics/report/README.md
@@ -20,7 +20,14 @@ function register_page( $report_pages ) {
 add_filter( 'woocommerce_analytics_report_menu_items', 'register_page' );
 ```
 
-Next, hook into the reports filter, `woocommerce_admin_reports_list`, to add a report component.
+Each menu item is defined by an array containing `id`, `title`, `parent`, and `path`.
+
+-   `report` (string): The report's id.
+-   `title` (string): The title shown in the sidebar.
+-   `parent` (string): The item's parent in the navigational heirarchy.
+-   `path` (string): The report's relative path.
+
+Next, hook into the JavaScript reports filter, `woocommerce_admin_reports_list`, to add a report component.
 
 ```js
 addFilter(
@@ -51,5 +58,3 @@ The component will get the following props:
 -   `path` (string): The exact path for this view.
 -   `pathMatch` (string): The route matched for this view, should always be `/analytics/:report`.
 -   `params` (object): This will contain the `report` from the path, which should match `report` in the page object.
-
-**Note:** Adding your page to `woocommerce_admin_reports_list` does not add the item to the admin menu, you'll need to do that in PHP with the `woocommerce_admin_report_menu_items` filter.

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -113,7 +113,7 @@ class Analytics {
 	 */
 	public function register_pages() {
 		$homepage_enabled = Loader::is_feature_enabled( 'homescreen' );
-		$report_pages = array(
+		$report_pages     = array(
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
@@ -123,10 +123,10 @@ class Analytics {
 				'position' => 56, // After WooCommerce & Product menu items.
 			),
 			$homepage_enabled ? array(
-				'id'       => 'woocommerce-analytics-overview',
-				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'id'     => 'woocommerce-analytics-overview',
+				'title'  => __( 'Overview', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
-				'path'     => '/analytics/overview',
+				'path'   => '/analytics/overview',
 			) : null,
 			array(
 				'id'     => 'woocommerce-analytics-revenue',

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -129,7 +129,6 @@ class PageController {
 				}
 			}
 		}
-
 		$this->current_page = false;
 	}
 


### PR DESCRIPTION
In providing testing instructions for https://github.com/woocommerce/woocommerce-admin/pull/4962, I got really tripped up with how to add a report. I didn't notice the note at the end of the README about needing to register the menu item first using `woocommerce_analytics_report_menu_items`. Not doing so will prevent the entire app from getting loaded at your example's path.

So I decided to update the docs.

### Detailed test instructions:

1. Proofread the README and see that it makes sense.

### Changelog Note:

none - documentation improvement.
