### PR TITLE
Pass Stripe supported countries in tasks status REST API

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -498,6 +498,15 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
+				'stripeSupportedCountries'       => array(
+					'type'        => 'array',
+					'description' => __( 'Country codes that are supported by Stripe.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
 				'taxJarActivated'                => array(
 					'type'        => 'boolean',
 					'description' => __( 'If the store has the TaxJar extension active.', 'woocommerce-admin' ),

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -605,13 +605,12 @@ class Onboarding {
 
 		// Only fetch if the onboarding wizard OR the task list is incomplete.
 		if ( self::should_show_profiler() || self::should_show_tasks() ) {
-			$settings['onboarding']['activeTheme']              = get_option( 'stylesheet' );
-			$settings['onboarding']['stripeSupportedCountries'] = self::get_stripe_supported_countries();
-			$settings['onboarding']['euCountries']              = WC()->countries->get_european_union_countries();
-			$current_user                                       = wp_get_current_user();
-			$settings['onboarding']['userEmail']                = esc_html( $current_user->user_email );
-			$settings['onboarding']['productTypes']             = self::get_allowed_product_types();
-			$settings['onboarding']['themes']                   = self::get_themes();
+			$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
+			$settings['onboarding']['euCountries']  = WC()->countries->get_european_union_countries();
+			$current_user                           = wp_get_current_user();
+			$settings['onboarding']['userEmail']    = esc_html( $current_user->user_email );
+			$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
+			$settings['onboarding']['themes']       = self::get_themes();
 		}
 
 		return $settings;
@@ -664,57 +663,6 @@ class Onboarding {
 		$options[] = 'general';
 
 		return $options;
-	}
-
-	/**
-	 * Returns a list of Stripe supported countries. This method can be removed once merged to core.
-	 *
-	 * @return array
-	 */
-	private static function get_stripe_supported_countries() {
-		// https://stripe.com/global.
-		return array(
-			'AU',
-			'AT',
-			'BE',
-			'BG',
-			// 'BR', // Preview, requires invite.
-			'CA',
-			'CY',
-			'CZ',
-			'DK',
-			'EE',
-			'FI',
-			'FR',
-			'DE',
-			'GR',
-			'HK',
-			'IN', // Preview.
-			'IE',
-			'IT',
-			'JP',
-			'LV',
-			'LT',
-			'LU',
-			'MY',
-			'MT',
-			'MX',
-			'NL',
-			'NZ',
-			'NO',
-			'PL',
-			'PT',
-			'RO',
-			'SG',
-			'SK',
-			'SI',
-			'ES',
-			'SE',
-			'CH',
-			'GB',
-			'US',
-			'PR',
-		);
 	}
 
 	/**

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -111,6 +111,7 @@ class OnboardingTasks {
 		$settings['isAppearanceComplete']           = get_option( 'woocommerce_task_list_appearance_complete' );
 		$settings['isTaxComplete']                  = self::check_task_completion( 'tax' );
 		$settings['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
+		$settings['stripeSupportedCountries']       = self::get_stripe_supported_countries();
 		$settings['stylesheet']                     = get_option( 'stylesheet' );
 		$settings['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 		$settings['themeMods']                      = get_theme_mods();
@@ -298,6 +299,57 @@ class OnboardingTasks {
 		);
 
 		return $tax_supported_countries;
+	}
+
+	/**
+	 * Returns a list of Stripe supported countries. This method can be removed once merged to core.
+	 *
+	 * @return array
+	 */
+	private static function get_stripe_supported_countries() {
+		// https://stripe.com/global.
+		return array(
+			'AU',
+			'AT',
+			'BE',
+			'BG',
+			// 'BR', // Preview, requires invite.
+			'CA',
+			'CY',
+			'CZ',
+			'DK',
+			'EE',
+			'FI',
+			'FR',
+			'DE',
+			'GR',
+			'HK',
+			'IN', // Preview.
+			'IE',
+			'IT',
+			'JP',
+			'LV',
+			'LT',
+			'LU',
+			'MY',
+			'MT',
+			'MX',
+			'NL',
+			'NZ',
+			'NO',
+			'PL',
+			'PT',
+			'RO',
+			'SG',
+			'SK',
+			'SI',
+			'ES',
+			'SE',
+			'CH',
+			'GB',
+			'US',
+			'PR',
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5185 

Fixes missing settings needed to show Stripe payment task.

@octaedro Pinged you in slack separately- sorry I did not see that you were simultaneously working on this issue.  If you have a PR ready for this we can close this one in favor of yours.

### Screenshots
<img width="716" alt="Screen Shot 2020-09-24 at 5 57 35 PM" src="https://user-images.githubusercontent.com/10561050/94204638-47392e00-feca-11ea-849a-fdafc131d51e.png">


### Detailed test instructions:

1. Pick a Stripe supported country.
1. Make sure you have not selected "CBD" as an industry previously in the profiler.
1. Go to the task list payments task.
1. Check that Stripe is shown.
1. Select a non-supported task country.
1. Revisit the payments screen and make sure Stripe is not shown.