### PR TITLE
Group tasks by completion status

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -232,7 +232,13 @@ export function getAllTasks( {
 
 	return applyFilters(
 		'woocommerce_admin_onboarding_task_list',
-		tasks,
+		tasks.sort( ( a, b ) => {
+			if ( a.completed === b.completed ) {
+				return 0;
+			}
+
+			return a.completed ? 1 : -1;
+		} ),
 		query
 	);
 }


### PR DESCRIPTION
Fixes #4529

Puts completed tasks at the end of the list and incomplete tasks at the top.

### Screenshots
<img width="529" alt="Screen Shot 2020-08-18 at 3 19 02 PM" src="https://user-images.githubusercontent.com/10561050/90556233-38f84380-e1a1-11ea-8cad-e5cc3725bf69.png">


### Detailed test instructions:

1. Enable the task list and make sure you have some completed and some incomplete tasks.
1. Note the incomplete tasks always appear at the top of the list.