### PR TITLE
Enable the home screen for everybody

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -2,17 +2,16 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Fragment, Suspense, lazy } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { partial } from 'lodash';
 import { Dropdown, Button, Icon } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { Icon as WPIcon, plusCircleFilled } from '@wordpress/icons';
 import { withSelect } from '@wordpress/data';
-import { H, Spinner } from '@woocommerce/components';
+import { H } from '@woocommerce/components';
 import {
 	SETTINGS_STORE_NAME,
-	OPTIONS_STORE_NAME,
 	useUserPreferences,
 } from '@woocommerce/data';
 import { getQuery } from '@woocommerce/navigation';
@@ -34,10 +33,6 @@ import {
 	CurrencyContext,
 	getFilteredCurrencyInstance,
 } from '../lib/currency-context';
-
-const TaskList = lazy( () =>
-	import( /* webpackChunkName: "task-list" */ '../task-list' )
-);
 
 const DASHBOARD_FILTERS_FILTER = 'woocommerce_admin_dashboard_filters';
 const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
@@ -73,20 +68,12 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 
 const CustomizableDashboard = ( {
 	defaultDateRange,
-	homepageEnabled,
 	path,
 	query,
-	taskListComplete,
-	taskListHidden,
 } ) => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 
 	const sections = mergeSectionsWithDefaults( userPrefs.dashboard_sections );
-
-	const isTaskListEnabled = ! homepageEnabled && ! taskListHidden;
-
-	const isDashboardShown =
-		! isTaskListEnabled || ( ! query.task && taskListComplete );
 
 	const updateSections = ( newSections ) => {
 		updateUserPreferences( { dashboard_sections: newSections } );
@@ -306,19 +293,13 @@ const CustomizableDashboard = ( {
 		<CurrencyContext.Provider
 			value={ getFilteredCurrencyInstance( getQuery() ) }
 		>
-			{ isTaskListEnabled && (
-				<Suspense fallback={ <Spinner /> }>
-					<TaskList query={ query } inline={ isDashboardShown } />
-				</Suspense>
-			) }
-			{ isDashboardShown && renderDashboardReports() }
+			{ renderDashboardReports() }
 		</CurrencyContext.Provider>
 	);
 };
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			SETTINGS_STORE_NAME
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
@@ -326,14 +307,6 @@ export default compose(
 		const withSelectData = {
 			defaultDateRange,
 		};
-
-		withSelectData.homepageEnabled =
-			window.wcAdminFeatures.homescreen &&
-			getOption( 'woocommerce_homescreen_enabled' ) === 'yes';
-		withSelectData.taskListHidden =
-			getOption( 'woocommerce_task_list_hidden' ) === 'yes';
-		withSelectData.taskListComplete =
-			getOption( 'woocommerce_task_list_complete' ) === 'yes';
 
 		return withSelectData;
 	} )

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -10,10 +10,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { Icon as WPIcon, plusCircleFilled } from '@wordpress/icons';
 import { withSelect } from '@wordpress/data';
 import { H } from '@woocommerce/components';
-import {
-	SETTINGS_STORE_NAME,
-	useUserPreferences,
-} from '@woocommerce/data';
+import { SETTINGS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
 import { getQuery } from '@woocommerce/navigation';
 import {
 	getCurrentDates,
@@ -66,11 +63,7 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 	return sections;
 };
 
-const CustomizableDashboard = ( {
-	defaultDateRange,
-	path,
-	query,
-} ) => {
+const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 
 	const sections = mergeSectionsWithDefaults( userPrefs.dashboard_sections );

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -24,7 +24,7 @@ const CustomizableDashboard = lazy( () =>
 class Dashboard extends Component {
 	render() {
 		const { path, query } = this.props;
-		
+
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {
 			return (
 				<Suspense fallback={ <Spinner /> }>
@@ -41,9 +41,7 @@ const onboardingData = getSetting( 'onboarding', {} );
 
 export default compose(
 	!! onboardingData.tasksStatus
-		? withOnboardingHydration( {
-			tasksStatus: onboardingData.tasksStatus,
-		} )
+		? withOnboardingHydration( { tasksStatus: onboardingData.tasksStatus } )
 		: identity,
 	withSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -11,7 +11,6 @@ import {
 	withOnboardingHydration,
 } from '@woocommerce/data';
 import { Spinner } from '@woocommerce/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,17 +23,8 @@ const CustomizableDashboard = lazy( () =>
 
 class Dashboard extends Component {
 	render() {
-		const { path, profileItems, query } = this.props;
-		const { completed: profileCompleted, skipped: profileSkipped } =
-			profileItems || {};
-		if (
-			! profileCompleted &&
-			! profileSkipped &&
-			! window.wcAdminFeatures.homescreen
-		) {
-			getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
-		}
-
+		const { path, query } = this.props;
+		
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {
 			return (
 				<Suspense fallback={ <Spinner /> }>
@@ -50,11 +40,10 @@ class Dashboard extends Component {
 const onboardingData = getSetting( 'onboarding', {} );
 
 export default compose(
-	onboardingData.profile || onboardingData.tasksStatus
+	!! onboardingData.tasksStatus
 		? withOnboardingHydration( {
-				profileItems: onboardingData.profile,
-				tasksStatus: onboardingData.tasksStatus,
-		  } )
+			tasksStatus: onboardingData.tasksStatus,
+		} )
 		: identity,
 	withSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -130,19 +130,12 @@ export class ActivityPanel extends Component {
 
 		// Don't show the inbox on the Home screen.
 		const { location } = this.props.getHistory();
-		const showInbox =
-			isEmbedded ||
-			location.pathname !== '/';
+		const showInbox = isEmbedded || location.pathname !== '/';
 		const isPerformingSetupTask =
 			query.task &&
 			! query.path &&
 			( requestingTaskListOptions === true ||
 				( taskListHidden === false && taskListComplete === false ) );
-
-		// To prevent a flicker between 2 different tab groups, while this option resolves just display no tabs.
-		if ( requestingTaskListOptions ) {
-			return [];
-		}
 
 		if ( ! taskListComplete && showInbox ) {
 			return [

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -123,7 +123,6 @@ export class ActivityPanel extends Component {
 			hasUnreadStock,
 			isEmbedded,
 			requestingTaskListOptions,
-			taskListEnabledResolving,
 			taskListComplete,
 			taskListHidden,
 			query,
@@ -133,7 +132,6 @@ export class ActivityPanel extends Component {
 		const { location } = this.props.getHistory();
 		const showInbox =
 			isEmbedded ||
-			! window.wcAdminFeatures.homescreen ||
 			location.pathname !== '/';
 		const isPerformingSetupTask =
 			query.task &&
@@ -142,7 +140,7 @@ export class ActivityPanel extends Component {
 				( taskListHidden === false && taskListComplete === false ) );
 
 		// To prevent a flicker between 2 different tab groups, while this option resolves just display no tabs.
-		if ( taskListEnabledResolving ) {
+		if ( requestingTaskListOptions ) {
 			return [];
 		}
 
@@ -389,10 +387,6 @@ export default compose(
 		const hasUnapprovedReviews = getUnapprovedReviews( select );
 		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
 
-		const taskListEnabledResolving = isResolving( 'getOption', [
-			'woocommerce_homescreen_enabled',
-		] );
-
 		const taskListComplete =
 			getOption( 'woocommerce_task_list_complete' ) === 'yes';
 		const taskListHidden =
@@ -407,7 +401,6 @@ export default compose(
 			hasUnreadStock,
 			hasUnapprovedReviews,
 			requestingTaskListOptions,
-			taskListEnabledResolving,
 			taskListComplete,
 			taskListHidden,
 		};

--- a/client/homescreen/stats-overview/stats-list.js
+++ b/client/homescreen/stats-overview/stats-list.js
@@ -46,13 +46,9 @@ export const StatsList = ( {
 		>
 			{ stats.map( ( item ) => {
 				if ( primaryRequesting || secondaryRequesting ) {
-					return (
-						<SummaryNumberPlaceholder
-							className="is-homescreen"
-							key={ item.stat }
-						/>
-					);
+					return <SummaryNumberPlaceholder key={ item.stat } />;
 				}
+
 				const {
 					primaryValue,
 					secondaryValue,

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -75,53 +75,30 @@ export const getPages = () => {
 		} );
 	}
 
-	if (
-		window.wcAdminFeatures[ 'analytics-dashboard' ] &&
-		! window.wcAdminFeatures.homescreen
-	) {
-		pages.push( {
-			container: Dashboard,
-			path: '/',
-			breadcrumbs: [
-				...initialBreadcrumbs,
-				__( 'Dashboard', 'woocommerce-admin' ),
-			],
-			wpOpenMenu: 'toplevel_page_woocommerce',
-		} );
-	}
-
-	if ( window.wcAdminFeatures.homescreen ) {
-		pages.push( {
-			container: Homescreen,
-			path: '/',
-			breadcrumbs: [
-				...initialBreadcrumbs,
-				__( 'Home', 'woocommerce-admin' ),
-			],
-			wpOpenMenu: 'toplevel_page_woocommerce',
-		} );
-	}
+	pages.push( {
+		container: Homescreen,
+		path: '/',
+		breadcrumbs: [
+			...initialBreadcrumbs,
+			__( 'Home', 'woocommerce-admin' ),
+		],
+		wpOpenMenu: 'toplevel_page_woocommerce',
+	} );
 
 	if ( window.wcAdminFeatures.analytics ) {
-		if ( window.wcAdminFeatures.homescreen ) {
-			pages.push( {
-				container: Dashboard,
-				path: '/analytics/overview',
-				breadcrumbs: [
-					...initialBreadcrumbs,
-					[
-						'/analytics/overview',
-						__( 'Analytics', 'woocommerce-admin' ),
-					],
-					__( 'Overview', 'woocommerce-admin' ),
+		pages.push( {
+			container: Dashboard,
+			path: '/analytics/overview',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				[
+					'/analytics/overview',
+					__( 'Analytics', 'woocommerce-admin' ),
 				],
-				wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
-			} );
-		}
-		const ReportWpOpenMenu = `toplevel_page_wc-admin-path--analytics-${
-			window.wcAdminFeatures.homescreen ? 'overview' : 'revenue'
-		}`;
-
+				__( 'Overview', 'woocommerce-admin' ),
+			],
+			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+		} );
 		pages.push( {
 			container: AnalyticsSettings,
 			path: '/analytics/settings',
@@ -133,7 +110,7 @@ export const getPages = () => {
 				],
 				__( 'Settings', 'woocommerce-admin' ),
 			],
-			wpOpenMenu: ReportWpOpenMenu,
+			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -163,7 +140,7 @@ export const getPages = () => {
 					report.title,
 				];
 			},
-			wpOpenMenu: ReportWpOpenMenu,
+			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 		} );
 	}
 
@@ -256,10 +233,7 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin( item.href ) ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const defaultPath = window.wcAdminFeatures.homescreen
-			? 'homescreen'
-			: 'dashboard';
-		const path = query.path || defaultPath;
+		const path = query.path || 'homescreen';
 		const screen = path.replace( '/analytics', '' ).replace( '/', '' );
 
 		const isExcludedScreen = excludedScreens.includes( screen );

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -91,11 +91,9 @@ class _Layout extends Component {
 		// Remove leading slash, and camel case remaining pathname
 		let path = pathname.substring( 1 ).replace( /\//g, '_' );
 
-		// When pathname is `/` we are on the dashboard
+		// When pathname is `/` we are on the home screen.
 		if ( path.length === 0 ) {
-			path = window.wcAdminFeatures.homescreen
-				? 'home_screen'
-				: 'dashboard';
+			path = 'home_screen';
 		}
 
 		recordPageView( path, {

--- a/config/core.json
+++ b/config/core.json
@@ -13,7 +13,6 @@
 		"store-alerts": true,
 		"unminified-js": false,
 		"wcpay": true,
-		"homescreen": true,
 		"mobile-app-banner": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,6 @@
 		"store-alerts": true,
 		"unminified-js": true,
 		"wcpay": true,
-		"homescreen": true,
 		"mobile-app-banner": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -13,7 +13,6 @@
 		"store-alerts": true,
 		"unminified-js": true,
 		"wcpay": true,
-		"homescreen": true,
 		"mobile-app-banner": true
 	}
 }

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -32,7 +32,6 @@ import Link from '../link';
  * @param {boolean} props.selected
  * @param {number|string} props.value
  * @param {Function} props.onLinkClickCallback
- * @param {boolean} props.isHomescreen
  * @return {Object} -
  */
 const SummaryNumber = ( {
@@ -47,11 +46,10 @@ const SummaryNumber = ( {
 	reverseTrend,
 	selected,
 	value,
-	onLinkClickCallback,
-	isHomescreen,
+	onLinkClickCallback
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
-		'is-homescreen': isHomescreen,
+		'is-homescreen': true,
 		'is-dropdown-button': onToggle,
 		'is-dropdown-expanded': isOpen,
 	} );
@@ -208,10 +206,6 @@ SummaryNumber.propTypes = {
 	 * A function to be called after a SummaryNumber, rendered as a link, is clicked.
 	 */
 	onLinkClickCallback: PropTypes.func,
-	/**
-	 * A boolean used to show if the Summary Number is on the Homescreen.
-	 */
-	isHomescreen: PropTypes.bool,
 };
 
 SummaryNumber.defaultProps = {

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -46,7 +46,7 @@ const SummaryNumber = ( {
 	reverseTrend,
 	selected,
 	value,
-	onLinkClickCallback
+	onLinkClickCallback,
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
 		'is-homescreen': true,

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -49,7 +49,6 @@ const SummaryNumber = ( {
 	onLinkClickCallback,
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
-		'is-homescreen': true,
 		'is-dropdown-button': onToggle,
 		'is-dropdown-expanded': isOpen,
 	} );

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -199,7 +199,7 @@ $border: $gray-200;
 .woocommerce-summary__item-container {
 	margin-bottom: 0;
 
-	&:not(.is-homescreen):last-of-type .woocommerce-summary__item {
+	&:last-of-type .woocommerce-summary__item {
 		// Make sure the last item always uses the outer-border color.
 		border-bottom-color: $border !important;
 	}

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -112,22 +112,21 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
-		$homepage_enabled = Loader::is_feature_enabled( 'homescreen' );
-		$report_pages     = array(
+		$report_pages = array(
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
 				'path'     => '/analytics/overview',
-				'path'     => $homepage_enabled ? '/analytics/overview' : '/analytics/revenue',
+				'path'     => '/analytics/overview',
 				'icon'     => 'dashicons-chart-bar',
 				'position' => 56, // After WooCommerce & Product menu items.
 			),
-			$homepage_enabled ? array(
+			array(
 				'id'     => 'woocommerce-analytics-overview',
 				'title'  => __( 'Overview', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/overview',
-			) : null,
+			),
 			array(
 				'id'     => 'woocommerce-analytics-revenue',
 				'title'  => __( 'Revenue', 'woocommerce-admin' ),

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -43,11 +43,7 @@ class AnalyticsDashboard {
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
-		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-
-		if ( Loader::is_feature_enabled( 'homescreen' ) ) {
-			add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
-		}
+		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 	}
 
 	/**
@@ -82,28 +78,13 @@ class AnalyticsDashboard {
 	}
 
 	/**
-	 * Preload options to prime state of the application.
-	 *
-	 * @param array $options Array of options to preload.
-	 * @return array
-	 */
-	public function preload_options( $options ) {
-		$options[] = 'woocommerce_homescreen_enabled';
-
-		return $options;
-	}
-
-	/**
 	 * Registers dashboard page.
 	 */
 	public function register_page() {
-		$id       = Loader::is_feature_enabled( 'homescreen' ) ? 'woocommerce-home' : 'woocommerce-dashboard';
-		$title    = Loader::is_feature_enabled( 'homescreen' ) ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
-
 		wc_admin_register_page(
 			array(
-				'id'     => $id,
-				'title'  => $title,
+				'id'     => 'woocommerce-home',
+				'title'  => __( 'Home', 'woocommerce-admin' ),
 				'parent' => 'woocommerce',
 				'path'   => self::MENU_SLUG,
 			)

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -78,7 +78,7 @@ class AnalyticsDashboard {
 	}
 
 	/**
-	 * Registers dashboard page.
+	 * Registers home page.
 	 */
 	public function register_page() {
 		wc_admin_register_page(

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -243,22 +243,11 @@ class Loader {
 	}
 
 	/**
-	 * Registers a basic page handler for the app entry point.
+	 * Connects existing WooCommerce pages.
 	 *
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
-		wc_admin_register_page(
-			array(
-				'id'         => 'homescreen',
-				'parent'     => 'woocommerce',
-				'title'      => null,
-				'path'       => self::APP_ENTRY_POINT,
-				'capability' => static::get_analytics_capability(),
-			)
-		);
-
-		// Connect existing WooCommerce pages.
 		require_once WC_ADMIN_ABSPATH . 'includes/connect-existing-pages.php';
 	}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -22,11 +22,6 @@ class Loader {
 	const APP_ENTRY_POINT = 'wc-admin';
 
 	/**
-	 * Option name for the homescreen enabled 1-shot option.
-	 */
-	const WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME = 'woocommerce_homescreen_enabled_as_default_experience';
-
-	/**
 	 * Class instance.
 	 *
 	 * @var Loader instance
@@ -99,13 +94,6 @@ class Loader {
 
 		// Combine JSON translation files (from chunks) when language packs are updated.
 		add_action( 'upgrader_process_complete', array( __CLASS__, 'combine_translation_chunk_files' ), 10, 2 );
-
-		// The "as default experience" option is used to act as a one-shot to
-		// enable the homescreen as the default experience for all sites.
-		if ( false === get_option( self::WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME ) ) {
-			update_option( 'woocommerce_homescreen_enabled', 'yes' );
-			update_option( self::WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME, true );
-		}
 	}
 
 	/**
@@ -177,10 +165,6 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
-		if ( 'homescreen' === $feature && 'yes' !== get_option( 'woocommerce_homescreen_enabled', 'no' ) ) {
-			return false;
-		}
-
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}
@@ -264,11 +248,9 @@ class Loader {
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
-		$id = self::is_feature_enabled( 'homescreen' ) ? 'woocommerce-home' : 'woocommerce-dashboard';
-
 		wc_admin_register_page(
 			array(
-				'id'         => $id, // Expected to be overridden if dashboard is enabled.
+				'id'         => 'homescreen',
 				'parent'     => 'woocommerce',
 				'title'      => null,
 				'path'       => self::APP_ENTRY_POINT,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -22,6 +22,11 @@ class Loader {
 	const APP_ENTRY_POINT = 'wc-admin';
 
 	/**
+	 * Option name for the homescreen enabled 1-shot option.
+	 */
+	const WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME = 'woocommerce_homescreen_enabled_as_default_experience';
+
+	/**
 	 * Class instance.
 	 *
 	 * @var Loader instance
@@ -94,6 +99,13 @@ class Loader {
 
 		// Combine JSON translation files (from chunks) when language packs are updated.
 		add_action( 'upgrader_process_complete', array( __CLASS__, 'combine_translation_chunk_files' ), 10, 2 );
+
+		// The "as default experience" option is used to act as a one-shot to
+		// enable the homescreen as the default experience for all sites.
+		if ( false === get_option( self::WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME ) ) {
+			update_option( 'woocommerce_homescreen_enabled', 'yes' );
+			update_option( self::WOOCOMMERCE_HOMESCREEN_ENABLED_AS_DEFAULT_EXPERIENCE_OPTION_NAME, true );
+		}
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Home_Screen_Feedback.php
+++ b/src/Notes/WC_Admin_Notes_Home_Screen_Feedback.php
@@ -42,10 +42,9 @@ class WC_Admin_Notes_Home_Screen_Feedback {
 			return;
 		}
 
-		// If the homescreen is enabled, set the current time stamp.
-		if ( 'yes' === get_option( 'woocommerce_homescreen_enabled', 'no' ) ) {
-			update_option( self::HOMESCREEN_ACCESSED_OPTION_NAME, time() );
-		}
+		// Set the current time stamp, as the home screen is the default
+		// experience.
+		update_option( self::HOMESCREEN_ACCESSED_OPTION_NAME, time() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4761

This removes the ability to opt out of the home screen, making the home screen the default (and only) experience. Note that when this is merged it will unblock https://github.com/woocommerce/woocommerce/pull/27047, so remember to update that ticket when this is merged.

### Detailed test instructions:

A store that is opted out of the home screen should be ignoring that option and showing the home screen. Smoke test the home screen, other WooCommerce pages and the analytics pages.

### Changelog Note:

Feature: Enable the home screen for everybody