### PR TITLE
Remove Customer Analytics Data Upon Order Deletion

### DIFF
--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -573,6 +573,34 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	}
 
 	/**
+	 * Retrieve the amount of orders made by a customer.
+	 *
+	 * @param int $customer_id Customer ID.
+	 * @return int|null Amount of orders for customer or null on failure.
+	 */
+	public static function get_order_count( $customer_id ) {
+		global $wpdb;
+		$customer_id = absint( $customer_id );
+
+		if ( 0 === $customer_id ) {
+			return null;
+		}
+
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT( order_id ) FROM {$wpdb->prefix}wc_order_stats WHERE customer_id = %d",
+				$customer_id
+			)
+		);
+
+		if ( is_null( $result ) ) {
+			return null;
+		}
+
+		return (int) $result;
+	}
+
+	/**
 	 * Update the database with customer data.
 	 *
 	 * @param int $user_id WP User ID to update customer data for.

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -559,13 +559,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return;
 		}
 
-		// Delete the customer, if this is their only order.
-		$order       = new \WC_Order( $order_id );
-		$customer_id = CustomersDataStore::get_existing_customer_id_from_order( $order );
-		$order_count = CustomersDataStore::get_order_count( $customer_id );
-		if ( 1 === $order_count ) {
-			CustomersDataStore::delete_customer( $customer_id );
-		}
+		// Retrieve customer details before the order is deleted.
+		$order       = wc_get_order( $order_id );
+		$customer_id = absint( CustomersDataStore::get_existing_customer_id_from_order( $order ) );
 
 		// Delete the order.
 		$wpdb->delete( self::get_db_table_name(), array( 'order_id' => $order_id ) );
@@ -573,8 +569,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * Fires when orders stats are deleted.
 		 *
 		 * @param int $order_id Order ID.
+		 * @param int $customer_id Customer ID.
 		 */
-		do_action( 'woocommerce_analytics_delete_order_stats', $order_id );
+		do_action( 'woocommerce_analytics_delete_order_stats', $order_id, $customer_id );
 
 		ReportsCache::invalidate();
 	}

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -12,6 +12,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use \Automattic\WooCommerce\Admin\API\Reports\SqlQuery;
 use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
+use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 
 /**
  * API\Reports\Orders\Stats\DataStore.
@@ -558,6 +559,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return;
 		}
 
+		// Delete the customer, if this is their only order.
+		$order       = new \WC_Order( $order_id );
+		$customer_id = CustomersDataStore::get_existing_customer_id_from_order( $order );
+		$order_count = CustomersDataStore::get_order_count( $customer_id );
+		if ( 1 === $order_count ) {
+			CustomersDataStore::delete_customer( $customer_id );
+		}
+
+		// Delete the order.
 		$wpdb->delete( self::get_db_table_name(), array( 'order_id' => $order_id ) );
 		/**
 		 * Fires when orders stats are deleted.

--- a/tests/reports/class-wc-tests-reports-customers.php
+++ b/tests/reports/class-wc-tests-reports-customers.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Admin\Tests\Customers
  */
 
-use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
+use \Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\DataStore;
 
 /**
  * Class WC_Tests_Reports_Customers
@@ -31,7 +31,7 @@ class WC_Tests_Reports_Customer extends WC_Unit_Test_Case {
 
 		WC_Helper_Queue::run_all_pending();
 
-		$customer_id = CustomersDataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
+		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
 
 		// Create 3 orders.
 		foreach ( range( 1, 3 ) as $i ) {
@@ -42,12 +42,77 @@ class WC_Tests_Reports_Customer extends WC_Unit_Test_Case {
 		WC_Helper_Queue::run_all_pending();
 
 		// Customer should have 3 orders.
-		$this->assertSame( 3, CustomersDataStore::get_order_count( $customer_id ) );
+		$this->assertSame( 3, DataStore::get_order_count( $customer_id ) );
 
 		// Failure from bad customer IDs.
-		$this->assertSame( null, CustomersDataStore::get_order_count( 0 ) );
-		$this->assertSame( null, CustomersDataStore::get_order_count( 'ABC' ) );
-		$this->assertSame( null, CustomersDataStore::get_order_count( false ) );
-		$this->assertSame( null, CustomersDataStore::get_order_count( null ) );
+		$this->assertSame( null, DataStore::get_order_count( 0 ) );
+		$this->assertSame( null, DataStore::get_order_count( 'ABC' ) );
+		$this->assertSame( null, DataStore::get_order_count( false ) );
+		$this->assertSame( null, DataStore::get_order_count( null ) );
+	}
+
+	/**
+	 * Test customer lookup tables are cleaned after deleting an order.
+	 *
+	 * A customer record should only be deleted if the customer has no other orders.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::sync_on_order_delete
+	 */
+	public function test_order_deletion_removes_customer() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a customer.
+		$customer = WC_Helper_Customer::create_customer();
+
+		// Create products.
+		$product1 = new WC_Product_Simple();
+		$product1->set_name( 'Test Product 1' );
+		$product1->set_regular_price( 1 );
+		$product1->save();
+
+		$product2 = new WC_Product_Simple();
+		$product2->set_name( 'Test Product 2' );
+		$product2->set_regular_price( 2 );
+		$product2->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Create the first order.
+		$order1 = WC_Helper_Order::create_order( $customer->get_id(), $product1 );
+		$order1->save();
+
+		// Create the second order.
+		$order2 = WC_Helper_Order::create_order( $customer->get_id(), $product2 );
+		$order2->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$customer_id = DataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
+
+		// Customer should remain in lookup table after first order deleted.
+		$order1->delete( true );
+		$this->assertCount( 1, $this->get_customer_record( $customer_id ), 'customer remains' );
+
+		// Customer should be removed in lookup table after both orders are deleted.
+		$order2->delete( true );
+		$this->assertCount( 0, $this->get_customer_record( $customer_id ), 'customer removed' );
+	}
+
+	/**
+	 * Get a customer's record from the database.
+	 *
+	 * @param int $customer_id Analytics Customer ID (not WP User ID).
+	 */
+	private function get_customer_record( $customer_id ) {
+		global $wpdb;
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}wc_customer_lookup WHERE customer_id = %d",
+				$customer_id
+			)
+		);
+
+		return $results;
 	}
 }

--- a/tests/reports/class-wc-tests-reports-customers.php
+++ b/tests/reports/class-wc-tests-reports-customers.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Reports customers tests.
+ *
+ * @package WooCommerce\Admin\Tests\Customers
+ */
+
+use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
+
+/**
+ * Class WC_Tests_Reports_Customers
+ */
+class WC_Tests_Reports_Customer extends WC_Unit_Test_Case {
+
+	/**
+	 * Test order count caluclation for customer.
+	 *
+	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_order_count
+	 */
+	public function test_customer_order_count() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a customer.
+		$customer = WC_Helper_Customer::create_customer();
+
+		// Create product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$customer_id = CustomersDataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
+
+		// Create 3 orders.
+		foreach ( range( 1, 3 ) as $i ) {
+			$order = WC_Helper_Order::create_order( $customer->get_id(), $product );
+			$order->save();
+		}
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Customer should have 3 orders.
+		$this->assertSame( 3, CustomersDataStore::get_order_count( $customer_id ) );
+
+		// Failure from bad customer IDs.
+		$this->assertSame( null, CustomersDataStore::get_order_count( 0 ) );
+		$this->assertSame( null, CustomersDataStore::get_order_count( 'ABC' ) );
+		$this->assertSame( null, CustomersDataStore::get_order_count( false ) );
+		$this->assertSame( null, CustomersDataStore::get_order_count( null ) );
+	}
+}

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Admin\Tests\Orders
  */
 
-use \Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\DataStore as CustomersStatsDataStore;
-use \Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Query as CustomersStatsQuery;
 use \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\Query as OrdersStatsQuery;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
@@ -3893,55 +3891,6 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', $default_customer_address );
 		update_option( 'woocommerce_default_customer_address', $default_calc_taxes );
 		update_option( 'woocommerce_tax_based_on', $default_tax_based_on );
-	}
-
-	/**
-	 * Test customer lookup tables are cleaned after deleting an order.
-	 *
-	 * A customer record should only be deleted if the customer has no other orders.
-	 *
-	 * @covers \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore::delete_order
-	 */
-	public function test_order_deletion_removes_customer() {
-		WC_Helper_Reports::reset_stats_dbs();
-
-		// Create a customer.
-		$customer = WC_Helper_Customer::create_customer();
-
-		// Create product.
-		$product = new WC_Product_Simple();
-		$product->set_name( 'Test Product' );
-		$product->set_regular_price( 25 );
-		$product->save();
-
-		WC_Helper_Queue::run_all_pending();
-
-		// Create the first order.
-		$order1 = WC_Helper_Order::create_order( $customer->get_id(), $product );
-		$order1->save();
-
-		// Create the second order.
-		$order2 = WC_Helper_Order::create_order( $customer->get_id(), $product );
-		$order2->save();
-
-		WC_Helper_Queue::run_all_pending();
-
-		$customer_id = CustomersStatsDataStore::get_customer_id_by_user_id( $customer->get_id() ); // This is the customer ID from lookup table.
-
-		$customers_query = new CustomersStatsQuery(
-			array(
-				'customers' => array( $customer_id ),
-			)
-		);
-
-		// Customer should remain in lookup table after first order deleted.
-		$order1->delete( true );
-		$this->assertSame( 1, $customers_query->get_data()->customers_count );
-
-		// Customer should be removed in lookup table after both orders are deleted.
-		$order2->delete( true );
-		$this->assertSame( 0, $customers_query->get_data()->customers_count );
-
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4946 

This removes associated customer analytics data upon order deletion. When analytics data for an order is removed, a WP action is run: `woocommerce_analytics_delete_order_stats`. The Products, Coupon, and Taxes `DataStore` classes hook into this action to further remove their associated data. [Example here](https://github.com/woocommerce/woocommerce-admin/blob/aecd050aff498d997adea9ec3e00a6bce8bd8a61/src/API/Reports/Products/DataStore.php#L503).

This change applies same approach to the Customers `DataStore` to remove associated customer data.

The `woocommerce_analytics_delete_order_stats` action is modified to pass a new `$customer_id` argument. This was added because the Customer ID for an order cannot be reliably obtained from inside the hook. This is because the previous order data is unavailable since the action is run after the order is deleted.

A check is made to ensure data is deleted only if the customer has a single order belonging to it. This is to preserve the customer record in cases where the customer has other orders. A new method is added to the Customers `DataStore` to count the amount of orders for a customer. It is similar to the `get_oldest_orders` method, however does not exclude types of orders.

Tests are added for customer deletion and counting customer orders.

### Detailed test instructions:

- With a new customer, create two or more orders.
- As an administrator, delete one order by moving it to the trash and permanently deleting it.
- Inspect the `*wc_customer_lookup` table and ensure the customer record exists.
- As an administrator, delete the remaining orders for the new customer.
- Inspect the `*wc_customer_lookup` table and ensure the customer record does not exist 

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
