### PR TITLE
Revise Excluded Countries from Auto Completion of Shipping Task

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -98,7 +98,7 @@ export function getAllTasks( {
 		shippingZonesCount > 0 &&
 		isJetpackConnected &&
 		activePlugins.includes( 'woocommerce-services' ) &&
-		! [ 'AU', 'NZ', 'UK' ].includes( countryCode );
+		! [ 'AU', 'CA', 'UK' ].includes( countryCode );
 
 	const tasks = [
 		{


### PR DESCRIPTION
Follow up to #5312 - the incorrect list of countries was used on the original PR, so this quick change revises the list to include Canada instead of New Zealand.