### PR TITLE
Update navigation width to match designs

### DIFF
--- a/client/navigation/stylesheets/_variables.scss
+++ b/client/navigation/stylesheets/_variables.scss
@@ -1,5 +1,5 @@
 // WooCommerce Navigation
-$navigation-width: 272px;
+$navigation-width: 240px;
 $navigation-x-padding: 30px;
 
 // WordPress defaults.


### PR DESCRIPTION
Fixes #5488

Updates the nav width to `240px` to match the latest designs.

### Screenshots

<img width="437" alt="Screen Shot 2020-10-28 at 10 16 25 AM" src="https://user-images.githubusercontent.com/10561050/97448111-a691c000-1906-11eb-893f-79d6c4017270.png">


### Detailed test instructions:

1. Enable the nav feature.
1. Check that the width is `240px` and surrounding elements are positioned correctly.