### PR TITLE
Navigation package: Declare script dependencies

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -323,7 +323,7 @@ class Loader {
 		wp_register_script(
 			'wc-navigation',
 			self::get_url( 'navigation/index', 'js' ),
-			array(),
+			array( 'wp-url', 'wp-hooks' ),
 			$js_file_version,
 			true
 		);


### PR DESCRIPTION
Using `@woocommerce/navigation` as an external in a separate project can cause an issue because it depends on `wp-url` and `wp-hooks` to be loaded first. This PR adds that info in `Loader.php` so those assets are loaded first.

### Detailed test instructions:

1. Spin up a separate repo and configure webpack to use wc-navigation as an external available at `window.wc.navigation`. Use https://github.com/woocommerce/navigation/compare/add/wc-admin-dep?expand=1 as an example.
2. See it being consumed error free.

....OR

1. See that package depends on those items being available and feel good about it making sense.

https://github.com/woocommerce/woocommerce-admin/blob/cbf2dfb6435cdd68c49815e6c6ff3e743f3a3e4e/packages/navigation/src/index.js#L4-L7


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- Dev: Add appropriate script dependencies for `@woocommerce/navigation`
