### PR TITLE
Update Starter Pack

### DIFF
--- a/bin/starter-pack/._eslintrc
+++ b/bin/starter-pack/._eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": [ "plugin:@woocommerce/eslint-plugin/recommended" ]
+}

--- a/bin/starter-pack/_main.php
+++ b/bin/starter-pack/_main.php
@@ -31,10 +31,10 @@ function add_extension_register_script() {
 
 	wp_register_style(
 		'{{extension_slug}}',
-		plugins_url( '/build/style.css', __FILE__ ),
+		plugins_url( '/build/index.css', __FILE__ ),
 		// Add any dependencies styles may have, such as wp-components.
 		array(),
-		filemtime( dirname( __FILE__ ) . '/build/style.css' )
+		filemtime( dirname( __FILE__ ) . '/build/index.css' )
 	);
 
 	wp_enqueue_script( '{{extension_slug}}' );

--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -1,25 +1,26 @@
 {
-  "name": "{{extension_slug}}",
-  "title": "{{extension_name}}",
-  "license": "GPL-3.0-or-later",
-  "version": "0.1.0",
-  "description": "{{extension_name}}",
-  "scripts": {
-    "build": "wp-scripts build",
-    "check-engines": "wp-scripts check-engines",
-    "check-licenses": "wp-scripts check-licenses",
-    "lint:css": "wp-scripts lint-style",
-    "lint:js": "wp-scripts lint-js",
-    "lint:pkg-json": "wp-scripts lint-pkg-json",
-    "start": "wp-scripts start",
-    "test:e2e": "wp-scripts test-e2e",
-    "test:unit": "wp-scripts test-unit-js"
-  },
-  "devDependencies": {
-    "@wordpress/scripts": "^6.0.0",
-    "mini-css-extract-plugin": "^0.8.0",
-    "sass-loader": "7.3.1",
-    "css-loader": "3.3.0",
-    "node-sass": "4.13.0"
-  }
+	"name": "{{extension_slug}}",
+	"title": "{{extension_name}}",
+	"license": "GPL-3.0-or-later",
+	"version": "0.1.0",
+	"description": "{{extension_name}}",
+	"scripts": {
+		"build": "wp-scripts build",
+		"check-engines": "wp-scripts check-engines",
+		"check-licenses": "wp-scripts check-licenses",
+		"format:js": "wp-scripts format-js",
+		"lint:css": "wp-scripts lint-style",
+		"lint:js": "wp-scripts lint-js",
+		"lint:md:docs": "wp-scripts lint-md-docs",
+		"lint:md:js": "wp-scripts lint-md-js",
+		"lint:pkg-json": "wp-scripts lint-pkg-json",
+		"packages-update": "wp-scripts packages-update",
+		"start": "wp-scripts start",
+		"test:e2e": "wp-scripts test-e2e",
+		"test:unit": "wp-scripts test-unit-js"
+	},
+	"devDependencies": {
+		"@wordpress/scripts": "^12.2.1",
+		"@woocommerce/eslint-plugin": "1.0.0-beta.0"
+	}
 }

--- a/bin/starter-pack/_webpack.config.js
+++ b/bin/starter-pack/_webpack.config.js
@@ -1,8 +1,7 @@
-const defaultConfig = require( "@wordpress/scripts/config/webpack.config" );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
-const requestToExternal = request => {
+const requestToExternal = ( request ) => {
 	const wcDepMap = {
 		'@woocommerce/components': [ 'window', 'wc', 'components' ],
 		'@woocommerce/csv-export': [ 'window', 'wc', 'csvExport' ],
@@ -19,7 +18,7 @@ const requestToExternal = request => {
 	}
 };
 
-const requestToHandle = request => {
+const requestToHandle = ( request ) => {
 	const wcHandleMap = {
 		'@woocommerce/components': 'wc-components',
 		'@woocommerce/csv-export': 'wc-csv',
@@ -40,31 +39,13 @@ module.exports = {
 	...defaultConfig,
 	plugins: [
 		...defaultConfig.plugins.filter(
-			plugin => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
+			( plugin ) =>
+				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new DependencyExtractionWebpackPlugin( {
 			injectPolyfill: true,
 			requestToExternal,
 			requestToHandle,
 		} ),
-		new MiniCssExtractPlugin( {
-			filename: 'style.css',
-		} ),
 	],
-	module: {
-		...defaultConfig.module,
-		rules: [
-			...defaultConfig.module.rules,
-			{
-				test: /\.(sa|sc|c)ss$/,
-				use: [
-					{
-						loader: MiniCssExtractPlugin.loader,
-					},
-					'css-loader',
-					'sass-loader',
-				],
-			},
-		],
-	},
 };

--- a/bin/starter-pack/starter-pack.js
+++ b/bin/starter-pack/starter-pack.js
@@ -9,6 +9,7 @@ const files = [
 	'_webpack.config.js',
 	'_main.php',
 	'_package.json',
+	'._eslintrc',
 ];
 const maybeThrowError = ( error ) => {
 	if ( error ) throw error;


### PR DESCRIPTION
Update Starter Pack used to quickly create a WC extension.

* Update `@wordpress/scripts`
* Remove CSS handling because thats now built into `@wordpress/scripts`
* Add `@woocommerce/eslint-plugin`

### Detailed test instructions:

1. `npm run create-wc-extension`
2. `cd` into your extension
3. `npm install && npm start`
4. Make sure it builds and see new js linting rules in effect

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

- Dev: Update starter pack dependencies
