### PR TITLE
Navigation: Prep feature flags and option

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -222,15 +222,19 @@ export const PageLayout = compose(
 		: identity
 )( _PageLayout );
 
-export class EmbedLayout extends Component {
-	render() {
-		return (
-			<Layout
-				page={ {
-					breadcrumbs: getSetting( 'embedBreadcrumbs', [] ),
-				} }
-				isEmbedded
-			/>
-		);
-	}
-}
+const _EmbedLayout = () => (
+	<Layout
+		page={ {
+			breadcrumbs: getSetting( 'embedBreadcrumbs', [] ),
+		} }
+		isEmbedded
+	/>
+);
+
+export const EmbedLayout = compose(
+	window.wcSettings.preloadOptions
+		? withOptionsHydration( {
+				...window.wcSettings.preloadOptions,
+		  } )
+		: identity
+)( _EmbedLayout );

--- a/config/core.json
+++ b/config/core.json
@@ -13,6 +13,7 @@
 		"store-alerts": true,
 		"minified-js": false,
 		"wcpay": true,
-		"mobile-app-banner": true
+		"mobile-app-banner": true,
+		"navigation": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -14,6 +14,6 @@
 		"minified-js": true,
 		"wcpay": true,
 		"mobile-app-banner": true,
-		"navigation": false
+		"navigation": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,7 @@
 		"store-alerts": true,
 		"minified-js": true,
 		"wcpay": true,
-		"mobile-app-banner": true
+		"mobile-app-banner": true,
+		"navigation": false
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -13,6 +13,7 @@
 		"store-alerts": true,
 		"minified-js": true,
 		"wcpay": true,
-		"mobile-app-banner": true
+		"mobile-app-banner": true,
+		"navigation": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -14,6 +14,6 @@
 		"minified-js": true,
 		"wcpay": true,
 		"mobile-app-banner": true,
-		"navigation": true
+		"navigation": false
 	}
 }

--- a/src/Features/Navigation.php
+++ b/src/Features/Navigation.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Navigation Experience
+ *
+ * @package Woocommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Features;
+
+/**
+ * Contains logic for the Navigation
+ */
+class Navigation {
+	/**
+	 * Hook into WooCommerce.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+	}
+
+	/**
+	 * Preload options to prime state of the application.
+	 *
+	 * @param array $options Array of options to preload.
+	 * @return array
+	 */
+	public function preload_options( $options ) {
+		$options[] = 'woocommerce_navigation_enabled';
+
+		return $options;
+	}
+}

--- a/src/Features/Navigation.php
+++ b/src/Features/Navigation.php
@@ -16,7 +16,7 @@ class Navigation {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature ' ), 0 );
+		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
 	}
 
 		/**

--- a/src/Features/Navigation.php
+++ b/src/Features/Navigation.php
@@ -16,7 +16,7 @@ class Navigation {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-		add_filter( 'woocommerce_admin_features', array( $this, 'replace_supported_features' ), 0 );
+		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature ' ), 0 );
 	}
 
 		/**
@@ -24,7 +24,7 @@ class Navigation {
 		 *
 		 * @param array $features Array of feature slugs.
 		 */
-	public function replace_supported_features( $features ) {
+	public function maybe_remove_nav_feature( $features ) {
 		if ( in_array( 'navigation', $features, true ) && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
 			$features = array_diff( $features, array( 'navigation' ) );
 		}

--- a/src/Features/Navigation.php
+++ b/src/Features/Navigation.php
@@ -16,6 +16,19 @@ class Navigation {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+		add_filter( 'woocommerce_admin_features', array( $this, 'replace_supported_features' ), 0 );
+	}
+
+		/**
+		 * Overwrites the allowed features array using a local `feature-config.php` file.
+		 *
+		 * @param array $features Array of feature slugs.
+		 */
+	public function replace_supported_features( $features ) {
+		if ( in_array( 'navigation', $features, true ) && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
+			$features = array_diff( $features, array( 'navigation' ) );
+		}
+		return $features;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,6 +165,10 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
+		if ( 'navigation' === $feature && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
+			return false;
+		}
+
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,10 +165,6 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
-		if ( 'navigation' === $feature && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
-			return false;
-		}
-
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}


### PR DESCRIPTION
Add a feature flag and option to enable/disable the new Navigation experience. Much of this is based off the enable/disable setup for the Homescreen, which was removed in https://github.com/woocommerce/woocommerce-admin/pull/5108.

* Add feature flag.
* Add the feature `src/Features/Navigation.php`.
* Hydrate options on Embedded pages as well. cc @samueljseay as this is related to your investigations as part of https://github.com/woocommerce/woocommerce-admin/pull/5161.

### Detailed test instructions:

1. `composer install` and a fresh `npm start` to get the features array built correctly.
1. Visit any page, embedded or not.
2. Check the feature `window.wcAdminFeatures.navigation` reflects your option.
3. Check the option is correctly pre-loaded `wcSettings.preloadOptions.woocommerce_navigation_enabled`.
4. Change the option value to "yes" in your DB and repeat steps 2 and 3.

### Changelog Note:

none: unreleased changes
