### PR TITLE
Add complete and incomplete task counts to tasklist_complete event

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -203,19 +203,11 @@ class TaskDashboard extends Component {
 		} );
 	}
 
-	keepTaskCard() {
-		recordEvent( 'tasklist_completed', {
-			action: 'keep_card',
-		} );
-
-		this.props.updateOptions( {
-			woocommerce_task_list_prompt_shown: true,
-		} );
-	}
-
 	hideTaskCard( action ) {
 		recordEvent( 'tasklist_completed', {
 			action,
+			completed_task_count: this.getCompletedTaskKeys().length,
+			incomplete_task_count: this.getIncompleteTasks().length,
 		} );
 		this.props.updateOptions( {
 			woocommerce_task_list_hidden: 'yes',


### PR DESCRIPTION
Fixes #4973

Adds incomplete and complete task counts so we can better understand reasons for hiding the task list.

### Screenshots
<img width="542" alt="Screen Shot 2020-08-18 at 3 06 49 PM" src="https://user-images.githubusercontent.com/10561050/90554864-27ae3780-e19f-11ea-9427-19bc9fb180f2.png">
<img width="735" alt="Screen Shot 2020-08-18 at 3 06 28 PM" src="https://user-images.githubusercontent.com/10561050/90554865-2846ce00-e19f-11ea-888e-f97a12b31b79.png">


### Detailed test instructions:

1. Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` into your console. Leave your console open.
1. Enable the task list and visit it.
1. Hide the task list using the dropdown.
1. Note the events logged include counts for complete and incomplete