### PR TITLE
Don't include "min" suffix in build JavaScript when targeting core.

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -11,7 +11,7 @@
 		"remote-inbox-notifications": false,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"unminified-js": false,
+		"minified-js": false,
 		"wcpay": true,
 		"homescreen": true,
 		"mobile-app-banner": true

--- a/config/development.json
+++ b/config/development.json
@@ -11,7 +11,7 @@
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"unminified-js": true,
+		"minified-js": true,
 		"wcpay": true,
 		"homescreen": true,
 		"mobile-app-banner": true

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -11,7 +11,7 @@
 		"remote-inbox-notifications": false,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"unminified-js": true,
+		"minified-js": true,
 		"wcpay": true,
 		"homescreen": true,
 		"mobile-app-banner": true

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -180,9 +180,9 @@ class Loader {
 	 * @return boolean If js asset should use minified version.
 	 */
 	public static function should_use_minified_js_file( $script_debug ) {
-		// un-minified files are only shipped in non-core versions of wc-admin, return true if unminified files are not available.
-		if ( ! self::is_feature_enabled( 'unminified-js' ) ) {
-			return true;
+		// minified files are only shipped in non-core versions of wc-admin, return false if minified files are not available.
+		if ( ! self::is_feature_enabled( 'minified-js' ) ) {
+			return false;
 		}
 
 		// Otherwise we will serve un-minified files if SCRIPT_DEBUG is on, or if anything truthy is passed in-lieu of SCRIPT_DEBUG.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,8 @@ wpAdminScripts.forEach( ( name ) => {
 
 const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 
+const suffix = WC_ADMIN_PHASE === 'core' ? '' : '.min';
+
 const webpackConfig = {
 	mode: NODE_ENV,
 	entry: {
@@ -87,10 +89,10 @@ const webpackConfig = {
 	output: {
 		filename: ( data ) => {
 			return wpAdminScripts.includes( data.chunk.name )
-				? `wp-admin-scripts/[name].min.js`
-				: `[name]/index.min.js`;
+				? `wp-admin-scripts/[name]${ suffix }.js`
+				: `[name]/index${ suffix }.js`;
 		},
-		chunkFilename: `chunks/[id].[chunkhash].min.js`,
+		chunkFilename: `chunks/[id].[chunkhash]${ suffix }.js`,
 		path: path.join( __dirname, 'dist' ),
 		library: [ 'wc', '[modulename]' ],
 		libraryTarget: 'this',


### PR DESCRIPTION
Files with "min" are ignored by GlotPress / translate.wp.org.

Fixes https://github.com/woocommerce/woocommerce/issues/26994.

This PR seeks to remove "min" from the minified JS files packaged up for the core build. This is to ensure that the files are parsed by GlotPress and language pack files are built.

### Detailed test instructions:

Testing this is definitely tricky. There really isn't a way to test this in situ where it will actually solve the problem.

- Run a normal build, e.g. `npm start` or `npm run build`
- Verify that `*.js` and `*.min.js` files are built in `/dist`
- Verify that loading script files works with and without `SCRIPT_DEBUG` defined as `true`
- Delete the `/dist` dir
- Run a core build: `WC_ADMIN_PHASE=core npm run build`
- Verify there are no `*.min.js` files in `/dist`
- Verify the JS contents are minified
- Verify that loading script files works with and without `SCRIPT_DEBUG` defined as `true`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: ensure GlotPress finds JavaScript files when building language packs for core WooCommerce.