### PR TITLE
Onboarding - Store Profiler - Removed selected CBD option for eCommerce plan

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -309,9 +309,11 @@ export default compose(
 		const { createNotice } = dispatch( 'core/notices' );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
-		const { invalidateResolutionForStoreSelector } = dispatch(
-			ONBOARDING_STORE_NAME
-		);
+		const {
+			invalidateResolution,
+			invalidateResolutionForStoreSelector,
+		} = dispatch( ONBOARDING_STORE_NAME );
+		invalidateResolution( 'getProfileItems', [] );
 		return {
 			clearTaskStatusCache: () =>
 				invalidateResolutionForStoreSelector( 'getTasksStatus' ),

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -100,6 +100,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 
 		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+		$onboarding_data['industry'] =  isset( $onboarding_data['industry'] ) ? $this->filter_industries( $onboarding_data['industry'] ) : null;
 		$item_schema     = $this->get_item_schema();
 
 		$items = array();
@@ -114,6 +115,19 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		$data = $this->prepare_response_for_collection( $item );
 
 		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Filter the industries.
+	 *
+	 * @param  array $industries list of industries.
+	 * @return array
+	 */
+	public function filter_industries( $industries ) {
+		return apply_filters(
+			'woocommerce_admin_onboarding_industries',
+			$industries
+		);
 	}
 
 	/**

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -99,11 +99,10 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	public function get_items( $request ) {
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 
-		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+		$onboarding_data             = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$onboarding_data['industry'] = isset( $onboarding_data['industry'] ) ? $this->filter_industries( $onboarding_data['industry'] ) : null;
-		$item_schema     = $this->get_item_schema();
-
-		$items = array();
+		$item_schema                 = $this->get_item_schema();
+		$items                       = array();
 		foreach ( $item_schema['properties'] as $key => $property_schema ) {
 			$items[ $key ] = isset( $onboarding_data[ $key ] ) ? $onboarding_data[ $key ] : null;
 		}

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -100,7 +100,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 
 		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
-		$onboarding_data['industry'] =  isset( $onboarding_data['industry'] ) ? $this->filter_industries( $onboarding_data['industry'] ) : null;
+		$onboarding_data['industry'] = isset( $onboarding_data['industry'] ) ? $this->filter_industries( $onboarding_data['industry'] ) : null;
 		$item_schema     = $this->get_item_schema();
 
 		$items = array();


### PR DESCRIPTION
Fixes [573](https://github.com/automattic/wc-calypso-bridge/issues/573)

WordPress.com doesn't support CBD. This is solved [here](https://github.com/Automattic/wc-calypso-bridge). For users with the `eCommerce` plan who previously selected the `CBD and other hemp-derived products` option before that modification applies, this PR removes the industry `CBD and other hemp-derived products` from the selected industries list.

### Screenshots
![screenshot-three wordpress test-2020 09 10-10_49_02](https://user-images.githubusercontent.com/1314156/92739491-54471080-f353-11ea-9122-247f7d47881a.png)


### Detailed test instructions:
To test this PR it's necessary to use a site with [wc-calypso-bridge](https://github.com/Automattic/wc-calypso-bridge) installed.
- In the `wc-calypso-bridge` project, checkout to `master`. 
- Go to the industry step in the store profiler (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry&calypsoify=1`)
- Be sure the option `CBD and other hemp-derived products` is selected.
- Go to the `home` screen.
- In `wc-calypso-bridge` checkout to the branch `remove/option-CBD-from-onboarding`
- Be sure you have added `&calypsoify=1` at the end of the URL.
- Go to the payment methods (URL `/wp-admin/admin.php?page=wc-admin&task=payments`)
- Verify the following option is not visible
![screenshot-three wordpress test-2020 09 16-09_07_18](https://user-images.githubusercontent.com/1314156/93334990-27d04000-f7fc-11ea-9bd3-36fd450cb78d.png)


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Removed selected CBD option from onboarding for eCommerce plan
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->