### PR TITLE
Enqueue styles on non-WC pages

### DIFF
--- a/client/navigation/stylesheets/index.scss
+++ b/client/navigation/stylesheets/index.scss
@@ -31,11 +31,6 @@
 		}
 	}
 
-	#adminmenu
-	li.toplevel_page_woocommerce.wp-has-submenu.wp-not-current-submenu.opensub:hover::after {
-		display: none;
-	}
-
 	#woocommerce-embedded-navigation {
 		position: fixed;
 		top: 0;
@@ -45,15 +40,5 @@
 		box-sizing: border-box;
 		// @todo This should be updated to G2.darkGray.primary when possible.
 		background-color: #1e1e1e;
-	}
-
-	body.is-folded #woocommerce-embedded-navigation {
-		height: 60px;
-		width: 60px;
-		overflow: hidden;
-	}
-
-	.toplevel_page_woocommerce ul.wp-submenu {
-		display: none;
 	}
 }

--- a/packages/navigation/src/style.scss
+++ b/packages/navigation/src/style.scss
@@ -1,0 +1,11 @@
+// Hide elements on non-WooCommerce pages.
+body.js:not(.has-woocommerce-navigation) {
+	#adminmenu
+	li.toplevel_page_woocommerce.wp-has-submenu.wp-not-current-submenu.opensub:hover::after {
+		display: none;
+	}
+
+	.toplevel_page_woocommerce ul.wp-submenu {
+		display: none;
+	}
+}

--- a/src/Features/Navigation/Navigation.php
+++ b/src/Features/Navigation/Navigation.php
@@ -22,6 +22,7 @@ class Navigation {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
@@ -68,5 +69,23 @@ class Navigation {
 		?>
 		<div id="woocommerce-embedded-navigation"></div>
 		<?php
+	}
+
+	/**
+	 * Enqueue scripts on non-WooCommerce pages.
+	 */
+	public function maybe_enqueue_scripts() {
+		if ( Screen::is_woocommerce_page() ) {
+			return;
+		}
+
+		$rtl = is_rtl() ? '-rtl' : '';
+
+		wp_enqueue_style(
+			'wc-admin-navigation',
+			Loader::get_url( "navigation/style{$rtl}", 'css' ),
+			array(),
+			Loader::get_file_version( 'css' )
+		);
 	}
 }

--- a/src/Features/Navigation/Navigation.php
+++ b/src/Features/Navigation/Navigation.php
@@ -22,10 +22,10 @@ class Navigation {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_scripts' ) );
 
 			Menu::instance()->init();
 			CoreMenu::instance()->init();


### PR DESCRIPTION
Fixes #5380

Add styles to non-WC pages to hide submenu styling.

### Screenshots

#### Before
<img width="332" alt="Screen Shot 2020-10-19 at 12 24 59 PM" src="https://user-images.githubusercontent.com/10561050/96478836-2680a180-1206-11eb-9091-6ceb60f0ddad.png">


#### After
<img width="194" alt="Screen Shot 2020-10-19 at 12 24 42 PM" src="https://user-images.githubusercontent.com/10561050/96478831-25e80b00-1206-11eb-8d00-025d1aef4614.png">

### Detailed test instructions:

1. Enable the nav feature.
1. Hover the "WooCommerce" menu item.
1. Make sure that the submenu and arrow are no longer shown.