### PR TITLE
Remove the chevron icons from the “Finish setup” task list

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -13,7 +13,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Icon, check, chevronRight } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 import { xor } from 'lodash';
 import { List, EllipsisMenu } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
@@ -298,8 +298,8 @@ class TaskDashboard extends Component {
 				</Text>
 			);
 
-			if ( ! task.completed ) {
-				task.after = task.isDismissable ? (
+			if ( ! task.completed && task.isDismissable ) {
+				task.after = (
 					<Button
 						isTertiary
 						onClick={ ( event ) => {
@@ -309,8 +309,6 @@ class TaskDashboard extends Component {
 					>
 						{ __( 'Dismiss', 'woocommerce-admin' ) }
 					</Button>
-				) : (
-					<Icon icon={ chevronRight } />
 				);
 			}
 

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -301,6 +301,7 @@ class TaskDashboard extends Component {
 			if ( ! task.completed && task.isDismissable ) {
 				task.after = (
 					<Button
+						data-testid={ `${ task.key }-dismiss-button` }
 						isTertiary
 						onClick={ ( event ) => {
 							event.stopPropagation();

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, findByText, queryByTestId } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -53,20 +53,24 @@ describe( 'TaskDashboard', () => {
 	it( 'renders a dismiss button for tasks that are optional and incomplete', async () => {
 		apiFetch.mockResolvedValue( {} );
 
-		render( <TaskDashboard query={ {} } /> );
+		const { container } = render( <TaskDashboard query={ {} } /> );
 
 		// Wait for the task list to render.
-		expect( await screen.findByText( 'Finish setup' ) ).toBeDefined();
+		expect( await findByText( container, 'Finish setup' ) ).toBeDefined();
 
 		// The `optional` task has a dismiss button.
 		expect(
-			screen.queryByTestId( 'optional-dismiss-button' )
+			queryByTestId( container, 'optional-dismiss-button' )
 		).toBeDefined();
 
 		// The `required` task does not have a dismiss button.
-		expect( screen.queryByTestId( 'required-dismiss-button' ) ).toBeNull();
+		expect(
+			queryByTestId( container, 'required-dismiss-button' )
+		).toBeNull();
 
 		// The `completed` task does not have a dismiss button.
-		expect( screen.queryByTestId( 'completed-dismiss-button' ) ).toBeNull();
+		expect(
+			queryByTestId( container, 'completed-dismiss-button' )
+		).toBeNull();
 	} );
 } );

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import TaskDashboard from '../index.js';
+
+jest.mock( '@wordpress/api-fetch' );
+
+// Mock the tasks.
+jest.mock( '../tasks', () => {
+	return {
+		getAllTasks: jest.fn().mockImplementation( () => [
+			{
+				key: 'optional',
+				title: 'This task is optional',
+				container: null,
+				completed: false,
+				visible: true,
+				time: '1 minute',
+				isDismissable: true,
+			},
+			{
+				key: 'required',
+				title: 'This task is required',
+				container: null,
+				completed: false,
+				visible: true,
+				time: '1 minute',
+				isDismissable: false,
+			},
+			{
+				key: 'completed',
+				title: 'This task is completed',
+				container: null,
+				completed: true,
+				visible: true,
+				time: '1 minute',
+				isDismissable: true,
+			},
+		] ),
+	};
+} );
+
+describe( 'TaskDashboard', () => {
+	afterEach( () => jest.clearAllMocks() );
+
+	it( 'renders a dismiss button for tasks that are optional and incomplete', async () => {
+		apiFetch.mockResolvedValue( {} );
+
+		render( <TaskDashboard query={ {} } /> );
+
+		// Wait for the task list to render.
+		expect( await screen.findByText( 'Finish setup' ) ).toBeDefined();
+
+		// The `optional` task has a dismiss button.
+		expect(
+			screen.queryByTestId( 'optional-dismiss-button' )
+		).toBeDefined();
+
+		// The `required` task does not have a dismiss button.
+		expect( screen.queryByTestId( 'required-dismiss-button' ) ).toBeNull();
+
+		// The `completed` task does not have a dismiss button.
+		expect( screen.queryByTestId( 'completed-dismiss-button' ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Fixes #4896

This aligns with the update of the Store Management card in #4790 by removing the chevron icon from the item rows in this task list.

Now, only a "Dismiss" button renders in the right-side area of a row. This occurs if the task is optional and incomplete. Due to this a small refactor is made to remove the conditional operator when assigning `task.after`.

A test is added to assert the logic for rendering the "Dismiss" button.

### Screenshots

![Screen Shot 2020-09-09 at 1 48 10 pm](https://user-images.githubusercontent.com/9312929/92561162-42f3fa80-f2a6-11ea-95e7-9ead9f31d7d9.png)

### Detailed test instructions:

- Start on a site that hasn’t finished the setup tasks, and has the "Purchase & install extensions" task still to do.
- Confirm that chevron icons have been removed from the right-hand side of each incomplete task.
- Confirm that a "Dismiss" button is still present for the  "Purchase & install extensions" task.

### Changelog Note:

Tweak: The "Finish setup" task list no longer displays a chevron icon for incompleted tasks.
