### PR TITLE
Taxes Sync: Force float before addition of string numbers

### DIFF
--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -287,7 +287,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 					'tax_rate_id'  => $tax_item->get_rate_id(),
 					'shipping_tax' => $tax_item->get_shipping_tax_total(),
 					'order_tax'    => $tax_item->get_tax_total(),
-					'total_tax'    => $tax_item->get_tax_total() + $tax_item->get_shipping_tax_total(),
+					'total_tax'    => (float) $tax_item->get_tax_total() + (float) $tax_item->get_shipping_tax_total(),
 				),
 				array(
 					'%d',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5136

aka Explorations in PHP numbers as strings.

So apparently PHP adds numbers as strings 🤭 

```php
$number = "33" + "66"; 
error_log( $number); // 99
error_log( gettype( $number ) ); // integer
```
But maybe not with all versions because https://github.com/woocommerce/woocommerce-admin/issues/5136 🤔 

In any case, this PR forces stringed values to be floats before adding them because [WC_Order_Item_Tax](https://woocommerce.github.io/code-reference/classes/WC-Order-Item-Tax.html) returns strings for some values where you'd expect numbers.

Interestingly, PHP is smart enough to caste as double where appropriate.

```php
$number = (float) "33.33" + (float) "66.66"; 
error_log( gettype( $number ) ); // double 👍 
```

### Question

Since PHP handles adding stringed numbers (but not always) are the changes done here best practice? I find it interesting that this doesn't happen ALL the time. Is it possible a simple update to PHP will solve this problem? 

### Detailed test instructions:

1. Create an order, making sure it has taxes applied.
2. Visit the Taxes Report and make sure it was correctly synced.

### Changelog Note:

- Dev: Caste WC_Order_Item_Tax 's `get_tax_total` and `get_shipping_tax_total` results before adding them
