### PR TITLE
Update Notes deprecation versions.

### DIFF
--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -11,7 +11,7 @@
  *
  * class DeprecatedGoose extends DeprecatedClassFacade {
  *     static $facade_over_classname = 'Goose';
- *     static $deprecated_in_version = '1.6.0';
+ *     static $deprecated_in_version = '1.7.0';
  * }
  */
 

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
 /**
  * WC_Admin_Note.
  *
- * @deprecated since 1.6.0, use Note
+ * @deprecated since 1.7.0, use Note
  */
 class WC_Admin_Note extends DeprecatedClassFacade {
 	// These constants must be redeclared as to not break plugins that use them.
@@ -42,7 +42,7 @@ class WC_Admin_Note extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 
 	/**
 	 * Note constructor. Loads note data.
@@ -57,7 +57,7 @@ class WC_Admin_Note extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes.
  *
- * @deprecated since 1.6.0, use Notes
+ * @deprecated since 1.7.0, use Notes
  */
 class WC_Admin_Notes extends DeprecatedClassFacade {
 	/**
@@ -72,13 +72,13 @@ class WC_Admin_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Choose_Niche.
  *
- * @deprecated since 1.6.0, use Choose_Niche
+ * @deprecated since 1.7.0, use Choose_Niche
  */
 class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 	/**
@@ -93,13 +93,13 @@ class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Coupon_Page_Moved.
  *
- * @deprecated since 1.6.0, use Coupon_Page_Moved
+ * @deprecated since 1.7.0, use Coupon_Page_Moved
  */
 class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 	/**
@@ -114,13 +114,13 @@ class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Customize_Store_With_Blocks.
  *
- * @deprecated since 1.6.0, use Customize_Store_With_Blocks
+ * @deprecated since 1.7.0, use Customize_Store_With_Blocks
  */
 class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 	/**
@@ -135,13 +135,13 @@ class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Deactivate_Plugin.
  *
- * @deprecated since 1.6.0, use Deactivate_Plugin
+ * @deprecated since 1.7.0, use Deactivate_Plugin
  */
 class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 	/**
@@ -156,13 +156,13 @@ class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Draw_Attention.
  *
- * @deprecated since 1.6.0, use Draw_Attention
+ * @deprecated since 1.7.0, use Draw_Attention
  */
 class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 	/**
@@ -177,13 +177,13 @@ class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Edit_Products_On_The_Move.
  *
- * @deprecated since 1.6.0, use Edit_Products_On_The_Move
+ * @deprecated since 1.7.0, use Edit_Products_On_The_Move
  */
 class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 	/**
@@ -198,13 +198,13 @@ class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_EU_VAT_Number.
  *
- * @deprecated since 1.6.0, use EU_VAT_Number
+ * @deprecated since 1.7.0, use EU_VAT_Number
  */
 class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 	/**
@@ -219,13 +219,13 @@ class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Facebook_Marketing_Expert.
  *
- * @deprecated since 1.6.0, use Facebook_Marketing_Expert
+ * @deprecated since 1.7.0, use Facebook_Marketing_Expert
  */
 class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 	/**
@@ -240,13 +240,13 @@ class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_First_Product.
  *
- * @deprecated since 1.6.0, use First_Product
+ * @deprecated since 1.7.0, use First_Product
  */
 class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 	/**
@@ -261,13 +261,13 @@ class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Giving_Feedback_Notes.
  *
- * @deprecated since 1.6.0, use Giving_Feedback_Notes
+ * @deprecated since 1.7.0, use Giving_Feedback_Notes
  */
 class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 	/**
@@ -282,13 +282,13 @@ class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Historical_Data.
  *
- * @deprecated since 1.6.0, use Historical_Data
+ * @deprecated since 1.7.0, use Historical_Data
  */
 class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 	/**
@@ -303,13 +303,13 @@ class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Home_Screen_Feedback.
  *
- * @deprecated since 1.6.0, use Home_Screen_Feedback
+ * @deprecated since 1.7.0, use Home_Screen_Feedback
  */
 class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 	/**
@@ -324,13 +324,13 @@ class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Insight_First_Sale.
  *
- * @deprecated since 1.6.0, use Insight_First_Sale
+ * @deprecated since 1.7.0, use Insight_First_Sale
  */
 class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 	/**
@@ -345,13 +345,13 @@ class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Install_JP_And_WCS_Plugins.
  *
- * @deprecated since 1.6.0, use Install_JP_And_WCS_Plugins
+ * @deprecated since 1.7.0, use Install_JP_And_WCS_Plugins
  */
 class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 	/**
@@ -366,13 +366,13 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Launch_Checklist.
  *
- * @deprecated since 1.6.0, use Launch_Checklist
+ * @deprecated since 1.7.0, use Launch_Checklist
  */
 class WC_Admin_Notes_Launch_Checklist extends DeprecatedClassFacade {
 	/**
@@ -387,13 +387,13 @@ class WC_Admin_Notes_Launch_Checklist extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Marketing.
  *
- * @deprecated since 1.6.0, use Marketing
+ * @deprecated since 1.7.0, use Marketing
  */
 class WC_Admin_Notes_Marketing extends DeprecatedClassFacade {
 	/**
@@ -408,13 +408,13 @@ class WC_Admin_Notes_Marketing extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Migrate_From_Shopify.
  *
- * @deprecated since 1.6.0, use Migrate_From_Shopify
+ * @deprecated since 1.7.0, use Migrate_From_Shopify
  */
 class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 	/**
@@ -429,13 +429,13 @@ class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Mobile_App.
  *
- * @deprecated since 1.6.0, use Mobile_App
+ * @deprecated since 1.7.0, use Mobile_App
  */
 class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 	/**
@@ -450,13 +450,13 @@ class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Need_Some_Inspiration.
  *
- * @deprecated since 1.6.0, use Need_Some_Inspiration
+ * @deprecated since 1.7.0, use Need_Some_Inspiration
  */
 class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 	/**
@@ -471,13 +471,13 @@ class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_New_Sales_Record.
  *
- * @deprecated since 1.6.0, use New_Sales_Record
+ * @deprecated since 1.7.0, use New_Sales_Record
  */
 class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 	/**
@@ -492,13 +492,13 @@ class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Onboarding_Email_Marketing.
  *
- * @deprecated since 1.6.0, use Onboarding_Email_Marketing
+ * @deprecated since 1.7.0, use Onboarding_Email_Marketing
  */
 class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 	/**
@@ -513,13 +513,13 @@ class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Onboarding_Payments.
  *
- * @deprecated since 1.6.0, use Onboarding_Payments
+ * @deprecated since 1.7.0, use Onboarding_Payments
  */
 class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 	/**
@@ -534,13 +534,13 @@ class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Onboarding_Profiler.
  *
- * @deprecated since 1.6.0, use Onboarding_Profiler
+ * @deprecated since 1.7.0, use Onboarding_Profiler
  */
 class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 	/**
@@ -555,13 +555,13 @@ class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Online_Clothing_Store.
  *
- * @deprecated since 1.6.0, use Online_Clothing_Store
+ * @deprecated since 1.7.0, use Online_Clothing_Store
  */
 class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 	/**
@@ -576,13 +576,13 @@ class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Order_Milestones.
  *
- * @deprecated since 1.6.0, use Order_Milestones
+ * @deprecated since 1.7.0, use Order_Milestones
  */
 class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 	/**
@@ -597,13 +597,13 @@ class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Performance_On_Mobile.
  *
- * @deprecated since 1.6.0, use Performance_On_Mobile
+ * @deprecated since 1.7.0, use Performance_On_Mobile
  */
 class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 	/**
@@ -618,13 +618,13 @@ class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Personalize_Store.
  *
- * @deprecated since 1.6.0, use Personalize_Store
+ * @deprecated since 1.7.0, use Personalize_Store
  */
 class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 	/**
@@ -639,13 +639,13 @@ class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Real_Time_Order_Alerts.
  *
- * @deprecated since 1.6.0, use Real_Time_Order_Alerts
+ * @deprecated since 1.7.0, use Real_Time_Order_Alerts
  */
 class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 	/**
@@ -660,13 +660,13 @@ class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Review_Shipping_Settings.
  *
- * @deprecated since 1.6.0, use Review_Shipping_Settings
+ * @deprecated since 1.7.0, use Review_Shipping_Settings
  */
 class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 	/**
@@ -681,13 +681,13 @@ class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Selling_Online_Courses.
  *
- * @deprecated since 1.6.0, use Selling_Online_Courses
+ * @deprecated since 1.7.0, use Selling_Online_Courses
  */
 class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 	/**
@@ -702,13 +702,13 @@ class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Set_Up_Additional_Payment_Types.
  *
- * @deprecated since 1.6.0, use Set_Up_Additional_Payment_Types
+ * @deprecated since 1.7.0, use Set_Up_Additional_Payment_Types
  */
 class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFacade {
 	/**
@@ -723,13 +723,13 @@ class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFaca
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Start_Dropshipping_Business.
  *
- * @deprecated since 1.6.0, use Start_Dropshipping_Business
+ * @deprecated since 1.7.0, use Start_Dropshipping_Business
  */
 class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 	/**
@@ -744,13 +744,13 @@ class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Test_Checkout.
  *
- * @deprecated since 1.6.0, use Test_Checkout
+ * @deprecated since 1.7.0, use Test_Checkout
  */
 class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 	/**
@@ -765,13 +765,13 @@ class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Tracking_Opt_In.
  *
- * @deprecated since 1.6.0, use Tracking_Opt_In
+ * @deprecated since 1.7.0, use Tracking_Opt_In
  */
 class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 	/**
@@ -786,13 +786,13 @@ class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_Woo_Subscriptions_Notes.
  *
- * @deprecated since 1.6.0, use Woo_Subscriptions_Notes
+ * @deprecated since 1.7.0, use Woo_Subscriptions_Notes
  */
 class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	/**
@@ -807,13 +807,13 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_WooCommerce_Payments.
  *
- * @deprecated since 1.6.0, use WooCommerce_Payments
+ * @deprecated since 1.7.0, use WooCommerce_Payments
  */
 class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 	/**
@@ -828,13 +828,13 @@ class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }
 
 /**
  * WC_Admin_Notes_WooCommerce_Subscriptions.
  *
- * @deprecated since 1.6.0, use WooCommerce_Subscriptions
+ * @deprecated since 1.7.0, use WooCommerce_Subscriptions
  */
 class WC_Admin_Notes_WooCommerce_Subscriptions extends DeprecatedClassFacade {
 	/**
@@ -849,5 +849,5 @@ class WC_Admin_Notes_WooCommerce_Subscriptions extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $deprecated_in_version = '1.6.0';
+	protected static $deprecated_in_version = '1.7.0';
 }


### PR DESCRIPTION
While working on the release last week, I saw we had added deprecation notices for notes under the 1.6.0 release. Since that change didn't go into 1.6.0, this branch updates those version numbers to 1.7.0

I _think_ this is correct but will flag @becdetat for review to verify :)