### PR TITLE
Fix Advanced Filters Screen Reader Text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Fixed default value for `<Table />` component `onQueryChange` prop.Fixed default value for `<Table />` component `onQueryChange` prop.
 -   Deprecate our bespoke component `useFilters` in favor of using the WordPress variety `withFilters`.
+-   Fix screen reader text in `<AdvancedFilters />`.
 
 # 5.0.0
 

--- a/packages/components/src/advanced-filters/date-filter.js
+++ b/packages/components/src/advanced-filters/date-filter.js
@@ -88,6 +88,7 @@ class DateFilter extends Component {
 				components: {
 					filter: <Fragment>{ filterStr }</Fragment>,
 					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
 				},
 			} )
 		);

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -63,6 +63,7 @@ class NumberFilter extends Component {
 				components: {
 					filter: <Fragment>{ filterStr }</Fragment>,
 					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
 				},
 			} )
 		);

--- a/packages/components/src/advanced-filters/search-filter.js
+++ b/packages/components/src/advanced-filters/search-filter.js
@@ -91,6 +91,7 @@ class SearchFilter extends Component {
 				components: {
 					filter: <Fragment>{ filterStr }</Fragment>,
 					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
 				},
 			} )
 		);

--- a/packages/components/src/advanced-filters/select-filter.js
+++ b/packages/components/src/advanced-filters/select-filter.js
@@ -59,6 +59,7 @@ class SelectFilter extends Component {
 				components: {
 					filter: <Fragment>{ value.label }</Fragment>,
 					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
 				},
 			} )
 		);


### PR DESCRIPTION
While developing the Product Attribute filter, I noticed that the screen reader text was broken for all advanced filters.

The issue stems from the call to `interpolateComponents()` missing the `title` component. `interpolateComponents()` [will return the `mixedString` if there is a missing component](https://github.com/Automattic/interpolate-components/blob/master/test/test.jsx#L78-L89).

This PR fixes missing title component in advanced filter screen reader interpolation.

### Detailed test instructions:

- Open a report with advanced filters (like Orders)
- Add an advanced filter and select some values
- Inspect the filter element and verify the `screen-reader-text` spans have intelligible strings without component placeholders like `{{title}}`, etc.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: `<AdvancedFilters />` screen reader text.