### PR TITLE
Home Screen - Changed accordion styles

### DIFF
--- a/packages/components/src/accordion/index.js
+++ b/packages/components/src/accordion/index.js
@@ -3,6 +3,7 @@
  */
 import { Panel } from '@wordpress/components';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 /**
  * Use `Accordion` to display an accordion that renders the children inside.
@@ -13,7 +14,11 @@ import PropTypes from 'prop-types';
  * @return {Object} -
  */
 const Accordion = ( { className, children } ) => {
-	return <Panel className={ className }>{ children }</Panel>;
+	return (
+		<Panel className={ classnames( className, 'woocommerce-accordion' ) }>
+			{ children }
+		</Panel>
+	);
 };
 
 Accordion.propTypes = {

--- a/packages/components/src/accordion/panel.js
+++ b/packages/components/src/accordion/panel.js
@@ -4,6 +4,7 @@
 import { Card, PanelBody, PanelRow } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { useState } from '@wordpress/element';
 
 /**
  * `AccordionPanel` is used to give the panel content an accessible wrapper.
@@ -23,6 +24,7 @@ const AccordionPanel = ( {
 	initialOpen,
 	children,
 } ) => {
+	const [ isPanelOpen, setIsPanelOpen ] = useState( initialOpen );
 	const getTitleAndCount = ( titleText, countUnread ) => {
 		return (
 			<span className="woocommerce-accordion-header">
@@ -37,14 +39,20 @@ const AccordionPanel = ( {
 			</span>
 		);
 	};
+	const onToggle = () => {
+		setIsPanelOpen( ! isPanelOpen );
+	};
 	return (
 		<Card
 			size="large"
-			className={ classnames( className, 'woocommerce-accordion-card' ) }
+			className={ classnames( className, 'woocommerce-accordion-card', {
+				'is-panel-opened': isPanelOpen,
+			} ) }
 		>
 			<PanelBody
 				title={ getTitleAndCount( title, count ) }
 				initialOpen={ initialOpen }
+				onToggle={ () => onToggle() }
 			>
 				<PanelRow> { children } </PanelRow>
 			</PanelBody>

--- a/packages/components/src/accordion/style.scss
+++ b/packages/components/src/accordion/style.scss
@@ -1,5 +1,5 @@
-.woocommerce-accordion-card {
-	.woocommerce-accordion-badge {
+.woocommerce-accordion {
+	&-badge {
 		background-color: $gray-100;
 		border-radius: 20px;
 		display: inline-block;
@@ -12,5 +12,15 @@
 		width: 32px;
 		height: 28px;
 		margin-left: $gap;
+	}
+	&-card {
+		&.is-panel-opened {
+			&:not(:first-child) {
+				margin-top: 20px;
+			}
+			&:not(:last-child) {
+				margin-bottom: 20px;
+			}
+		}
 	}
 }


### PR DESCRIPTION

This PR modifies a few Accordion styles when toggling.

### Screenshots
![screenshot-one wordpress test-2020 10 29-14_09_50](https://user-images.githubusercontent.com/1314156/97607991-7fafb880-19f0-11eb-90c3-7d321a3176ac.png)

### Detailed test instructions:

- Go to `Home` screen.
- Verify that the panels are separated when they are open.

_To make the code reviewing easier I created the branch `add/5238_modify_accordion_styles_test` with a few panels to test._

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Home Screen - Changed accordion styles
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
