### PR TITLE
Update Jetpack Autoloader to match Woo Core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"require": {
 		"composer/installers": "1.7.0",
 		"php": ">=5.6|>=7.0",
-		"automattic/jetpack-autoloader": "^2.0.0"
+		"automattic/jetpack-autoloader": "2.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"require": {
 		"composer/installers": "1.7.0",
 		"php": ">=5.6|>=7.0",
-		"automattic/jetpack-autoloader": "2.2.0"
+		"automattic/jetpack-autoloader": "^2.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "713e0c86cd8c89e21306f3a5797e1b93",
+    "content-hash": "ce606c4a72c31af7161d2099fb4cbe1b",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -1059,6 +1059,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8837c7177a8dddaf71dcaafb0090d15",
+    "content-hash": "713e0c86cd8c89e21306f3a5797e1b93",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.0.1",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf"
+                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/415269dbc7bf4771372c28b1ea866efa4f2501bf",
-                "reference": "415269dbc7bf4771372c28b1ea866efa4f2501bf",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/66a5d150b3928be718d86696f85631a7f0b98a7b",
+                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-07-02T09:39:59+00:00"
+            "time": "2020-08-14T20:34:36+00:00"
         },
         {
             "name": "composer/installers",
@@ -1713,16 +1713,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -1760,20 +1760,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.1",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -1785,7 +1785,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1822,7 +1822,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
This change is needed prior to 1.4.0 being released - @ObliviousHarmony has already done quite a bit of testing on the Woo Core side of things, but p9dueE-1K5-p2 has further details about the bug that is requiring us to update ahead of 1.4.0, and how to fully test out the changes.