### PR TITLE
Add/confirm tax settings note

### DIFF
--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+use Automattic\WooCommerce\Admin\Notes\Confirm_Tax_Settings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -58,13 +59,7 @@ class OnboardingAutomateTaxes {
 		if ( $jetpack_connected && $wcs_version && $wcs_tos_accepted ) {
 			update_option( 'wc_connect_taxes_enabled', 'yes' );
 			update_option( 'woocommerce_calc_taxes', 'yes' );
+			Confirm_Tax_Settings::possibly_add_note();
 		}
-	}
-
-	/**
-	 * Check if automated taxes are supported.
-	 */
-	private static function automated_tax_is_supported() {
-		return in_array( WC()->countries->get_base_country(), \OnboardingTasks::get_automated_tax_supported_countries(), true );
 	}
 }

--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -62,4 +62,11 @@ class OnboardingAutomateTaxes {
 			Confirm_Tax_Settings::possibly_add_note();
 		}
 	}
+
+	/**
+	 * Check if automated taxes are supported.
+	 */
+	private static function automated_tax_is_supported() {
+		return in_array( WC()->countries->get_base_country(), \OnboardingTasks::get_automated_tax_supported_countries(), true );
+	}
 }

--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WooCommerce Admin: Confirm tax settings
+ *
+ * Adds a note to ask the user to confirm tax settings after automated taxes
+ * has been automatically enabled (see OnboardingAutomateTaxes).
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ConfirmTaxSettings.
+ */
+class Confirm_Tax_Settings {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-confirm-tax-settings';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$note = new Note();
+
+		$note->set_title( __( 'Confirm tax settings', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Automated tax calculations are enabled on your store through WooCommerce Services. Learn more about automated taxes <a href="https://docs.woocommerce.com/document/woocommerce-services/#section-12">here</a>.', 'woocommerce-admin' ) );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'confirm-tax-settings_edit-tax-settings',
+			__( 'Edit tax settings', 'woocommerce-admin' ),
+			admin_url( 'admin.php?page=wc-settings&tab=tax' ),
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5258

This adds the "Confirm tax settings" note when the onboarding wizard is complete and taxes are automatically calculated.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/95277796-04943000-0892-11eb-84c0-91847e16167e.png)

### Detailed test instructions:

Same as https://github.com/woocommerce/woocommerce-admin/pull/5076:

1. Have Jetpack installed and connected
1. Have WCS installed and accept TOS
1. Have an uncompleted onboarding wizard
1. Once all these are met you can go through the onboarding wizard, choices don't matter too much
1. Once you finish the last step of the Wizard and are redirected to the Woo home page, you should see ~that the tax setup task is complete~ the new note.

### Changelog Note:

Add: Confirm tax settings note