### PR TITLE
Orders Panel: get selectors from wc-api

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -332,13 +332,13 @@ export default compose(
 		const { hasActionableOrders } = props;
 		const {
 			getItems,
-			getItemsTotalCount,
 			getItemsError,
+			getItemsTotalCount,
 			isGetItemsRequesting,
-			getReportItems,
-			getReportItemsError,
-			isResolving,
-		} = select( REPORTS_STORE_NAME );
+		} = select( 'wc-api' );
+		const { getReportItems, getReportItemsError, isResolving } = select(
+			REPORTS_STORE_NAME
+		);
 		const { getSetting: getMutableSetting } = select( SETTINGS_STORE_NAME );
 		const {
 			woocommerce_actionable_order_statuses: orderStatuses = DEFAULT_ACTIONABLE_STATUSES,


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/4966 mistakingly moved some selectors in the Orders Panel away from wc-api prematurely. This PR changes it back as that task will be handled in https://github.com/woocommerce/woocommerce-admin/issues/3381

### Detailed test instructions:

Make sure the Orders Notification Panel does not produce a fatal error.

### Changelog Note:

none: unreleased bug
