### PR TITLE
Tweak button padding so it works on Safari

### DIFF
--- a/client/homescreen/welcome-modal/style.scss
+++ b/client/homescreen/welcome-modal/style.scss
@@ -41,7 +41,7 @@
 		.components-guide__forward-button,
 		.components-guide__back-button {
 			position: initial;
-			padding: 10px 16px;
+			padding: 0 16px;
 			font-weight: 500;
 			font-size: 14px;
 			line-height: 18px;


### PR DESCRIPTION
Fixes #5011

This fixes the padding on the finish, forward, and back buttons on the welcome modal. This only affects Safari, not Chrome. I've tested it in both browsers.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/91244373-8707db00-e78f-11ea-96e4-2b9c91a0f590.png)

### Detailed test instructions:

- Either start a new site or delete the `woocommerce_task_list_welcome_modal_dismissed` option
- Go to WooCommerce Home in Safari
- The welcome modal's buttons should be aligned correctly

### Changelog Note:

Fix: Padding on finish, forward, and back buttons on the welcome modal