### PR TITLE
Preventing the legacy coupons page from being readded when the naviga…

### DIFF
--- a/src/Features/CouponsMovedTrait.php
+++ b/src/Features/CouponsMovedTrait.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\PluginsHelper;
+
 /**
  * CouponsMovedTrait trait.
  */
@@ -88,7 +90,7 @@ trait CouponsMovedTrait {
 	 * @return bool
 	 */
 	protected static function should_display_legacy_menu() {
-		return (bool) get_option( self::$option_key, 1 );
+		return (get_option( self::$option_key, 1 ) && ! PluginsHelper::is_plugin_active('navigation'));
 	}
 
 	/**

--- a/src/Features/CouponsMovedTrait.php
+++ b/src/Features/CouponsMovedTrait.php
@@ -90,7 +90,7 @@ trait CouponsMovedTrait {
 	 * @return bool
 	 */
 	protected static function should_display_legacy_menu() {
-		return (get_option( self::$option_key, 1 ) && ! PluginsHelper::is_plugin_active('navigation'));
+		return ( get_option( self::$option_key, 1 ) && ! PluginsHelper::is_plugin_active( 'navigation' ) );
 	}
 
 	/**

--- a/src/Features/CouponsMovedTrait.php
+++ b/src/Features/CouponsMovedTrait.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
-use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Admin\Loader;
 
 /**
  * CouponsMovedTrait trait.
@@ -90,7 +90,7 @@ trait CouponsMovedTrait {
 	 * @return bool
 	 */
 	protected static function should_display_legacy_menu() {
-		return ( get_option( self::$option_key, 1 ) && ! PluginsHelper::is_plugin_active( 'navigation' ) );
+		return ( get_option( self::$option_key, 1 ) && ! Loader::is_feature_enabled( 'navigation' ) );
 	}
 
 	/**

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -55,8 +55,8 @@ class Coupon_Page_Moved {
 			return false;
 		}
 
-		// If new navigation plugin is active
-		if(PluginsHelper::is_plugin_active('navigation')) {
+		// If new navigation plugin is active.
+		if ( PluginsHelper::is_plugin_active( 'navigation' ) ) {
 			return false;
 		}
 

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Notes;
 
 use Automattic\WooCommerce\Admin\Features\CouponsMovedTrait;
+use Automattic\WooCommerce\Admin\PluginsHelper;
 use stdClass;
 use WC_Data_Store;
 
@@ -51,6 +52,11 @@ class Coupon_Page_Moved {
 
 		// If we already have a notice, don't add a new one.
 		if ( self::has_unactioned_note() ) {
+			return false;
+		}
+
+		// If new navigation plugin is active
+		if(PluginsHelper::is_plugin_active('navigation')) {
 			return false;
 		}
 

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -55,7 +55,7 @@ class Coupon_Page_Moved {
 			return false;
 		}
 
-		// If new navigation plugin is active.
+		// If new navigation feature is enabled.
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			return false;
 		}

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Notes;
 
 use Automattic\WooCommerce\Admin\Features\CouponsMovedTrait;
-use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Admin\Loader;
 use stdClass;
 use WC_Data_Store;
 
@@ -56,7 +56,7 @@ class Coupon_Page_Moved {
 		}
 
 		// If new navigation plugin is active.
-		if ( PluginsHelper::is_plugin_active( 'navigation' ) ) {
+		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #5330 

This change is to address the issue that's logged in the woocommerce/navigation repo, #122. In short, the marketing team has recently removed the Coupons page from the main `WooCommerce -> Coupons` into `Marketing -> Coupons` instead. However, to assist people in find it in it's new place it's actually re-added into the original spot based on a few conditions with a note at the top of the page allowing users to dismiss it and remove the obsolete one. 

When the new navigation is in use "re-adding" the coupon page just causes it to be duplicated and sent into the general `WooCommerce -> Settings` category. We're basically just suppressing the activity if the navigation plugin is active.

I also noticed that the note pictured below can still continue to appear after the original menu was suppressed. I added a condition to prevent this behavior within `CouponPageMoved.php -> can_be_added()`. 

Note that I'm still a _little_ uncertain on whether this note could still be added before the navigation plugin was active, and consequently remain if the plugin was activated thereafter. I haven't entirely unraveled the ins and outs of the Notes, but I'm skeptical that this would be a real world issue. 

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/444632/95513509-5363c780-096f-11eb-880d-41e385676d21.png)


After:
![image](https://user-images.githubusercontent.com/444632/95513564-65de0100-096f-11eb-9f47-18b788b3dc71.png)

Note:
![image](https://user-images.githubusercontent.com/444632/95512857-4abec180-096e-11eb-9f41-581e1316b29a.png)

### Detailed test instructions:
_Note:_ This is not currently testable in this branch without merging since navigation was migrated as a feature instead of a plugin in `main`, and I adapted the code to suit this change. I temporarily merged `main` to test myself, but leaving the merge commit in this branch heavily pollutes the "files changed" on this PR, so I've rebased it back out. If anyone has awesome git powers that can resolve this, let me know!

_Cumbersome test instructions_
- Create a new branch from `main` and temporarily merge this branch (or visa versa) (see note above)
- Create new site (or ensure that the `wc_admin_show_legacy_coupon_menu` option key does not exist)
- Have the new navigation feature is enabled
- Navigate to WooCommerce -> Settings via the new nav
- You should **not** see the Coupons page listed
- Navigate to WooCommerce -> Marketing
- You **should** see the Coupons page listed
- If the pictured note appears, you may need to delete `wc-admin-coupon-page-moved` from the `wp_wc_admin_notes` table, and ensure it's not recreated
