### PR TITLE
Automated taxes smart default

### DIFF
--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -217,7 +217,7 @@ class ProfileWizard extends Component {
 			updateNote,
 			updateProfileItems,
 			connectToJetpack,
-			clearSettingsCache,
+			clearTaskCache,
 		} = this.props;
 		recordEvent( 'storeprofiler_complete' );
 
@@ -235,14 +235,14 @@ class ProfileWizard extends Component {
 		}
 
 		updateProfileItems( { completed: true } ).then( () => {
+			clearTaskCache();
+
 			if ( shouldConnectJetpack ) {
 				document.body.classList.add( 'woocommerce-admin-is-loading' );
 
 				connectToJetpack(
 					getHistory().push( getNewPath( {}, '/', {} ) )
 				);
-
-				clearSettingsCache();
 			} else {
 				getHistory().push( getNewPath( {}, '/', {} ) );
 			}
@@ -341,8 +341,7 @@ export default compose(
 		} = dispatch( ONBOARDING_STORE_NAME );
 		const { createNotice } = dispatch( 'core/notices' );
 
-		const clearSettingsCache = () => {
-			console.log( 'invalidate occurs' );
+		const clearTaskCache = () => {
 			invalidateResolutionForStoreSelector( 'getTasksStatus' );
 		};
 
@@ -359,7 +358,7 @@ export default compose(
 			updateNote,
 			updateOptions,
 			updateProfileItems,
-			clearSettingsCache,
+			clearTaskCache,
 		};
 	} ),
 	window.wcSettings.plugins

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -17,7 +17,6 @@ import {
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
 	withPluginsHydration,
-	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -10,6 +10,7 @@ use \Automattic\WooCommerce\Admin\Loader;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Profiler;
 use \Automattic\WooCommerce\Admin\PluginsHelper;
 use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
+use \Automattic\WooCommerce\Admin\Features\OnboardingAutomateTaxes;
 
 /**
  * Contains backend logic for the onboarding profile and checklist feature.
@@ -71,6 +72,7 @@ class Onboarding {
 
 		// Hook up dependent classes.
 		new OnboardingSetUpShipping();
+		new OnboardingAutomateTaxes();
 	}
 
 	/**

--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Onboarding - set up automated tax calculation.
+ *
+ * @package Woocommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Features;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+/**
+ * This contains logic for setting up shipping when the profiler completes.
+ */
+class OnboardingAutomateTaxes {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action(
+			'woocommerce_onboarding_profile_completed',
+			array(
+				__CLASS__,
+				'on_onboarding_profile_completed',
+			)
+		);
+	}
+
+	/**
+	 * Set up automated taxes.
+	 */
+	public static function on_onboarding_profile_completed() {
+		$jetpack_connected = null;
+		$wcs_version       = null;
+		$wcs_tos_accepted  = null;
+
+		if ( class_exists( '\Jetpack_Data' ) ) {
+			$user_token        = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+			$jetpack_connected = isset( $user_token->external_user_id );
+		}
+
+		if ( class_exists( '\WC_Connect_Loader' ) ) {
+			$wcs_version = \WC_Connect_Loader::get_wcs_version();
+		}
+
+		if ( class_exists( '\WC_Connect_Options' ) ) {
+			$wcs_tos_accepted = \WC_Connect_Options::get_option( 'tos_accepted' );
+		}
+
+		if ( $jetpack_connected && $wcs_version && $wcs_tos_accepted ) {
+			update_option( 'wc_connect_taxes_enabled', 'yes' );
+			update_option( 'woocommerce_calc_taxes', 'yes' );
+		}
+	}
+
+	/**
+	 * Check if automated taxes are supported.
+	 */
+	private static function automated_tax_is_supported() {
+		return in_array( WC()->countries->get_base_country(), \OnboardingTasks::get_automated_tax_supported_countries(), true );
+	}
+}


### PR DESCRIPTION
Fixes #4594

This opts in to automated tax calculation for the user when they complete the profiler if the following conditions are met:

1. Jetpack is installed and connected
2. WCS is installed and TOS accepted
3. You're in a country where automated tax is supported

Originally I looked at solving this in the client, but found that there was an existing pattern for running code after profiler completion which @becdetat implemented in https://github.com/woocommerce/woocommerce-admin/pull/4857

This approach ended up being quite a lot simpler with just one caveat: When completing the profiler in the client we have to force the onboarding task status cache to be invalidated to ensure that when we do a client side navigate to the home page, the status of the tax task will correctly update.

### Accessibility
n/a

### Detailed test instructions:

This one is a hassle to test as you'll need to:

1. Have Jetpack installed and connected
2. Have WCS installed and accept TOS
3. Have an uncompleted onboarding wizard
4. Once all these are met you can go through the onboarding wizard, choices don't matter too much
5. Once you finish the last step of the Wizard and are redirected to the Woo home page, you should see that the tax setup task is complete.

### Changelog Note:

Enhancement: opt in to automated taxes by default for users who Jetpack and WCS installed.