### PR TITLE
Added Accordion component

### DIFF
--- a/packages/components/src/accordion/README.md
+++ b/packages/components/src/accordion/README.md
@@ -1,0 +1,44 @@
+# Accordion
+
+A component designed for use in the `Home` screen. It returns an accordion with the panels it receives.
+
+## Usage
+
+```jsx
+const panels = [
+	{
+		className: 'class-name',
+		count: 15,
+		initialOpen: true,
+		panel: <div>Panel 1 content</div>,
+		title: 'Panel 1',
+	},
+	{
+		className: 'class-name',
+		count: 20,
+		initialOpen: false,
+		panel: <div>Panel 2 content</div>,
+		title: 'Panel 2',
+	},
+	];
+
+}
+
+<div>
+	<Accordion panels={ panels }/>
+</div>
+```
+
+### Props
+
+| Name     | Type  | Default | Description                                    |
+| -------- | ----- | ------- | ---------------------------------------------- |
+| `panels` | Array | `null`  | A list of objects with data to set the panels. |
+
+Each object in the `panels` array has the following structure:
+
+-   `className` | String | `null` | Additional CSS classes
+-   `count`: Number - Number of unread elements in the panel that will be shown next to the panel's title.
+-   `initialOpen`: Boolean - Whether or not the panel will start open. Default: true.
+-   `panel`: ReactNode - Content displayed in the panel.
+-   `title`: String - The panel title.

--- a/packages/components/src/accordion/README.md
+++ b/packages/components/src/accordion/README.md
@@ -1,44 +1,59 @@
 # Accordion
 
-A component designed for use in the `Home` screen. It returns an accordion with the panels it receives.
+This is an accordion that renders the children inside. It will toggle the panel's content when the title is clicked.
 
 ## Usage
 
 ```jsx
-const panels = [
-	{
-		className: 'class-name',
-		count: 15,
-		initialOpen: true,
-		panel: <div>Panel 1 content</div>,
-		title: 'Panel 1',
-	},
-	{
-		className: 'class-name',
-		count: 20,
-		initialOpen: false,
-		panel: <div>Panel 2 content</div>,
-		title: 'Panel 2',
-	},
-	];
-
-}
-
-<div>
-	<Accordion panels={ panels }/>
-</div>
+<Accordion>
+	<AccordionPanel
+		className="class-name"
+		count={ 15 }
+		title="Panel 1"
+		initialOpen={ true }
+	>
+		<span>Panel 1 content</span>
+	</AccordionPanel>
+	<AccordionPanel
+		className="class-name"
+		count={ 20 }
+		title="Panel 2"
+		initialOpen={ false }
+	>
+		<span>Panel 2 content</span>
+	</AccordionPanel>
+</Accordion>
 ```
 
 ### Props
 
-| Name     | Type  | Default | Description                                    |
-| -------- | ----- | ------- | ---------------------------------------------- |
-| `panels` | Array | `null`  | A list of objects with data to set the panels. |
+| Name        | Type   | Default | Description             |
+| ----------- | ------ | ------- | ----------------------- |
+| `className` | String | `null`  | Additional CSS classes. |
 
-Each object in the `panels` array has the following structure:
+# AccordionPanel
 
--   `className` | String | `null` | Additional CSS classes
--   `count`: Number - Number of unread elements in the panel that will be shown next to the panel's title.
--   `initialOpen`: Boolean - Whether or not the panel will start open. Default: true.
--   `panel`: ReactNode - Content displayed in the panel.
--   `title`: String - The panel title.
+A component designed for use inside of the `Accordion` component.
+`AccordionPanel` is used to give the panel content an accessible wrapper.
+
+## Usage
+
+```jsx
+<AccordionPanel
+	className="class-name"
+	count={ 15 }
+	title="Panel 1"
+	initialOpen={ true }
+>
+	<span>Panel 1 content</span>
+</AccordionPanel>
+```
+
+### Props
+
+| Name          | Type    | Default | Description                                                                          |
+| ------------- | ------- | ------- | ------------------------------------------------------------------------------------ |
+| `className`   | Array   | `null`  | A list of objects with data to set the panels.                                       |
+| `count`       | Number  | `null`  | Number of unread elements in the panel that will be shown next to the panel's title. |
+| `initialOpen` | Boolean | `true`  | Whether or not the panel will start open.                                            |
+| `title`       | String  | `null`  | The panel title.                                                                     |

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -10,29 +10,21 @@ import PropTypes from 'prop-types';
 import './style.scss';
 import AccordionPanel from './panel';
 
-const Accordion = ( { panels } ) => {
+const Accordion = ( { className, children } ) => {
 	return (
 		<Panel>
-			{ panels.map( ( panelData, index ) => (
-				<AccordionPanel key={ index } { ...panelData } />
-			) ) }
+			<AccordionPanel className={ className }>
+				{ children }
+			</AccordionPanel>
 		</Panel>
 	);
 };
 
-Accordion.propTypes = {
+AccordionPanel.propTypes = {
 	/**
-	 * A list of objects with information to set the panels.
+	 * Additional CSS classes.
 	 */
-	panels: PropTypes.arrayOf(
-		PropTypes.shape( {
-			className: PropTypes.string,
-			count: PropTypes.number,
-			title: PropTypes.string,
-			initialOpen: PropTypes.bool,
-			panel: PropTypes.node.isRequired,
-		} )
-	).isRequired,
+	className: PropTypes.string,
 };
 
 export default Accordion;

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -7,9 +7,15 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import AccordionPanel from './panel';
 
+/**
+ * Use `Accordion` to display an accordion that renders the children inside.
+ *
+ * @param {Object} props
+ * @param {string} props.className
+ * @return {Object} -
+ */
 const Accordion = ( { className, children } ) => {
 	return (
 		<Panel>
@@ -20,7 +26,7 @@ const Accordion = ( { className, children } ) => {
 	);
 };
 
-AccordionPanel.propTypes = {
+Accordion.propTypes = {
 	/**
 	 * Additional CSS classes.
 	 */

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -5,25 +5,15 @@ import { Panel } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
- * Internal dependencies
- */
-import AccordionPanel from './panel';
-
-/**
  * Use `Accordion` to display an accordion that renders the children inside.
  *
  * @param {Object} props
+ * @param {string} props.children
  * @param {string} props.className
  * @return {Object} -
  */
 const Accordion = ( { className, children } ) => {
-	return (
-		<Panel>
-			<AccordionPanel className={ className }>
-				{ children }
-			</AccordionPanel>
-		</Panel>
-	);
+	return <Panel className={ className }>{ children }</Panel>;
 };
 
 Accordion.propTypes = {

--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { Panel } from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import AccordionPanel from './panel';
+
+const Accordion = ( { panels } ) => {
+	return (
+		<Panel>
+			{ panels.map( ( panelData, index ) => (
+				<AccordionPanel key={ index } { ...panelData } />
+			) ) }
+		</Panel>
+	);
+};
+
+Accordion.propTypes = {
+	/**
+	 * A list of objects with information to set the panels.
+	 */
+	panels: PropTypes.arrayOf(
+		PropTypes.shape( {
+			className: PropTypes.string,
+			count: PropTypes.number,
+			title: PropTypes.string,
+			initialOpen: PropTypes.bool,
+			panel: PropTypes.node.isRequired,
+		} )
+	).isRequired,
+};
+
+export default Accordion;

--- a/packages/components/src/accordion/panel.js
+++ b/packages/components/src/accordion/panel.js
@@ -6,6 +6,16 @@ import { more } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+/**
+ * `AccordionPanel` is used to give the panel content an accessible wrapper.
+ *
+ * @param {Object} props
+ * @param {string} props.className
+ * @param {string} props.count
+ * @param {string} props.title
+ * @param {string} props.initialOpen
+ * @return {Object} -
+ */
 const AccordionPanel = ( {
 	className,
 	count,
@@ -60,6 +70,10 @@ AccordionPanel.propTypes = {
 	 * Whether or not the panel will start open.
 	 */
 	initialOpen: PropTypes.bool,
+};
+
+AccordionPanel.defaultProps = {
+	initialOpen: true,
 };
 
 export default AccordionPanel;

--- a/packages/components/src/accordion/panel.js
+++ b/packages/components/src/accordion/panel.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Card, PanelBody, PanelRow } from '@wordpress/components';
-import { more } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -12,6 +11,7 @@ import classnames from 'classnames';
  * @param {Object} props
  * @param {string} props.className
  * @param {string} props.count
+ * @param {string} props.children
  * @param {string} props.title
  * @param {string} props.initialOpen
  * @return {Object} -
@@ -44,7 +44,6 @@ const AccordionPanel = ( {
 		>
 			<PanelBody
 				title={ getTitleAndCount( title, count ) }
-				icon={ more }
 				initialOpen={ initialOpen }
 			>
 				<PanelRow> { children } </PanelRow>

--- a/packages/components/src/accordion/panel.js
+++ b/packages/components/src/accordion/panel.js
@@ -6,7 +6,13 @@ import { more } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const AccordionPanel = ( { className, count, title, initialOpen, panel } ) => {
+const AccordionPanel = ( {
+	className,
+	count,
+	title,
+	initialOpen,
+	children,
+} ) => {
 	const getTitleAndCount = ( titleText, countUnread ) => {
 		return (
 			<span className="woocommerce-accordion-header">
@@ -31,13 +37,17 @@ const AccordionPanel = ( { className, count, title, initialOpen, panel } ) => {
 				icon={ more }
 				initialOpen={ initialOpen }
 			>
-				<PanelRow> { panel } </PanelRow>
+				<PanelRow> { children } </PanelRow>
 			</PanelBody>
 		</Card>
 	);
 };
 
 AccordionPanel.propTypes = {
+	/**
+	 * Additional CSS classes.
+	 */
+	className: PropTypes.string,
 	/**
 	 * Number of unread elements in the panel that will be shown next to the panel's title.
 	 */
@@ -50,10 +60,6 @@ AccordionPanel.propTypes = {
 	 * Whether or not the panel will start open.
 	 */
 	initialOpen: PropTypes.bool,
-	/**
-	 * Content displayed in the panel.
-	 */
-	panel: PropTypes.node.isRequired,
 };
 
 export default AccordionPanel;

--- a/packages/components/src/accordion/panel/index.js
+++ b/packages/components/src/accordion/panel/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { Card, PanelBody, PanelRow } from '@wordpress/components';
+import { more } from '@wordpress/icons';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const AccordionPanel = ( { className, count, title, initialOpen, panel } ) => {
+	const getTitleAndCount = ( titleText, countUnread ) => {
+		return (
+			<span className="woocommerce-accordion-header">
+				<span className="woocommerce-accordion-title">
+					{ titleText }
+				</span>
+				{ countUnread !== null && (
+					<span className="woocommerce-accordion-badge">
+						{ countUnread }
+					</span>
+				) }
+			</span>
+		);
+	};
+	return (
+		<Card
+			size="large"
+			className={ classnames( className, 'woocommerce-accordion-card' ) }
+		>
+			<PanelBody
+				title={ getTitleAndCount( title, count ) }
+				icon={ more }
+				initialOpen={ initialOpen }
+			>
+				<PanelRow> { panel } </PanelRow>
+			</PanelBody>
+		</Card>
+	);
+};
+
+AccordionPanel.propTypes = {
+	/**
+	 * Number of unread elements in the panel that will be shown next to the panel's title.
+	 */
+	count: PropTypes.number,
+	/**
+	 * The panel title.
+	 */
+	title: PropTypes.string,
+	/**
+	 * Whether or not the panel will start open.
+	 */
+	initialOpen: PropTypes.bool,
+	/**
+	 * Content displayed in the panel.
+	 */
+	panel: PropTypes.node.isRequired,
+};
+
+export default AccordionPanel;

--- a/packages/components/src/accordion/stories/index.js
+++ b/packages/components/src/accordion/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { Accordion, AccordionPanel } from '@woocommerce/components';
+
+export const Basic = () => (
+	<Accordion>
+		<AccordionPanel
+			className="class-name"
+			count={ 15 }
+			title="Panel 1"
+			initialOpen={ true }
+		>
+			<span>Panel 1 content</span>
+		</AccordionPanel>
+		<AccordionPanel
+			className="class-name"
+			count={ 20 }
+			title="Panel 2"
+			initialOpen={ false }
+		>
+			<span>Panel 2 content</span>
+		</AccordionPanel>
+	</Accordion>
+);
+
+export default {
+	title: 'WooCommerce Admin/components/Accordion',
+	component: Accordion,
+};

--- a/packages/components/src/accordion/style.scss
+++ b/packages/components/src/accordion/style.scss
@@ -1,0 +1,16 @@
+.woocommerce-accordion-card {
+	.woocommerce-accordion-badge {
+		background-color: $gray-100;
+		border-radius: 20px;
+		display: inline-block;
+		text-align: center;
+		font-style: normal;
+		font-weight: 600;
+		font-size: 14px;
+		line-height: 27px;
+		align-items: center;
+		width: 32px;
+		height: 28px;
+		margin-left: $gap;
+	}
+}

--- a/packages/components/src/accordion/test/index.js
+++ b/packages/components/src/accordion/test/index.js
@@ -7,33 +7,38 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import Accordion from '../';
+import AccordionPanel from '../panel';
 
-const panels = [
-	{
-		className: 'panel-1',
-		count: 10000,
-		title: 'panel-1',
-		initialOpen: true,
-		panel: <span>Custom panel 1</span>,
-	},
-	{
-		className: 'panel-2',
-		count: 20000,
-		title: 'panel-2',
-		initialOpen: false,
-		panel: <span>Custom panel 2</span>,
-	},
-];
+const panels = (
+	<>
+		<AccordionPanel
+			className="panel-1"
+			count={ 10000 }
+			title="panel-1"
+			initialOpen={ true }
+		>
+			<span>Custom panel 1</span>
+		</AccordionPanel>
+		<AccordionPanel
+			className="panel-2"
+			count={ 20000 }
+			title="panel-2"
+			initialOpen={ false }
+		>
+			<span>Custom panel 1</span>
+		</AccordionPanel>
+	</>
+);
 
 describe( 'Accordion', () => {
 	it( 'should render a panel with two rows', () => {
-		render( <Accordion panels={ panels } /> );
+		render( <Accordion> { panels } </Accordion> );
 		expect( screen.getByText( 'panel-1' ) ).not.toBeNull();
 		expect( screen.getByText( 'panel-2' ) ).not.toBeNull();
 	} );
 
 	it( 'should render one visible panel and one hidden panel', () => {
-		render( <Accordion panels={ panels } /> );
+		render( <Accordion> { panels } </Accordion> );
 		expect( screen.queryByText( 'Custom panel 1' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByText( 'Custom panel 2' )
@@ -41,7 +46,7 @@ describe( 'Accordion', () => {
 	} );
 
 	it( 'should render the count of unread items', () => {
-		render( <Accordion panels={ panels } /> );
+		render( <Accordion> { panels } </Accordion> );
 		expect( screen.queryByText( '10000' ) ).toBeInTheDocument();
 		expect( screen.queryByText( '20000' ) ).toBeInTheDocument();
 	} );

--- a/packages/components/src/accordion/test/index.js
+++ b/packages/components/src/accordion/test/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Accordion from '../';
+
+const panels = [
+	{
+		className: 'panel-1',
+		count: 10000,
+		title: 'panel-1',
+		initialOpen: true,
+		panel: <span>Custom panel 1</span>,
+	},
+	{
+		className: 'panel-2',
+		count: 20000,
+		title: 'panel-2',
+		initialOpen: false,
+		panel: <span>Custom panel 2</span>,
+	},
+];
+
+describe( 'Accordion', () => {
+	it( 'should render a panel with two rows', () => {
+		render( <Accordion panels={ panels } /> );
+		expect( screen.getByText( 'panel-1' ) ).not.toBeNull();
+		expect( screen.getByText( 'panel-2' ) ).not.toBeNull();
+	} );
+
+	it( 'should render one visible panel and one hidden panel', () => {
+		render( <Accordion panels={ panels } /> );
+		expect( screen.queryByText( 'Custom panel 1' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Custom panel 2' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the count of unread items', () => {
+		render( <Accordion panels={ panels } /> );
+		expect( screen.queryByText( '10000' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '20000' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -4,6 +4,8 @@
 import 'react-dates/initialize';
 // The above: Turn on react-dates classes/styles, see https://github.com/airbnb/react-dates#initialize
 
+export { default as Accordion } from './accordion';
+export { default as AccordionPanel } from './accordion/panel';
 export { default as AdvancedFilters } from './advanced-filters';
 export { default as AnimationSlider } from './animation-slider';
 export { default as Chart } from './chart';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -1,6 +1,7 @@
 /**
  * Internal Dependencies
  */
+@import 'accordion/style.scss';
 @import 'animation-slider/style.scss';
 @import 'calendar/style.scss';
 @import 'card/style.scss';


### PR DESCRIPTION
Partially fixes [5238](https://github.com/woocommerce/woocommerce-admin/issues/5238)

This PR adds an Accordion component to our available components.

### Screenshots
![Screen Capture on 2020-10-22 at 10-43-10](https://user-images.githubusercontent.com/1314156/96880354-756f4680-1453-11eb-99c5-4968a755151f.gif)

### Detailed test instructions:

- The easiest way to test this PR is to checkout the branch: `add/5238` and follow the instructions described [in this PR](https://github.com/woocommerce/woocommerce-admin/pull/5455)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Added Accordion component
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
