### PR TITLE
Renamed task list item

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -97,7 +97,7 @@ export function getAllTasks( {
 	const tasks = [
 		{
 			key: 'store_details',
-			title: __( 'Setup wizard', 'woocommerce-admin' ),
+			title: __( 'Store details', 'woocommerce-admin' ),
 			container: null,
 			onClick: () => {
 				recordEvent( 'tasklist_click', {


### PR DESCRIPTION
Fixes #5183

This PR renames the task list item "Store wizard" to "Store details"

### Screenshots
![screenshot-one wordpress test-2020 09 23-16_49_55](https://user-images.githubusercontent.com/1314156/94062351-ef60d100-fdbc-11ea-8f2a-1a7fb730c150.png)

### Detailed test instructions:

- Go to the Home screen.
- Verify that the task item name `Store wizard` was changed to `Store details`.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Renamed task list item to "Store details"
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
