### PR TITLE
Add ToS copy to OBW business details

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -357,14 +357,16 @@ class BusinessDetails extends Component {
 				</p>
 			);
 		}
+
 		const accountRequiredText = this.bundleInstall
 			? __(
 					'User accounts are required to use these features.',
 					'woocommerce-admin'
 			  )
 			: '';
+
 		return (
-			<Fragment>
+			<div className="woocommerce-profile-wizard__footnote">
 				<p>
 					{ sprintf(
 						_n(
@@ -377,7 +379,28 @@ class BusinessDetails extends Component {
 						accountRequiredText
 					) }
 				</p>
-			</Fragment>
+				{ this.bundleInstall && (
+					<p>
+						{ interpolateComponents( {
+							mixedString: __(
+								'By installing Jetpack and WooCommerce Services plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
+								'woocommerce-admin'
+							),
+							components: {
+								link: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a
+										href="https://wordpress.com/tos/"
+										target="_blank"
+										type="external"
+										rel="noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</p>
+				) }
+			</div>
 		);
 	}
 

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -137,6 +137,14 @@
 		width: 100%;
 	}
 
+	.woocommerce-profile-wizard__footnote {
+		p {
+			color: $gray-700;
+			text-align: left;
+			margin-bottom: 12px;
+		}
+	}
+
 	.woocommerce-layout .woocommerce-layout__main {
 		padding-right: 0;
 	}


### PR DESCRIPTION
Fixes #5081 (in 1.5.0)

This adds some text to the business details step if the bundle is able to be installed, including a link to the ToS.

@timmyc [originally did this](https://github.com/woocommerce/woocommerce-admin/pull/5096) however there were some conflicts when cherry-picking it into the 1.5.0-rc.5 branch, so I've recreated it.

### Screenshots
Before:
![](https://user-images.githubusercontent.com/22080/92165980-b603f980-edec-11ea-9ad5-fc53073cfe1e.png)

After:
![image](https://user-images.githubusercontent.com/224531/92199689-398c1c00-eebb-11ea-8334-ddb74901ed8a.png)

### Detailed test instructions:

- Check out this branch and launch the profile wizard: `wp-admin/admin.php?page=wc-admin&reset_profiler=1`
- Be sure to use a US-based address on the first step and select the fashion industry on step 2.
- Proceed to step 4 and verify your screen looks like the after above.

### Changelog Note:

Tweak: Add terms of service link to bundled extension install.