### PR TITLE
Fixed action of "Continue Store Setup" button

### DIFF
--- a/src/Notes/OnboardingProfiler.php
+++ b/src/Notes/OnboardingProfiler.php
@@ -60,8 +60,8 @@ class Onboarding_Profiler {
 		$note->add_action(
 			'skip-profiler',
 			__( 'Skip Setup', 'woocommerce-admin' ),
-			wc_admin_url( '&reset_profiler=0' ),
-			'actioned',
+			false,
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false
 		);
 		return $note;

--- a/src/Notes/OnboardingProfiler.php
+++ b/src/Notes/OnboardingProfiler.php
@@ -53,7 +53,7 @@ class Onboarding_Profiler {
 		$note->add_action(
 			'continue-profiler',
 			__( 'Continue Store Setup', 'woocommerce-admin' ),
-			wc_admin_url( '&enable_onboarding=1' ),
+			wc_admin_url( '&path=/setup-wizard' ),
 			NOTE::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);


### PR DESCRIPTION
Fixes #5251

This PR fixes the action of the "Continue Store Setup" button.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-10-05 at 16-17-09](https://user-images.githubusercontent.com/1314156/95211878-7487b500-07c3-11eb-9a9f-fb9f4c975f5c.gif)


### Detailed test instructions:

- Create a brand new site or set the `wp_options` variable `woocommerce_onboarding_profile` as `a:0:{}` and delete the note named: `wc-admin-onboarding-profiler-reminder`.

The SQL sentence should look like this:
```
DELETE FROM `wp_wc_admin_notes` WHERE `name` = 'wc-admin-onboarding-profiler-reminder';
UPDATE `wp_options` SET `option_value` = 'a:0:{}' WHERE `option_name` = 'woocommerce_onboarding_profile';
```
- Execute the daily cron (`wc_admin_daily`). To do this you can install and use the plugin [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/).
- Go to the `Home` screen.
- The sign: `Welcome to WooCommerce! Set up your store and start selling` should be visible

![screenshot-one wordpress test-2020 10 06-11_36_54](https://user-images.githubusercontent.com/1314156/95216364-5a040a80-07c8-11eb-8b4e-9accf067af8f.png)


- Press `Continue Store Setup`.
- It should redirect you to the OBW.

- Also, verify the `Skip setup` button sets the note as `actioned`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Action of "Continue Store Setup" button
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
