### PR TITLE
Removing breadcrumbs from wc-admin header, replacing with simple titl…

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -5,11 +5,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Link } from '@woocommerce/components';
 import { useUserPreferences } from '@woocommerce/data';
-import { getNewPath } from '@woocommerce/navigation';
-import { recordEvent } from '@woocommerce/tracks';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
+import { __experimentalText as Text } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,23 +16,12 @@ import './style.scss';
 import ActivityPanel from './activity-panel';
 import { MobileAppBanner } from '../mobile-banner';
 
-const trackLinkClick = ( event ) => {
-	const target = event.target.closest( 'a' );
-	const href = target.getAttribute( 'href' );
-
-	if ( href ) {
-		recordEvent( 'navbar_breadcrumb_click', {
-			href,
-			text: target.innerText,
-		} );
-	}
-};
-
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );
 	const rafHandle = useRef( null );
 	const threshold = useRef( null );
 	const siteTitle = getSetting( 'siteTitle', '' );
+	const pageTitle = sections.slice( -1 )[ 0 ];
 	const [ isScrolled, setIsScrolled ] = useState( false );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 
@@ -106,29 +93,10 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 					onInstall={ dismissHandler }
 				/>
 			) }
-			<h1 className="woocommerce-layout__header-breadcrumbs">
-				{ sections.map( ( section, i ) => {
-					const sectionPiece = Array.isArray( section ) ? (
-						<Link
-							href={
-								isEmbedded
-									? getAdminLink( section[ 0 ] )
-									: getNewPath( {}, section[ 0 ], {} )
-							}
-							type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
-							onClick={ trackLinkClick }
-						>
-							{ section[ 1 ] }
-						</Link>
-					) : (
-						section
-					);
-					return (
-						<span key={ i }>
-							{ decodeEntities( sectionPiece ) }
-						</span>
-					);
-				} ) }
+			<h1 className="woocommerce-layout__header-heading">
+				<Text variant="subtitle.small">
+					{ decodeEntities( pageTitle ) }
+				</Text>
 			</h1>
 			{ window.wcAdminFeatures[ 'activity-panels' ] && (
 				<ActivityPanel isEmbedded={ isEmbedded } query={ query } />

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -93,11 +93,14 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 					onInstall={ dismissHandler }
 				/>
 			) }
-			<h1 className="woocommerce-layout__header-heading">
-				<Text variant="subtitle.small">
-					{ decodeEntities( pageTitle ) }
-				</Text>
-			</h1>
+
+			<Text
+				className="woocommerce-layout__header-heading"
+				as="h1"
+				variant="subtitle.small"
+			>
+				{ decodeEntities( pageTitle ) }
+			</Text>
 			{ window.wcAdminFeatures[ 'activity-panels' ] && (
 				<ActivityPanel isEmbedded={ isEmbedded } query={ query } />
 			) }

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -26,8 +26,6 @@
 	.woocommerce-layout__header-heading {
 		display: flex;
 		align-items: center;
-		font-size: 13px;
-		font-weight: normal;
 		padding: 0 0 0 $fallback-gutter-large;
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -9,7 +9,7 @@
 	z-index: 1001; /* on top of #wp-content-editor-tools */
 
 	&.is-scrolled {
-		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);
+		box-shadow: 0 8px 8px 0 rgba( 85, 93, 102, 0.3 );
 	}
 
 	@include breakpoint( '<782px' ) {
@@ -23,7 +23,9 @@
 		flex-direction: row;
 	}
 
-	.woocommerce-layout__header-breadcrumbs {
+	.woocommerce-layout__header-heading {
+		display: flex;
+		align-items: center;
 		font-size: 13px;
 		font-weight: normal;
 		padding: 0 0 0 $fallback-gutter-large;
@@ -32,6 +34,11 @@
 		height: $header-height;
 		line-height: $header-height;
 		background: $studio-white;
+
+		> p.is-embed {
+			font-weight: 600;
+			font-size: 14px;
+		}
 
 		span + span::before {
 			content: ' / ';

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -9,7 +9,7 @@
 	z-index: 1001; /* on top of #wp-content-editor-tools */
 
 	&.is-scrolled {
-		box-shadow: 0 8px 8px 0 rgba( 85, 93, 102, 0.3 );
+		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);
 	}
 
 	@include breakpoint( '<782px' ) {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -32,21 +32,9 @@
 		height: $header-height;
 		line-height: $header-height;
 		background: $studio-white;
-
-		> p.is-embed {
-			font-weight: 600;
-			font-size: 14px;
-		}
-
-		> p {
-			text-transform: capitalize;
-		}
-
-		span + span::before {
-			content: ' / ';
-			color: $gray-text;
-			margin: 0 2px 0 2px;
-		}
+		font-weight: 600;
+		font-size: 14px;
+		text-transform: capitalize;
 	}
 }
 

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -40,6 +40,10 @@
 			font-size: 14px;
 		}
 
+		> p {
+			text-transform: capitalize;
+		}
+
 		span + span::before {
 			content: ' / ';
 			color: $gray-text;

--- a/client/header/test/index.js
+++ b/client/header/test/index.js
@@ -23,7 +23,6 @@ jest.mock( '@woocommerce/data', () => ( {
  * External dependencies
  */
 import { render, fireEvent } from '@testing-library/react';
-import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -81,19 +80,5 @@ describe( 'Header', () => {
 		expect( document.title ).toBe(
 			'Accounts & Privacy ‹ Settings ‹ Fake Site Title — WooCommerce'
 		);
-	} );
-
-	it( 'tracks link clicks with recordEvent', () => {
-		const { queryByRole } = render(
-			<Header sections={ encodedBreadcrumb } isEmbedded={ false } />
-		);
-
-		const firstLink = queryByRole( 'link' );
-		fireEvent.click( firstLink );
-
-		expect( recordEvent ).toBeCalledWith( 'navbar_breadcrumb_click', {
-			href: firstLink.getAttribute( 'href' ),
-			text: firstLink.innerText,
-		} );
 	} );
 } );

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -120,7 +120,7 @@
 	}
 
 	.woocommerce-activity-card__actions {
-		a.components-button:not( .is-primary ) {
+		a.components-button:not(.is-primary) {
 			color: $gray-text;
 		}
 	}

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -1,5 +1,3 @@
-
-
 .woocommerce-embed-page {
 	#wpbody .woocommerce-layout,
 	.woocommerce-layout__notice-list-hide + .wrap {
@@ -64,7 +62,7 @@
 			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
 		}
 
-		.woocommerce-layout__header-breadcrumbs {
+		.woocommerce-layout__header-heading {
 			margin-top: 0;
 			margin-bottom: 0;
 		}
@@ -122,7 +120,7 @@
 	}
 
 	.woocommerce-activity-card__actions {
-		a.components-button:not(.is-primary) {
+		a.components-button:not( .is-primary ) {
 			color: $gray-text;
 		}
 	}

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -8,7 +8,7 @@
 	&.woocommerce_page_wc-admin #wpbody-content {
 		padding: 0;
 		overflow-x: hidden !important;
-		min-height: calc( 100vh - #{$adminbar-height} );
+		min-height: calc(100vh - #{$adminbar-height});
 	}
 
 	@include breakpoint( '>782px' ) {
@@ -27,7 +27,7 @@
 
 		#wpcontent,
 		#wpbody-content {
-			min-height: calc( 100vh - #{$adminbar-height-mobile} );
+			min-height: calc(100vh - #{$adminbar-height-mobile});
 		}
 	}
 
@@ -54,7 +54,7 @@
 		}
 	}
 
-	.components-popover:not( .is-mobile ) {
+	.components-popover:not(.is-mobile) {
 		z-index: 2; /* below of woocommerce-layout__header */
 	}
 }

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -1,4 +1,3 @@
-
 // css resets some wp-admin specific rules so that the app fits better in the extension container
 .woocommerce-page {
 	.wrap {
@@ -9,7 +8,7 @@
 	&.woocommerce_page_wc-admin #wpbody-content {
 		padding: 0;
 		overflow-x: hidden !important;
-		min-height: calc(100vh - #{$adminbar-height});
+		min-height: calc( 100vh - #{$adminbar-height} );
 	}
 
 	@include breakpoint( '>782px' ) {
@@ -28,7 +27,7 @@
 
 		#wpcontent,
 		#wpbody-content {
-			min-height: calc(100vh - #{$adminbar-height-mobile});
+			min-height: calc( 100vh - #{$adminbar-height-mobile} );
 		}
 	}
 
@@ -55,7 +54,7 @@
 		}
 	}
 
-	.components-popover:not(.is-mobile) {
+	.components-popover:not( .is-mobile ) {
 		z-index: 2; /* below of woocommerce-layout__header */
 	}
 }
@@ -75,7 +74,7 @@
 		}
 
 		// #wpwrap id added for specificity
-		#wpwrap .woocommerce-layout__header-breadcrumbs {
+		#wpwrap .woocommerce-layout__header-heading {
 			padding-left: 60px;
 		}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -809,7 +809,7 @@ class Loader {
 			<div class="woocommerce-layout">
 				<div class="woocommerce-layout__header is-embed-loading">
 					<h1 class="woocommerce-layout__header-heading">
-						<?php self::output_breadcrumbs( end($sections) ); ?>
+						<?php self::output_breadcrumbs( end( $sections ) ); ?>
 					</h1>
 				</div>
 			</div>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -779,13 +779,9 @@ class Loader {
 			return;
 		}
 		?>
-		<span>
-		<?php if ( is_array( $section ) ) : ?>
-			<a href="<?php echo esc_url( admin_url( $section[0] ) ); ?>"><?php echo esc_html( $section[1] ); ?></a>
-		<?php else : ?>
+		<p class="is-embed">
 			<?php echo esc_html( $section ); ?>
-		<?php endif; ?>
-		</span>
+		</p>
 		<?php
 	}
 
@@ -812,10 +808,8 @@ class Loader {
 		<div id="woocommerce-embedded-root" class="is-embed-loading">
 			<div class="woocommerce-layout">
 				<div class="woocommerce-layout__header is-embed-loading">
-					<h1 class="woocommerce-layout__header-breadcrumbs">
-						<?php foreach ( $sections as $section ) : ?>
-							<?php self::output_breadcrumbs( $section ); ?>
-						<?php endforeach; ?>
+					<h1 class="woocommerce-layout__header-heading">
+						<?php self::output_breadcrumbs( end($sections) ); ?>
 					</h1>
 				</div>
 			</div>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -774,7 +774,7 @@ class Loader {
 	 *
 	 * @param array $section Section to create breadcrumb from.
 	 */
-	private static function output_breadcrumbs( $section ) {
+	private static function output_heading( $section ) {
 		if ( ! static::user_can_analytics() ) {
 			return;
 		}
@@ -809,7 +809,7 @@ class Loader {
 			<div class="woocommerce-layout">
 				<div class="woocommerce-layout__header is-embed-loading">
 					<h1 class="woocommerce-layout__header-heading">
-						<?php self::output_breadcrumbs( end( $sections ) ); ?>
+						<?php self::output_heading( end( $sections ) ); ?>
 					</h1>
 				</div>
 			</div>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -778,11 +778,8 @@ class Loader {
 		if ( ! static::user_can_analytics() ) {
 			return;
 		}
-		?>
-		<p class="is-embed">
-			<?php echo esc_html( $section ); ?>
-		</p>
-		<?php
+
+		echo esc_html( $section );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3963 

This is an interim step towards the integration of wc-navigation and the addition of a back button within this header. This issue only encompasses the removal of the breadcrumbs in favor of using a simple title with the name of the current page, with a few small revisions to JS and CSS. 

Some small revisions were required in Layout.php as well to account for embed pages displaying the old-style breadcrumbs temporarily while the React view loaded. 

In the issue it was specified to use the <Text> component with variant `subtitle.small` for the heading. Simple enough, although this component obviously wasn't available on the PHP side, so I added a couple styles to account for any stark visual differences tied to the `is-embed` class. Just let me know if there's a more elegant solution for this available. 

### Screenshots

**Before:**
![image](https://user-images.githubusercontent.com/444632/94748603-8934fa80-0336-11eb-8e22-84b0b4620a98.png)


**After:**
![image](https://user-images.githubusercontent.com/444632/94748712-c7321e80-0336-11eb-9196-c8f8ae8fb46e.png)


### Detailed test instructions:

- Navigate to any page with wc-admin header bar
- Ensure that breadcrumbs are _not_ displayed, and instead a simple title is visible with correct styling/etc
- Navigate to embed page, and ensure that no FOUC-like behavior occurs with subtitle, and it's displayed as expected.