### PR TITLE
Home Screen - Added empty activity panel for orders

### DIFF
--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -44,21 +44,23 @@ class ActivityCard extends Component {
 						{ icon }
 					</span>
 				) }
-				<header className="woocommerce-activity-card__header">
-					<H className="woocommerce-activity-card__title">
-						{ title }
-					</H>
-					{ subtitle && (
-						<div className="woocommerce-activity-card__subtitle">
-							{ subtitle }
-						</div>
-					) }
-					{ date && (
-						<span className="woocommerce-activity-card__date">
-							{ moment.utc( date ).fromNow() }
-						</span>
-					) }
-				</header>
+				{ title && (
+					<header className="woocommerce-activity-card__header">
+						<H className="woocommerce-activity-card__title">
+							{ title }
+						</H>
+						{ subtitle && (
+							<div className="woocommerce-activity-card__subtitle">
+								{ subtitle }
+							</div>
+						) }
+						{ date && (
+							<span className="woocommerce-activity-card__date">
+								{ moment.utc( date ).fromNow() }
+							</span>
+						) }
+					</header>
+				) }
 				{ children && (
 					<Section className="woocommerce-activity-card__body">
 						{ children }
@@ -86,8 +88,7 @@ ActivityCard.propTypes = {
 	date: PropTypes.string,
 	icon: PropTypes.node,
 	subtitle: PropTypes.node,
-	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] )
-		.isRequired,
+	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 	unread: PropTypes.bool,
 };
 

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -6,7 +6,6 @@ import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import { keyBy, map, merge } from 'lodash';
@@ -40,66 +39,34 @@ class OrdersPanel extends Component {
 	}
 
 	renderEmptyCard() {
-		const { hasNonActionableOrders } = this.props;
-		if ( hasNonActionableOrders ) {
-			return (
-				<Fragment>
-					<ActivityCard
-						className="woocommerce-empty-activity-card"
-						title=""
-						icon=""
-					>
-						<span
-							className="woocommerce-order-empty__success-icon"
-							role="img"
-							aria-labelledby="woocommerce-order-empty-message"
-						>
-							🎉
-						</span>
-						<H id="woocommerce-order-empty-message">
-							{ __(
-								'You’ve fulfilled all your orders',
-								'woocommerce-admin'
-							) }
-						</H>
-					</ActivityCard>
-					<ActivityOutboundLink
-						href={ 'edit.php?post_type=shop_order' }
-						onClick={ () =>
-							this.recordOrderEvent( 'orders_manage' )
-						}
-					>
-						{ __( 'Manage all orders', 'woocommerce-admin' ) }
-					</ActivityOutboundLink>
-				</Fragment>
-			);
-		}
-
 		return (
-			<ActivityCard
-				className="woocommerce-empty-activity-card"
-				title={ __(
-					'You have no orders to fulfill',
-					'woocommerce-admin'
-				) }
-				icon={ <Gridicon icon="time" size={ 48 } /> }
-				actions={
-					<Button
-						href="https://docs.woocommerce.com/document/managing-orders/"
-						isSecondary
-						onClick={ () => this.recordOrderEvent( 'learn_more' ) }
-						target="_blank"
+			<Fragment>
+				<ActivityCard
+					className="woocommerce-empty-activity-card"
+					title=""
+					icon=""
+				>
+					<span
+						className="woocommerce-order-empty__success-icon"
+						role="img"
+						aria-labelledby="woocommerce-order-empty-message"
 					>
-						{ __( 'Learn more', 'woocommerce-admin' ) }
-					</Button>
-				}
-			>
-				{ __(
-					"You're still waiting for your customers to make their first orders. " +
-						'While you wait why not learn how to manage orders?',
-					'woocommerce-admin'
-				) }
-			</ActivityCard>
+						🎉
+					</span>
+					<H id="woocommerce-order-empty-message">
+						{ __(
+							'You’ve fulfilled all your orders',
+							'woocommerce-admin'
+						) }
+					</H>
+				</ActivityCard>
+				<ActivityOutboundLink
+					href={ 'edit.php?post_type=shop_order' }
+					onClick={ () => this.recordOrderEvent( 'orders_manage' ) }
+				>
+					{ __( 'Manage all orders', 'woocommerce-admin' ) }
+				</ActivityOutboundLink>
+			</Fragment>
 		);
 	}
 
@@ -299,7 +266,7 @@ class OrdersPanel extends Component {
 							className="woocommerce-order-activity-card"
 							hasAction
 							hasDate
-							lines={ 2 }
+							lines={ 1 }
 						/>
 					) : (
 						this.renderOrders()
@@ -326,7 +293,7 @@ OrdersPanel.contextType = CurrencyContext;
 
 export default compose(
 	withSelect( ( select, props ) => {
-		const { hasActionableOrders } = props;
+		const { countUnreadOrders } = props;
 		const { getItems, getItemsError, getItemsTotalCount } = select(
 			ITEMS_STORE_NAME
 		);
@@ -346,7 +313,7 @@ export default compose(
 			};
 		}
 
-		if ( hasActionableOrders ) {
+		if ( countUnreadOrders > 0 ) {
 			// Query the core Orders endpoint for the most up-to-date statuses.
 			const actionableOrdersQuery = {
 				page: 1,
@@ -428,10 +395,10 @@ export default compose(
 			allOrdersQuery
 		);
 		const isError = Boolean( getItemsError( 'orders', allOrdersQuery ) );
-		const isRequesting = isResolving( 'getItems', [
-			'orders',
-			allOrdersQuery,
-		] );
+		const isRequesting =
+			countUnreadOrders !== null
+				? isResolving( 'getItems', [ 'orders', allOrdersQuery ] )
+				: true;
 
 		return {
 			hasNonActionableOrders: totalNonActionableOrders > 0,

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import { keyBy, map, merge } from 'lodash';
 
-import { EmptyContent, Flag, Link, Section } from '@woocommerce/components';
+import { EmptyContent, Flag, H, Link, Section } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
@@ -32,6 +32,7 @@ import {
 import ActivityOutboundLink from '../../../header/activity-panel/activity-outbound-link';
 import { DEFAULT_ACTIONABLE_STATUSES } from '../../../analytics/settings/config';
 import { CurrencyContext } from '../../../lib/currency-context';
+import './style.scss';
 
 class OrdersPanel extends Component {
 	recordOrderEvent( eventName ) {
@@ -42,19 +43,35 @@ class OrdersPanel extends Component {
 		const { hasNonActionableOrders } = this.props;
 		if ( hasNonActionableOrders ) {
 			return (
-				<ActivityCard
-					className="woocommerce-empty-activity-card"
-					title={ __(
-						'You have no orders to fulfill',
-						'woocommerce-admin'
-					) }
-					icon={ <Gridicon icon="checkmark" size={ 48 } /> }
-				>
-					{ __(
-						"Good job, you've fulfilled all of your new orders!",
-						'woocommerce-admin'
-					) }
-				</ActivityCard>
+				<Fragment>
+					<ActivityCard
+						className="woocommerce-empty-activity-card"
+						title=""
+						icon=""
+					>
+						<span
+							className="woocommerce-order-empty__success-icon"
+							role="img"
+							aria-labelledby="woocommerce-order-empty-message"
+						>
+							🎉
+						</span>
+						<H id="woocommerce-order-empty-message">
+							{ __(
+								'You’ve fulfilled all your orders',
+								'woocommerce-admin'
+							) }
+						</H>
+					</ActivityCard>
+					<ActivityOutboundLink
+						href={ 'edit.php?post_type=shop_order' }
+						onClick={ () =>
+							this.recordOrderEvent( 'orders_manage' )
+						}
+					>
+						{ __( 'Manage all orders', 'woocommerce-admin' ) }
+					</ActivityOutboundLink>
+				</Fragment>
 			);
 		}
 

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -294,9 +294,7 @@ OrdersPanel.contextType = CurrencyContext;
 export default compose(
 	withSelect( ( select, props ) => {
 		const { countUnreadOrders } = props;
-		const { getItems, getItemsError, getItemsTotalCount } = select(
-			ITEMS_STORE_NAME
-		);
+		const { getItems, getItemsError } = select( ITEMS_STORE_NAME );
 		const { getReportItems, getReportItemsError, isResolving } = select(
 			REPORTS_STORE_NAME
 		);
@@ -390,10 +388,6 @@ export default compose(
 		};
 
 		getItems( 'orders', allOrdersQuery );
-		const totalNonActionableOrders = getItemsTotalCount(
-			'orders',
-			allOrdersQuery
-		);
 		const isError = Boolean( getItemsError( 'orders', allOrdersQuery ) );
 		const isRequesting =
 			countUnreadOrders !== null
@@ -401,7 +395,6 @@ export default compose(
 				: true;
 
 		return {
-			hasNonActionableOrders: totalNonActionableOrders > 0,
 			isError,
 			isRequesting,
 			orderStatuses,

--- a/client/homescreen/activity-panel/orders/style.scss
+++ b/client/homescreen/activity-panel/orders/style.scss
@@ -1,4 +1,4 @@
-.woocommerce-activity-panel-card {
+.woocommerce-accordion-card {
 	.woocommerce-empty-activity-card {
 		background: unset;
 		text-align: center;

--- a/client/homescreen/activity-panel/orders/style.scss
+++ b/client/homescreen/activity-panel/orders/style.scss
@@ -11,4 +11,28 @@
 	.woocommerce-order-empty__success-icon {
 		font-size: 36px;
 	}
+
+	// Needs the double-class for specificity
+	.woocommerce-activity-card.woocommerce-order-activity-card {
+		.woocommerce-activity-card__header {
+			margin-bottom: $gap-smallest;
+			.woocommerce-activity-card__title.is-placeholder {
+				width: 45%;
+			}
+		}
+
+		.woocommerce-activity-card__body {
+			& > .is-placeholder {
+				width: 30%;
+			}
+		}
+
+		.woocommerce-activity-card__actions {
+			& > .is-placeholder {
+				height: 24px;
+				margin-top: $gap-smallest;
+				width: 65px;
+			}
+		}
+	}
 }

--- a/client/homescreen/activity-panel/orders/style.scss
+++ b/client/homescreen/activity-panel/orders/style.scss
@@ -1,0 +1,14 @@
+.woocommerce-activity-panel-card {
+	.woocommerce-empty-activity-card {
+		background: unset;
+		text-align: center;
+		padding: ( $fallback-gutter / 2 ) $gutter 0;
+		h4 {
+			color: $gray-900;
+		}
+	}
+
+	.woocommerce-order-empty__success-icon {
+		font-size: 36px;
+	}
+}

--- a/client/homescreen/activity-panel/orders/test/index.js
+++ b/client/homescreen/activity-panel/orders/test/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import OrdersPanel from '../';
+
+describe( 'OrdersPanel', () => {
+	it( 'should render an empty order card', () => {
+		render(
+			<OrdersPanel
+				countUnreadOrders={ 0 }
+				isError={ false }
+				isRequesting={ false }
+				orderStatuses={ [] }
+			/>
+		);
+		expect(
+			screen.queryByText( 'You’ve fulfilled all your orders' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -15,7 +15,7 @@ export function getAllPanels( { countUnreadOrders } ) {
 			count: countUnreadOrders,
 			id: 'orders-panel',
 			initialOpen: true,
-			panel: <OrdersPanel countUnreadOrders />,
+			panel: <OrdersPanel countUnreadOrders={ countUnreadOrders } />,
 			title: __( 'Orders', 'woocommerce-admin' ),
 		},
 		// Add another panel row here

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -15,9 +15,7 @@ export function getAllPanels( { countUnreadOrders } ) {
 			count: countUnreadOrders,
 			id: 'orders-panel',
 			initialOpen: true,
-			panel: (
-				<OrdersPanel hasActionableOrders={ countUnreadOrders > 0 } />
-			),
+			panel: <OrdersPanel countUnreadOrders />,
 			title: __( 'Orders', 'woocommerce-admin' ),
 		},
 		// Add another panel row here


### PR DESCRIPTION
This PR is a follow-up of the [PR 5455](https://github.com/woocommerce/woocommerce-admin/pull/5455), so a rebase will be necessary.

This PR adds an empty activity panel for orders.

### Screenshots
![Screen Capture on 2020-10-22 at 16-11-55](https://user-images.githubusercontent.com/1314156/96919074-a1092580-1481-11eb-83cd-8ac7bed525c8.gif)

### Detailed test instructions:

- Go to the `Orders` page (URL `/wp-admin/edit.php?post_type=shop_order`).
- Verify there aren't any orders in `Progress`.
- Go to the `Home` screen.
- Verify the `Orders` panel is empty and looks like it should.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Home Screen - Added empty activity panel for orders
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
