### PR TITLE
Add Edit products on the move admin note

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -36,6 +36,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_First_Product;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Customize_Store_With_Blocks;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Marketing_Expert;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Test_Checkout;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Edit_Products_On_The_Move;
 
 /**
  * WC_Admin_Events Class.
@@ -105,6 +106,7 @@ class Events {
 		WC_Admin_Notes_Customize_Store_With_Blocks::possibly_add_note();
 		WC_Admin_Notes_Facebook_Marketing_Expert::possibly_add_note();
 		WC_Admin_Notes_Test_Checkout::possibly_add_note();
+		WC_Admin_Notes_Edit_Products_On_The_Move::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -104,4 +104,24 @@ trait NoteTraits {
 			}
 		}
 	}
+
+	/**
+	 * Get if the note has been actioned.
+	 *
+	 * @return bool
+	 */
+	public static function has_note_been_actioned() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( ! empty( $note_ids ) ) {
+			$note = WC_Admin_Notes::get_note( $note_ids[0] );
+
+			if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/src/Notes/WC_Admin_Notes_Edit_Products_On_The_Move.php
+++ b/src/Notes/WC_Admin_Notes_Edit_Products_On_The_Move.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin Edit products on the move note.
+ *
+ * Adds a note to download the mobile app.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Edit_Products_On_The_Move
+ */
+class WC_Admin_Notes_Edit_Products_On_The_Move {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-edit-products-on-the-move';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		// Only add this note if this store is at least a year old.
+		$year_in_seconds = 365 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $year_in_seconds ) ) {
+			return;
+		}
+
+		// Check that the previous mobile app notes have not been actioned.
+		if ( WC_Admin_Notes_Mobile_App::has_note_been_actioned() ) {
+			return;
+		}
+
+		if ( WC_Admin_Notes_Real_Time_Order_Alerts::has_note_been_actioned() ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+
+		$note->set_title( __( 'Edit products on the move', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Edit and create new products from your mobile devices with the Woo app', 'woocommerce-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/mobile/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
+++ b/src/Notes/WC_Admin_Notes_Real_Time_Order_Alerts.php
@@ -34,13 +34,8 @@ class WC_Admin_Notes_Real_Time_Order_Alerts {
 		}
 
 		// Check that the previous mobile app note was not actioned.
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( WC_Admin_Notes_Mobile_App::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
-			$note = WC_Admin_Notes::get_note( $note_ids[0] );
-			if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
-				return;
-			}
+		if ( WC_Admin_Notes_Mobile_App::has_note_been_actioned() ) {
+			return;
 		}
 
 		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app.', 'woocommerce-admin' );


### PR DESCRIPTION
Fixes #4228 

This adds a new note "Edit products on the move" which displays if:

- the store has been active for more than a year
- the "Install Woo mobile app" note has not been actioned
- the "Get real-time order alerts anywhere" note has not been actioned

### Screenshots
![image](https://user-images.githubusercontent.com/224531/91388648-25249f80-e87b-11ea-96ed-3de1453c15f9.png)

### Detailed test instructions:

- On a store more than 90 days old  - set `woocommerce_admin_install_timestamp` option to `1588133382` - 4*30 days ago
- Run the `wc_admin_daily` cron task
- The "Get real-time order alerts anywhere" note should be on the home page
- On a store more than 365 days old - set `woocommerce_admin_install_timestamp` option to `1460262391` - 400 days ago
- Run the `wc_admin_daily` cron task
- The "Edit products on the move" note should be on the home page

Now test the condition that the note not be added because the "Get real-time order alerts anywhere" note has been actioned .

- delete all admin notes from the database - `delete from wp_wc_admin_notes`
- set `woocommerce_admin_install_timestamp` option to `1588133382` - 4*30 days ago
- Run the `wc_admin_daily` cron task
- The "Get real-time order alerts anywhere" note should be on the home page
- Action that note
set `woocommerce_admin_install_timestamp` option to `1460262391` - 400 days ago
- Run the `wc_admin_daily` cron task
- The "Edit products on the move" note should *not* be on the home page

### Changelog Note:

Add: Edit products on the move admin note