### PR TITLE
Search all variation attribute values, not just global ones.

### DIFF
--- a/src/API/ProductVariations.php
+++ b/src/API/ProductVariations.php
@@ -79,7 +79,7 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 		if ( $search ) {
 			$join .= " LEFT JOIN {$wpdb->postmeta} AS attr_search_meta
 						ON {$wpdb->posts}.ID = attr_search_meta.post_id
-						AND attr_search_meta.meta_key LIKE 'attribute_pa_%' ";
+						AND attr_search_meta.meta_key LIKE 'attribute_%' ";
 		}
 
 		if ( wc_product_sku_enabled() && ! strstr( $join, 'wc_product_meta_lookup' ) ) {

--- a/tests/api/variations.php
+++ b/tests/api/variations.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Variations REST API Test
+ *
+ * @package WooCommerce\Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Variations
+ */
+class WC_Tests_API_Variations extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-analytics/variations';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test variation search works for global and local product attributes.
+	 */
+	public function test_variation_search() {
+		wp_set_current_user( $this->user );
+
+		// Create a variable product, then create a variation using "global" product attributes.
+		$product    = WC_Helper_Product::create_variation_product();
+		$data_store = $product->get_data_store();
+		$data_store->create_all_product_variations( $product, 1 );
+		$child_product_ids = $product->get_children();
+		$variation_1       = wc_get_product( $child_product_ids[0] );
+
+		// Create a variation, using "local" attribute key/value pairs.
+		$variation_2 = WC_Helper_Product::create_product_variation_object( $product->get_id(), '', 23, array( 'flavor' => 'banana' ) );
+
+		// Test searching for the "global" size attribute.
+		$request = new WP_REST_Request( 'GET', "/wc-analytics/products/{$product->get_id()}/variations" );
+		$request->set_param( 'search', 'small' );
+		$response   = $this->server->dispatch( $request );
+		$variations = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $variations ) );
+		$this->assertEquals( $variation_1->get_id(), $variations[0]['id'] );
+
+		// Test searching for the "local" flavor attribute.
+		$request = new WP_REST_Request( 'GET', "/wc-analytics/products/{$product->get_id()}/variations" );
+		$request->set_param( 'search', 'banana' );
+		$response   = $this->server->dispatch( $request );
+		$variations = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $variations ) );
+		$this->assertEquals( $variation_2->get_id(), $variations[0]['id'] );
+	}
+}

--- a/tests/api/variations.php
+++ b/tests/api/variations.php
@@ -44,7 +44,16 @@ class WC_Tests_API_Variations extends WC_REST_Unit_Test_Case {
 		$variation_1       = wc_get_product( $child_product_ids[0] );
 
 		// Create a variation, using "local" attribute key/value pairs.
-		$variation_2 = WC_Helper_Product::create_product_variation_object( $product->get_id(), '', 23, array( 'flavor' => 'banana' ) );
+		// NOTE: WC_Helper_Product::create_product_variation_object() is only available for WC 4.4+.
+		$variation_2 = new WC_Product_Variation();
+		$variation_2->set_props(
+			array(
+				'parent_id'     => $product->get_id(),
+				'regular_price' => 23,
+			)
+		);
+		$variation_2->set_attributes( array( 'flavor' => 'banana' ) );
+		$variation_2->save();
 
 		// Test searching for the "global" size attribute.
 		$request = new WP_REST_Request( 'GET', "/wc-analytics/products/{$product->get_id()}/variations" );


### PR DESCRIPTION
Fixes an issue with the implementation in #5100.

The prior PR only search "global" product attribute values - those created through the Products > Attributes term management screens.

This PR seeks to reduce the specificity of the SQL `LIKE` clause to match all `attribute_%` meta_keys, not just `attribute_pa_%`.

### Detailed test instructions:

The included test case illustrates the problem - variations that have "one off" or non-global attributes vs. those that use attributes and values that have been defined in the Product Attribute taxonomy.

To be honest, I'm not sure how to create non-global product attributes through the WooCommerce dashboard. My test store populated with WC Smooth Generator does have products with both `attribute_` and `attribute_pa_` prefixed postmeta keys.

If you query your post meta table and find both types of keys, you can test with the UI:

- Visit the Product Report > Single Product and search for a variable product.
- See the Product Report's variation names shown in full.
- Select "single variation" from the dropdown
- Search for variations using a global attribute value ( like, "orange" color )
- Verify results are shown as expected
- Search for variations using a non-global attribute value ( like, "banana" flavor )
- Verify results are shown as expected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug.