### PR TITLE
Add features section and settings

### DIFF
--- a/src/Features/Navigation/Navigation.php
+++ b/src/Features/Navigation/Navigation.php
@@ -22,6 +22,7 @@ class Navigation {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
+		add_action( 'update_option_woocommerce_navigation_enabled', array( $this, 'reload_page_on_toggle' ), 10, 2 );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
@@ -87,5 +88,21 @@ class Navigation {
 			array(),
 			Loader::get_file_version( 'css' )
 		);
+	}
+
+	/**
+	 * Reloads the page when the option is toggled to make sure all nav features are loaded.
+	 *
+	 * @param string $old_value Old value.
+	 * @param string $value     New value.
+	 */
+	public static function reload_page_on_toggle( $old_value, $value ) {
+		if ( $old_value === $value ) {
+			return;
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			wp_safe_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		}
 	}
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -60,6 +60,8 @@ class Loader {
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		// Load feature before WooCommerce update hooks.
 		add_action( 'init', array( __CLASS__, 'load_features' ), 4 );
+		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
+		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );
@@ -230,6 +232,52 @@ class Loader {
 				new $feature();
 			}
 		}
+	}
+
+	/**
+	 * Adds the Features section to the advanced tab of WooCommerce Settings
+	 *
+	 * @param array $sections Sections.
+	 * @return array
+	 */
+	public static function add_features_section( $sections ) {
+		$sections['features'] = __( 'Features', 'woocommerce-admin' );
+		return $sections;
+	}
+
+	/**
+	 * Adds the Features settings.
+	 *
+	 * @param array  $settings Settings.
+	 * @param string $current_section Current section slug.
+	 * @return array
+	 */
+	public static function add_features_settings( $settings, $current_section ) {
+		if ( 'features' !== $current_section ) {
+			return $settings;
+		}
+
+		return apply_filters(
+			'woocommerce_settings_features',
+			array(
+				array(
+					'title' => __( 'Features', 'woocommerce-admin' ),
+					'type'  => 'title',
+					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
+					'id'    => 'features_options',
+				),
+				array(
+					'title' => __( 'Navigation', 'woocommerce-admin' ),
+					'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
+					'id'    => 'woocommerce_navigation_enabled',
+					'type'  => 'checkbox',
+				),
+				array(
+					'type' => 'sectionend',
+					'id'   => 'features_options',
+				),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5333

Adds the features section and setting for the navigation.

Note that a refresh or page navigation is needed to get this working since the option update fires after features are already loaded.  Do we think this is worth fixing (maybe with a forced redirect) or fine as is?

### Screenshots

<img width="983" alt="Screen Shot 2020-10-14 at 2 33 30 PM" src="https://user-images.githubusercontent.com/10561050/96030684-4f7dec80-0e2a-11eb-9b1e-5bb0c99060fe.png">


### Detailed test instructions:

1. Visit WooCommerce -> Settings -> Advanced -> Features ( `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` )
`. 
1. Toggle the feature on/off and save.
1. Check that the feature is turned on or off as necessary. (note the above issue with refresh).