### PR TITLE
Set WCA pages as top level in navigation if no parent exists

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -485,8 +485,8 @@ class PageController {
 			'title'        => $options['title'],
 			'capability'   => $options['capability'],
 			'url'          => $options['path'],
-			'order'        => isset( $options['order'] ) ? $options['order'] : 20,
-			'is_top_level' => isset( $options['is_top_level'] ) && $options['is_top_level'],
+			'order'        => isset( $options['order'] ) ? $options['order'] : 100,
+			'is_top_level' => ( isset( $options['is_top_level'] ) && $options['is_top_level'] ) || ! $options['parent'],
 		);
 
 		if ( isset( $options['is_category'] ) && $options['is_category'] ) {


### PR DESCRIPTION
Fixes #5442 

Sets all WCA-registered pages as top level if no parent was explicitly registered.   Also sets the default order for these items to the end of the list.

Note: this could pretty quickly pollute the top-level of the navigation.  I'm wondering if these shouldn't be put into a category by default unless the category is explicitly stated or if `is_top_level` is explicitly declared.

Also related - https://github.com/woocommerce/woocommerce-admin/issues/5335

### Screenshots

<img width="322" alt="Screen Shot 2020-10-21 at 5 15 51 PM" src="https://user-images.githubusercontent.com/10561050/96788274-3d1f2800-13c1-11eb-837b-0ca8240c4fad.png">


### Detailed test instructions:

1. Install WC Pay.
1. Enable the navigation.
1. Check that "Payments" has been added to the end of the primary menu in the navigation.