### PR TITLE
Try: Lock top level items in navigation

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -99,7 +99,7 @@ const Container = ( { menuItems } ) => {
 				{ categories.map( ( category ) => {
 					const [ primaryItems, secondaryItems ] = categorizedItems[
 						category.id
-					];
+					] || [ [], [] ];
 					return (
 						<NavigationMenu
 							key={ category.id }
@@ -110,16 +110,34 @@ const Container = ( { menuItems } ) => {
 						>
 							{ !! primaryItems.length && (
 								<NavigationGroup>
-									{ primaryItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
+									{ primaryItems.map(
+										( item ) =>
+											( ! item.isCategory ||
+												categorizedItems[
+													item.id
+												] ) && (
+												<Item
+													key={ item.id }
+													item={ item }
+												/>
+											)
+									) }
 								</NavigationGroup>
 							) }
 							{ !! secondaryItems.length && (
 								<NavigationGroup>
-									{ secondaryItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
+									{ secondaryItems.map(
+										( item ) =>
+											( ! item.isCategory ||
+												categorizedItems[
+													item.id
+												] ) && (
+												<Item
+													key={ item.id }
+													item={ item }
+												/>
+											)
+									) }
 								</NavigationGroup>
 							) }
 						</NavigationMenu>

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -78,6 +78,24 @@ const Container = ( { menuItems } ) => {
 		[ menuItems ]
 	);
 
+	const renderNavigationGroup = ( items ) => {
+		if ( ! items.length ) {
+			return null;
+		}
+
+		return (
+			<NavigationGroup>
+				{ items.map(
+					( item ) =>
+						( ! item.isCategory ||
+							categorizedItems[ item.id ] ) && (
+							<Item key={ item.id } item={ item } />
+						)
+				) }
+			</NavigationGroup>
+		);
+	};
+
 	return (
 		<div className="woocommerce-navigation">
 			<Header />
@@ -108,38 +126,8 @@ const Container = ( { menuItems } ) => {
 							parentMenu={ category.parent }
 							backButtonLabel={ category.backButtonLabel || null }
 						>
-							{ !! primaryItems.length && (
-								<NavigationGroup>
-									{ primaryItems.map(
-										( item ) =>
-											( ! item.isCategory ||
-												categorizedItems[
-													item.id
-												] ) && (
-												<Item
-													key={ item.id }
-													item={ item }
-												/>
-											)
-									) }
-								</NavigationGroup>
-							) }
-							{ !! secondaryItems.length && (
-								<NavigationGroup>
-									{ secondaryItems.map(
-										( item ) =>
-											( ! item.isCategory ||
-												categorizedItems[
-													item.id
-												] ) && (
-												<Item
-													key={ item.id }
-													item={ item }
-												/>
-											)
-									) }
-								</NavigationGroup>
-							) }
+							{ renderNavigationGroup( primaryItems ) }
+							{ renderNavigationGroup( secondaryItems ) }
 						</NavigationMenu>
 					);
 				} ) }

--- a/docs/page-controller.md
+++ b/docs/page-controller.md
@@ -90,6 +90,7 @@ Register pages with `wc_admin_register_page()` using these parameters:
 
 * `id` - Identifies the page with the controller. Required.
 * `parent` - Denotes the page as a child of `parent`. Used for breadcrumbs. Optional.
+* `category` - Specifies the category the item should fall under in the new WooCommerce Navigation. Optional.
 * `title` - Page title. Used to build breadcrumbs. String or array of breadcrumb pieces. Required.
 * `path` - Page path (relative to `#wc-admin`). Used for identifying this page and for linking breadcrumb pieces when this page is a `parent`. Required.
 * `capability` - User capability needed to access this page. Optional (defaults to `manage_options`).

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -121,6 +121,7 @@ class Analytics {
 			'icon'     => 'dashicons-chart-bar',
 			'position' => 56, // After WooCommerce & Product menu items.
 			'order'    => 10,
+			'category' => false,
 		);
 
 		$report_pages = array(

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -115,14 +115,12 @@ class Analytics {
 		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
 
 		$overview_page = array(
-			'id'           => 'woocommerce-analytics',
-			'title'        => __( 'Analytics', 'woocommerce-admin' ),
-			'path'         => '/analytics/overview',
-			'icon'         => 'dashicons-chart-bar',
-			'position'     => 56, // After WooCommerce & Product menu items.
-			'order'        => 10,
-			'is_category'  => true,
-			'is_top_level' => true,
+			'id'       => 'woocommerce-analytics',
+			'title'    => __( 'Analytics', 'woocommerce-admin' ),
+			'path'     => '/analytics/overview',
+			'icon'     => 'dashicons-chart-bar',
+			'position' => 56, // After WooCommerce & Product menu items.
+			'order'    => 10,
 		);
 
 		$report_pages = array(
@@ -133,6 +131,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/overview',
 				'order'  => 10,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-products',
@@ -140,6 +139,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/products',
 				'order'  => 20,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-revenue',
@@ -147,6 +147,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/revenue',
 				'order'  => 30,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-orders',
@@ -154,6 +155,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/orders',
 				'order'  => 40,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-variations',
@@ -161,6 +163,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/variations',
 				'order'  => 50,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-categories',
@@ -168,6 +171,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/categories',
 				'order'  => 60,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-coupons',
@@ -175,6 +179,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/coupons',
 				'order'  => 70,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-taxes',
@@ -182,6 +187,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/taxes',
 				'order'  => 80,
+				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-downloads',
@@ -189,6 +195,7 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/downloads',
 				'order'  => 90,
+				'parent' => 'analytics',
 			),
 			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
 				'id'     => 'woocommerce-analytics-stock',
@@ -196,14 +203,15 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/stock',
 				'order'  => 100,
+				'parent' => 'analytics',
 			) : null,
 			array(
-				'id'           => 'woocommerce-analytics-customers',
-				'title'        => __( 'Customers', 'woocommerce-admin' ),
-				'parent'       => 'woocommerce',
-				'path'         => '/customers',
-				'is_top_level' => true,
-				'order'        => 50,
+				'id'     => 'woocommerce-analytics-customers',
+				'title'  => __( 'Customers', 'woocommerce-admin' ),
+				'parent' => 'woocommerce',
+				'path'   => '/customers',
+				'order'  => 50,
+				'parent' => $navigation_enabled ? 'customers' : null,
 			),
 			array(
 				'id'     => 'woocommerce-analytics-settings',

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -131,7 +131,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/overview',
 				'order'  => 10,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-products',
@@ -139,7 +138,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/products',
 				'order'  => 20,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-revenue',
@@ -147,7 +145,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/revenue',
 				'order'  => 30,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-orders',
@@ -155,7 +152,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/orders',
 				'order'  => 40,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-variations',
@@ -163,7 +159,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/variations',
 				'order'  => 50,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-categories',
@@ -171,7 +166,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/categories',
 				'order'  => 60,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-coupons',
@@ -179,7 +173,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/coupons',
 				'order'  => 70,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-taxes',
@@ -187,7 +180,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/taxes',
 				'order'  => 80,
-				'parent' => 'analytics',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-downloads',
@@ -195,7 +187,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/downloads',
 				'order'  => 90,
-				'parent' => 'analytics',
 			),
 			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
 				'id'     => 'woocommerce-analytics-stock',
@@ -203,7 +194,6 @@ class Analytics {
 				'parent' => 'woocommerce-analytics',
 				'path'   => '/analytics/stock',
 				'order'  => 100,
-				'parent' => 'analytics',
 			) : null,
 			array(
 				'id'     => 'woocommerce-analytics-customers',
@@ -211,13 +201,13 @@ class Analytics {
 				'parent' => 'woocommerce',
 				'path'   => '/customers',
 				'order'  => 50,
-				'parent' => $navigation_enabled ? 'customers' : null,
 			),
 			array(
-				'id'     => 'woocommerce-analytics-settings',
-				'title'  => $navigation_enabled ? __( 'Analytics', 'woocommerce-admin' ) : __( 'Settings', 'woocommerce-admin' ),
-				'parent' => $navigation_enabled ? 'settings' : 'woocommerce-analytics',
-				'path'   => '/analytics/settings',
+				'id'       => 'woocommerce-analytics-settings',
+				'title'    => $navigation_enabled ? __( 'Analytics', 'woocommerce-admin' ) : __( 'Settings', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'category' => 'settings',
+				'path'     => '/analytics/settings',
 			),
 		);
 
@@ -225,6 +215,9 @@ class Analytics {
 
 		foreach ( $report_pages as $report_page ) {
 			if ( ! is_null( $report_page ) ) {
+				if ( ! isset( $report_page['category'] ) ) {
+					$report_page['category'] = 'analytics';
+				}
 				wc_admin_register_page( $report_page );
 			}
 		}

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -84,12 +84,11 @@ class AnalyticsDashboard {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'           => 'woocommerce-home',
-				'title'        => __( 'Home', 'woocommerce-admin' ),
-				'parent'       => 'woocommerce',
-				'path'         => self::MENU_SLUG,
-				'is_top_level' => true,
-				'order'        => 0,
+				'id'     => 'home',
+				'title'  => __( 'Home', 'woocommerce-admin' ),
+				'parent' => 'woocommerce',
+				'path'   => self::MENU_SLUG,
+				'order'  => 0,
 			)
 		);
 	}

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -84,11 +84,12 @@ class AnalyticsDashboard {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'     => 'home',
-				'title'  => __( 'Home', 'woocommerce-admin' ),
-				'parent' => 'woocommerce',
-				'path'   => self::MENU_SLUG,
-				'order'  => 0,
+				'id'       => 'home',
+				'title'    => __( 'Home', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce',
+				'category' => 'woocommerce',
+				'path'     => self::MENU_SLUG,
+				'order'    => 0,
 			)
 		);
 	}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -129,13 +129,15 @@ class Marketing {
 	protected function register_overview_page() {
 		global $submenu;
 
+		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
+
 		// First register the page.
 		PageController::get_instance()->register_page(
 			[
 				'id'     => 'woocommerce-marketing-overview',
 				'title'  => __( 'Overview', 'woocommerce-admin' ),
 				'path'   => 'wc-admin&path=/marketing',
-				'parent' => 'woocommerce-marketing',
+				'parent' => $navigation_enabled ? 'marketing' : 'woocommerce-marketing',
 			]
 		);
 

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -134,10 +134,11 @@ class Marketing {
 		// First register the page.
 		PageController::get_instance()->register_page(
 			[
-				'id'     => 'woocommerce-marketing-overview',
-				'title'  => __( 'Overview', 'woocommerce-admin' ),
-				'path'   => 'wc-admin&path=/marketing',
-				'parent' => $navigation_enabled ? 'marketing' : 'woocommerce-marketing',
+				'id'       => 'woocommerce-marketing-overview',
+				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'path'     => 'wc-admin&path=/marketing',
+				'parent'   => 'woocommerce-marketing',
+				'category' => 'marketing',
 			]
 		);
 

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -72,37 +72,17 @@ class CoreMenu {
 	 */
 	public function add_core_items() {
 		// Orders category.
-		Screen::register_post_type( 'shop_order', null );
-		Menu::add_post_type_category( 'shop_order', array( 'order' => 20 ) );
+		Screen::register_post_type( 'shop_order', 'orders' );
+		// Menu::add_post_type_category( 'shop_order', array( 'order' => 20 ) );
 
 		// Products category.
-		Screen::register_post_type( 'product', null );
-		Menu::add_post_type_category( 'product', array( 'order' => 40 ) );
+		Screen::register_post_type( 'product', 'products' );
+		// Menu::add_post_type_category( 'product', array( 'order' => 40 ) );
 
 		// Marketing category.
-		Menu::add_category(
-			array(
-				'title'        => __( 'Marketing', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-marketing',
-				'order'        => 30,
-				'is_top_level' => true,
-			)
-		);
-		Screen::register_post_type( 'shop_coupon', 'woocommerce-marketing' );
+		Screen::register_post_type( 'shop_coupon', 'marketing' );
 
 		// Extensions category.
-		Menu::add_category(
-			array(
-				'title'        => __( 'Extensions', 'woocommerce-admin' ),
-				'capability'   => 'activate_plugins',
-				'id'           => 'extensions',
-				'migrate'      => false,
-				'menuId'       => 'secondary',
-				'order'        => 20,
-				'is_top_level' => true,
-			)
-		);
 		Menu::add_item(
 			array(
 				'parent'     => 'extensions',
@@ -123,30 +103,7 @@ class CoreMenu {
 			)
 		);
 
-		// Settings category.
-		Menu::add_category(
-			array(
-				'title'        => __( 'Settings', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'settings',
-				'menuId'       => 'secondary',
-				'order'        => 10,
-				'url'          => 'admin.php?page=wc-settings',
-				'is_top_level' => true,
-			)
-		);
-
 		// Tools category.
-		Menu::add_category(
-			array(
-				'title'        => __( 'Tools', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'tools',
-				'menuId'       => 'secondary',
-				'order'        => 30,
-				'is_top_level' => true,
-			)
-		);
 		Menu::add_item(
 			array(
 				'parent'     => 'tools',

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -72,15 +72,30 @@ class CoreMenu {
 	 */
 	public function add_core_items() {
 		// Orders category.
-		Screen::register_post_type( 'shop_order', 'orders' );
-		// Menu::add_post_type_category( 'shop_order', array( 'order' => 20 ) );
+		Screen::register_post_type(
+			'shop_order',
+			array(
+				'parent'   => 'orders',
+				'multiple' => true,
+			)
+		);
 
 		// Products category.
-		Screen::register_post_type( 'product', 'products' );
-		// Menu::add_post_type_category( 'product', array( 'order' => 40 ) );
+		Screen::register_post_type(
+			'product',
+			array(
+				'parent'   => 'products',
+				'multiple' => true,
+			)
+		);
 
 		// Marketing category.
-		Screen::register_post_type( 'shop_coupon', 'marketing' );
+		Screen::register_post_type(
+			'shop_coupon',
+			array(
+				'parent' => 'marketing',
+			)
+		);
 
 		// Extensions category.
 		Menu::add_item(

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -313,50 +313,6 @@ class Menu {
 	}
 
 	/**
-	 * Adds a post type as a menu category.
-	 *
-	 * @param string $post_type Post type.
-	 * @param array  $args Array of menu item args.
-	 */
-	public static function add_post_type_category( $post_type, $args = array() ) {
-		$post_type_object = get_post_type_object( $post_type );
-
-		if ( ! $post_type_object ) {
-			return;
-		}
-
-		self::add_category(
-			array_merge(
-				array(
-					'title'        => esc_attr( $post_type_object->labels->menu_name ),
-					'capability'   => $post_type_object->cap->edit_posts,
-					'id'           => $post_type,
-					'is_top_level' => true,
-				),
-				$args
-			)
-		);
-		self::add_item(
-			array(
-				'parent'     => $post_type,
-				'title'      => esc_attr( $post_type_object->labels->all_items ),
-				'capability' => $post_type_object->cap->edit_posts,
-				'id'         => "{$post_type}-all-items",
-				'url'        => "edit.php?post_type={$post_type}",
-			)
-		);
-		self::add_item(
-			array(
-				'parent'     => $post_type,
-				'title'      => esc_attr( $post_type_object->labels->add_new ),
-				'capability' => $post_type_object->cap->create_posts,
-				'id'         => "{$post_type}-add-new",
-				'url'        => "post-new.php?post_type={$post_type}",
-			)
-		);
-	}
-
-	/**
 	 * Hides all WP admin menus items and adds screen IDs to check for new items.
 	 *
 	 * @param array $menu Menu items.

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -168,7 +168,7 @@ class Menu {
 		);
 		$menu_item           = wp_parse_args( $args, $defaults );
 		$menu_item['title']  = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
-		$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
+		$menu_item['parent'] = self::get_item_parent( $menu_item );
 		unset( $menu_item['url'] );
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
@@ -183,13 +183,6 @@ class Menu {
 	 */
 	public function add_top_level_items() {
 		$items = array(
-			array(
-				'title'      => __( 'Home', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'home',
-				'order'      => 0,
-				'url'        => apply_filters( 'woocommerce_navigation_home_url', 'admin.php?page=woocommerce' ),
-			),
 			array(
 				'title'      => __( 'Analytics', 'woocommerce-admin' ),
 				'capability' => 'manage_woocommerce',
@@ -290,26 +283,43 @@ class Menu {
 		}
 
 		$defaults            = array(
-			'id'           => '',
-			'title'        => '',
-			'parent'       => self::DEFAULT_PARENT,
-			'capability'   => 'manage_woocommerce',
-			'url'          => '',
-			'order'        => 100,
-			'migrate'      => true,
-			'menuId'       => 'primary',
-			'is_top_level' => false,
+			'id'         => '',
+			'title'      => '',
+			'parent'     => self::DEFAULT_PARENT,
+			'capability' => 'manage_woocommerce',
+			'url'        => '',
+			'order'      => 100,
+			'migrate'    => true,
+			'menuId'     => 'primary',
 		);
 		$menu_item           = wp_parse_args( $args, $defaults );
 		$menu_item['title']  = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
 		$menu_item['url']    = self::get_callback_url( $menu_item['url'] );
-		$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
+		$menu_item['parent'] = self::get_item_parent( $menu_item );
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
 
 		if ( isset( $args['url'] ) ) {
 			self::$callbacks[ $args['url'] ] = $menu_item['migrate'];
 		}
+	}
+
+	/**
+	 * Get the item's parent.
+	 *
+	 * @param array $menu_item Menu item args.
+	 * @return string
+	 */
+	public static function get_item_parent( $menu_item ) {
+		if ( 'home' === $menu_item['id'] ) {
+			return 'woocommerce';
+		}
+
+		if ( 'woocommerce' === $menu_item['parent'] ) {
+			return self::DEFAULT_PARENT;
+		}
+
+		return $menu_item['parent'];
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -83,6 +83,7 @@ class Menu {
 	 * Init.
 	 */
 	public function init() {
+		self::add_top_level_items();
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
 	}
@@ -155,35 +156,116 @@ class Menu {
 			return;
 		}
 
-		$defaults           = array(
-			'id'           => '',
-			'title'        => '',
-			'capability'   => 'manage_woocommerce',
-			'order'        => 100,
-			'migrate'      => true,
-			'menuId'       => 'primary',
-			'isCategory'   => true,
-			'parent'       => self::DEFAULT_PARENT,
-			'is_top_level' => false,
+		$defaults            = array(
+			'id'         => '',
+			'title'      => '',
+			'capability' => 'manage_woocommerce',
+			'order'      => 100,
+			'migrate'    => true,
+			'menuId'     => 'primary',
+			'isCategory' => true,
+			'parent'     => self::DEFAULT_PARENT,
 		);
-		$menu_item          = wp_parse_args( $args, $defaults );
-		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
+		$menu_item           = wp_parse_args( $args, $defaults );
+		$menu_item['title']  = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
+		$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		unset( $menu_item['url'] );
-
-		if ( true === $menu_item['is_top_level'] ) {
-			$menu_item['parent']          = 'woocommerce';
-			$menu_item['backButtonLabel'] = __(
-				'WooCommerce Home',
-				'woocommerce-admin'
-			);
-		} else {
-			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
-		}
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
 
 		if ( isset( $args['url'] ) ) {
 			self::$callbacks[ $args['url'] ] = $menu_item['migrate'];
+		}
+	}
+
+	/**
+	 * Add top level menu items.
+	 */
+	public function add_top_level_items() {
+		$items = array(
+			array(
+				'title'      => __( 'Home', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'home',
+				'order'      => 0,
+				'url'        => apply_filters( 'woocommerce_navigation_home_url', 'admin.php?page=woocommerce' ),
+			),
+			array(
+				'title'      => __( 'Analytics', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'analytics',
+				'order'      => 10,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Orders', 'woocommerce-admin' ),
+				'capability' => 'edit_shop_orders',
+				'id'         => 'orders',
+				'order'      => 20,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Marketing', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'marketing',
+				'order'      => 30,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Products', 'woocommerce-admin' ),
+				'capability' => 'edit_products',
+				'id'         => 'products',
+				'order'      => 40,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Customers', 'woocommerce-admin' ),
+				'capability' => 'list_users',
+				'id'         => 'customers',
+				'order'      => 50,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Payments', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'payments',
+				'order'      => 60,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Settings', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'settings',
+				'menuId'     => 'secondary',
+				'order'      => 10,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Extensions', 'woocommerce-admin' ),
+				'capability' => 'activate_plugins',
+				'id'         => 'extensions',
+				'menuId'     => 'secondary',
+				'order'      => 20,
+				'isCategory' => true,
+			),
+			array(
+				'title'      => __( 'Tools', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'tools',
+				'menuId'     => 'secondary',
+				'order'      => 30,
+				'isCategory' => true,
+			),
+		);
+
+		foreach ( $items as $item ) {
+			$menu_item                       = $item;
+			$menu_item['parent']             = 'woocommerce';
+			$menu_item['backButtonLabel']    = __(
+				'WooCommerce Home',
+				'woocommerce-admin'
+			);
+			self::$menu_items[ $item['id'] ] = $menu_item;
 		}
 	}
 
@@ -207,7 +289,7 @@ class Menu {
 			return;
 		}
 
-		$defaults           = array(
+		$defaults            = array(
 			'id'           => '',
 			'title'        => '',
 			'parent'       => self::DEFAULT_PARENT,
@@ -218,15 +300,10 @@ class Menu {
 			'menuId'       => 'primary',
 			'is_top_level' => false,
 		);
-		$menu_item          = wp_parse_args( $args, $defaults );
-		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
-		$menu_item['url']   = self::get_callback_url( $menu_item['url'] );
-
-		if ( true === $menu_item['is_top_level'] ) {
-			$menu_item['parent'] = 'woocommerce';
-		} else {
-			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
-		}
+		$menu_item           = wp_parse_args( $args, $defaults );
+		$menu_item['title']  = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
+		$menu_item['url']    = self::get_callback_url( $menu_item['url'] );
+		$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
 

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -168,25 +168,58 @@ class Screen {
 	 * Register post type for use in WooCommerce Navigation screens.
 	 *
 	 * @param string $post_type Post type to add.
-	 * @param string $parent_id Parent menu item ID.
+	 * @param array  $args Menu item arguments.
 	 */
-	public static function register_post_type( $post_type, $parent_id ) {
+	public static function register_post_type( $post_type, $args ) {
 		self::$post_types[] = $post_type;
 
 		$post_type_object = get_post_type_object( $post_type );
 
-		if ( ! $post_type_object || ! $post_type_object->show_in_menu || ! $parent_id ) {
+		if ( ! $post_type_object || ! $post_type_object->show_in_menu ) {
 			return;
 		}
 
-		Menu::add_item(
-			array(
-				'parent'     => $parent_id,
-				'title'      => esc_attr( $post_type_object->labels->menu_name ),
-				'capability' => $post_type_object->cap->edit_posts,
-				'id'         => $post_type,
-				'url'        => "edit.php?post_type={$post_type}",
-			)
+		$defaults  = array(
+			'multiple' => false,
+			'parent'   => isset( $args['parent'] ) ? $args['parent'] : Menu::DEFAULT_PARENT,
 		);
+		$menu_args = wp_parse_args( $args, $defaults );
+
+		if ( ! $args['multiple'] ) {
+			Menu::add_item(
+				array_merge(
+					array(
+						'title'      => esc_attr( $post_type_object->labels->menu_name ),
+						'capability' => $post_type_object->cap->edit_posts,
+						'id'         => $post_type,
+						'url'        => "edit.php?post_type={$post_type}",
+					),
+					$menu_args
+				)
+			);
+		} else {
+			Menu::add_item(
+				array_merge(
+					array(
+						'title'      => esc_attr( $post_type_object->labels->all_items ),
+						'capability' => $post_type_object->cap->edit_posts,
+						'id'         => "{$post_type}-all-items",
+						'url'        => "edit.php?post_type={$post_type}",
+					),
+					$menu_args
+				)
+			);
+			Menu::add_item(
+				array_merge(
+					array(
+						'title'      => esc_attr( $post_type_object->labels->add_new ),
+						'capability' => $post_type_object->cap->create_posts,
+						'id'         => "{$post_type}-add-new",
+						'url'        => "post-new.php?post_type={$post_type}",
+					),
+					$menu_args
+				)
+			);
+		}
 	}
 }

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -185,7 +185,7 @@ class Screen {
 		);
 		$menu_args = wp_parse_args( $args, $defaults );
 
-		if ( ! $args['multiple'] ) {
+		if ( ! $menu_args['multiple'] ) {
 			Menu::add_item(
 				array_merge(
 					array(

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -407,6 +407,7 @@ class PageController {
 	 *   @type string      id           Id to reference the page.
 	 *   @type string      title        Page title. Used in menus and breadcrumbs.
 	 *   @type string|null parent       Parent ID. Null for new top level page.
+	 *   @type string|null category     Category ID. Null to forgo adding to the WooCommerce Navigation.
 	 *   @type string      path         Path for this page, full path in app context; ex /analytics/report
 	 *   @type string      capability   Capability needed to access the page.
 	 *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
@@ -468,6 +469,7 @@ class PageController {
 	 *   @type string      id           Id to reference the page.
 	 *   @type string      title        Page title. Used in menus and breadcrumbs.
 	 *   @type string|null parent       Parent ID. Null for new top level page.
+	 *   @type string|null category     Category ID. Null to forgo adding to the WooCommerce Navigation.
 	 *   @type string      path         Path for this page, full path in app context; ex /analytics/report
 	 *   @type string      capability   Capability needed to access the page.
 	 *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
@@ -477,13 +479,13 @@ class PageController {
 	public static function add_nav_item( $options ) {
 		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
 
-		if ( ! $navigation_enabled || ! $options['parent'] ) {
+		if ( ! $navigation_enabled || ! $options['category'] ) {
 			return;
 		}
 
 		$item_options = array(
 			'id'         => $options['id'],
-			'parent'     => $options['parent'],
+			'parent'     => $options['category'],
 			'title'      => $options['title'],
 			'capability' => $options['capability'],
 			'url'        => $options['path'],

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -252,7 +252,7 @@ class PageController {
 			}
 
 			// Editing a product taxonomy term.
-			if ( ! empty( $_GET['tag_ID'] ) ) {
+			if ( ! empty( $_GET['tag_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$screen_pieces = array( $current_screen->taxonomy );
 			}
 		}
@@ -290,12 +290,13 @@ class PageController {
 			)
 		);
 
+		/* phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
 		if ( ! empty( $_GET['page'] ) ) {
-			if ( in_array( $_GET['page'], array_keys( $pages_with_tabs ) ) ) { // WPCS: sanitization ok.
+			if ( in_array( $_GET['page'], array_keys( $pages_with_tabs ), true ) ) {
 				if ( ! empty( $_GET['tab'] ) ) {
 					$tab = wc_clean( wp_unslash( $_GET['tab'] ) );
 				} else {
-					$tab = $pages_with_tabs[ $_GET['page'] ]; // WPCS: sanitization ok.
+					$tab = $pages_with_tabs[ wp_unslash( $_GET['page'] ) ];
 				}
 
 				$screen_pieces[] = $tab;
@@ -303,7 +304,7 @@ class PageController {
 				if ( ! empty( $_GET['section'] ) ) {
 					if (
 						isset( $tabs_with_sections[ $tab ] ) &&
-						in_array( $_GET['section'], array_keys( $tabs_with_sections[ $tab ] ) ) // WPCS: sanitization ok.
+						in_array( $_GET['section'], array_keys( $tabs_with_sections[ $tab ] ), true )
 					) {
 						$screen_pieces[] = wc_clean( wp_unslash( $_GET['section'] ) );
 					}
@@ -315,6 +316,7 @@ class PageController {
 				}
 			}
 		}
+		/* phpcs:enable */
 
 		/**
 		 * The current screen id.
@@ -475,25 +477,20 @@ class PageController {
 	public static function add_nav_item( $options ) {
 		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
 
-		if ( ! $navigation_enabled ) {
+		if ( ! $navigation_enabled || ! $options['parent'] ) {
 			return;
 		}
 
 		$item_options = array(
-			'id'           => $options['id'],
-			'parent'       => $options['parent'],
-			'title'        => $options['title'],
-			'capability'   => $options['capability'],
-			'url'          => $options['path'],
-			'order'        => isset( $options['order'] ) ? $options['order'] : 100,
-			'is_top_level' => ( isset( $options['is_top_level'] ) && $options['is_top_level'] ) || ! $options['parent'],
+			'id'         => $options['id'],
+			'parent'     => $options['parent'],
+			'title'      => $options['title'],
+			'capability' => $options['capability'],
+			'url'        => $options['path'],
+			'order'      => isset( $options['order'] ) ? $options['order'] : 100,
 		);
 
-		if ( isset( $options['is_category'] ) && $options['is_category'] ) {
-			\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_category( $item_options );
-		} else {
-			\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item( $item_options );
-		}
+		\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item( $item_options );
 	}
 
 	/**

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -479,7 +479,7 @@ class PageController {
 	public static function add_nav_item( $options ) {
 		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
 
-		if ( ! $navigation_enabled || ! $options['category'] ) {
+		if ( ! $navigation_enabled || ! isset( $options['category'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR seeks to lock the top level items so that all extending plugins must choose a category.

* Creates default top-level items and categories
* Hides categories without items on the frontend
* Simplifies WCA nav item registration
* Simplifies post type registration

This solves some of the complexity around the guardrails needed, but introduces a few questions ( /cc @jameskoster @elizaan36 @psealock @joelclimbsthings  ):
* Should "Customers" be a category with a menu item of  "All Customers" instead of a link?  What if plugins want to add an item here?  (Note that I'm seeing a duplicate "Customers" nav item, but this is an issue also on main)
* Similarly, I would think that "Payments" would also be a category, otherwise it feels a bit like favoritism with WC Pay being allowed to register a top-level nav item.
* The current setup allows a nav item with the ID of "home" to be registered as the top menu item.  This could be overridden and we could introduce WCA as the dependency to "lock" this item, but I would think that plugin authors would not intentionally and maliciously try to override this item.
* As a note, if third party items are eventually separated into a "Plugins" section, they would need to re-register nav items there.

### Screenshots
<img width="318" alt="Screen Shot 2020-10-27 at 12 50 22 PM" src="https://user-images.githubusercontent.com/10561050/97335264-08ddb880-1854-11eb-9d30-c7b565211908.png">


### Detailed test instructions:

1. Enable the nav feature.
1. Check that all nav items continue working as expected.
1. Try to register a top-level item.
1. Note items default to the "Settings" category if a valid one is not provided.