### PR TITLE
Exclude TODO Comments from PHP Linter

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -52,4 +52,9 @@
 		<exclude-pattern>src/</exclude-pattern>
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
+
+	<rule ref="Generic.Commenting.Todo">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Fixes #5376 

This PR adds an exclusion rule to the `PHPCS` config for TODO comments.

Presently, PHP files containing TODO comments can not be committed. The commit is blocked because PHPCS runs in the pre-commit hook and reports a warning about TODO comments. This occurs if the staged file contains a TODO anywhere, even if it is not part of the change to be committed.

TODO comments are an established practice in this repo with ~100 occurrences across both PHP and JS. Real examples of these comments include:

```php
/**
 * Create an alert notification in response to an error installing a plugin.
 *
 * @todo This should be moved to a filter to make this API more generic and less plugin-specific.
 *
 * @param string $slug The slug of the plugin being installed.
 */
```

```php
// @todo Bring back ProductImage, but allow for product category image
```

```php
/**
 *  Returns true if we are on a "classic" (non JS app) powered admin page.
 *
 * TODO: See usage in `admin.php`. This needs refactored and implemented properly in core.
 */
```

Other types of PHPCS warnings also block commits presently. To reduce complexity I think it would be best to deal with these on a case-by-case basis in other PRs.

### Detailed test instructions

- Run the PHP linter on a file containing comments:
```bash
$ ./vendor/bin/phpcs --standard=phpcs.xml.dist src/Loader.php
```
- Ensure no warnings are reported.