### PR TITLE
Declare the note constants on the deprecated class.

### DIFF
--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -46,6 +46,10 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public function __call( $name, $arguments ) {
+		_deprecated_function(
+			static::$facade_over_classname . '::' . $name,
+			static::$deprecated_in_version
+		);
 		return call_user_func_array(
 			array(
 				$this->instance,
@@ -62,6 +66,10 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public static function __callStatic( $name, $arguments ) {
+		_deprecated_function(
+			static::$facade_over_classname . '::' . $name,
+			static::$deprecated_in_version
+		);
 		return call_user_func_array(
 			array(
 				static::$facade_over_classname,

--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -46,11 +46,7 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public function __call( $name, $arguments ) {
-		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
-			static::$deprecated_in_version
-		);
-		call_user_func_array(
+		return call_user_func_array(
 			array(
 				$this->instance,
 				$name,
@@ -66,11 +62,7 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
-			static::$deprecated_in_version
-		);
-		call_user_func_array(
+		return call_user_func_array(
 			array(
 				static::$facade_over_classname,
 				$name,

--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -30,7 +30,7 @@ class DeprecatedClassFacade {
 	 *
 	 * @var object
 	 */
-	private $instance;
+	protected $instance;
 
 	/**
 	 * Constructor.

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -16,6 +16,21 @@ use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
  * WC_Admin_Note (deprecated, use Note instead).
  */
 class WC_Admin_Note extends DeprecatedClassFacade {
+	// These constants must be redeclared as to not break plugins that use them.
+	// Note types.
+	const E_WC_ADMIN_NOTE_ERROR         = 'error';     // used for presenting error conditions.
+	const E_WC_ADMIN_NOTE_WARNING       = 'warning';   // used for presenting warning conditions.
+	const E_WC_ADMIN_NOTE_UPDATE        = 'update';    // i.e. used when a new version is available.
+	const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';      // used for presenting informational messages.
+	const E_WC_ADMIN_NOTE_MARKETING     = 'marketing'; // used for adding marketing messages.
+	const E_WC_ADMIN_NOTE_SURVEY        = 'survey';    // used for adding survey messages.
+
+	// Note status codes.
+	const E_WC_ADMIN_NOTE_PENDING    = 'pending';    // the note is pending - hidden but not actioned.
+	const E_WC_ADMIN_NOTE_UNACTIONED = 'unactioned'; // the note has not yet been actioned by a user.
+	const E_WC_ADMIN_NOTE_ACTIONED   = 'actioned';   // the note has had its action completed by a user.
+	const E_WC_ADMIN_NOTE_SNOOZED    = 'snoozed';    // the note has been snoozed by a user.
+
 	/**
 	 * The name of the non-deprecated class that this facade covers.
 	 *

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -17,19 +17,16 @@ use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
  */
 class WC_Admin_Note extends DeprecatedClassFacade {
 	// These constants must be redeclared as to not break plugins that use them.
-	// Note types.
-	const E_WC_ADMIN_NOTE_ERROR         = 'error';     // used for presenting error conditions.
-	const E_WC_ADMIN_NOTE_WARNING       = 'warning';   // used for presenting warning conditions.
-	const E_WC_ADMIN_NOTE_UPDATE        = 'update';    // i.e. used when a new version is available.
-	const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';      // used for presenting informational messages.
-	const E_WC_ADMIN_NOTE_MARKETING     = 'marketing'; // used for adding marketing messages.
-	const E_WC_ADMIN_NOTE_SURVEY        = 'survey';    // used for adding survey messages.
-
-	// Note status codes.
-	const E_WC_ADMIN_NOTE_PENDING    = 'pending';    // the note is pending - hidden but not actioned.
-	const E_WC_ADMIN_NOTE_UNACTIONED = 'unactioned'; // the note has not yet been actioned by a user.
-	const E_WC_ADMIN_NOTE_ACTIONED   = 'actioned';   // the note has had its action completed by a user.
-	const E_WC_ADMIN_NOTE_SNOOZED    = 'snoozed';    // the note has been snoozed by a user.
+	const E_WC_ADMIN_NOTE_ERROR         = Note::E_WC_ADMIN_NOTE_ERROR;
+	const E_WC_ADMIN_NOTE_WARNING       = Note::E_WC_ADMIN_NOTE_WARNING;
+	const E_WC_ADMIN_NOTE_UPDATE        = Note::E_WC_ADMIN_NOTE_UPDATE;
+	const E_WC_ADMIN_NOTE_INFORMATIONAL = Note::E_WC_ADMIN_NOTE_INFORMATIONAL;
+	const E_WC_ADMIN_NOTE_MARKETING     = Note::E_WC_ADMIN_NOTE_MARKETING;
+	const E_WC_ADMIN_NOTE_SURVEY        = Note::E_WC_ADMIN_NOTE_SURVEY;
+	const E_WC_ADMIN_NOTE_PENDING       = Note::E_WC_ADMIN_NOTE_PENDING;
+	const E_WC_ADMIN_NOTE_UNACTIONED    = Note::E_WC_ADMIN_NOTE_UNACTIONED;
+	const E_WC_ADMIN_NOTE_ACTIONED      = Note::E_WC_ADMIN_NOTE_ACTIONED;
+	const E_WC_ADMIN_NOTE_SNOOZED       = Note::E_WC_ADMIN_NOTE_SNOOZED;
 
 	/**
 	 * The name of the non-deprecated class that this facade covers.

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -41,6 +41,15 @@ class WC_Admin_Note extends DeprecatedClassFacade {
 	 * @var string
 	 */
 	protected static $deprecated_in_version = '1.6.0';
+
+	/**
+	 * Note constructor. Loads note data.
+	 *
+	 * @param mixed $data Note data, object, or ID.
+	 */
+	public function __construct( $data = '' ) {
+		$this->instance = new static::$facade_over_classname( $data );
+	}
 }
 
 /**


### PR DESCRIPTION
This avoids triggering PHP errors when third party code references the old class constants. Like core: https://github.com/woocommerce/woocommerce/blob/master/includes/admin/notes/class-wc-notes-run-db-update.php#L154

Fixes this error:

```
PHP Fatal error:  Uncaught Error: Undefined class constant 'E_WC_ADMIN_NOTE_ACTIONED' in /srv/www/wordpress-default/public_html/wp-content/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php:270
```

### Detailed test instructions:

- On `main`
- Trick WooCommerce into thinking it needs to update the DB by deleting the `woocommerce_db_version` option
- Go to WooCommerce > Home
- Note the PHP error
- Check out this branch
- Trick WooCommerce into thinking it needs to update the DB by deleting the `woocommerce_db_version` option
- Go to WooCommerce > Home
- Note no more PHP error

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug