### PR TITLE
Use 'yes' to update modal dismiss option.

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -123,8 +123,7 @@ export const Layout = ( {
 				<WelcomeModal
 					onClose={ () => {
 						updateOptions( {
-							woocommerce_task_list_welcome_modal_dismissed:
-								'yes',
+							woocommerce_task_list_welcome_modal_dismissed: true,
 						} );
 					} }
 				/>
@@ -167,7 +166,7 @@ export default compose(
 
 		const welcomeModalDismissed =
 			getOption( 'woocommerce_task_list_welcome_modal_dismissed' ) ===
-			'1';
+			'yes';
 
 		const welcomeModalDismissedIsResolving = isResolving( 'getOption', [
 			'woocommerce_task_list_welcome_modal_dismissed',

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -123,7 +123,8 @@ export const Layout = ( {
 				<WelcomeModal
 					onClose={ () => {
 						updateOptions( {
-							woocommerce_task_list_welcome_modal_dismissed: true,
+							woocommerce_task_list_welcome_modal_dismissed:
+								'yes',
 						} );
 					} }
 				/>


### PR DESCRIPTION
Fixes a bug I noticed in Atomic sites where dismissing the home screen modal would not set the option causing the modal to come back on each reload.

Under the hood our options rest API calls `update_option`. because of the implementation of this, its actually not clear if `update_option` is somehow coeercing the set value to false, or if its not actually setting the option, because `update_option` returns false if it doesn't update it. 

I confirmed though that changing to use `yes`, did set the option correctly with the same user as before, so I think this should fix the issue.

### Detailed test instructions:

1. Create an atomic ephemeral site
2. Package up this branch as a plugin by running `npm run test:zip`
3. Install the zip file as a plugin via the plugin manager (alongside WooCommerce 4.5.2)
4. Skip the OBW and go to the WooCommerce home screen
5. Click through all the buttons in the modal, clicking "lets go" to dismiss the modal
6. Refresh the page
7. Expected: the modal should not reappear

### Changelog Note:

Fix: persist the option to dismiss the home screen modal.