### PR TITLE
Change store details tooltip to a popover

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -9,8 +9,6 @@ import {
 	CardFooter,
 	CheckboxControl,
 	FlexItem,
-	Icon,
-	Tooltip,
 	__experimentalText as Text,
 	Popover,
 } from '@wordpress/components';
@@ -42,7 +40,8 @@ class StoreDetails extends Component {
 		this.state = {
 			showUsageModal: false,
 			skipping: false,
-			isPopoverVisible: false,
+			isStoreDetailsPopoverVisible: false,
+			isSkipSetupPopoverVisible: false,
 		};
 
 		// Check if a store address is set so that we don't default
@@ -167,7 +166,12 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { showUsageModal, skipping, isPopoverVisible } = this.state;
+		const {
+			showUsageModal,
+			skipping,
+			isStoreDetailsPopoverVisible,
+			isSkipSetupPopoverVisible,
+		} = this.state;
 		const { skipProfiler } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
@@ -201,7 +205,9 @@ class StoreDetails extends Component {
 								'woocommerce-admin'
 							) }
 							onClick={ () =>
-								this.setState( { isPopoverVisible: true } )
+								this.setState( {
+									isStoreDetailsPopoverVisible: true,
+								} )
 							}
 						>
 							<i
@@ -212,12 +218,14 @@ class StoreDetails extends Component {
 							</i>
 						</Button>
 					</Text>
-					{ isPopoverVisible && (
+					{ isStoreDetailsPopoverVisible && (
 						<Popover
 							focusOnMount="container"
 							position="top center"
 							onClose={ () =>
-								this.setState( { isPopoverVisible: false } )
+								this.setState( {
+									isStoreDetailsPopoverVisible: false,
+								} )
 							}
 						>
 							{ configureCurrencyText }
@@ -312,14 +320,33 @@ class StoreDetails extends Component {
 							'woocommerce-admin'
 						) }
 					</Button>
-					<Tooltip text={ skipSetupText }>
-						<span
-							aria-label={ skipSetupText }
-							className="woocommerce-profile-wizard__tooltip-icon"
+					<Button
+						isTertiary
+						label={ skipSetupText }
+						onClick={ () =>
+							this.setState( { isSkipSetupPopoverVisible: true } )
+						}
+					>
+						<i
+							className="material-icons-outlined"
+							aria-hidden="true"
 						>
-							<Icon icon="info-outline" size={ 16 } />
-						</span>
-					</Tooltip>
+							info
+						</i>
+					</Button>
+					{ isSkipSetupPopoverVisible && (
+						<Popover
+							focusOnMount="container"
+							position="top center"
+							onClose={ () =>
+								this.setState( {
+									isSkipSetupPopoverVisible: false,
+								} )
+							}
+						>
+							{ skipSetupText }
+						</Popover>
+					) }
 				</div>
 			</div>
 		);

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -12,8 +12,9 @@ import {
 	Icon,
 	Tooltip,
 	__experimentalText as Text,
+	Popover,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Form } from '@woocommerce/components';
@@ -24,13 +25,14 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { getCountryCode, getCurrencyRegion } from '../../dashboard/utils';
+import { getCountryCode, getCurrencyRegion } from '../../../dashboard/utils';
 import {
 	StoreAddress,
 	validateStoreAddress,
-} from '../../dashboard/components/settings/general/store-address';
-import UsageModal from './usage-modal';
-import { CurrencyContext } from '../../lib/currency-context';
+} from '../../../dashboard/components/settings/general/store-address';
+import UsageModal from '../usage-modal';
+import { CurrencyContext } from '../../../lib/currency-context';
+import './style.scss';
 
 class StoreDetails extends Component {
 	constructor( props ) {
@@ -40,6 +42,7 @@ class StoreDetails extends Component {
 		this.state = {
 			showUsageModal: false,
 			skipping: false,
+			isPopoverVisible: false,
 		};
 
 		// Check if a store address is set so that we don't default
@@ -164,7 +167,7 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { showUsageModal, skipping } = this.state;
+		const { showUsageModal, skipping, isPopoverVisible } = this.state;
 		const { skipProfiler } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
@@ -180,7 +183,7 @@ class StoreDetails extends Component {
 		/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
 		return (
-			<Fragment>
+			<div className="woocommerce-profile-wizard__store-details">
 				<div className="woocommerce-profile-wizard__step-header">
 					<Text variant="title.small" as="h2">
 						{ __( 'Welcome to WooCommerce', 'woocommerce-admin' ) }
@@ -191,15 +194,35 @@ class StoreDetails extends Component {
 							'woocommerce-admin'
 						) }
 
-						<Tooltip text={ configureCurrencyText }>
-							<span
-								aria-label={ configureCurrencyText }
-								className="woocommerce-profile-wizard__tooltip-icon"
+						<Button
+							isTertiary
+							label={ __(
+								'Learn more about store details',
+								'woocommerce-admin'
+							) }
+							onClick={ () =>
+								this.setState( { isPopoverVisible: true } )
+							}
+						>
+							<i
+								className="material-icons-outlined"
+								aria-hidden="true"
 							>
-								<Icon icon="info-outline" size={ 16 } />
-							</span>
-						</Tooltip>
+								info
+							</i>
+						</Button>
 					</Text>
+					{ isPopoverVisible && (
+						<Popover
+							focusOnMount="container"
+							position="top center"
+							onClose={ () =>
+								this.setState( { isPopoverVisible: false } )
+							}
+						>
+							{ configureCurrencyText }
+						</Popover>
+					) }
 				</div>
 
 				<Form
@@ -298,7 +321,7 @@ class StoreDetails extends Component {
 						</span>
 					</Tooltip>
 				</div>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/profile-wizard/steps/store-details/style.scss
+++ b/client/profile-wizard/steps/store-details/style.scss
@@ -1,0 +1,5 @@
+.woocommerce-profile-wizard__store-details {
+	.components-popover .components-popover__content {
+		min-width: 360px;
+	}
+}


### PR DESCRIPTION
Fixes #5189

The tooltip seemed to be working as designed so rather than messing around with it too much I decided to use the `Popover` component instead (which is already in use for product types). I think the result is better and more semantically correct than a tooltip.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/224531/94511217-0fc8d980-025c-11eb-92fd-892d4ff1bd38.png)
After:
![image](https://user-images.githubusercontent.com/224531/94511232-1b1c0500-025c-11eb-91ea-1f4bba9bb250.png)

### Detailed test instructions:

- Start the OBW
- On the store details page, click the information icon next to the "Tell us about your store and we'll get you set up in no time" text

### Changelog Note:

Dev: Change store details tooltip to a popover