### PR TITLE
Add performance on mobile admin note

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -37,6 +37,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Customize_Store_With_Bloc
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Marketing_Expert;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Test_Checkout;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Edit_Products_On_The_Move;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Performance_On_Mobile;
 
 /**
  * WC_Admin_Events Class.
@@ -107,6 +108,7 @@ class Events {
 		WC_Admin_Notes_Facebook_Marketing_Expert::possibly_add_note();
 		WC_Admin_Notes_Test_Checkout::possibly_add_note();
 		WC_Admin_Notes_Edit_Products_On_The_Move::possibly_add_note();
+		WC_Admin_Notes_Performance_On_Mobile::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/WC_Admin_Notes_Performance_On_Mobile.php
+++ b/src/Notes/WC_Admin_Notes_Performance_On_Mobile.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WooCommerce Admin Edit products on the move note.
+ * WooCommerce Admin Performance on mobile note.
  *
- * Adds a note to download the mobile app.
+ * Adds a note to download the mobile app, performance on mobile.
  */
 
 namespace Automattic\WooCommerce\Admin\Notes;
@@ -10,9 +10,9 @@ namespace Automattic\WooCommerce\Admin\Notes;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Admin_Notes_Edit_Products_On_The_Move
+ * WC_Admin_Notes_Performance_On_Mobile
  */
-class WC_Admin_Notes_Edit_Products_On_The_Move {
+class WC_Admin_Notes_Performance_On_Mobile {
 	/**
 	 * Note traits.
 	 */
@@ -21,15 +21,15 @@ class WC_Admin_Notes_Edit_Products_On_The_Move {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME = 'wc-admin-edit-products-on-the-move';
+	const NOTE_NAME = 'wc-admin-performance-on-mobile';
 
 	/**
 	 * Get the note.
 	 */
 	public static function get_note() {
-		// Only add this note if this store is at least a year old.
-		$year_in_seconds = 365 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $year_in_seconds ) ) {
+		// Only add this note if this store is at least 9 months old.
+		$nine_months_in_seconds = 365 / 12 * 9 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $nine_months_in_seconds ) ) {
 			return;
 		}
 
@@ -42,14 +42,10 @@ class WC_Admin_Notes_Edit_Products_On_The_Move {
 			return;
 		}
 
-		if ( WC_Admin_Notes_Performance_On_Mobile::has_note_been_actioned() ) {
-			return;
-		}
-
 		$note = new WC_Admin_Note();
 
-		$note->set_title( __( 'Edit products on the move', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Edit and create new products from your mobile devices with the Woo app', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Track your store performance on mobile', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Monitor your sales and high performing products with the Woo app.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/src/Notes/WC_Admin_Notes_Performance_On_Mobile.php
+++ b/src/Notes/WC_Admin_Notes_Performance_On_Mobile.php
@@ -28,7 +28,7 @@ class WC_Admin_Notes_Performance_On_Mobile {
 	 */
 	public static function get_note() {
 		// Only add this note if this store is at least 9 months old.
-		$nine_months_in_seconds = 365 / 12 * 9 * DAY_IN_SECONDS;
+		$nine_months_in_seconds = MONTH_IN_SECONDS * 9;
 		if ( ! self::wc_admin_active_for( $nine_months_in_seconds ) ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #4227 

This adds a new note "Track your store performance on mobile" which displays if:

- the store has been active for more than 9 months
- the "Install Woo mobile app" note has not been actioned
- the "Get real-time order alerts anywhere" note has not been actioned

This also adds a new condition to the "edit products on the move" admin note to not display if this admin note has already been actioned.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/92435646-3314e180-f1e6-11ea-9ca0-eb2b75394ea5.png)

### Detailed test instructions:

- On a store less than 9 months old  - set `woocommerce_admin_install_timestamp` option to `1578518250` - 8 months ago
- Run the `wc_admin_daily` cron task
- The "Track your store performance on mobile" note should *not* be on the home page
- On a store more than 9 months old - set `woocommerce_admin_install_timestamp` option to `1573262355` - 10 months ago
- Run the `wc_admin_daily` cron task
- The "Track your store performance on mobile" note should now be on the home page

Now test the condition that the note not be added because the "Get real-time order alerts anywhere" note has been actioned .

- delete all admin notes from the database - `delete from wp_wc_admin_notes`
- set `woocommerce_admin_install_timestamp` option to `1588133382` - 4*30 days ago
- Run the `wc_admin_daily` cron task
- The "Get real-time order alerts anywhere" note should be on the home page
- Action that note
set `woocommerce_admin_install_timestamp` option to `1573262355` - 10 months ago
- Run the `wc_admin_daily` cron task
- The "Track your store performance on mobile" note should *not* be on the home page

### Changelog Note:

Add: Performance on mobile admin note