### PR TITLE
Fix typo in reports store action creators.

### DIFF
--- a/packages/data/src/reports/actions.js
+++ b/packages/data/src/reports/actions.js
@@ -4,7 +4,7 @@
 import { getResourceName } from '../utils';
 import TYPES from './action-types';
 
-export function setItemError( endpoint, query, error ) {
+export function setReportItemsError( endpoint, query, error ) {
 	const resourceName = getResourceName( endpoint, query );
 
 	return {
@@ -34,7 +34,7 @@ export function setReportStats( endpoint, query, stats ) {
 	};
 }
 
-export function setStatError( endpoint, query, error ) {
+export function setReportStatsError( endpoint, query, error ) {
 	const resourceName = getResourceName( endpoint, query );
 
 	return {


### PR DESCRIPTION
`setReportItemsError()` and `setReportStatsError()` weren't defined in https://github.com/woocommerce/woocommerce-admin/pull/4966

### Detailed test instructions:

- Verify that the action creators used in the `reports` data store exist

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased change