### PR TITLE
Add product attribute filter to Orders Report.

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -310,6 +310,50 @@ export const advancedFilters = applyFilters(
 					getLabels: getTaxRateLabels,
 				},
 			},
+			attribute: {
+				allowMultiple: true,
+				labels: {
+					add: __( 'Attribute', 'woocommerce-admin' ),
+					placeholder: __( 'Search attributes', 'woocommerce-admin' ),
+					remove: __(
+						'Remove attribute filter',
+						'woocommerce-admin'
+					),
+					rule: __(
+						'Select a product attribute filter match',
+						'woocommerce-admin'
+					),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __(
+						'{{title}}Attribute{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
+					filter: __( 'Select attributes', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'is',
+						/* translators: Sentence fragment, logical, "Is" refers to searching for products matching a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x(
+							'Is',
+							'product attribute',
+							'woocommerce-admin'
+						),
+					},
+					{
+						value: 'is_not',
+						/* translators: Sentence fragment, logical, "Is Not" refers to searching for products that don\'t match a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x(
+							'Is Not',
+							'product attribute',
+							'woocommerce-admin'
+						),
+					},
+				],
+				input: {
+					component: 'ProductAttribute',
+				},
+			},
 		},
 	}
 );

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -61,6 +61,8 @@ class Controller extends ReportsController implements ExportableInterface {
 		$args['match']             = $request['match'];
 		$args['order_includes']    = $request['order_includes'];
 		$args['order_excludes']    = $request['order_excludes'];
+		$args['attribute_is']      = (array) $request['attribute_is'];
+		$args['attribute_is_not']  = (array) $request['attribute_is_not'];
 
 		return $args;
 	}
@@ -428,6 +430,24 @@ class Controller extends ReportsController implements ExportableInterface {
 			'items'             => array(
 				'type' => 'integer',
 			),
+		);
+		$params['attribute_is']      = array(
+			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'array',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['attribute_is_not']  = array(
+			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'array',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -160,6 +160,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$where_subquery[] = "{$order_tax_lookup_table}.tax_rate_id NOT IN ({$excluded_tax_rates}) OR {$order_tax_lookup_table}.tax_rate_id IS NULL";
 		}
 
+		$attribute_subqueries = $this->get_attribute_subqueries( $query_args );
+		if ( $attribute_subqueries['join'] && $attribute_subqueries['where'] ) {
+			// JOIN on product lookup if we haven't already.
+			if ( ! $included_products && ! $excluded_products ) {
+				$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id" );
+			}
+			// Add JOINs for matching attributes.
+			foreach ( $attribute_subqueries['join'] as $attribute_join ) {
+				$this->subquery->add_sql_clause( 'join', $attribute_join );
+			}
+			// Add WHEREs for matching attributes.
+			$where_subquery = array_merge( $where_subquery, $attribute_subqueries['where'] );
+		}
+
 		if ( 0 < count( $where_subquery ) ) {
 			$this->subquery->add_sql_clause( 'where', 'AND (' . implode( " {$operator} ", $where_subquery ) . ')' );
 		}

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -59,6 +59,8 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$args['tax_rate_excludes'] = (array) $request['tax_rate_excludes'];
 		$args['customer']          = $request['customer'];
 		$args['refunds']           = $request['refunds'];
+		$args['attribute_is']      = (array) $request['attribute_is'];
+		$args['attribute_is_not']  = (array) $request['attribute_is_not'];
 		$args['categories']        = (array) $request['categories'];
 		$args['segmentby']         = $request['segmentby'];
 
@@ -490,6 +492,24 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 				'full',
 				'none',
 			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['attribute_is']      = array(
+			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'array',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['attribute_is_not']  = array(
+			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'array',
+			),
+			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['segmentby']         = array(

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -140,7 +140,7 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$variable_product   = WC_Helper_Product::create_variation_product( new WC_Product_Variable() );
 		$product_variations = $variable_product->get_children();
 		$order_variation_1  = wc_get_product( $product_variations[1] ); // Variation: size = large.
-		$order_variation_2  = wc_get_product( $product_variations[4] ); // Variation: size = huge, colour = blue, number = 2.
+		$order_variation_2  = wc_get_product( $product_variations[3] ); // Variation: size = huge, colour = red, number = 2.
 
 		// Create orders for variations.
 		$variation_order_1 = WC_Helper_Order::create_order( $this->user, $order_variation_1 );

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -127,4 +127,83 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'total_customers', $subtotals );
 		$this->assertArrayHasKey( 'segments', $subtotals );
 	}
+
+	/**
+	 * Test filtering by product attribute(s).
+	 */
+	public function test_product_attributes_filter() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a variable product.
+		$variable_product   = WC_Helper_Product::create_variation_product( new WC_Product_Variable() );
+		$product_variations = $variable_product->get_children();
+		$order_variation_1  = wc_get_product( $product_variations[1] ); // Variation: size = large.
+		$order_variation_2  = wc_get_product( $product_variations[4] ); // Variation: size = huge, colour = blue, number = 2.
+
+		// Create orders for variations.
+		$variation_order_1 = WC_Helper_Order::create_order( $this->user, $order_variation_1 );
+		$variation_order_1->set_status( 'completed' );
+		$variation_order_1->save();
+
+		$variation_order_2 = WC_Helper_Order::create_order( $this->user, $order_variation_2 );
+		$variation_order_2->set_status( 'completed' );
+		$variation_order_2->save();
+
+		// Create more orders for simple products.
+		for ( $i = 0; $i < 10; $i++ ) {
+			$order = WC_Helper_Order::create_order( $this->user );
+			$order->set_status( 'completed' );
+			$order->save();
+		}
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'per_page' => 15 ) );
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		// Sanity check before filtering by attribute.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 12, $response_orders['totals']['orders_count'] );
+
+		// Filter by the "size" attribute, with value "large".
+		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
+		$small_term   = get_term_by( 'slug', 'large', 'pa_size' );
+		$request      = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'attribute_is' => array(
+					array( $size_attr_id, $small_term->term_id ),
+				),
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $response_orders['totals']['orders_count'] );
+		$this->assertEquals( $variation_order_1->get_total(), $response_orders['totals']['total_sales'] );
+
+		// Filter by excluding the "size" attribute, with value "large".
+		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
+		$small_term   = get_term_by( 'slug', 'large', 'pa_size' );
+		$request      = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'attribute_is_not' => array(
+					array( $size_attr_id, $small_term->term_id ),
+				),
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $response_orders['totals']['orders_count'] );
+		// This should be the second variation order.
+		$this->assertEquals( $variation_order_2->get_total(), $response_orders['totals']['total_sales'] );
+	}
 }

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -176,12 +176,12 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 
 		// Test bad values to filter parameter.
 		$bad_args = array(
-			'not an array!',                            // Not an array.
-			array( 1, 2, 3 ),                           // Not a tuple.
-			array( 'a', 1 ),                            // Non-numeric attribute ID.
-			array( 1, 'a' ),                            // Non-numeric term ID.
-			array( PHP_INT_MIN, $small_term->term_id ), // Invaid attribute ID.
-			array( $size_attr_id, PHP_INT_MAX ),        // Invaid term ID.
+			'not an array!',                   // Not an array.
+			array( 1, 2, 3 ),                  // Not a tuple.
+			array( 'a', 1 ),                   // Non-numeric attribute ID.
+			array( 1, 'a' ),                   // Non-numeric term ID.
+			array( -1, $small_term->term_id ), // Invaid attribute ID.
+			array( $size_attr_id, -1 ),        // Invaid term ID.
 		);
 
 		foreach ( $bad_args as $bad_arg ) {

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -128,4 +128,82 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'customer_type', $properties );
 		$this->assertArrayHasKey( 'extended_info', $properties );
 	}
+
+	/**
+	 * Test filtering by product attribute(s).
+	 */
+	public function test_product_attributes_filter() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a variable product.
+		$variable_product   = WC_Helper_Product::create_variation_product( new WC_Product_Variable() );
+		$product_variations = $variable_product->get_children();
+		$order_variation_1  = wc_get_product( $product_variations[0] ); // Variation: size = small.
+		$order_variation_2  = wc_get_product( $product_variations[2] ); // Variation: size = huge, colour = red, number = 0.
+
+		// Create orders for variations.
+		$variation_order_1 = WC_Helper_Order::create_order( $this->user, $order_variation_1 );
+		$variation_order_1->set_status( 'completed' );
+		$variation_order_1->save();
+
+		$variation_order_2 = WC_Helper_Order::create_order( $this->user, $order_variation_2 );
+		$variation_order_2->set_status( 'completed' );
+		$variation_order_2->save();
+
+		// Create more orders for simple products.
+		for ( $i = 0; $i < 10; $i++ ) {
+			$order = WC_Helper_Order::create_order( $this->user );
+			$order->set_status( 'completed' );
+			$order->save();
+		}
+
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'per_page' => 15 ) );
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		// Sanity check before filtering by attribute.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 12, count( $response_orders ) );
+
+		// Filter by the "size" attribute, with value "small".
+		$size_attr_id = wc_attribute_taxonomy_id_by_name( 'pa_size' );
+		$small_term   = get_term_by( 'slug', 'small', 'pa_size' );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'attribute_is' => array(
+					array( $size_attr_id, $small_term->term_id ),
+				),
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $response_orders ) );
+		$this->assertEquals( $response_orders[0]['order_id'], $variation_order_1->get_id() );
+
+		// Verify the opposite result set.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'attribute_is_not' => array(
+					array( $size_attr_id, $small_term->term_id ),
+				),
+				'per_page'         => 15,
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $response_orders ) );
+		$this->assertEquals( $response_orders[0]['order_id'], $variation_order_2->get_id() );
+	}
 }


### PR DESCRIPTION
Partially implements #4330.

This PR adds the Product Attribute advanced filter to the Orders Report. It handles the query parameters on the PHP side, modifying the orders and order stats queries appropriately.

### Screenshots

![](https://user-images.githubusercontent.com/63922/91182249-ee525c00-e6b7-11ea-8f43-316ec9862736.png)

### Detailed test instructions:

- Ensure you have orders placed for product variations
- Go to Analytics > Orders
- Add an attribute filter (or several)
- Verify the results - check the stats numbers, summary numbers, and table values

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add Product Attribute filter to Orders Report.