### PR TITLE
Remove ` @woocommerce/wc-admin-settings` from data package

### DIFF
--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { PLUGINS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
 import { H } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -96,7 +97,7 @@ export const InstallJetpackCTA = () => {
 	const { installJetpackAndConnect } = useDispatch( PLUGINS_STORE_NAME );
 
 	const onClickInstall = () => {
-		installJetpackAndConnect( createErrorNotice );
+		installJetpackAndConnect( createErrorNotice, getAdminLink );
 	};
 
 	return (

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -20,6 +20,7 @@ import {
 	QUERY_DEFAULTS,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -346,7 +347,8 @@ export default compose(
 		const connectToJetpack = ( failureRedirect ) => {
 			connectToJetpackWithFailureRedirect(
 				failureRedirect,
-				createErrorNotice
+				createErrorNotice,
+				getAdminLink
 			);
 		};
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.2
+
+-   Update dependencies.
+
 # 5.1.1
 
 -   Update dependencies.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
@@ -24,7 +24,7 @@
 		"@babel/runtime-corejs2": "7.11.2",
 		"@woocommerce/csv-export": "1.2.0",
 		"@woocommerce/currency": "3.0.0",
-		"@woocommerce/data": "1.1.0",
+		"@woocommerce/data": "1.1.1",
 		"@woocommerce/date": "2.0.0",
 		"@woocommerce/navigation": "5.1.0",
 		"@wordpress/components": "10.0.0",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+-   Remove usage of wc-admin alias `@woocommerce/wc-admin-settings`.
+
 # 1.1.0
 
 -   Add export, import, items, notes, reports, and reviews data stores.

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -146,12 +146,16 @@ export function* connectToJetpack( getAdminLink ) {
 	}
 }
 
-export function* installJetpackAndConnect( errorAction ) {
+export function* installJetpackAndConnect( errorAction, getAdminLink ) {
 	try {
 		yield dispatch( STORE_NAME, 'installPlugins', [ 'jetpack' ] );
 		yield dispatch( STORE_NAME, 'activatePlugins', [ 'jetpack' ] );
 
-		const url = yield dispatch( STORE_NAME, 'connectToJetpack' );
+		const url = yield dispatch(
+			STORE_NAME,
+			'connectToJetpack',
+			getAdminLink
+		);
 		window.location = url;
 	} catch ( error ) {
 		yield errorAction( error.message );
@@ -164,9 +168,11 @@ export function* connectToJetpackWithFailureRedirect(
 	getAdminLink
 ) {
 	try {
-		const url = yield dispatch( STORE_NAME, 'connectToJetpack', [
-			getAdminLink,
-		] );
+		const url = yield dispatch(
+			STORE_NAME,
+			'connectToJetpack',
+			getAdminLink
+		);
 		window.location = url;
 	} catch ( error ) {
 		yield errorAction( error.message );

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { apiFetch, dispatch, select } from '@wordpress/data-controls';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -130,7 +129,7 @@ export const createErrorNotice = ( errorMessage ) => {
 	return dispatch( 'core/notices', 'createNotice', errorMessage );
 };
 
-export function* connectToJetpack() {
+export function* connectToJetpack( getAdminLink ) {
 	const url = yield select( STORE_NAME, 'getJetpackConnectUrl', {
 		redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
 	} );
@@ -161,10 +160,13 @@ export function* installJetpackAndConnect( errorAction ) {
 
 export function* connectToJetpackWithFailureRedirect(
 	failureRedirect,
-	errorAction
+	errorAction,
+	getAdminLink
 ) {
 	try {
-		const url = yield dispatch( STORE_NAME, 'connectToJetpack' );
+		const url = yield dispatch( STORE_NAME, 'connectToJetpack', [
+			getAdminLink,
+		] );
 		window.location = url;
 	} catch ( error ) {
 		yield errorAction( error.message );

--- a/packages/data/src/plugins/test/actions.js
+++ b/packages/data/src/plugins/test/actions.js
@@ -36,7 +36,7 @@ describe( 'installJetPackAndConnect', () => {
 	} );
 
 	it( 'installs jetpack, then activates it', () => {
-		const installer = installJetpackAndConnect( () => {} );
+		const installer = installJetpackAndConnect( () => {}, getAdminLink );
 
 		// Run to first yield
 		installer.next();
@@ -60,7 +60,10 @@ describe( 'installJetPackAndConnect', () => {
 
 	it( 'calls the passed error handler if an exception is thrown into the generator', () => {
 		const errorHandler = jest.fn();
-		const installer = installJetpackAndConnect( errorHandler );
+		const installer = installJetpackAndConnect(
+			errorHandler,
+			getAdminLink
+		);
 
 		// Run to first yield
 		installer.next();
@@ -72,7 +75,7 @@ describe( 'installJetPackAndConnect', () => {
 	} );
 
 	it( 'redirects to the connect url if there are no errors', () => {
-		const installer = installJetpackAndConnect();
+		const installer = installJetpackAndConnect( undefined, getAdminLink );
 
 		// Run to yield any errors from getJetpackConnectUrl
 		installer.next();

--- a/packages/data/src/plugins/test/actions.js
+++ b/packages/data/src/plugins/test/actions.js
@@ -2,6 +2,11 @@
  * @jest-environment node
  */
 
+/**
+ * External dependencies
+ */
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
+
 jest.mock( '@wordpress/data-controls', () => ( {
 	dispatch: jest.fn(),
 	select: jest.fn(),
@@ -84,7 +89,8 @@ describe( 'connectToJetpack', () => {
 	it( 'redirects to the failure url if there is an error', () => {
 		const connect = connectToJetpackWithFailureRedirect(
 			'https://example.com/failure',
-			() => {}
+			() => {},
+			getAdminLink
 		);
 
 		connect.next();
@@ -97,7 +103,8 @@ describe( 'connectToJetpack', () => {
 	it( 'redirects to the jetpack url if there is no error', () => {
 		const connect = connectToJetpackWithFailureRedirect(
 			'https://example.com/failure',
-			() => {}
+			() => {},
+			getAdminLink
 		);
 
 		connect.next();
@@ -110,7 +117,11 @@ describe( 'connectToJetpack', () => {
 
 	it( 'calls the passed error handler if an exception is thrown into the generator', () => {
 		const errorHandler = jest.fn();
-		const connect = connectToJetpackWithFailureRedirect( '', errorHandler );
+		const connect = connectToJetpackWithFailureRedirect(
+			'',
+			errorHandler,
+			getAdminLink
+		);
 
 		// Run to first yield
 		connect.next();


### PR DESCRIPTION
The data package made a reference to `@woocommerce/wc-admin-settings` which is a webpack alias in wc-admin and not an actual package. This means usage outside of the wc-admin context will cause fatal errors.

https://github.com/woocommerce/woocommerce-admin/blob/aeb6b9801d21cf382bfedf879913eea5614c7b89/webpack.config.js#L162-L165

This PR remove that dependency by passing in `getAdminLink` to plugin store actions. Changes are also made in preparation for releasing `@woocommerce/data` and `@woocommerce/components` which uses the data package.

### Detailed test instructions:

1. `npm run test:zip`
2. Fire up a Jurassic Ninja site
3. Connect to Jetpack from either the Homescreen or OBW

### Changelog Note:

- Dev: Remove `getAdminLink` from data package