### PR TITLE
New marketing copy for the Kliken Google Ads plugin

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -407,10 +407,13 @@ class BusinessDetails extends Component {
 			},
 			{
 				slug: 'kliken-marketing-for-google',
-				title: __( 'Drive sales with Google Ads', 'woocommerce-admin' ),
+				title: __(
+					'Drive traffic to your store with Google Ads & Marketing by Kliken',
+					'woocommerce-admin'
+				),
 				icon: 'onboarding/g-shopping.png',
 				description: __(
-					'Get in front of new customers on Google and secure $150 in ads credit with Kliken’s integration.',
+					'Get in front of shoppers and drive traffic so you can grow your business with Smart Shopping Campaigns and free listings.',
 					'woocommerce-admin'
 				),
 			},


### PR DESCRIPTION
Fixes #5063 

This updates the marketing copy for the Kliken Google Ads plugin

### Screenshots
![image](https://user-images.githubusercontent.com/224531/91928724-1e38d980-ed20-11ea-9922-ea35ed5d3084.png)

### Detailed test instructions:

1. Start the onboarding wizard
2. Set the store's country to outside of the US
3. Continue to the business details page
4. Set the product count and 'currently selling elsewhere' dropdowns
5. The plugins to install will appear. Verify that the Kliken copy matches the screenshot.

### Changelog Note:

Tweak: New marketing copy for the Kliken Google Ads plugin