### PR TITLE
Fix downloads report

### DIFF
--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -438,7 +438,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		 */
 		return apply_filters(
 			'woocommerce_report_downloads_prepare_export_item',
-			$export_item,
+			$export_columns,
 			$item
 		);
 	}

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -204,12 +204,6 @@ class Controller extends ReportsController implements ExportableInterface {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'File URL.', 'woocommerce-admin' ),
 				),
-				'product_id'   => array(
-					'type'        => 'integer',
-					'readonly'    => true,
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
-				),
 				'order_id'     => array(
 					'type'        => 'integer',
 					'readonly'    => true,

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -415,7 +415,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		$export_columns = array(
+		$export_item = array(
 			'date'         => $item['date'],
 			'product'      => $item['_embedded']['product'][0]['name'],
 			'file_name'    => $item['file_name'],
@@ -432,7 +432,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		 */
 		return apply_filters(
 			'woocommerce_report_downloads_prepare_export_item',
-			$export_columns,
+			$export_item,
 			$item
 		);
 	}


### PR DESCRIPTION
This is a copy of https://github.com/woocommerce/woocommerce-admin/pull/5321, a PR from @sultann. I've copied it to:

- get CI building the branch
- change `prepare_item_for_export` to use `$export_item` to match other controllers

Note that I've tested @sultann's PR, this just needs approval for merging.

### Detailed test instructions:

- Unless you have several hundred downloads this will be impossible to test
- The easiest way to see what happens with the typo is to introduce it to `/src/API/Reports/Orders/Controller.php` and run a orders download. The error log should fill up with errors and the downloaded report (emailed) will be full of empty lines.
