### PR TITLE
Show usage modal when skipping the OBW

### DIFF
--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -38,6 +38,7 @@ class StoreDetails extends Component {
 
 		this.state = {
 			showUsageModal: false,
+			skipping: false,
 		};
 
 		// Check if a store address is set so that we don't default
@@ -71,7 +72,10 @@ class StoreDetails extends Component {
 	}
 
 	onSubmit() {
-		this.setState( { showUsageModal: true } );
+		this.setState( {
+			showUsageModal: true,
+			skipping: false,
+		} );
 	}
 
 	async onContinue( values ) {
@@ -159,7 +163,7 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { showUsageModal } = this.state;
+		const { showUsageModal, skipping } = this.state;
 		const { skipProfiler } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
@@ -210,12 +214,17 @@ class StoreDetails extends Component {
 						<Card>
 							{ showUsageModal && (
 								<UsageModal
-									onContinue={ () =>
-										this.onContinue( values )
-									}
+									onContinue={ () => {
+										if ( skipping ) {
+											skipProfiler();
+										} else {
+											this.onContinue( values );
+										}
+									} }
 									onClose={ () =>
 										this.setState( {
 											showUsageModal: false,
+											skipping: false,
 										} )
 									}
 								/>
@@ -265,7 +274,11 @@ class StoreDetails extends Component {
 						isLink
 						className="woocommerce-profile-wizard__footer-link"
 						onClick={ () => {
-							skipProfiler();
+							this.setState( {
+								showUsageModal: true,
+								skipping: true,
+							} );
+							return false;
 						} }
 					>
 						{ __( 'Skip setup wizard', 'woocommerce-admin' ) }


### PR DESCRIPTION
Fixes #5030 

This shows the usage modal (which allows opting in to tracking) when skipping the OBW.

### Detailed test instructions:

1. Start a new store or just delete the `woocommerce_allow_tracking` option.
2. Start the OBW.
3. Skip the OBW (link at the bottom of the first step).
4. The usage modal should appear.
5. Check the "Yes, count me in" checkbox and click "Continue".
6. You should be taken to the home screen.
7. The `woocommerce_allow_tracking` option should be set to `'yes'` - alternatively this can be tested by starting the OBW again, the usage modal won't be displayed either when continuing or when skipping.

### Changelog Note:

Fix: Show usage modal when skipping the OBW