### PR TITLE
Onboarding: Set woocommerce_setup_jetpack_opted_in on Jetpack connect

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -101,6 +101,9 @@ class Onboarding {
 			2
 		);
 
+		// Always hook into Jetpack connection even if outside of admin.
+		add_action( 'jetpack_site_registered', array( $this, 'set_woocommerce_setup_jetpack_opted_in' ) );
+
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -113,6 +116,13 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
+	}
+
+	/**
+	 * Sets the woocommerce_setup_jetpack_opted_in to true when Jetpack connects to WPCOM.
+	 */
+	public function set_woocommerce_setup_jetpack_opted_in() {
+		update_option( 'woocommerce_setup_jetpack_opted_in', true );
 	}
 
 	/**


### PR DESCRIPTION
An attempt at

Fixes #5087

The problem detailed in the issue above is that the new bundled install flow results in a state where Jetpack could be connected, but WooCommerce Services seems unaware of this. Thankfully @c-shultz pointed out that WCS keys off the value of the `woocommerce_setup_jetpack_opted_in` option to determine if things like automated taxes can be setup.

In the non-bundle install flow, [we are currently manually toggling this site option](https://github.com/woocommerce/woocommerce-admin/blob/main/client/profile-wizard/steps/benefits/index.js#L101-L103) on the benefits screen, but since the bundle flow does not load the benefits screen, the option never seems to be set.

The proposed solution here is to hook into [the action](https://github.com/Automattic/jetpack/blob/c2e0519b8c4224472505184584a211f6af98cb68/packages/connection/src/class-manager.php#L926-L931) that fires in Jetpack when a connection is established to WordPress.com - instead of having to remember to manually set the WCS option to true.

Looking ahead, it seems like this logic should probably be handled on the WCS side of things so we don't have to wrangle these random site options here in wc-admin. The current solution, as we have seen here, is quite brittle and prone to errors.

One nice side-affect of this route is if a user ends up establishing a Jetpack connection outside of the context of wc-admin, this should get everything in a state in WCS that is ready to roll.

### Detailed test instructions:
Testing this is kind of a beast, sorry. It is also best done on a JN or atomic ephemeral site.

- Install WooCommerce and update to the latest rc of 4.5
- `npm run test:zip` this branch, upload, and activate
- Visit your WooCommerce System Status page and verify the plugin version is being used ( paranoia )
- Next go through the OBW, use a US based address, and a fashion industry to enable the bundle install option

Here I've had a variety of experiences after completing the OBW during 4.5, but it seems now if you do the bundle install flow, you will land on the home screen of Woo.

- Next go to the wp-admin main dashboard, and follow the Jetpack prompt to connect to WordPress.com
- Do that entire process, then go back to the Woo home screen, and click on the tax step in the task list.
- Verify you are prompted with the option of setting up automated taxes, Click Yes.
- Then navigate to WooCommerce > Settings > Taxes and verify indeed that it is setup for automated taxes.

cc @becdetat for possible inclusion in 1.5 final.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
