### PR TITLE
Store setup shortcut - not showing up anymore after dismissing the setup tasks

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -153,7 +153,7 @@ export class ActivityPanel extends Component {
 			: null;
 
 		const setup =
-			! taskListComplete && ! isPerformingSetupTask
+			! taskListComplete && ! isPerformingSetupTask && ! taskListHidden
 				? {
 						name: 'setup',
 						title: __( 'Store Setup', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #5343

This PR adds a check to show the "Store Setup" button. Now we verify that the `taskListHidden` is `no` to show the mentioned button.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screen Capture on 2020-10-13 at 13-29-19](https://user-images.githubusercontent.com/1314156/95889032-4b819a00-0d58-11eb-8768-0863fef87b5a.gif)


### Detailed test instructions:
- Go to the home screen and dismiss the setup task list
- Verify the Store Setup button is not visible anymore in the navbar.

_To make it visible again you execute a SQL like_
```
UPDATE `wp_options` SET `option_value` = 'no' WHERE `option_name` = 'woocommerce_task_list_hidden';
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Added a check to not show the Store Setup button after dismissing the setup tasks.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
