### PR TITLE
Fix smart tax defaults Jetpack connection logic 

### DIFF
--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -24,6 +24,14 @@ class OnboardingAutomateTaxes {
 				'on_onboarding_profile_completed',
 			)
 		);
+
+		add_action(
+			'jetpack_authorize_ending_authorized',
+			array(
+				__CLASS__,
+				'on_onboarding_profile_completed',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5182.

This PR ensures the smart tax defaults (read: WCS Tax) will be set when JP+WCS are opted into at the end of the Store Details flow.

Previously, the logic expected to see that Jetpack was connected. The code checking for the existence of that connection fired before the connection could be made from the OBW flow.

This PR adds an additional check on the `jetpack_authorize_ending_authorized` action, which fires after a Jetpack authorization occurs.

### Detailed test instructions:

- On a new store
- Complete the Store Details flow choosing a country where the automated taxes is available
- Complete the JP & WCS account connection flow
- See that the Tax task is marked as completed

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased quirk/bug