### PR TITLE
Add navigation feedback notes

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -38,7 +38,8 @@ use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
 use \Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove;
 use \Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile;
 use \Automattic\WooCommerce\Admin\Notes\ManageOrdersOnTheGo;
-
+use \Automattic\WooCommerce\Admin\Notes\Navigation_Feedback;
+use \Automattic\WooCommerce\Admin\Notes\Navigation_Feedback_Follow_Up;
 /**
  * Events Class.
  */
@@ -109,6 +110,8 @@ class Events {
 		EditProductsOnTheMove::possibly_add_note();
 		PerformanceOnMobile::possibly_add_note();
 		ManageOrdersOnTheGo::possibly_add_note();
+		Navigation_Feedback::possibly_add_note();
+		Navigation_Feedback_Follow_Up::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Events.php
+++ b/src/Events.php
@@ -38,8 +38,9 @@ use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
 use \Automattic\WooCommerce\Admin\Notes\EditProductsOnTheMove;
 use \Automattic\WooCommerce\Admin\Notes\PerformanceOnMobile;
 use \Automattic\WooCommerce\Admin\Notes\ManageOrdersOnTheGo;
-use \Automattic\WooCommerce\Admin\Notes\Navigation_Feedback;
-use \Automattic\WooCommerce\Admin\Notes\Navigation_Feedback_Follow_Up;
+use \Automattic\WooCommerce\Admin\Notes\NavigationFeedback;
+use \Automattic\WooCommerce\Admin\Notes\NavigationFeedbackFollowUp;
+
 /**
  * Events Class.
  */
@@ -110,8 +111,8 @@ class Events {
 		EditProductsOnTheMove::possibly_add_note();
 		PerformanceOnMobile::possibly_add_note();
 		ManageOrdersOnTheGo::possibly_add_note();
-		Navigation_Feedback::possibly_add_note();
-		Navigation_Feedback_Follow_Up::possibly_add_note();
+		NavigationFeedback::possibly_add_note();
+		NavigationFeedbackFollowUp::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/NavigationFeedback.php
+++ b/src/Notes/NavigationFeedback.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WooCommerce Admin Navigation Feature Feedback
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\Loader;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Navigation_Feedback
+ */
+class Navigation_Feedback {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-navigation-feedback';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		if ( ! Loader::is_feature_enabled( 'navigation' ) ) {
+			return;
+		}
+
+		$content = __( "We're introducing the new navigation for a more intuitive and improved user experience. We'd like to hear your thoughts and first impressions.", 'woocommerce-admin' );
+
+		$note = new Note();
+		$note->set_title( __( 'You now have access to the new WooCommerce navigation', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), 'https://automattic.survey.fm/new-navigation' );
+		return $note;
+	}
+}

--- a/src/Notes/NavigationFeedback.php
+++ b/src/Notes/NavigationFeedback.php
@@ -10,9 +10,9 @@ use Automattic\WooCommerce\Admin\Loader;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Navigation_Feedback
+ * NavigationFeedback
  */
-class Navigation_Feedback {
+class NavigationFeedback {
 	/**
 	 * Note traits.
 	 */

--- a/src/Notes/NavigationFeedbackFollowUp.php
+++ b/src/Notes/NavigationFeedbackFollowUp.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * WooCommerce Admin Navigation Feature Feedback Follow Up.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\Loader;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Navigation_Feedback_Follow_Up
+ */
+class Navigation_Feedback_Follow_Up {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-navigation-feedback-follow-up';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		if ( ! Loader::is_feature_enabled( 'navigation' ) ) {
+			return;
+		}
+
+		// Check that the first note was created.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( 'wc-admin-navigation-feedback' );
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		// Check that first note is at least 5 days old.
+		$note      = Notes::get_note( $note_ids[0] );
+		$timestamp = strtotime( $note->get_date_created() );
+		if ( ( time() - $timestamp ) < DAY_IN_SECONDS * 5 ) {
+			return;
+		}
+
+		$content = __( "We recently introduced the new navigation for a more intuitive and improved user experience. Now that you've had some time to give it a try, let us know how this will impact your store.", 'woocommerce-admin' );
+
+		$note = new Note();
+		$note->set_title( __( 'Share your thoughts on the new WooCommerce navigation', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), 'https://automattic.survey.fm/new-navigation' );
+		return $note;
+	}
+}

--- a/src/Notes/NavigationFeedbackFollowUp.php
+++ b/src/Notes/NavigationFeedbackFollowUp.php
@@ -10,9 +10,9 @@ use Automattic\WooCommerce\Admin\Loader;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Navigation_Feedback_Follow_Up
+ * NavigationFeedbackFollowUp
  */
-class Navigation_Feedback_Follow_Up {
+class NavigationFeedbackFollowUp {
 	/**
 	 * Note traits.
 	 */


### PR DESCRIPTION
Fixes #5334

Adds notes for navigation feedback.

### Screenshots
<img width="539" alt="Screen Shot 2020-10-26 at 5 07 50 PM" src="https://user-images.githubusercontent.com/10561050/97228801-cbbeeb00-17ad-11eb-964e-00ab2fc5ef2e.png">


### Detailed test instructions:

1. With the navigation feature disabled, trigger the `wc_admin_daily` cron event.
1. Make sure no note is created.
1. Enable the navigation feature.
1. Trigger `wc_admin_daily`.
1. Check that the first feedback note is created.
1. After 5 days of creating the first note (or speed things up by changing the first note's date back in time), trigger `wc_admin_daily`.
1. Check that the second feedback note is created.