### PR TITLE
Add animation to Inbox note deletion

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -11,6 +11,7 @@ import {
 	QUERY_DEFAULTS,
 } from '@woocommerce/data';
 import { withSelect } from '@wordpress/data';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 /**
  * Internal dependencies
@@ -46,23 +47,29 @@ const renderNotes = ( { hasNotes, isBatchUpdating, lastRead, notes } ) => {
 
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
-	return notesArray.map( ( note ) => {
-		if ( note.isUpdating ) {
-			return (
-				<InboxNotePlaceholder
-					className="banner message-is-unread"
-					key={ note.id }
-				/>
-			);
-		}
-		return (
-			<InboxNoteCard
-				key={ note.id }
-				note={ note }
-				lastRead={ lastRead }
-			/>
-		);
-	} );
+	return (
+		<TransitionGroup role="menu">
+			{ notesArray.map( ( note ) => {
+				const { id: noteId, is_deleted: isDeleted } = note;
+				if ( isDeleted ) {
+					return null;
+				}
+				return (
+					<CSSTransition
+						key={ noteId }
+						timeout={ 500 }
+						classNames="woocommerce-inbox-message"
+					>
+						<InboxNoteCard
+							key={ noteId }
+							note={ note }
+							lastRead={ lastRead }
+						/>
+					</CSSTransition>
+				);
+			} ) }
+		</TransitionGroup>
+	);
 };
 
 const InboxPanel = ( props ) => {

--- a/client/inbox-panel/style.scss
+++ b/client/inbox-panel/style.scss
@@ -217,3 +217,29 @@
 		}
 	}
 }
+
+.woocommerce-inbox-message-enter {
+	opacity: 0;
+	max-height: 0;
+	transform: translateX(50%);
+}
+
+.woocommerce-inbox-message-enter-active {
+	opacity: 1;
+	max-height: 100vh;
+	transform: translateX(0%);
+	transition: opacity 500ms, transform 500ms, max-height 500ms;
+}
+
+.woocommerce-inbox-message-exit {
+	opacity: 1;
+	max-height: 100vh;
+	transform: translateX(0%);
+}
+
+.woocommerce-inbox-message-exit-active {
+	opacity: 0;
+	max-height: 0;
+	transform: translateX(50%);
+	transition: opacity 500ms, transform 500ms, max-height 500ms;
+}


### PR DESCRIPTION
Fixes #5260

This PR animates the Inbox note deletion.

_This PR needs a rebase since it uses changes applied to PR [5252](https://github.com/woocommerce/woocommerce-admin/pull/5252)_

### Screenshots
![kZ6UJZKkF7](https://user-images.githubusercontent.com/1314156/94940393-d685a900-04a9-11eb-9457-345aad4a022e.gif)

### Detailed test instructions:

- Verify the note deletion works well on `Home` screen (URL: `/wp-admin/admin.php?page=wc-admin`)
![screenshot-one wordpress test-2020 10 01-16_50_13](https://user-images.githubusercontent.com/1314156/94856546-830e4f00-0406-11eb-873e-0f518e374156.png)
- Verify the note deletion works well on other screens.
![screenshot-one wordpress test-2020 10 01-16_50_51](https://user-images.githubusercontent.com/1314156/94856566-8bff2080-0406-11eb-9da9-f9a0cdb3851c.png)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Added animation to Inbox note deletion
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
