### PR TITLE
Prevent double fill of Customers nav slot

### DIFF
--- a/client/analytics/report/get-reports.js
+++ b/client/analytics/report/get-reports.js
@@ -107,7 +107,7 @@ export default () => {
 			report: 'customers',
 			title: __( 'Customers', 'woocommerce-admin' ),
 			component: CustomersReport,
-			id: 'woocommerce-analytics-customers',
+			id: null,
 		},
 		{
 			report: 'downloads',


### PR DESCRIPTION
Fixes #5493 

The "Customers" nav item is registered twice in WCA and the slot was being filled twice because of this.  This ignore the `/analytics/customers` one in favor the `/customers` path since it won't reside under the `Analytics` menu in the new navigation.

### Screenshots
<img width="293" alt="Screen Shot 2020-10-28 at 3 49 15 PM" src="https://user-images.githubusercontent.com/10561050/97488834-26368380-1935-11eb-9258-b82be2b58b01.png">


### Detailed test instructions:

1. Enable the navigation.
1. Make sure that 2 "Customers" items aren't shown.
1. Make sure it continues to work as expected.