### PR TITLE
Add ToS agreement copy to the WCPay setup task

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -32,6 +32,7 @@ import './style.scss';
 import CartModal from '../dashboard/components/cart-modal';
 import { getAllTasks, recordTaskViewEvent } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
+import sanitizeHTML from '../lib/sanitize-html';
 
 class TaskDashboard extends Component {
 	constructor( props ) {
@@ -281,10 +282,18 @@ class TaskDashboard extends Component {
 					variant={ task.completed ? 'body.small' : 'button' }
 				>
 					{ task.title }
+					{ task.additionalInfo && (
+						<div
+							className="woocommerce-task__additional-info"
+							dangerouslySetInnerHTML={ sanitizeHTML(
+								task.additionalInfo
+							) }
+						></div>
+					) }
 					{ task.time && ! task.completed && (
-						<span className="woocommerce-task__estimated-time">
+						<div className="woocommerce-task__estimated-time">
 							{ task.time }
-						</span>
+						</div>
 					) }
 				</Text>
 			);
@@ -306,7 +315,14 @@ class TaskDashboard extends Component {
 			}
 
 			if ( ! task.onClick ) {
-				task.onClick = () => updateQueryString( { task: task.key } );
+				task.onClick = ( e ) => {
+					if ( e.target.nodeName === 'A' ) {
+						// This is a nested link, so don't activate this task.
+						return false;
+					}
+
+					updateQueryString( { task: task.key } );
+				};
 			}
 
 			return task;

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -40,11 +40,11 @@
 		}
 	}
 
+	.woocommerce-task__additional-info,
 	.woocommerce-task__estimated-time {
 		color: $gray-700;
 		font-weight: 400;
 		font-size: 12px;
-		display: block;
 	}
 
 	.woocommerce-card.is-narrow {

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -143,7 +143,12 @@ export function getAllTasks( {
 			title: __( 'Set up WooCommerce Payments', 'woocommerce-admin' ),
 			container: <Fragment />,
 			completed: wcPayIsConnected,
-			onClick: async () => {
+			onClick: async ( e ) => {
+				if ( e.target.nodeName === 'A' ) {
+					// This is a nested link, so don't activate the task.
+					return false;
+				}
+
 				await new Promise( ( resolve, reject ) => {
 					// This task doesn't have a view, so the recordEvent call
 					// in TaskDashboard.recordTaskView() is never called. So
@@ -169,6 +174,10 @@ export function getAllTasks( {
 				window.wcAdminFeatures.wcpay &&
 				woocommercePaymentsInstalled &&
 				countryCode === 'US',
+			additionalInfo: __(
+				'By setting up, you are agreeing to the <a href="https://wordpress.com/tos/" target="_blank">Terms of Service</a>',
+				'woocommerce-admin'
+			),
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 		{


### PR DESCRIPTION
Fixes #5078

This adds copy re accepting the ToS to the WCPay task

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
![image](https://user-images.githubusercontent.com/224531/92059955-ee4c0d80-edd5-11ea-9eb1-5d61e9df37b0.png)

### Detailed test instructions:

- Create a site in the US, with WooCommerce Payments installed
- Go to the WooCommerce home screen
- The above copy should be added to the WCPay task
- Following the link should open the ToS in a new tab, and not activate the task
- Clicking the task outside of the link should activate the task

### Changelog Note:

Tweak: Add ToS agreement copy to the WCPay setup task