### PR TITLE
Remove composite products from onboarding

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -388,10 +388,6 @@ class Onboarding {
 					'label'   => __( 'Memberships', 'woocommerce-admin' ),
 					'product' => 958589,
 				),
-				'composite'       => array(
-					'label'   => __( 'Composite Products', 'woocommerce-admin' ),
-					'product' => 216836,
-				),
 				'bookings'        => array(
 					'label'   => __( 'Bookings', 'woocommerce-admin' ),
 					'product' => 390890,


### PR DESCRIPTION
Partially addresses #4577

This removes the "Composite products" option from the product selection step in the OBW.

## Detailed test instructions:
- start the OBW
- carry through to the product selection step
- note that the "Composite products" option is no longer present