### PR TITLE
Add "Product Attribute" advanced report filter.

### DIFF
--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -114,6 +114,32 @@ const variationsConfig = {
 			value: 'all',
 		},
 		{
+			label: __( 'Single Variation', 'woocommerce-admin' ),
+			value: 'select_variation',
+			subFilters: [
+				{
+					component: 'Search',
+					value: 'single_variation',
+					path: [ 'select_variation' ],
+					settings: {
+						type: 'variations',
+						param: 'variations',
+						getLabels: getVariationLabels,
+						labels: {
+							placeholder: __(
+								'Type to search for a variation',
+								'woocommerce-admin'
+							),
+							button: __(
+								'Single Variation',
+								'woocommerce-admin'
+							),
+						},
+					},
+				},
+			],
+		},
+		{
 			label: __( 'Comparison', 'woocommerce-admin' ),
 			chartMode: 'item-comparison',
 			value: 'compare-variations',

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -82,14 +82,9 @@ export const getVariationLabels = getRequestByIdString(
 	( variation ) => {
 		return {
 			key: variation.id,
-			label: variation.attributes.reduce(
-				( desc, attribute, index, arr ) =>
-					desc +
-					`${ attribute.option }${
-						arr.length === index + 1 ? '' : ', '
-					}`,
-				''
-			),
+			label: variation.attributes
+				.map( ( { option } ) => option )
+				.join( ', ' ),
 		};
 	}
 );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,8 +1,9 @@
 # 5.1.0 (unreleased)
 
--   Fixed default value for `<Table />` component `onQueryChange` prop.Fixed default value for `<Table />` component `onQueryChange` prop.
+-   Fixed default value for `<Table />` component `onQueryChange` prop.
 -   Deprecate our bespoke component `useFilters` in favor of using the WordPress variety `withFilters`.
 -   Fix screen reader text in `<AdvancedFilters />`.
+-   Added `<AttributeFilter />` component to `<AdvancedFilters />`.
 
 # 5.0.0
 

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -6,7 +6,7 @@ import { SelectControl as Select, Spinner } from '@wordpress/components';
 import { partial } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
-import { useEffect, useState } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -23,7 +23,7 @@ const AttributeFilter = ( props ) => {
 	const { key: filterKey, rule, value } = filter;
 	const { labels, rules } = config;
 
-	const [ attributes, setAttributes ] = useState();
+	const [ attributes, setAttributes ] = useState( [] );
 
 	// Fetch all product attributes on mount.
 	useEffect( () => {
@@ -31,22 +31,48 @@ const AttributeFilter = ( props ) => {
 			path: '/wc/v3/products/attributes',
 		} )
 			.then( ( attrs ) =>
-				attrs.map( ( { name, slug } ) => ( {
-					key: slug,
+				attrs.map( ( { id, name } ) => ( {
+					key: id.toString(),
 					label: name,
 				} ) )
 			)
 			.then( setAttributes );
 	}, [] );
 
-	const [ selectedAttribute, setSelectedAttribute ] = useState();
+	const [ selectedAttribute, setSelectedAttribute ] = useState(
+		Array.isArray( value ) ? value[ 0 ] : ''
+	);
 
 	// Set selected attribute from filter value (in query string).
 	useEffect( () => {
-		if ( Array.isArray( value ) && value[ 0 ] !== selectedAttribute ) {
+		if ( Array.isArray( value ) ) {
 			setSelectedAttribute( value[ 0 ] );
 		}
-	}, [ value, selectedAttribute ] );
+	}, [ value ] );
+
+	const [ attributeTerms, setAttributeTerms ] = useState( [] );
+
+	// Fetch all product attributes on mount.
+	useEffect( () => {
+		if ( ! selectedAttribute ) {
+			return;
+		}
+		setAttributeTerms( [] );
+		apiFetch( {
+			path: `/wc/v3/products/attributes/${ selectedAttribute }/terms`,
+		} )
+			.then( ( terms ) =>
+				terms.map( ( { id, name } ) => ( {
+					key: id.toString(),
+					label: name,
+				} ) )
+			)
+			.then( setAttributeTerms );
+	}, [ selectedAttribute ] );
+
+	const [ selectedAttributeTerm, setSelectedAttributeTerm ] = useState(
+		Array.isArray( value ) ? value[ 1 ] || '' : ''
+	);
 
 	const screenReaderText = getScreenReaderText( filter, config );
 
@@ -86,21 +112,40 @@ const AttributeFilter = ( props ) => {
 								) }
 							>
 								{ attributes ? (
-									<SelectControl
-										label="Attribute name"
-										isSearchable
-										showAllOnFocus
-										options={ attributes }
-										selected={ selectedAttribute || '' }
-										onChange={ ( attr ) => {
-											setSelectedAttribute( attr );
-											onFilterChange(
-												filterKey,
-												'value',
-												[ attr ]
-											);
-										} }
-									/>
+									<Fragment>
+										<SelectControl
+											label="Attribute name"
+											isSearchable
+											showAllOnFocus
+											options={ attributes }
+											selected={ selectedAttribute }
+											onChange={ ( attr ) => {
+												setSelectedAttribute( attr );
+												onFilterChange(
+													filterKey,
+													'value',
+													[ attr ]
+												);
+											} }
+										/>
+										<SelectControl
+											label="Attribute value"
+											isSearchable
+											showAllOnFocus
+											options={ attributeTerms }
+											selected={ selectedAttributeTerm }
+											onChange={ ( term ) => {
+												setSelectedAttributeTerm(
+													term
+												);
+												onFilterChange(
+													filterKey,
+													'value',
+													[ selectedAttribute, term ]
+												);
+											} }
+										/>
+									</Fragment>
 								) : (
 									<Spinner />
 								) }

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -46,14 +46,26 @@ const getScreenReaderText = ( {
 		( term ) => term.key === selectedAttributeTerm
 	);
 
-	const filterStr = `${ attributeName } = ${ attributeTerm }`;
+	const filterStr = interpolateComponents( {
+		/* eslint-disable-next-line max-len */
+		/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
+		mixedString: __(
+			'{{attribute /}} {{equals /}} {{value /}}',
+			'woocommerce-admin'
+		),
+		components: {
+			attribute: <Fragment>{ attributeName }</Fragment>,
+			equals: <Fragment>{ rule.label }</Fragment>,
+			value: <Fragment>{ attributeTerm }</Fragment>,
+		},
+	} );
 
 	return textContent(
 		interpolateComponents( {
 			mixedString: config.labels.title,
 			components: {
 				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
+				rule: <Fragment />,
 				title: <Fragment />,
 			},
 		} )

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -127,7 +127,12 @@ const AttributeFilter = ( props ) => {
 										options={ attributes }
 										selected={ selectedAttribute }
 										onChange={ ( attr ) => {
+											// Clearing the input using delete/backspace causes an empty array to be passed here.
+											if ( typeof attr !== 'string' ) {
+												attr = '';
+											}
 											setSelectedAttribute( attr );
+											setSelectedAttributeTerm( '' );
 											onFilterChange(
 												filterKey,
 												'value',
@@ -149,6 +154,12 @@ const AttributeFilter = ( props ) => {
 											options={ attributeTerms }
 											selected={ selectedAttributeTerm }
 											onChange={ ( term ) => {
+												// Clearing the input using delete/backspace causes an empty array to be passed here.
+												if (
+													typeof term !== 'string'
+												) {
+													term = '';
+												}
 												setSelectedAttributeTerm(
 													term
 												);

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -19,7 +19,7 @@ const getScreenReaderText = ( filter, config ) => {
 };
 
 const AttributeFilter = ( props ) => {
-	const { className, config, filter, onFilterChange } = props;
+	const { className, config, filter, isEnglish, onFilterChange } = props;
 	const { key: filterKey, rule, value } = filter;
 	const { labels, rules } = config;
 
@@ -83,7 +83,14 @@ const AttributeFilter = ( props ) => {
 			tabIndex="0"
 		>
 			<legend className="screen-reader-text">{ labels.add || '' }</legend>
-			<div className="woocommerce-filters-advanced__fieldset">
+			<div
+				className={ classnames(
+					'woocommerce-filters-advanced__fieldset',
+					{
+						'is-english': isEnglish,
+					}
+				) }
+			>
 				{ interpolateComponents( {
 					mixedString: labels.title,
 					components: {
@@ -108,12 +115,13 @@ const AttributeFilter = ( props ) => {
 							<div
 								className={ classnames(
 									className,
-									'woocommerce-filters-advanced__input' // -range?
+									'woocommerce-filters-advanced__attribute-fieldset'
 								) }
 							>
 								{ attributes ? (
 									<Fragment>
 										<SelectControl
+											className="woocommerce-filters-advanced__input woocommerce-search"
 											label="Attribute name"
 											isSearchable
 											showAllOnFocus
@@ -129,6 +137,7 @@ const AttributeFilter = ( props ) => {
 											} }
 										/>
 										<SelectControl
+											className="woocommerce-filters-advanced__input woocommerce-search"
 											label="Attribute value"
 											isSearchable
 											showAllOnFocus

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -13,9 +13,50 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import SelectControl from '../select-control';
+import { textContent } from './utils';
 
-const getScreenReaderText = ( filter, config ) => {
-	return '';
+const getScreenReaderText = ( {
+	attributes,
+	attributeTerms,
+	config,
+	filter,
+	selectedAttribute,
+	selectedAttributeTerm,
+} ) => {
+	if (
+		attributes.length === 0 ||
+		attributeTerms.length === 0 ||
+		selectedAttribute === '' ||
+		selectedAttributeTerm === ''
+	) {
+		return '';
+	}
+
+	const rule = Array.isArray( config.rules )
+		? config.rules.find(
+				( configRule ) => configRule.value === filter.rule
+		  ) || {}
+		: {};
+
+	const { label: attributeName } = attributes.find(
+		( attr ) => attr.key === selectedAttribute
+	);
+	const { label: attributeTerm } = attributeTerms.find(
+		( term ) => term.key === selectedAttributeTerm
+	);
+
+	const filterStr = `${ attributeName } = ${ attributeTerm }`;
+
+	return textContent(
+		interpolateComponents( {
+			mixedString: config.labels.title,
+			components: {
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
+				title: <Fragment />,
+			},
+		} )
+	);
 };
 
 const AttributeFilter = ( props ) => {
@@ -74,7 +115,14 @@ const AttributeFilter = ( props ) => {
 		Array.isArray( value ) ? value[ 1 ] || '' : ''
 	);
 
-	const screenReaderText = getScreenReaderText( filter, config );
+	const screenReaderText = getScreenReaderText( {
+		attributes,
+		attributeTerms,
+		config,
+		filter,
+		selectedAttribute,
+		selectedAttributeTerm,
+	} );
 
 	/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 	return (

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -118,24 +118,29 @@ const AttributeFilter = ( props ) => {
 									'woocommerce-filters-advanced__attribute-fieldset'
 								) }
 							>
-								{ attributes ? (
-									<Fragment>
-										<SelectControl
-											className="woocommerce-filters-advanced__input woocommerce-search"
-											label="Attribute name"
-											isSearchable
-											showAllOnFocus
-											options={ attributes }
-											selected={ selectedAttribute }
-											onChange={ ( attr ) => {
-												setSelectedAttribute( attr );
-												onFilterChange(
-													filterKey,
-													'value',
-													[ attr ]
-												);
-											} }
-										/>
+								{ attributes.length > 0 ? (
+									<SelectControl
+										className="woocommerce-filters-advanced__input woocommerce-search"
+										label="Attribute name"
+										isSearchable
+										showAllOnFocus
+										options={ attributes }
+										selected={ selectedAttribute }
+										onChange={ ( attr ) => {
+											setSelectedAttribute( attr );
+											onFilterChange(
+												filterKey,
+												'value',
+												[ attr ]
+											);
+										} }
+									/>
+								) : (
+									<Spinner />
+								) }
+								{ attributes.length > 0 &&
+									selectedAttribute !== '' &&
+									( attributeTerms.length ? (
 										<SelectControl
 											className="woocommerce-filters-advanced__input woocommerce-search"
 											label="Attribute value"
@@ -154,10 +159,9 @@ const AttributeFilter = ( props ) => {
 												);
 											} }
 										/>
-									</Fragment>
-								) : (
-									<Spinner />
-								) }
+									) : (
+										<Spinner />
+									) ) }
 							</div>
 						),
 					},

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -8,6 +8,7 @@ import interpolateComponents from 'interpolate-components';
 import classnames from 'classnames';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -169,7 +170,10 @@ const AttributeFilter = ( props ) => {
 								{ attributes.length > 0 ? (
 									<SelectControl
 										className="woocommerce-filters-advanced__input woocommerce-search"
-										label="Attribute name"
+										label={ __(
+											'Attribute name',
+											'woocommerce-admin'
+										) }
 										isSearchable
 										showAllOnFocus
 										options={ attributes }
@@ -194,30 +198,43 @@ const AttributeFilter = ( props ) => {
 								{ attributes.length > 0 &&
 									selectedAttribute !== '' &&
 									( attributeTerms.length ? (
-										<SelectControl
-											className="woocommerce-filters-advanced__input woocommerce-search"
-											label="Attribute value"
-											isSearchable
-											showAllOnFocus
-											options={ attributeTerms }
-											selected={ selectedAttributeTerm }
-											onChange={ ( term ) => {
-												// Clearing the input using delete/backspace causes an empty array to be passed here.
-												if (
-													typeof term !== 'string'
-												) {
-													term = '';
+										<Fragment>
+											<span className="woocommerce-filters-advanced__attribute-field-separator">
+												=
+											</span>
+											<SelectControl
+												className="woocommerce-filters-advanced__input woocommerce-search"
+												label={ __(
+													'Attribute value',
+													'woocommerce-admin'
+												) }
+												isSearchable
+												showAllOnFocus
+												options={ attributeTerms }
+												selected={
+													selectedAttributeTerm
 												}
-												setSelectedAttributeTerm(
-													term
-												);
-												onFilterChange(
-													filterKey,
-													'value',
-													[ selectedAttribute, term ]
-												);
-											} }
-										/>
+												onChange={ ( term ) => {
+													// Clearing the input using delete/backspace causes an empty array to be passed here.
+													if (
+														typeof term !== 'string'
+													) {
+														term = '';
+													}
+													setSelectedAttributeTerm(
+														term
+													);
+													onFilterChange(
+														filterKey,
+														'value',
+														[
+															selectedAttribute,
+															term,
+														]
+													);
+												} }
+											/>
+										</Fragment>
 									) : (
 										<Spinner />
 									) ) }

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -27,6 +27,7 @@ import SelectFilter from './select-filter';
 import SearchFilter from './search-filter';
 import NumberFilter from './number-filter';
 import DateFilter from './date-filter';
+import AttributeFilter from './attribute-filter';
 
 const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
@@ -322,6 +323,20 @@ class AdvancedFilters extends Component {
 									) }
 									{ input.component === 'Date' && (
 										<DateFilter
+											className="woocommerce-filters-advanced__fieldset-item"
+											filter={ filter }
+											config={ config.filters[ key ] }
+											onFilterChange={
+												this.onFilterChange
+											}
+											isEnglish={ isEnglish }
+											query={ query }
+											updateFilter={ this.updateFilter }
+										/>
+									) }
+									{ input.component ===
+										'ProductAttribute' && (
+										<AttributeFilter
 											className="woocommerce-filters-advanced__fieldset-item"
 											filter={ filter }
 											config={ config.filters[ key ] }

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -241,5 +241,9 @@
 .woocommerce-filters-advanced__attribute-fieldset {
 	align-items: center;
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 1fr 20px 1fr;
+
+	.woocommerce-filters-advanced__attribute-field-separator {
+		padding: 0 6px;
+	}
 }

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -99,7 +99,7 @@
 		display: inline-block;
 	}
 
-	.components-popover:not( .is-mobile ) .components-popover__content {
+	.components-popover:not(.is-mobile) .components-popover__content {
 		min-width: 180px;
 	}
 }
@@ -133,7 +133,7 @@
 		.woocommerce-filters-advanced__fieldset-item {
 			@include set-grid-item-position( 3, 3 );
 
-			&:nth-child( 1 ) {
+			&:nth-child(1) {
 				display: flex;
 				align-items: center;
 			}
@@ -177,11 +177,11 @@
 		margin: 0 6px 0 0;
 	}
 
-	&.components-icon-button:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
+	&.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
 		color: $studio-woocommerce-purple-30;
 	}
 
-	&:not( :disabled ):not( [aria-disabled='true'] ):focus {
+	&:not(:disabled):not([aria-disabled='true']):focus {
 		color: $studio-woocommerce-purple;
 		background-color: transparent;
 	}
@@ -212,7 +212,7 @@
 			background-color: $gray-200;
 		}
 
-		&:not( :disabled ):not( [aria-disabled='true'] ):focus {
+		&:not(:disabled):not([aria-disabled='true']):focus {
 			background-color: $gray-100;
 			box-shadow: none;
 		}

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -99,7 +99,7 @@
 		display: inline-block;
 	}
 
-	.components-popover:not(.is-mobile) .components-popover__content {
+	.components-popover:not( .is-mobile ) .components-popover__content {
 		min-width: 180px;
 	}
 }
@@ -133,7 +133,7 @@
 		.woocommerce-filters-advanced__fieldset-item {
 			@include set-grid-item-position( 3, 3 );
 
-			&:nth-child(1) {
+			&:nth-child( 1 ) {
 				display: flex;
 				align-items: center;
 			}
@@ -177,11 +177,11 @@
 		margin: 0 6px 0 0;
 	}
 
-	&.components-icon-button:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
+	&.components-icon-button:not( :disabled ):not( [aria-disabled='true'] ):not( .is-default ):hover {
 		color: $studio-woocommerce-purple-30;
 	}
 
-	&:not(:disabled):not([aria-disabled='true']):focus {
+	&:not( :disabled ):not( [aria-disabled='true'] ):focus {
 		color: $studio-woocommerce-purple;
 		background-color: transparent;
 	}
@@ -212,7 +212,7 @@
 			background-color: $gray-200;
 		}
 
-		&:not(:disabled):not([aria-disabled='true']):focus {
+		&:not( :disabled ):not( [aria-disabled='true'] ):focus {
 			background-color: $gray-100;
 			box-shadow: none;
 		}
@@ -236,4 +236,10 @@
 	.separator {
 		text-align: center;
 	}
+}
+
+.woocommerce-filters-advanced__attribute-fieldset {
+	align-items: center;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
 }

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -112,7 +112,8 @@ export default {
 		const query = search
 			? {
 					search,
-					per_page: 10,
+					per_page: 30,
+					_fields: [ 'id', 'sku', 'description', 'attributes' ],
 			  }
 			: {};
 		const product = getQuery().products;

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -150,7 +150,6 @@ export default {
 					height={ 18 }
 					alt=""
 				/>
-				,
 				<span
 					key="name"
 					className="woocommerce-search__result-name"
@@ -162,7 +161,6 @@ export default {
 					</strong>
 					{ match.suggestionAfterMatch }
 				</span>
-				,
 			</Fragment>
 		);
 	},

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -96,12 +96,7 @@ import ProductImage from '../../product-image';
  * @return {string} - variation name
  */
 function getVariationName( variation ) {
-	return variation.attributes.reduce(
-		( desc, attribute, index, arr ) =>
-			desc +
-			`${ attribute.option }${ arr.length === index + 1 ? '' : ', ' }`,
-		''
-	);
+	return variation.attributes.map( ( { option } ) => option ).join( ', ' );
 }
 
 /**


### PR DESCRIPTION
Partially implements #4330.

This PR introduced a new advanced filter for selecting product attributes. It will be added to the Orders report in a follow up.

### Accessibility

Admittedly, our report filters needs some attention again on the accessibility front. The filter being introduced in this PR is of the same quality as the others.

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2020-08-25 at 9 46 54 AM](https://user-images.githubusercontent.com/63922/91182249-ee525c00-e6b7-11ea-8f43-316ec9862736.png)

![2020-08-24 17 50 46](https://user-images.githubusercontent.com/63922/91182677-7a648380-e6b8-11ea-9abe-6ea074e24b24.gif)

### Detailed test instructions:

Add an `attribute` filter to the advanced filters config of any report:

```javascript


			attribute: {
				labels: {
					add: __( 'Attribute', 'woocommerce-admin' ),
					placeholder: __( 'Search attributes', 'woocommerce-admin' ),
					remove: __(
						'Remove attribute filter',
						'woocommerce-admin'
					),
					rule: __(
						'Select a product attribute filter match',
						'woocommerce-admin'
					),
					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
					title: __(
						'{{title}}Attribute{{/title}} {{rule /}} {{filter /}}',
						'woocommerce-admin'
					),
					filter: __( 'Select attributes', 'woocommerce-admin' ),
				},
				rules: [
					{
						value: 'is',
						/* translators: Sentence fragment, logical, "Is" refers to searching for products matching a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
						label: _x(
							'Is',
							'product attribute',
							'woocommerce-admin'
						),
					},
					{
						value: 'is_not',
						/* translators: Sentence fragment, logical, "Is Not" refers to searching for products that don\'t match a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
						label: _x(
							'Is Not',
							'product attribute',
							'woocommerce-admin'
						),
					},
				],
				input: {
					component: 'ProductAttribute',
				},
			},
```

- Go to the report
- Add the "attribute" filter
- Verify the function of selecting an attribute name and value - try different combinations of mouse/keyboard inputs and generally attempt to break things 😄 
- Verify that the URL query is updated when clicking "filter" - `attribute_is[0]=1&attribute_is[1]=2` the value should be a tuple of attribute ID and term ID

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add product attribute advanced report filter component.