### PR TITLE
Show parent as default back button label

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -106,7 +106,10 @@ const Container = ( { menuItems } ) => {
 							title={ category.title }
 							menu={ category.id }
 							parentMenu={ category.parent }
-							backButtonLabel={ category.backButtonLabel }
+							backButtonLabel={ category.backButtonLabel
+								? category.backButtonLabel
+								: null
+							}
 						>
 							{ !! primaryItems.length && (
 								<NavigationGroup>

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -106,10 +106,7 @@ const Container = ( { menuItems } ) => {
 							title={ category.title }
 							menu={ category.id }
 							parentMenu={ category.parent }
-							backButtonLabel={ category.backButtonLabel
-								? category.backButtonLabel
-								: null
-							}
+							backButtonLabel={ category.backButtonLabel || null }
 						>
 							{ !! primaryItems.length && (
 								<NavigationGroup>

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -156,26 +156,26 @@ class Menu {
 		}
 
 		$defaults           = array(
-			'id'              => '',
-			'title'           => '',
-			'capability'      => 'manage_woocommerce',
-			'order'           => 100,
-			'migrate'         => true,
-			'menuId'          => 'primary',
-			'isCategory'      => true,
-			'parent'          => self::DEFAULT_PARENT,
-			'backButtonLabel' => __(
-				'WooCommerce Home',
-				'woocommerce-admin'
-			),
-			'is_top_level'    => false,
+			'id'           => '',
+			'title'        => '',
+			'capability'   => 'manage_woocommerce',
+			'order'        => 100,
+			'migrate'      => true,
+			'menuId'       => 'primary',
+			'isCategory'   => true,
+			'parent'       => self::DEFAULT_PARENT,
+			'is_top_level' => false,
 		);
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
 		unset( $menu_item['url'] );
 
 		if ( true === $menu_item['is_top_level'] ) {
-			$menu_item['parent'] = 'woocommerce';
+			$menu_item['parent']          = 'woocommerce';
+			$menu_item['backButtonLabel'] = __(
+				'WooCommerce Home',
+				'woocommerce-admin'
+			);
 		} else {
 			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		}


### PR DESCRIPTION
Fixes #5434

Shows the parent menu as the default back button label if none is supplied by the category.

### Screenshots

<img width="289" alt="Screen Shot 2020-10-20 at 5 22 42 PM" src="https://user-images.githubusercontent.com/10561050/96645725-febe3600-12f8-11eb-9587-1a017e54f453.png">


### Detailed test instructions:

1. Enable the navigation.
1. Activate the plugin from this PR https://github.com/woocommerce/woocommerce-admin/pull/5425
1. Navigate to Marketing-> Example Marketing Category.1
1. Note the back button label is "Marketing."
1. Make sure no other regressions have occurred with other categories.
