### PR TITLE
Fix header height and positioning for wc nav

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -262,3 +262,7 @@
 .woocommerce-layout__notice-list-hide {
 	display: none;
 }
+
+.has-woocommerce-navigation .woocommerce-layout__activity-panel {
+	top: 0;
+}

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -1,7 +1,6 @@
 .woocommerce-layout__header {
 	background: $studio-white;
 	box-sizing: border-box;
-	border-bottom: 1px solid $studio-white;
 	padding: 0;
 	min-height: $header-height;
 	position: fixed;
@@ -40,6 +39,10 @@
 			margin: 0 2px 0 2px;
 		}
 	}
+}
+
+.has-woocommerce-navigation .woocommerce-layout__header {
+	top: 0;
 }
 
 .woocommerce-page {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -50,6 +50,7 @@
 	color: $studio-gray-60;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
+	margin-top: -32px;
 
 	#wpwrap {
 		top: 0;
@@ -73,7 +74,7 @@
 	}
 
 	#wpcontent {
-		margin-left: 0;
+		margin-left: 0 !important;
 
 		> #wpbody {
 			display: block;

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -75,7 +75,6 @@ class ProfileWizard extends Component {
 		const { activePlugins, profileItems, updateProfileItems } = this.props;
 
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );
-		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );
 		document.body.classList.add( 'woocommerce-admin-full-screen' );
@@ -100,7 +99,6 @@ class ProfileWizard extends Component {
 	}
 
 	componentWillUnmount() {
-		document.documentElement.classList.add( 'wp-toolbar' );
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
 		document.body.classList.remove( 'woocommerce-admin-full-screen' );

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -194,7 +194,7 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 		background: $studio-white;
 		flex-direction: row;
 		display: flex;
-		height: 56px;
+		height: $header-height;
 		border-bottom: 1px solid $studio-gray-5;
 		padding-left: $gap;
 		padding-right: $gap;

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -60,7 +60,7 @@
 	}
 
 	.woocommerce-profile-wizard__header {
-		height: 56px;
+		height: $header-height;
 		border-bottom: 1px solid $studio-gray-5;
 		display: flex;
 		align-items: center;

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -24,7 +24,7 @@ $gap-smaller: 8px;
 $gap-smallest: 4px;
 
 // Header
-$header-height: 56px;
+$header-height: 60px;
 
 // Sidebar
 $sidebar-width: 272px;


### PR DESCRIPTION
Fixes #5172 

Updates the header height to be 60px and puts it flush against the top of the window when the new nav experience is enabled.

### Screenshots

#### Before
<img width="618" alt="Screen Shot 2020-09-22 at 2 42 24 PM" src="https://user-images.githubusercontent.com/10561050/93927190-34372a00-fd21-11ea-8366-77c7cec56b1b.png">
<img width="357" alt="Screen Shot 2020-09-04 at 6 13 52 PM" src="https://user-images.githubusercontent.com/10561050/93927200-38634780-fd21-11ea-897c-62771d181cf4.png">


#### After
<img width="252" alt="Screen Shot 2020-09-22 at 3 12 55 PM" src="https://user-images.githubusercontent.com/10561050/93927159-2a152b80-fd21-11ea-813e-edddaffee6be.png">
<img width="605" alt="Screen Shot 2020-09-22 at 3 12 37 PM" src="https://user-images.githubusercontent.com/10561050/93927160-2a152b80-fd21-11ea-86d7-a3f892aa911a.png">


### Detailed test instructions:

1. Fire up the nav project and check out https://github.com/woocommerce/navigation/pull/101
1. Check that the WCA header sits at the top of the screen.
1. Click the WordPress logo in the top left of the screen.
1. Make sure the folded nav logo/button and WCA header heights line up correctly.