### PR TITLE
Optimize the wc-admin bundle size by unbundling @wordpress/components

### DIFF
--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -4,8 +4,10 @@
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { __experimentalText as Text } from '@wordpress/components';
-import { EllipsisMenu } from '@woocommerce/components';
+import {
+	EllipsisMenu,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 
 /**
  * Internal dependencies

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -2,14 +2,17 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalText as Text } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { Icon, chevronRight, page } from '@wordpress/icons';
 import { partial } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { List, Section } from '@woocommerce/components';
+import {
+	List,
+	Section,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
 	PLUGINS_STORE_NAME,

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -10,7 +10,6 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { get, xor } from 'lodash';
 import {
@@ -18,6 +17,7 @@ import {
 	MenuItem,
 	MenuTitle,
 	Link,
+	__experimentalText as Text,
 } from '@woocommerce/components';
 import { useUserPreferences, PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -2,13 +2,18 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { filter } from 'lodash';
 import interpolateComponents from 'interpolate-components';
-import { Card, H, Link } from '@woocommerce/components';
+import {
+	Card,
+	H,
+	Link,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 import {
 	pluginNames,
 	ONBOARDING_STORE_NAME,

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -9,7 +9,6 @@ import {
 	CheckboxControl,
 	FormToggle,
 	Popover,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -21,6 +20,7 @@ import {
 	SelectControl,
 	Form,
 	TextControl,
+	__experimentalText as Text,
 } from '@woocommerce/components';
 import { formatValue } from '@woocommerce/number';
 import { getSetting } from '@woocommerce/wc-admin-settings';

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -3,17 +3,17 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import {
-	Button,
-	CheckboxControl,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { filter, find, findIndex, get } from 'lodash';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { Card, TextControl } from '@woocommerce/components';
+import {
+	Card,
+	TextControl,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -4,15 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import {
-	Button,
-	CheckboxControl,
-	FormToggle,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, CheckboxControl, FormToggle } from '@wordpress/components';
 import { includes, filter, get } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { Card } from '@woocommerce/components';
+import { Card, __experimentalText as Text } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';

--- a/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -9,12 +9,12 @@ exports[`ProductTypes should render product types 1`] = `
       class="woocommerce-profile-wizard__step-header"
     >
       <h2
-        class="css-1ahfdc3-Text e15wbhsk0"
+        class="css-vs1sg7"
       >
         What type of products will be listed?
       </h2>
       <p
-        class="css-1f0yw52-Text e15wbhsk0"
+        class="css-1mcmzt5"
       >
         Choose any that apply
       </p>
@@ -67,7 +67,7 @@ exports[`ProductTypes should render product types 1`] = `
                 </button>
                 
                 <span
-                  class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+                  class="woocommerce-pill css-1y33v7p"
                 >
                   <span
                     class="screen-reader-text"
@@ -112,7 +112,7 @@ you can purchase and install it later.
               for="woocommerce-product-types__pricing-toggle"
             >
               <p
-                class="css-1f0yw52-Text e15wbhsk0"
+                class="css-1mcmzt5"
               >
                 Display monthly prices
               </p>
@@ -152,7 +152,7 @@ you can purchase and install it later.
       class="woocommerce-profile-wizard__card-help-text"
     >
       <p
-        class="css-1qmnemh-Text e15wbhsk0"
+        class="css-1y33v7p"
       >
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </p>
@@ -170,12 +170,12 @@ exports[`ProductTypes should show annual prices on toggle 1`] = `
       class="woocommerce-profile-wizard__step-header"
     >
       <h2
-        class="css-1ahfdc3-Text e15wbhsk0"
+        class="css-vs1sg7"
       >
         What type of products will be listed?
       </h2>
       <p
-        class="css-1f0yw52-Text e15wbhsk0"
+        class="css-1mcmzt5"
       >
         Choose any that apply
       </p>
@@ -228,7 +228,7 @@ exports[`ProductTypes should show annual prices on toggle 1`] = `
                 </button>
                 
                 <span
-                  class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+                  class="woocommerce-pill css-1y33v7p"
                 >
                   <span
                     class="screen-reader-text"
@@ -273,7 +273,7 @@ you can purchase and install it later.
               for="woocommerce-product-types__pricing-toggle"
             >
               <p
-                class="css-1f0yw52-Text e15wbhsk0"
+                class="css-1mcmzt5"
               >
                 Display monthly prices
               </p>
@@ -313,7 +313,7 @@ you can purchase and install it later.
       class="woocommerce-profile-wizard__card-help-text"
     >
       <p
-        class="css-1qmnemh-Text e15wbhsk0"
+        class="css-1y33v7p"
       >
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </p>

--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -11,12 +11,11 @@ import {
 	FlexItem,
 	Icon,
 	Tooltip,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Form } from '@woocommerce/components';
+import { Form, __experimentalText as Text } from '@woocommerce/components';
 import { getCurrencyData } from '@woocommerce/currency';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -7,14 +7,9 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import Gridicon from 'gridicons';
-import {
-	Button,
-	TabPanel,
-	Tooltip,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, TabPanel, Tooltip } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, H } from '@woocommerce/components';
+import { Card, H, __experimentalText as Text } from '@woocommerce/components';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';

--- a/client/quick-links/index.js
+++ b/client/quick-links/index.js
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import {
 	Icon,
 	megaphone,
@@ -23,7 +18,7 @@ import {
 } from '@wordpress/icons';
 import { partial } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { List } from '@woocommerce/components';
+import { List, __experimentalText as Text } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -5,17 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { Component, cloneElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
 import { xor } from 'lodash';
-import { List, EllipsisMenu } from '@woocommerce/components';
+import {
+	List,
+	EllipsisMenu,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import {
 	PLUGINS_STORE_NAME,

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -2,13 +2,20 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { difference, filter } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, H, Link, Stepper, Plugins } from '@woocommerce/components';
+import {
+	Card,
+	H,
+	Link,
+	Stepper,
+	Plugins,
+	__experimentalText as Text,
+} from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7972,6 +7972,8 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs2": "7.11.2",
+				"@emotion/core": "^10.0.35",
+				"@emotion/styled": "^10.0.27",
 				"@woocommerce/csv-export": "1.2.0",
 				"@woocommerce/currency": "2.0.0",
 				"@woocommerce/data": "1.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,8 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.11.2",
+		"@emotion/core": "^10.0.35",
+		"@emotion/styled": "^10.0.27",
 		"@woocommerce/csv-export": "1.2.0",
 		"@woocommerce/currency": "2.0.0",
 		"@woocommerce/data": "1.0.0",

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -4,6 +4,7 @@
 import 'react-dates/initialize';
 // The above: Turn on react-dates classes/styles, see https://github.com/airbnb/react-dates#initialize
 
+export { default as __experimentalText } from './text';
 export { default as AdvancedFilters } from './advanced-filters';
 export { default as AnimationSlider } from './animation-slider';
 export { default as Chart } from './chart';

--- a/packages/components/src/pill/pill.js
+++ b/packages/components/src/pill/pill.js
@@ -1,7 +1,8 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { __experimentalText as Text } from '@wordpress/components';
+import Text from '../text';
+
 export function Pill( { children } ) {
 	return (
 		<Text className="woocommerce-pill" variant="caption" as="span">

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -1,20 +1,18 @@
 /**
  * External dependencies
  */
-import {
-	Button,
-	Tooltip,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { isNil, noop } from 'lodash';
 import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
 import Link from '../link';
+import Text from '../text';
 
 /**
  * A component to show a value, label, and an optional change percentage. Can also act as a link to a specific report focus.

--- a/packages/components/src/text/index.js
+++ b/packages/components/src/text/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { text } from './styles/text-mixins';
+
+// This is the @wordpress/components Text component forked inside
+// wc-admin for now. The reason for doing this, is that bundling
+// this one component drastically reduces the size of the wc-admin
+// payload, because we don't need to bundle `@wordpress/components`
+// anymore. Once the Text component is promoted out of experimental
+// we should be able to remove this code.
+
+const Text = styled.p(
+	`
+	box-sizing: border-box;
+	margin: 0;
+`,
+	text
+);
+
+export default Text;

--- a/packages/components/src/text/styles/emotion-css.js
+++ b/packages/components/src/text/styles/emotion-css.js
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/core';
+
+export default css;

--- a/packages/components/src/text/styles/font-family.js
+++ b/packages/components/src/text/styles/font-family.js
@@ -1,0 +1,2 @@
+export const fontFamily = `font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;`;

--- a/packages/components/src/text/styles/text-mixins.js
+++ b/packages/components/src/text/styles/text-mixins.js
@@ -1,0 +1,150 @@
+/**
+ * Internal dependencies
+ */
+import { fontFamily } from './font-family';
+import css from './emotion-css';
+
+const fontWeightNormal = `font-weight: 400;`;
+const fontWeightSemibold = `font-weight: 600;`;
+
+const title = `
+  ${ fontWeightNormal }
+`;
+
+const titleLarge = `
+	font-size: 32px;
+	line-height: 40px;
+`;
+
+const titleMedium = `
+	font-size: 24px;
+	line-height: 32px;
+`;
+
+const titleSmall = `
+	font-size: 20px;
+	line-height: 28px;
+`;
+
+const subtitle = `
+	${ fontWeightSemibold }
+	font-size: 14px;
+	line-height: 20px;
+`;
+
+const subtitleLarge = `
+	font-size: 16px;
+	line-height: 24px;
+`;
+
+const subtitleSmall = `
+	font-size: 14px;
+	line-height: 20px;
+`;
+
+const body = `
+	${ fontWeightNormal }
+`;
+
+const bodyLarge = `
+	font-size: 16px;
+	line-height: 24px;
+`;
+
+const bodySmall = `
+	font-size: 14px;
+	line-height: 20px;
+`;
+
+const button = `
+  ${ fontWeightSemibold }
+  font-size: 14px;
+  line-height: 20px;
+`;
+
+const caption = `
+	${ fontWeightNormal }
+	font-size: 12px;
+	line-height: 16px;
+`;
+
+const label = `
+	${ fontWeightSemibold }
+	font-size: 12px;
+	line-height: 16px;
+`;
+
+/**
+ * @typedef {'title.large'|'title.medium'|'title.small'|'subtitle'|'subtitle.small'|'body'|'body.large'|'body.small'|'button'|'caption'|'label'} TextVariant
+ */
+
+/**
+ * @param {TextVariant} variantName
+ */
+const variant = ( variantName = 'body' ) => {
+	switch ( variantName ) {
+		case 'title.large':
+			return css`
+				${ title }
+				${ titleLarge }
+			`;
+		case 'title.medium':
+			return css`
+				${ title }
+				${ titleMedium }
+			`;
+		case 'title.small':
+			return css`
+				${ title }
+				${ titleSmall }
+			`;
+
+		case 'subtitle':
+			return css`
+				${ subtitle }
+				${ subtitleLarge }
+			`;
+		case 'subtitle.small':
+			return css`
+				${ subtitle }
+				${ subtitleSmall }
+			`;
+
+		case 'body':
+			return css`
+				${ body }
+			`;
+		case 'body.large':
+			return css`
+				${ body }
+				${ bodyLarge }
+			`;
+		case 'body.small':
+			return css`
+				${ body }
+				${ bodySmall }
+			`;
+
+		case 'button':
+			return button;
+
+		case 'caption':
+			return caption;
+
+		case 'label':
+			return label;
+	}
+};
+
+/**
+ * @typedef {Object} TextProps
+ * @property {TextVariant} variant one of TextVariant to be used
+ */
+
+/**
+ * @param {TextProps} props
+ */
+export const text = ( props ) => css`
+	${ fontFamily }
+	${ variant( props.variant ) }
+`;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -368,6 +368,7 @@ class Loader {
 			array(
 				'moment',
 				'wp-api-fetch',
+				'wp-components',
 				'wp-data',
 				'wp-data-controls',
 				'wp-element',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ const externals = {
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/data-controls': { this: [ 'wp', 'dataControls' ] },
+	'@wordpress/components': { this: [ 'wp', 'components' ] },
 	tinymce: 'tinymce',
 	moment: 'moment',
 	react: 'React',


### PR DESCRIPTION
Fixes #5034

Unbundle `@wordpress/components` to save significant size across all the JS bundles.

To do this, I've forked `__experimentalText` for now as a temporary solution. It is the only piece of `@wordpress/components` that we currently use that cannot be loaded from the browser global. It is exposed from our
components package because it is used in both `client` and `packages` at the moment. Any ideas of a better
place for it would be welcome, I've kept it marked as experimental in the hope that others would not use it without
realizing it is unstable.

This is however a less than ideal solution and I'm happy to hear if anyone has issues with this approach.

As a result of forking `__experimentalText` and unbundling `@wordpress/components` we save a total
of `1.31mb` over all scripts. The `app` entry point alone drops by `353.31kb`.

### Testing

To test this I recommend a smoke test of all the areas of the application, looking for any errors in console. You should also smoke test Wordpress version `5.3` and `5.4` in the same way.

If you would like to see the bundle size differences for yourself then you can do:

1. Check out `main`, run `npm clean && npm i && npm run analyze`. A browser window will open and show you the size of the all the bundles. It's crucial that you run `npm clean` because leftover artifacts from other builds may be counted.

2. Check out this branch and run `npm clean && npm i && npm run analyze`. Compare the sizes to see the differences.



