### PR TITLE
Fix components internal deps

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -25,6 +25,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import { createNoticesFromResponse } from '../../../lib/notices';
 import { getCountryCode } from '../../../dashboard/utils';
 import withSelect from '../../../wc-api/with-select';
 import { getPaymentMethods } from './methods';
@@ -125,6 +126,7 @@ class Payments extends Component {
 					} }
 					autoInstall
 					pluginSlugs={ currentMethod.plugins }
+					onResponse={ createNoticesFromResponse }
 				/>
 			),
 			isComplete: ! pluginsToInstall.length,

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -119,14 +119,17 @@ class Payments extends Component {
 			),
 			content: (
 				<Plugins
-					onComplete={ () => {
+					onComplete={ ( plugins, response ) => {
+						createNoticesFromResponse( response );
 						recordEvent( 'tasklist_payment_install_method', {
 							plugins: currentMethod.plugins,
 						} );
 					} }
+					onError={ ( errors, response ) =>
+						createNoticesFromResponse( response )
+					}
 					autoInstall
 					pluginSlugs={ currentMethod.plugins }
-					onResponse={ createNoticesFromResponse }
 				/>
 			),
 			isComplete: ! pluginsToInstall.length,

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -251,13 +251,17 @@ class Shipping extends Component {
 					  ),
 				content: (
 					<Plugins
-						onComplete={ () => {
+						onComplete={ ( plugins, response ) => {
+							createNoticesFromResponse( response );
 							recordEvent( 'tasklist_shipping_label_printing', {
 								install: true,
 								plugins_to_activate: pluginsToActivate,
 							} );
 							this.completeStep();
 						} }
+						onError={ ( errors, response ) =>
+							createNoticesFromResponse( response )
+						}
 						onSkip={ () => {
 							recordEvent( 'tasklist_shipping_label_printing', {
 								install: false,
@@ -266,7 +270,6 @@ class Shipping extends Component {
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }
 						pluginSlugs={ pluginsToActivate }
-						onResponse={ createNoticesFromResponse }
 						{ ...this.props }
 					/>
 				),

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -21,6 +21,7 @@ import Connect from '../../../dashboard/components/connect';
 import { getCountryCode } from '../../../dashboard/utils';
 import StoreLocation from '../steps/location';
 import ShippingRates from './rates';
+import { createNoticesFromResponse } from '../../../lib/notices';
 
 class Shipping extends Component {
 	constructor( props ) {
@@ -265,6 +266,7 @@ class Shipping extends Component {
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }
 						pluginSlugs={ pluginsToActivate }
+						onResponse={ createNoticesFromResponse }
 						{ ...this.props }
 					/>
 				),

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -216,7 +216,8 @@ class Tax extends Component {
 				content: (
 					<Fragment>
 						<Plugins
-							onComplete={ () => {
+							onComplete={ ( plugins, response ) => {
+								createNoticesFromResponse( response );
 								recordEvent(
 									'tasklist_tax_install_extensions',
 									{
@@ -228,6 +229,9 @@ class Tax extends Component {
 								} );
 								this.completeStep();
 							} }
+							onError={ ( errors, response ) =>
+								createNoticesFromResponse( response )
+							}
 							onSkip={ () => {
 								queueRecordEvent(
 									'tasklist_tax_install_extensions',
@@ -241,7 +245,6 @@ class Tax extends Component {
 								'Set up tax rates manually',
 								'woocommerce-admin'
 							) }
-							onResponse={ createNoticesFromResponse }
 						/>
 						{ ! tosAccepted && (
 							<Text

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -241,6 +241,7 @@ class Tax extends Component {
 								'Set up tax rates manually',
 								'woocommerce-admin'
 							) }
+							onResponse={ createNoticesFromResponse }
 						/>
 						{ ! tosAccepted && (
 							<Text

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 5.1.0 (unreleased)
 
--   Fixed default value for `<Table />` component `onQueryChange` prop.
+-   Fix default value for `<Table />` component `onQueryChange` prop.
 -   Deprecate our bespoke component `useFilters` in favor of using the WordPress variety `withFilters`.
 -   Fix screen reader text in `<AdvancedFilters />`.
--   Added `<AttributeFilter />` component to `<AdvancedFilters />`.
+-   Add `<AttributeFilter />` component to `<AdvancedFilters />`.
+-   Fix internal dependencies for `<Plugins />`.
 
 # 5.0.0
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Fix screen reader text in `<AdvancedFilters />`.
 -   Add `<AttributeFilter />` component to `<AdvancedFilters />`.
 -   Fix internal dependencies for `<Plugins />`.
+-   Add full response to `<Plugins />` callbacks `onError` and `onComplete`.
 
 # 5.0.0
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,7 @@
 		"@babel/runtime-corejs2": "7.11.2",
 		"@woocommerce/csv-export": "1.2.0",
 		"@woocommerce/currency": "2.0.0",
+		"@woocommerce/data": "1.0.0",
 		"@woocommerce/date": "2.0.0",
 		"@woocommerce/navigation": "4.0.0",
 		"@wordpress/components": "10.0.0",

--- a/packages/components/src/plugins/README.md
+++ b/packages/components/src/plugins/README.md
@@ -1,20 +1,24 @@
-Plugins
-===
+# Plugins
 
 Use `Plugins` to install and activate a list of plugins.
 
 ## Usage
 
 ```jsx
-<Plugins onComplete={ this.complete } pluginSlugs={ [ 'jetpack', 'woocommerce-services' ] } />
+<Plugins
+	onComplete={ this.complete }
+	pluginSlugs={ [ 'jetpack', 'woocommerce-services' ] }
+/>
 ```
 
 ### Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`onComplete` | Function |  | Called when the plugin installer is completed
-`onSkip` | Function | `noop` | Called when the plugin installer is skipped
-`skipText` | String |  | Text used for the skip installer button
-`autoInstall` | Boolean | false | If installation should happen automatically, or require user confirmation
-`pluginSlugs` | Array | `[ 'jetpack', 'woocommerce-services' ],` | An array of plugin slugs to install.
+| Name          | Type     | Default                                  | Description                                                               |
+| ------------- | -------- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| `onComplete`  | Function |                                          | Called when the plugin installer is completed                             |
+| `onError`     | Function |                                          | Called when the plugin installer completes with an error                  |
+| `onResponse`  | Function |                                          | Called when the plugin installer response returns                         |
+| `onSkip`      | Function | `noop`                                   | Called when the plugin installer is skipped                               |
+| `skipText`    | String   |                                          | Text used for the skip installer button                                   |
+| `autoInstall` | Boolean  | false                                    | If installation should happen automatically, or require user confirmation |
+| `pluginSlugs` | Array    | `[ 'jetpack', 'woocommerce-services' ],` | An array of plugin slugs to install.                                      |

--- a/packages/components/src/plugins/README.md
+++ b/packages/components/src/plugins/README.md
@@ -17,7 +17,6 @@ Use `Plugins` to install and activate a list of plugins.
 | ------------- | -------- | ---------------------------------------- | ------------------------------------------------------------------------- |
 | `onComplete`  | Function |                                          | Called when the plugin installer is completed                             |
 | `onError`     | Function |                                          | Called when the plugin installer completes with an error                  |
-| `onResponse`  | Function |                                          | Called when the plugin installer response returns                         |
 | `onSkip`      | Function | `noop`                                   | Called when the plugin installer is skipped                               |
 | `skipText`    | String   |                                          | Text used for the skip installer button                                   |
 | `autoInstall` | Boolean  | false                                    | If installation should happen automatically, or require user confirmation |

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -9,11 +9,6 @@ import PropTypes from 'prop-types';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
-/**
- * Internal dependencies
- */
-import { createNoticesFromResponse } from '../../../../client/lib/notices';
-
 export class Plugins extends Component {
 	constructor() {
 		super( ...arguments );
@@ -45,6 +40,7 @@ export class Plugins extends Component {
 			installAndActivatePlugins,
 			isRequesting,
 			pluginSlugs,
+			onResponse,
 		} = this.props;
 
 		// Avoid double activating.
@@ -54,11 +50,11 @@ export class Plugins extends Component {
 
 		installAndActivatePlugins( pluginSlugs )
 			.then( ( response ) => {
-				createNoticesFromResponse( response );
+				onResponse( response );
 				this.handleSuccess( response.data.activated );
 			} )
 			.catch( ( error ) => {
-				createNoticesFromResponse( error );
+				onResponse( error );
 				this.handleErrors( error.errors );
 			} );
 	}
@@ -140,9 +136,17 @@ export class Plugins extends Component {
 
 Plugins.propTypes = {
 	/**
-	 * Called when the plugin installer is completed.
+	 * Called when the plugin installer is successfully completed.
 	 */
 	onComplete: PropTypes.func.isRequired,
+	/**
+	 * Called when the plugin installer completes with an error.
+	 */
+	onError: PropTypes.func,
+	/**
+	 * Called when the plugin installer response returns.
+	 */
+	onResponse: PropTypes.func,
 	/**
 	 * Called when the plugin installer is skipped.
 	 */
@@ -164,6 +168,7 @@ Plugins.propTypes = {
 Plugins.defaultProps = {
 	autoInstall: false,
 	onError: () => {},
+	onResponse: () => {},
 	onSkip: () => {},
 	pluginSlugs: [ 'jetpack', 'woocommerce-services' ],
 };

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -40,7 +40,6 @@ export class Plugins extends Component {
 			installAndActivatePlugins,
 			isRequesting,
 			pluginSlugs,
-			onResponse,
 		} = this.props;
 
 		// Avoid double activating.
@@ -50,25 +49,23 @@ export class Plugins extends Component {
 
 		installAndActivatePlugins( pluginSlugs )
 			.then( ( response ) => {
-				onResponse( response );
-				this.handleSuccess( response.data.activated );
+				this.handleSuccess( response.data.activated, response );
 			} )
-			.catch( ( error ) => {
-				onResponse( error );
-				this.handleErrors( error.errors );
+			.catch( ( response ) => {
+				this.handleErrors( response.errors, response );
 			} );
 	}
 
-	handleErrors( errors ) {
+	handleErrors( errors, response ) {
 		const { onError } = this.props;
 
 		this.setState( { hasErrors: true } );
-		onError( errors );
+		onError( errors, response );
 	}
 
-	handleSuccess( activePlugins ) {
+	handleSuccess( activePlugins, response ) {
 		const { onComplete } = this.props;
-		onComplete( activePlugins );
+		onComplete( activePlugins, response );
 	}
 
 	skipInstaller() {
@@ -144,10 +141,6 @@ Plugins.propTypes = {
 	 */
 	onError: PropTypes.func,
 	/**
-	 * Called when the plugin installer response returns.
-	 */
-	onResponse: PropTypes.func,
-	/**
 	 * Called when the plugin installer is skipped.
 	 */
 	onSkip: PropTypes.func,
@@ -168,7 +161,6 @@ Plugins.propTypes = {
 Plugins.defaultProps = {
 	autoInstall: false,
 	onError: () => {},
-	onResponse: () => {},
 	onSkip: () => {},
 	pluginSlugs: [ 'jetpack', 'woocommerce-services' ],
 };

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -18,7 +18,6 @@ describe( 'Rendering', () => {
 				activated: [ 'jetpack' ],
 			},
 		} );
-		const createNotice = jest.fn();
 		const onComplete = jest.fn();
 
 		const pluginsWrapper = shallow(
@@ -27,7 +26,6 @@ describe( 'Rendering', () => {
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ onComplete }
 				installAndActivatePlugins={ installAndActivatePlugins }
-				createNotice={ createNotice }
 			/>
 		);
 
@@ -59,19 +57,22 @@ describe( 'Rendering', () => {
 
 describe( 'Installing and activating', () => {
 	let pluginsWrapper;
-	const installAndActivatePlugins = jest.fn().mockResolvedValue( {
+	const response = {
 		success: true,
 		data: {
 			activated: [ 'jetpack' ],
 		},
-	} );
+	};
+	const installAndActivatePlugins = jest.fn().mockResolvedValue( response );
 	const onComplete = jest.fn();
+	const onResponse = jest.fn();
 
 	beforeEach( () => {
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ onComplete }
+				onResponse={ onResponse }
 				installAndActivatePlugins={ installAndActivatePlugins }
 			/>
 		);
@@ -91,6 +92,13 @@ describe( 'Installing and activating', () => {
 		installButton.simulate( 'click' );
 
 		await expect( onComplete ).toHaveBeenCalledWith( [ 'jetpack' ] );
+	} );
+
+	it( 'should call the onResponse callback', async () => {
+		const installButton = pluginsWrapper.find( Button ).at( 0 );
+		installButton.simulate( 'click' );
+
+		await expect( onResponse ).toHaveBeenCalledWith( response );
 	} );
 } );
 

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -129,6 +129,6 @@ describe( 'Installing and activating errors', () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( onError ).toHaveBeenCalledWith( response.errors, response ); //sdfs
+		expect( onError ).toHaveBeenCalledWith( response.errors, response );
 	} );
 } );

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -65,14 +65,12 @@ describe( 'Installing and activating', () => {
 	};
 	const installAndActivatePlugins = jest.fn().mockResolvedValue( response );
 	const onComplete = jest.fn();
-	const onResponse = jest.fn();
 
 	beforeEach( () => {
 		pluginsWrapper = shallow(
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ onComplete }
-				onResponse={ onResponse }
 				installAndActivatePlugins={ installAndActivatePlugins }
 			/>
 		);
@@ -91,27 +89,21 @@ describe( 'Installing and activating', () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		await expect( onComplete ).toHaveBeenCalledWith( [ 'jetpack' ] );
-	} );
-
-	it( 'should call the onResponse callback', async () => {
-		const installButton = pluginsWrapper.find( Button ).at( 0 );
-		installButton.simulate( 'click' );
-
-		await expect( onResponse ).toHaveBeenCalledWith( response );
+		await expect( onComplete ).toHaveBeenCalledWith(
+			[ 'jetpack' ],
+			response
+		);
 	} );
 } );
 
 describe( 'Installing and activating errors', () => {
 	let pluginsWrapper;
-	const errors = {
+	const response = {
 		errors: {
 			'failed-plugin': [ 'error message' ],
 		},
 	};
-	const installAndActivatePlugins = jest.fn().mockRejectedValue( {
-		errors,
-	} );
+	const installAndActivatePlugins = jest.fn().mockRejectedValue( response );
 	const onComplete = jest.fn();
 	const onError = jest.fn();
 
@@ -137,6 +129,6 @@ describe( 'Installing and activating errors', () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( onError ).toHaveBeenCalledWith( errors );
+		expect( onError ).toHaveBeenCalledWith( response.errors, response ); //sdfs
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5006

The `<Plugins />` component had internal dependencies to the wc-admin client which causes issues for anyone outside wc-admin trying to use the component.

This PR adds a `@woocommerce/data` dependency to the component's `package.json`. An `onResponse` prop was also created so consuming js app can choose to handle the response any way they'd like, ie create a notice.

### Detailed test instructions:

1. Remove the WooCommerce Services plugin.
1. Enable the Task List.
2. Add the WooCommerce Services plugin via the Task List's Tax task.
3. See the plugin success notice created.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- Fix: Remove internal dependencies from Plugins component.
