### PR TITLE
Add filters for columns in reports

### DIFF
--- a/src/API/Reports/Categories/Controller.php
+++ b/src/API/Reports/Categories/Controller.php
@@ -325,12 +325,23 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'category'       => __( 'Category', 'woocommerce-admin' ),
 			'items_sold'     => __( 'Items Sold', 'woocommerce-admin' ),
 			'net_revenue'    => __( 'Net Revenue', 'woocommerce-admin' ),
 			'products_count' => __( 'Products', 'woocommerce-admin' ),
 			'orders_count'   => __( 'Orders', 'woocommerce-admin' ),
+		);
+
+		/**
+		 * Filter to add or remove column names from the categories report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_categories_export_columns',
+			$export_columns
 		);
 	}
 
@@ -341,12 +352,24 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_item = array(
 			'category'       => $item['extended_info']['name'],
 			'items_sold'     => $item['items_sold'],
 			'net_revenue'    => $item['net_revenue'],
 			'products_count' => $item['products_count'],
 			'orders_count'   => $item['orders_count'],
+		);
+
+		/**
+		 * Filter to prepare extra columns in the export item for the
+		 * categories export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_categories_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }

--- a/src/API/Reports/Coupons/Controller.php
+++ b/src/API/Reports/Coupons/Controller.php
@@ -295,13 +295,24 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'code'         => __( 'Coupon Code', 'woocommerce-admin' ),
 			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
 			'amount'       => __( 'Amount Discounted', 'woocommerce-admin' ),
 			'created'      => __( 'Created', 'woocommerce-admin' ),
 			'expires'      => __( 'Expires', 'woocommerce-admin' ),
 			'type'         => __( 'Type', 'woocommerce-admin' ),
+		);
+
+		/**
+		 * Filter to add or remove column names from the coupons report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_coupons_export_columns',
+			$export_columns
 		);
 	}
 
@@ -316,13 +327,25 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			? __( 'N/A', 'woocommerce-admin' )
 			: $item['extended_info']['date_expires'];
 
-		return array(
+		$export_item = array(
 			'code'         => $item['extended_info']['code'],
 			'orders_count' => $item['orders_count'],
 			'amount'       => $item['amount'],
 			'created'      => $item['extended_info']['date_created'],
 			'expires'      => $date_expires,
 			'type'         => $item['extended_info']['discount_type'],
+		);
+
+		/**
+		 * Filter to prepare extra columns in the export item for the coupons
+		 * report.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_coupons_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }

--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -582,7 +582,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'name'            => __( 'Name', 'woocommerce-admin' ),
 			'username'        => __( 'Username', 'woocommerce-admin' ),
 			'last_active'     => __( 'Last Active', 'woocommerce-admin' ),
@@ -596,6 +596,17 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'region'          => __( 'Region', 'woocommerce-admin' ),
 			'postcode'        => __( 'Postal Code', 'woocommerce-admin' ),
 		);
+
+		/**
+		 * Filter to add or remove column names from the customers report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_customers_export_columns',
+			$export_columns
+		);
 	}
 
 	/**
@@ -605,7 +616,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_item = array(
 			'name'            => $item['name'],
 			'username'        => $item['username'],
 			'last_active'     => $item['date_last_active'],
@@ -618,6 +629,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'city'            => $item['city'],
 			'region'          => $item['state'],
 			'postcode'        => $item['postcode'],
+		);
+
+		return apply_filters(
+			'woocommerce_report_customers_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -393,13 +393,24 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'date'         => __( 'Date', 'woocommerce-admin' ),
 			'product'      => __( 'Product Title', 'woocommerce-admin' ),
 			'file_name'    => __( 'File Name', 'woocommerce-admin' ),
 			'order_number' => __( 'Order #', 'woocommerce-admin' ),
 			'user_id'      => __( 'User Name', 'woocommerce-admin' ),
 			'ip_address'   => __( 'IP', 'woocommerce-admin' ),
+		);
+
+		/**
+		 * Filter to add or remove column names from the downloads report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_filter_downloads_export_columns',
+			$export_columns
 		);
 	}
 
@@ -410,13 +421,25 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_columns = array(
 			'date'         => $item['date'],
 			'product'      => $item['_embedded']['product'][0]['name'],
 			'file_name'    => $item['file_name'],
 			'order_number' => $item['order_number'],
 			'user_id'      => $item['username'],
 			'ip_address'   => $item['ip_address'],
+		);
+
+		/**
+		 * Filter to prepare extra columns in the export item for the downloads
+		 * report.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_downloads_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -490,7 +490,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'date_created'   => __( 'Date', 'woocommerce-admin' ),
 			'order_number'   => __( 'Order #', 'woocommerce-admin' ),
 			'status'         => __( 'Status', 'woocommerce-admin' ),
@@ -499,6 +499,17 @@ class Controller extends ReportsController implements ExportableInterface {
 			'num_items_sold' => __( 'Items Sold', 'woocommerce-admin' ),
 			'coupons'        => __( 'Coupon(s)', 'woocommerce-admin' ),
 			'net_total'      => __( 'N. Revenue', 'woocommerce-admin' ),
+		);
+
+		/**
+		 * Filter to add or remove column names from the orders report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_orders_export_columns',
+			$export_columns
 		);
 	}
 
@@ -509,7 +520,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_item = array(
 			'date_created'   => $item['date_created'],
 			'order_number'   => $item['order_number'],
 			'status'         => $item['status'],
@@ -518,6 +529,18 @@ class Controller extends ReportsController implements ExportableInterface {
 			'num_items_sold' => $item['num_items_sold'],
 			'coupons'        => isset( $item['extended_info']['coupons'] ) ? $this->_get_coupons( $item['extended_info']['coupons'] ) : null,
 			'net_total'      => $item['net_total'],
+		);
+
+		/**
+		 * Filter to prepare extra columns in the export item for the orders
+		 * report.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_orders_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -397,7 +397,16 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$export_columns['stock']        = __( 'Stock', 'woocommerce-admin' );
 		}
 
-		return $export_columns;
+		/**
+		 * Filter to add or remove column names from the products report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_products_export_columns',
+			$export_columns
+		);
 	}
 
 	/**
@@ -427,6 +436,16 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			}
 		}
 
-		return $export_item;
+		/**
+		 * Filter to prepare extra columns in the export item for the products
+		 * report.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_products_prepare_export_item',
+			$export_item,
+			$item
+		);
 	}
 }

--- a/src/API/Reports/Stock/Controller.php
+++ b/src/API/Reports/Stock/Controller.php
@@ -520,11 +520,22 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'title'          => __( 'Product / Variation', 'woocommerce-admin' ),
 			'sku'            => __( 'SKU', 'woocommerce-admin' ),
 			'stock_status'   => __( 'Status', 'woocommerce-admin' ),
 			'stock_quantity' => __( 'Stock', 'woocommerce-admin' ),
+		);
+
+		/**
+		 * Filter to add or remove column names from the stock report for
+		 * export.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_stock_export_columns',
+			$export_columns
 		);
 	}
 
@@ -535,11 +546,23 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_item = array(
 			'title'          => $item['name'],
 			'sku'            => $item['sku'],
 			'stock_status'   => $item['stock_status'],
 			'stock_quantity' => $item['stock_quantity'],
+		);
+
+		/**
+		 * Filter to prepare extra columns in the export item for the stock
+		 * report.
+		 *
+		 * @since 1.6.0
+		 */
+		return apply_filters(
+			'woocommerce_report_stock_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }


### PR DESCRIPTION
Fixes #4235

This adds filters to the available analytics report controllers so that columns can be added or removed from the downloaded CSV:

- `woocommerce_report_[REPORT]_export_columns` - add the columns
- `woocommerce_report_[REPORT]_prepare_export_item` - add the column values to the item

Note that this only applies to the downloaded CSV - the columns shown in the UI stay the same as that seems out of scope of this PR.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/93047057-deb6a980-f69e-11ea-99ca-cc1e802aa5bf.png)

### Detailed test instructions:

I've created a test plugin (https://gist.github.com/becdetat/0de2f79672e768f4e72b43d7ab07e2e3) that demonstrates the new filters.

- Install and activate the test plugin zip from [here](https://gist.github.com/becdetat/0de2f79672e768f4e72b43d7ab07e2e3/archive/5b57045ecb5a7840b9e9b088b6add7acc4ddcd06.zip).
- Open an analytics page such as Products (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts&period=year&compare=previous_year`) - note that the report table must extend past the number of rows per page, so that the download from the server is triggered.
- Make sure the new "Random number" column is present.

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
