### PR TITLE
Shipping task smart default: add exceptions

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -94,6 +94,11 @@ export function getAllTasks( {
 		purchaseAndInstallText = sprintf( purchaseAndInstallFormat, itemName );
 	}
 
+	const shippingCompleted =
+		shippingZonesCount > 0 &&
+		isJetpackConnected &&
+		activePlugins.includes( 'woocommerce-services' );
+
 	const tasks = [
 		{
 			key: 'store_details',
@@ -218,7 +223,7 @@ export function getAllTasks( {
 				} );
 				updateQueryString( { task: 'shipping' } );
 			},
-			completed: shippingZonesCount > 0,
+			completed: shippingCompleted,
 			visible:
 				( productTypes && productTypes.includes( 'physical' ) ) ||
 				hasPhysicalProducts,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -97,7 +97,8 @@ export function getAllTasks( {
 	const shippingCompleted =
 		shippingZonesCount > 0 &&
 		isJetpackConnected &&
-		activePlugins.includes( 'woocommerce-services' );
+		activePlugins.includes( 'woocommerce-services' ) &&
+		! [ 'AU', 'NZ', 'UK' ].includes( countryCode );
 
 	const tasks = [
 		{


### PR DESCRIPTION
Fixes #5298

This adds some exceptions to the completed criteria for the shipping task:

- Jetpack must be connected and WCS must be active
- Country must not be AU, NZ, or UK

### Detailed test instructions:

- Start with a fresh site
- Go through the OBW. Select a US state.
- When on the home screen, the shipping task should _not_ be completed
- Connect Jetpack
- Return to the home screen, the shipping task should now be completed
- Go through the OBW again, and select a location in AU, NZ, or UK
- Return to the home screen, the shipping task should _not_ be completed again

### Changelog Note:

Fix: Shipping task smart default: add exceptions