### PR TITLE
Update menu sorting for new nav structure

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -103,15 +103,6 @@ class CoreMenu {
 				'is_top_level' => true,
 			),
 			array(
-				'title'        => __( 'Extensions', 'woocommerce-admin' ),
-				'capability'   => 'activate_plugins',
-				'id'           => 'extensions',
-				'migrate'      => false,
-				'menuId'       => 'secondary',
-				'order'        => 20,
-				'is_top_level' => true,
-			),
-			array(
 				'title'        => __( 'Settings', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'settings',
@@ -178,21 +169,15 @@ class CoreMenu {
 				$product_items[1],
 				$product_items[2],
 				$coupon_items[0],
-				// Extensions category.
+				// Marketplace category.
 				array(
-					'parent'     => 'extensions',
-					'title'      => __( 'My extensions', 'woocommerce-admin' ),
-					'capability' => 'manage_woocommerce',
-					'id'         => 'my-extensions',
-					'url'        => 'plugins.php',
-					'migrate'    => false,
-				),
-				array(
-					'parent'     => 'extensions',
-					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
-					'capability' => 'manage_woocommerce',
-					'id'         => 'marketplace',
-					'url'        => 'wc-addons',
+					'title'        => __( 'Marketplace', 'woocommerce-admin' ),
+					'capability'   => 'manage_woocommerce',
+					'id'           => 'marketplace',
+					'url'          => 'wc-addons',
+					'menuId'       => 'secondary',
+					'order'        => 20,
+					'is_top_level' => true,
 				),
 				// Tools category.
 				array(

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -248,7 +248,6 @@ class Menu {
 	 *      'parent'     => (string) Parent menu item ID.
 	 *      'capability' => (string) Capability to view this menu item.
 	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'order'      => (int) Menu item order.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
 	 *      'menuId'     => (string) The ID of the menu to add the item to.
 	 *    ).
@@ -257,6 +256,7 @@ class Menu {
 		$item_args = array_merge(
 			$args,
 			array(
+				'order'        => null,
 				'menuId'       => 'plugins',
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
@@ -273,7 +273,6 @@ class Menu {
 	 *      'title'      => (string) Title of the menu item. Required.
 	 *      'capability' => (string) Capability to view this menu item.
 	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'order'      => (int) Menu item order.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
 	 *      'menuId'     => (string) The ID of the menu to add the category to.
 	 *    ).
@@ -282,6 +281,7 @@ class Menu {
 		$category_args = array_merge(
 			$args,
 			array(
+				'order'        => null,
 				'menuId'       => 'plugins',
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
@@ -519,7 +519,8 @@ class Menu {
 
 		// Sort the menu items.
 		$order = array_column( $menu_items, 'order' );
-		array_multisort( $order, SORT_ASC, $menu_items );
+		$title = array_column( $menu_items, 'title' );
+		array_multisort( $order, SORT_ASC, $title, SORT_ASC, $menu_items );
 
 		return array_values( $menu_items );
 	}


### PR DESCRIPTION
Fixes #5531

* Updates "Extensions" to "Marketplace" and moves up one level.
* Sorts extensions by alphabetical order

### Screenshots
<img width="327" alt="Screen Shot 2020-11-04 at 12 39 17 PM" src="https://user-images.githubusercontent.com/10561050/98150407-98124e00-1e9c-11eb-9e53-3fd15305bbff.png">


### Detailed test instructions:

1. Add some extensions to the menu.

```php
	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
		array(
			'id'    => 'test-c',
			'title' => 'C',
			'url'   => '#',
			'order' => 1,
		)
	);

	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
		array(
			'id'    => 'test-a',
			'title' => 'A',
			'url'   => '#',
			'order' => 2,
		)
	);

	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
		array(
			'id'    => 'test-b',
			'title' => 'B',
			'url'   => '#',
			'order' => 3,
		)
	);
```

2. Note that the extensions are in alphabetical order and that the `order` property does not change the order.
3. Check that the "Extensions" category is now named "Marketplace" and goes to the wc addons page.