### PR TITLE
Remove store registration checks that are no longer needed.

### DIFF
--- a/packages/data/src/export/index.js
+++ b/packages/data/src/export/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { select, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,17 +13,11 @@ import * as actions from './actions';
 import controls from '../controls';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+} );
 
 export const EXPORT_STORE_NAME = STORE_NAME;

--- a/packages/data/src/import/index.js
+++ b/packages/data/src/import/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { select, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -14,19 +14,12 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const IMPORT_STORE_NAME = STORE_NAME;

--- a/packages/data/src/items/index.js
+++ b/packages/data/src/items/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { registerStore, select } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,19 +14,12 @@ import * as resolvers from './resolvers';
 import controls from '../controls';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const ITEMS_STORE_NAME = STORE_NAME;

--- a/packages/data/src/notes/index.js
+++ b/packages/data/src/notes/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { select, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -14,18 +14,12 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const NOTES_STORE_NAME = STORE_NAME;

--- a/packages/data/src/onboarding/index.js
+++ b/packages/data/src/onboarding/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { select, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -14,19 +14,12 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const ONBOARDING_STORE_NAME = STORE_NAME;

--- a/packages/data/src/plugins/index.js
+++ b/packages/data/src/plugins/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerStore, select } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -13,19 +13,12 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const PLUGINS_STORE_NAME = STORE_NAME;

--- a/packages/data/src/reports/index.js
+++ b/packages/data/src/reports/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { select, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,19 +14,12 @@ import * as resolvers from './resolvers';
 import controls from '../controls';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const REPORTS_STORE_NAME = STORE_NAME;

--- a/packages/data/src/reviews/index.js
+++ b/packages/data/src/reviews/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { registerStore, select } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,19 +14,12 @@ import * as resolvers from './resolvers';
 import controls from '../controls';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const REVIEWS_STORE_NAME = STORE_NAME;

--- a/packages/data/src/settings/index.js
+++ b/packages/data/src/settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { registerStore, select } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 
 /**
@@ -14,19 +14,12 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducer';
 
-const storeSelectors = select( STORE_NAME );
-
-// @todo This is used to prevent double registration of the store due to webpack chunks.
-// The `storeSelectors` condition can be removed once this is fixed.
-// See https://github.com/woocommerce/woocommerce-admin/issues/4443.
-if ( ! storeSelectors ) {
-	registerStore( STORE_NAME, {
-		reducer,
-		actions,
-		controls,
-		selectors,
-		resolvers,
-	} );
-}
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	controls,
+	selectors,
+	resolvers,
+} );
 
 export const SETTINGS_STORE_NAME = STORE_NAME;


### PR DESCRIPTION
Fixes #4443 

Some investigation found that #4443 is no longer a reproducible issue. Why this issue no longer exists is not clear, but it makes sense now to disable the store registration checks as they are only called once. This PR just removes the checks but does not change any other behaviour.

### Detailed test instructions:

The simplest way to test this is to confirm that store registration does not happen multiple times per store. To do this place a `console.log` statement next to the site of the `registerStore` call. such as here: https://github.com/woocommerce/woocommerce-admin/blob/main/packages/data/src/onboarding/index.js#L23

The data store linked above is the onboarding one, so you could go through the onboarding wizard and look for your `console.log` statement. On any one full page load the `registerStore` call should happen just once. 

### Changelog Note:

Dev: remove checks of store registration that are no longer needed.
