### PR TITLE
Homescreen: Indicator labels i18n

### DIFF
--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -170,7 +170,7 @@ class Controller extends \WC_REST_Reports_Controller {
 					$stat                   = $prefix . '/' . $property_key;
 					$this->allowed_stats[]  = $stat;
 					$stat_label             = empty( $schema_info['title'] ) ? $schema_info['description'] : $schema_info['title'];
-					$this->labels[ $stat ]  = trim( preg_replace( '/\.+/', ' ', $stat_label ) );
+					$this->labels[ $stat ]  = trim( $stat_label, '.' );
 					$this->formats[ $stat ] = isset( $schema_info['format'] ) ? $schema_info['format'] : 'number';
 				}
 

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -167,11 +167,10 @@ class Controller extends \WC_REST_Reports_Controller {
 						continue;
 					}
 
-					$stat                  = $prefix . '/' . $property_key;
-					$this->allowed_stats[] = $stat;
-					$stat_label            = empty( $schema_info['title'] ) ? $schema_info['description'] : $schema_info['title'];
-
-					$this->labels[ $stat ]  = trim( preg_replace( '/\W+/', ' ', $stat_label ) );
+					$stat                   = $prefix . '/' . $property_key;
+					$this->allowed_stats[]  = $stat;
+					$stat_label             = empty( $schema_info['title'] ) ? $schema_info['description'] : $schema_info['title'];
+					$this->labels[ $stat ]  = trim( preg_replace( '/\.+/', ' ', $stat_label ) );
 					$this->formats[ $stat ] = isset( $schema_info['format'] ) ? $schema_info['format'] : 'number';
 				}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4854

Descriptions were being overly regex'ed with `/\W+/` to replace non word characters with spaces. This removed special characters like `é`. Since we're fairly certain to be parsing titles and descriptions from our schemas, I think its safe to explicitly remove just the period.

### Screenshots

<img width="276" alt="Screen Shot 2020-10-16 at 11 44 20 AM" src="https://user-images.githubusercontent.com/1922453/96193599-f5edfd00-0fa4-11eb-8ba0-dd82c6d57f93.png">

### Detailed test instructions:

You'll need to download and setup a language with diacritics, such as Polish to see the error. Instead of going through that, its much easier to replace a value in our code.

1. Replace "Total Sales." in this line with "Zamówienia."
https://github.com/woocommerce/woocommerce-admin/blob/bc076d5a07b5ecfc0addf38801e19f9ebbc523bf/src/API/Reports/Revenue/Stats/Controller.php#L167
2. Go to the Homescreen and confirm the Polish word is correctly rendered.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- Fix: Respect languages with diacritics in Homescreen labels
