### PR TITLE
Load onboarding data when enabled or directly visiting

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -318,6 +318,17 @@ class Onboarding {
 	 * @return bool
 	 */
 	public static function should_show_profiler() {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		$is_current_page = isset( $_GET['page'] ) &&
+			'wc-admin' === $_GET['page'] &&
+			isset( $_GET['path'] ) &&
+			'/setup-wizard' === $_GET['path'];
+		/* phpcs: enable */
+
+		if ( $is_current_page ) {
+			return true;
+		}
+
 		$onboarding_data = get_option( self::PROFILE_DATA_OPTION, array() );
 
 		$is_completed = isset( $onboarding_data['completed'] ) && true === $onboarding_data['completed'];
@@ -629,20 +640,26 @@ class Onboarding {
 	 * @param array $settings Component settings.
 	 */
 	public function component_settings( $settings ) {
-		$profile = get_option( self::PROFILE_DATA_OPTION, array() );
+		$profile                = get_option( self::PROFILE_DATA_OPTION, array() );
+		$settings['onboarding'] = array(
+			'profile' => $profile,
+		);
+
+		// Only fetch if the onboarding wizard OR the task list is incomplete or currently shown.
+		if ( ! self::should_show_profiler() && ! self::should_show_tasks() ) {
+			return $settings;
+		}
 
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 		$wccom_auth                 = \WC_Helper_Options::get( 'auth' );
 		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
-		$settings['onboarding'] = array(
-			'activeTheme'  => get_option( 'stylesheet' ),
-			'euCountries'  => WC()->countries->get_european_union_countries(),
-			'industries'   => self::get_allowed_industries(),
-			'productTypes' => self::get_allowed_product_types(),
-			'profile'      => $profile,
-			'themes'       => self::get_themes(),
-		);
+		$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
+		$settings['onboarding']['euCountries']  = WC()->countries->get_european_union_countries();
+		$settings['onboarding']['industries']   = self::get_allowed_industries();
+		$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
+		$settings['onboarding']['profile']      = $profile;
+		$settings['onboarding']['themes']       = self::get_themes();
 
 		return $settings;
 	}
@@ -755,18 +772,12 @@ class Onboarding {
 	 */
 	public function is_loading( $is_loading ) {
 		$show_profiler = self::should_show_profiler();
-		$is_dashboard  = ! isset( $_GET['path'] ); // phpcs:ignore csrf ok.
-		$is_profiler   = isset( $_GET['path'] ) && '/setup-wizard' === $_GET['path']; // phpcs:ignore csrf ok.
 
-		if ( $is_profiler ) {
+		if ( $show_profiler ) {
 			return true;
 		}
 
-		if ( ! $show_profiler || ! $is_dashboard ) {
-			return $is_loading;
-		}
-
-		return true;
+		return $is_loading;
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -636,19 +636,13 @@ class Onboarding {
 		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
 		$settings['onboarding'] = array(
-			'industries' => self::get_allowed_industries(),
-			'profile'    => $profile,
+			'activeTheme'  => get_option( 'stylesheet' ),
+			'euCountries'  => WC()->countries->get_european_union_countries(),
+			'industries'   => self::get_allowed_industries(),
+			'productTypes' => self::get_allowed_product_types(),
+			'profile'      => $profile,
+			'themes'       => self::get_themes(),
 		);
-
-		// Only fetch if the onboarding wizard OR the task list is incomplete.
-		if ( self::should_show_profiler() || self::should_show_tasks() ) {
-			$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
-			$settings['onboarding']['euCountries']  = WC()->countries->get_european_union_countries();
-			$current_user                           = wp_get_current_user();
-			$settings['onboarding']['userEmail']    = esc_html( $current_user->user_email );
-			$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
-			$settings['onboarding']['themes']       = self::get_themes();
-		}
 
 		return $settings;
 	}


### PR DESCRIPTION
Fixes #5269 

This loads the data needed for onboarding when onboarding has not been skipped/completed or when it is directly visited.

Note that this is a short-term fix and works by allowing the onboarding to be directly visited via a URL.  Long-term we'll want to introduce REST APIs for this data and loading states for the components so that we don't need to rely on this much preloading.

### Screenshots

#### Before
<img width="569" alt="Screen Shot 2020-10-07 at 3 17 26 PM" src="https://user-images.githubusercontent.com/10561050/95379723-6c786400-08ee-11eb-9002-5f68693c4526.png">


#### After
<img width="548" alt="Screen Shot 2020-10-07 at 3 17 23 PM" src="https://user-images.githubusercontent.com/10561050/95379721-6b473700-08ee-11eb-9c1b-394af64b2869.png">


### Detailed test instructions:

1. On a fresh install, walk through the onboarding and make sure things work as expected.
1. Note that the loading screens work for the profiler at all times (no flashes of the WP admin bar prior to the profiler loading).
1. Skip or complete the profiler.
1. Set the task list to hidden `update_option( 'woocommerce_task_list_hidden', 'yes' );`
1. Visit the profiler directly. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
1. Make sure you can walk through all steps and that industries, product types, etc, are all shown.