### PR TITLE
Fix PSR-4 Classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,6 @@
 		}
 	},
 	"autoload": {
-		"classmap": [
-			"includes/"
-		],
 		"psr-4": {
 			"Automattic\\WooCommerce\\Admin\\": "src/"
 		}

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -9,7 +9,7 @@
 
 use \Automattic\WooCommerce\Admin\Install as Installer;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin;
+use \Automattic\WooCommerce\Admin\Notes\DeactivatePlugin;
 
 /**
  * Update order stats `status` index length.
@@ -115,7 +115,7 @@ function wc_admin_update_130_db_version() {
 function wc_admin_update_140_change_deactivate_plugin_note_type() {
 	global $wpdb;
 
-	$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}wc_admin_notes SET type = 'info' WHERE name = %s", Deactivate_Plugin::NOTE_NAME ) );
+	$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}wc_admin_notes SET type = 'info' WHERE name = %s", DeactivatePlugin::NOTE_NAME ) );
 }
 
 /**
@@ -129,7 +129,7 @@ function wc_admin_update_140_db_version() {
  * Remove Facebook Experts note.
  */
 function wc_admin_update_160_remove_facebook_note() {
-	WC_Admin_Notes::delete_notes_with_name( 'wc-admin-facebook-marketing-expert' );
+	Notes::delete_notes_with_name( 'wc-admin-facebook-marketing-expert' );
 }
 
 /**

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\PluginsHelper;
-use \Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins;
+use \Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -194,7 +194,7 @@ class Plugins extends \WC_REST_Data_Controller {
 			return;
 		}
 
-		Install_JP_And_WCS_Plugins::possibly_add_note();
+		InstallJPAndWCSPlugins::possibly_add_note();
 	}
 
 	/**

--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -47,7 +47,7 @@ class DeprecatedClassFacade {
 	 */
 	public function __call( $name, $arguments ) {
 		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
+			static::class . '::' . $name,
 			static::$deprecated_in_version
 		);
 		return call_user_func_array(
@@ -67,7 +67,7 @@ class DeprecatedClassFacade {
 	 */
 	public static function __callStatic( $name, $arguments ) {
 		_deprecated_function(
-			static::$facade_over_classname . '::' . $name,
+			static::class . '::' . $name,
 			static::$deprecated_in_version
 		);
 		return call_user_func_array(

--- a/src/Events.php
+++ b/src/Events.php
@@ -8,39 +8,39 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Notes\Choose_Niche;
-use \Automattic\WooCommerce\Admin\Notes\Giving_Feedback_Notes;
-use \Automattic\WooCommerce\Admin\Notes\Mobile_App;
-use \Automattic\WooCommerce\Admin\Notes\New_Sales_Record;
-use \Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Email_Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Payments;
-use \Automattic\WooCommerce\Admin\Notes\Personalize_Store;
-use \Automattic\WooCommerce\Admin\Notes\EU_VAT_Number;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
+use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
+use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
+use \Automattic\WooCommerce\Admin\Notes\MobileApp;
+use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
+use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingEmailMarketing;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingPayments;
+use \Automattic\WooCommerce\Admin\Notes\PersonalizeStore;
+use \Automattic\WooCommerce\Admin\Notes\EUVATNumber;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
 use \Automattic\WooCommerce\Admin\Notes\Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Start_Dropshipping_Business;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Subscriptions;
-use \Automattic\WooCommerce\Admin\Notes\Migrate_From_Shopify;
-use \Automattic\WooCommerce\Admin\Notes\Launch_Checklist;
-use \Automattic\WooCommerce\Admin\Notes\Real_Time_Order_Alerts;
+use \Automattic\WooCommerce\Admin\Notes\StartDropshippingBusiness;
+use \Automattic\WooCommerce\Admin\Notes\WooCommerceSubscriptions;
+use \Automattic\WooCommerce\Admin\Notes\MigrateFromShopify;
+use \Automattic\WooCommerce\Admin\Notes\LaunchChecklist;
+use \Automattic\WooCommerce\Admin\Notes\RealTimeOrderAlerts;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Loader;
-use \Automattic\WooCommerce\Admin\Notes\Insight_First_Sale;
-use \Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback;
-use \Automattic\WooCommerce\Admin\Notes\Need_Some_Inspiration;
-use \Automattic\WooCommerce\Admin\Notes\Online_Clothing_Store;
-use \Automattic\WooCommerce\Admin\Notes\First_Product;
-use \Automattic\WooCommerce\Admin\Notes\Customize_Store_With_Blocks;
-use \Automattic\WooCommerce\Admin\Notes\Google_Ads_And_Marketing;
-use \Automattic\WooCommerce\Admin\Notes\Test_Checkout;
-use \Automattic\WooCommerce\Admin\Notes\Edit_Products_On_The_Move;
-use \Automattic\WooCommerce\Admin\Notes\Performance_On_Mobile;
-use \Automattic\WooCommerce\Admin\Notes\Manage_Orders_On_The_Go;
+use \Automattic\WooCommerce\Admin\Notes\InsightFirstSale;
+use \Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback;
+use \Automattic\WooCommerce\Admin\Notes\NeedSomeInspiration;
+use \Automattic\WooCommerce\Admin\Notes\OnlineClothingStore;
+use \Automattic\WooCommerce\Admin\Notes\FirstProduct;
+use \Automattic\WooCommerce\Admin\Notes\CustomizeStoreWithBlocks;
+use \Automattic\WooCommerce\Admin\Notes\GoogleAdsAndMarketing;
+use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
+use \Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove;
+use \Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile;
+use \Automattic\WooCommerce\Admin\Notes\ManageOrdersOnTheGo;
 
 /**
- * WC_Admin_Events Class.
+ * Events Class.
  */
 class Events {
 	/**
@@ -82,33 +82,33 @@ class Events {
 	 * Note: Order_Milestones::other_milestones is hooked to this as well.
 	 */
 	public function do_wc_admin_daily() {
-		New_Sales_Record::possibly_add_note();
-		Mobile_App::possibly_add_note();
-		Tracking_Opt_In::possibly_add_note();
-		Onboarding_Email_Marketing::possibly_add_note();
-		Onboarding_Payments::possibly_add_note();
-		Personalize_Store::possibly_add_note();
-		WooCommerce_Payments::possibly_add_note();
-		EU_VAT_Number::possibly_add_note();
+		NewSalesRecord::possibly_add_note();
+		MobileApp::possibly_add_note();
+		TrackingOptIn::possibly_add_note();
+		OnboardingEmailMarketing::possibly_add_note();
+		OnboardingPayments::possibly_add_note();
+		PersonalizeStore::possibly_add_note();
+		WooCommercePayments::possibly_add_note();
+		EUVATNumber::possibly_add_note();
 		Marketing::possibly_add_note();
-		Giving_Feedback_Notes::possibly_add_note();
-		Start_Dropshipping_Business::possibly_add_note();
-		WooCommerce_Subscriptions::possibly_add_note();
-		Migrate_From_Shopify::possibly_add_note();
-		Insight_First_Sale::possibly_add_note();
-		Launch_Checklist::possibly_add_note();
-		Home_Screen_Feedback::possibly_add_note();
-		Need_Some_Inspiration::possibly_add_note();
-		Online_Clothing_Store::possibly_add_note();
-		First_Product::possibly_add_note();
-		Choose_Niche::possibly_add_note();
-		Real_Time_Order_Alerts::possibly_add_note();
-		Customize_Store_With_Blocks::possibly_add_note();
-		Google_Ads_And_Marketing::possibly_add_note();
-		Test_Checkout::possibly_add_note();
-		Edit_Products_On_The_Move::possibly_add_note();
-		Performance_On_Mobile::possibly_add_note();
-		Manage_Orders_On_The_Go::possibly_add_note();
+		GivingFeedbackNotes::possibly_add_note();
+		StartDropshippingBusiness::possibly_add_note();
+		WooCommerceSubscriptions::possibly_add_note();
+		MigrateFromShopify::possibly_add_note();
+		InsightFirstSale::possibly_add_note();
+		LaunchChecklist::possibly_add_note();
+		HomeScreenFeedback::possibly_add_note();
+		NeedSomeInspiration::possibly_add_note();
+		OnlineClothingStore::possibly_add_note();
+		FirstProduct::possibly_add_note();
+		ChooseNiche::possibly_add_note();
+		RealTimeOrderAlerts::possibly_add_note();
+		CustomizeStoreWithBlocks::possibly_add_note();
+		GoogleAdsAndMarketing::possibly_add_note();
+		TestCheckout::possibly_add_note();
+		EditProductsOnTheMove::possibly_add_note();
+		PerformanceOnMobile::possibly_add_note();
+		ManageOrdersOnTheGo::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -8,19 +8,19 @@ namespace Automattic\WooCommerce\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
-use \Automattic\WooCommerce\Admin\Notes\Order_Milestones;
-use \Automattic\WooCommerce\Admin\Notes\Woo_Subscriptions_Notes;
-use \Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
-use \Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins;
-use \Automattic\WooCommerce\Admin\Notes\Draw_Attention;
-use \Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved;
+use \Automattic\WooCommerce\Admin\Notes\HistoricalData;
+use \Automattic\WooCommerce\Admin\Notes\OrderMilestones;
+use \Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes;
+use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
+use \Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins;
+use \Automattic\WooCommerce\Admin\Notes\DrawAttention;
+use \Automattic\WooCommerce\Admin\Notes\CouponPageMoved;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
-use \Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback;
-use \Automattic\WooCommerce\Admin\Notes\Set_Up_Additional_Payment_Types;
-use \Automattic\WooCommerce\Admin\Notes\Test_Checkout;
-use \Automattic\WooCommerce\Admin\Notes\Selling_Online_Courses;
+use \Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback;
+use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
+use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
+use \Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses;
 
 /**
  * Feature plugin main class.
@@ -70,6 +70,7 @@ class FeaturePlugin {
 
 		$this->define_constants();
 
+		require_once WC_ADMIN_ABSPATH . '/src/Notes/DeprecatedNotes.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/page-controller-functions.php';
@@ -181,17 +182,17 @@ class FeaturePlugin {
 
 		// Admin note providers.
 		// @todo These should be bundled in the features/ folder, but loading them from there currently has a load order issue.
-		new Woo_Subscriptions_Notes();
-		new Historical_Data();
-		new Order_Milestones();
-		new Tracking_Opt_In();
-		new WooCommerce_Payments();
-		new Install_JP_And_WCS_Plugins();
-		new Draw_Attention();
-		new Home_Screen_Feedback();
-		new Set_Up_Additional_Payment_Types();
-		new Test_Checkout();
-		new Selling_Online_Courses();
+		new WooSubscriptionsNotes();
+		new HistoricalData();
+		new OrderMilestones();
+		new TrackingOptIn();
+		new WooCommercePayments();
+		new InstallJPAndWCSPlugins();
+		new DrawAttention();
+		new HomeScreenFeedback();
+		new SetUpAdditionalPaymentTypes();
+		new TestCheckout();
+		new SellingOnlineCourses();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Features/Coupons.php
+++ b/src/Features/Coupons.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Loader;
-use Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved;
+use Automattic\WooCommerce\Admin\Notes\CouponPageMoved;
 use Automattic\WooCommerce\Admin\PageController;
 
 /**
@@ -53,7 +53,7 @@ class Coupons {
 			return;
 		}
 
-		( new Coupon_Page_Moved() )->init();
+		( new CouponPageMoved() )->init();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_add_marketing_coupon_script' ) );
 		add_action( 'woocommerce_register_post_type_shop_coupon', array( $this, 'move_coupons' ) );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -7,7 +7,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
-use \Automattic\WooCommerce\Admin\Notes\Onboarding_Profiler;
+use \Automattic\WooCommerce\Admin\Notes\OnboardingProfiler;
 use \Automattic\WooCommerce\Admin\PluginsHelper;
 use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
 use \Automattic\WooCommerce\Admin\Features\OnboardingAutomateTaxes;
@@ -64,7 +64,7 @@ class Onboarding {
 		}
 
 		// Add onboarding notes.
-		new Onboarding_Profiler();
+		new OnboardingProfiler();
 
 		// Add actions and filters.
 		$this->add_actions();

--- a/src/Features/OnboardingAutomateTaxes.php
+++ b/src/Features/OnboardingAutomateTaxes.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
-use Automattic\WooCommerce\Admin\Notes\Confirm_Tax_Settings;
+use Automattic\WooCommerce\Admin\Notes\ConfirmTaxSettings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -60,7 +60,7 @@ class OnboardingAutomateTaxes {
 			update_option( 'wc_connect_taxes_enabled', 'yes' );
 			update_option( 'woocommerce_calc_taxes', 'yes' );
 			self::track_tax_automation();
-			Confirm_Tax_Settings::possibly_add_note();
+			ConfirmTaxSettings::possibly_add_note();
 		}
 	}
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -8,7 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\PluginsHelper;
-use \Automattic\WooCommerce\Admin\Notes\Review_Shipping_Settings;
+use \Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -73,7 +73,7 @@ class OnboardingSetUpShipping {
 		}
 
 		self::set_up_free_local_shipping();
-		Review_Shipping_Settings::possibly_add_note();
+		ReviewShippingSettings::possibly_add_note();
 		wc_admin_record_tracks_event( 'shipping_automatically_set_up' );
 	}
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-use \Automattic\WooCommerce\Admin\Notes\Historical_Data;
+use \Automattic\WooCommerce\Admin\Notes\HistoricalData;
 
 /**
  * Install Class.
@@ -493,7 +493,7 @@ class Install {
 	 * Create notes.
 	 */
 	protected static function create_notes() {
-		Historical_Data::possibly_add_note();
+		HistoricalData::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/ChooseNiche.php
+++ b/src/Notes/ChooseNiche.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Choose_Niche.
  */
-class Choose_Niche {
+class ChooseNiche {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * ConfirmTaxSettings.
  */
-class Confirm_Tax_Settings {
+class ConfirmTaxSettings {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Coupon_Page_Moved class.
  */
-class Coupon_Page_Moved {
+class CouponPageMoved {
 
 	use NoteTraits, CouponsMovedTrait;
 

--- a/src/Notes/CustomizeStoreWithBlocks.php
+++ b/src/Notes/CustomizeStoreWithBlocks.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Customize_Store_With_Blocks.
  */
-class Customize_Store_With_Blocks {
+class CustomizeStoreWithBlocks {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/DeactivatePlugin.php
+++ b/src/Notes/DeactivatePlugin.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Deactivate_Plugin.
  */
-class Deactivate_Plugin {
+class DeactivatePlugin {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/DeprecatedNotes.php
+++ b/src/Notes/DeprecatedNotes.php
@@ -86,7 +86,7 @@ class WC_Admin_Notes_Choose_Niche extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Choose_Niche';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\ChooseNiche';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -107,7 +107,7 @@ class WC_Admin_Notes_Coupon_Page_Moved extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Coupon_Page_Moved';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\CouponPageMoved';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -128,7 +128,7 @@ class WC_Admin_Notes_Customize_Store_With_Blocks extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Customize_Store_With_Blocks';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\CustomizeStoreWithBlocks';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -149,7 +149,7 @@ class WC_Admin_Notes_Deactivate_Plugin extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\DeactivatePlugin';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -170,7 +170,7 @@ class WC_Admin_Notes_Draw_Attention extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Draw_Attention';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\DrawAttention';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -191,7 +191,7 @@ class WC_Admin_Notes_Edit_Products_On_The_Move extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Edit_Products_On_The_Move';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -212,7 +212,7 @@ class WC_Admin_Notes_EU_VAT_Number extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EU_VAT_Number';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\EUVATNumber';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -233,7 +233,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Facebook_Marketing_Expert';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\FacebookMarketingExpert';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -254,7 +254,7 @@ class WC_Admin_Notes_First_Product extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\First_Product';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\FirstProduct';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -275,7 +275,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Giving_Feedback_Notes';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -296,7 +296,7 @@ class WC_Admin_Notes_Historical_Data extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Historical_Data';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\HistoricalData';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -317,7 +317,7 @@ class WC_Admin_Notes_Home_Screen_Feedback extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Home_Screen_Feedback';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\HomeScreenFeedback';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -338,7 +338,7 @@ class WC_Admin_Notes_Insight_First_Sale extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Insight_First_Sale';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\InsightFirstSale';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -359,7 +359,7 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Install_JP_And_WCS_Plugins';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -380,7 +380,7 @@ class WC_Admin_Notes_Launch_Checklist extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Launch_Checklist';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\LaunchChecklist';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -422,7 +422,7 @@ class WC_Admin_Notes_Migrate_From_Shopify extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Migrate_From_Shopify';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\MigrateFromShopify';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -443,7 +443,7 @@ class WC_Admin_Notes_Mobile_App extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Mobile_App';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\MobileApp';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -464,7 +464,7 @@ class WC_Admin_Notes_Need_Some_Inspiration extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Need_Some_Inspiration';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\NeedSomeInspiration';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -485,7 +485,7 @@ class WC_Admin_Notes_New_Sales_Record extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\New_Sales_Record';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\NewSalesRecord';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -506,7 +506,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Email_Marketing';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingEmailMarketing';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -527,7 +527,7 @@ class WC_Admin_Notes_Onboarding_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Payments';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingPayments';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -548,7 +548,7 @@ class WC_Admin_Notes_Onboarding_Profiler extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Onboarding_Profiler';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnboardingProfiler';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -569,7 +569,7 @@ class WC_Admin_Notes_Online_Clothing_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Online_Clothing_Store';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OnlineClothingStore';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -590,7 +590,7 @@ class WC_Admin_Notes_Order_Milestones extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Order_Milestones';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\OrderMilestones';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -611,7 +611,7 @@ class WC_Admin_Notes_Performance_On_Mobile extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Performance_On_Mobile';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -632,7 +632,7 @@ class WC_Admin_Notes_Personalize_Store extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Personalize_Store';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\PersonalizeStore';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -653,7 +653,7 @@ class WC_Admin_Notes_Real_Time_Order_Alerts extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Real_Time_Order_Alerts';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\RealTimeOrderAlerts';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -674,7 +674,7 @@ class WC_Admin_Notes_Review_Shipping_Settings extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Review_Shipping_Settings';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -695,7 +695,7 @@ class WC_Admin_Notes_Selling_Online_Courses extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Selling_Online_Courses';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -716,7 +716,7 @@ class WC_Admin_Notes_Set_Up_Additional_Payment_Types extends DeprecatedClassFaca
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Set_Up_Additional_Payment_Types';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -737,7 +737,7 @@ class WC_Admin_Notes_Start_Dropshipping_Business extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Start_Dropshipping_Business';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\StartDropshippingBusiness';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -758,7 +758,7 @@ class WC_Admin_Notes_Test_Checkout extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Test_Checkout';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\TestCheckout';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -779,7 +779,7 @@ class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Tracking_Opt_In';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\TrackingOptIn';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -792,7 +792,7 @@ class WC_Admin_Notes_Tracking_Opt_In extends DeprecatedClassFacade {
 /**
  * WC_Admin_Notes_Woo_Subscriptions_Notes.
  *
- * @deprecated since 1.6.0, use Woo_Subscriptions_Notes
+ * @deprecated since 1.6.0, use WooSubscriptionsNotes
  */
 class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	/**
@@ -800,7 +800,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\Woo_Subscriptions_Notes';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -821,7 +821,7 @@ class WC_Admin_Notes_WooCommerce_Payments extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommercePayments';
 
 	/**
 	 * The version that this class was deprecated in.
@@ -842,7 +842,7 @@ class WC_Admin_Notes_WooCommerce_Subscriptions extends DeprecatedClassFacade {
 	 *
 	 * @var string
 	 */
-	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerce_Subscriptions';
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Admin\Notes\WooCommerceSubscriptions';
 
 	/**
 	 * The version that this class was deprecated in.

--- a/src/Notes/DrawAttention.php
+++ b/src/Notes/DrawAttention.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Draw_Attention
  */
-class Draw_Attention {
+class DrawAttention {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/EUVATNumber.php
+++ b/src/Notes/EUVATNumber.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * EU_VAT_Number
  */
-class EU_VAT_Number {
+class EUVATNumber {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/EditProductsOnTheMove.php
+++ b/src/Notes/EditProductsOnTheMove.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Edit_Products_On_The_Move
  */
-class Edit_Products_On_The_Move {
+class EditProductsOnTheMove {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/FirstProduct.php
+++ b/src/Notes/FirstProduct.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * First_Product.
  */
-class First_Product {
+class FirstProduct {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/GivingFeedbackNotes.php
+++ b/src/Notes/GivingFeedbackNotes.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Giving_Feedback_Notes
  */
-class Giving_Feedback_Notes {
+class GivingFeedbackNotes {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/GoogleAdsAndMarketing.php
+++ b/src/Notes/GoogleAdsAndMarketing.php
@@ -16,7 +16,7 @@ use \Automattic\WooCommerce\Admin\PluginsHelper;
 /**
  * WC_Admin_Notes_Google_Ads_And_Marketing
  */
-class Google_Ads_And_Marketing {
+class GoogleAdsAndMarketing {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/HistoricalData.php
+++ b/src/Notes/HistoricalData.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Install;
 /**
  * Historical_Data.
  */
-class Historical_Data {
+class HistoricalData {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/HomeScreenFeedback.php
+++ b/src/Notes/HomeScreenFeedback.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Home_Screen_Feedback.
  */
-class Home_Screen_Feedback {
+class HomeScreenFeedback {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/InsightFirstSale.php
+++ b/src/Notes/InsightFirstSale.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Insight_First_Sale.
  */
-class Insight_First_Sale {
+class InsightFirstSale {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/InstallJPAndWCSPlugins.php
+++ b/src/Notes/InstallJPAndWCSPlugins.php
@@ -16,7 +16,7 @@ use \Automattic\WooCommerce\Admin\PluginsHelper;
 /**
  * Install_JP_And_WCS_Plugins
  */
-class Install_JP_And_WCS_Plugins {
+class InstallJPAndWCSPlugins {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/LaunchChecklist.php
+++ b/src/Notes/LaunchChecklist.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Launch_Checklist
  */
-class Launch_Checklist {
+class LaunchChecklist {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ManageOrdersOnTheGo.php
+++ b/src/Notes/ManageOrdersOnTheGo.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Manage_Orders_On_The_Go
  */
-class Manage_Orders_On_The_Go {
+class ManageOrdersOnTheGo {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/MigrateFromShopify.php
+++ b/src/Notes/MigrateFromShopify.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Migrate_From_Shopify.
  */
-class Migrate_From_Shopify {
+class MigrateFromShopify {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/MobileApp.php
+++ b/src/Notes/MobileApp.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Mobile_App
  */
-class Mobile_App {
+class MobileApp {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/NeedSomeInspiration.php
+++ b/src/Notes/NeedSomeInspiration.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Need_Some_Inspiration.
  */
-class Need_Some_Inspiration {
+class NeedSomeInspiration {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/NewSalesRecord.php
+++ b/src/Notes/NewSalesRecord.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * New_Sales_Record
  */
-class New_Sales_Record {
+class NewSalesRecord {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingEmailMarketing.php
+++ b/src/Notes/OnboardingEmailMarketing.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Onboarding_Email_Marketing
  */
-class Onboarding_Email_Marketing {
+class OnboardingEmailMarketing {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingPayments.php
+++ b/src/Notes/OnboardingPayments.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Onboarding_Payments.
  */
-class Onboarding_Payments {
+class OnboardingPayments {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnboardingProfiler.php
+++ b/src/Notes/OnboardingProfiler.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * Onboarding_Profiler.
  */
-class Onboarding_Profiler {
+class OnboardingProfiler {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OnlineClothingStore.php
+++ b/src/Notes/OnlineClothingStore.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Online_Clothing_Store.
  */
-class Online_Clothing_Store {
+class OnlineClothingStore {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/OrderMilestones.php
+++ b/src/Notes/OrderMilestones.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Order_Milestones
  */
-class Order_Milestones {
+class OrderMilestones {
 	/**
 	 * Name of the "other milestones" note.
 	 */

--- a/src/Notes/PerformanceOnMobile.php
+++ b/src/Notes/PerformanceOnMobile.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Performance_On_Mobile
  */
-class Performance_On_Mobile {
+class PerformanceOnMobile {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/PersonalizeStore.php
+++ b/src/Notes/PersonalizeStore.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Personalize_Store
  */
-class Personalize_Store {
+class PersonalizeStore {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/RealTimeOrderAlerts.php
+++ b/src/Notes/RealTimeOrderAlerts.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Real_Time_Order_Alerts
  */
-class Real_Time_Order_Alerts {
+class RealTimeOrderAlerts {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/ReviewShippingSettings.php
+++ b/src/Notes/ReviewShippingSettings.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Review_Shipping_Settings
  */
-class Review_Shipping_Settings {
+class ReviewShippingSettings {
 	use NoteTraits;
 
 	const NOTE_NAME = 'wc-admin-review-shipping-settings';

--- a/src/Notes/SellingOnlineCourses.php
+++ b/src/Notes/SellingOnlineCourses.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * Selling_Online_Courses
  */
-class Selling_Online_Courses {
+class SellingOnlineCourses {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/SetUpAdditionalPaymentTypes.php
+++ b/src/Notes/SetUpAdditionalPaymentTypes.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Set_Up_Additional_Payment_Types
  */
-class Set_Up_Additional_Payment_Types {
+class SetUpAdditionalPaymentTypes {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/StartDropshippingBusiness.php
+++ b/src/Notes/StartDropshippingBusiness.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Start_Dropshipping_Business.
  */
-class Start_Dropshipping_Business {
+class StartDropshippingBusiness {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/TestCheckout.php
+++ b/src/Notes/TestCheckout.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Test_Checkout
  */
-class Test_Checkout {
+class TestCheckout {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/TrackingOptIn.php
+++ b/src/Notes/TrackingOptIn.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Tracking_Opt_In
  */
-class Tracking_Opt_In {
+class TrackingOptIn {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WooCommerce_Payments
  */
-class WooCommerce_Payments {
+class WooCommercePayments {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooCommerceSubscriptions.php
+++ b/src/Notes/WooCommerceSubscriptions.php
@@ -14,7 +14,7 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 /**
  * WooCommerce_Subscriptions.
  */
-class WooCommerce_Subscriptions {
+class WooCommerceSubscriptions {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/WooSubscriptionsNotes.php
+++ b/src/Notes/WooSubscriptionsNotes.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Woo_Subscriptions_Notes
  */
-class Woo_Subscriptions_Notes {
+class WooSubscriptionsNotes {
 	const LAST_REFRESH_OPTION_KEY = 'woocommerce_admin-wc-helper-last-refresh';
 	const CONNECTION_NOTE_NAME    = 'wc-admin-wc-helper-connection';
 	const SUBSCRIPTION_NOTE_NAME  = 'wc-admin-wc-helper-subscription';

--- a/src/Package.php
+++ b/src/Package.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\Admin\Composer;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Notes\Deactivate_Plugin;
+use Automattic\WooCommerce\Admin\Notes\DeactivatePlugin;
 use Automattic\WooCommerce\Admin\FeaturePlugin;
 
 /**
@@ -49,7 +49,7 @@ class Package {
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
-			$update_version       = new Deactivate_Plugin();
+			$update_version       = new DeactivatePlugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
 				if ( method_exists( $update_version, 'possibly_add_note' ) ) {
 					$update_version::possibly_add_note();
@@ -123,7 +123,7 @@ class Package {
 	 * Add deactivation hook for versions of the plugin that don't have the deactivation note.
 	 */
 	public static function on_deactivation() {
-		$update_version = new Deactivate_Plugin();
+		$update_version = new DeactivatePlugin();
 		$update_version::delete_note();
 	}
 }

--- a/tests/notes/class-wc-tests-marketing-notes.php
+++ b/tests/notes/class-wc-tests-marketing-notes.php
@@ -7,7 +7,7 @@
 
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\Note;
-use \Automattic\WooCommerce\Admin\Notes\WooCommerce_Payments;
+use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
 
 /**
  * Class WC_Tests_Marketing_Notes
@@ -61,7 +61,7 @@ class WC_Tests_Marketing_Notes extends WC_Unit_Test_Case {
 		// Set user preferences to disallow marketing suggestions.
 		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
 
-		WooCommerce_Payments::possibly_add_note();
+		WooCommercePayments::possibly_add_note();
 
 		// Load all marketing notes and check that the note was not added.
 		$data_store = \WC_Data_Store::load( 'admin-note' );


### PR DESCRIPTION
Fixes PHP Fatal errors due to missing classes when updating to the `2.4.x` Jetpack autoloader.

Version `2.4.0` strictly enforces PSR-4 conformity, which our classes were failing. This PR seeks to update the class names so that they properly implement PSR-4, specifically that the class name matches the file name.

### Detailed test instructions:

- `rm -rf vendor && composer install`
- Check that app works (no PHP Fatals missing classes, etc)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
