### PR TITLE
Fix up menu item migrations in WC navigation

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -113,15 +113,14 @@ class Analytics {
 	 */
 	public function register_pages() {
 		$overview_page = array(
-			'id'       => 'woocommerce-analytics',
-			'title'    => __( 'Analytics', 'woocommerce-admin' ),
-			'path'     => '/analytics/overview',
-			'icon'     => 'dashicons-chart-bar',
-			'position' => 56, // After WooCommerce & Product menu items.
+			'id'           => 'woocommerce-analytics',
+			'title'        => __( 'Analytics', 'woocommerce-admin' ),
+			'path'         => '/analytics/overview',
+			'icon'         => 'dashicons-chart-bar',
+			'position'     => 56, // After WooCommerce & Product menu items.
+			'is_category'  => true,
+			'is_top_level' => true,
 		);
-		if ( Loader::is_feature_enabled( 'navigation' ) ) {
-			unset( $overview_page['path'] );
-		}
 
 		$report_pages = array(
 			$overview_page,
@@ -186,10 +185,11 @@ class Analytics {
 				'path'   => '/analytics/stock',
 			) : null,
 			array(
-				'id'     => 'woocommerce-analytics-customers',
-				'title'  => __( 'Customers', 'woocommerce-admin' ),
-				'parent' => 'woocommerce',
-				'path'   => '/customers',
+				'id'           => 'woocommerce-analytics-customers',
+				'title'        => __( 'Customers', 'woocommerce-admin' ),
+				'parent'       => 'woocommerce',
+				'path'         => '/customers',
+				'is_top_level' => true,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-settings',

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -83,10 +83,11 @@ class AnalyticsDashboard {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'     => 'woocommerce-home',
-				'title'  => __( 'Home', 'woocommerce-admin' ),
-				'parent' => 'woocommerce',
-				'path'   => self::MENU_SLUG,
+				'id'           => 'woocommerce-home',
+				'title'        => __( 'Home', 'woocommerce-admin' ),
+				'parent'       => 'woocommerce',
+				'path'         => self::MENU_SLUG,
+				'is_top_level' => true,
 			)
 		);
 	}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -69,15 +69,17 @@ class Marketing {
 	 * Uses priority of 9 so other items can easily be added at the default priority (10).
 	 */
 	public function add_parent_menu_item() {
-		add_menu_page(
-			__( 'Marketing', 'woocommerce-admin' ),
-			__( 'Marketing', 'woocommerce-admin' ),
-			'manage_woocommerce',
-			'woocommerce-marketing',
-			null,
-			'dashicons-megaphone',
-			58
-		);
+		if ( ! Loader::is_feature_enabled( 'navigation' ) ) {
+			add_menu_page(
+				__( 'Marketing', 'woocommerce-admin' ),
+				__( 'Marketing', 'woocommerce-admin' ),
+				'manage_woocommerce',
+				'woocommerce-marketing',
+				null,
+				'dashicons-megaphone',
+				58
+			);
+		}
 
 		PageController::get_instance()->connect_page(
 			[

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -129,6 +129,7 @@ class CoreMenu {
 				'id'           => 'settings',
 				'menuId'       => 'secondary',
 				'order'        => 10,
+				'url'          => 'admin.php?page=wc-settings',
 				'is_top_level' => true,
 			)
 		);

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -167,9 +167,7 @@ class Menu {
 		);
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
-		if ( isset( $menu_item['url'] ) ) {
-			$menu_item['url'] = self::get_callback_url( $menu_item['url'] );
-		}
+		unset( $menu_item['url'] );
 
 		if ( true === $menu_item['is_top_level'] ) {
 			$menu_item['parent'] = 'woocommerce';

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -297,8 +297,14 @@ class Menu {
 		foreach ( $submenu as $parent_key => $parent ) {
 			foreach ( $parent as $key => $menu_item ) {
 				if (
-					isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
-					self::$callbacks[ $menu_item[ self::CALLBACK ] ]
+					(
+						isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
+						self::$callbacks[ $menu_item[ self::CALLBACK ] ]
+					) ||
+					(
+						isset( self::$callbacks[ self::get_callback_url( $menu_item[ self::CALLBACK ] ) ] ) &&
+						self::$callbacks[ self::get_callback_url( $menu_item[ self::CALLBACK ] ) ]
+					)
 				) {
 					// Disable phpcs since we need to override submenu classes.
 					// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.


### PR DESCRIPTION
Fixes #5350 

Fixes up the menu item's not being properly migrated after moving WC Nav into WCA.

Note that this does not resolve the submenu shown when hovering WooCommerce.  That one is a bit trickier since we need to hide the menu without loading our stylesheet (or load our styles on all pages).

### Screenshots

<img width="215" alt="Screen Shot 2020-10-13 at 7 43 33 PM" src="https://user-images.githubusercontent.com/10561050/95927321-653cd480-0d8c-11eb-9a56-67db5d25200c.png">


### Detailed test instructions:

1. Make sure `woocommerce_navigation_enabled` is set to `yes` in your options table.
1. Check a non-WC page.
1. Make sure the only WC related page left is the "WooCommerce" parent menu item.