### PR TITLE
Store Profiler - Industry: reduced padding and removed industry

### DIFF
--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -291,8 +291,8 @@
 			margin-top: 0;
 			margin-bottom: 0;
 			position: relative;
-			padding: $gap $gap-large;
-			min-height: 56px;
+			padding: $gap-small $gap-large;
+			min-height: 44px;
 			border-bottom: 1px solid $gray-100;
 
 			.components-base-control {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -315,11 +315,6 @@ class Onboarding {
 					'use_description'   => false,
 					'description_label' => '',
 				),
-				'art-music-photography'           => array(
-					'label'             => __( 'Art, music, and photography', 'woocommerce-admin' ),
-					'use_description'   => false,
-					'description_label' => '',
-				),
 				'electronics-computers'           => array(
 					'label'             => __( 'Electronics and computers', 'woocommerce-admin' ),
 					'use_description'   => false,

--- a/tests/e2e/specs/activate-and-setup/complete-industry-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-industry-section.js
@@ -9,7 +9,7 @@ import { clickContinue, setCheckboxToChecked, getText } from './utils';
 import { waitForElementCount } from '../../utils/lib';
 const config = require( 'config' );
 
-export async function completeIndustrySection( expectedIndustryCount = 9 ) {
+export async function completeIndustrySection( expectedIndustryCount = 8 ) {
 	// Query for the industries checkboxes
 	await waitForElementCount(
 		page,

--- a/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
@@ -44,7 +44,7 @@ describe( 'Non-US store does not get the install recommended features checkbox',
 		} );
 	} );
 	it( 'can complete the industry section', async () => {
-		await completeIndustrySection( 8 );
+		await completeIndustrySection( 7 );
 	} );
 	it( 'can complete the product types section', completeProductTypesSection );
 	it( 'does not have the install recommended features checkbox', async () => {


### PR DESCRIPTION
Fixes #5155

This PR aims to reduce the size of the industries list in the second step of the Store profiler.
- The top/bottom padding of each list item is reduced by 4px
- The industry `Art, Music & Photography` is removed from the list.

### Screenshots
![screenshot-one wordpress test-2020 09 17-17_46_55](https://user-images.githubusercontent.com/1314156/93526506-ec259b00-f90d-11ea-8037-9fdb43619489.png)


### Detailed test instructions:

- Go to the second step of the OBW (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`)
- Verify the item `Art, Music & Photography` is not visible.
- Verify that the list looks like the image above.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Store Profiler - Industry step: reduced padding and removed industry
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
