### PR TITLE
Provide a URL that remote inbox notification actions can use to trigger server-side actions

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\Install_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\Order_Milestones;
@@ -192,6 +193,7 @@ class FeaturePlugin {
 		new Set_Up_Additional_Payment_Types();
 		new Test_Checkout();
 		new Selling_Online_Courses();
+		new Install_WooCommerce_Payments();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/InstallWooCommercePayments.php
+++ b/src/Notes/InstallWooCommercePayments.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\API\Plugins;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Install_WooCommerce_Payments.
+ */
+class Install_WooCommerce_Payments {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'install_woocommerce_payments' ) );
+	}
+
+	/**
+	 * Install Woocommerce Payments.
+	 */
+	public function install_woocommerce_payments() {
+		// TODO: Need to validate this request more strictly since we're taking install actions directly?
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if (
+			! isset( $_GET['page'] ) ||
+			'wc-admin' !== $_GET['page'] ||
+			! isset( $_GET['action'] ) ||
+			'install-woocommerce-payments' !== $_GET['action']
+		) {
+			return;
+		}
+		/* phpcs:enable */
+
+		// Install WooCommerce Payments
+		$installer = new Plugins();
+
+		$install_request = array( 'plugins' => 'woocommerce-payments' );
+		$result = $installer->install_plugins( $install_request );
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		$activate_request = array( 'plugins' => 'woocommerce-payments' );
+		$installer->activate_plugins( $activate_request );
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		// TODO: WooCommerce Payments is installed at this point, so we could link straight into the on-boarding flow.
+		$wcpay_settings_url = admin_url( 'admin.php?page=wc-admin&path=/payments/connect' );
+		wp_safe_redirect( $wcpay_settings_url );
+		exit;
+	}
+}


### PR DESCRIPTION
Experimenting with remote inbox notifications, add some server-side processing to a remote inbox notification. In this case we install WooCommerce Payments before redirecting to the setup page for the plugin.

This is 1 of 3 PRs experimenting with approaches (paJDYF-RI-p2#comment-3762 for context).

<h3>Detailed test instructions:</h3>

* There's a new class in the PR, so run `composer dump-autoload`
* Ensure WooCommerce Payments isn't installed
* Add this url to DataSourcePoller::DATA_SOURCES: `https://gist.githubusercontent.com/jrodger/7b4af322b2b6b0d638a6c747e5d0b84f/raw/c73ec7c2f18c8e0ee206ec40698876e908df1067/note-action-install.json`
* Run the wc_admin_daily cron task
* The "WooCommerce Payments" note should appear
* Click the "Sign-up" action button
* The button shows the busy animation, WooCommerce Payments is installed and activated, and finally we are redirected to the WooCommerce Payments on-boarding screen

<h3>Pros</h3>

* No changes needed to the Note's JavaScript. It's a standard URL we're navigating to.
* Handling the redirect server-side allows us to handle more complex cases like needing a nonce in the URL.
* Precedent for the approach in `DeactivatePlugin::decativate_feature_plugin`.

<h3>Cons</h3>

* Having the server-side note code feels a little strange for remote inbox notifications. I don’t know if we might want to encapsulate this logic elsewhere because of this.
* The server-side note class does a lot of the same work as the current WooCommerce Payments note. Would there be some value in combining them?
* I think we need more validation in the action, triggering the installation of a plugin purely from a URL isn't ideal