### PR TITLE
Display the store setup link on the homescreen if the task list is incomplete.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -128,79 +128,80 @@ export class ActivityPanel extends Component {
 			query,
 		} = this.props;
 
-		// Don't show the inbox on the Home screen.
-		const { location } = this.props.getHistory();
-		const showInbox = isEmbedded || location.pathname !== '/';
 		const isPerformingSetupTask =
 			query.task &&
 			! query.path &&
 			( requestingTaskListOptions === true ||
 				( taskListHidden === false && taskListComplete === false ) );
 
-		if ( ! taskListComplete && showInbox ) {
-			return [
-				{
+		// Don't show the inbox on the Home screen.
+		const { location } = this.props.getHistory();
+
+		const showInbox =
+			( isEmbedded || location.pathname !== '/' ) &&
+			! isPerformingSetupTask;
+
+		const inbox = showInbox
+			? {
 					name: 'inbox',
 					title: __( 'Inbox', 'woocommerce-admin' ),
 					icon: <i className="material-icons-outlined">inbox</i>,
 					unread: hasUnreadNotes,
-				},
-				{
-					name: 'setup',
-					title: __( 'Store Setup', 'woocommerce-admin' ),
-					icon: <SetupProgress />,
-				},
-				isPerformingSetupTask && {
+			  }
+			: null;
+
+		const setup =
+			! taskListComplete && ! isPerformingSetupTask
+				? {
+						name: 'setup',
+						title: __( 'Store Setup', 'woocommerce-admin' ),
+						icon: <SetupProgress />,
+				  }
+				: null;
+
+		const ordersStockAndReviews =
+			taskListComplete && ! isPerformingSetupTask
+				? [
+						{
+							name: 'orders',
+							title: __( 'Orders', 'woocommerce-admin' ),
+							icon: <PagesIcon />,
+							unread: hasUnreadOrders,
+						},
+						manageStock === 'yes' && {
+							name: 'stock',
+							title: __( 'Stock', 'woocommerce-admin' ),
+							icon: (
+								<i className="material-icons-outlined">
+									widgets
+								</i>
+							),
+							unread: hasUnreadStock,
+						},
+						reviewsEnabled === 'yes' && {
+							name: 'reviews',
+							title: __( 'Reviews', 'woocommerce-admin' ),
+							icon: (
+								<i className="material-icons-outlined">
+									star_border
+								</i>
+							),
+							unread: hasUnapprovedReviews,
+						},
+				  ].filter( Boolean )
+				: [];
+
+		const help = isPerformingSetupTask
+			? {
 					name: 'help',
 					title: __( 'Help', 'woocommerce-admin' ),
-					icon: <i className="material-icons-outlined">support</i>,
-				},
-			].filter( Boolean );
-		}
+					icon: <Icon icon={ lifesaver } />,
+			  }
+			: null;
 
-		return [
-			! isPerformingSetupTask && showInbox
-				? {
-						name: 'inbox',
-						title: __( 'Inbox', 'woocommerce-admin' ),
-						icon: <i className="material-icons-outlined">inbox</i>,
-						unread: hasUnreadNotes,
-				  }
-				: null,
-			! isPerformingSetupTask && {
-				name: 'orders',
-				title: __( 'Orders', 'woocommerce-admin' ),
-				icon: <PagesIcon />,
-				unread: hasUnreadOrders,
-			},
-			! isPerformingSetupTask && manageStock === 'yes'
-				? {
-						name: 'stock',
-						title: __( 'Stock', 'woocommerce-admin' ),
-						icon: (
-							<i className="material-icons-outlined">widgets</i>
-						),
-						unread: hasUnreadStock,
-				  }
-				: null,
-			! isPerformingSetupTask && reviewsEnabled === 'yes'
-				? {
-						name: 'reviews',
-						title: __( 'Reviews', 'woocommerce-admin' ),
-						icon: (
-							<i className="material-icons-outlined">
-								star_border
-							</i>
-						),
-						unread: hasUnapprovedReviews,
-				  }
-				: null,
-			isPerformingSetupTask && {
-				name: 'help',
-				title: __( 'Help', 'woocommerce-admin' ),
-				icon: <Icon icon={ lifesaver } />,
-			},
-		].filter( Boolean );
+		return [ inbox, ...ordersStockAndReviews, setup, help ].filter(
+			Boolean
+		);
 	}
 
 	getPanelContent( tab ) {

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -120,4 +120,32 @@ describe( 'Activity Panel', () => {
 		// Expect that "Help" tab is absent.
 		expect( screen.queryByText( 'Help' ) ).toBeNull();
 	} );
+
+	it( 'should only render the store setup link when TaskList is not complete', () => {
+		const { queryByText, rerender } = render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden={ false }
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+
+		rerender(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete
+				taskListHidden={ false }
+				query={ {
+					task: 'products',
+				} }
+			/>
+		);
+
+		expect( queryByText( 'Store Setup' ) ).toBeNull();
+	} );
 } );


### PR DESCRIPTION
Fixes #5137 

The original PR that implemented the store setup link made some assumptions about when it should be shown. This fixes the incorrect assumptions made there (See the comments in #5137 for more details).

The original PR assumed that we wouldn't want to show the store setup link on the home screen, but that was incorrect. The desire is not to show the other options and *just* show the setup link if the setup task list is not complete yet.

### Detailed test instructions:

1. On a woocommerce site that has not had the task list complete yet, go to the homescreen
2. Observe that the only tab displayed is the store setup link
3. Finish the task list
4. Observe that now the orders stock and reviews tabs are available but the store setup link is no longer displayed.

Also note that the existing display logic should be respected such as:

1. The store setup link will not display when you're performing a setup task
2. reviews should only display if reviews are enabled
3. stock should only display if the manage stock setting is enabled
4. help should only display when performing setup tasks

### Changelog Note:
Fix: display the store setup link on the homescreen if the task list is incomplete.
