### PR TITLE
Wait for wcpay installed and update action button text to proceed with setup.

### DIFF
--- a/client/inbox-panel/action.js
+++ b/client/inbox-panel/action.js
@@ -120,11 +120,19 @@ class InboxNoteAction extends Component {
 			actionCallback( true );
 		} else {
 			this.setState( { inAction }, () => {
-				triggerNoteAction( noteId, action.id );
-
-				if ( !! onClick ) {
-					onClick();
-				}
+				triggerNoteAction( noteId, action.id )
+					.then( () => {
+						// We can detect inAction state by monitoring note.isUpdating param data store.
+						this.setState( { inAction: false } );
+						if ( !! onClick ) {
+							onClick();
+						}
+					} )
+					.catch( ( err ) => {
+						this.setState( { inAction: false } );
+						// eslint-disable-next-line no-console
+						console.error( err );
+					} );
 			} );
 		}
 	}


### PR DESCRIPTION
Similar to #5358. This is 1 of 3 PRs experimenting with approaches (paJDYF-RI-p2#comment-3762 for context).

* Use existing note handler class to install the plugin.
* Update note once the plugin install with next step url/text.
* Direct user to the WC Pay connect page for further set up.

<h3>Detailed test instructions:</h3>

* Ensure WooCommerce Payments isn't installed
* Add this url to DataSourcePoller::DATA_SOURCES: `https://gist.githubusercontent.com/jrodger/9b757e6c30163ea7c1f62140b8ef0534/raw/df6d7538ca799422627e3da3e6297f8cd105eb8e/note-two-step-install.json`
* Run the wc_admin_daily cron task
* The "WooCommerce Payments" note should appear
* Click the "Install" action button
* The button shows the busy animation, then updates to say "Get Started"
* Clicking "Get Started" navigates to the WCPay setup page

<h3>Pros</h3>

 * Doesn't do anything non-standard with links. Just fires a server-side action and then follows a normal link to get the user to the setup screen.

<h3>Cons</h3>

* As with #5358, we need to tweak the JavaScript so it doesn't stay in the "loading" state. I think this implementation is a little less problematic than #5358, because we're not trying to block a link click and fire it later. However, it still might need a little testing.
* Having the server-side note code feels a little strange for remote inbox notifications. I don’t know if we might want to encapsulate this logic elsewhere because of this. We've taken a slightly different approach here and combined the logic into the existing WooCommerce Payment note class. I'm not sure if that's preferable to creating a new Note class (as in #5361).
