### PR TITLE
Update store setup link to redirect to setup wizard

### DIFF
--- a/src/Notes/OnboardingProfiler.php
+++ b/src/Notes/OnboardingProfiler.php
@@ -53,15 +53,15 @@ class Onboarding_Profiler {
 		$note->add_action(
 			'continue-profiler',
 			__( 'Continue Store Setup', 'woocommerce-admin' ),
-			wc_admin_url( '&enable_onboarding=1' ),
-			NOTE::E_WC_ADMIN_NOTE_UNACTIONED,
+			wc_admin_url( '&path=/setup-wizard' ),
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 		$note->add_action(
 			'skip-profiler',
 			__( 'Skip Setup', 'woocommerce-admin' ),
 			wc_admin_url( '&reset_profiler=0' ),
-			'actioned',
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false
 		);
 		return $note;


### PR DESCRIPTION
Fixes #4989

Replaces an old flag `enable_onboarding` that no longer exists with the setup wizard path.

To resolve #4989 the WooCommerce screen that redirects or skips onboarding should also be updated to include `reset_profiler=0`, but it looks like all references to this file may have been removed so this is no longer needed.

https://github.com/woocommerce/woocommerce/blob/51029986b5b8e20933901750478cd0aee00e6c7b/includes/admin/class-wc-admin-setup-wizard.php#L367

### Detailed test instructions:

1. Use a new site or trigger the onboarding profile note by making sure `skipped` and `completed` are not truthy in the `woocommerce_onboarding_profile` option in your wp_options table.
1. Run the `wc_admin_daily` cron event.
1. Note the onboarding profiler reminder note.
1. Click the `Continue Store Setup` to make sure it directs to the setup wizard.