### PR TITLE
Remove industry option for travel.

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -333,11 +333,6 @@ class Onboarding {
 					'use_description'   => false,
 					'description_label' => '',
 				),
-				'travel-and-tourism'              => array(
-					'label'             => __( 'Travel and tourism', 'woocommerce-admin' ),
-					'use_description'   => false,
-					'description_label' => '',
-				),
 				'other'                           => array(
 					'label'             => __( 'Other', 'woocommerce-admin' ),
 					'use_description'   => true,


### PR DESCRIPTION
This is a quick change requested by @pmcpinto in response to some of the tracks data around the Industries step in onboarding. The only change here is the removal of "Travel and Tourism"

__To Test__
- Visit the industries page `wp-admin/admin.php?page=wc-admin&path=%2Fprofiler&step=industry`
- Verify "Travel and Tourism" is no longer shown

<img width="1788" alt="Profiler ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-08-31 09-02-15" src="https://user-images.githubusercontent.com/22080/91741661-e5570400-eb69-11ea-943a-144e044065fd.png">

@becdetat we would like to pick in this change to 1.5
