### PR TITLE
Try: Register plugins under separate navigation menu

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -122,13 +122,6 @@ const Container = ( { menuItems } ) => {
 									) ) }
 								</NavigationGroup>
 							) }
-							{ !! secondaryItems.length && (
-								<NavigationGroup>
-									{ secondaryItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
-								</NavigationGroup>
-							) }
 							{ !! pluginItems.length && (
 								<NavigationGroup
 									title={
@@ -141,6 +134,13 @@ const Container = ( { menuItems } ) => {
 									}
 								>
 									{ pluginItems.map( ( item ) => (
+										<Item key={ item.id } item={ item } />
+									) ) }
+								</NavigationGroup>
+							) }
+							{ !! secondaryItems.length && (
+								<NavigationGroup>
+									{ secondaryItems.map( ( item ) => (
 										<Item key={ item.id } item={ item } />
 									) ) }
 								</NavigationGroup>

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -106,7 +106,7 @@ const Container = ( { menuItems } ) => {
 						primaryItems,
 						secondaryItems,
 						pluginItems,
-					] = categorizedItems[ category.id ];
+					] = categorizedItems[ category.id ] || [ [], [], [] ];
 					return (
 						<NavigationMenu
 							key={ category.id }

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -127,7 +127,7 @@ const Container = ( { menuItems } ) => {
 									title={
 										category.id === 'woocommerce'
 											? __(
-													'Plugins',
+													'Extensions',
 													'woocommerce-admin'
 											  )
 											: null

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -130,17 +130,20 @@ const Container = ( { menuItems } ) => {
 								</NavigationGroup>
 							) }
 							{ !! pluginItems.length && (
-								<>
-									<h3>Plugins</h3>
-									<NavigationGroup>
-										{ pluginItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
-								</>
+								<NavigationGroup
+									title={
+										category.id === 'woocommerce'
+											? __(
+													'Plugins',
+													'woocommerce-admin'
+											  )
+											: null
+									}
+								>
+									{ pluginItems.map( ( item ) => (
+										<Item key={ item.id } item={ item } />
+									) ) }
+								</NavigationGroup>
 							) }
 						</NavigationMenu>
 					);

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -65,9 +65,14 @@ const Container = ( { menuItems } ) => {
 	const getMenuItemsByCategory = ( items ) => {
 		return items.reduce( ( acc, item ) => {
 			if ( ! acc[ item.parent ] ) {
-				acc[ item.parent ] = [ [], [] ];
+				acc[ item.parent ] = [ [], [], [] ];
 			}
-			const index = item.menuId !== 'secondary' ? 0 : 1;
+			let index = 0;
+			if ( item.menuId === 'secondary' ) {
+				index = 1;
+			} else if ( item.menuId === 'plugins' ) {
+				index = 2;
+			}
 			acc[ item.parent ][ index ].push( item );
 			return acc;
 		}, {} );
@@ -97,9 +102,11 @@ const Container = ( { menuItems } ) => {
 					></NavigationBackButton>
 				) }
 				{ categories.map( ( category ) => {
-					const [ primaryItems, secondaryItems ] = categorizedItems[
-						category.id
-					];
+					const [
+						primaryItems,
+						secondaryItems,
+						pluginItems,
+					] = categorizedItems[ category.id ];
 					return (
 						<NavigationMenu
 							key={ category.id }
@@ -121,6 +128,19 @@ const Container = ( { menuItems } ) => {
 										<Item key={ item.id } item={ item } />
 									) ) }
 								</NavigationGroup>
+							) }
+							{ !! pluginItems.length && (
+								<>
+									<h3>Plugins</h3>
+									<NavigationGroup>
+										{ pluginItems.map( ( item ) => (
+											<Item
+												key={ item.id }
+												item={ item }
+											/>
+										) ) }
+									</NavigationGroup>
+								</>
 							) }
 						</NavigationMenu>
 					);

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -1,4 +1,7 @@
 .woocommerce-navigation {
+	height: 100vh;
+	overflow: scroll;
+
 	h2 {
 		color: inherit; // This should be handled at component level.
 	}

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -1,7 +1,4 @@
 .woocommerce-navigation {
-	height: 100vh;
-	overflow: scroll;
-
 	h2 {
 		color: inherit; // This should be handled at component level.
 	}

--- a/docs/examples/extensions/add-navigation-items/js/index.js
+++ b/docs/examples/extensions/add-navigation-items/js/index.js
@@ -12,7 +12,7 @@ const MyPlugin = () => {
     }
 
     return (
-        <WooNavigationItem item="example-marketing-category-child-2">
+        <WooNavigationItem item="example-category-child-2">
             <Button onClick={ handleClick }>
                 { __( 'JavaScript Example', 'plugin-domain' ) }
             </Button>

--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -80,5 +80,241 @@ function add_navigation_items_register_items() {
 			'url'        => 'https://www.google.com',
 		)
 	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'facebook',
+			'title'      => 'Facebook',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+		array(
+			'id'         => 'stripe',
+			'title'      => 'Stripe',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'stripe-payments',
+			'parent'     => 'stripe',
+			'title'      => 'Payments',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'stripe-settings',
+			'parent'     => 'stripe',
+			'title'      => 'Settings',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+		array(
+			'id'         => 'square',
+			'title'      => 'Square',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'square-payments',
+			'parent'     => 'square',
+			'title'      => 'Payments',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'square-transactions',
+			'parent'     => 'square',
+			'title'      => 'Transactions',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'square-settings',
+			'parent'     => 'square',
+			'title'      => 'Settings',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'amazon-pay',
+			'title'      => 'Amazon Pay',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'google-analytics',
+			'title'      => 'Google Analytics',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'paypal-checkout',
+			'title'      => 'PayPal Checkout',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'shipstation',
+			'title'      => 'ShipStation',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+		array(
+			'id'         => 'woocommerce-subscriptions',
+			'title'      => 'WooCommerce Subscriptions',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-subscriptions-subscriptions',
+			'parent'     => 'woocommerce-subscriptions',
+			'title'      => 'Subscriptions',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-subscriptions-settings',
+			'parent'     => 'woocommerce-settings',
+			'title'      => 'Settings',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-subscriptions-emails',
+			'parent'     => 'woocommerce-emails',
+			'title'      => 'Emails',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-product-addons',
+			'title'      => 'Product Add-Ons',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'payfast',
+			'title'      => 'PayFast',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-shipping',
+			'title'      => 'WooCommerce Shipping',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+		array(
+			'id'         => 'woocommerce-payments',
+			'title'      => 'WooCommerce Payments',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-payments-deposits',
+			'parent'     => 'woocommerce-payments',
+			'title'      => 'Deposits',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-payments-transactions',
+			'parent'     => 'woocommerce-payments',
+			'title'      => 'Transactions',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-payments-settings',
+			'parent'     => 'woocommerce-payments',
+			'title'      => 'Settings',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'usps',
+			'title'      => 'USPS Shipping',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
+
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'woocommerce-tax',
+			'title'      => 'WooCommerce Tax',
+			'capability' => 'manage_woocommerce',
+			'url'        => '#',
+		)
+	);
 }
 add_filter( 'admin_menu', 'add_navigation_items_register_items' );

--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -36,284 +36,46 @@ add_action( 'admin_enqueue_scripts', 'add_navigation_items_register_script' );
  */
 function add_navigation_items_register_items() {
 	if (
-		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_category' ) ||
-		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_item' )
+		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_plugin_category' ) ||
+		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_plugin_item' )
 	) {
 		return;
 	}
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
 		array(
-			'id'         => 'example-marketing-plugin',
-			'title'      => 'Example Marketing Settings',
+			'id'         => 'example-plugin',
+			'title'      => 'Example Plugin',
 			'capability' => 'view_woocommerce_reports',
-			'parent'     => 'settings',
 			'url'        => 'https://www.google.com',
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_category(
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
 		array(
-			'id'         => 'example-marketing-category',
-			'parent'     => 'woocommerce-marketing',
-			'title'      => 'Example Marketing Category',
+			'id'         => 'example-category',
+			'title'      => 'Example Category',
 			'capability' => 'view_woocommerce_reports',
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
 		array(
-			'id'         => 'example-marketing-category-child-1',
-			'parent'     => 'example-marketing-category',
+			'id'         => 'example-category-child-1',
+			'parent'     => 'example-category',
 			'title'      => 'Sub Menu Child 1',
 			'capability' => 'view_woocommerce_reports',
 			'url'        => 'https://www.google.com',
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item(
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
 		array(
-			'id'         => 'example-marketing-category-child-2',
-			'parent'     => 'example-marketing-category',
+			'id'         => 'example-category-child-2',
+			'parent'     => 'example-category',
 			'title'      => 'Sub Menu Child 2',
 			'capability' => 'view_woocommerce_reports',
 			'url'        => 'https://www.google.com',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'facebook',
-			'title'      => 'Facebook',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
-		array(
-			'id'         => 'stripe',
-			'title'      => 'Stripe',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'stripe-payments',
-			'parent'     => 'stripe',
-			'title'      => 'Payments',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'stripe-settings',
-			'parent'     => 'stripe',
-			'title'      => 'Settings',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
-		array(
-			'id'         => 'square',
-			'title'      => 'Square',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'square-payments',
-			'parent'     => 'square',
-			'title'      => 'Payments',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'square-transactions',
-			'parent'     => 'square',
-			'title'      => 'Transactions',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'square-settings',
-			'parent'     => 'square',
-			'title'      => 'Settings',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'amazon-pay',
-			'title'      => 'Amazon Pay',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'google-analytics',
-			'title'      => 'Google Analytics',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'paypal-checkout',
-			'title'      => 'PayPal Checkout',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'shipstation',
-			'title'      => 'ShipStation',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
-		array(
-			'id'         => 'woocommerce-subscriptions',
-			'title'      => 'WooCommerce Subscriptions',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-subscriptions-subscriptions',
-			'parent'     => 'woocommerce-subscriptions',
-			'title'      => 'Subscriptions',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-subscriptions-settings',
-			'parent'     => 'woocommerce-settings',
-			'title'      => 'Settings',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-subscriptions-emails',
-			'parent'     => 'woocommerce-emails',
-			'title'      => 'Emails',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-product-addons',
-			'title'      => 'Product Add-Ons',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'payfast',
-			'title'      => 'PayFast',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-shipping',
-			'title'      => 'WooCommerce Shipping',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
-		array(
-			'id'         => 'woocommerce-payments',
-			'title'      => 'WooCommerce Payments',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-payments-deposits',
-			'parent'     => 'woocommerce-payments',
-			'title'      => 'Deposits',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-payments-transactions',
-			'parent'     => 'woocommerce-payments',
-			'title'      => 'Transactions',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-payments-settings',
-			'parent'     => 'woocommerce-payments',
-			'title'      => 'Settings',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'usps',
-			'title'      => 'USPS Shipping',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
-		)
-	);
-
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
-		array(
-			'id'         => 'woocommerce-tax',
-			'title'      => 'WooCommerce Tax',
-			'capability' => 'manage_woocommerce',
-			'url'        => '#',
 		)
 	);
 }

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -112,114 +112,153 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
-		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
-
-		$overview_page = array(
-			'id'           => 'woocommerce-analytics',
-			'title'        => __( 'Analytics', 'woocommerce-admin' ),
-			'path'         => '/analytics/overview',
-			'icon'         => 'dashicons-chart-bar',
-			'position'     => 56, // After WooCommerce & Product menu items.
-			'order'        => 10,
-			'is_category'  => true,
-			'is_top_level' => true,
-		);
-
-		$report_pages = array(
-			$overview_page,
-			array(
-				'id'     => 'woocommerce-analytics-overview',
-				'title'  => __( 'Overview', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/overview',
-				'order'  => 10,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-products',
-				'title'  => __( 'Products', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/products',
-				'order'  => 20,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-revenue',
-				'title'  => __( 'Revenue', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/revenue',
-				'order'  => 30,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-orders',
-				'title'  => __( 'Orders', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/orders',
-				'order'  => 40,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-variations',
-				'title'  => __( 'Variations', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/variations',
-				'order'  => 50,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-categories',
-				'title'  => __( 'Categories', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/categories',
-				'order'  => 60,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-coupons',
-				'title'  => __( 'Coupons', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/coupons',
-				'order'  => 70,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-taxes',
-				'title'  => __( 'Taxes', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/taxes',
-				'order'  => 80,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-downloads',
-				'title'  => __( 'Downloads', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/downloads',
-				'order'  => 90,
-			),
-			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
-				'id'     => 'woocommerce-analytics-stock',
-				'title'  => __( 'Stock', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/stock',
-				'order'  => 100,
-			) : null,
-			array(
-				'id'           => 'woocommerce-analytics-customers',
-				'title'        => __( 'Customers', 'woocommerce-admin' ),
-				'parent'       => 'woocommerce',
-				'path'         => '/customers',
-				'is_top_level' => true,
-				'order'        => 50,
-			),
-			array(
-				'id'     => 'woocommerce-analytics-settings',
-				'title'  => $navigation_enabled ? __( 'Analytics', 'woocommerce-admin' ) : __( 'Settings', 'woocommerce-admin' ),
-				'parent' => $navigation_enabled ? 'settings' : 'woocommerce-analytics',
-				'path'   => '/analytics/settings',
-			),
-		);
-
-		$report_pages = apply_filters( 'woocommerce_analytics_report_menu_items', $report_pages );
-
+		$report_pages = self::get_report_pages();
 		foreach ( $report_pages as $report_page ) {
 			if ( ! is_null( $report_page ) ) {
 				wc_admin_register_page( $report_page );
 			}
 		}
+	}
+
+	/**
+	 * Get report pages.
+	 */
+	public static function get_report_pages() {
+		$overview_page = array(
+			'id'       => 'woocommerce-analytics',
+			'title'    => __( 'Analytics', 'woocommerce-admin' ),
+			'path'     => '/analytics/overview',
+			'icon'     => 'dashicons-chart-bar',
+			'position' => 56, // After WooCommerce & Product menu items.
+		);
+
+		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
+
+		$report_pages = array(
+			$overview_page,
+			array(
+				'id'       => 'woocommerce-analytics-overview',
+				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/overview',
+				'nav_args' => array(
+					'order'  => 10,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-products',
+				'title'    => __( 'Products', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/products',
+				'nav_args' => array(
+					'order'  => 20,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-revenue',
+				'title'    => __( 'Revenue', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/revenue',
+				'nav_args' => array(
+					'order'  => 30,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-orders',
+				'title'    => __( 'Orders', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/orders',
+				'nav_args' => array(
+					'order'  => 40,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-variations',
+				'title'    => __( 'Variations', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/variations',
+				'nav_args' => array(
+					'order'  => 50,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-categories',
+				'title'    => __( 'Categories', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/categories',
+				'nav_args' => array(
+					'order'  => 60,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-coupons',
+				'title'    => __( 'Coupons', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/coupons',
+				'nav_args' => array(
+					'order'  => 70,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-taxes',
+				'title'    => __( 'Taxes', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/taxes',
+				'nav_args' => array(
+					'order'  => 80,
+					'parent' => 'analytics',
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-downloads',
+				'title'    => __( 'Downloads', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/downloads',
+				'nav_args' => array(
+					'order'  => 90,
+					'parent' => 'analytics',
+				),
+			),
+			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
+				'id'       => 'woocommerce-analytics-stock',
+				'title'    => __( 'Stock', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/stock',
+				'nav_args' => array(
+					'order'  => 100,
+					'parent' => 'analytics',
+				),
+			) : null,
+			array(
+				'id'       => 'woocommerce-analytics-customers',
+				'title'    => __( 'Customers', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce',
+				'path'     => '/customers',
+				'nav_args' => array(
+					'is_top_level' => true,
+					'order'        => 50,
+				),
+			),
+			array(
+				'id'       => 'woocommerce-analytics-settings',
+				'title'    => __( 'Settings', 'woocommerce-admin' ),
+				'parent'   => 'woocommerce-analytics',
+				'path'     => '/analytics/settings',
+				'nav_args' => array(
+					'title'  => __( 'Analytics', 'woocommerce-admin' ),
+					'parent' => 'settings',
+				),
+			),
+		);
+
+		return apply_filters( 'woocommerce_analytics_report_menu_items', $report_pages );
 	}
 
 	/**

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -132,8 +132,6 @@ class Analytics {
 			'position' => 56, // After WooCommerce & Product menu items.
 		);
 
-		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
-
 		$report_pages = array(
 			$overview_page,
 			array(

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -84,12 +84,10 @@ class AnalyticsDashboard {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'           => 'woocommerce-home',
-				'title'        => __( 'Home', 'woocommerce-admin' ),
-				'parent'       => 'woocommerce',
-				'path'         => self::MENU_SLUG,
-				'is_top_level' => true,
-				'order'        => 0,
+				'id'     => 'woocommerce-home',
+				'title'  => __( 'Home', 'woocommerce-admin' ),
+				'parent' => 'woocommerce',
+				'path'   => self::MENU_SLUG,
 			)
 		);
 	}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -132,10 +132,13 @@ class Marketing {
 		// First register the page.
 		PageController::get_instance()->register_page(
 			[
-				'id'     => 'woocommerce-marketing-overview',
-				'title'  => __( 'Overview', 'woocommerce-admin' ),
-				'path'   => 'wc-admin&path=/marketing',
-				'parent' => 'woocommerce-marketing',
+				'id'       => 'woocommerce-marketing-overview',
+				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'path'     => 'wc-admin&path=/marketing',
+				'parent'   => 'woocommerce-marketing',
+				'nav_args' => array(
+					'parent' => 'marketing',
+				),
 			]
 		);
 

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -36,25 +36,24 @@ class CoreMenu {
 	 * Init.
 	 */
 	public function init() {
-		add_action( 'admin_menu', array( $this, 'add_core_items' ) );
-		add_action( 'admin_menu', array( $this, 'add_core_setting_items' ) );
-		add_filter( 'add_menu_classes', array( $this, 'migrate_child_items' ) );
+		add_action( 'admin_menu', array( $this, 'register_post_types' ) );
 	}
 
 	/**
 	 * Add registered admin settings as menu items.
 	 */
-	public function add_core_setting_items() {
+	public static function get_setting_items() {
 		$setting_pages = \WC_Admin_Settings::get_settings_pages();
 		$settings      = array();
 		foreach ( $setting_pages as $setting_page ) {
 			$settings = $setting_page->add_settings_page( $settings );
 		}
 
-		$order = 0;
+		$menu_items = array();
+		$order      = 0;
 		foreach ( $settings as $key => $setting ) {
-			$order += 10;
-			Menu::add_item(
+			$order       += 10;
+			$menu_items[] = (
 				array(
 					'parent'     => 'settings',
 					'title'      => $setting,
@@ -65,34 +64,45 @@ class CoreMenu {
 				)
 			);
 		}
+
+		return $menu_items;
 	}
 
 	/**
-	 * Add the core menu items to the new navigation
+	 * Get all menu categories.
+	 *
+	 * @return array
 	 */
-	public function add_core_items() {
-		// Orders category.
-		Screen::register_post_type( 'shop_order', null );
-		Menu::add_post_type_category( 'shop_order', array( 'order' => 20 ) );
-
-		// Products category.
-		Screen::register_post_type( 'product', null );
-		Menu::add_post_type_category( 'product', array( 'order' => 40 ) );
-
-		// Marketing category.
-		Menu::add_category(
+	public static function get_categories() {
+		return array(
+			array(
+				'title'        => __( 'Analytics', 'woocommerce-admin' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'analytics',
+				'order'        => 10,
+				'is_top_level' => true,
+			),
+			array(
+				'title'        => __( 'Orders', 'woocommerce-admin' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'orders',
+				'order'        => 20,
+				'is_top_level' => true,
+			),
 			array(
 				'title'        => __( 'Marketing', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-marketing',
+				'id'           => 'marketing',
 				'order'        => 30,
 				'is_top_level' => true,
-			)
-		);
-		Screen::register_post_type( 'shop_coupon', 'woocommerce-marketing' );
-
-		// Extensions category.
-		Menu::add_category(
+			),
+			array(
+				'title'        => __( 'Products', 'woocommerce-admin' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'products',
+				'order'        => 40,
+				'is_top_level' => true,
+			),
 			array(
 				'title'        => __( 'Extensions', 'woocommerce-admin' ),
 				'capability'   => 'activate_plugins',
@@ -101,30 +111,7 @@ class CoreMenu {
 				'menuId'       => 'secondary',
 				'order'        => 20,
 				'is_top_level' => true,
-			)
-		);
-		Menu::add_item(
-			array(
-				'parent'     => 'extensions',
-				'title'      => __( 'My extensions', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'my-extensions',
-				'url'        => 'plugins.php',
-				'migrate'    => false,
-			)
-		);
-		Menu::add_item(
-			array(
-				'parent'     => 'extensions',
-				'title'      => __( 'Marketplace', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'marketplace',
-				'url'        => 'wc-addons',
-			)
-		);
-
-		// Settings category.
-		Menu::add_category(
+			),
 			array(
 				'title'        => __( 'Settings', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
@@ -133,11 +120,7 @@ class CoreMenu {
 				'order'        => 10,
 				'url'          => 'admin.php?page=wc-settings',
 				'is_top_level' => true,
-			)
-		);
-
-		// Tools category.
-		Menu::add_category(
+			),
 			array(
 				'title'        => __( 'Tools', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
@@ -145,36 +128,79 @@ class CoreMenu {
 				'menuId'       => 'secondary',
 				'order'        => 30,
 				'is_top_level' => true,
-			)
+			),
 		);
-		Menu::add_item(
+	}
+
+	/**
+	 * Get all menu items.
+	 *
+	 * @return array
+	 */
+	public static function get_items() {
+		$order_items   = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'orders' ) );
+		$product_items = Menu::get_post_type_items( 'product', array( 'parent' => 'products' ) );
+		$coupon_items  = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'marketing' ) );
+		$setting_items = self::get_setting_items();
+
+		return array_merge(
 			array(
-				'parent'     => 'tools',
-				'title'      => __( 'System status', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'system-status',
-				'url'        => 'wc-status',
-			)
+				$order_items[1],
+				$product_items[1],
+				$product_items[2],
+				$coupon_items[0],
+				// Extensions category.
+				array(
+					'parent'     => 'extensions',
+					'title'      => __( 'My extensions', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'my-extensions',
+					'url'        => 'plugins.php',
+					'migrate'    => false,
+				),
+				array(
+					'parent'     => 'extensions',
+					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'marketplace',
+					'url'        => 'wc-addons',
+				),
+				// Tools category.
+				array(
+					'parent'     => 'tools',
+					'title'      => __( 'System status', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'system-status',
+					'url'        => 'wc-status',
+				),
+				array(
+					'parent'     => 'tools',
+					'title'      => __( 'Import / Export', 'woocommerce-admin' ),
+					'capability' => 'import',
+					'id'         => 'import-export',
+					'url'        => 'import.php',
+					'migrate'    => false,
+				),
+				array(
+					'parent'     => 'tools',
+					'title'      => __( 'Utilities', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'utilities',
+					'url'        => 'admin.php?page=wc-status&tab=tools',
+				),
+			),
+			// Settings category.
+			$setting_items
 		);
-		Menu::add_item(
-			array(
-				'parent'     => 'tools',
-				'title'      => __( 'Import / Export', 'woocommerce-admin' ),
-				'capability' => 'import',
-				'id'         => 'import-export',
-				'url'        => 'import.php',
-				'migrate'    => false,
-			)
-		);
-		Menu::add_item(
-			array(
-				'parent'     => 'tools',
-				'title'      => __( 'Utilities', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'utilities',
-				'url'        => 'admin.php?page=wc-status&tab=tools',
-			)
-		);
+	}
+
+	/**
+	 * Register all core post types.
+	 */
+	public function register_post_types() {
+		Screen::register_post_type( 'shop_order' );
+		Screen::register_post_type( 'product' );
+		Screen::register_post_type( 'shop_coupon' );
 	}
 
 	/**
@@ -189,43 +215,5 @@ class CoreMenu {
 		);
 
 		return apply_filters( 'woocommerce_navigation_core_excluded_items', $excluded_items );
-	}
-
-	/**
-	 * Migrate any remaining WooCommerce child items.
-	 *
-	 * @param array $menu Menu items.
-	 * @return array
-	 */
-	public function migrate_child_items( $menu ) {
-		global $submenu;
-
-		if ( ! isset( $submenu['woocommerce'] ) ) {
-			return;
-		}
-
-		foreach ( $submenu['woocommerce'] as $menu_item ) {
-			if ( in_array( $menu_item[2], self::get_excluded_items(), true ) ) {
-				continue;
-			}
-
-			// Don't add already added items.
-			$callbacks = Menu::instance()::get_callbacks();
-			if ( array_key_exists( $menu_item[2], $callbacks ) ) {
-				continue;
-			}
-
-			Menu::add_item(
-				array(
-					'parent'     => 'settings',
-					'title'      => $menu_item[0],
-					'capability' => $menu_item[1],
-					'id'         => sanitize_title( $menu_item[0] ),
-					'url'        => $menu_item[2],
-				)
-			);
-		}
-
-		return $menu;
 	}
 }

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -10,7 +10,6 @@ namespace Automattic\WooCommerce\Admin\Features\Navigation;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 
-
 /**
  * CoreMenu class. Handles registering Core menu items.
  */
@@ -138,10 +137,24 @@ class CoreMenu {
 	 * @return array
 	 */
 	public static function get_items() {
-		$order_items   = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'orders' ) );
-		$product_items = Menu::get_post_type_items( 'product', array( 'parent' => 'products' ) );
-		$coupon_items  = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'marketing' ) );
-		$setting_items = self::get_setting_items();
+		$order_items     = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'orders' ) );
+		$product_items   = Menu::get_post_type_items( 'product', array( 'parent' => 'products' ) );
+		$coupon_items    = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'marketing' ) );
+		$setting_items   = self::get_setting_items();
+		$analytics_items = array();
+		if ( method_exists( '\Automattic\WooCommerce\Admin\Features\Analytics', 'get_report_pages' ) ) {
+			$report_pages = \Automattic\WooCommerce\Admin\Features\Analytics::get_report_pages();
+			foreach ( $report_pages as $report_page ) {
+				if ( ! isset( $report_page['nav_args'] ) ) {
+					continue;
+				}
+
+				$analytics_items[] = array_merge(
+					$report_page,
+					$report_page['nav_args']
+				);
+			}
+		}
 
 		return array_merge(
 			array(
@@ -189,6 +202,8 @@ class CoreMenu {
 					'url'        => 'admin.php?page=wc-status&tab=tools',
 				),
 			),
+			// Analytics category.
+			$analytics_items,
 			// Settings category.
 			$setting_items
 		);

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -156,8 +156,20 @@ class CoreMenu {
 			}
 		}
 
+		$home_item = array();
+		if ( defined( '\Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG' ) ) {
+			$home_item = array(
+				'id'           => 'home',
+				'title'        => __( 'Home', 'woocommerce-admin' ),
+				'url'          => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
+				'is_top_level' => true,
+				'order'        => 0,
+			);
+		}
+
 		return array_merge(
 			array(
+				$home_item,
 				$order_items[1],
 				$product_items[1],
 				$product_items[2],

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -137,23 +137,27 @@ class CoreMenu {
 	 * @return array
 	 */
 	public static function get_items() {
-		$order_items     = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'orders' ) );
-		$product_items   = Menu::get_post_type_items( 'product', array( 'parent' => 'products' ) );
-		$coupon_items    = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'marketing' ) );
-		$setting_items   = self::get_setting_items();
-		$analytics_items = array();
-		if ( method_exists( '\Automattic\WooCommerce\Admin\Features\Analytics', 'get_report_pages' ) ) {
-			$report_pages = \Automattic\WooCommerce\Admin\Features\Analytics::get_report_pages();
-			foreach ( $report_pages as $report_page ) {
-				if ( ! isset( $report_page['nav_args'] ) ) {
-					continue;
-				}
+		$order_items   = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'orders' ) );
+		$product_items = Menu::get_post_type_items( 'product', array( 'parent' => 'products' ) );
+		$coupon_items  = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'marketing' ) );
+		$setting_items = self::get_setting_items();
+		$wca_items     = array();
+		$wca_pages     = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_pages();
 
-				$analytics_items[] = array_merge(
-					$report_page,
-					$report_page['nav_args']
-				);
+		foreach ( $wca_pages as $page ) {
+			if ( ! isset( $page['nav_args'] ) ) {
+				continue;
 			}
+
+			$wca_items[] = array_merge(
+				array(
+					'id'         => $page['id'],
+					'url'        => $page['path'],
+					'title'      => $page['title'][0],
+					'capability' => $page['capability'],
+				),
+				$page['nav_args']
+			);
 		}
 
 		$home_item = array();
@@ -214,8 +218,8 @@ class CoreMenu {
 					'url'        => 'admin.php?page=wc-status&tab=tools',
 				),
 			),
-			// Analytics category.
-			$analytics_items,
+			// WooCommerce Admin items.
+			$wca_items,
 			// Settings category.
 			$setting_items
 		);

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -283,7 +283,7 @@ class Menu {
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
 		);
-		self::add_item( $category_args );
+		self::add_category( $category_args );
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features\Navigation;
 
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
 
 /**
  * Contains logic for the WooCommerce Navigation menu.
@@ -83,8 +84,10 @@ class Menu {
 	 * Init.
 	 */
 	public function init() {
+		add_action( 'admin_menu', array( $this, 'add_core_items' ) );
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
+		add_filter( 'add_menu_classes', array( $this, 'migrate_core_child_items' ) );
 	}
 
 	/**
@@ -150,7 +153,7 @@ class Menu {
 	 *      'menuId'     => (string) The ID of the menu to add the category to.
 	 *    ).
 	 */
-	public static function add_category( $args ) {
+	private static function add_category( $args ) {
 		if ( ! isset( $args['id'] ) || isset( self::$menu_items[ $args['id'] ] ) ) {
 			return;
 		}
@@ -202,7 +205,7 @@ class Menu {
 	 *      'menuId'     => (string) The ID of the menu to add the item to.
 	 *    ).
 	 */
-	public static function add_item( $args ) {
+	private static function add_item( $args ) {
 		if ( ! isset( $args['id'] ) || isset( self::$menu_items[ $args['id'] ] ) ) {
 			return;
 		}
@@ -328,6 +331,106 @@ class Menu {
 				'url'        => "post-new.php?post_type={$post_type}",
 			)
 		);
+	}
+
+	/**
+	 * Get menu item templates for a given post type.
+	 *
+	 * @param string $post_type Post type to add.
+	 * @param array  $menu_args Arguments merged with the returned menu items.
+	 * @return array
+	 */
+	public static function get_post_type_items( $post_type, $menu_args = array() ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object || ! $post_type_object->show_in_menu ) {
+			return;
+		}
+
+		return array(
+			array_merge(
+				array(
+					'title'      => esc_attr( $post_type_object->labels->menu_name ),
+					'capability' => $post_type_object->cap->edit_posts,
+					'id'         => $post_type,
+					'url'        => "edit.php?post_type={$post_type}",
+				),
+				$menu_args
+			),
+			array_merge(
+				array(
+					'parent'     => $post_type,
+					'title'      => esc_attr( $post_type_object->labels->all_items ),
+					'capability' => $post_type_object->cap->edit_posts,
+					'id'         => "{$post_type}-all-items",
+					'url'        => "edit.php?post_type={$post_type}",
+				),
+				$menu_args
+			),
+			array_merge(
+				array(
+					'parent'     => $post_type,
+					'title'      => esc_attr( $post_type_object->labels->add_new ),
+					'capability' => $post_type_object->cap->create_posts,
+					'id'         => "{$post_type}-add-new",
+					'url'        => "post-new.php?post_type={$post_type}",
+				),
+				$menu_args
+			),
+		);
+	}
+
+	/**
+	 * Add core menu items.
+	 */
+	public function add_core_items() {
+		$categories = CoreMenu::get_categories();
+		foreach ( $categories as $category ) {
+			self::add_category( $category );
+		}
+
+		$items = CoreMenu::get_items();
+		foreach ( $items as $item ) {
+			self::add_item( $item );
+		}
+	}
+
+	/**
+	 * Migrate any remaining WooCommerce child items.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
+	 */
+	public function migrate_core_child_items( $menu ) {
+		global $submenu;
+
+		if ( ! isset( $submenu['woocommerce'] ) ) {
+			return;
+		}
+
+		foreach ( $submenu['woocommerce'] as $menu_item ) {
+			if ( in_array( $menu_item[2], CoreMenu::get_excluded_items(), true ) ) {
+				continue;
+			}
+
+			// Don't add already added items.
+			$callbacks = self::get_callbacks();
+			if ( array_key_exists( $menu_item[2], $callbacks ) ) {
+				continue;
+			}
+
+			self::add_item(
+				array(
+					'parent'     => 'settings',
+					'title'      => $menu_item[0],
+					'capability' => $menu_item[1],
+					'id'         => sanitize_title( $menu_item[0] ),
+					'url'        => $menu_item[2],
+				)
+			);
+		}
+
+		return $menu;
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -236,6 +236,57 @@ class Menu {
 	}
 
 	/**
+	 * Adds a plugin item.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'parent'     => (string) Parent menu item ID.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'order'      => (int) Menu item order.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'     => (string) The ID of the menu to add the item to.
+	 *    ).
+	 */
+	public static function add_plugin_item( $args ) {
+		$item_args = array_merge(
+			$args,
+			array(
+				'menuId'       => 'plugins',
+				'is_top_level' => ! isset( $args['parent'] ),
+			)
+		);
+		self::add_item( $item_args );
+	}
+
+	/**
+	 * Adds a plugin category.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'order'      => (int) Menu item order.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'     => (string) The ID of the menu to add the category to.
+	 *    ).
+	 */
+	public static function add_plugin_category( $args ) {
+		$category_args = array_merge(
+			$args,
+			array(
+				'menuId'       => 'plugins',
+				'is_top_level' => ! isset( $args['parent'] ),
+			)
+		);
+		self::add_item( $category_args );
+	}
+
+	/**
 	 * Adds a post type as a menu category.
 	 *
 	 * @param string $post_type Post type.

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -168,25 +168,8 @@ class Screen {
 	 * Register post type for use in WooCommerce Navigation screens.
 	 *
 	 * @param string $post_type Post type to add.
-	 * @param string $parent_id Parent menu item ID.
 	 */
-	public static function register_post_type( $post_type, $parent_id ) {
+	public static function register_post_type( $post_type ) {
 		self::$post_types[] = $post_type;
-
-		$post_type_object = get_post_type_object( $post_type );
-
-		if ( ! $post_type_object || ! $post_type_object->show_in_menu || ! $parent_id ) {
-			return;
-		}
-
-		Menu::add_item(
-			array(
-				'parent'     => $parent_id,
-				'title'      => esc_attr( $post_type_object->labels->menu_name ),
-				'capability' => $post_type_object->cap->edit_posts,
-				'id'         => $post_type,
-				'url'        => "edit.php?post_type={$post_type}",
-			)
-		);
 	}
 }

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -457,6 +457,15 @@ class PageController {
 	}
 
 	/**
+	 * Get registered pages.
+	 *
+	 * @return array
+	 */
+	public function get_pages() {
+		return $this->pages;
+	}
+
+	/**
 	 * Set up a div for the app to render into.
 	 */
 	public static function page_wrapper() {

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -453,47 +453,7 @@ class PageController {
 			);
 		}
 
-		self::add_nav_item( $options );
 		$this->connect_page( $options );
-	}
-
-	/**
-	 * Add the item to the WooCommerce Navigation menu.
-	 *
-	 * @param array $options {
-	 *   Array describing the page.
-	 *
-	 *   @type string      id           Id to reference the page.
-	 *   @type string      title        Page title. Used in menus and breadcrumbs.
-	 *   @type string|null parent       Parent ID. Null for new top level page.
-	 *   @type string      path         Path for this page, full path in app context; ex /analytics/report
-	 *   @type string      capability   Capability needed to access the page.
-	 *   @type string      icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
-	 *   @type int         order        Navigation item order.
-	 * }
-	 */
-	public static function add_nav_item( $options ) {
-		$navigation_enabled = Loader::is_feature_enabled( 'navigation' );
-
-		if ( ! $navigation_enabled ) {
-			return;
-		}
-
-		$item_options = array(
-			'id'           => $options['id'],
-			'parent'       => $options['parent'],
-			'title'        => $options['title'],
-			'capability'   => $options['capability'],
-			'url'          => $options['path'],
-			'order'        => isset( $options['order'] ) ? $options['order'] : 100,
-			'is_top_level' => ( isset( $options['is_top_level'] ) && $options['is_top_level'] ) || ! $options['parent'],
-		);
-
-		if ( isset( $options['is_category'] ) && $options['is_category'] ) {
-			\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_category( $item_options );
-		} else {
-			\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_item( $item_options );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Update the nav to the "Plugins" approach.

Fixes https://github.com/woocommerce/woocommerce-admin/issues/5530

* Locks core menu items, creating dependency on WCA features within the navigation.
* Adds methods to register plugin categories and items.
* Adds extensions group to client.
* Updates the example plugin.

Note: this PR does not update the styling to the group title "Extensions."  The group title styling is different than that shown in https://github.com/woocommerce/woocommerce-admin/issues/5530.  I think this is something we may want to tackle upstream.

### Screenshots
<img width="301" alt="Screen Shot 2020-11-04 at 10 45 41 AM" src="https://user-images.githubusercontent.com/10561050/98134294-98a2e880-1e8c-11eb-8fbe-c32867ac9a83.png">


### Detailed test instructions:

1. Run the extension `npm run example -- --ext=add-navigation-items` and activate.
1. Note the extensions group and items/categories.
1. Make sure you can't register items in the main menu.
1. Make sure all relevant nav items still exist in the core nav menu.