### PR TITLE
Fix `analytics_filters_filter` event props.

### DIFF
--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -72,7 +72,7 @@ class ReportFilters extends Component {
 				);
 				recordEvent( 'analytics_filters_filter', {
 					report,
-					snakeCaseData,
+					...snakeCaseData,
 				} );
 				break;
 			case 'clear_all':


### PR DESCRIPTION
This PR seeks to remedy the camel case `snakeCaseData` (lol) event property causing the `analytics_filters_filter` event to be rejected by Tracks.

### Detailed test instructions:

- Enable tracking
- Go to Analytics > Orders
- Open dev tools
- Apply some advanced filters (click "filter" button)
- Verify that the tracks event props for `analytics_filters_filter` **are not** camel case

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - non user facing issue that doesn't break anything.