### PR TITLE
Add support for advanced filters with multiple instances.

### DIFF
--- a/packages/components/src/advanced-filters/README.md
+++ b/packages/components/src/advanced-filters/README.md
@@ -1,5 +1,4 @@
-Advanced Filters
-===
+# Advanced Filters
 
 Displays a configurable set of filters which can modify query parameters. Display, behavior, and types of filters can be designated by a configuration object.
 
@@ -20,10 +19,16 @@ const config = {
 			labels: {
 				add: __( 'Order Status', 'woocommerce-admin' ),
 				remove: __( 'Remove order status filter', 'woocommerce-admin' ),
-				rule: __( 'Select an order status filter match', 'woocommerce-admin' ),
+				rule: __(
+					'Select an order status filter match',
+					'woocommerce-admin'
+				),
 				// A sentence describing an Order Status filter
 				// See screen shot for context: https://cloudup.com/cSsUY9VeCVJ
-				title: __( 'Order Status {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+				title: __(
+					'Order Status {{rule /}} {{filter /}}',
+					'woocommerce-admin'
+				),
 				filter: __( 'Select an order status', 'woocommerce-admin' ),
 			},
 			rules: [
@@ -44,11 +49,12 @@ const config = {
 			],
 			input: {
 				component: 'SelectControl',
-				options: Object.keys( orderStatuses ).map( key => ( {
+				options: Object.keys( orderStatuses ).map( ( key ) => ( {
 					value: key,
 					label: orderStatuses[ key ],
 				} ) ),
 			},
+			allowMultiple: false, // Set to true to allow multiple instances of this filter.
 		},
 	},
 };
@@ -60,18 +66,16 @@ Taking the above configuration as an example, applying the filter will result in
 
 ### Props
 
-Name | Type | Default | Description
---- | --- | --- | ---
-`config` | Object | `null` | (required) The configuration object required to render filters. See example above.
-`path` | String | `null` | (required) Name of this filter, used in translations.
-`query` | Object | `null` | The query string represented in object form.
-`onAdvancedFilterAction` | Function | `null` | Function to be called after an advanced filter action has been taken.
-`siteLocale` | string | `'en_US'` | The siteLocale for the site.
-`currency` | Object | `null` | (required) The currency instance for the site (@woocommerce/currency).
-
+| Name                     | Type     | Default   | Description                                                                        |
+| ------------------------ | -------- | --------- | ---------------------------------------------------------------------------------- |
+| `config`                 | Object   | `null`    | (required) The configuration object required to render filters. See example above. |
+| `path`                   | String   | `null`    | (required) Name of this filter, used in translations.                              |
+| `query`                  | Object   | `null`    | The query string represented in object form.                                       |
+| `onAdvancedFilterAction` | Function | `null`    | Function to be called after an advanced filter action has been taken.              |
+| `siteLocale`             | string   | `'en_US'` | The siteLocale for the site.                                                       |
+| `currency`               | Object   | `null`    | (required) The currency instance for the site (@woocommerce/currency).             |
 
 ## Input Components
-
 
 ### SelectControl
 
@@ -98,7 +102,6 @@ const config = {
 
 `options`: An array of objects with `key` and `label` properties.
 
-
 ### Search
 
 Render an input for users to search and select using an autocomplete.
@@ -123,7 +126,6 @@ const config = {
 
 `type`: A string Autocompleter type used by the [Search Component](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/components/src/search).
 `getLabels`: A function returning a Promise resolving to an array of objects with `id` and `label` properties.
-
 
 ### Date
 
@@ -155,7 +157,6 @@ const config = {
 	},
 };
 ```
-
 
 ### Numeric Value
 

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -164,11 +164,7 @@ const AttributeFilter = ( props ) => {
 								) }
 								options={ rules }
 								value={ rule }
-								onChange={ partial(
-									onFilterChange,
-									filterKey,
-									'rule'
-								) }
+								onChange={ partial( onFilterChange, 'rule' ) }
 								aria-label={ labels.rule }
 							/>
 						),
@@ -197,11 +193,7 @@ const AttributeFilter = ( props ) => {
 											}
 											setSelectedAttribute( attr );
 											setSelectedAttributeTerm( '' );
-											onFilterChange(
-												filterKey,
-												'value',
-												[ attr ]
-											);
+											onFilterChange( 'value', [ attr ] );
 										} }
 									/>
 								) : (
@@ -236,14 +228,10 @@ const AttributeFilter = ( props ) => {
 													setSelectedAttributeTerm(
 														term
 													);
-													onFilterChange(
-														filterKey,
-														'value',
-														[
-															selectedAttribute,
-															term,
-														]
-													);
+													onFilterChange( 'value', [
+														selectedAttribute,
+														term,
+													] );
 												} }
 											/>
 										</Fragment>

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -25,7 +25,9 @@ const getScreenReaderText = ( {
 	selectedAttributeTerm,
 } ) => {
 	if (
+		! attributes ||
 		attributes.length === 0 ||
+		! attributeTerms ||
 		attributeTerms.length === 0 ||
 		selectedAttribute === '' ||
 		selectedAttributeTerm === ''

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -39,12 +39,15 @@ const getScreenReaderText = ( {
 		  ) || {}
 		: {};
 
-	const { label: attributeName } = attributes.find(
-		( attr ) => attr.key === selectedAttribute
-	);
-	const { label: attributeTerm } = attributeTerms.find(
-		( term ) => term.key === selectedAttributeTerm
-	);
+	const { label: attributeName } =
+		attributes.find( ( attr ) => attr.key === selectedAttribute ) || {};
+	const { label: attributeTerm } =
+		attributeTerms.find( ( term ) => term.key === selectedAttributeTerm ) ||
+		{};
+
+	if ( ! attributeName || ! attributeTerm ) {
+		return '';
+	}
 
 	const filterStr = interpolateComponents( {
 		/* eslint-disable-next-line max-len */
@@ -74,7 +77,7 @@ const getScreenReaderText = ( {
 
 const AttributeFilter = ( props ) => {
 	const { className, config, filter, isEnglish, onFilterChange } = props;
-	const { key: filterKey, rule, value } = filter;
+	const { rule, value } = filter;
 	const { labels, rules } = config;
 
 	const [ attributes, setAttributes ] = useState( [] );

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -107,14 +107,14 @@ const AttributeFilter = ( props ) => {
 		}
 	}, [ value ] );
 
-	const [ attributeTerms, setAttributeTerms ] = useState( [] );
+	const [ attributeTerms, setAttributeTerms ] = useState( false );
 
 	// Fetch all product attributes on mount.
 	useEffect( () => {
 		if ( ! selectedAttribute ) {
 			return;
 		}
-		setAttributeTerms( [] );
+		setAttributeTerms( false );
 		apiFetch( {
 			path: `/wc/v3/products/attributes/${ selectedAttribute }/terms`,
 		} )
@@ -204,7 +204,7 @@ const AttributeFilter = ( props ) => {
 								) }
 								{ attributes.length > 0 &&
 									selectedAttribute !== '' &&
-									( attributeTerms.length ? (
+									( attributeTerms !== false ? (
 										<Fragment>
 											<span className="woocommerce-filters-advanced__attribute-field-separator">
 												=

--- a/packages/components/src/advanced-filters/date-filter.js
+++ b/packages/components/src/advanced-filters/date-filter.js
@@ -40,7 +40,6 @@ class DateFilter extends Component {
 
 		this.onSingleDateChange = this.onSingleDateChange.bind( this );
 		this.onRangeDateChange = this.onRangeDateChange.bind( this );
-		this.onRuleChange = this.onRuleChange.bind( this );
 	}
 
 	getBetweenString() {
@@ -140,8 +139,20 @@ class DateFilter extends Component {
 		return moment().isBefore( moment( dateString ), 'day' );
 	}
 
-	getFilterInputs() {
-		const { filter } = this.props;
+	getFormControl( { date, error, onUpdate, text } ) {
+		return (
+			<DatePicker
+				date={ date }
+				dateFormat={ dateFormat }
+				error={ error }
+				isInvalidDate={ this.isFutureDate }
+				onUpdate={ onUpdate }
+				text={ text }
+			/>
+		);
+	}
+
+	getRangeInput() {
 		const {
 			before,
 			beforeText,
@@ -150,71 +161,51 @@ class DateFilter extends Component {
 			afterText,
 			afterError,
 		} = this.state;
-
-		if ( filter.rule === 'between' ) {
-			return interpolateComponents( {
-				mixedString: this.getBetweenString(),
-				components: {
-					after: (
-						<DatePicker
-							date={ after }
-							text={ afterText }
-							error={ afterError }
-							onUpdate={ partial(
-								this.onRangeDateChange,
-								'after'
-							) }
-							dateFormat={ dateFormat }
-							isInvalidDate={ this.isFutureDate }
-						/>
-					),
-					before: (
-						<DatePicker
-							date={ before }
-							text={ beforeText }
-							error={ beforeError }
-							onUpdate={ partial(
-								this.onRangeDateChange,
-								'before'
-							) }
-							dateFormat={ dateFormat }
-							isInvalidDate={ this.isFutureDate }
-						/>
-					),
-					span: <span className="separator" />,
-				},
-			} );
-		}
-
-		return (
-			<DatePicker
-				date={ before }
-				text={ beforeText }
-				error={ beforeError }
-				onUpdate={ this.onSingleDateChange }
-				dateFormat={ dateFormat }
-				isInvalidDate={ this.isFutureDate }
-			/>
-		);
+		return interpolateComponents( {
+			mixedString: this.getBetweenString(),
+			components: {
+				after: this.getFormControl( {
+					date: after,
+					error: afterError,
+					onUpdate: partial( this.onRangeDateChange, 'after' ),
+					text: afterText,
+				} ),
+				before: this.getFormControl( {
+					date: before,
+					error: beforeError,
+					onUpdate: partial( this.onRangeDateChange, 'before' ),
+					text: beforeText,
+				} ),
+				span: <span className="separator" />,
+			},
+		} );
 	}
 
-	onRuleChange( value ) {
-		const { onFilterChange, filter, updateFilter } = this.props;
-		const { before } = this.state;
-		if ( filter.rule === 'between' && value !== 'between' ) {
-			updateFilter( {
-				key: filter.key,
-				rule: value,
-				value: before ? before.format( isoDateFormat ) : undefined,
-			} );
-		} else {
-			onFilterChange( filter.key, 'rule', value );
+	getFilterInputs() {
+		const { filter } = this.props;
+		const { before, beforeText, beforeError } = this.state;
+
+		if ( filter.rule === 'between' ) {
+			return this.getRangeInput();
 		}
+
+		return this.getFormControl( {
+			date: before,
+			error: beforeError,
+			onUpdate: this.onSingleDateChange,
+			text: beforeText,
+		} );
 	}
 
 	render() {
-		const { className, config, filter, isEnglish } = this.props;
-		const { rule } = filter;
+		const {
+			className,
+			config,
+			filter,
+			isEnglish,
+			onFilterChange,
+		} = this.props;
+		const { key, rule } = filter;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
 		const children = interpolateComponents( {
@@ -229,7 +220,7 @@ class DateFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ this.onRuleChange }
+						onChange={ partial( onFilterChange, key, 'rule' ) }
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/date-filter.js
+++ b/packages/components/src/advanced-filters/date-filter.js
@@ -94,16 +94,16 @@ class DateFilter extends Component {
 	}
 
 	onSingleDateChange( { date, text, error } ) {
-		const { filter, onFilterChange } = this.props;
+		const { onFilterChange } = this.props;
 		this.setState( { before: date, beforeText: text, beforeError: error } );
 
 		if ( date ) {
-			onFilterChange( filter.key, 'value', date.format( isoDateFormat ) );
+			onFilterChange( 'value', date.format( isoDateFormat ) );
 		}
 	}
 
 	onRangeDateChange( input, { date, text, error } ) {
-		const { filter, onFilterChange } = this.props;
+		const { onFilterChange } = this.props;
 
 		this.setState( {
 			[ input ]: date,
@@ -127,10 +127,7 @@ class DateFilter extends Component {
 			}
 
 			if ( nextAfter && nextBefore ) {
-				onFilterChange( filter.key, 'value', [
-					nextAfter,
-					nextBefore,
-				] );
+				onFilterChange( 'value', [ nextAfter, nextBefore ] );
 			}
 		}
 	}
@@ -220,7 +217,7 @@ class DateFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, key, 'rule' ) }
+						onChange={ partial( onFilterChange, 'rule' ) }
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/date-filter.js
+++ b/packages/components/src/advanced-filters/date-filter.js
@@ -202,7 +202,7 @@ class DateFilter extends Component {
 			isEnglish,
 			onFilterChange,
 		} = this.props;
-		const { key, rule } = filter;
+		const { rule } = filter;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( filter, config );
 		const children = interpolateComponents( {

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -76,19 +76,14 @@ class AdvancedFilters extends Component {
 		onAdvancedFilterAction( 'match', { match } );
 	}
 
-	onFilterChange( key, property, value ) {
-		const activeFilters = this.state.activeFilters.map(
-			( activeFilter ) => {
-				if ( key === activeFilter.key ) {
-					return Object.assign( {}, activeFilter, {
-						[ property ]: value,
-					} );
-				}
-				return activeFilter;
-			}
-		);
+	onFilterChange( index, property, value ) {
+		const newActiveFilters = [ ...this.state.activeFilters ];
+		newActiveFilters[ index ] = {
+			...newActiveFilters[ index ],
+			[ property ]: value,
+		};
 
-		this.setState( { activeFilters } );
+		this.setState( { activeFilters: newActiveFilters } );
 	}
 
 	removeFilter( index ) {
@@ -245,6 +240,7 @@ class AdvancedFilters extends Component {
 						.sort( this.orderFilters )
 						.map( ( filter, idx ) => {
 							const { key } = filter;
+							// TODO: try using an ID in the key for multiples to avoid rerendering on filter removal.
 							return (
 								<AdvancedFilterItem
 									key={ key + idx }
@@ -252,7 +248,10 @@ class AdvancedFilters extends Component {
 									currency={ currency }
 									filter={ filter }
 									isEnglish={ isEnglish }
-									onFilterChange={ this.onFilterChange }
+									onFilterChange={ partial(
+										this.onFilterChange,
+										idx
+									) }
 									query={ query }
 									removeFilter={ () =>
 										this.removeFilter( idx )

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -35,13 +35,27 @@ const matches = [
 class AdvancedFilters extends Component {
 	constructor( { query, config } ) {
 		super( ...arguments );
+		this.instanceCounts = {};
+
+		const filtersFromQuery = getActiveFiltersFromQuery(
+			query,
+			config.filters
+		);
+		// @todo: This causes rerenders when instance numbers don't match (from adding/remove before updating query string).
+		const activeFilters = filtersFromQuery.map( ( filter ) => {
+			if ( config.filters[ filter.key ].allowMultiple ) {
+				filter.instance = this.getInstanceNumber( filter.key );
+			}
+
+			return filter;
+		} );
+
 		this.state = {
 			match: query.match || 'all',
-			activeFilters: getActiveFiltersFromQuery( query, config.filters ),
+			activeFilters,
 		};
 
 		this.filterListRef = createRef();
-		this.instanceCounts = {};
 
 		this.onMatchChange = this.onMatchChange.bind( this );
 		this.onFilterChange = this.onFilterChange.bind( this );
@@ -65,8 +79,8 @@ class AdvancedFilters extends Component {
 
 			// Update all multiple instance counts.
 			this.instanceCounts = {};
-			// @todo: This causes rerenders when instance numbers don't match.
-			const newActiveFilters = filtersFromQuery.map( ( filter ) => {
+			// @todo: This causes rerenders when instance numbers don't match (from adding/remove before updating query string).
+			const activeFilters = filtersFromQuery.map( ( filter ) => {
 				if ( config.filters[ filter.key ].allowMultiple ) {
 					filter.instance = this.getInstanceNumber( filter.key );
 				}
@@ -75,9 +89,7 @@ class AdvancedFilters extends Component {
 			} );
 
 			/* eslint-disable react/no-did-update-set-state */
-			this.setState( {
-				activeFilters: newActiveFilters,
-			} );
+			this.setState( { activeFilters } );
 			/* eslint-enable react/no-did-update-set-state */
 		}
 	}

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { SelectControl, Button, Dropdown } from '@wordpress/components';
-import { partial, findIndex, difference, isEqual } from 'lodash';
+import { partial, difference, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
@@ -91,13 +91,9 @@ class AdvancedFilters extends Component {
 		this.setState( { activeFilters } );
 	}
 
-	removeFilter( key ) {
+	removeFilter( index ) {
 		const { onAdvancedFilterAction } = this.props;
 		const activeFilters = [ ...this.state.activeFilters ];
-		const index = findIndex(
-			activeFilters,
-			( filter ) => filter.key === key
-		);
 		onAdvancedFilterAction( 'remove', activeFilters[ index ] );
 		activeFilters.splice( index, 1 );
 		this.setState( { activeFilters } );
@@ -247,18 +243,20 @@ class AdvancedFilters extends Component {
 				>
 					{ activeFilters
 						.sort( this.orderFilters )
-						.map( ( filter ) => {
+						.map( ( filter, idx ) => {
 							const { key } = filter;
 							return (
 								<AdvancedFilterItem
-									key={ key }
+									key={ key + idx }
 									config={ config }
 									currency={ currency }
 									filter={ filter }
 									isEnglish={ isEnglish }
 									onFilterChange={ this.onFilterChange }
 									query={ query }
-									removeFilter={ this.removeFilter }
+									removeFilter={ () =>
+										this.removeFilter( idx )
+									}
 								/>
 							);
 						} ) }

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -146,7 +146,17 @@ class AdvancedFilters extends Component {
 	getAvailableFilterKeys() {
 		const { config } = this.props;
 		const activeFilterKeys = this.state.activeFilters.map( ( f ) => f.key );
-		return difference( Object.keys( config.filters ), activeFilterKeys );
+		const multipleValueFilterKeys = Object.keys( config.filters ).filter(
+			( f ) => config.filters[ f ].allowMultiple || false
+		);
+		const inactiveFilterKeys = difference(
+			Object.keys( config.filters ),
+			activeFilterKeys,
+			multipleValueFilterKeys
+		);
+
+		// Ensure filters that allow multiples are alway present.
+		return [ ...inactiveFilterKeys, ...multipleValueFilterKeys ];
 	}
 
 	addFilter( key, onClose ) {

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -49,7 +49,6 @@ class AdvancedFilters extends Component {
 		this.removeFilter = this.removeFilter.bind( this );
 		this.clearFilters = this.clearFilters.bind( this );
 		this.getUpdateHref = this.getUpdateHref.bind( this );
-		this.updateFilter = this.updateFilter.bind( this );
 		this.onFilter = this.onFilter.bind( this );
 	}
 
@@ -84,19 +83,6 @@ class AdvancedFilters extends Component {
 					return Object.assign( {}, activeFilter, {
 						[ property ]: value,
 					} );
-				}
-				return activeFilter;
-			}
-		);
-
-		this.setState( { activeFilters } );
-	}
-
-	updateFilter( filter ) {
-		const activeFilters = this.state.activeFilters.map(
-			( activeFilter ) => {
-				if ( filter.key === activeFilter.key ) {
-					return filter;
 				}
 				return activeFilter;
 			}
@@ -273,7 +259,6 @@ class AdvancedFilters extends Component {
 									onFilterChange={ this.onFilterChange }
 									query={ query }
 									removeFilter={ this.removeFilter }
-									updateFilter={ this.updateFilter }
 								/>
 							);
 						} ) }

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -8,7 +8,6 @@ import { partial, findIndex, difference, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
-import classnames from 'classnames';
 
 import {
 	getActiveFiltersFromQuery,
@@ -23,11 +22,7 @@ import {
  */
 import Card from '../card';
 import Link from '../link';
-import SelectFilter from './select-filter';
-import SearchFilter from './search-filter';
-import NumberFilter from './number-filter';
-import DateFilter from './date-filter';
-import AttributeFilter from './attribute-filter';
+import AdvancedFilterItem from './item';
 
 const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
@@ -258,110 +253,18 @@ class AdvancedFilters extends Component {
 						.sort( this.orderFilters )
 						.map( ( filter ) => {
 							const { key } = filter;
-							const { input, labels } = config.filters[ key ];
 							return (
-								<li
-									className="woocommerce-filters-advanced__list-item"
+								<AdvancedFilterItem
 									key={ key }
-								>
-									{ input.component === 'SelectControl' && (
-										<SelectFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ config.filters[ key ] }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-										/>
-									) }
-									{ input.component === 'Search' && (
-										<SearchFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ config.filters[ key ] }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-											query={ query }
-										/>
-									) }
-									{ input.component === 'Number' && (
-										<NumberFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ config.filters[ key ] }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-											query={ query }
-											currency={ currency }
-										/>
-									) }
-									{ input.component === 'Currency' && (
-										<NumberFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ {
-												...config.filters[ key ],
-												...{
-													input: {
-														type: 'currency',
-														component: 'Currency',
-													},
-												},
-											} }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-											query={ query }
-											currency={ currency }
-										/>
-									) }
-									{ input.component === 'Date' && (
-										<DateFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ config.filters[ key ] }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-											query={ query }
-											updateFilter={ this.updateFilter }
-										/>
-									) }
-									{ input.component ===
-										'ProductAttribute' && (
-										<AttributeFilter
-											className="woocommerce-filters-advanced__fieldset-item"
-											filter={ filter }
-											config={ config.filters[ key ] }
-											onFilterChange={
-												this.onFilterChange
-											}
-											isEnglish={ isEnglish }
-											query={ query }
-											updateFilter={ this.updateFilter }
-										/>
-									) }
-									<Button
-										className={ classnames(
-											'woocommerce-filters-advanced__line-item',
-											'woocommerce-filters-advanced__remove'
-										) }
-										label={ labels.remove }
-										onClick={ partial(
-											this.removeFilter,
-											key
-										) }
-									>
-										<Gridicon icon="cross-small" />
-									</Button>
-								</li>
+									config={ config }
+									currency={ currency }
+									filter={ filter }
+									isEnglish={ isEnglish }
+									onFilterChange={ this.onFilterChange }
+									query={ query }
+									removeFilter={ this.removeFilter }
+									updateFilter={ this.updateFilter }
+								/>
 							);
 						} ) }
 				</ul>

--- a/packages/components/src/advanced-filters/item.js
+++ b/packages/components/src/advanced-filters/item.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { partial } from 'lodash';
+import Gridicon from 'gridicons';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import SelectFilter from './select-filter';
+import SearchFilter from './search-filter';
+import NumberFilter from './number-filter';
+import DateFilter from './date-filter';
+import AttributeFilter from './attribute-filter';
+
+const AdvancedFilterItem = ( props ) => {
+	const {
+		config,
+		currency,
+		filter: filterValue,
+		isEnglish,
+		onFilterChange,
+		query,
+		removeFilter,
+		updateFilter,
+	} = props;
+	const { key } = filterValue;
+	let filterConfig = config.filters[ key ];
+	const { input, labels } = filterConfig;
+
+	const componentMap = {
+		Currency: NumberFilter,
+		Date: DateFilter,
+		Number: NumberFilter,
+		ProductAttribute: AttributeFilter,
+		Search: SearchFilter,
+		SelectControl: SelectFilter,
+	};
+
+	if ( ! componentMap.hasOwnProperty( input.component ) ) {
+		return;
+	}
+
+	if ( input.component === 'Currency' ) {
+		filterConfig = {
+			...filterConfig,
+			...{
+				input: {
+					type: 'currency',
+					component: 'Currency',
+				},
+			},
+		};
+	}
+
+	const FilterComponent = componentMap[ input.component ];
+
+	return (
+		<li className="woocommerce-filters-advanced__list-item">
+			<FilterComponent
+				className="woocommerce-filters-advanced__fieldset-item"
+				currency={ currency }
+				filter={ filterValue }
+				config={ filterConfig }
+				onFilterChange={ onFilterChange }
+				isEnglish={ isEnglish }
+				query={ query }
+				updateFilter={ updateFilter }
+			/>
+			<Button
+				className={ classnames(
+					'woocommerce-filters-advanced__line-item',
+					'woocommerce-filters-advanced__remove'
+				) }
+				label={ labels.remove }
+				onClick={ partial( removeFilter, key ) }
+			>
+				<Gridicon icon="cross-small" />
+			</Button>
+		</li>
+	);
+};
+
+export default AdvancedFilterItem;

--- a/packages/components/src/advanced-filters/item.js
+++ b/packages/components/src/advanced-filters/item.js
@@ -24,7 +24,6 @@ const AdvancedFilterItem = ( props ) => {
 		onFilterChange,
 		query,
 		removeFilter,
-		updateFilter,
 	} = props;
 	const { key } = filterValue;
 	let filterConfig = config.filters[ key ];
@@ -67,7 +66,6 @@ const AdvancedFilterItem = ( props ) => {
 				onFilterChange={ onFilterChange }
 				isEnglish={ isEnglish }
 				query={ query }
-				updateFilter={ updateFilter }
 			/>
 			<Button
 				className={ classnames(

--- a/packages/components/src/advanced-filters/item.js
+++ b/packages/components/src/advanced-filters/item.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { partial } from 'lodash';
 import Gridicon from 'gridicons';
 import classnames from 'classnames';
 
@@ -73,7 +72,7 @@ const AdvancedFilterItem = ( props ) => {
 					'woocommerce-filters-advanced__remove'
 				) }
 				label={ labels.remove }
-				onClick={ partial( removeFilter, key ) }
+				onClick={ removeFilter }
 			>
 				<Gridicon icon="cross-small" />
 			</Button>

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -137,7 +137,7 @@ class NumberFilter extends Component {
 		if ( Boolean( rangeEnd ) ) {
 			// If there's a value for rangeEnd, we've just changed from "between"
 			// to "less than" or "more than" and need to transition the value
-			onFilterChange( filter.key, 'value', rangeStart || rangeEnd );
+			onFilterChange( 'value', rangeStart || rangeEnd );
 		}
 
 		let labelFormat = '';
@@ -166,7 +166,7 @@ class NumberFilter extends Component {
 			label: sprintf( labelFormat, {
 				field: get( config, [ 'labels', 'add' ] ),
 			} ),
-			onChange: partial( onFilterChange, filter.key, 'value' ),
+			onChange: partial( onFilterChange, 'value' ),
 			currencySymbol,
 			symbolPosition,
 		} );
@@ -181,11 +181,11 @@ class NumberFilter extends Component {
 			: [ filter.value ];
 
 		const rangeStartOnChange = ( newRangeStart ) => {
-			onFilterChange( filter.key, 'value', [ newRangeStart, rangeEnd ] );
+			onFilterChange( 'value', [ newRangeStart, rangeEnd ] );
 		};
 
 		const rangeEndOnChange = ( newRangeEnd ) => {
-			onFilterChange( filter.key, 'value', [ rangeStart, newRangeEnd ] );
+			onFilterChange( 'value', [ rangeStart, newRangeEnd ] );
 		};
 
 		return interpolateComponents( {
@@ -230,7 +230,7 @@ class NumberFilter extends Component {
 			onFilterChange,
 			isEnglish,
 		} = this.props;
-		const { key, rule } = filter;
+		const { rule } = filter;
 		const { labels, rules } = config;
 
 		const children = interpolateComponents( {
@@ -245,7 +245,7 @@ class NumberFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, key, 'rule' ) }
+						onChange={ partial( onFilterChange, 'rule' ) }
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/search-filter.js
+++ b/packages/components/src/advanced-filters/search-filter.js
@@ -70,9 +70,9 @@ class SearchFilter extends Component {
 		this.setState( {
 			selected: values,
 		} );
-		const { filter, onFilterChange } = this.props;
+		const { onFilterChange } = this.props;
 		const idList = values.map( ( value ) => value.key ).join( ',' );
-		onFilterChange( filter.key, 'value', idList );
+		onFilterChange( 'value', idList );
 	}
 
 	getScreenReaderText( filter, config ) {
@@ -106,7 +106,7 @@ class SearchFilter extends Component {
 			isEnglish,
 		} = this.props;
 		const { selected } = this.state;
-		const { key, rule } = filter;
+		const { rule } = filter;
 		const { input, labels, rules } = config;
 		const children = interpolateComponents( {
 			mixedString: labels.title,
@@ -120,7 +120,7 @@ class SearchFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, key, 'rule' ) }
+						onChange={ partial( onFilterChange, 'rule' ) }
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/select-filter.js
+++ b/packages/components/src/advanced-filters/select-filter.js
@@ -33,7 +33,7 @@ class SelectFilter extends Component {
 							config,
 							returnedOptions
 						);
-						onFilterChange( filter.key, 'value', value );
+						onFilterChange( 'value', value );
 					}
 				} );
 		}
@@ -74,7 +74,7 @@ class SelectFilter extends Component {
 			isEnglish,
 		} = this.props;
 		const { options } = this.state;
-		const { key, rule, value } = filter;
+		const { rule, value } = filter;
 		const { labels, rules } = config;
 		const children = interpolateComponents( {
 			mixedString: labels.title,
@@ -88,7 +88,7 @@ class SelectFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, key, 'rule' ) }
+						onChange={ partial( onFilterChange, 'rule' ) }
 						aria-label={ labels.rule }
 					/>
 				),
@@ -100,11 +100,7 @@ class SelectFilter extends Component {
 						) }
 						options={ options }
 						value={ value }
-						onChange={ partial(
-							onFilterChange,
-							filter.key,
-							'value'
-						) }
+						onChange={ partial( onFilterChange, 'value' ) }
 						aria-label={ labels.filter }
 					/>
 				) : (

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -11,6 +11,7 @@ import {
 import {
 	flattenFilters,
 	getActiveFiltersFromQuery,
+	getQueryFromActiveFilters,
 	getUrlKey,
 } from '@woocommerce/navigation';
 
@@ -114,18 +115,18 @@ export function getQueryFromConfig( config, advancedFilters, query ) {
 			return {};
 		}
 
-		return activeFilters
-			.map( ( filter ) =>
+		const filterQuery = getQueryFromActiveFilters(
+			activeFilters.map( ( filter ) =>
 				timeStampFilterDates( advancedFilters, filter )
-			)
-			.reduce(
-				( result, activeFilter ) => {
-					const { key, rule, value } = activeFilter;
-					result[ getUrlKey( key, rule ) ] = value;
-					return result;
-				},
-				{ match: query.match || 'all' }
-			);
+			),
+			{},
+			advancedFilters.filters
+		);
+
+		return {
+			match: query.match || 'all',
+			...filterQuery,
+		};
 	}
 
 	const filter = find( flattenFilters( config.filters ), {

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -12,7 +12,6 @@ import {
 	flattenFilters,
 	getActiveFiltersFromQuery,
 	getQueryFromActiveFilters,
-	getUrlKey,
 } from '@woocommerce/navigation';
 
 /**

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased Changes
+
+-   Support multiple advanced filter instances in getActiveFiltersFromQuery() and getQueryFromActiveFilters().
+
 # 5.0.0
 
 -   `getPersistedQuery` Add a filter for extensions to add a persisted query, `woocommerce_admin_persisted_queries`.

--- a/packages/navigation/src/filters.js
+++ b/packages/navigation/src/filters.js
@@ -152,7 +152,7 @@ export function getQueryFromActiveFilters( activeFilters, query, config ) {
 		if ( filter.value ) {
 			const urlKey = getUrlKey( filter.key, filter.rule );
 
-			if ( config[ filter.key ].allowMultiple ) {
+			if ( config[ filter.key ] && config[ filter.key ].allowMultiple ) {
 				if ( ! data.hasOwnProperty( urlKey ) ) {
 					data[ urlKey ] = [];
 				}

--- a/packages/navigation/src/filters.js
+++ b/packages/navigation/src/filters.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, find, get, omit } from 'lodash';
+import { find, get, omit } from 'lodash';
 
 /**
  * Collapse an array of filter values with subFilters into a 1-dimensional array.

--- a/packages/navigation/src/filters.js
+++ b/packages/navigation/src/filters.js
@@ -40,35 +40,64 @@ export function flattenFilters( filters ) {
  * @return {Array} - array of activeFilters
  */
 export function getActiveFiltersFromQuery( query, config ) {
-	return compact(
-		Object.keys( config ).map( ( configKey ) => {
-			const filter = config[ configKey ];
-			if ( filter.rules ) {
-				const match = find( filter.rules, ( rule ) => {
-					return query.hasOwnProperty(
-						getUrlKey( configKey, rule.value )
-					);
-				} );
+	return Object.keys( config ).reduce( ( activeFilters, configKey ) => {
+		const filter = config[ configKey ];
 
-				if ( match ) {
-					const value = query[ getUrlKey( configKey, match.value ) ];
-					return {
+		if ( filter.rules ) {
+			// Get all rules found in the query string.
+			const matches = filter.rules.filter( ( rule ) =>
+				query.hasOwnProperty( getUrlKey( configKey, rule.value ) )
+			);
+
+			if ( matches.length ) {
+				if ( filter.allowMultiple ) {
+					// If rules were found in the query string, and this filter supports
+					// multiple instances, add all matches to the active filters array.
+					matches.forEach( ( match ) => {
+						const value =
+							query[ getUrlKey( configKey, match.value ) ];
+
+						value.forEach( ( filterValue ) => {
+							activeFilters.push( {
+								key: configKey,
+								rule: match.value,
+								value: filterValue,
+							} );
+						} );
+					} );
+				} else {
+					// If the filter is a single instance, just process the first rule match.
+					const value =
+						query[ getUrlKey( configKey, matches[ 0 ].value ) ];
+					activeFilters.push( {
 						key: configKey,
-						rule: match.value,
+						rule: matches[ 0 ].value,
 						value,
-					};
+					} );
 				}
-				return null;
 			}
-			if ( query[ configKey ] ) {
-				return {
+		} else if ( query[ configKey ] ) {
+			// If the filter doesn't have rules, but allows multiples.
+			if ( filter.allowMultiple ) {
+				const value = query[ configKey ];
+
+				value.forEach( ( filterValue ) => {
+					activeFilters.push( {
+						key: configKey,
+						value: filterValue,
+					} );
+				} );
+			} else {
+				// Filter with no rules and only one instance.
+				activeFilters.push( {
 					key: configKey,
 					value: query[ configKey ],
-				};
+				} );
 			}
-			return null;
-		} )
-	);
+		}
+
+		return activeFilters;
+	}, [] );
 }
 
 /**
@@ -121,7 +150,16 @@ export function getQueryFromActiveFilters( activeFilters, query, config ) {
 		}
 
 		if ( filter.value ) {
-			data[ getUrlKey( filter.key, filter.rule ) ] = filter.value;
+			const urlKey = getUrlKey( filter.key, filter.rule );
+
+			if ( config[ filter.key ].allowMultiple ) {
+				if ( ! data.hasOwnProperty( urlKey ) ) {
+					data[ urlKey ] = [];
+				}
+				data[ urlKey ].push( filter.value );
+			} else {
+				data[ urlKey ] = filter.value;
+			}
 		}
 		return data;
 	}, {} );

--- a/packages/navigation/src/test/filters.js
+++ b/packages/navigation/src/test/filters.js
@@ -79,6 +79,67 @@ describe( 'getActiveFiltersFromQuery', () => {
 		expect( with_no_rules.value ).toEqual( 'pending' );
 	} );
 
+	it( 'should handle multiple filter instances', () => {
+		const filterConfig = {
+			status: {
+				allowMultiple: true,
+				input: {
+					component: 'SelectControl',
+				},
+			},
+			attribute: {
+				allowMultiple: true,
+				rules: [
+					{
+						value: 'is',
+					},
+					{
+						value: 'is_not',
+					},
+				],
+				input: {
+					component: 'ProductAttribute',
+				},
+			},
+		};
+		const query = {
+			status: [ 'pending', 'processing' ],
+			attribute_is: [ [ 1, 2 ] ],
+			attribute_is_not: [
+				[ 1, 3 ],
+				[ 2, 4 ],
+			],
+		};
+
+		const activeFilters = getActiveFiltersFromQuery( query, filterConfig );
+
+		expect( activeFilters ).toEqual( [
+			{
+				key: 'status',
+				value: 'pending',
+			},
+			{
+				key: 'status',
+				value: 'processing',
+			},
+			{
+				key: 'attribute',
+				rule: 'is',
+				value: [ 1, 2 ],
+			},
+			{
+				key: 'attribute',
+				rule: 'is_not',
+				value: [ 1, 3 ],
+			},
+			{
+				key: 'attribute',
+				rule: 'is_not',
+				value: [ 2, 4 ],
+			},
+		] );
+	} );
+
 	it( 'should ignore irrelevant query parameters', () => {
 		const query = {
 			with_select: 'pending', // no rule associated
@@ -161,6 +222,71 @@ describe( 'getQueryFromActiveFilters', () => {
 		expect( nextQuery.valid_date_between ).toBeDefined();
 		expect( nextQuery.invalid_date_1_between ).toBeUndefined();
 		expect( nextQuery.invalid_date_2_between ).toBeUndefined();
+	} );
+
+	it( 'should handle filters with multiple instances', () => {
+		const filterConfig = {
+			status: {
+				allowMultiple: true,
+				input: {
+					component: 'SelectControl',
+				},
+			},
+			attribute: {
+				allowMultiple: true,
+				rules: [
+					{
+						value: 'is',
+					},
+					{
+						value: 'is_not',
+					},
+				],
+				input: {
+					component: 'ProductAttribute',
+				},
+			},
+		};
+		const activeFilters = [
+			{
+				key: 'status',
+				value: 'pending',
+			},
+			{
+				key: 'status',
+				value: 'processing',
+			},
+			{
+				key: 'attribute',
+				rule: 'is',
+				value: [ 1, 2 ],
+			},
+			{
+				key: 'attribute',
+				rule: 'is_not',
+				value: [ 1, 3 ],
+			},
+			{
+				key: 'attribute',
+				rule: 'is_not',
+				value: [ 2, 4 ],
+			},
+		];
+		const query = {};
+		const nextQuery = getQueryFromActiveFilters(
+			activeFilters,
+			query,
+			filterConfig
+		);
+
+		expect( nextQuery ).toEqual( {
+			status: [ 'pending', 'processing' ],
+			attribute_is: [ [ 1, 2 ] ],
+			attribute_is_not: [
+				[ 1, 3 ],
+				[ 2, 4 ],
+			],
+		} );
 	} );
 } );
 


### PR DESCRIPTION
In support of #4330.

This PR adds the ability to define advanced filters that allow for multiple instances/values. The primary use case necessitating this is the Product Attribute filter.

### Screenshots

![2020-08-26 13 21 00](https://user-images.githubusercontent.com/63922/91335869-0224bd80-e79f-11ea-8f7b-14d25f1bfdc0.gif)

### Detailed test instructions:

Add a filter to the advanced filters config of any report **that specifies `allowMultiple: true`**:

```javascript
			attribute: {
				allowMultiple: true,
				labels: {
					add: __( 'Attribute', 'woocommerce-admin' ),
					placeholder: __( 'Search attributes', 'woocommerce-admin' ),
					remove: __(
						'Remove attribute filter',
						'woocommerce-admin'
					),
					rule: __(
						'Select a product attribute filter match',
						'woocommerce-admin'
					),
					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
					title: __(
						'{{title}}Attribute{{/title}} {{rule /}} {{filter /}}',
						'woocommerce-admin'
					),
					filter: __( 'Select attributes', 'woocommerce-admin' ),
				},
				rules: [
					{
						value: 'is',
						/* translators: Sentence fragment, logical, "Is" refers to searching for products matching a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
						label: _x(
							'Is',
							'product attribute',
							'woocommerce-admin'
						),
					},
					{
						value: 'is_not',
						/* translators: Sentence fragment, logical, "Is Not" refers to searching for products that don\'t match a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
						label: _x(
							'Is Not',
							'product attribute',
							'woocommerce-admin'
						),
					},
				],
				input: {
					component: 'ProductAttribute',
				},
			},
```

- Go to the report
- Add the "attribute" filter
- Select an attribute name and value
- Click "add a filter"
- Verify the attribute filter can be selected again
- Add another attribute filter
- Select a different attribute name and value pairing
- Verify that the URL query is updated when clicking "filter" - the value should now be a multidimensional array like: `&attribute_is[0][0]=3&attribute_is[0][1]=119&attribute_is_not[0][0]=1&attribute_is_not[0][1]=33`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: support multiple advanced filter instances.