### PR TITLE
Add option to not charge sales tax

### DIFF
--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -58,7 +58,14 @@ class Connect extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting, onSkip, skipText } = this.props;
+		const {
+			hasErrors,
+			isRequesting,
+			onSkip,
+			skipText,
+			onAbort,
+			abortText,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -82,6 +89,11 @@ class Connect extends Component {
 				{ onSkip && (
 					<Button onClick={ onSkip }>
 						{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
+					</Button>
+				) }
+				{ onAbort && (
+					<Button onClick={ onAbort }>
+						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
 					</Button>
 				) }
 			</Fragment>
@@ -134,6 +146,14 @@ Connect.propTypes = {
 	 * Control the `isPending` logic of the parent containing the Stepper.
 	 */
 	setIsPending: PropTypes.func,
+	/**
+	 * Called when the plugin connection is aborted.
+	 */
+	onAbort: PropTypes.func,
+	/**
+	 * Text used for the abort connection button.
+	 */
+	abortText: PropTypes.string,
 };
 
 Connect.defaultProps = {

--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
-class Connect extends Component {
+export class Connect extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {

--- a/client/dashboard/components/connect/test/index.js
+++ b/client/dashboard/components/connect/test/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Connect } from '../index.js';
+
+describe( 'Rendering', () => {
+	it( 'should render an abort button when the abort handler is provided', async () => {
+		const connectWrapper = shallow( <Connect onAbort={ () => {} } /> );
+
+		const buttons = connectWrapper.find( Button );
+
+		expect( buttons.length ).toBe( 2 );
+		expect( buttons.at( 1 ).text() ).toBe( 'Abort' );
+	} );
+} );

--- a/client/dashboard/components/connect/test/index.js
+++ b/client/dashboard/components/connect/test/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
-import { Button } from '@wordpress/components';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -11,11 +10,11 @@ import { Connect } from '../index.js';
 
 describe( 'Rendering', () => {
 	it( 'should render an abort button when the abort handler is provided', async () => {
-		const connectWrapper = shallow( <Connect onAbort={ () => {} } /> );
+		const { container } = render( <Connect onAbort={ () => {} } /> );
 
-		const buttons = connectWrapper.find( Button );
+		const buttons = container.querySelectorAll( 'button' );
 
 		expect( buttons.length ).toBe( 2 );
-		expect( buttons.at( 1 ).text() ).toBe( 'Abort' );
+		expect( buttons[ 1 ].textContent ).toBe( 'Abort' );
 	} );
 } );

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -177,6 +177,7 @@ class Tax extends Component {
 
 		updateOptions( {
 			woocommerce_no_sales_tax: true,
+			woocommerce_calc_taxes: 'no',
 		} ).then( () => {
 			window.location = getAdminLink( 'admin.php?page=wc-admin' );
 		} );

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -178,7 +178,7 @@ class Tax extends Component {
 			connect: false,
 			no_tax: true,
 		} );
-		
+
 		updateOptions( {
 			woocommerce_no_sales_tax: true,
 		} ).then( this.redirectToHomePage );
@@ -322,7 +322,7 @@ class Tax extends Component {
 						) }
 						onAbort={ () => this.doNotChargeSalesTax() }
 						abortText={ __(
-							'My business doesn\'t charge sales tax',
+							"My business doesn't charge sales tax",
 							'woocommerce-admin'
 						) }
 					/>
@@ -381,7 +381,7 @@ class Tax extends Component {
 
 	renderSuccessScreen() {
 		const { isPending } = this.props;
-		
+
 		return (
 			<div className="woocommerce-task-tax__success">
 				<span
@@ -411,12 +411,9 @@ class Tax extends Component {
 					isPrimary
 					isBusy={ isPending }
 					onClick={ () => {
-						recordEvent(
-							'tasklist_tax_setup_automated_proceed',
-							{
-								setup_automatically: true,
-							}
-						);
+						recordEvent( 'tasklist_tax_setup_automated_proceed', {
+							setup_automatically: true,
+						} );
 						this.updateAutomatedTax( true );
 					} }
 				>
@@ -426,12 +423,9 @@ class Tax extends Component {
 					disabled={ isPending }
 					isBusy={ isPending }
 					onClick={ () => {
-						recordEvent(
-							'tasklist_tax_setup_automated_proceed',
-							{
-								setup_automatically: false,
-							}
-						);
+						recordEvent( 'tasklist_tax_setup_automated_proceed', {
+							setup_automatically: false,
+						} );
 						this.updateAutomatedTax( false );
 					} }
 				>
@@ -446,8 +440,8 @@ class Tax extends Component {
 					onClick={ () => this.doNotChargeSalesTax() }
 				>
 					{ __(
-							'My business doesn\'t charge sales tax',
-							'woocommerce-admin'
+						"My business doesn't charge sales tax",
+						'woocommerce-admin'
 					) }
 				</Button>
 			</div>
@@ -462,7 +456,9 @@ class Tax extends Component {
 		return (
 			<div className="woocommerce-task-tax">
 				<Card className="is-narrow">
-					{ this.shouldShowSuccessScreen() ? this.renderSuccessScreen() : (
+					{ this.shouldShowSuccessScreen() ? (
+						this.renderSuccessScreen()
+					) : (
 						<Stepper
 							isPending={ isPending || isResolving }
 							isVertical={ true }

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -262,6 +262,11 @@ class Tax extends Component {
 								'Set up tax rates manually',
 								'woocommerce-admin'
 							) }
+							onAbort={ () => this.doNotChargeSalesTax() }
+							abortText={ __(
+								"My business doesn't charge sales tax",
+								'woocommerce-admin'
+							) }
 						/>
 						{ ! tosAccepted && (
 							<Text

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -167,10 +167,6 @@ class Tax extends Component {
 		);
 	}
 
-	redirectToHomePage() {
-		window.location = getAdminLink( 'admin.php?page=wc-admin' );
-	}
-
 	doNotChargeSalesTax() {
 		const { updateOptions } = this.props;
 
@@ -181,7 +177,9 @@ class Tax extends Component {
 
 		updateOptions( {
 			woocommerce_no_sales_tax: true,
-		} ).then( this.redirectToHomePage );
+		} ).then( () => {
+			window.location = getAdminLink( 'admin.php?page=wc-admin' );
+		} );
 	}
 
 	getSteps() {

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -73,7 +73,14 @@ export class Plugins extends Component {
 	}
 
 	render() {
-		const { isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
+		const {
+			isRequesting,
+			skipText,
+			autoInstall,
+			pluginSlugs,
+			onAbort,
+			abortText,
+		} = this.props;
 		const { hasErrors } = this.state;
 
 		if ( hasErrors ) {
@@ -126,6 +133,11 @@ export class Plugins extends Component {
 				<Button onClick={ this.skipInstaller }>
 					{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
 				</Button>
+				{ onAbort && (
+					<Button onClick={ onAbort }>
+						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
+					</Button>
+				) }
 			</Fragment>
 		);
 	}
@@ -156,6 +168,14 @@ Plugins.propTypes = {
 	 * An array of plugin slugs to install.
 	 */
 	pluginSlugs: PropTypes.arrayOf( PropTypes.string ),
+	/**
+	 * Called when the plugin connection is aborted.
+	 */
+	onAbort: PropTypes.func,
+	/**
+	 * Text used for the abort connection button.
+	 */
+	abortText: PropTypes.string,
 };
 
 Plugins.defaultProps = {

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -53,6 +53,17 @@ describe( 'Rendering', () => {
 		expect( buttons.at( 0 ).text() ).toBe( 'Install & enable' );
 		expect( buttons.at( 1 ).text() ).toBe( 'No thanks' );
 	} );
+
+	it( 'should render an abort button when the abort handler is provided', async () => {
+		const pluginsWrapper = shallow(
+			<Plugins pluginSlugs={ [ 'jetpack' ] } onAbort={ () => {} } />
+		);
+
+		const buttons = pluginsWrapper.find( Button );
+
+		expect( buttons.length ).toBe( 3 );
+		expect( buttons.at( 2 ).text() ).toBe( 'Abort' );
+	} );
 } );
 
 describe( 'Installing and activating', () => {

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -217,7 +217,9 @@ class OnboardingTasks {
 				$completed = $post && 'publish' === $post->post_status;
 				return $completed;
 			case 'tax':
-				return 'yes' === get_option( 'wc_connect_taxes_enabled' ) || count( DataStore::get_taxes( array() ) ) > 0;
+				return 'yes' === get_option( 'wc_connect_taxes_enabled' ) ||
+					count( DataStore::get_taxes( array() ) ) > 0 ||
+					false !== get_option( 'woocommerce_no_sales_tax' );
 		}
 		return false;
 	}


### PR DESCRIPTION
Fixes #3456

This adds an option to not charge sales tax to the onboarding tax task (both with Jetpack/WCS connected and without).

### Detailed test instructions:

Without Jetpack/WCS connected:

- Set up a test site with this plugin installed
- Go through the OBW, don't set up WCS or Jetpack
- Enter the "Set up tax" task
- The "My business doesn't charge sales tax" option should be displayed per below:
![image](https://user-images.githubusercontent.com/224531/92544808-1afa9c00-f292-11ea-92dd-a8f3f572abf8.png)
- Select "My business doesn't charge sales tax"
- You should be redirected to the home page and the "Set up tax" task should be marked as complete

With Jetpack/WCS connected:

- Set up a test site with this plugin installed
- Go through the OBW, set up WCS and Jetpack
- Make sure Jetpack is connected
- Enter the "Set up tax" task
- The "My business doesn't charge sales tax" option should be displayed per below:
![image](https://user-images.githubusercontent.com/224531/92545048-aaa04a80-f292-11ea-864c-b940d2985bbc.png)
- Select "My business doesn't charge sales tax"
- You should be redirected to the home page and the "Set up tax" task should be marked as complete

### Changelog Note:

Add: Option to not charge sales tax