### PR TITLE
Fix navigation and WooCommerce menu ordering

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -112,12 +112,15 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
+		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
+
 		$overview_page = array(
 			'id'           => 'woocommerce-analytics',
 			'title'        => __( 'Analytics', 'woocommerce-admin' ),
 			'path'         => '/analytics/overview',
 			'icon'         => 'dashicons-chart-bar',
 			'position'     => 56, // After WooCommerce & Product menu items.
+			'order'        => 10,
 			'is_category'  => true,
 			'is_top_level' => true,
 		);
@@ -129,60 +132,70 @@ class Analytics {
 				'title'  => __( 'Overview', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/overview',
+				'order'  => 10,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-revenue',
 				'title'  => __( 'Revenue', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/revenue',
+				'order'  => 20,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-orders',
 				'title'  => __( 'Orders', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/orders',
+				'order'  => 30,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-products',
 				'title'  => __( 'Products', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/products',
+				'order'  => 40,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-variations',
 				'title'  => __( 'Variations', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/variations',
+				'order'  => 50,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-categories',
 				'title'  => __( 'Categories', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/categories',
+				'order'  => 60,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-coupons',
 				'title'  => __( 'Coupons', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/coupons',
+				'order'  => 70,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-taxes',
 				'title'  => __( 'Taxes', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/taxes',
+				'order'  => 80,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-downloads',
 				'title'  => __( 'Downloads', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/downloads',
+				'order'  => 90,
 			),
 			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
 				'id'     => 'woocommerce-analytics-stock',
 				'title'  => __( 'Stock', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/stock',
+				'order'  => 100,
 			) : null,
 			array(
 				'id'           => 'woocommerce-analytics-customers',
@@ -190,11 +203,12 @@ class Analytics {
 				'parent'       => 'woocommerce',
 				'path'         => '/customers',
 				'is_top_level' => true,
+				'order'        => 50,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-settings',
-				'title'  => __( 'Settings', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
+				'title'  => $navigation_enabled ? __( 'Analytics', 'woocommerce-admin' ) : __( 'Settings', 'woocommerce-admin' ),
+				'parent' => $navigation_enabled ? 'settings' : 'woocommerce-analytics',
 				'path'   => '/analytics/settings',
 			),
 		);

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -135,24 +135,24 @@ class Analytics {
 				'order'  => 10,
 			),
 			array(
+				'id'     => 'woocommerce-analytics-products',
+				'title'  => __( 'Products', 'woocommerce-admin' ),
+				'parent' => 'woocommerce-analytics',
+				'path'   => '/analytics/products',
+				'order'  => 20,
+			),
+			array(
 				'id'     => 'woocommerce-analytics-revenue',
 				'title'  => __( 'Revenue', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/revenue',
-				'order'  => 20,
+				'order'  => 30,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-orders',
 				'title'  => __( 'Orders', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/orders',
-				'order'  => 30,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-products',
-				'title'  => __( 'Products', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/products',
 				'order'  => 40,
 			),
 			array(

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -88,7 +88,7 @@ class AnalyticsDashboard {
 				'parent'       => 'woocommerce',
 				'path'         => self::MENU_SLUG,
 				'is_top_level' => true,
-				'order'        => 1,
+				'order'        => 0,
 			)
 		);
 	}

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -88,6 +88,7 @@ class AnalyticsDashboard {
 				'parent'       => 'woocommerce',
 				'path'         => self::MENU_SLUG,
 				'is_top_level' => true,
+				'order'        => 1,
 			)
 		);
 	}

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -50,7 +50,10 @@ class CoreMenu {
 		foreach ( $setting_pages as $setting_page ) {
 			$settings = $setting_page->add_settings_page( $settings );
 		}
+
+		$order = 0;
 		foreach ( $settings as $key => $setting ) {
+			$order += 10;
 			Menu::add_item(
 				array(
 					'parent'     => 'settings',
@@ -58,6 +61,7 @@ class CoreMenu {
 					'capability' => 'manage_woocommerce',
 					'id'         => $key,
 					'url'        => 'admin.php?page=wc-settings&tab=' . $key,
+					'order'      => $order,
 				)
 			);
 		}

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -409,6 +409,7 @@ class PageController {
 	 *   @type string      capability   Capability needed to access the page.
 	 *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
 	 *   @type int         position     Menu item position.
+	 *   @type int         order        Navigation item order.
 	 * }
 	 */
 	public function register_page( $options ) {
@@ -468,7 +469,7 @@ class PageController {
 	 *   @type string      path         Path for this page, full path in app context; ex /analytics/report
 	 *   @type string      capability   Capability needed to access the page.
 	 *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
-	 *   @type int         position     Menu item position.
+	 *   @type int         order        Navigation item order.
 	 * }
 	 */
 	public static function add_nav_item( $options ) {
@@ -484,6 +485,7 @@ class PageController {
 			'title'        => $options['title'],
 			'capability'   => $options['capability'],
 			'url'          => $options['path'],
+			'order'        => isset( $options['order'] ) ? $options['order'] : 20,
 			'is_top_level' => isset( $options['is_top_level'] ) && $options['is_top_level'],
 		);
 


### PR DESCRIPTION
Fixes #5331

Fixes the order of the registered items to match the designs.

This continues to use order increments of `10` to allow other items to register between if necessary.

### Screenshots
<img width="323" alt="Screen Shot 2020-10-14 at 3 37 31 PM" src="https://user-images.githubusercontent.com/10561050/96037004-42193000-0e33-11eb-8a27-2e919d0ab990.png">
<img width="311" alt="Screen Shot 2020-10-14 at 3 37 37 PM" src="https://user-images.githubusercontent.com/10561050/96037005-42193000-0e33-11eb-851b-d34f057d9fe0.png">
<img width="296" alt="Screen Shot 2020-10-14 at 3 37 55 PM" src="https://user-images.githubusercontent.com/10561050/96037007-42b1c680-0e33-11eb-9663-d0eaf60716ae.png">


### Detailed test instructions:

1. Enable the navigation feature.
1. Check that items are in the correct order (matching the Figma designs).
1. Make sure no regressions occur when the new nav is turned off.