### PR TITLE
Home Screen: Fixed card to connect to woo.com account

### DIFF
--- a/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
@@ -62,8 +62,8 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 			return;
 		}
 
-		// The site just connected.
-		if ( empty( $old_token ) && ! empty( $new_token ) ) {
+		// The site is connected.
+		if ( $this->is_connected() ) {
 			$this->remove_notes();
 			$this->refresh_subscription_notes();
 			return;


### PR DESCRIPTION
Fixes #4673

This PR modifies the connection check for the note `wc-admin-wc-helper-connection`.
There was a problem with the connection check in the `wc-admin-wc-helper-connection` note. It didn't work in some flows.
Now the method `is_connected` is being used to make it work.

### Screenshots
![screenshot-one wordpress test-2020 09 11-12_07_21](https://user-images.githubusercontent.com/1314156/92942128-9772b380-f427-11ea-83fa-659caa9b797f.png)


### Detailed test instructions:
Case 1
1. Complete onboarding on a fresh install.
- Use an ephemeral site.
- Make sure to select one of the paid extensions to be purchased during onboarding in the `Product Types` step (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`). For instance select `Bundles`.
2. After finishing the onboarding process, press the task list item: `Purchase & install extensions`.
- Complete the payment flow, add the extension to the site, and connect the site with woo.com.
![screenshot-woocommerce com-2020 09 11-13_35_31](https://user-images.githubusercontent.com/1314156/92951344-9300c780-f434-11ea-81a9-99c407d6472f.png)


3. Navigate to `WooCommerce / Extensions / WooCommerce.com subscriptions` and confirm that you are connected to WooCommerce.com:
![woocom](https://user-images.githubusercontent.com/19143190/85449758-1e6d6980-b566-11ea-8b36-a6abad9e9d2e.jpg)
4. The card `Connect to WooCommerce.com` shouldn't be visible now:
![screenshot-one wordpress test-2020 09 11-12_07_21](https://user-images.githubusercontent.com/1314156/92942128-9772b380-f427-11ea-83fa-659caa9b797f.png)
5. Go back to `WooCommerce / Extensions / WooCommerce.com subscriptions`.
6. Press `Connected to WooCommerce` and then press `Disconnect`
![screenshot2020-09-11 a la(s) 13 01 14](https://user-images.githubusercontent.com/1314156/92947895-fee03180-f42e-11ea-8a49-f9f3c8a91494.png)
7. Verify the card `Connect to WooCommerce.com` is now visible again.

Case 2
1. Navigate to `WooCommerce / Extensions / WooCommerce.com subscriptions` and press `Connect`:
![screenshot-one wordpress test-2020 09 11-12_57_34](https://user-images.githubusercontent.com/1314156/92947519-7bbedb80-f42e-11ea-8d54-09419a17c627.png)
2. Go through the connection process.
3. Verify the card `Connect to WooCommerce.com` is not visible anymore.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
Fix: Modified connection check for the note `wc-admin-wc-helper-connection`