### PR TITLE
Onboarding: Add TOS note to bundle install.

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -17,6 +17,7 @@ import { keys, get, pickBy } from 'lodash';
 import {
 	H,
 	Card,
+	Link,
 	SelectControl,
 	Form,
 	TextControl,
@@ -361,18 +362,39 @@ class BusinessDetails extends Component {
 			  )
 			: '';
 		return (
-			<Text variant="caption" as="p">
-				{ sprintf(
-					_n(
-						'The following plugin will be installed for free: %s. %s',
-						'The following plugins will be installed for free: %s. %s',
-						extensions.length,
-						'woocommerce-admin'
-					),
-					extensionsList,
-					accountRequiredText
+			<div className="woocommerce-profile-wizard__footnote">
+				<Text variant="caption" as="p">
+					{ sprintf(
+						_n(
+							'The following plugin will be installed for free: %s. %s',
+							'The following plugins will be installed for free: %s. %s',
+							extensions.length,
+							'woocommerce-admin'
+						),
+						extensionsList,
+						accountRequiredText
+					) }
+				</Text>
+				{ this.bundleInstall && (
+					<Text variant="caption" as="p">
+						{ interpolateComponents( {
+							mixedString: __(
+								'By installing Jetpack and WooCommerce Services plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
+								'woocommerce-admin'
+							),
+							components: {
+								link: (
+									<Link
+										href="https://wordpress.com/tos/"
+										target="_blank"
+										type="external"
+									/>
+								),
+							},
+						} ) }
+					</Text>
 				) }
-			</Text>
+			</div>
 		);
 	}
 

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -133,6 +133,14 @@
 			display: flex;
 			text-decoration: none;
 		}
+
+		.woocommerce-profile-wizard__footnote {
+			p {
+				color: $gray-700;
+				text-align: left;
+				margin-bottom: 12px;
+			}
+		}
 	}
 
 	#woocommerce-layout__primary {


### PR DESCRIPTION
Fixes #5081

This branch adds in a line of text around terms of service when installing the "bundle" of extensions.

### Screenshots

__Before__
<img width="1393" alt="Setup Wizard ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-09-03 13-51-31" src="https://user-images.githubusercontent.com/22080/92165980-b603f980-edec-11ea-9ad5-fc53073cfe1e.png">

__After__
<img width="1393" alt="Setup Wizard ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-09-03 13-48-01" src="https://user-images.githubusercontent.com/22080/92165998-bb614400-edec-11ea-8e1c-6dde4a704d70.png">

### Detailed test instructions:

- Check out this branch and launch the profile wizard: `wp-admin/admin.php?page=wc-admin&reset_profiler=1`
- Be sure to use a US-based address on the first step and select the fashion industry on step 2.
- Proceed to step 4 and verify your screen looks like the _after_ above.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Tweak: Add terms of service link to bundled extension install.

cc @becdetat 
