### PR TITLE
Attempt to check for a theme step specific element when completing e2e test

### DIFF
--- a/tests/e2e/specs/activate-and-setup/complete-theme-selection-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-theme-selection-section.js
@@ -1,3 +1,4 @@
+import { waitForSelector } from '../../utils/lib';
 /**
  * @format
  */
@@ -8,5 +9,11 @@
 import { clickContinue } from './utils';
 
 export async function completeThemeSelectionSection() {
+	// Make sure we're on the theme selection page before clicking continue
+	await waitForSelector(
+		page,
+		'.woocommerce-profile-wizard__themes-tab-panel'
+	);
+
 	await clickContinue();
 }


### PR DESCRIPTION
The theme selection page e2e test is intermittently failing and it
is not clear why. Its possible that between checking for a button
with class `primary` and then clicking it, that the business step 
is still rendered on screen and then when going to click the button
there is nothing rendered. I can't prove this, but this piece of code
does close up that edge case.

3 runs of this build so far have passed and this is still an improvement
to the test even if it doesn't solve the problem completely.