### PR TITLE
Home Screen - Changed design and onClick behavior

### DIFF
--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -84,7 +84,7 @@ class ActivityCard extends Component {
 			return (
 				<Button
 					className="woocommerce-activity-card__button"
-					onClick={ ( element ) => onClick( element ) }
+					onClick={ onClick }
 				>
 					{ this.getCard() }
 				</Button>

--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -7,6 +7,7 @@ import Gridicon from 'gridicons';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { H, Section } from '@woocommerce/components';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import { H, Section } from '@woocommerce/components';
 import './style.scss';
 
 class ActivityCard extends Component {
-	render() {
+	getCard() {
 		const {
 			actions,
 			className,
@@ -76,6 +77,21 @@ class ActivityCard extends Component {
 			</section>
 		);
 	}
+
+	render() {
+		const { onClick } = this.props;
+		if ( onClick ) {
+			return (
+				<Button
+					className="woocommerce-activity-card__button"
+					onClick={ ( element ) => onClick( element ) }
+				>
+					{ this.getCard() }
+				</Button>
+			);
+		}
+		return this.getCard();
+	}
 }
 
 ActivityCard.propTypes = {
@@ -83,6 +99,7 @@ ActivityCard.propTypes = {
 		PropTypes.arrayOf( PropTypes.element ),
 		PropTypes.element,
 	] ),
+	onClick: PropTypes.func,
 	className: PropTypes.string,
 	children: PropTypes.node,
 	date: PropTypes.string,

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -19,6 +19,17 @@
 			grid-template-columns: 76px 1fr;
 		}
 	}
+
+	&__button {
+		display: block;
+		height: unset;
+		background: none;
+		align-items: unset;
+		transition: unset;
+		text-align: left;
+		width: 100%;
+		padding: 0;
+	}
 }
 
 .woocommerce-activity-card__unread {
@@ -54,6 +65,10 @@
 			font-style: normal;
 			line-height: 24px;
 			font-weight: normal;
+		}
+
+		.woocommerce-activity-card__button & {
+			margin-bottom: $gap-smaller;
 		}
 	}
 

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -82,6 +82,9 @@
 
 	.woocommerce-activity-card__subtitle {
 		order: 3;
+		.woocommerce-activity-card__button & {
+			margin-bottom: $gap-smallest;
+		}
 	}
 
 	@include breakpoint( '>782px' ) {

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -180,9 +180,9 @@ class OrdersPanel extends Component {
 					className="woocommerce-order-activity-card"
 					title={ orderCardTitle( order ) }
 					date={ dateCreatedGmt }
-					onClick={ ( element ) => {
+					onClick={ ( { target } ) => {
 						this.recordOrderEvent( 'orders_begin_fulfillment' );
-						if ( ! element.target.href ) {
+						if ( ! target.href ) {
 							window.location.href = getAdminLink(
 								`post.php?action=edit&post=${ orderId }`
 							);

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -2,17 +2,22 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import { keyBy, map, merge } from 'lodash';
-
-import { EmptyContent, Flag, H, Link, Section } from '@woocommerce/components';
+import {
+	EmptyContent,
+	Flag,
+	H,
+	Link,
+	OrderStatus,
+	Section,
+} from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import {
 	SETTINGS_STORE_NAME,
 	REPORTS_STORE_NAME,
@@ -156,20 +161,33 @@ class OrdersPanel extends Component {
 
 		const cards = [];
 		orders.forEach( ( order ) => {
-			const extendedInfo = order.extended_info || {};
+			const {
+				date_created_gmt: dateCreatedGmt,
+				extended_info: extendedInfo,
+				order_id: orderId,
+				total_sales: totalSales,
+			} = order;
 			const productsCount =
 				extendedInfo && extendedInfo.products
 					? extendedInfo.products.length
 					: 0;
 
-			const total = order.total_sales;
+			const total = totalSales;
 
 			cards.push(
 				<ActivityCard
-					key={ order.order_id }
+					key={ orderId }
 					className="woocommerce-order-activity-card"
 					title={ orderCardTitle( order ) }
-					date={ order.date_created_gmt }
+					date={ dateCreatedGmt }
+					onClick={ ( element ) => {
+						this.recordOrderEvent( 'orders_begin_fulfillment' );
+						if ( ! element.target.href ) {
+							window.location.href = getAdminLink(
+								`post.php?action=edit&post=${ orderId }`
+							);
+						}
+					} }
 					subtitle={
 						<div>
 							<span>
@@ -186,22 +204,12 @@ class OrdersPanel extends Component {
 							<span>{ Currency.formatAmount( total ) }</span>
 						</div>
 					}
-					actions={
-						<Button
-							isSecondary
-							href={ getAdminLink(
-								'post.php?action=edit&post=' + order.order_id
-							) }
-							onClick={ () =>
-								this.recordOrderEvent(
-									'orders_begin_fulfillment'
-								)
-							}
-						>
-							{ __( 'Open', 'woocommerce-admin' ) }
-						</Button>
-					}
-				></ActivityCard>
+				>
+					<OrderStatus
+						order={ order }
+						orderStatusMap={ getSetting( 'orderStatuses', {} ) }
+					/>
+				</ActivityCard>
 			);
 		} );
 		return (

--- a/client/homescreen/activity-panel/orders/style.scss
+++ b/client/homescreen/activity-panel/orders/style.scss
@@ -34,5 +34,9 @@
 				width: 65px;
 			}
 		}
+
+		.woocommerce-order-activity-card {
+			cursor: pointer;
+		}
 	}
 }

--- a/client/homescreen/activity-panel/style.scss
+++ b/client/homescreen/activity-panel/style.scss
@@ -44,7 +44,7 @@
 	}
 
 	.woocommerce-activity-card {
-		padding: ( $fallback-gutter / 2 ) $gutter;
+		padding: $gap-largest/2 $gutter $gutter;
 		&__header {
 			margin-bottom: $gap-smaller;
 		}


### PR DESCRIPTION
This is a follow-up PR related to [PR 5455](https://github.com/woocommerce/woocommerce-admin/pull/5455)

This PR addresses the changes suggested by @elizaan36 [here](https://github.com/woocommerce/woocommerce-admin/issues/5238#issuecomment-718954046) and via Slack.

The status indicator was modified and also clicking anywhere in the row now opens the order details.

### Screenshots
![Screen Capture on 2020-11-02 at 14-32-49](https://user-images.githubusercontent.com/1314156/97899694-640e2000-1d18-11eb-8700-f8f27eced30d.gif)


### Detailed test instructions:

- Verify the order card inside the accordion has its status indicator. E.g.: `Processing`
- Click on the order and verify that the redirection to the order details works as expected.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Dev: Changed design and onClick behavior
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
