### PR TITLE
Update dependencies in prep for Composer 2.x.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -179,10 +179,6 @@ install_deps() {
 	# As zip file does not include tests, we have to get it from git repo.
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
-	# Bring in WooCommerce Core dependencies
-	cd "woocommerce"
-	composer install --no-dev
-
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce
 

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,6 @@
 		}
 	},
 	"autoload": {
-		"classmap": [
-			"includes/"
-		],
 		"psr-4": {
 			"Automattic\\WooCommerce\\Admin\\": "src/"
 		}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	"require": {
 		"composer/installers": "1.9.0",
 		"php": ">=5.6|>=7.0",
-		"automattic/jetpack-autoloader": "2.3.0"
+		"automattic/jetpack-autoloader": "2.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"composer/installers": "1.7.0",
+		"composer/installers": "1.9.0",
 		"php": ">=5.6|>=7.0",
-		"automattic/jetpack-autoloader": "^2.2.0"
+		"automattic/jetpack-autoloader": "2.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",
-		"woocommerce/woocommerce-sniffs": "0.0.9"
+		"woocommerce/woocommerce-sniffs": "0.1.0"
 	},
 	"config": {
 		"platform": {

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"composer/installers": "1.9.0",
+		"composer/installers": "^1.9.0",
 		"php": ">=5.6|>=7.0",
-		"automattic/jetpack-autoloader": "2.2.0"
+		"automattic/jetpack-autoloader": "^2.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71729fd90cf3dd6c3211e1b56b934404",
+    "content-hash": "fafcc7e31f054c6ce40cc4ecc5477fef",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.3.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "841976bc8322af907a3efd7acd028a5dec35a5f9"
+                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/841976bc8322af907a3efd7acd028a5dec35a5f9",
-                "reference": "841976bc8322af907a3efd7acd028a5dec35a5f9",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/66a5d150b3928be718d86696f85631a7f0b98a7b",
+                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b",
                 "shasum": ""
             },
             "require": {
@@ -43,7 +43,7 @@
             "support": {
                 "source": "https://github.com/Automattic/jetpack-autoloader/tree/master"
             },
-            "time": "2020-08-21T20:08:55+00:00"
+            "time": "2020-08-14T20:34:36+00:00"
         },
         {
             "name": "composer/installers",
@@ -1872,16 +1872,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -1924,24 +1924,24 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1949,7 +1949,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1987,7 +1987,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.18.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
             },
             "funding": [
                 {
@@ -2003,7 +2003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e26baafeb05c951e8d7cb108d28f5595",
+    "content-hash": "71729fd90cf3dd6c3211e1b56b934404",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -40,32 +40,38 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/master"
+            },
             "time": "2020-08-21T20:08:55+00:00"
         },
         {
             "name": "composer/installers",
-            "version": "v1.7.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/141b272484481432cda342727a427dc1e206bfa0",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -101,6 +107,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -155,6 +162,7 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -162,28 +170,42 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2019-08-12T15:00:31+00:00"
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -230,7 +252,11 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -286,6 +312,24 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.3.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-29T17:27:14+00:00"
         },
         {
@@ -333,6 +377,16 @@
                 "duplicate",
                 "object",
                 "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -389,6 +443,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2018-07-08T19:23:20+00:00"
         },
         {
@@ -436,6 +494,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
             "time": "2018-07-08T19:19:57+00:00"
         },
         {
@@ -494,6 +556,10 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
@@ -546,6 +612,10 @@
                 "polyfill",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
             "time": "2019-11-04T15:17:54+00:00"
         },
         {
@@ -596,6 +666,10 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
             "time": "2019-08-28T14:22:28+00:00"
         },
         {
@@ -645,6 +719,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+            },
             "time": "2020-04-27T09:25:28+00:00"
         },
         {
@@ -697,6 +775,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/4.x"
+            },
             "time": "2019-12-28T18:55:12+00:00"
         },
         {
@@ -744,6 +826,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/0.7.2"
+            },
             "time": "2019-08-22T18:11:29+00:00"
         },
         {
@@ -807,6 +893,10 @@
                 "spy",
                 "stub"
             ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+            },
             "time": "2020-03-05T15:02:03+00:00"
         },
         {
@@ -870,6 +960,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+            },
             "time": "2018-10-31T16:06:48+00:00"
         },
         {
@@ -920,6 +1014,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.2"
+            },
             "time": "2018-09-13T20:33:42+00:00"
         },
         {
@@ -961,6 +1059,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -1010,6 +1112,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
             "time": "2019-06-07T04:22:29+00:00"
         },
         {
@@ -1059,6 +1165,11 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.1"
+            },
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -1143,6 +1254,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
+            },
             "time": "2020-01-08T08:45:45+00:00"
         },
         {
@@ -1188,6 +1303,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/master"
+            },
             "time": "2017-03-04T06:30:41+00:00"
         },
         {
@@ -1252,6 +1371,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/master"
+            },
             "time": "2018-07-12T15:12:46+00:00"
         },
         {
@@ -1308,6 +1431,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+            },
             "time": "2019-02-04T06:01:07+00:00"
         },
         {
@@ -1361,6 +1488,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.3"
+            },
             "time": "2019-11-20T08:46:58+00:00"
         },
         {
@@ -1428,6 +1559,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+            },
             "time": "2019-09-14T09:02:43+00:00"
         },
         {
@@ -1479,6 +1614,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
             "time": "2017-04-27T15:39:26+00:00"
         },
         {
@@ -1526,6 +1665,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
+            },
             "time": "2017-08-03T12:35:26+00:00"
         },
         {
@@ -1571,6 +1714,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/master"
+            },
             "time": "2017-03-29T09:07:27+00:00"
         },
         {
@@ -1624,6 +1771,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+            },
             "time": "2017-03-03T06:23:57+00:00"
         },
         {
@@ -1666,6 +1817,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+            },
             "time": "2018-10-04T04:07:39+00:00"
         },
         {
@@ -1709,6 +1864,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -1760,6 +1919,11 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-08-10T04:50:15+00:00"
         },
         {
@@ -1822,6 +1986,23 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.18.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -1862,6 +2043,10 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
             "time": "2019-06-13T22:48:21+00:00"
         },
         {
@@ -1911,27 +2096,31 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
-            "version": "0.0.9",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
-                "reference": "7677a84e9a355fe1e088f704090be891e7a6d427"
+                "reference": "b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/7677a84e9a355fe1e088f704090be891e7a6d427",
-                "reference": "7677a84e9a355fe1e088f704090be891e7a6d427",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79",
+                "reference": "b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
                 "php": ">=7.0",
                 "phpcompatibility/phpcompatibility-wp": "2.1.0",
-                "wp-coding-standards/wpcs": "2.2.0"
+                "wp-coding-standards/wpcs": "2.3.0"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1951,20 +2140,24 @@
                 "woocommerce",
                 "wordpress"
             ],
-            "time": "2019-11-11T15:48:34+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/master"
+            },
+            "time": "2020-08-06T18:23:45+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -1972,12 +2165,13 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1996,7 +2190,12 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-11-11T12:34:03+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],
@@ -2011,5 +2210,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fafcc7e31f054c6ce40cc4ecc5477fef",
+    "content-hash": "4dd601e4232287cf0c8c9abc932a0d48",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b"
+                "reference": "75596db2f4843668792a1d2cc786cf82f60e9b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/66a5d150b3928be718d86696f85631a7f0b98a7b",
-                "reference": "66a5d150b3928be718d86696f85631a7f0b98a7b",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/75596db2f4843668792a1d2cc786cf82f60e9b72",
+                "reference": "75596db2f4843668792a1d2cc786cf82f60e9b72",
                 "shasum": ""
             },
             "require": {
@@ -31,6 +31,9 @@
                 "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
             },
             "autoload": {
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ],
                 "psr-4": {
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
@@ -41,9 +44,9 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/master"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.4.0"
             },
-            "time": "2020-08-14T20:34:36+00:00"
+            "time": "2020-09-28T14:13:14+00:00"
         },
         {
             "name": "composer/installers",
@@ -170,10 +173,6 @@
                 "zend",
                 "zikula"
             ],
-            "support": {
-                "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.9.0"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -252,10 +251,6 @@
                 "stylecheck",
                 "tests"
             ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
             "time": "2020-06-25T14:57:39+00:00"
         },
         {
@@ -1919,11 +1914,6 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
@@ -1986,9 +1976,6 @@
                 "polyfill",
                 "portable"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2140,10 +2127,6 @@
                 "woocommerce",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
-                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/master"
-            },
             "time": "2020-08-06T18:23:45+00:00"
         },
         {
@@ -2190,11 +2173,6 @@
                 "standards",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
-            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],
@@ -2210,5 +2188,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "75596db2f4843668792a1d2cc786cf82f60e9b72"
+                "reference": "7945e862473e39f05e6f698f1598ea30a12e5965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/75596db2f4843668792a1d2cc786cf82f60e9b72",
-                "reference": "75596db2f4843668792a1d2cc786cf82f60e9b72",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7945e862473e39f05e6f698f1598ea30a12e5965",
+                "reference": "7945e862473e39f05e6f698f1598ea30a12e5965",
                 "shasum": ""
             },
             "require": {
@@ -44,9 +44,9 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.4.0"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.5.0"
             },
-            "time": "2020-09-28T14:13:14+00:00"
+            "time": "2020-10-08T19:51:11+00:00"
         },
         {
             "name": "composer/installers",
@@ -173,6 +173,10 @@
                 "zend",
                 "zikula"
             ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.9.0"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -251,6 +255,10 @@
                 "stylecheck",
                 "tests"
             ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
             "time": "2020-06-25T14:57:39+00:00"
         },
         {
@@ -1914,6 +1922,11 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
@@ -1976,6 +1989,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2127,6 +2143,10 @@
                 "woocommerce",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/master"
+            },
             "time": "2020-08-06T18:23:45+00:00"
         },
         {
@@ -2173,6 +2193,11 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],
@@ -2188,5 +2213,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -9,7 +9,7 @@
 
 use \Automattic\WooCommerce\Admin\Install as Installer;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin;
+use \Automattic\WooCommerce\Admin\Notes\DeactivatePlugin;
 
 /**
  * Update order stats `status` index length.
@@ -115,7 +115,7 @@ function wc_admin_update_130_db_version() {
 function wc_admin_update_140_change_deactivate_plugin_note_type() {
 	global $wpdb;
 
-	$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}wc_admin_notes SET type = 'info' WHERE name = %s", Deactivate_Plugin::NOTE_NAME ) );
+	$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}wc_admin_notes SET type = 'info' WHERE name = %s", DeactivatePlugin::NOTE_NAME ) );
 }
 
 /**
@@ -129,7 +129,7 @@ function wc_admin_update_140_db_version() {
  * Remove Facebook Experts note.
  */
 function wc_admin_update_160_remove_facebook_note() {
-	WC_Admin_Notes::delete_notes_with_name( 'wc-admin-facebook-marketing-expert' );
+	Notes::delete_notes_with_name( 'wc-admin-facebook-marketing-expert' );
 }
 
 /**

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\PluginsHelper;
-use \Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins;
+use \Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -194,7 +194,7 @@ class Plugins extends \WC_REST_Data_Controller {
 			return;
 		}
 
-		Install_JP_And_WCS_Plugins::possibly_add_note();
+		InstallJPAndWCSPlugins::possibly_add_note();
 	}
 
 	/**

--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -47,7 +47,7 @@ class DeprecatedClassFacade {
 	 */
 	public function __call( $name, $arguments ) {
 		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
+			static::class . '::' . $name,
 			static::$deprecated_in_version
 		);
 		return call_user_func_array(
@@ -67,7 +67,7 @@ class DeprecatedClassFacade {
 	 */
 	public static function __callStatic( $name, $arguments ) {
 		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
+			static::class . '::' . $name,
 			static::$deprecated_in_version
 		);
 		return call_user_func_array(

--- a/src/Events.php
+++ b/src/Events.php
@@ -8,39 +8,39 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Notes\Choose_Niche;
-use \Automattic\WooCommerce\Admin\Notes\Giving_Feedback_Notes;
-use \Automattic\WooCommerce\Admin\Notes\Mobile_App;
-use \Automattic\WooCommerce\Admin\Notes\New_Sales_Record;
-use \Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Email_Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Payments;
-use \Automattic\WooCommerce\Admin\Notes\Personalize_Store;
-use \Automattic\WooCommerce\Admin\Notes\EU_VAT_Number;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
+use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
+use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
+use \Automattic\WooCommerce\Admin\Notes\MobileApp;
+use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
+use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingEmailMarketing;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingPayments;
+use \Automattic\WooCommerce\Admin\Notes\PersonalizeStore;
+use \Automattic\WooCommerce\Admin\Notes\EUVATNumber;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
 use \Automattic\WooCommerce\Admin\Notes\Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Start_Dropshipping_Business;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Subscriptions;
-use \Automattic\WooCommerce\Admin\Notes\Migrate_From_Shopify;
-use \Automattic\WooCommerce\Admin\Notes\Launch_Checklist;
-use \Automattic\WooCommerce\Admin\Notes\Real_Time_Order_Alerts;
+use \Automattic\WooCommerce\Admin\Notes\StartDropshippingBusiness;
+use \Automattic\WooCommerce\Admin\Notes\WooCommerceSubscriptions;
+use \Automattic\WooCommerce\Admin\Notes\MigrateFromShopify;
+use \Automattic\WooCommerce\Admin\Notes\LaunchChecklist;
+use \Automattic\WooCommerce\Admin\Notes\RealTimeOrderAlerts;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Loader;
-use \Automattic\WooCommerce\Admin\Notes\Insight_First_Sale;
-use \Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback;
-use \Automattic\WooCommerce\Admin\Notes\Need_Some_Inspiration;
-use \Automattic\WooCommerce\Admin\Notes\Online_Clothing_Store;
-use \Automattic\WooCommerce\Admin\Notes\First_Product;
-use \Automattic\WooCommerce\Admin\Notes\Customize_Store_With_Blocks;
-use \Automattic\WooCommerce\Admin\Notes\Google_Ads_And_Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Test_Checkout;
-use \Automattic\WooCommerce\Admin\Notes\Edit_Products_On_The_Move;
-use \Automattic\WooCommerce\Admin\Notes\Performance_On_Mobile;
-use \Automattic\WooCommerce\Admin\Notes\Manage_Orders_On_The_Go;
+use \Automattic\WooCommerce\Admin\Notes\InsightFirstSale;
+use \Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback;
+use \Automattic\WooCommerce\Admin\Notes\NeedSomeInspiration;
+use \Automattic\WooCommerce\Admin\Notes\OnlineClothingStore;
+use \Automattic\WooCommerce\Admin\Notes\FirstProduct;
+use \Automattic\WooCommerce\Admin\Notes\CustomizeStoreWithBlocks;
+use \Automattic\WooCommerce\Admin\Notes\GoogleAdsAndMarketing;
+use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
+use \Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove;
+use \Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile;
+use \Automattic\WooCommerce\Admin\Notes\ManageOrdersOnTheGo;
 
 /**
- * WC_Admin_Events Class.
+ * Events Class.
  */
 class Events {
 	/**
@@ -82,33 +82,33 @@ class Events {
 	 * Note: Order_Milestones::other_milestones is hooked to this as well.
 	 */
 	public function do_wc_admin_daily() {
-		New_Sales_Record::possibly_add_note();
-		Mobile_App::possibly_add_note();
-		Tracking_Opt_In::possibly_add_note();
-		Onboarding_Email_Marketing::possibly_add_note();
-		Onboarding_Payments::possibly_add_note();
-		Personalize_Store::possibly_add_note();
-		WooCommerce_Payments::possibly_add_note();
-		EU_VAT_Number::possibly_add_note();
+		NewSalesRecord::possibly_add_note();
+		MobileApp::possibly_add_note();
+		TrackingOptIn::possibly_add_note();
+		OnboardingEmailMarketing::possibly_add_note();
+		OnboardingPayments::possibly_add_note();
+		PersonalizeStore::possibly_add_note();
+		WooCommercePayments::possibly_add_note();
+		EUVATNumber::possibly_add_note();
 		Marketing::possibly_add_note();
-		Giving_Feedback_Notes::possibly_add_note();
-		Start_Dropshipping_Business::possibly_add_note();
-		WooCommerce_Subscriptions::possibly_add_note();
-		Migrate_From_Shopify::possibly_add_note();
-		Insight_First_Sale::possibly_add_note();
-		Launch_Checklist::possibly_add_note();
-		Home_Screen_Feedback::possibly_add_note();
-		Need_Some_Inspiration::possibly_add_note();
-		Online_Clothing_Store::possibly_add_note();
-		First_Product::possibly_add_note();
-		Choose_Niche::possibly_add_note();
-		Real_Time_Order_Alerts::possibly_add_note();
-		Customize_Store_With_Blocks::possibly_add_note();
-		Google_Ads_And_Marketing::possibly_add_note();
-		Test_Checkout::possibly_add_note();
-		Edit_Products_On_The_Move::possibly_add_note();
-		Performance_On_Mobile::possibly_add_note();
-		Manage_Orders_On_The_Go::possibly_add_note();
+		GivingFeedbackNotes::possibly_add_note();
+		StartDropshippingBusiness::possibly_add_note();
+		WooCommerceSubscriptions::possibly_add_note();
+		MigrateFromShopify::possibly_add_note();
+		InsightFirstSale::possibly_add_note();
+		LaunchChecklist::possibly_add_note();
+		HomeScreenFeedback::possibly_add_note();
+		NeedSomeInspiration::possibly_add_note();
+		OnlineClothingStore::possibly_add_note();
+		FirstProduct::possibly_add_note();
+		ChooseNiche::possibly_add_note();
+		RealTimeOrderAlerts::possibly_add_note();
+		CustomizeStoreWithBlocks::possibly_add_note();
+		GoogleAdsAndMarketing::possibly_add_note();
+		TestCheckout::possibly_add_note();
+		EditProductsOnTheMove::possibly_add_note();
+		PerformanceOnMobile::possibly_add_note();
+		ManageOrdersOnTheGo::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -8,19 +8,19 @@ namespace Automattic\WooCommerce\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
-use \Automattic\WooCommerce\Admin\Notes\Order_Milestones;
-use \Automattic\WooCommerce\Admin\Notes\Woo_Subscriptions_Notes;
-use \Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
-use \Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins;
-use \Automattic\WooCommerce\Admin\Notes\Draw_Attention;
-use \Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved;
+use \Automattic\WooCommerce\Admin\Notes\HistoricalData;
+use \Automattic\WooCommerce\Admin\Notes\OrderMilestones;
+use \Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes;
+use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
+use \Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins;
+use \Automattic\WooCommerce\Admin\Notes\DrawAttention;
+use \Automattic\WooCommerce\Admin\Notes\CouponPageMoved;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
-use \Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback;
-use \Automattic\WooCommerce\Admin\Notes\Set_Up_Additional_Payment_Types;
-use \Automattic\WooCommerce\Admin\Notes\Test_Checkout;
-use \Automattic\WooCommerce\Admin\Notes\Selling_Online_Courses;
+use \Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback;
+use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
+use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
+use \Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses;
 
 /**
  * Feature plugin main class.
@@ -70,6 +70,7 @@ class FeaturePlugin {
 
 		$this->define_constants();
 
+		require_once WC_ADMIN_ABSPATH . '/src/Notes/DeprecatedNotes.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/page-controller-functions.php';
@@ -181,17 +182,17 @@ class FeaturePlugin {
 
 		// Admin note providers.
 		// @todo These should be bundled in the features/ folder, but loading them from there currently has a load order issue.
-		new Woo_Subscriptions_Notes();
-		new Historical_Data();
-		new Order_Milestones();
-		new Tracking_Opt_In();
-		new WooCommerce_Payments();
-		new Install_JP_And_WCS_Plugins();
-		new Draw_Attention();
-		new Home_Screen_Feedback();
-		new Set_Up_Additional_Payment_Types();
-		new Test_Checkout();
-		new Selling_Online_Courses();
+		new WooSubscriptionsNotes();
+		new HistoricalData();
+		new OrderMilestones();
+		new TrackingOptIn();
+		new WooCommercePayments();
+		new InstallJPAndWCSPlugins();
+		new DrawAttention();
+		new HomeScreenFeedback();
+		new SetUpAdditionalPaymentTypes();
+		new TestCheckout();
+		new SellingOnlineCourses();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Features/Coupons.php
+++ b/src/Features/Coupons.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Loader;
-use Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved;
+use Automattic\WooCommerce\Admin\Notes\CouponPageMoved;
 use Automattic\WooCommerce\Admin\PageController;
 
 /**
@@ -53,7 +53,7 @@ class Coupons {
 			return;
 		}
 
-		( new Coupon_Page_Moved() )->init();
+		( new CouponPageMoved() )->init();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_add_marketing_coupon_script' ) );
 		add_action( 'woocommerce_register_post_type_shop_coupon', array( $this, 'move_coupons' ) );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -7,7 +7,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Profiler;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingProfiler;
 use \Automattic\WooCommerce\Admin\PluginsHelper;
 use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
 use \Automattic\WooCommerce\Admin\Features\OnboardingAutomateTaxes;
@@ -64,7 +64,7 @@ class Onboarding {
 		}
 
 		// Add onboarding notes.
-		new Onboarding_Profiler();
+		new OnboardingProfiler();
 
 		// Add actions and filters.
 		$this->add_actions();

--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
-use Automattic\WooCommerce\Admin\Notes\Confirm_Tax_Settings;
+use Automattic\WooCommerce\Admin\Notes\ConfirmTaxSettings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -60,7 +60,7 @@ class OnboardingAutomateTaxes {
 			update_option( 'wc_connect_taxes_enabled', 'yes' );
 			update_option( 'woocommerce_calc_taxes', 'yes' );
 			self::track_tax_automation();
-			Confirm_Tax_Settings::possibly_add_note();
+			ConfirmTaxSettings::possibly_add_note();
 		}
 	}
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\PluginsHelper;
-use \Automattic\WooCommerce\Admin\Notes\Review_Shipping_Settings;
+use \Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -73,7 +73,7 @@ class OnboardingSetUpShipping {
 		}
 
 		self::set_up_free_local_shipping();
-		Review_Shipping_Settings::possibly_add_note();
+		ReviewShippingSettings::possibly_add_note();
 		wc_admin_record_tracks_event( 'shipping_automatically_set_up' );
 	}
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
+use \Automattic\WooCommerce\Admin\Notes\HistoricalData;
 
 /**
  * Install Class.
@@ -493,7 +493,7 @@ class Install {
 	 * Create notes.
 	 */
 	protected static function create_notes() {
-		Historical_Data::possibly_add_note();
+		HistoricalData::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/ChooseNiche.php
+++ b/src/Notes/ChooseNiche.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Choose_Niche.
  */
-class Choose_Niche {
+class ChooseNiche {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * ConfirmTaxSettings.
  */
-class Confirm_Tax_Settings {
+class ConfirmTaxSettings {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Coupon_Page_Moved class.
  */
-class Coupon_Page_Moved {
+class CouponPageMoved {
 
 	use NoteTraits, CouponsMovedTrait;
 

--- a/src/Notes/CustomizeStoreWithBlocks.php
+++ b/src/Notes/CustomizeStoreWithBlocks.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Customize_Store_With_Blocks.
  */
-class Customize_Store_With_Blocks {
+class CustomizeStoreWithBlocks {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/DeactivatePlugin.php
+++ b/src/Notes/DeactivatePlugin.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Deactivate_Plugin.
  */
-class Deactivate_Plugin {
+class DeactivatePlugin {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -78,7 +78,7 @@ class WC_Admin_Notes extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Choose_Niche.
  *
- * @deprecated since 1.7.0, use Choose_Niche
+ * @deprecated since 1.7.0, use ChooseNiche
  */
 class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 	/**
@@ -99,7 +99,7 @@ class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Coupon_Page_Moved.
  *
- * @deprecated since 1.7.0, use Coupon_Page_Moved
+ * @deprecated since 1.7.0, use CouponPageMoved
  */
 class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 	/**
@@ -120,7 +120,7 @@ class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Customize_Store_With_Blocks.
  *
- * @deprecated since 1.7.0, use Customize_Store_With_Blocks
+ * @deprecated since 1.7.0, use CustomizeStoreWithBlocks
  */
 class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 	/**
@@ -141,7 +141,7 @@ class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Deactivate_Plugin.
  *
- * @deprecated since 1.7.0, use Deactivate_Plugin
+ * @deprecated since 1.7.0, use DeactivatePlugin
  */
 class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 	/**
@@ -162,7 +162,7 @@ class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Draw_Attention.
  *
- * @deprecated since 1.7.0, use Draw_Attention
+ * @deprecated since 1.7.0, use DrawAttention
  */
 class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 	/**
@@ -183,7 +183,7 @@ class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Edit_Products_On_The_Move.
  *
- * @deprecated since 1.7.0, use Edit_Products_On_The_Move
+ * @deprecated since 1.7.0, use EditProductsOnTheMove
  */
 class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 	/**
@@ -204,7 +204,7 @@ class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_EU_VAT_Number.
  *
- * @deprecated since 1.7.0, use EU_VAT_Number
+ * @deprecated since 1.7.0, use EUVATNumber
  */
 class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 	/**
@@ -225,7 +225,7 @@ class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Facebook_Marketing_Expert.
  *
- * @deprecated since 1.7.0, use Facebook_Marketing_Expert
+ * @deprecated since 1.7.0, use FacebookMarketingExpert
  */
 class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 	/**
@@ -246,7 +246,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_First_Product.
  *
- * @deprecated since 1.7.0, use First_Product
+ * @deprecated since 1.7.0, use FirstProduct
  */
 class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 	/**
@@ -267,7 +267,7 @@ class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Giving_Feedback_Notes.
  *
- * @deprecated since 1.7.0, use Giving_Feedback_Notes
+ * @deprecated since 1.7.0, use GivingFeedbackNotes
  */
 class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 	/**
@@ -288,7 +288,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Historical_Data.
  *
- * @deprecated since 1.7.0, use Historical_Data
+ * @deprecated since 1.7.0, use HistoricalData
  */
 class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 	/**
@@ -309,7 +309,7 @@ class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Home_Screen_Feedback.
  *
- * @deprecated since 1.7.0, use Home_Screen_Feedback
+ * @deprecated since 1.7.0, use HomeScreenFeedback
  */
 class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 	/**
@@ -330,7 +330,7 @@ class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Insight_First_Sale.
  *
- * @deprecated since 1.7.0, use Insight_First_Sale
+ * @deprecated since 1.7.0, use InsightFirstSale
  */
 class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 	/**
@@ -351,7 +351,7 @@ class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Install_JP_And_WCS_Plugins.
  *
- * @deprecated since 1.7.0, use Install_JP_And_WCS_Plugins
+ * @deprecated since 1.7.0, use InstallJPAndWCSPlugins
  */
 class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 	/**
@@ -372,7 +372,7 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Launch_Checklist.
  *
- * @deprecated since 1.7.0, use Launch_Checklist
+ * @deprecated since 1.7.0, use LaunchChecklist
  */
 class WC_Admin_Notes_Launch_Checklist extends DeprecatedClassFacade {
 	/**
@@ -414,7 +414,7 @@ class WC_Admin_Notes_Marketing extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Migrate_From_Shopify.
  *
- * @deprecated since 1.7.0, use Migrate_From_Shopify
+ * @deprecated since 1.7.0, use MigrateFromShopify
  */
 class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 	/**
@@ -435,7 +435,7 @@ class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Mobile_App.
  *
- * @deprecated since 1.7.0, use Mobile_App
+ * @deprecated since 1.7.0, use MobileApp
  */
 class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 	/**
@@ -456,7 +456,7 @@ class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Need_Some_Inspiration.
  *
- * @deprecated since 1.7.0, use Need_Some_Inspiration
+ * @deprecated since 1.7.0, use NeedSomeInspiration
  */
 class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 	/**
@@ -477,7 +477,7 @@ class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_New_Sales_Record.
  *
- * @deprecated since 1.7.0, use New_Sales_Record
+ * @deprecated since 1.7.0, use NewSalesRecord
  */
 class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 	/**
@@ -498,7 +498,7 @@ class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Onboarding_Email_Marketing.
  *
- * @deprecated since 1.7.0, use Onboarding_Email_Marketing
+ * @deprecated since 1.7.0, use OnboardingEmailMarketing
  */
 class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 	/**
@@ -519,7 +519,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Onboarding_Payments.
  *
- * @deprecated since 1.7.0, use Onboarding_Payments
+ * @deprecated since 1.7.0, use OnboardingPayments
  */
 class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 	/**
@@ -540,7 +540,7 @@ class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Onboarding_Profiler.
  *
- * @deprecated since 1.7.0, use Onboarding_Profiler
+ * @deprecated since 1.7.0, use OnboardingProfiler
  */
 class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 	/**
@@ -561,7 +561,7 @@ class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Online_Clothing_Store.
  *
- * @deprecated since 1.7.0, use Online_Clothing_Store
+ * @deprecated since 1.7.0, use OnlineClothingStore
  */
 class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 	/**
@@ -582,7 +582,7 @@ class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Order_Milestones.
  *
- * @deprecated since 1.7.0, use Order_Milestones
+ * @deprecated since 1.7.0, use OrderMilestones
  */
 class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 	/**
@@ -603,7 +603,7 @@ class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Performance_On_Mobile.
  *
- * @deprecated since 1.7.0, use Performance_On_Mobile
+ * @deprecated since 1.7.0, use PerformanceOnMobile
  */
 class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 	/**
@@ -624,7 +624,7 @@ class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Personalize_Store.
  *
- * @deprecated since 1.7.0, use Personalize_Store
+ * @deprecated since 1.7.0, use PersonalizeStore
  */
 class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 	/**
@@ -645,7 +645,7 @@ class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Real_Time_Order_Alerts.
  *
- * @deprecated since 1.7.0, use Real_Time_Order_Alerts
+ * @deprecated since 1.7.0, use RealTimeOrderAlerts
  */
 class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 	/**
@@ -666,7 +666,7 @@ class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Review_Shipping_Settings.
  *
- * @deprecated since 1.7.0, use Review_Shipping_Settings
+ * @deprecated since 1.7.0, use ReviewShippingSettings
  */
 class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 	/**
@@ -687,7 +687,7 @@ class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Selling_Online_Courses.
  *
- * @deprecated since 1.7.0, use Selling_Online_Courses
+ * @deprecated since 1.7.0, use SellingOnlineCourses
  */
 class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 	/**
@@ -708,7 +708,7 @@ class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Set_Up_Additional_Payment_Types.
  *
- * @deprecated since 1.7.0, use Set_Up_Additional_Payment_Types
+ * @deprecated since 1.7.0, use SetUpAdditionalPaymentTypes
  */
 class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFacade {
 	/**
@@ -729,7 +729,7 @@ class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFaca
 /**
  * WC_Admin_Notes_Start_Dropshipping_Business.
  *
- * @deprecated since 1.7.0, use Start_Dropshipping_Business
+ * @deprecated since 1.7.0, use StartDropshippingBusiness
  */
 class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 	/**
@@ -750,7 +750,7 @@ class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Test_Checkout.
  *
- * @deprecated since 1.7.0, use Test_Checkout
+ * @deprecated since 1.7.0, use TestCheckout
  */
 class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 	/**
@@ -771,7 +771,7 @@ class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Tracking_Opt_In.
  *
- * @deprecated since 1.7.0, use Tracking_Opt_In
+ * @deprecated since 1.7.0, use TrackingOptIn
  */
 class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 	/**
@@ -813,7 +813,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_WooCommerce_Payments.
  *
- * @deprecated since 1.7.0, use WooCommerce_Payments
+ * @deprecated since 1.7.0, use WooCommercePayments
  */
 class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 	/**
@@ -834,7 +834,7 @@ class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_WooCommerce_Subscriptions.
  *
- * @deprecated since 1.7.0, use WooCommerce_Subscriptions
+ * @deprecated since 1.7.0, use WooCommerceSubscriptions
  */
 class WC_Admin_Notes_WooCommerce_Subscriptions extends DeprecatedClassFacade {
 	/**

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -86,7 +86,7 @@ class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Choose_Niche';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\ChooseNiche';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -107,7 +107,7 @@ class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\CouponPageMoved';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -128,7 +128,7 @@ class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Customize_Store_With_Blocks';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\CustomizeStoreWithBlocks';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -149,7 +149,7 @@ class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\DeactivatePlugin';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -170,7 +170,7 @@ class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Draw_Attention';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\DrawAttention';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -191,7 +191,7 @@ class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Edit_Products_On_The_Move';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -212,7 +212,7 @@ class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EU_VAT_Number';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EUVATNumber';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -233,7 +233,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Facebook_Marketing_Expert';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\FacebookMarketingExpert';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -254,7 +254,7 @@ class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\First_Product';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\FirstProduct';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -275,7 +275,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Giving_Feedback_Notes';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -296,7 +296,7 @@ class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Historical_Data';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\HistoricalData';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -317,7 +317,7 @@ class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -338,7 +338,7 @@ class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Insight_First_Sale';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\InsightFirstSale';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -359,7 +359,7 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -380,7 +380,7 @@ class WC_Admin_Notes_Launch_Checklist extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Launch_Checklist';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\LaunchChecklist';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -422,7 +422,7 @@ class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Migrate_From_Shopify';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\MigrateFromShopify';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -443,7 +443,7 @@ class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Mobile_App';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\MobileApp';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -464,7 +464,7 @@ class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Need_Some_Inspiration';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\NeedSomeInspiration';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -485,7 +485,7 @@ class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\New_Sales_Record';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\NewSalesRecord';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -506,7 +506,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Email_Marketing';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingEmailMarketing';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -527,7 +527,7 @@ class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Payments';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingPayments';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -548,7 +548,7 @@ class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Profiler';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingProfiler';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -569,7 +569,7 @@ class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Online_Clothing_Store';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnlineClothingStore';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -590,7 +590,7 @@ class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Order_Milestones';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OrderMilestones';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -611,7 +611,7 @@ class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Performance_On_Mobile';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -632,7 +632,7 @@ class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Personalize_Store';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\PersonalizeStore';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -653,7 +653,7 @@ class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Real_Time_Order_Alerts';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\RealTimeOrderAlerts';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -674,7 +674,7 @@ class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Review_Shipping_Settings';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -695,7 +695,7 @@ class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Selling_Online_Courses';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -716,7 +716,7 @@ class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFaca
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Set_Up_Additional_Payment_Types';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -737,7 +737,7 @@ class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Start_Dropshipping_Business';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\StartDropshippingBusiness';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -758,7 +758,7 @@ class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Test_Checkout';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\TestCheckout';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -779,7 +779,7 @@ class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\TrackingOptIn';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -792,7 +792,7 @@ class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Woo_Subscriptions_Notes.
  *
- * @deprecated since 1.7.0, use Woo_Subscriptions_Notes
+ * @deprecated since 1.7.0, use WooSubscriptionsNotes
  */
 class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	/**
@@ -800,7 +800,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Woo_Subscriptions_Notes';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -821,7 +821,7 @@ class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommercePayments';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -842,7 +842,7 @@ class WC_Admin_Notes_WooCommerce_Subscriptions extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerce_Subscriptions';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerceSubscriptions';
 
 	/**
 	 * The version that this class was deprecated in.

--- a/src/Notes/DrawAttention.php
+++ b/src/Notes/DrawAttention.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Draw_Attention
  */
-class Draw_Attention {
+class DrawAttention {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/EUVATNumber.php
+++ b/src/Notes/EUVATNumber.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * EU_VAT_Number
  */
-class EU_VAT_Number {
+class EUVATNumber {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/EditProductsOnTheMove.php
+++ b/src/Notes/EditProductsOnTheMove.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Edit_Products_On_The_Move
  */
-class Edit_Products_On_The_Move {
+class EditProductsOnTheMove {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/FirstProduct.php
+++ b/src/Notes/FirstProduct.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * First_Product.
  */
-class First_Product {
+class FirstProduct {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/GivingFeedbackNotes.php
+++ b/src/Notes/GivingFeedbackNotes.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Giving_Feedback_Notes
  */
-class Giving_Feedback_Notes {
+class GivingFeedbackNotes {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/GoogleAdsAndMarketing.php
+++ b/src/Notes/GoogleAdsAndMarketing.php
@@ -16,7 +16,7 @@ use \Automattic\WooCommerce\Admin\PluginsHelper;
 /**
  * WC_Admin_Notes_Google_Ads_And_Marketing
  */
-class Google_Ads_And_Marketing {
+class GoogleAdsAndMarketing {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/HistoricalData.php
+++ b/src/Notes/HistoricalData.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Install;
 /**
  * Historical_Data.
  */
-class Historical_Data {
+class HistoricalData {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/HomeScreenFeedback.php
+++ b/src/Notes/HomeScreenFeedback.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Home_Screen_Feedback.
  */
-class Home_Screen_Feedback {
+class HomeScreenFeedback {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/InsightFirstSale.php
+++ b/src/Notes/InsightFirstSale.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Insight_First_Sale.
  */
-class Insight_First_Sale {
+class InsightFirstSale {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/InstallJPAndWCSPlugins.php
+++ b/src/Notes/InstallJPAndWCSPlugins.php
@@ -16,7 +16,7 @@ use \Automattic\WooCommerce\Admin\PluginsHelper;
 /**
  * Install_JP_And_WCS_Plugins
  */
-class Install_JP_And_WCS_Plugins {
+class InstallJPAndWCSPlugins {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/LaunchChecklist.php
+++ b/src/Notes/LaunchChecklist.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Launch_Checklist
  */
-class Launch_Checklist {
+class LaunchChecklist {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ManageOrdersOnTheGo.php
+++ b/src/Notes/ManageOrdersOnTheGo.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Manage_Orders_On_The_Go
  */
-class Manage_Orders_On_The_Go {
+class ManageOrdersOnTheGo {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/MigrateFromShopify.php
+++ b/src/Notes/MigrateFromShopify.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Migrate_From_Shopify.
  */
-class Migrate_From_Shopify {
+class MigrateFromShopify {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/MobileApp.php
+++ b/src/Notes/MobileApp.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Mobile_App
  */
-class Mobile_App {
+class MobileApp {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/NeedSomeInspiration.php
+++ b/src/Notes/NeedSomeInspiration.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Need_Some_Inspiration.
  */
-class Need_Some_Inspiration {
+class NeedSomeInspiration {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/NewSalesRecord.php
+++ b/src/Notes/NewSalesRecord.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * New_Sales_Record
  */
-class New_Sales_Record {
+class NewSalesRecord {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingEmailMarketing.php
+++ b/src/Notes/OnboardingEmailMarketing.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Onboarding_Email_Marketing
  */
-class Onboarding_Email_Marketing {
+class OnboardingEmailMarketing {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingPayments.php
+++ b/src/Notes/OnboardingPayments.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Onboarding_Payments.
  */
-class Onboarding_Payments {
+class OnboardingPayments {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingProfiler.php
+++ b/src/Notes/OnboardingProfiler.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * Onboarding_Profiler.
  */
-class Onboarding_Profiler {
+class OnboardingProfiler {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnlineClothingStore.php
+++ b/src/Notes/OnlineClothingStore.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Online_Clothing_Store.
  */
-class Online_Clothing_Store {
+class OnlineClothingStore {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OrderMilestones.php
+++ b/src/Notes/OrderMilestones.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Order_Milestones
  */
-class Order_Milestones {
+class OrderMilestones {
 	/**
 	 * Name of the "other milestones" note.
 	 */

--- a/src/Notes/PerformanceOnMobile.php
+++ b/src/Notes/PerformanceOnMobile.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Performance_On_Mobile
  */
-class Performance_On_Mobile {
+class PerformanceOnMobile {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/PersonalizeStore.php
+++ b/src/Notes/PersonalizeStore.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Personalize_Store
  */
-class Personalize_Store {
+class PersonalizeStore {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/RealTimeOrderAlerts.php
+++ b/src/Notes/RealTimeOrderAlerts.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Real_Time_Order_Alerts
  */
-class Real_Time_Order_Alerts {
+class RealTimeOrderAlerts {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ReviewShippingSettings.php
+++ b/src/Notes/ReviewShippingSettings.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Review_Shipping_Settings
  */
-class Review_Shipping_Settings {
+class ReviewShippingSettings {
 	use NoteTraits;
 
 	const NOTE_NAME = 'wc-admin-review-shipping-settings';

--- a/src/Notes/SellingOnlineCourses.php
+++ b/src/Notes/SellingOnlineCourses.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * Selling_Online_Courses
  */
-class Selling_Online_Courses {
+class SellingOnlineCourses {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/SetUpAdditionalPaymentTypes.php
+++ b/src/Notes/SetUpAdditionalPaymentTypes.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Set_Up_Additional_Payment_Types
  */
-class Set_Up_Additional_Payment_Types {
+class SetUpAdditionalPaymentTypes {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/StartDropshippingBusiness.php
+++ b/src/Notes/StartDropshippingBusiness.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Start_Dropshipping_Business.
  */
-class Start_Dropshipping_Business {
+class StartDropshippingBusiness {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/TestCheckout.php
+++ b/src/Notes/TestCheckout.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Test_Checkout
  */
-class Test_Checkout {
+class TestCheckout {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/TrackingOptIn.php
+++ b/src/Notes/TrackingOptIn.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Tracking_Opt_In
  */
-class Tracking_Opt_In {
+class TrackingOptIn {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WooCommerce_Payments
  */
-class WooCommerce_Payments {
+class WooCommercePayments {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooCommerceSubscriptions.php
+++ b/src/Notes/WooCommerceSubscriptions.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * WooCommerce_Subscriptions.
  */
-class WooCommerce_Subscriptions {
+class WooCommerceSubscriptions {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooSubscriptionsNotes.php
+++ b/src/Notes/WooSubscriptionsNotes.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Woo_Subscriptions_Notes
  */
-class Woo_Subscriptions_Notes {
+class WooSubscriptionsNotes {
 	const LAST_REFRESH_OPTION_KEY = 'woocommerce_admin-wc-helper-last-refresh';
 	const CONNECTION_NOTE_NAME    = 'wc-admin-wc-helper-connection';
 	const SUBSCRIPTION_NOTE_NAME  = 'wc-admin-wc-helper-subscription';

--- a/src/Package.php
+++ b/src/Package.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Admin\Composer;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin;
+use Automattic\WooCommerce\Admin\Notes\DeactivatePlugin;
 use Automattic\WooCommerce\Admin\FeaturePlugin;
 
 /**
@@ -49,7 +49,7 @@ class Package {
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
-			$update_version       = new Deactivate_Plugin();
+			$update_version       = new DeactivatePlugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
 				if ( method_exists( $update_version, 'possibly_add_note' ) ) {
 					$update_version::possibly_add_note();
@@ -123,7 +123,7 @@ class Package {
 	 * Add deactivation hook for versions of the plugin that don't have the deactivation note.
 	 */
 	public static function on_deactivation() {
-		$update_version = new Deactivate_Plugin();
+		$update_version = new DeactivatePlugin();
 		$update_version::delete_note();
 	}
 }

--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -2,6 +2,10 @@
 
 echo "Initializing WooCommerce E2E"
 
+# Turn off error display temporarily. This is to prevent deprecated function
+# notices from breaking the display of some screens and then E2E tests.
+# Message was for WC_Admin_Notes_Deactivate_Plugin usage in core WC.
+wp config set WP_DEBUG_DISPLAY false --raw
 wp config set JETPACK_AUTOLOAD_DEV true --raw
 wp plugin install woocommerce --activate
 wp theme install twentynineteen --activate

--- a/tests/notes/class-wc-tests-marketing-notes.php
+++ b/tests/notes/class-wc-tests-marketing-notes.php
@@ -7,7 +7,7 @@
 
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\Note;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
 
 /**
  * Class WC_Tests_Marketing_Notes
@@ -61,7 +61,7 @@ class WC_Tests_Marketing_Notes extends WC_Unit_Test_Case {
 		// Set user preferences to disallow marketing suggestions.
 		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
 
-		WooCommerce_Payments::possibly_add_note();
+		WooCommercePayments::possibly_add_note();
 
 		// Load all marketing notes and check that the note was not added.
 		$data_store = \WC_Data_Store::load( 'admin-note' );


### PR DESCRIPTION
This PR seeks to ready our repository for the upcoming Composer 2.x update.

See: pc2DNy-3j-p2 for more information.

Some packages needed updating to facilitate compatibility with Composer 2, but I experienced errors with the latest Jetpack Autoloader which is why it gets pinned to `2.3.0` in this PR.

### Detailed test instructions:

- Verify installation works on Composer 1.x:
- `rm -rf vendor && composer install`
- Check that app works (no PHP Fatals missing classes, etc)
- Verify installation works on Composer 2.x:
- `composer self-update --preview`
- `rm -rf vendor && composer install`
- Check that app works (no PHP Fatals missing classes, etc)


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A