### PR TITLE
Onboarding: Do not show extensions bundle test if CBD is selected.

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -84,7 +84,8 @@ class BusinessDetails extends Component {
 		this.bundleInstall =
 			getCountryCode( settings.woocommerce_default_country ) === 'US' &&
 			( industrySlugs.includes( 'fashion-apparel-accessories' ) ||
-				industrySlugs.includes( 'health-beauty' ) );
+				industrySlugs.includes( 'health-beauty' ) ) &&
+			! industrySlugs.includes( 'cbd-other-hemp-derived-products' );
 		this.onContinue = this.onContinue.bind( this );
 		this.validate = this.validate.bind( this );
 		this.getNumberRangeString = this.getNumberRangeString.bind( this );


### PR DESCRIPTION
While testing out some things today, I stumbled upon a little bug. If you go through the onboarding flow using a US-based address and select a fashion industry, **and** CBD - you are still presented with the "bundled extensions" test on the Business Details Step of the onboarding wizard.

The issue with this is the bundled extensions includes WC Pay, which does not support merchants in the CBD space.

The proposed fix in this branch is to check and see if the site has selected the CBD industry option, and if so, do not display the bundled extensions test.

### Screenshots

<img width="1387" alt="Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-08-25 16-00-08" src="https://user-images.githubusercontent.com/22080/91236688-81f24f80-e6ed-11ea-8d60-1359dacfe777.png">

<img width="1383" alt="Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-08-25 16-01-47" src="https://user-images.githubusercontent.com/22080/91236699-8a4a8a80-e6ed-11ea-93f5-e8e5dd4272f6.png">


### Detailed test instructions:

- Launch the onboarding wizard
- On the Industry step, make selections like seen above
- Proceed to the Business Details step and verify that the bundled extension test **is not shown** ( i.e. your screen looks like above )

### Changelog Note:

Tweak: Do not show bundled extensions in OBW when a CBD industry has been selected.

/cc @pmcpinto and @becdetat thinking we might want to pull this in before 1.5.0 final
