### PR TITLE
Fix missing custom autocompleter attribute in Search component of Adv…

### DIFF
--- a/packages/components/src/advanced-filters/search-filter.js
+++ b/packages/components/src/advanced-filters/search-filter.js
@@ -132,6 +132,7 @@ class SearchFilter extends Component {
 						) }
 						onChange={ this.onSearchChange }
 						type={ input.type }
+						autocompleter={ input.autocompleter }
 						placeholder={ labels.placeholder }
 						selected={ selected }
 						inlineTags


### PR DESCRIPTION
Fix missing custom autocompleter attribute in Search component of Advanced Filter

- Problem: It breaks layout when using a custom autocompleter in Search component of Advanced Filter. I saw the issue in v1.5, v1.6, v1.7-dev as well
- Cause: because `wp-content/plugins/woocommerce-admin/packages/components/src/advanced-filters/search-filter.js` didn't specify `autocompleter` attribute when declaring `<Search>`. Original code:
  ```js
  <Search
	className={ classnames(
		className,
		'woocommerce-filters-advanced__input'
	) }
	onChange={ this.onSearchChange }
	type={ input.type }
	placeholder={ labels.placeholder }
	selected={ selected }
	inlineTags
	aria-label={ labels.filter }
  />
  ```
- Solution: put `autocompleter={ input.autocompleter }` into the code
   ```js
   <Search
	className={ classnames(
		className,
		'woocommerce-filters-advanced__input'
	) }
	onChange={ this.onSearchChange }
	type={ input.type }
	autocompleter={ input.autocompleter }
	placeholder={ labels.placeholder }
	selected={ selected }
	inlineTags
	aria-label={ labels.filter }
   />
   ```

### Screenshots
<img width="1686" alt="Screen Shot 2020-10-16 at 11 20 22 AM" src="https://user-images.githubusercontent.com/4528159/96213397-26349c00-0fa3-11eb-9a53-a1bdc048d616.png">

### Detailed test instructions:

- Ex: Adding a new search component (color) for "Order report advanced filter". Creating custom autocompleter, it doesn't fetch data from server, just returns what user inputted
```js
const autocompleter =  {
    options: (query) => {
        return Promise.resolve([{key: query, label: query}])
    },
    getOptionIdentifier( opt ) {
        return opt.key;
    },
    getOptionKeywords( opt ) {
        return [ opt.label ];
    },
    getOptionCompletion( opt ) {
        const value = {
            key: opt.key,
            label: opt.label,
        };
        return value;
    },
    getOptionLabel( opt, query ) {
        return (
            <span
                key="name"
                className="woocommerce-search__result-name"
                aria-label={ opt.name }
            >
                        {opt.label}
                </span>
        );
    },
};

const addOrderAdvancedFilters = (advancedFilters) => {
        advancedFilters.filters['color'] = {
            labels: {
                add   : __('color', 'woocommerce-admin'),
                remove: __(
                    `Remove color filter`,
                    'woocommerce-admin'
                ),
                rule  : __(
                    `Select color filter match`,
                    'woocommerce-admin'
                ),
                title : __(
                    `{{title}}color{{/title}} {{rule /}} {{filter /}}`,
                    'woocommerce-admin'
                ),
                filter: __(`Select color`, 'woocommerce-admin'),
            },
            rules : [
                {
                    value: 'is',
                    label: _x('Is', 'color', 'woocommerce-admin'),
                },
            ],
            input : {
                component: 'Search',
                autocompleter: autocompleter,
                type: 'custom',
                getLabels: ( value, query ) => {
                    return Promise.resolve ([{
                        key: value,
                        label: value,
                    }]);
                },
            },
        };
    
    return advancedFilters;
};
addFilter(
    'woocommerce_admin_orders_report_advanced_filters',
    'k0-sow',
    addOrderAdvancedFilters
);
```
- Access Analytics > Order > choose "Advanced filters" > Add a filter > color. It breaks layout and raise a exception as screenshot

### Changelog Note:
- Fix: missing custom autocompleter attribute in Search component of Advanced Filter