### PR TITLE
Allow full URLs to be used for nav items

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -94,6 +94,11 @@ class Menu {
 	 * @return string
 	 */
 	public static function get_callback_url( $callback ) {
+		// Return the full URL.
+		if ( strpos( $callback, 'http' ) === 0 ) {
+			return $callback;
+		}
+
 		$pos  = strpos( $callback, '?' );
 		$file = $pos > 0 ? substr( $callback, 0, $pos ) : $callback;
 		if ( file_exists( ABSPATH . "/wp-admin/$file" ) ) {


### PR DESCRIPTION
Fixes #5452

Allows full URLs to be passed in to nav items as opposed to all links being dashboard links.

### Detailed test instructions:

1. Add an item with a full URL or activate the plugin in this PR - https://github.com/woocommerce/woocommerce-admin/pull/5425
1. Navigate to the added links.
1. Note that the link works as expected.