### PR TITLE
Show payments task for non-US stores when wcpay installed

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -191,7 +191,7 @@ export function getAllTasks( {
 				} );
 				updateQueryString( { task: 'payments' } );
 			},
-			visible: ! woocommercePaymentsInstalled,
+			visible: ! woocommercePaymentsInstalled || countryCode !== 'US',
 			time: __( '2 minutes', 'woocommerce-admin' ),
 		},
 		{


### PR DESCRIPTION
The payment task is hidden when WC Pay is installed, which means that non-US stores see no payments on ecomm plans.  This always shows the normal payments task if the store is non-US based.

### Screenshots
<img width="532" alt="Screen Shot 2020-09-18 at 3 48 40 PM" src="https://user-images.githubusercontent.com/10561050/93639074-1c9a3180-fa01-11ea-95bc-5df3d7c53f4d.png">


### Detailed test instructions:

1. Install wcpay (does not have to be active).
1. Check that in the US the payments task is not shown, but the wc pay task is shown.
1. Change to a non-US store.
1. Check that the payments task is now shown.