### PR TITLE
Fix version update script for composer.json

### DIFF
--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -25,8 +25,8 @@ function replace_version( $filename, $package_json ) {
 		if ( stripos( $line, 'Stable tag: ' ) !== false ) {
 			$line = "Stable tag: {$package_json->version}\n";
 		}
-		if ( stripos( $line, '"name": "woocommerce/woocommerce-admin",' ) !== false ) {
-			$line .= "\t\"version\": \"{$package_json->version}\",\n";
+		if ( stripos( $line, '"version":' ) !== false ) {
+			$line = "\t\"version\": \"{$package_json->version}\",\n";
 		}
 		$lines[] = $line;
 	}


### PR DESCRIPTION
Fixes the version update in `composer.json`.  Previously this was adding 2 version lines.

### Screenshots

**Before**
<img width="267" alt="Screen Shot 2020-09-18 at 3 37 24 PM" src="https://user-images.githubusercontent.com/10561050/93638231-9c270100-f9ff-11ea-8e9c-9898fe1cfeda.png">


**After**
<img width="449" alt="Screen Shot 2020-09-18 at 3 37 48 PM" src="https://user-images.githubusercontent.com/10561050/93638237-9df0c480-f9ff-11ea-9248-74f2dacd9f96.png">


### Detailed test instructions:

1. Bump the version in `package.json`.
1. Run `npm run predev`
1. Make sure the version is correctly updated in `composer.json` and that 2 lines for the version aren't added.