### PR TITLE
Update contributors list to include woocommerce.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WooCommerce Admin ===
-Contributors: automattic
+Contributors: woocommerce, automattic
 Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activity, notices, insights, stats, woo commerce, woocommerce
 Requires at least: 5.3.0
 Tested up to: 5.4.2


### PR DESCRIPTION
This is a quick change that we are making to all Woo plugins in the .org repo to included `woocommerce, automattic` as contributors on the plugins.

No real test case here :) just a small text change.

@becdetat - not critical, but if we are cherry-picking further items for 1.5 - it would be nice to include this update too.