### PR TITLE
Fixing features contained in subdirectories are not loaded when using Composer v2

### DIFF
--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -5,7 +5,7 @@
  * @package Woocommerce Admin
  */
 
-namespace Automattic\WooCommerce\Admin\Features;
+namespace Automattic\WooCommerce\Admin\Features\Navigation;
 
 use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
 /**
  * Contains logic for the Navigation
  */
-class Navigation {
+class Init {
 	/**
 	 * Hook into WooCommerce.
 	 */

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -225,11 +225,16 @@ class Loader {
 	public static function load_features() {
 		$features = self::get_features();
 		foreach ( $features as $feature ) {
-			$feature = str_replace( '-', '', ucwords( strtolower( $feature ), '-' ) );
-			$feature = 'Automattic\\WooCommerce\\Admin\\Features\\' . $feature;
+			$feature       = str_replace( '-', '', ucwords( strtolower( $feature ), '-' ) );
+			$feature_class = 'Automattic\\WooCommerce\\Admin\\Features\\' . $feature;
 
-			if ( class_exists( $feature ) ) {
-				new $feature();
+			// Handle features contained in subdirectory.
+			if ( ! class_exists( $feature_class ) && class_exists( $feature_class . '\\Init' ) ) {
+				$feature_class = $feature_class . '\\Init';
+			}
+
+			if ( class_exists( $feature_class ) ) {
+				new $feature_class();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #5509

Composer 2 enforces stricter naming conventions that are breaking current logic in loading conditional features. This is currently resulting in the Navigation feature not being loaded when using Composer 2.

To resolve I'm currently fixing the incorrect namespace of the `Navigation.php` file (which composer v1 tolerated), and making a couple changes to the logic to accommodate features that are nested within a subdirectory under `/Features`. Currently opting to use the convention of naming the bootstrapping file within a feature `Init.php`.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/97640266-9dcfe580-19fd-11eb-859c-b672a68a0558.png)


### Detailed test instructions:

- Upgrade to Composer v2
- Run `composer install`
- Enable new Navigation (via feature config as well as `woocommerce_navigation_enabled` option)
- Ensure new navigation is shown when you navigation to WooCommerce
