### PR TITLE
Fix a bug where the activity panel options flicker on non-homescreen pages.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -51,6 +51,7 @@ const ReviewsPanel = lazy( () =>
 
 const manageStock = getSetting( 'manageStock', 'no' );
 const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
+
 export class ActivityPanel extends Component {
 	constructor( props ) {
 		super( props );
@@ -136,6 +137,12 @@ export class ActivityPanel extends Component {
 			! query.path &&
 			( requestingTaskListOptions === true ||
 				( taskListHidden === false && taskListComplete === false ) );
+
+		// If still loading the task list options present an empty list to prevent
+		// flickering between 2 lists of options.
+		if ( requestingTaskListOptions && ! isPerformingSetupTask ) {
+			return [];
+		}
 
 		if ( ! taskListComplete && showInbox ) {
 			return [

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -36,6 +36,19 @@ describe( 'Activity Panel', () => {
 		expect( screen.queryByText( 'Inbox' ) ).toBeNull();
 	} );
 
+	it( 'should not render any tabs if task list options are loading and its not a setup task', async () => {
+		const { queryAllByRole } = render(
+			<ActivityPanel
+				requestingTaskListOptions
+				isPerformingSetupTask={ false }
+				query={ {} }
+			/>
+		);
+
+		// Expect no tabs to display
+		expect( queryAllByRole( 'tab' ) ).toHaveLength( 0 );
+	} );
+
 	it( 'should render help tab before options load', async () => {
 		render(
 			<ActivityPanel

--- a/client/index.js
+++ b/client/index.js
@@ -6,6 +6,7 @@ import { render } from '@wordpress/element';
 import {
 	withCurrentUserHydration,
 	withSettingsHydration,
+	withOptionsHydration,
 } from '@woocommerce/data';
 
 /**
@@ -21,6 +22,7 @@ __webpack_public_path__ = global.wcAdminAssets.path;
 const appRoot = document.getElementById( 'root' );
 const settingsGroup = 'wc_admin';
 const hydrateUser = window.wcSettings.currentUserData;
+const hydratedOptions = window.wcSettings.preloadOptions;
 
 if ( appRoot ) {
 	let HydratedPageLayout = withSettingsHydration(
@@ -50,6 +52,11 @@ if ( appRoot ) {
 	)( EmbedLayout );
 	if ( hydrateUser ) {
 		HydratedEmbedLayout = withCurrentUserHydration( hydrateUser )(
+			HydratedEmbedLayout
+		);
+	}
+	if ( window.wcSettings.preloadOptions ) {
+		HydratedEmbedLayout = withOptionsHydration( { ...hydratedOptions } )(
 			HydratedEmbedLayout
 		);
 	}


### PR DESCRIPTION
While investigating another issue I noticed a display bug in ActivityPanel. On non-homescreen pages while resolving task list options from the API it displays one set of tabs and then another once they have resolved, resulting in a janky experience.

This has been resolved here by displaying no tabs while resolving the task list options. Although there is still a delay in the tabs shown it at least doesn't flicker between 2 sets of options.

### Detailed test instructions:

1. Complete the task list on the homescreen.
2. Go to "Orders" page, note that there should be no flicker between 2 sets of tabs in the `ActivityPanel`

### Changelog Note:

Fix: stop a flicker of 2 sets of options on the ActivityPanel on non-homescreen pages.
