### PR TITLE
Enlarged store profiler text in two steps

### DIFF
--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -304,6 +304,7 @@
 			}
 
 			label.components-checkbox-control__label {
+				font-size: $gap;
 				margin-left: 0;
 			}
 

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -292,7 +292,7 @@
 			margin-bottom: 0;
 			position: relative;
 			padding: $gap-small $gap-large;
-			min-height: 44px;
+			min-height: 46px;
 			border-bottom: 1px solid $gray-100;
 
 			.components-base-control {


### PR DESCRIPTION
Fixes #5188

This PR makes some OBW texts larger. The 2nd and 3rd steps had texts that were too small. Now they are larger.

In the [PR 5157](https://github.com/woocommerce/woocommerce-admin/pull/5157) we made the list items of the 2nd step of the OBW smaller. Since the text will be bigger now, I made the list items bigger too.

cc: @elizaan36 @jameskoster 

### Screenshots
Second step
![screenshot-one wordpress test-2020 09 24-10_00_47](https://user-images.githubusercontent.com/1314156/94152300-c8081380-fe51-11ea-8432-15a0d4bd5734.png)

Third step
![screenshot-one wordpress test-2020 09 24-10_01_45](https://user-images.githubusercontent.com/1314156/94152330-ccccc780-fe51-11ea-92e7-e410fbb16dc9.png)

### Detailed test instructions:

- Go to the second step of the OBW (URL `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`).
- Verify the `font-size` of the list items text is `16px`.
- Go to the third step of the OBW (URL `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`).
- Verify the `font-size` of the list items text is `16px`.  

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Enlarged store profiler text in two steps
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
