### PR TITLE
Change constants to use old notes class name.

### DIFF
--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -39,7 +39,7 @@ class Confirm_Tax_Settings {
 			'confirm-tax-settings_edit-tax-settings',
 			__( 'Edit tax settings', 'woocommerce-admin' ),
 			admin_url( 'admin.php?page=wc-settings&tab=tax' ),
-			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -52,14 +52,14 @@ class WC_Admin_Notes_Onboarding_Profiler {
 			'continue-profiler',
 			__( 'Continue Store Setup', 'woocommerce-admin' ),
 			wc_admin_url( '&path=/setup-wizard' ),
-			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 		$note->add_action(
 			'skip-profiler',
 			__( 'Skip Setup', 'woocommerce-admin' ),
 			wc_admin_url( '&reset_profiler=0' ),
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false
 		);
 		return $note;


### PR DESCRIPTION
While smoke testing the 1.6.0 release, we encountered the following fatal error:

```
Fatal error: Uncaught Error: Class 'Automattic\WooCommerce\Admin\Notes\Note' not found in /srv/users/user78e8a368/apps/user78e8a368/public/wp-content/plugins/woocommerce-admin/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php:55 Stack trace: #0 /srv/users/user78e8a368/apps/user78e8a368/public/wp-content/plugins/woocommerce-admin/src/Notes/NoteTraits.php(74): Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Profiler::get_note() #1 /srv/users/user78e8a368/apps/user78e8a368/public/wp-includes/class-wp-hook.php(287): Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Profiler::possibly_add_note('') #2 /srv/users/user78e8a368/apps/user78e8a368/public/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(NULL, Array) #3 /srv/users/user78e8a368/apps/user78e8a368/public/wp-includes/plugin.php(478): WP_Hook->do_action(Array) #4 /srv/users/user78e8a368/apps/user78e8a368/public/wp-admin/admin.php(175): do_action('admin_init') #5 {main} thrown in /srv/users/user78e8a368/apps/user78e8a368/public/wp-content/plugins/woocommerce-admin/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php on line 55
```

This appears to be due to a fix that was developed against `main` which has since gone through a class rename on the Note classes in #5142 - and the cherry picked PRs of #5200 and #5279 both were referencing the new notes class name to access the actioned/unactioned constants.

__To Test__
This is best tested on a fresh site. Build a test zip, install and activate, and proceed to the OBW. Verify no fatal is shown. 