### PR TITLE
Use the Puppeteer waitForSelector to fix flakyness in e2e tests.

### DIFF
--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -1,6 +1,18 @@
 const path = require( 'path' );
 const { jestConfig: baseE2Econfig } = require( '@woocommerce/e2e-environment' );
 
+global.it = async function ( name, func ) {
+	return await test( name, async () => {
+		try {
+			await func();
+		} catch ( e ) {
+			await fs.ensureDir( 'e2e/screenshots' );
+			await page.screenshot( { path: `e2e/screenshots/${ name }.png` } );
+			throw e;
+		}
+	} );
+};
+
 module.exports = {
 	...baseE2Econfig,
 	// Specify the path of your project's E2E tests here.

--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -1,18 +1,6 @@
 const path = require( 'path' );
 const { jestConfig: baseE2Econfig } = require( '@woocommerce/e2e-environment' );
 
-global.it = async function ( name, func ) {
-	return await test( name, async () => {
-		try {
-			await func();
-		} catch ( e ) {
-			await fs.ensureDir( 'e2e/screenshots' );
-			await page.screenshot( { path: `e2e/screenshots/${ name }.png` } );
-			throw e;
-		}
-	} );
-};
-
 module.exports = {
 	...baseE2Econfig,
 	// Specify the path of your project's E2E tests here.

--- a/tests/e2e/specs/activate-and-setup/complete-benefits-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-benefits-section.js
@@ -2,14 +2,12 @@
  * @format
  */
 
-import { waitForSelector } from '../../utils/lib';
-
 export async function completeBenefitsSection() {
 	// Wait for Benefits section to appear
-	await waitForSelector( page, '.woocommerce-profile-wizard__header-title' );
+	await page.waitForSelector( '.woocommerce-profile-wizard__header-title' );
 
 	// Wait for "No thanks" button to become active
-	await waitForSelector( page, 'button.is-secondary:not(:disabled)' );
+	await page.waitForSelector( 'button.is-secondary:not(:disabled)' );
 
 	// Click on "No thanks" button to move to the next step
 	await page.click( 'button.is-secondary' );

--- a/tests/e2e/specs/activate-and-setup/complete-benefits-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-benefits-section.js
@@ -4,7 +4,9 @@
 
 export async function completeBenefitsSection() {
 	// Wait for Benefits section to appear
-	await page.waitForSelector( '.woocommerce-profile-wizard__header-title' );
+	await page.waitForSelector(
+		'.woocommerce-profile-wizard__container.benefits'
+	);
 
 	// Wait for "No thanks" button to become active
 	await page.waitForSelector( 'button.is-secondary:not(:disabled)' );

--- a/tests/e2e/specs/activate-and-setup/complete-business-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-business-section.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { setCheckboxToUnchecked, clickContinue } from './utils';
-import { waitForSelector, waitForElementCount } from '../../utils/lib';
+import { waitForElementCount } from '../../utils/lib';
 const config = require( 'config' );
 
 export async function completeBusinessSection() {
@@ -16,14 +16,14 @@ export async function completeBusinessSection() {
 
 	// Fill the number of products you plan to sell
 	await selectControls[ 0 ].click();
-	await waitForSelector( page, '.woocommerce-select-control__listbox' );
+	await page.waitForSelector( '.woocommerce-select-control__listbox' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', {
 		text: config.get( 'onboardingwizard.numberofproducts' ),
 	} );
 
 	// Fill currently selling elsewhere
 	await selectControls[ 1 ].click();
-	await waitForSelector( page, '.woocommerce-select-control__listbox' );
+	await page.waitForSelector( '.woocommerce-select-control__listbox' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', {
 		text: config.get( 'onboardingwizard.sellingelsewhere' ),
 	} );

--- a/tests/e2e/specs/activate-and-setup/complete-store-details-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-store-details-section.js
@@ -6,7 +6,6 @@
  * Internal dependencies
  */
 import { verifyCheckboxIsUnset } from '../../utils/actions';
-import { waitForSelector } from '../../utils/lib';
 const config = require( 'config' );
 
 export async function completeStoreDetailsSection( storeDetails = {} ) {
@@ -63,13 +62,13 @@ export async function completeStoreDetailsSection( storeDetails = {} ) {
 	await verifyCheckboxIsUnset( '.components-checkbox-control__input' );
 
 	// Wait for "Continue" button to become active
-	await waitForSelector( page, 'button.is-primary:not(:disabled)' );
+	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
 
 	// Click on "Continue" button to move to the next step
 	await page.click( 'button.is-primary', { text: 'Continue' } );
 
 	// Wait for usage tracking pop-up window to appear
-	await waitForSelector( page, '.components-modal__header-heading' );
+	await page.waitForSelector( '.components-modal__header-heading' );
 	await expect( page ).toMatchElement( '.components-modal__header-heading', {
 		text: 'Build a better WooCommerce',
 	} );

--- a/tests/e2e/specs/activate-and-setup/complete-theme-selection-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-theme-selection-section.js
@@ -1,4 +1,3 @@
-import { waitForSelector } from '../../utils/lib';
 /**
  * @format
  */
@@ -10,8 +9,7 @@ import { clickContinue } from './utils';
 
 export async function completeThemeSelectionSection() {
 	// Make sure we're on the theme selection page before clicking continue
-	await waitForSelector(
-		page,
+	await page.waitForSelector(
 		'.woocommerce-profile-wizard__themes-tab-panel'
 	);
 

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -13,7 +13,6 @@ import {
 	verifyCheckboxIsSet,
 	verifyValueOfInputField,
 } from '../../utils/actions';
-import { waitForSelector, waitForElementCount } from '../../utils/lib';
 
 const config = require( 'config' );
 const baseUrl = config.get( 'url' );
@@ -36,10 +35,7 @@ describe( 'Store owner can login and make sure WooCommerce is activated', () => 
 		}
 		await page.click( `tr[data-slug="${ slug }"] .activate a` );
 
-		await waitForSelector(
-			page,
-			`tr[data-slug="${ slug }"] .deactivate a`
-		);
+		await page.waitForSelector( `tr[data-slug="${ slug }"] .deactivate a` );
 	} );
 } );
 

--- a/tests/e2e/specs/activate-and-setup/utils.js
+++ b/tests/e2e/specs/activate-and-setup/utils.js
@@ -2,11 +2,9 @@
  * @format
  */
 
-import { waitForSelector } from '../../utils/lib';
-
 export async function clickContinue() {
 	// Wait for "Continue" button to become active
-	await waitForSelector( page, 'button.is-primary:not(:disabled)' );
+	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
 
 	// Click on "Continue" button to move to the next step
 	await page.click( 'button.is-primary' );

--- a/tests/e2e/utils/actions.js
+++ b/tests/e2e/utils/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { pressKeyWithModifier } from '@wordpress/e2e-test-utils';
-import { waitForSelector } from './lib';
 
 /**
  * Perform a "select all" and then fill a input.
@@ -108,7 +107,7 @@ const verifyPublishAndTrash = async (
 	// Publish
 	await expect( page ).toClick( button );
 
-	await waitForSelector( page, publishNotice );
+	await page.waitForSelector( publishNotice );
 
 	// Verify
 	await expect( page ).toMatchElement( publishNotice, {
@@ -130,7 +129,7 @@ const verifyPublishAndTrash = async (
 
 	// Trash
 	await expect( page ).toClick( 'a', { text: 'Move to Trash' } );
-	await waitForSelector( page, '#message' );
+	await page.waitForSelector( '#message' );
 
 	// Verify
 	await expect( page ).toMatchElement( publishNotice, {

--- a/tests/e2e/utils/lib.js
+++ b/tests/e2e/utils/lib.js
@@ -1,4 +1,4 @@
-export const waitForElementCount = async function ( page, domSelector, count ) {
+export const waitForElementCount = function ( page, domSelector, count ) {
 	return page.waitForFunction(
 		( domSelector, count ) => {
 			return document.querySelectorAll( domSelector ).length === count;

--- a/tests/e2e/utils/lib.js
+++ b/tests/e2e/utils/lib.js
@@ -1,12 +1,5 @@
-export const waitForSelector = async function ( page, selector ) {
-	return await page.evaluate(
-		( selector ) => Boolean( document.querySelector( selector ) ),
-		selector
-	);
-};
-
 export const waitForElementCount = async function ( page, domSelector, count ) {
-	return await page.waitForFunction(
+	return page.waitForFunction(
 		( domSelector, count ) => {
 			return document.querySelectorAll( domSelector ).length === count;
 		},


### PR DESCRIPTION
There was a critical flaw in the helper code to wait on selectors. I am not sure why I wrote that function instead of relying on Puppeteers core `waitForSelector` API.

The incorrect implementation of this helper, was causing a situation where the `page.click` failed sometimes for the theme selection spec in the onboarding wizard.

To clarify what was happening before:

1. my helper did not properly wait for the selector to appear
2. then calling page.click with the same selector failed
3. then it seemed like it was testing the benefits section, but actually it was clicking a secondary button on the theme page, which would pass.

This was confirmed after fixing waitForSelector the benefits page failed because that spec had a selector that was not correct for that page and it started failing. I've also fixed the benefit step to represent what is rendered in that step.