### PR TITLE
Add rule processors for country and state

### DIFF
--- a/src/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/src/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Rule processor that performs a comparison operation against the base
+ * location - country.
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor that performs a comparison operation against the base
+ * location - country.
+ */
+class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Performs a comparison operation against the base location - country.
+	 *
+	 * @param object $rule         The specific rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$base_location = wc_get_base_location();
+		if ( ! $base_location ) {
+			return false;
+		}
+
+		return ComparisonOperation::compare(
+			$base_location['country'],
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/RemoteInboxNotifications/BaseLocationStateRuleProcessor.php
+++ b/src/RemoteInboxNotifications/BaseLocationStateRuleProcessor.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Rule processor that performs a comparison operation against the base
+ * location - state.
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor that performs a comparison operation against the base
+ * location - state.
+ */
+class BaseLocationStateRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Performs a comparison operation against the base location - state.
+	 *
+	 * @param object $rule         The specific rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$base_location = wc_get_base_location();
+		if ( ! $base_location ) {
+			return false;
+		}
+
+		return ComparisonOperation::compare(
+			$base_location['state'],
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -48,6 +48,10 @@ class GetRuleProcessor {
 				return new OnboardingProfileRuleProcessor();
 			case 'is_ecommerce':
 				return new IsEcommerceRuleProcessor();
+			case 'base_location_country':
+				return new BaseLocationCountryRuleProcessor();
+			case 'base_location_state':
+				return new BaseLocationStateRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -342,4 +342,30 @@ This passes when the store is on a WordPress.com site with the eCommerce plan.
 
 `value` is required.
 
+### Base location - country
+This passes when the store is located in the specified country.
+
+```
+{
+	"type": "base_location_country",
+	"value": "US",
+	"operation": "="
+}
+```
+
+`value` and `operation` are both required.
+
+### Base location - state
+This passes when the store is located in the specified state.
+
+```
+{
+	"type": "base_location_state",
+	"value": "TX",
+	"operation": "="
+}
+```
+
+`value` and `operation` are both required.
+
 


### PR DESCRIPTION
This adds rule processors for the selected (in the profiler) country and state.

### Detailed test instructions:

- Add this test feed to `DataSourcePoller::DATA_SOURCES`: `https://gist.github.com/becdetat/ac0acbaa547d2af7c56d63f8fd8eee82/raw/51a8116a83faddce42e44a0e914a35ca90217386/base-location-test.json`
- Set the store location to something other than US - Texas
- Run the `wc_admin_daily` cron task
- A note with the title "This should appear in Texas stores" should _not_ appear
- Set the store location to US - Texas
- Run the `wc_admin_daily` cron task
- The note with the title "This should appear in Texas stores" _should_ appear

### Changelog Note:

Dev: Add remote inbox notification rule processors for country and state