### PR TITLE
Copy the snackbar component from Gutenberg into wp-admin

### DIFF
--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -5,12 +5,12 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
-import { SnackbarList } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import SnackbarList from './snackbar/list';
 import './style.scss';
 
 class TransientNotices extends Component {

--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -45,11 +45,15 @@ TransientNotices.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
-		const notices = select( 'core/notices' ).getNotices();
+		// NOTE: This uses core/notices2, if this file is copied back upstream
+		// to Gutenberg this needs to be changed back to core/notices.
+		const notices = select( 'core/notices2' ).getNotices();
 
 		return { notices };
 	} ),
 	withDispatch( ( dispatch ) => ( {
-		onRemove: dispatch( 'core/notices' ).removeNotice,
+		// NOTE: This uses core/notices2, if this file is copied back upstream
+		// to Gutenberg this needs to be changed back to core/notices.
+		onRemove: dispatch( 'core/notices2' ).removeNotice,
 	} ) )
 )( TransientNotices );

--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import classnames from 'classnames';
+import { speak } from '@wordpress/a11y';
+import { useEffect, forwardRef, renderToString } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import warning from '@wordpress/warning';
+import { Button } from '@wordpress/components';
+
+const NOTICE_TIMEOUT = 10000;
+
+/** @typedef {import('@wordpress/element').WPElement} WPElement */
+
+/**
+ * Custom hook which announces the message with the given politeness, if a
+ * valid message is provided.
+ *
+ * @param {string|WPElement}     [message]  Message to announce.
+ * @param {'polite'|'assertive'} politeness Politeness to announce.
+ */
+function useSpokenMessage( message, politeness ) {
+	const spokenMessage =
+		typeof message === 'string' ? message : renderToString( message );
+
+	useEffect( () => {
+		if ( spokenMessage ) {
+			speak( spokenMessage, politeness );
+		}
+	}, [ spokenMessage, politeness ] );
+}
+
+function Snackbar(
+	{
+		className,
+		children,
+		spokenMessage = children,
+		politeness = 'polite',
+		actions = [],
+		onRemove = noop,
+	},
+	ref
+) {
+	useSpokenMessage( spokenMessage, politeness );
+	useEffect( () => {
+		const timeoutHandle = setTimeout( () => {
+			onRemove();
+		}, NOTICE_TIMEOUT );
+
+		return () => clearTimeout( timeoutHandle );
+	}, [] );
+
+	const classes = classnames( className, 'components-snackbar' );
+	if ( actions && actions.length > 1 ) {
+		// we need to inform developers that snackbar only accepts 1 action
+		warning(
+			'Snackbar can only have 1 action, use Notice if your message require many messages'
+		);
+		// return first element only while keeping it inside an array
+		actions = [ actions[ 0 ] ];
+	}
+
+	return (
+		<div
+			ref={ ref }
+			className={ classes }
+			onClick={ onRemove }
+			tabIndex="0"
+			role="button"
+			onKeyPress={ onRemove }
+			aria-label={ __( 'Dismiss this notice' ) }
+		>
+			<div className="components-snackbar__content">
+				{ children }
+				{ actions.map( ( { label, onClick, url }, index ) => {
+					return (
+						<Button
+							key={ index }
+							href={ url }
+							isTertiary
+							onClick={ ( event ) => {
+								event.stopPropagation();
+								if ( onClick ) {
+									onClick( event );
+								}
+							} }
+							className="components-snackbar__action"
+						>
+							{ label }
+						</Button>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}
+
+export default forwardRef( Snackbar );

--- a/client/layout/transient-notices/snackbar/list.js
+++ b/client/layout/transient-notices/snackbar/list.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { omit, noop } from 'lodash';
+import { useTransition, animated } from 'react-spring/web.cjs';
+import { useReducedMotion } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Snackbar from './';
+
+/**
+ * Renders a list of notices.
+ *
+ * @param  {Object}   $0           Props passed to the component.
+ * @param  {Array}    $0.notices   Array of notices to render.
+ * @param  {Function} $0.onRemove  Function called when a notice should be removed / dismissed.
+ * @param  {Object}   $0.className Name of the class used by the component.
+ * @param  {Object}   $0.children  Array of children to be rendered inside the notice list.
+ * @return {Object}                The rendered notices list.
+ */
+function SnackbarList( { notices, className, children, onRemove = noop } ) {
+	const isReducedMotion = useReducedMotion();
+	const [ refMap ] = useState( () => new WeakMap() );
+	const transitions = useTransition( notices, ( notice ) => notice.id, {
+		from: { opacity: 0, height: 0 },
+		enter: ( item ) => async ( next ) =>
+			await next( {
+				opacity: 1,
+				height: refMap.get( item ).offsetHeight,
+			} ),
+		leave: () => async ( next ) => {
+			await next( { opacity: 0 } );
+			await next( { height: 0 } );
+		},
+		immediate: isReducedMotion,
+	} );
+
+	className = classnames( 'components-snackbar-list', className );
+	const removeNotice = ( notice ) => () => onRemove( notice.id );
+
+	return (
+		<div className={ className }>
+			{ children }
+			{ transitions.map( ( { item: notice, key, props: style } ) => (
+				<animated.div key={ key } style={ style }>
+					<div
+						className="components-snackbar-list__notice-container"
+						ref={ ( ref ) => ref && refMap.set( notice, ref ) }
+					>
+						<Snackbar
+							{ ...omit( notice, [ 'content' ] ) }
+							onRemove={ removeNotice( notice ) }
+						>
+							{ notice.content }
+						</Snackbar>
+					</div>
+				</animated.div>
+			) ) }
+		</div>
+	);
+}
+
+export default SnackbarList;

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
 		"@woocommerce/date": "file:packages/date",
 		"@woocommerce/eslint-plugin": "file:packages/eslint-plugin",
 		"@woocommerce/navigation": "file:packages/navigation",
+		"@woocommerce/notices": "file:packages/notices",
 		"@woocommerce/number": "file:packages/number",
 		"@woocommerce/tracks": "file:packages/tracks",
 		"@wordpress/babel-plugin-makepot": "2.1.3",

--- a/packages/customer-effort-score/src/index.js
+++ b/packages/customer-effort-score/src/index.js
@@ -85,7 +85,7 @@ CustomerEffortScore.propTypes = {
 
 export default compose(
 	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
+		const { createNotice } = dispatch( 'core/notices2' );
 
 		return {
 			createNotice,

--- a/packages/notices/.npmrc
+++ b/packages/notices/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,0 +1,43 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+## 2.0.0 (2020-02-10)
+
+### Breaking Change
+
+- A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
+
+## 1.5.0 (2019-06-12)
+
+### New Features
+
+- Support a new `snackbar` notice type in the `createNotice` action.
+
+## 1.1.2 (2019-01-03)
+
+## 1.1.1 (2018-12-12)
+
+## 1.1.0 (2018-11-20)
+
+### New Feature
+
+- New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
+
+### Bug Fixes
+
+- While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
+
+## 1.0.5 (2018-11-15)
+
+## 1.0.4 (2018-11-09)
+
+## 1.0.3 (2018-11-09)
+
+## 1.0.2 (2018-11-03)
+
+## 1.0.1 (2018-10-30)
+
+## 1.0.0 (2018-10-29)
+
+- Initial release.

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -1,0 +1,30 @@
+Notices
+=======
+
+State management for notices.
+
+NOTE: This has been copied from Gutenberg so that we can iterate on it faster
+than if we were relying on Gutenberg releasing a new version with our
+requirements. Once Gutenberg supports our requirements this package should be
+removed.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/notices
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+
+## Usage
+
+When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( 'core/notices' )`.
+
+For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
+
+For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](/docs/designers-developers/developers/data/data-core-notices.md).
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@woocommerce/notices",
+	"version": "2.11.0",
+	"description": "State management for notices.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"notices"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/notices/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/notices"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@babel/runtime": "^7.11.2",
+		"@wordpress/a11y": "^2.13.0",
+		"@wordpress/data": "^4.25.0",
+		"lodash": "^4.17.19"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/notices/src/index.js
+++ b/packages/notices/src/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './store';

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
+
+/**
+ * @typedef {Object} WPNoticeAction Object describing a user action option associated with a notice.
+ *
+ * @property {string}    label    Message to use as action label.
+ * @property {?string}   url      Optional URL of resource if action incurs
+ *                                browser navigation.
+ * @property {?Function} onClick  Optional function to invoke when action is
+ *                                triggered by user.
+ *
+ */
+
+/**
+ * Returns an action object used in signalling that a notice is to be created.
+ *
+ * @param {string}                [status='info']              Notice status.
+ * @param {string}                content                      Notice message.
+ * @param {Object}                [options]                    Notice options.
+ * @param {string}                [options.context='global']   Context under which to
+ *                                                             group notice.
+ * @param {string}                [options.id]                 Identifier for notice.
+ *                                                             Automatically assigned
+ *                                                             if not specified.
+ * @param {boolean}               [options.isDismissible=true] Whether the notice can
+ *                                                             be dismissed by user.
+ * @param {string}                [options.type='default']     Type of notice, one of
+ *                                                             `default`, or `snackbar`.
+ * @param {boolean}               [options.speak=true]         Whether the notice
+ *                                                             content should be
+ *                                                             announced to screen
+ *                                                             readers.
+ * @param {Array<WPNoticeAction>} [options.actions]            User actions to be
+ *                                                             presented with notice.
+ *
+ * @return {Object} Action object.
+ */
+export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
+	const {
+		speak = true,
+		isDismissible = true,
+		context = DEFAULT_CONTEXT,
+		id = uniqueId( context ),
+		actions = [],
+		type = 'default',
+		__unstableHTML,
+	} = options;
+
+	// The supported value shape of content is currently limited to plain text
+	// strings. To avoid setting expectation that e.g. a WPElement could be
+	// supported, cast to a string.
+	content = String( content );
+
+	return {
+		type: 'CREATE_NOTICE',
+		context,
+		notice: {
+			id,
+			status,
+			content,
+			spokenMessage: speak ? content : null,
+			__unstableHTML,
+			isDismissible,
+			actions,
+			type,
+		},
+	};
+}
+
+/**
+ * Returns an action object used in signalling that a success notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string} content   Notice message.
+ * @param {Object} [options] Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createSuccessNotice( content, options ) {
+	return createNotice( 'success', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that an info notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string} content   Notice message.
+ * @param {Object} [options] Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createInfoNotice( content, options ) {
+	return createNotice( 'info', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that an error notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string} content   Notice message.
+ * @param {Object} [options] Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createErrorNotice( content, options ) {
+	return createNotice( 'error', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that a warning notice is to be
+ * created. Refer to `createNotice` for options documentation.
+ *
+ * @see createNotice
+ *
+ * @param {string} content   Notice message.
+ * @param {Object} [options] Optional notice options.
+ *
+ * @return {Object} Action object.
+ */
+export function createWarningNotice( content, options ) {
+	return createNotice( 'warning', content, options );
+}
+
+/**
+ * Returns an action object used in signalling that a notice is to be removed.
+ *
+ * @param {string} id                 Notice unique identifier.
+ * @param {string} [context='global'] Optional context (grouping) in which the notice is
+ *                                    intended to appear. Defaults to default context.
+ *
+ * @return {Object} Action object.
+ */
+export function removeNotice( id, context = DEFAULT_CONTEXT ) {
+	return {
+		type: 'REMOVE_NOTICE',
+		id,
+		context,
+	};
+}

--- a/packages/notices/src/store/constants.js
+++ b/packages/notices/src/store/constants.js
@@ -1,0 +1,15 @@
+/**
+ * Default context to use for notice grouping when not otherwise specified. Its
+ * specific value doesn't hold much meaning, but it must be reasonably unique
+ * and, more importantly, referenced consistently in the store implementation.
+ *
+ * @type {string}
+ */
+export const DEFAULT_CONTEXT = 'global';
+
+/**
+ * Default notice status.
+ *
+ * @type {string}
+ */
+export const DEFAULT_STATUS = 'info';

--- a/packages/notices/src/store/controls.js
+++ b/packages/notices/src/store/controls.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+export default {
+	SPEAK( action ) {
+		speak( action.message, action.ariaLive || 'assertive' );
+	},
+};

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+// NOTE: This uses core/notices2, if this file is copied back upstream
+// to Gutenberg this needs to be changed back to core/notices.
+export default registerStore( 'core/notices2', {
+	reducer,
+	actions,
+	selectors,
+} );

--- a/packages/notices/src/store/reducer.js
+++ b/packages/notices/src/store/reducer.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { reject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import onSubKey from './utils/on-sub-key';
+
+/**
+ * Reducer returning the next notices state. The notices state is an object
+ * where each key is a context, its value an array of notice objects.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+const notices = onSubKey( 'context' )( ( state = [], action ) => {
+	switch ( action.type ) {
+		case 'CREATE_NOTICE':
+			// Avoid duplicates on ID.
+			return [
+				...reject( state, { id: action.notice.id } ),
+				action.notice,
+			];
+
+		case 'REMOVE_NOTICE':
+			return reject( state, { id: action.id } );
+	}
+
+	return state;
+} );
+
+export default notices;

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_CONTEXT } from './constants';
+
+/** @typedef {import('./actions').WPNoticeAction} WPNoticeAction */
+
+/**
+ * The default empty set of notices to return when there are no notices
+ * assigned for a given notices context. This can occur if the getNotices
+ * selector is called without a notice ever having been created for the
+ * context. A shared value is used to ensure referential equality between
+ * sequential selector calls, since otherwise `[] !== []`.
+ *
+ * @type {Array}
+ */
+const DEFAULT_NOTICES = [];
+
+/**
+ * @typedef {Object} WPNotice Notice object.
+ *
+ * @property {string}  id               Unique identifier of notice.
+ * @property {string}  status           Status of notice, one of `success`,
+ *                                      `info`, `error`, or `warning`. Defaults
+ *                                      to `info`.
+ * @property {string}  content          Notice message.
+ * @property {string}  spokenMessage    Audibly announced message text used by
+ *                                      assistive technologies.
+ * @property {string}  __unstableHTML   Notice message as raw HTML. Intended to
+ *                                      serve primarily for compatibility of
+ *                                      server-rendered notices, and SHOULD NOT
+ *                                      be used for notices. It is subject to
+ *                                      removal without notice.
+ * @property {boolean} isDismissible    Whether the notice can be dismissed by
+ *                                      user. Defaults to `true`.
+ * @property {string}  type             Type of notice, one of `default`,
+ *                                      or `snackbar`. Defaults to `default`.
+ * @property {boolean} speak            Whether the notice content should be
+ *                                      announced to screen readers. Defaults to
+ *                                      `true`.
+ * @property {WPNoticeAction[]} actions User actions to present with notice.
+ *
+ */
+
+/**
+ * Returns all notices as an array, optionally for a given context. Defaults to
+ * the global context.
+ *
+ * @param {Object}  state   Notices state.
+ * @param {?string} context Optional grouping context.
+ *
+ * @return {WPNotice[]} Array of notices.
+ */
+export function getNotices( state, context = DEFAULT_CONTEXT ) {
+	return state[ context ] || DEFAULT_NOTICES;
+}

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -1,0 +1,210 @@
+/**
+ * Internal dependencies
+ */
+import {
+	createNotice,
+	createSuccessNotice,
+	createInfoNotice,
+	createErrorNotice,
+	createWarningNotice,
+	removeNotice,
+} from '../actions';
+import { DEFAULT_CONTEXT, DEFAULT_STATUS } from '../constants';
+
+describe( 'actions', () => {
+	describe( 'createNotice', () => {
+		const id = 'my-id';
+		const status = 'status';
+		const content = 'my message';
+
+		it( 'returns an action when options is empty', () => {
+			const result = createNotice( status, content );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status,
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+					actions: [],
+					type: 'default',
+				},
+			} );
+		} );
+
+		it( 'normalizes content to string', () => {
+			const result = createNotice( status, <strong>Hello</strong> );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status,
+					content: expect.any( String ),
+					isDismissible: true,
+					id: expect.any( String ),
+					actions: [],
+					type: 'default',
+				},
+			} );
+		} );
+
+		it( 'returns an action when options passed', () => {
+			const context = 'foo';
+			const options = {
+				id,
+				isDismissible: false,
+				context: 'foo',
+			};
+
+			const result = createNotice( status, content, options );
+
+			expect( result ).toEqual( {
+				type: 'CREATE_NOTICE',
+				context,
+				notice: {
+					id,
+					status,
+					content,
+					spokenMessage: content,
+					isDismissible: false,
+					actions: [],
+					type: 'default',
+				},
+			} );
+		} );
+
+		it( 'returns an action when speak disabled', () => {
+			const result = createNotice(
+				undefined,
+				'my <strong>message</strong>',
+				{
+					id,
+					__unstableHTML: true,
+					isDismissible: false,
+					speak: false,
+				}
+			);
+
+			expect( result ).toEqual( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					id,
+					status: DEFAULT_STATUS,
+					content: 'my <strong>message</strong>',
+					spokenMessage: null,
+					__unstableHTML: true,
+					isDismissible: false,
+					actions: [],
+					type: 'default',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createSuccessNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createSuccessNotice( content );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'success',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+					type: 'default',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createInfoNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createInfoNotice( content );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: DEFAULT_STATUS,
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+					type: 'default',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createErrorNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createErrorNotice( content );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'error',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+					type: 'default',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createWarningNotice', () => {
+		it( 'should return action', () => {
+			const content = 'my message';
+
+			const result = createWarningNotice( content );
+
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status: 'warning',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+					type: 'default',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'removeNotice', () => {
+		it( 'should return action', () => {
+			const id = 'id';
+
+			expect( removeNotice( id ) ).toEqual( {
+				type: 'REMOVE_NOTICE',
+				id,
+				context: DEFAULT_CONTEXT,
+			} );
+		} );
+
+		it( 'should return action with custom context', () => {
+			const id = 'id';
+			const context = 'foo';
+
+			expect( removeNotice( id, context ) ).toEqual( {
+				type: 'REMOVE_NOTICE',
+				id,
+				context,
+			} );
+		} );
+	} );
+} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { createNotice, removeNotice } from '../actions';
+import { getNotices } from '../selectors';
+import { DEFAULT_CONTEXT } from '../constants';
+
+describe( 'reducer', () => {
+	it( 'should default to an empty object', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'should track a notice', () => {
+		const action = createNotice( 'error', 'save error' );
+		const state = reducer( undefined, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					spokenMessage: 'save error',
+					status: 'error',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+				},
+			],
+		} );
+	} );
+
+	it( 'should track a notice by context', () => {
+		const action = createNotice( 'error', 'save error', {
+			context: 'foo',
+		} );
+		const state = reducer( undefined, action );
+
+		expect( state ).toEqual( {
+			foo: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					spokenMessage: 'save error',
+					status: 'error',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+				},
+			],
+		} );
+	} );
+
+	it( 'should track notices, respecting order by which they were created', () => {
+		let action = createNotice( 'error', 'save error' );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = createNotice( 'success', 'successfully saved' );
+		const state = reducer( original, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: expect.any( String ),
+					content: 'save error',
+					spokenMessage: 'save error',
+					status: 'error',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+				},
+				{
+					id: expect.any( String ),
+					content: 'successfully saved',
+					spokenMessage: 'successfully saved',
+					status: 'success',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+				},
+			],
+		} );
+	} );
+
+	it( 'should omit a removed notice', () => {
+		const action = createNotice( 'error', 'save error' );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id ) );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [],
+		} );
+	} );
+
+	it( 'should omit a removed notice by context', () => {
+		const action = createNotice( 'error', 'save error', {
+			context: 'foo',
+		} );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original, 'foo' )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id, 'foo' ) );
+
+		expect( state ).toEqual( {
+			foo: [],
+		} );
+	} );
+
+	it( 'should omit a removed notice across contexts', () => {
+		const action = createNotice( 'error', 'save error' );
+		const original = deepFreeze( reducer( undefined, action ) );
+		const id = getNotices( original )[ 0 ].id;
+
+		const state = reducer( original, removeNotice( id, 'foo' ) );
+
+		expect( state[ DEFAULT_CONTEXT ] ).toHaveLength( 1 );
+	} );
+
+	it( 'should dedupe distinct ids, preferring new', () => {
+		let action = createNotice( 'error', 'save error (1)', {
+			id: 'error-message',
+		} );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = createNotice( 'error', 'save error (2)', {
+			id: 'error-message',
+		} );
+		const state = reducer( original, action );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: 'error-message',
+					content: 'save error (2)',
+					spokenMessage: 'save error (2)',
+					status: 'error',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+				},
+			],
+		} );
+	} );
+} );

--- a/packages/notices/src/store/test/selectors.js
+++ b/packages/notices/src/store/test/selectors.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { getNotices } from '../selectors';
+import { DEFAULT_CONTEXT } from '../constants';
+
+describe( 'selectors', () => {
+	describe( 'getNotices', () => {
+		it( 'should return a consistent empty array for empty state', () => {
+			const state = {};
+
+			expect( getNotices( state ) ).toEqual( [] );
+			expect( getNotices( state ) ).toBe( getNotices( state ) );
+		} );
+
+		it( 'should return the notices array for the default context', () => {
+			const state = {
+				[ DEFAULT_CONTEXT ]: [
+					{ id: 'b', content: 'message 1' },
+					{ id: 'a', content: 'message 2' },
+				],
+			};
+
+			expect( getNotices( state ) ).toEqual( [
+				{ id: 'b', content: 'message 1' },
+				{ id: 'a', content: 'message 2' },
+			] );
+		} );
+
+		it( 'should return the notices array for a given context', () => {
+			const state = {
+				foo: [ { id: 'c', content: 'message 3' } ],
+			};
+
+			expect( getNotices( state, 'foo' ) ).toEqual( [
+				{ id: 'c', content: 'message 3' },
+			] );
+		} );
+	} );
+} );

--- a/packages/notices/src/store/utils/on-sub-key.js
+++ b/packages/notices/src/store/utils/on-sub-key.js
@@ -1,0 +1,33 @@
+/**
+ * Higher-order reducer creator which creates a combined reducer object, keyed
+ * by a property on the action object.
+ *
+ * @param {string} actionProperty Action property by which to key object.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+export const onSubKey = ( actionProperty ) => ( reducer ) => (
+	state = {},
+	action
+) => {
+	// Retrieve subkey from action. Do not track if undefined; useful for cases
+	// where reducer is scoped by action shape.
+	const key = action[ actionProperty ];
+	if ( key === undefined ) {
+		return state;
+	}
+
+	// Avoid updating state if unchanged. Note that this also accounts for a
+	// reducer which returns undefined on a key which is not yet tracked.
+	const nextKeyState = reducer( state[ key ], action );
+	if ( nextKeyState === state[ key ] ) {
+		return state;
+	}
+
+	return {
+		...state,
+		[ key ]: nextKeyState,
+	};
+};
+
+export default onSubKey;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -379,6 +379,16 @@ class Loader {
 			true
 		);
 
+			// NOTE: This should be removed when Gutenberg is updated and
+			// the notices package is removed from WooCommerce Admin.
+			wp_register_script(
+				'wc-notices',
+				self::get_url( 'notices/index', 'js' ),
+				array(),
+				$js_file_version,
+				true
+			);
+
 		wp_register_script(
 			'wc-number',
 			self::get_url( 'number/index', 'js' ),
@@ -431,6 +441,9 @@ class Loader {
 				'wc-customer-effort-score',
 				'wc-date',
 				'wc-navigation',
+				// NOTE: This should be removed when Gutenberg is updated and
+				// the notices package is removed from WooCommerce Admin.
+				'wc-notices',
 				'wc-number',
 				'wc-store-data',
 			),
@@ -1372,6 +1385,9 @@ class Loader {
 				'wc-currency',
 				'wc-customer-effort-score',
 				'wc-navigation',
+				// NOTE: This should be removed when Gutenberg is updated and
+				// the notices package is removed from WooCommerce Admin.
+				'wc-notices',
 				'wc-number',
 				'wc-date',
 				'wc-components',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ const wcAdminPackages = [
 	'customer-effort-score',
 	'date',
 	'navigation',
+	'notices',
 	'number',
 	'data',
 	'tracks',


### PR DESCRIPTION
_EDIT: I needed to copy the `core/notices` data source (which is where `createNotice` lives), because the entire options object isn't passed down to the snackbar component meaning that each new option needed for the CES feature will have to be implemented in `core/notices` as well._

This copies the [`SnackbarList`](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/snackbar/list.js) and [`Snackbar`](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/snackbar/index.js) components in from Gutenberg, as well as the `core/notices` data source (renamed to `core/notices2`) from the `@wordpress/notices` package. This is so we can iterate over the snackbar designs in the Customer Effort Score feature without being blocked by a Gutenberg release.

NOTE: When the changes to the snackbar are pushed upstream to Gutenberg and released, the components and data source can be removed.

### Detailed test instructions:

Follow the test instructions in this PR #5406, and make sure the snackbar works as expected.

### Changelog Note:

Dev: Copy the snackbar component and core/notices from Gutenberg into WordPress Admin
