### PR TITLE
Clean up copy/paste

### DIFF
--- a/client/task-list/tasks/payments/bacs.js
+++ b/client/task-list/tasks/payments/bacs.js
@@ -9,7 +9,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { Form, H, TextControl } from '@woocommerce/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
-class PayFast extends Component {
+class Bacs extends Component {
 	getInitialConfigValues = () => {
 		return {
 			account_name: '',
@@ -168,4 +168,4 @@ export default compose(
 			updateOptions,
 		};
 	} )
-)( PayFast );
+)( Bacs );


### PR DESCRIPTION
Fixes #3959

Quick PR to clean up some copy/pasted strings and replace with a proper named constant for this component.

__To Test__

- Enable the setup checklist
- Visit the Payments step
- Verify BACS/Direct Bank Transfer works as expected

<img width="1217" alt="Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-08-25 13-16-58" src="https://user-images.githubusercontent.com/22080/91224121-79dae580-e6d6-11ea-9c89-4f6f305aed6b.png">
