### PR TITLE
Shell script to release a tagged version to wordpress.org

### DIFF
--- a/bin/release-plugin-to-dot-org.sh
+++ b/bin/release-plugin-to-dot-org.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+CURRENT_PATH=`pwd`
+
+# Pull down the SVN repository.
+echo "Pulling down the SVN repository for woocommerce-admin"
+SVN_WOOCOMMERCE_ADMIN_PATH=/tmp/woocommerce/svn-woocommerce-admin
+svn co https://plugins.svn.wordpress.org/woocommerce-admin/ $SVN_WOOCOMMERCE_ADMIN_PATH
+cd  $SVN_WOOCOMMERCE_ADMIN_PATH
+
+# Get the tagged version to release.
+echo "Please enter the version number to release to woocommerce.org, for example, 1.0.0: "
+read -r VERSION
+
+# Empty trunk/.
+rm -rf trunk
+mkdir trunk
+
+# Download and unzip the plugin into trunk/.
+echo "Downloading and unzipping the plugin"
+PLUGIN_URL=https://github.com/woocommerce/woocommerce-admin/releases/download/v${VERSION}-plugin/woocommerce-admin.zip
+curl -Lo woocommerce-admin.zip $PLUGIN_URL
+unzip woocommerce-admin.zip -d trunk
+rm woocommerce-admin.zip
+
+# Add files in trunk/ to SVN.
+cd trunk
+svn add --force .
+cd ..
+
+# Commit the changes, which will automatically release the plugin to wordpress.org.
+echo "Checking in the new version"
+svn ci -m "Release v${VERSION}"
+
+# Clean up.
+cd ..
+rm -rf svn-woocommerce-admin
+
+cd $CURRENT_PATH
+
+

--- a/bin/release-plugin-to-dot-org.sh
+++ b/bin/release-plugin-to-dot-org.sh
@@ -32,6 +32,11 @@ cd ..
 echo "Checking in the new version"
 svn ci -m "Release v${VERSION}"
 
+# Tag the release
+echo "Tagging the release"
+svn cp trunk tags/$VERSION
+svn ci -m "Tagging v${VERSION}"
+
 # Clean up.
 cd ..
 rm -rf svn-woocommerce-admin

--- a/bin/release-plugin-to-dot-org.sh
+++ b/bin/release-plugin-to-dot-org.sh
@@ -9,7 +9,7 @@ svn co https://plugins.svn.wordpress.org/woocommerce-admin/ $SVN_WOOCOMMERCE_ADM
 cd  $SVN_WOOCOMMERCE_ADMIN_PATH
 
 # Get the tagged version to release.
-echo "Please enter the version number to release to woocommerce.org, for example, 1.0.0: "
+echo "Please enter the version number to release to wordpress.org, for example, 1.0.0: "
 read -r VERSION
 
 # Empty trunk/.


### PR DESCRIPTION
Fixes #5235

This adds a shell script that replaces most of the manual steps involved in pushing a tagged release of the WooCommerce Admin plugin to WordPress.org:

1. Pull down a fresh copy of the WCA SVN repository
2. Replace the `trunk` with the downloaded and decompressed plugin zip from GitHub
3. Check in the trunk changes, which triggers the push to WordPress.org
4. Removes the SVN repository

### Detailed test instructions:

I've tested this for the 1.8.1 release and everything worked. It can be tested by committing to a dummy SVN repo but that isn't a true e2e test. So you could either a) trust me or b) wait until the next release and use the script.