### PR TITLE
Navigation: Adding Tracks by tying into wc-admin page view

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -78,9 +78,16 @@ class _Layout extends Component {
 			isJetpackConnected,
 		} = this.props;
 
+		const navigationFlag = {
+			has_navigation: !! window.wcAdminFeatures.navigation,
+		};
+
 		if ( isEmbedded ) {
 			const path = document.location.pathname + document.location.search;
-			recordPageView( path, { is_embedded: true } );
+			recordPageView( path, {
+				is_embedded: true,
+				...navigationFlag,
+			} );
 			return;
 		}
 
@@ -101,6 +108,7 @@ class _Layout extends Component {
 			jetpack_installed: installedPlugins.includes( 'jetpack' ),
 			jetpack_active: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
+			...navigationFlag,
 		} );
 	}
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -79,7 +79,7 @@ class _Layout extends Component {
 		} = this.props;
 
 		const navigationFlag = {
-			has_navigation: !! window.wcAdminFeatures.navigation,
+			has_navigation: !! window.wcNavigation,
 		};
 
 		if ( isEmbedded ) {


### PR DESCRIPTION
Fixes #5332

Adding the property `has_navigation` to the tracks pageView events to indicate if the new navigation feature is active or not (boolean value).

### Screenshots

![image](https://user-images.githubusercontent.com/444632/96927299-b5422800-146b-11eb-8adb-ae57bae2acc1.png)

### Detailed test instructions:

- Checkout branch
- Run this in your console to view tracks events: `localStorage.setItem( 'debug', 'wc-admin:*' );`
- Ensure navigation feature is enabled
- View an embedded WC page and ensure the `has_navigation` property exists and is `true` within the pageView event, as in the screenshot above.
- Go to a non-embedded page and verify the same flag is present and `true`.
- Disable the new navigation feature, and repeat the last two steps to verify that the value is now `false`.
