### PR TITLE
Fix wakeup visibility for PHP 8 compatibility

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -313,5 +313,7 @@ class FeaturePlugin {
 	/**
 	 * Prevent unserializing.
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {
+		die();
+	}
 }


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce-admin/pull/5163 - this recreates the PR as CI wasn't running on a the main branch of a fork.