### PR TITLE
Wait for server-side processing when clicking on a note

### DIFF
--- a/client/inbox-panel/action.js
+++ b/client/inbox-panel/action.js
@@ -36,6 +36,10 @@ class InboxNoteAction extends Component {
 		const href = event.target.href || '';
 		let inAction = true;
 
+		// Conditionally suppress navigation for certain notes, obviously this isn't conditional yet so will probably
+		// break things.
+		event.preventDefault();
+
 		if ( href.length && ! href.startsWith( adminUrl ) ) {
 			event.preventDefault();
 			inAction = false; // link buttons shouldn't be "busy".
@@ -120,11 +124,15 @@ class InboxNoteAction extends Component {
 			actionCallback( true );
 		} else {
 			this.setState( { inAction }, () => {
-				triggerNoteAction( noteId, action.id );
-
-				if ( !! onClick ) {
-					onClick();
-				}
+				triggerNoteAction( noteId, action.id ).then(
+					() => {
+						if ( !! onClick ) {
+							onClick();
+						}
+						// Now that any server-side actions have been performed, navigate to the clicked link / button.
+						window.location = href;
+					}
+				);
 			} );
 		}
 	}

--- a/packages/data/src/notes/actions.js
+++ b/packages/data/src/notes/actions.js
@@ -14,9 +14,10 @@ export function* triggerNoteAction( noteId, actionId ) {
 
 	const url = `${ NAMESPACE }/admin/notes/${ noteId }/action/${ actionId }`;
 	try {
-		const result = yield apiFetch( { path: url, method: 'POST' } );
-		yield updateNote( noteId, result );
+		const response = yield apiFetch( { path: url, method: 'POST' } );
+		yield updateNote( noteId, response );
 		yield setIsRequesting( 'triggerNoteAction', false );
+		return response;
 	} catch ( error ) {
 		yield setError( 'triggerNoteAction', error );
 		yield setIsRequesting( 'triggerNoteAction', false );

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\Install_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\Order_Milestones;
@@ -192,6 +193,7 @@ class FeaturePlugin {
 		new Set_Up_Additional_Payment_Types();
 		new Test_Checkout();
 		new Selling_Online_Courses();
+		new Install_WooCommerce_Payments();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/InstallWooCommercePayments.php
+++ b/src/Notes/InstallWooCommercePayments.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\API\Plugins;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Install_WooCommerce_Payments.
+ */
+class Install_WooCommerce_Payments {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_note_action_get-woocommerce-payments', array( $this, 'install_woocommerce_payments' ) );
+	}
+
+	/**
+	 * Install Woocommerce Payments.
+	 */
+	public function install_woocommerce_payments() {
+		// Install WooCommerce Payments
+		$installer = new Plugins();
+
+		$install_request = array( 'plugins' => 'woocommerce-payments' );
+		$result = $installer->install_plugins( $install_request );
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		$activate_request = array( 'plugins' => 'woocommerce-payments' );
+		$installer->activate_plugins( $activate_request );
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+	}
+}


### PR DESCRIPTION
A small experiment to explore inbox notifications and waiting for server-side processing to complete before navigating away.

This is 1 of 3 PRs experimenting with approaches (paJDYF-RI-p2#comment-3762 for context).

* Return a promise from triggerNoteAction
* Wait for the promise to resolve before navigating to the action button's URL

<h3>Detailed test instructions:</h3>

* There's a new class in the PR, so run `composer dump-autoload`
* Ensure WooCommerce Payments isn't installed
* Add this url to DataSourcePoller::DATA_SOURCES: `https://gist.githubusercontent.com/jrodger/d2737468bc55408b4d0ecee35f5c8b44/raw/7d8a4b4dc1112d5ea2b4548fc96cf47d8caf7f90/note-install.json`
* Run the `wc_admin_daily` cron task
* The "WooCommerce Payments" note should appear
* Click the "Sign-up" action button
* The button shows the busy animation, WooCommerce Payments is installed and activated, and finally we successfully load the WooCommerce Payments on-boarding screen

<h3>Pros</h3>

* Nearly everything is handled from the inbox notification
* Successfully redirects the user to the target page after running some server-side setup

<h3>Cons</h3>

* Obviously the implementation is very naive, but we’d need a way to only stall on actions that actually have something to process. If we applied this globally we’d slow down “normal” button presses (for example, links out to WooCommerce.com pages and things like that).
* Having the server-side note code feels a little strange for remote inbox notifications. I don’t know if we might want to encapsulate this logic elsewhere because of this.
* The server-side note class does a lot of the same work as the current WooCommerce Payments note. Would there be some value in combining them?
* We have to define the link we redirect to ahead of time, so no using links that need a nonce or dynamically linking to Jetpack onboarding flows etc.