### PR TITLE
Renamed OBW skip button 

### DIFF
--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -284,7 +284,10 @@ class StoreDetails extends Component {
 							return false;
 						} }
 					>
-						{ __( 'Skip setup wizard', 'woocommerce-admin' ) }
+						{ __(
+							'Skip setup store details',
+							'woocommerce-admin'
+						) }
 					</Button>
 					<Tooltip text={ skipSetupText }>
 						<span


### PR DESCRIPTION
This PR is a follow up of the [PR 5190](https://github.com/woocommerce/woocommerce-admin/pull/5190). To address [this modification](https://github.com/woocommerce/woocommerce-admin/issues/5183#issuecomment-698220380), the OBW skip button was renamed to "Skip setup store details"

### Screenshots
![screenshot-one wordpress test-2020 09 24-11_27_15](https://user-images.githubusercontent.com/1314156/94158640-03f2a700-fe59-11ea-84d0-8945c3276790.png)


### Detailed test instructions:

- Go to the first step of the OBW (URL: `http://one.wordpress.test/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=store-details`).
- Verify the skip button text is: "Skip setup store details".

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Renamed OBW skip button 
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
