### PR TITLE
Navigation: Adding ability for new navigation to scroll when list of links exceed viewport height

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -84,7 +84,7 @@ const Container = ( { menuItems } ) => {
 			<Navigation
 				activeItem={ activeItem ? activeItem.id : null }
 				activeMenu={ activeLevel }
-				onActivateMenu={ ( { menuId } ) => {
+				onActivateMenu={ ( ...args ) => {
 					const navDomRef = document.querySelector(
 						'.components-navigation'
 					);
@@ -93,7 +93,7 @@ const Container = ( { menuItems } ) => {
 						navDomRef.scrollTop = 0;
 					}
 
-					setActiveLevel( menuId );
+					setActiveLevel( ...args );
 				} }
 			>
 				{ activeLevel === 'woocommerce' && dashboardUrl && (

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -84,7 +84,17 @@ const Container = ( { menuItems } ) => {
 			<Navigation
 				activeItem={ activeItem ? activeItem.id : null }
 				activeMenu={ activeLevel }
-				onActivateMenu={ setActiveLevel }
+				onActivateMenu={ ( { menuId } ) => {
+					const navDomRef = document.querySelector(
+						'.components-navigation'
+					);
+
+					if ( navDomRef ) {
+						navDomRef.scrollTop = 0;
+					}
+
+					setActiveLevel( menuId );
+				} }
 			>
 				{ activeLevel === 'woocommerce' && dashboardUrl && (
 					<NavigationBackButton

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -3,11 +3,6 @@
 		color: inherit; // This should be handled at component level.
 	}
 
-	.components-navigation {
-		height: 100%;
-		box-sizing: border-box;
-	}
-
 	.components-navigation__menu {
 		display: flex;
 		flex-direction: column;

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -22,6 +22,12 @@
 		z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
 	}
 
+	.components-navigation {
+		overflow-y: auto;
+		height: calc(100vh - #{$header-height});
+		box-sizing: border-box;
+	}
+
 	&:not(.is-folded) {
 		#wpcontent,
 		#wpfooter {


### PR DESCRIPTION
Fixes #5508 

The new side navigation needs to having scrolling capability to accommodate large lists of links or short viewports as per the issue. 

**Requirements:**

- [x] Navigation scrolls on short viewports or long menus
- [x] It should scroll independently of main screen area
- [x] It should work on mobile
- [x] Add a padding bottom so the last link isn't crowded down there.

- [x] Determine the overscroll issue is best suited to being in Gutenberg.
- [x] Ensure the scroll works intuitively with the header bar.
- [x] Make sure the scroll is reset on navigation so user doesn't have to scroll to the top when navigating.

I'm a little uncertain if this change is appropriate in GB, partially due to the fact that it involves the variable `$header-height` which is only available in wc-admin. 

I haven't witnessed any funny business with the header bar, but if @psealock  wants to expand on the weirdness he mentioned then I'd like to be sure I'm not just missing this.

The last point, in terms of the scroll height being reset when navigation to submenus, would likely be a bit of an edge case since most submenus will likely be pretty short. That said, in order to address this properly we might have to issue a PR to the Gutenberg component logic to scroll to the top when navigation happens. I'm still looking into this.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/98044200-5bcae900-1ddb-11eb-8bce-2e4f4c962d35.png)


### Detailed test instructions:

- Check out branch
- Enable new navigation feature
- Go into WooCommerce menu
- If your viewport is larger than the navigation menu, no scroll bar should appear
- Shrink your viewport window to a smaller screensize, and ensure that scrollbar appears
- Simulate or use on mobile, ensure behavior still meets requirements. 
