### PR TITLE
Inbox Panel: Remove no longer used isPanelEmpty logic.

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -75,7 +75,6 @@ const renderNotes = ( { hasNotes, isBatchUpdating, lastRead, notes } ) => {
 const InboxPanel = ( props ) => {
 	const {
 		isError,
-		isPanelEmpty,
 		isResolving,
 		isBatchUpdating,
 		notes,
@@ -121,10 +120,6 @@ const InboxPanel = ( props ) => {
 	const hasNotes = hasValidNotes( notes );
 
 	const isActivityHeaderVisible = hasNotes || isResolving || isUpdatingNote;
-
-	if ( isPanelEmpty ) {
-		isPanelEmpty( ! hasNotes && ! isActivityHeaderVisible );
-	}
 
 	// @todo After having a pagination implemented we should call the method "getNotes" with a different query since
 	// the current one is only getting 25 notes and the count of unread notes only will refer to this 25 and not all the existing ones.


### PR DESCRIPTION
This is a follow-up to #5416 - which removed the need for the `isPanelEmpty` logic since we are now always showing the inbox panel to alleviate some of the bugs we had been encountering with the Gutenberg plugin installed alongside wc-admin.

__To Test__
- Verify the Inbox panel is still shown on the home screen, even if no inbox messages are present.
- Verify the Inbox panel still operates on an embedded page like the Orders Listing page.