### PR TITLE
Add navigation plugin example

### DIFF
--- a/docs/examples/extensions/add-navigation-items/js/index.js
+++ b/docs/examples/extensions/add-navigation-items/js/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { registerPlugin } from "@wordpress/plugins";
 import { WooNavigationItem } from "@woocommerce/navigation";
 
@@ -12,9 +13,9 @@ const MyPlugin = () => {
 
     return (
         <WooNavigationItem item="example-marketing-category-child-2">
-            <button onClick={ handleClick }>
+            <Button onClick={ handleClick }>
                 { __( 'JavaScript Example', 'plugin-domain' ) }
-            </button>
+            </Button>
         </WooNavigationItem>
     );
 };

--- a/docs/examples/extensions/add-navigation-items/js/index.js
+++ b/docs/examples/extensions/add-navigation-items/js/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from "@wordpress/plugins";
+import { WooNavigationItem } from "@woocommerce/navigation";
+
+const MyPlugin = () => {
+    const handleClick = () => {
+        alert( 'Menu item clicked!' );
+    }
+
+    return (
+        <WooNavigationItem item="example-marketing-category-child-2">
+            <button onClick={ handleClick }>
+                { __( 'JavaScript Example', 'plugin-domain' ) }
+            </button>
+        </WooNavigationItem>
+    );
+};
+
+registerPlugin('my-plugin', { render: MyPlugin });

--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -48,7 +48,7 @@ function add_navigation_items_register_items() {
 			'title'      => 'Example Marketing Settings',
 			'capability' => 'view_woocommerce_reports',
 			'parent'     => 'settings',
-			'url'        => 'http//:www.google.com',
+			'url'        => 'https://www.google.com',
 		)
 	);
 
@@ -67,7 +67,7 @@ function add_navigation_items_register_items() {
 			'parent'     => 'example-marketing-category',
 			'title'      => 'Sub Menu Child 1',
 			'capability' => 'view_woocommerce_reports',
-			'url'        => 'https//:www.google.com',
+			'url'        => 'https://www.google.com',
 		)
 	);
 
@@ -77,7 +77,7 @@ function add_navigation_items_register_items() {
 			'parent'     => 'example-marketing-category',
 			'title'      => 'Sub Menu Child 2',
 			'capability' => 'view_woocommerce_reports',
-			'url'        => 'https//:www.google.com',
+			'url'        => 'https://www.google.com',
 		)
 	);
 }

--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Admin Add Navigation Items Example
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * Register the JS.
+ */
+function add_navigation_items_register_script() {
+	if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) || ! \Automattic\WooCommerce\Admin\Features\Navigation\Screen::is_woocommerce_page() ) {
+		return;
+	}
+
+	wp_register_script(
+		'add-navigation-items',
+		plugins_url( '/dist/index.js', __FILE__ ),
+		array(
+			'wp-hooks',
+			'wp-element',
+			'wp-i18n',
+			'wc-components',
+			'wp-plugins',
+		),
+		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		true
+	);
+
+	wp_enqueue_script( 'add-navigation-items' );
+}
+add_action( 'admin_enqueue_scripts', 'add_navigation_items_register_script' );
+
+/**
+ * Add Example items to WooCommerce Navigation
+ */
+function add_navigation_items_register_items() {
+	if (
+		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_category' ) ||
+		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_item' )
+	) {
+		return;
+	}
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+		array(
+			'id'         => 'example-marketing-plugin',
+			'title'      => 'Example Marketing Settings',
+			'capability' => 'view_woocommerce_reports',
+			'parent'     => 'settings',
+			'url'        => 'http//:www.google.com',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_category(
+		array(
+			'id'         => 'example-marketing-category',
+			'parent'     => 'woocommerce-marketing',
+			'title'      => 'Example Marketing Category',
+			'capability' => 'view_woocommerce_reports',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+		array(
+			'id'         => 'example-marketing-category-child-1',
+			'parent'     => 'example-marketing-category',
+			'title'      => 'Sub Menu Child 1',
+			'capability' => 'view_woocommerce_reports',
+			'url'        => 'https//:www.google.com',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+		array(
+			'id'         => 'example-marketing-category-child-2',
+			'parent'     => 'example-marketing-category',
+			'title'      => 'Sub Menu Child 2',
+			'capability' => 'view_woocommerce_reports',
+			'url'        => 'https//:www.google.com',
+		)
+	);
+}
+add_filter( 'admin_menu', 'add_navigation_items_register_items' );


### PR DESCRIPTION
Fixes #5421

Adds a navigation plugin example to show how to register nav items.

This is blocked pending fix of the slot fill in WCA.

### Screenshots

<img width="288" alt="Screen Shot 2020-10-19 at 5 46 43 PM" src="https://user-images.githubusercontent.com/10561050/96515478-65791c00-1233-11eb-9b7c-e9d74299ef5b.png">


### Detailed test instructions:

1. `npm run example -- --ext=add-navigation-items`
1. Activate the plugin "WooCommerce Admin Add Navigation Items Example"
1. Note the example items under "Marketing" and "Settings."
1. Check that the submenu nav works correctly.
1. Check that the slot fill using JS works as expected (should see a "JavaScript Example" item under the marketing submenu).