### PR TITLE
Fix a number of crashes that occur in reports when Gutenberg is active

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -38,8 +38,11 @@ export class ReportSummary extends Component {
 		const { emptySearchResults, summaryData } = this.props;
 		const { totals } = summaryData;
 
-		const primaryValue = emptySearchResults ? 0 : totals.primary[ key ];
-		const secondaryValue = emptySearchResults ? 0 : totals.secondary[ key ];
+		const primaryTotal = totals.primary ? totals.primary[ key ] : 0;
+		const secondaryTotal = totals.secondary ? totals.secondary[ key ] : 0;
+
+		const primaryValue = emptySearchResults ? 0 : primaryTotal;
+		const secondaryValue = emptySearchResults ? 0 : secondaryTotal;
 
 		return {
 			delta: calculateDelta( primaryValue, secondaryValue ),

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -617,11 +617,12 @@ export default compose(
 
 		return {
 			primaryData,
-			ids: itemIdField
-				? extendedTableData.items.data.map(
-						( item ) => item[ itemIdField ]
-				  )
-				: [],
+			ids:
+				itemIdField && extendedTableData.items.data
+					? extendedTableData.items.data.map(
+							( item ) => item[ itemIdField ]
+					  )
+					: [],
 			tableData: extendedTableData,
 			query: { ...tableQuery, ...query },
 		};

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -116,7 +116,7 @@ class CustomersReportTable extends Component {
 			getCurrencyConfig,
 		} = this.context;
 
-		return customers.map( ( customer ) => {
+		return customers?.map( ( customer ) => {
 			const {
 				avg_order_value: avgOrderValue,
 				date_last_active: dateLastActive,

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -55,7 +55,7 @@ class StockReportTable extends Component {
 		];
 	}
 
-	getRowsContent( products ) {
+	getRowsContent( products = [] ) {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -150,6 +150,7 @@ export const getPages = () => {
 export class Controller extends Component {
 	componentDidMount() {
 		window.document.documentElement.scrollTop = 0;
+		window.document.body.classList.remove( 'woocommerce-admin-is-loading' );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/task-list/tasks/connect.js
+++ b/client/task-list/tasks/connect.js
@@ -94,6 +94,7 @@ class Connect extends Component {
 					);
 
 					// @todo Show a notice for when extensions are correctly installed.
+
 					document.body.classList.remove(
 						'woocommerce-admin-is-loading'
 					);

--- a/client/task-list/tasks/connect.js
+++ b/client/task-list/tasks/connect.js
@@ -94,7 +94,6 @@ class Connect extends Component {
 					);
 
 					// @todo Show a notice for when extensions are correctly installed.
-
 					document.body.classList.remove(
 						'woocommerce-admin-is-loading'
 					);

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -57,9 +57,8 @@ export function getLeaderboard( options ) {
 	}
 
 	const leaderboard = leaderboards.get( options.id );
-	return { ...response, rows: leaderboard.rows };
+	return { ...response, rows: leaderboard?.rows };
 }
-
 /**
  * Returns items based on a search query.
  *


### PR DESCRIPTION
Fixes #5385 Also note that on `main` there were other crashes happening
on all the report pages.

It seems there are some behaviour changes in how data is resolved
due to some recent updates to Gutenberg. I was not able to find
out why these happen but there were a lot of situations where
reports did not handle empty data well.

This adds more defensive code where the objects being drilled
into could have null or undefined properties.

### Detailed test instructions:

- Setup an environment woocommerce and this branch of wc-admin installed
- Install the gutenberg plugin
- Visit all the submenus of the `Analytics` section
- Confirm they do not crash

**Note:** this does not remove the warnings that will show as errors in console in development. Some new ones do appear as a result of Gutenberg being installed but there were existing ones too. I will raise a separate issue to fix all of these.

### Changelog Note:

Fix: a bug where reports crashed when Gutenberg was installed
