### PR TITLE
Home Screen: Always show the inbox for temporary gutenberg plugin fix.

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -64,13 +64,6 @@ export const Layout = ( {
 	const isTaskListEnabled = taskListHidden === false && ! taskListComplete;
 	const isDashboardShown = ! isTaskListEnabled || ! query.task;
 
-	const isInboxPanelEmpty = ( isEmpty ) => {
-		if ( isBatchUpdating ) {
-			return;
-		}
-		setShowInbox( ! isEmpty );
-	};
-
 	if ( isBatchUpdating && ! showInbox ) {
 		setShowInbox( true );
 	}
@@ -80,7 +73,7 @@ export const Layout = ( {
 			<Fragment>
 				{ showInbox && (
 					<div className="woocommerce-homescreen-column is-inbox">
-						<InboxPanel isPanelEmpty={ isInboxPanelEmpty } />
+						<InboxPanel />
 					</div>
 				) }
 				<div


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/609

While this is not the ultimate fix for the missing Inbox on the home screen when the Gutenberg plugin is active, it at least gets the inbox back to a functional state there. The change I'm proposing here is to remove the feature we have where when the inbox is empty, it is not shown on the home screen.

So the big change visually would be that when the inbox is empty, we still show the two column layout ( which I prefer TBH ), with an empty inbox:

_Empty Inbox on Home_
![image](https://user-images.githubusercontent.com/22080/96278765-bf0aed80-0f8a-11eb-9cd1-ca45dddedc6d.png)

_How the home screen looks in 4.6 with Gutenberg 9.1.1 Installed_
<img width="1113" alt="Home ‹ WooCommerce ‹ bend outdoors — WooCommerce 2020-10-16 08-30-28" src="https://user-images.githubusercontent.com/22080/96279201-35a7eb00-0f8b-11eb-8985-d842bfe2b61d.png">

__Home Screen Gutenberg 9.1.1, with this branch and notes in inbox__
<img width="1108" alt="home-with-inbox" src="https://user-images.githubusercontent.com/22080/96279248-422c4380-0f8b-11eb-912a-e23018806345.png">

@pmcpinto  wanted to see if you were okay with this work-around until we can come up with a longer-term solution to have the inbox not shown on the home screen when empty.

### Detailed test instructions:

- Probably best to setup the "error state" for this PR first, so install and activate Gutenberg 9.1.1
- Make sure you have WooCommerce 4.6 installed
- Go to the home screen and note that the inbox is not shown, probably good to verify you had inbox notes before, or you can do this by visiting the orders listing page to see your inbox does have notes
- Checkout this branch and activate. Since this is on 1.7.0-dev, it should be auto used by Jetpack autoloader
- Refresh the home screen a few times and verify the Inbox is now shown.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Tweak: Always show the inbox on the home screen