### PR TITLE
Add note status remote inbox notifications rule processor

### DIFF
--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -282,4 +282,23 @@ class Notes {
 			}
 		}
 	}
+
+	/**
+	 * Get the status of a given note by name.
+	 *
+	 * @param string $note_name Name of the note.
+	 * @return string|bool The note status.
+	 */
+	public static function get_note_status( $note_name ) {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( $note_name );
+
+		if ( empty( $note_ids ) ) {
+			return false;
+		}
+
+		$note = self::get_note( $note_ids[0] );
+
+		return $note->get_status();
+	}
 }

--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -48,6 +48,8 @@ class GetRuleProcessor {
 				return new OnboardingProfileRuleProcessor();
 			case 'is_ecommerce':
 				return new IsEcommerceRuleProcessor();
+			case 'note_status':
+				return new NoteStatusRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/NoteStatusRuleProcessor.php
+++ b/src/RemoteInboxNotifications/NoteStatusRuleProcessor.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Rule processor that compares against the status of another note. For
+ * example, this could be used to conditionally create a note only if another
+ * note has not been actioned.
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
+/**
+ * Rule processor that compares against the status of another note.
+ */
+class NoteStatusRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Compare against the status of another note.
+	 *
+	 * @param object $rule         The rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$status = WC_Admin_Notes::get_note_status( $rule->note_name );
+		if ( ! $status ) {
+			return false;
+		}
+
+		return ComparisonOperation::compare(
+			$status,
+			$rule->status,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->note_name ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->status ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/RemoteInboxNotifications/NoteStatusRuleProcessor.php
+++ b/src/RemoteInboxNotifications/NoteStatusRuleProcessor.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 
 /**
  * Rule processor that compares against the status of another note.
@@ -24,7 +24,7 @@ class NoteStatusRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$status = WC_Admin_Notes::get_note_status( $rule->note_name );
+		$status = Notes::get_note_status( $rule->note_name );
 		if ( ! $status ) {
 			return false;
 		}

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -342,4 +342,18 @@ This passes when the store is on a WordPress.com site with the eCommerce plan.
 
 `value` is required.
 
+### Note status
+This passes when the status of the specified note matches the specified status.
+The below example passes when the `wc-admin-mobile-app` note has not been
+actioned.
+
+```
+{
+	"type": "note_status",
+	"note_name": "wc-admin-mobile-app",
+	"status": "actioned",
+	"operation": "!="
+}
+```
+
 


### PR DESCRIPTION
This adds a remote inbox notifications rule that looks at the status of another note.

For example, a note might only be displayed if another note has not been actioned, to avoid hassling the user when an action has already been taken.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/94386709-aaa5b300-018b-11eb-8b95-60986c06caa2.png)

### Detailed test instructions:

- Start on a store with the "Connect with your audience" admin note _not_ actioned
- Add this url to `DataSourcePoller::DATA_SOURCES`: `https://gist.github.com/becdetat/df80073b4c7283c2be89b26d19723b36/raw/fb794f5916d915f1bde4addc9d8672a7e2789de1/note-status.json`
- Run the `wc_admin_daily` cron task
- The "This should appear when the marketing intro note is actioned" note should _not_ appear
- Action the "Connect with your audience" admin note
- Run the `wc_admin_daily` cron task
- The "This should appear when the marketing intro note is actioned" note should now appear

### Changelog Note:

Dev: Add note status remote inbox notifications rule processor