### PR TITLE
Avoid changing product titles by removing variation title filter usage.

### DIFF
--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -19,6 +19,13 @@ import { CurrencyContext } from '../../../lib/currency-context';
 const manageStock = getSetting( 'manageStock', 'no' );
 const stockStatuses = getSetting( 'stockStatuses', {} );
 
+const getFullVariationName = ( rowData ) =>
+	get( rowData, [ 'extended_info', 'name' ], '' ) +
+	' - ' +
+	get( rowData, [ 'extended_info', 'attributes' ], [] )
+		.map( ( { option } ) => option )
+		.join( ', ' );
+
 class VariationsReportTable extends Component {
 	constructor() {
 		super();
@@ -103,7 +110,7 @@ class VariationsReportTable extends Component {
 				low_stock_amount: lowStockAmount,
 				sku,
 			} = extendedInfo;
-			const name = get( row, [ 'extended_info', 'name' ], '' );
+			const name = getFullVariationName( row );
 			const ordersLink = getNewPath(
 				persistedQuery,
 				'/analytics/orders',

--- a/src/API/ProductVariations.php
+++ b/src/API/ProductVariations.php
@@ -30,11 +30,64 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 	public function get_collection_params() {
 		$params           = parent::get_collection_params();
 		$params['search'] = array(
-			'description'       => __( 'Search by similar product name or sku.', 'woocommerce-admin' ),
+			'description'       => __( 'Search by similar product name, sku, or attribute value.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		return $params;
+	}
+
+	/**
+	 * Add in conditional search filters for variations.
+	 *
+	 * @param string $where Where clause used to search posts.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public static function add_wp_query_filter( $where, $wp_query ) {
+		global $wpdb;
+
+		$search = $wp_query->get( 'search' );
+		if ( $search ) {
+			$like       = '%' . $wpdb->esc_like( $search ) . '%';
+			$conditions = array(
+				$wpdb->prepare( "{$wpdb->posts}.post_title LIKE %s", $like ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->prepare( 'attr_search_meta.meta_value LIKE %s', $like ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			);
+
+			if ( wc_product_sku_enabled() ) {
+				$conditions[] = $wpdb->prepare( 'wc_product_meta_lookup.sku LIKE %s', $like );
+			}
+
+			$where .= ' AND (' . implode( ' OR ', $conditions ) . ')';
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Join posts meta tables when variation search query is present.
+	 *
+	 * @param string $join Join clause used to search posts.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public static function add_wp_query_join( $join, $wp_query ) {
+		global $wpdb;
+
+		$search = $wp_query->get( 'search' );
+		if ( $search ) {
+			$join .= " LEFT JOIN {$wpdb->postmeta} AS attr_search_meta
+						ON {$wpdb->posts}.ID = attr_search_meta.post_id
+						AND attr_search_meta.meta_key LIKE 'attribute_pa_%' ";
+		}
+
+		if ( wc_product_sku_enabled() && ! strstr( $join, 'wc_product_meta_lookup' ) ) {
+			$join .= " LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup
+						ON $wpdb->posts.ID = wc_product_meta_lookup.product_id ";
+		}
+
+		return $join;
 	}
 
 	/**
@@ -61,12 +114,12 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		add_filter( 'posts_where', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_filter' ), 10, 2 );
-		add_filter( 'posts_join', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_join' ), 10, 2 );
+		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
+		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
-		remove_filter( 'posts_where', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_filter' ), 10 );
-		remove_filter( 'posts_join', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_join' ), 10 );
+		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
+		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
 		remove_filter( 'posts_groupby', array( 'Automattic\WooCommerce\Admin\API\Products', 'add_wp_query_group_by' ), 10 );
 		return $response;
 	}

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -128,14 +128,6 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
-			// Ensure full variation titles are queried.
-			add_filter(
-				'woocommerce_product_variation_title_include_attributes',
-				function() {
-					return true;
-				}
-			);
-
 			$this->initialize_queries();
 
 			$selections = $this->selected_columns( $query_args );

--- a/src/API/Reports/Segmenter.php
+++ b/src/API/Reports/Segmenter.php
@@ -380,9 +380,13 @@ class Segmenter {
 			$segment_objects = wc_get_products( $args );
 
 			foreach ( $segment_objects as $segment ) {
-				$id                    = $segment->get_id();
-				$segments[]            = $id;
-				$segment_labels[ $id ] = $segment->get_name();
+				$id           = $segment->get_id();
+				$segments[]   = $id;
+				$product_name = $segment->get_name();
+				$separator    = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', $segment );
+				$attributes   = wc_get_formatted_variation( $segment, true, false );
+
+				$segment_labels[ $id ] = $product_name . $separator . $attributes;
 			}
 
 			// If no variations were specified, add a segment for the parent product (variation = 0).

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -172,14 +172,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array $query_args Query parameters.
 	 */
 	protected function include_extended_info( &$products_data, $query_args ) {
-		// Ensure full variation titles are queried.
-		add_filter(
-			'woocommerce_product_variation_title_include_attributes',
-			function() {
-				return true;
-			}
-		);
-
 		foreach ( $products_data as $key => $product_data ) {
 			$extended_info = new \ArrayObject();
 			if ( $query_args['extended_info'] ) {


### PR DESCRIPTION
I'm considering the use of `woocommerce_product_variation_title_include_attributes` harmful. It was introduced in https://github.com/woocommerce/woocommerce-admin/pull/4715.

When determining the product title, the variations data store will **update the database** if the value differs!

https://github.com/woocommerce/woocommerce/blob/9c6c0d73d817328e3a90b6e3e0b1b0f0b7662270/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L86-94

We're using this filter so attribute values are included in Product Variation titles, but **we should not be modifying products** just to make querying them easier. (I'm sure this was 100% an unintended side effect)

This PR
* Removes the use of the `woocommerce_product_variation_title_include_attributes ` filter
* Generates a title using the attribute values on the client side (JS)
* Queries the attribute values when searching for variations (SQL)

### Detailed test instructions:

- Visit the Product Report > Single Product and search for a variable product.
- See the Product Report's variation names shown in full.
- Select "single variation" from the dropdown
- Search for variations using attribute values ( like, "orange" color )
- Verify results are shown as expected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: avoid filter usage that potentially modifies Product Variation titles.