### PR TITLE
Added array casting to avoid PHP Warning

### DIFF
--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -138,7 +138,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	public function update_items( $request ) {
 		$params          = $request->get_json_params();
 		$query_args      = $this->prepare_objects_query( $params );
-		$onboarding_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+		$onboarding_data = (array) get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		update_option( Onboarding::PROFILE_DATA_OPTION, array_merge( $onboarding_data, $query_args ) );
 
 		$result = array(

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -656,7 +656,7 @@ class Onboarding {
 	 * @param array $settings Component settings.
 	 */
 	public function component_settings( $settings ) {
-		$profile                = get_option( self::PROFILE_DATA_OPTION, array() );
+		$profile                = (array) get_option( self::PROFILE_DATA_OPTION, array() );
 		$settings['onboarding'] = array(
 			'profile' => $profile,
 		);


### PR DESCRIPTION
Fixes #5398

This PR adds an array casting after getting the option `woocommerce_onboarding_profile` in order to avoid a PHP Warning.

### Screenshots
![stringoffset](https://user-images.githubusercontent.com/22080/96149400-1f802900-0ebe-11eb-97e1-0915f903ed4c.png)

### Detailed test instructions:
- Checkout the `main` branch.
- Update the option `woocommerce_onboarding_profile`
```
update_option( 'woocommerce_onboarding_profile', 'foo' )
```
- Go to the `Home` screen.
- Verify this PHP warning is visible.
```
PHP Warning:  Illegal string offset 'wccom_connected' in /srv/www/wordpress-one/public_html/wp-content/plugins/woocommerce-admin/src/Features/Onboarding.php on line 674
```
- Checkout this branch.
- Verify that the option `woocommerce_onboarding_profile` is still `foo`.
- Reload the `Home` screen.
- The warning shouldn't be visible anymore.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Added array casting to avoid PHP Warning
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
