### PR TITLE
Add new note: Selling online courses

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -20,6 +20,7 @@ use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificati
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Home_Screen_Feedback;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Set_Up_Additional_Payment_Types;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Test_Checkout;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Selling_Online_Courses;
 
 /**
  * Feature plugin main class.
@@ -190,6 +191,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Home_Screen_Feedback();
 		new WC_Admin_Notes_Set_Up_Additional_Payment_Types();
 		new WC_Admin_Notes_Test_Checkout();
+		new WC_Admin_Notes_Selling_Online_Courses();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -78,7 +78,7 @@ class Onboarding {
 		$this->add_actions();
 		$this->add_filters();
 
-		// Hook up dependant classes.
+		// Hook up dependent classes.
 		new OnboardingSetUpShipping();
 	}
 

--- a/src/Notes/WC_Admin_Notes_Selling_Online_Courses.php
+++ b/src/Notes/WC_Admin_Notes_Selling_Online_Courses.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WooCommerce Admin: Selling Online Courses note
+ *
+ * Adds a note to encourage selling online courses.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * WC_Admin_Notes_Selling_Online_Courses
+ */
+class WC_Admin_Notes_Selling_Online_Courses {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-selling-online-courses';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action(
+			'update_option_' . Onboarding::PROFILE_DATA_OPTION,
+			array( $this, 'check_onboarding_profile' ),
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Check to see if the profiler options match before possibly adding note.
+	 *
+	 * @param object $old_value The old option value.
+	 * @param object $value     The new option value.
+	 * @param string $option    The name of the option.
+	 */
+	public static function check_onboarding_profile( $old_value, $value, $option ) {
+		// Skip adding if this store is in the education/learning industry.
+		if ( ! isset( $value['industry'] ) ) {
+			return;
+		}
+		$industry_slugs = array_column( $value['industry'], 'slug' );
+		if ( ! in_array( 'education-and-learning', $industry_slugs, true ) ) {
+			return;
+		}
+
+		self::possibly_add_note();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note = new WC_Admin_Note();
+
+		$note->set_title( __( 'Do you want to sell online courses?', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Online courses are a great solution for any business that can teach a new skill. Since courses don’t require physical product development or shipping, they’re affordable, fast to create, and can generate passive income for years to come. In this article, we provide you more information about selling courses using WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/how-to-sell-online-courses-wordpress/?utm_source=inbox',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4477

This adds a note about selling online courses if the education and learning industry was selected within the OBW.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/91118410-3b442b80-e6d4-11ea-89a9-1206b4e08e58.png)

### Detailed test instructions:

1. Run through the OBW but _don't_ select the education and learning industry
2. The new note should _not_ appear
3. Run through the OBW again but this time _do_ select the education and learning industry
4. The new note should appear
5. The learn more action should go to a WooCommerce blog post