### PR TITLE
Notes: Change WooCommerce Services to WooCommerce Shipping & Tax.

### DIFF
--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -33,7 +33,7 @@ class Confirm_Tax_Settings {
 		$note = new Note();
 
 		$note->set_title( __( 'Confirm tax settings', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Automated tax calculations are enabled on your store through WooCommerce Services. Learn more about automated taxes <a href="https://docs.woocommerce.com/document/woocommerce-services/#section-12">here</a>.', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Automated tax calculations are enabled on your store through WooCommerce Shipping & Tax. Learn more about automated taxes <a href="https://docs.woocommerce.com/document/woocommerce-services/#section-12">here</a>.', 'woocommerce-admin' ) );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'confirm-tax-settings_edit-tax-settings',


### PR DESCRIPTION
Super quick follow-up to  #5279 - this changes WooCommerce Services to WooCommerce Shipping & Tax in a new notification.

__To Test__
Follow the steps listed on the original PR  #5279