### PR TITLE
Add the jest-environment tag to known tags for jsdoc lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,9 @@ module.exports = {
 		'@wordpress/i18n-translator-comments': 'warn',
 		'@wordpress/valid-sprintf': 'warn',
 		'react-hooks/rules-of-hooks': 'warn',
+		'jsdoc/check-tag-names': [
+			'error',
+			{ definedTags: [ 'jest-environment' ] },
+		],
 	},
 };

--- a/packages/data/src/export/test/reducer.js
+++ b/packages/data/src/export/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/data/src/notes/test/reducer.js
+++ b/packages/data/src/notes/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/data/src/onboarding/test/reducer.js
+++ b/packages/data/src/onboarding/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/data/src/options/test/reducer.js
+++ b/packages/data/src/options/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/data/src/reports/test/reducer.js
+++ b/packages/data/src/reports/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';

--- a/packages/data/src/reviews/test/reducer.js
+++ b/packages/data/src/reviews/test/reducer.js
@@ -1,4 +1,8 @@
 /**
+ * @jest-environment node
+ */
+
+/**
  * Internal dependencies
  */
 import reducer from '../reducer';


### PR DESCRIPTION
The JS doc lint recognises the `jest-environment` header as a tag, and it errors because it is not a defined tag. The simplest way to avoid this is to add the tag to known tags in the eslintrc.

I've also added the tag to our reducer tests where possible which will speed these tests up and also prove that this new lint config works.