### PR TITLE
Show orders, stock and reviews activity panels

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -143,6 +143,12 @@ export class ActivityPanel extends Component {
 			( isEmbedded || location.pathname !== '/' ) &&
 			! isPerformingSetupTask;
 
+		const showOrdersStockAndReviews =
+			( taskListComplete || taskListHidden ) && ! isPerformingSetupTask;
+
+		const showStoreSetup =
+			! taskListComplete && ! taskListHidden && ! isPerformingSetupTask;
+
 		const inbox = showInbox
 			? {
 					name: 'inbox',
@@ -152,46 +158,42 @@ export class ActivityPanel extends Component {
 			  }
 			: null;
 
-		const setup =
-			! taskListComplete && ! isPerformingSetupTask && ! taskListHidden
-				? {
-						name: 'setup',
-						title: __( 'Store Setup', 'woocommerce-admin' ),
-						icon: <SetupProgress />,
-				  }
-				: null;
+		const setup = showStoreSetup
+			? {
+					name: 'setup',
+					title: __( 'Store Setup', 'woocommerce-admin' ),
+					icon: <SetupProgress />,
+			  }
+			: null;
 
-		const ordersStockAndReviews =
-			taskListComplete && ! isPerformingSetupTask
-				? [
-						{
-							name: 'orders',
-							title: __( 'Orders', 'woocommerce-admin' ),
-							icon: <PagesIcon />,
-							unread: hasUnreadOrders,
-						},
-						manageStock === 'yes' && {
-							name: 'stock',
-							title: __( 'Stock', 'woocommerce-admin' ),
-							icon: (
-								<i className="material-icons-outlined">
-									widgets
-								</i>
-							),
-							unread: hasUnreadStock,
-						},
-						reviewsEnabled === 'yes' && {
-							name: 'reviews',
-							title: __( 'Reviews', 'woocommerce-admin' ),
-							icon: (
-								<i className="material-icons-outlined">
-									star_border
-								</i>
-							),
-							unread: hasUnapprovedReviews,
-						},
-				  ].filter( Boolean )
-				: [];
+		const ordersStockAndReviews = showOrdersStockAndReviews
+			? [
+					{
+						name: 'orders',
+						title: __( 'Orders', 'woocommerce-admin' ),
+						icon: <PagesIcon />,
+						unread: hasUnreadOrders,
+					},
+					manageStock === 'yes' && {
+						name: 'stock',
+						title: __( 'Stock', 'woocommerce-admin' ),
+						icon: (
+							<i className="material-icons-outlined">widgets</i>
+						),
+						unread: hasUnreadStock,
+					},
+					reviewsEnabled === 'yes' && {
+						name: 'reviews',
+						title: __( 'Reviews', 'woocommerce-admin' ),
+						icon: (
+							<i className="material-icons-outlined">
+								star_border
+							</i>
+						),
+						unread: hasUnapprovedReviews,
+					},
+			  ].filter( Boolean )
+			: [];
 
 		const help = isPerformingSetupTask
 			? {


### PR DESCRIPTION
Fixes #5393

This PR fixes the check to show Orders, Stock, and Reviews activity panels.

### Screenshots
![Screen Capture on 2020-10-15 at 14-05-51](https://user-images.githubusercontent.com/1314156/96162979-a3063e00-0eef-11eb-92cd-2984a2d6da6a.gif)


### Detailed test instructions:

The Task list should be visible *:
- Go to the `Home` screen.
- Verify the `Store Setup` button is there.
- Press a list item (not the `Store details` button).
- Verify the `Help` button is visible in the navbar.
- Go to the `Home` screen and dismiss the setup task list
- Verify the `Store Setup` button is not visible anymore in the navbar.
- Verify the `Orders`, `Stock` and `Reviews` buttons are visible now.


_* To make it visible again you execute an SQL like_
```
UPDATE `wp_options` SET `option_value` = 'no' WHERE `option_name` = 'woocommerce_task_list_hidden';
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Show orders, stock and reviews activity panels
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
