### PR TITLE
Task List - Solving browser back button issue

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -314,6 +314,7 @@ export default compose(
 			invalidateResolutionForStoreSelector,
 		} = dispatch( ONBOARDING_STORE_NAME );
 		invalidateResolution( 'getProfileItems', [] );
+		invalidateResolution( 'getTasksStatus', [] );
 		return {
 			clearTaskStatusCache: () =>
 				invalidateResolutionForStoreSelector( 'getTasksStatus' ),


### PR DESCRIPTION
Fixes #5261

This PR solves the browser back button issue. 
Before, when using the browser back button during `Purchase & install extension` or `Set up WooCommerce Payments`, some completed tasks were being changed to incomplete.

### Screenshots
![Screen Capture on 2020-10-07 at 17-04-10](https://user-images.githubusercontent.com/1314156/95381966-4d161280-08bf-11eb-8a1a-be8d5c9770ff.gif)


### Detailed test instructions:

1. Create a brand new test site and upload a test version of the plugin with the changes added in this PR (`npm run test:zip`)
2. Go through Onboarding Wizard
3. On `Product Types` select one or more paid extensions
4. Finish Wizard and arrive on `Home` screen
5. Complete the `Personalize my store` task and observe that the task list shows it as complete
6. Now complete the `Set up tax` task. This task should appear as completed too
7. Click `Purchase & install extension` task
8. Use the browser back button while on `woocommerce.com/cart` page
![Screenshot_2020-10-02_at_21_26_29](https://user-images.githubusercontent.com/24649833/94967781-ac5ad800-04f7-11eb-9359-55d9de4f85c0.png)
9. `Personalize my store` and `Set up tax` tasks should appear as `completed`.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Task List - Solving browser back button issue
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
