### PR TITLE
Ensure that the iOS smart banner is rendered on all WC pages

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -859,7 +859,7 @@ class Loader {
 	 * See https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html
 	 */
 	public static function smart_app_banner() {
-		if ( self::is_admin_page() ) {
+		if ( self::is_admin_or_embed_page() ) {
 			echo "
 				<meta name='apple-itunes-app' content='app-id=1389130815'>
 			";


### PR DESCRIPTION
Fixes #5267

When the smart app banner was made, it was not considered that it should be displayed on non wc-admin powered pages. This should rectify that mistake.

Looking at the logic that determines an `embed_page` I believe that should cover all other non wc-admin pages.

### Detailed test instructions:

The smart app banner is a meta tag. it must contain this content: `<meta name='apple-itunes-app' content='app-id=1389130815'>`

Here's a screenshot using dev tools to search and find the meta tag (type cmd +f to search the html):

<img width="1667" alt="Screenshot 2020-10-09 at 1 51 30 PM" src="https://user-images.githubusercontent.com/1281828/95529133-9f2d7400-0a36-11eb-91d7-1dc19296e645.png">


1. As a baseline, open a non woo commerce page in wordpress. Inspect the html and you should *not* see the meta tag in the content.

2. Visit woocommerce home page.  Inspect the html, the meta tag *should* be rendered

3. Visit woocommerce orders page.  Inspect the html, the meta tag *should* be rendered
### Changelog Note:

Fix: Display the iOS smart app banner on non wc-admin powered pages.
