### PR TITLE
Navigation: Include Animation Styles

### DIFF
--- a/client/stylesheets/shared/_gutenberg-components.scss
+++ b/client/stylesheets/shared/_gutenberg-components.scss
@@ -21,3 +21,4 @@ allows Woo themed components based on the config found in postcss.config.js
 @import 'gutenberg-components/drop-zone/style.scss';
 @import 'gutenberg-components/tab-panel/style.scss';
 @import 'gutenberg-components/guide/style.scss';
+@import 'gutenberg-components/animate/style.scss';


### PR DESCRIPTION
Animation styles from Gutenberg weren't included so the fancy slide effect was missing from Navigation. Since we're bundling wp.components, indirectly used components don't have their CSS included, so we have to add it manually.

### Detailed test instructions:

1. Turn on navigation by setting the `woocommerce_navigation_enabled` option to "yes".
2. Play around with the Nav going forwards and back to see the animation between menus.