### PR TITLE
Version bump: WP components and base styles

### DIFF
--- a/client/stylesheets/shared/_gutenberg-components.scss
+++ b/client/stylesheets/shared/_gutenberg-components.scss
@@ -4,7 +4,6 @@ allows Woo themed components based on the config found in postcss.config.js
  */
 @import 'gutenberg-components/button/style.scss';
 @import 'gutenberg-components/checkbox-control/style.scss';
-@import 'gutenberg-components/dashicon/style.scss';
 @import 'gutenberg-components/form-toggle/style.scss';
 @import 'gutenberg-components/notice/style.scss';
 @import 'gutenberg-components/select-control/style.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8103,6 +8103,165 @@
 						"qs": "6.9.4"
 					}
 				},
+				"@wordpress/components": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.0.0.tgz",
+					"integrity": "sha512-2iJw70xAhIQSjR7DLRbYTZx84OFqjGUZNE4U2fy7vg30z5TItP3KQ133VOW9uqQwl4U9gzovIAluq1nq8TuX1A==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@emotion/core": "^10.0.22",
+						"@emotion/css": "^10.0.22",
+						"@emotion/native": "^10.0.22",
+						"@emotion/styled": "^10.0.23",
+						"@wordpress/a11y": "^2.11.0",
+						"@wordpress/compose": "^3.19.0",
+						"@wordpress/deprecated": "^2.9.0",
+						"@wordpress/dom": "^2.13.0",
+						"@wordpress/element": "^2.16.0",
+						"@wordpress/hooks": "^2.9.0",
+						"@wordpress/i18n": "^3.14.0",
+						"@wordpress/icons": "^2.4.0",
+						"@wordpress/is-shallow-equal": "^2.1.0",
+						"@wordpress/keycodes": "^2.14.0",
+						"@wordpress/primitives": "^1.7.0",
+						"@wordpress/rich-text": "^3.20.0",
+						"@wordpress/warning": "^1.2.0",
+						"classnames": "^2.2.5",
+						"dom-scroll-into-view": "^1.2.1",
+						"downshift": "^5.4.0",
+						"gradient-parser": "^0.1.5",
+						"lodash": "^4.17.15",
+						"memize": "^1.1.0",
+						"moment": "^2.22.1",
+						"re-resizable": "^6.4.0",
+						"react-dates": "^17.1.1",
+						"react-resize-aware": "^3.0.1",
+						"react-spring": "^8.0.20",
+						"react-use-gesture": "^7.0.15",
+						"reakit": "^1.1.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^7.0.2"
+					},
+					"dependencies": {
+						"@wordpress/compose": {
+							"version": "3.21.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.21.0.tgz",
+							"integrity": "sha512-GoFe2jwVdo6fU6MuDgI59cXwp8DyH1IpLNKSYGqeaDm69ky1cnMQXKV9mFQ8USZbYRn1f5LYV1Dg4IRsqSGqCw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"@wordpress/element": "^2.18.0",
+								"@wordpress/is-shallow-equal": "^2.3.0",
+								"@wordpress/priority-queue": "^1.9.0",
+								"clipboard": "^2.0.1",
+								"lodash": "^4.17.19",
+								"mousetrap": "^1.6.5",
+								"react-resize-aware": "^3.0.1"
+							},
+							"dependencies": {
+								"@wordpress/is-shallow-equal": {
+									"version": "2.3.0",
+									"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
+									"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
+									"dev": true,
+									"requires": {
+										"@babel/runtime": "^7.11.2"
+									}
+								},
+								"lodash": {
+									"version": "4.17.20",
+									"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+									"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+									"dev": true
+								}
+							}
+						},
+						"@wordpress/dom": {
+							"version": "2.15.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.15.0.tgz",
+							"integrity": "sha512-eoNfM7QnrZJfdJr1DMaIi1oWlaFJ0BtHBy/0IjGhDYeZIzKRhGzCkz4vhRMwxeTPCGbG0PZg4uwPvys4Vugp9Q==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"lodash": "^4.17.19"
+							},
+							"dependencies": {
+								"lodash": {
+									"version": "4.17.20",
+									"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+									"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+									"dev": true
+								}
+							}
+						},
+						"@wordpress/element": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
+							"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
+								"@wordpress/escape-html": "^1.10.0",
+								"lodash": "^4.17.19",
+								"react": "^16.13.1",
+								"react-dom": "^16.13.1"
+							},
+							"dependencies": {
+								"lodash": {
+									"version": "4.17.20",
+									"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+									"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+									"dev": true
+								}
+							}
+						},
+						"@wordpress/i18n": {
+							"version": "3.16.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.16.0.tgz",
+							"integrity": "sha512-ZyRWplETgD90caVaBuGBFcnYVpcogji1g9Ctbb5AO2bGFeHpmPpjvWm0NE64iQTtLFEJoaCiq6oqUvAOPIQJpw==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"gettext-parser": "^1.3.1",
+								"lodash": "^4.17.19",
+								"memize": "^1.1.0",
+								"sprintf-js": "^1.1.1",
+								"tannin": "^1.2.0"
+							},
+							"dependencies": {
+								"lodash": {
+									"version": "4.17.20",
+									"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+									"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+									"dev": true
+								}
+							}
+						},
+						"@wordpress/keycodes": {
+							"version": "2.16.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.16.0.tgz",
+							"integrity": "sha512-8CfxB+9f08FXMUsaO625abmbx2ZinFUz6upzXbe0Da8W3oy7+/TZz6EWsMVBEWz+alSR3Z2FUZ7xUuopHZFcow==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"@wordpress/i18n": "^3.16.0",
+								"lodash": "^4.17.19"
+							},
+							"dependencies": {
+								"lodash": {
+									"version": "4.17.20",
+									"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+									"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+									"dev": true
+								}
+							}
+						}
+					}
+				},
 				"@wordpress/compose": {
 					"version": "3.13.1",
 					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.13.1.tgz",
@@ -8117,6 +8276,78 @@
 						"react-resize-aware": "^3.0.0"
 					}
 				},
+				"@wordpress/escape-html": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.10.0.tgz",
+					"integrity": "sha512-peG+Ypnw8L3YiUWSe/3Nmyzlaoqqbn5JaBaLpL0o6pBxFvGwKr00fFJoi+Yq2yZ3LEFDrHBHlVYAB6A2aYIbew==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.10.0.tgz",
+					"integrity": "sha512-DOHahghdZD74feOa36pE1t4E1NpaftAnYP3n41s7YlT2hUKQLCQyo7XQyI38ZsoZwuVCM5b4e9rG4kaNQE6BzA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.7.0.tgz",
+					"integrity": "sha512-UnFoieW6dZjYOpQTU+cIdoDTU2NNMiBQ5nUFP1RnNcNcwEiXVrhLqJS9ZXsy+mECeR0K1wT3UUUN7rTiMtITGw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/element": "^2.18.0",
+						"@wordpress/primitives": "^1.9.0"
+					},
+					"dependencies": {
+						"@wordpress/element": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
+							"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
+								"@wordpress/escape-html": "^1.10.0",
+								"lodash": "^4.17.19",
+								"react": "^16.13.1",
+								"react-dom": "^16.13.1"
+							}
+						},
+						"@wordpress/primitives": {
+							"version": "1.9.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.9.0.tgz",
+							"integrity": "sha512-dbYivYpHunYMTXBlY5Mxy/YSBY2RbMV+Z3/MgdkZJMkGL1k+C5/JFAsHSt8Y1UyvWR3lZnWpH+MeF+oq04TWYg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.11.2",
+								"@wordpress/element": "^2.18.0",
+								"classnames": "^2.2.5"
+							}
+						},
+						"lodash": {
+							"version": "4.17.20",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+							"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+							"dev": true
+						}
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.9.0.tgz",
+					"integrity": "sha512-Kfk89IF5giemrgMyQ3avkEdEyYqOgSrC2S/vdYUidoGqg3xhDTeSknIRJy82C8/hwSGAB/hLaAkTjK5/T2OYTg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -8127,6 +8358,12 @@
 					"version": "2.27.0",
 					"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
 					"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
 					"dev": true
 				}
 			}
@@ -8464,9 +8701,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.0.0.tgz",
-			"integrity": "sha512-l0/j0+nVBvCtd/PFj/g6J2R8XuVLLRCNV2jSlnf0SPuswBZ2NYPvCLmf/OZ1Nw/c2O+Erdvq8IdYvXOObewqxQ=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.1.0.tgz",
+			"integrity": "sha512-+HR6Cw0E95IHLixWmDCy54kMCmPxTxwAx7UTkJY/9YvOZyK8Nu3plWbX4c/6MhsASJ9RVFVhJPSJWleQ8bDEkQ=="
 		},
 		"@wordpress/browserslist-config": {
 			"version": "2.6.0",
@@ -8475,37 +8712,39 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.0.0.tgz",
-			"integrity": "sha512-2iJw70xAhIQSjR7DLRbYTZx84OFqjGUZNE4U2fy7vg30z5TItP3KQ133VOW9uqQwl4U9gzovIAluq1nq8TuX1A==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-11.0.0.tgz",
+			"integrity": "sha512-DAtGJoV0FcfdbO/POmbtbBpMpnvt4j8ffxPmaKD/XiO0A9FfyVKy3h2lrJ/g6/P2kyzaaS+LJbCyy186+PNQoA==",
 			"requires": {
-				"@babel/runtime": "^7.9.2",
+				"@babel/runtime": "^7.11.2",
 				"@emotion/core": "^10.0.22",
 				"@emotion/css": "^10.0.22",
 				"@emotion/native": "^10.0.22",
 				"@emotion/styled": "^10.0.23",
-				"@wordpress/a11y": "^2.11.0",
-				"@wordpress/compose": "^3.19.0",
-				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/dom": "^2.13.0",
-				"@wordpress/element": "^2.16.0",
-				"@wordpress/hooks": "^2.9.0",
-				"@wordpress/i18n": "^3.14.0",
-				"@wordpress/icons": "^2.4.0",
-				"@wordpress/is-shallow-equal": "^2.1.0",
-				"@wordpress/keycodes": "^2.14.0",
-				"@wordpress/primitives": "^1.7.0",
-				"@wordpress/rich-text": "^3.20.0",
-				"@wordpress/warning": "^1.2.0",
+				"@wordpress/a11y": "^2.13.0",
+				"@wordpress/compose": "^3.21.0",
+				"@wordpress/date": "^3.12.0",
+				"@wordpress/deprecated": "^2.10.0",
+				"@wordpress/dom": "^2.15.0",
+				"@wordpress/element": "^2.18.0",
+				"@wordpress/hooks": "^2.10.0",
+				"@wordpress/i18n": "^3.16.0",
+				"@wordpress/icons": "^2.7.0",
+				"@wordpress/is-shallow-equal": "^2.3.0",
+				"@wordpress/keycodes": "^2.16.0",
+				"@wordpress/primitives": "^1.9.0",
+				"@wordpress/rich-text": "^3.22.0",
+				"@wordpress/warning": "^1.3.0",
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^5.4.0",
 				"gradient-parser": "^0.1.5",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"re-resizable": "^6.4.0",
 				"react-dates": "^17.1.1",
+				"react-merge-refs": "^1.0.0",
 				"react-resize-aware": "^3.0.1",
 				"react-spring": "^8.0.20",
 				"react-use-gesture": "^7.0.15",
@@ -8515,43 +8754,103 @@
 				"uuid": "^7.0.2"
 			},
 			"dependencies": {
-				"@wordpress/dom": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.14.0.tgz",
-					"integrity": "sha512-7M9SGHvXr9PKcxQCRy8uT/Q2Jg1FqL6cB23f6llY9Ogaw4JcI83Q/D7RvK8oCQ3mvfEqovLjWmqQ5we7Q1BxAA==",
+				"@wordpress/a11y": {
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.13.0.tgz",
+					"integrity": "sha512-hZm5O8piFe5TQxzc1ti3zcLgCRRYNZz8FiGSTFvF1LlMPxbt4usOD4op+MLRPCyYhMQ+1hdodFBUsa40NfzXwg==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/dom-ready": "^2.11.0",
+						"@wordpress/i18n": "^3.16.0"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.21.0.tgz",
+					"integrity": "sha512-GoFe2jwVdo6fU6MuDgI59cXwp8DyH1IpLNKSYGqeaDm69ky1cnMQXKV9mFQ8USZbYRn1f5LYV1Dg4IRsqSGqCw==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/element": "^2.18.0",
+						"@wordpress/is-shallow-equal": "^2.3.0",
+						"@wordpress/priority-queue": "^1.9.0",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.19",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.0.1"
+					}
+				},
+				"@wordpress/date": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.12.0.tgz",
+					"integrity": "sha512-sVLSWS3ViLTz4JVM9mmWXKcIrtzkkd+hqDoVyLGZRIBZAK1Fp5c/uDmTCUf7arYW856g8vftWy35r9GC+f6D+A==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"moment": "^2.22.1",
+						"moment-timezone": "^0.5.31"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.10.0.tgz",
+					"integrity": "sha512-eyHZMRtq7XItAep7vpeqaLQbF5Guud49UiO0ib5UBT97hrORtd6hM+rlqlFOB3ENvs42XPDCV9jR+jwYJPU9DQ==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/hooks": "^2.10.0"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.15.0.tgz",
+					"integrity": "sha512-eoNfM7QnrZJfdJr1DMaIi1oWlaFJ0BtHBy/0IjGhDYeZIzKRhGzCkz4vhRMwxeTPCGbG0PZg4uwPvys4Vugp9Q==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
 						"lodash": "^4.17.19"
 					}
 				},
-				"@wordpress/element": {
-					"version": "2.17.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
-					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
+				"@wordpress/dom-ready": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.11.0.tgz",
+					"integrity": "sha512-q9MZqYPHUtioT/2tgzyAtnEFXRgUJ6eMxLDQaOprBQkGoD2Ue/V+wEX6cJGy+x8AafFataPC2i2jPsnYqE9+zQ==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
+					"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
 						"@types/react": "^16.9.0",
 						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^1.9.0",
+						"@wordpress/escape-html": "^1.10.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
 						"react-dom": "^16.13.1"
 					}
 				},
-				"@wordpress/hooks": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.9.0.tgz",
-					"integrity": "sha512-RL7bIIwy1BJWPOicwtDdC1cO+0HqHhnRtry8qeatv+/qN7O5YrJaslCMot7R4Y9cIgzX8C8Vj2BN2QsXLqUAGg==",
+				"@wordpress/escape-html": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.10.0.tgz",
+					"integrity": "sha512-peG+Ypnw8L3YiUWSe/3Nmyzlaoqqbn5JaBaLpL0o6pBxFvGwKr00fFJoi+Yq2yZ3LEFDrHBHlVYAB6A2aYIbew==",
 					"requires": {
-						"@babel/runtime": "^7.9.2"
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.10.0.tgz",
+					"integrity": "sha512-DOHahghdZD74feOa36pE1t4E1NpaftAnYP3n41s7YlT2hUKQLCQyo7XQyI38ZsoZwuVCM5b4e9rG4kaNQE6BzA==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.15.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.15.0.tgz",
-					"integrity": "sha512-AawJgHEGPyMoPATl8a3Qa+cCZV3S6azPfvqeStbN2pSc7v0HqYhJhWaw80WToHkN4kyOsfu1PUVf1wefuoMNEA==",
+					"version": "3.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.16.0.tgz",
+					"integrity": "sha512-ZyRWplETgD90caVaBuGBFcnYVpcogji1g9Ctbb5AO2bGFeHpmPpjvWm0NE64iQTtLFEJoaCiq6oqUvAOPIQJpw==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
+						"@babel/runtime": "^7.11.2",
 						"gettext-parser": "^1.3.1",
 						"lodash": "^4.17.19",
 						"memize": "^1.1.0",
@@ -8560,23 +8859,49 @@
 					}
 				},
 				"@wordpress/icons": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.6.0.tgz",
-					"integrity": "sha512-cVy2r9mMZiTdQlhkrb3IIbAfdMndI52spQlxRhv2Yzsjec97vMNyX7x6S8Amz/0JBttNDnxhQ9To8xrRBhMBlg==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.7.0.tgz",
+					"integrity": "sha512-UnFoieW6dZjYOpQTU+cIdoDTU2NNMiBQ5nUFP1RnNcNcwEiXVrhLqJS9ZXsy+mECeR0K1wT3UUUN7rTiMtITGw==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.1",
-						"@wordpress/primitives": "^1.8.1"
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/element": "^2.18.0",
+						"@wordpress/primitives": "^1.9.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
+					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
 					}
 				},
 				"@wordpress/keycodes": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.15.0.tgz",
-					"integrity": "sha512-XHyBmhzWjp0svzwiGLOwovlQHH42KkACKTfakDizB5OaaAzlmgZ34Fdl03S7pWl+HUBa7MqItRhGsd4kxdo0bQ==",
+					"version": "2.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.16.0.tgz",
+					"integrity": "sha512-8CfxB+9f08FXMUsaO625abmbx2ZinFUz6upzXbe0Da8W3oy7+/TZz6EWsMVBEWz+alSR3Z2FUZ7xUuopHZFcow==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/i18n": "^3.15.0",
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/i18n": "^3.16.0",
 						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/primitives": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.9.0.tgz",
+					"integrity": "sha512-dbYivYpHunYMTXBlY5Mxy/YSBY2RbMV+Z3/MgdkZJMkGL1k+C5/JFAsHSt8Y1UyvWR3lZnWpH+MeF+oq04TWYg==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/element": "^2.18.0",
+						"classnames": "^2.2.5"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.9.0.tgz",
+					"integrity": "sha512-Kfk89IF5giemrgMyQ3avkEdEyYqOgSrC2S/vdYUidoGqg3xhDTeSknIRJy82C8/hwSGAB/hLaAkTjK5/T2OYTg==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
 					}
 				},
 				"uuid": {
@@ -9158,6 +9483,12 @@
 				"postcss-custom-properties": "^9.1.1"
 			},
 			"dependencies": {
+				"@wordpress/base-styles": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.1.0.tgz",
+					"integrity": "sha512-Ljb1xX4fYHSzvw+p8NnCF3WCNPEY6RlDrtWbJvAOeJe2LiAxiQcbgQa/WdFd21jdSgfet0Wmqk+YwwUyyeermw==",
+					"dev": true
+				},
 				"@wordpress/postcss-themes": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-2.6.0.tgz",
@@ -9281,36 +9612,51 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.21.1.tgz",
-			"integrity": "sha512-3whSSmvpXfTbI56dWe594654USOV6lUj3Tw+xvRxgpi0wSq9ca9om+g7dmlM9nwJ8BZGrl/AKpY5/ldN7QEsEQ==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.22.0.tgz",
+			"integrity": "sha512-Bch6yyE3EckctjUZ5oS/X5VjmHP2JqO4tzrcgD1abHET7LeZIVUg7cXFnz+4byOVvkrgFtuQl+Tk6CINyLpKMQ==",
 			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.20.1",
-				"@wordpress/data": "^4.23.1",
-				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/element": "^2.17.1",
-				"@wordpress/escape-html": "^1.9.0",
-				"@wordpress/is-shallow-equal": "^2.2.0",
-				"@wordpress/keycodes": "^2.15.0",
+				"@babel/runtime": "^7.11.2",
+				"@wordpress/compose": "^3.21.0",
+				"@wordpress/data": "^4.24.0",
+				"@wordpress/deprecated": "^2.10.0",
+				"@wordpress/element": "^2.18.0",
+				"@wordpress/escape-html": "^1.10.0",
+				"@wordpress/is-shallow-equal": "^2.3.0",
+				"@wordpress/keycodes": "^2.16.0",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
 				"memize": "^1.1.0",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.23.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.23.1.tgz",
-					"integrity": "sha512-PKX5UNZkJ1QxGpc9HjHynhtMk1Qo2ASXM53tHk90Rw94TGVSp/4jkcvwwtml05RjTyuDAqFD2D8AGnzsR98Cpg==",
+				"@wordpress/compose": {
+					"version": "3.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.21.0.tgz",
+					"integrity": "sha512-GoFe2jwVdo6fU6MuDgI59cXwp8DyH1IpLNKSYGqeaDm69ky1cnMQXKV9mFQ8USZbYRn1f5LYV1Dg4IRsqSGqCw==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.1",
-						"@wordpress/deprecated": "^2.9.0",
-						"@wordpress/element": "^2.17.1",
-						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/priority-queue": "^1.8.0",
-						"@wordpress/redux-routine": "^3.11.0",
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/element": "^2.18.0",
+						"@wordpress/is-shallow-equal": "^2.3.0",
+						"@wordpress/priority-queue": "^1.9.0",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.19",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.0.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "4.24.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.24.0.tgz",
+					"integrity": "sha512-QlM+dmHLJJROCYIve5sCARt9BDL6eP6VF2IWnYYjJ5yHMlTf6lKp5fyWdGcInY0HmPigLduSTcfgbLUIG3b//Q==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/compose": "^3.21.0",
+						"@wordpress/deprecated": "^2.10.0",
+						"@wordpress/element": "^2.18.0",
+						"@wordpress/is-shallow-equal": "^2.3.0",
+						"@wordpress/priority-queue": "^1.9.0",
+						"@wordpress/redux-routine": "^3.12.0",
 						"equivalent-key-map": "^0.2.2",
 						"is-promise": "^4.0.0",
 						"lodash": "^4.17.19",
@@ -9320,26 +9666,51 @@
 						"use-memo-one": "^1.1.1"
 					}
 				},
-				"@wordpress/element": {
-					"version": "2.17.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
-					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
+				"@wordpress/deprecated": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.10.0.tgz",
+					"integrity": "sha512-eyHZMRtq7XItAep7vpeqaLQbF5Guud49UiO0ib5UBT97hrORtd6hM+rlqlFOB3ENvs42XPDCV9jR+jwYJPU9DQ==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/hooks": "^2.10.0"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
+					"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
 						"@types/react": "^16.9.0",
 						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^1.9.0",
+						"@wordpress/escape-html": "^1.10.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
 						"react-dom": "^16.13.1"
 					}
 				},
-				"@wordpress/i18n": {
-					"version": "3.15.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.15.0.tgz",
-					"integrity": "sha512-AawJgHEGPyMoPATl8a3Qa+cCZV3S6azPfvqeStbN2pSc7v0HqYhJhWaw80WToHkN4kyOsfu1PUVf1wefuoMNEA==",
+				"@wordpress/escape-html": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.10.0.tgz",
+					"integrity": "sha512-peG+Ypnw8L3YiUWSe/3Nmyzlaoqqbn5JaBaLpL0o6pBxFvGwKr00fFJoi+Yq2yZ3LEFDrHBHlVYAB6A2aYIbew==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.10.0.tgz",
+					"integrity": "sha512-DOHahghdZD74feOa36pE1t4E1NpaftAnYP3n41s7YlT2hUKQLCQyo7XQyI38ZsoZwuVCM5b4e9rG4kaNQE6BzA==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.16.0.tgz",
+					"integrity": "sha512-ZyRWplETgD90caVaBuGBFcnYVpcogji1g9Ctbb5AO2bGFeHpmPpjvWm0NE64iQTtLFEJoaCiq6oqUvAOPIQJpw==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
 						"gettext-parser": "^1.3.1",
 						"lodash": "^4.17.19",
 						"memize": "^1.1.0",
@@ -9347,14 +9718,41 @@
 						"tannin": "^1.2.0"
 					}
 				},
-				"@wordpress/keycodes": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.15.0.tgz",
-					"integrity": "sha512-XHyBmhzWjp0svzwiGLOwovlQHH42KkACKTfakDizB5OaaAzlmgZ34Fdl03S7pWl+HUBa7MqItRhGsd4kxdo0bQ==",
+				"@wordpress/is-shallow-equal": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
+					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
 					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/i18n": "^3.15.0",
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.16.0.tgz",
+					"integrity": "sha512-8CfxB+9f08FXMUsaO625abmbx2ZinFUz6upzXbe0Da8W3oy7+/TZz6EWsMVBEWz+alSR3Z2FUZ7xUuopHZFcow==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"@wordpress/i18n": "^3.16.0",
 						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.9.0.tgz",
+					"integrity": "sha512-Kfk89IF5giemrgMyQ3avkEdEyYqOgSrC2S/vdYUidoGqg3xhDTeSknIRJy82C8/hwSGAB/hLaAkTjK5/T2OYTg==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/redux-routine": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.12.0.tgz",
+					"integrity": "sha512-YJanhB9jHF8089gMzsvI4HNWePC4FL0CKQ+qGacp8rr4AgQ05VkmCmnSO/Y5dAxgXIHAtluz8NlXYgN65l5hAg==",
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.19",
+						"rungen": "^0.3.2"
 					}
 				}
 			}
@@ -24936,6 +25334,15 @@
 				"path-exists": "^3.0.0"
 			}
 		},
+		"locutus": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.2.5"
+			}
+		},
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -30841,6 +31248,11 @@
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
 			"dev": true
+		},
+		"react-merge-refs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+			"integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
 		},
 		"react-moment-proptypes": {
 			"version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
 	"dependencies": {
 		"@woocommerce/e2e-environment": "0.1.5",
 		"@wordpress/api-fetch": "2.2.8",
-		"@wordpress/base-styles": "2.0.0",
-		"@wordpress/components": "10.0.0",
+		"@wordpress/base-styles": "3.1.0",
+		"@wordpress/components": "11.0.0",
 		"@wordpress/data": "4.16.1",
 		"@wordpress/data-controls": "1.10.1",
 		"@wordpress/date": "3.9.0",


### PR DESCRIPTION
The `Navigation` component is only available in wp.components version `11.0.0`, which requires the latest base styles as well. This bumps each and removes an import to a file that no longer exists (See https://github.com/WordPress/gutenberg/commit/06d17403c68dfdce73a494b6eeff1f9a49c3e244 for why). So this bump is required to accept the Navigation into wc-admin.

### Detailed test instructions:

1. `npm install && npm start`.
2. Make sure the build succeeds with no errors.
3. Spot check the app for visual regressions.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

none: fix for unreleased changes