### PR TITLE
Adding 24px spacing between any sibling nav groups (#5329)

### DIFF
--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -14,8 +14,12 @@
 		height: 100%;
 	}
 
-	.components-navigation__group:nth-of-type(2) {
-		margin-top: auto;
+	.components-navigation__group {
+		margin-bottom: 0;
+	}
+
+	.components-navigation__group + .components-navigation__group {
+		margin-top: 24px;
 	}
 
 	.woocommerce-navigation__back-to-dashboard {

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -14,12 +14,12 @@
 		height: 100%;
 	}
 
-	.components-navigation__group {
-		margin-bottom: 0;
-	}
-
 	.components-navigation__group + .components-navigation__group {
 		margin-top: 24px;
+	}
+
+	.components-navigation__item:last-child {
+		margin-bottom: 0;
 	}
 
 	.woocommerce-navigation__back-to-dashboard {

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -18,7 +18,7 @@
 		margin-top: 24px;
 	}
 
-	.components-navigation__item:last-child {
+	.components-navigation__item {
 		margin-bottom: 0;
 	}
 


### PR DESCRIPTION
Fixes #5329

Adding margin between the two menu subgroups, per the design.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/95525437-f96ffb80-0988-11eb-8530-96ee0f353d8a.png)


### Detailed test instructions:

- Ensure navigation feature is enabled
- Click on WooCommerce to view new navigation
- Ensure the margin is present as per the screenshot
- For extra credit, use inspector to confirm 24 pixel spacing


_Note:_ This PR was migrated from the navigation repo [here](https://github.com/woocommerce/navigation/pull/133)