### PR TITLE
Add help tab to the home screen

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -10,7 +10,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import CrossIcon from 'gridicons/dist/cross-small';
 import classnames from 'classnames';
-import { Icon, lifesaver } from '@wordpress/icons';
+import { Icon, help as helpIcon } from '@wordpress/icons';
 import { getSetting, getAdminLink } from '@woocommerce/wc-admin-settings';
 import { H, Section, Spinner } from '@woocommerce/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
@@ -151,6 +151,8 @@ export class ActivityPanel extends Component {
 		const showInbox =
 			( isEmbedded || ! this.isHomescreen() ) && ! isPerformingSetupTask;
 
+		const showHelp = this.isHomescreen() && ! isEmbedded;
+
 		const showStockAndReviews =
 			( taskListComplete || taskListHidden ) && ! isPerformingSetupTask;
 
@@ -197,11 +199,11 @@ export class ActivityPanel extends Component {
 			  ].filter( Boolean )
 			: [];
 
-		const help = isPerformingSetupTask
+		const help = showHelp
 			? {
 					name: 'help',
 					title: __( 'Help', 'woocommerce-admin' ),
-					icon: <Icon icon={ lifesaver } />,
+					icon: <Icon icon={ helpIcon } />,
 			  }
 			: null;
 

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -151,7 +151,8 @@ export class ActivityPanel extends Component {
 		const showInbox =
 			( isEmbedded || ! this.isHomescreen() ) && ! isPerformingSetupTask;
 
-		const showHelp = this.isHomescreen() && ! isEmbedded;
+		const showHelp =
+			( this.isHomescreen() && ! isEmbedded ) || isPerformingSetupTask;
 
 		const showStockAndReviews =
 			( taskListComplete || taskListHidden ) && ! isPerformingSetupTask;

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -28,6 +28,39 @@ import { getPaymentMethods } from '../../../task-list/tasks/payments/methods';
 export const SETUP_TASK_HELP_ITEMS_FILTER =
 	'woocommerce_admin_setup_task_help_items';
 
+function getHomeItems() {
+	return [
+		{
+			title: __( 'Get Support', 'woocommerce-admin' ),
+			link: 'https://woocommerce.com/my-account/create-a-ticket/',
+		},
+		{
+			title: __( 'Home Screen', 'woocommerce-admin' ),
+			link: 'https://docs.woocommerce.com/document/home-screen',
+		},
+		{
+			title: __( 'Inbox', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/home-screen/#section-1',
+		},
+		{
+			title: __( 'Stats Overview', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/home-screen/#section-2',
+		},
+		{
+			title: __( 'Store Management', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/home-screen/#section-3',
+		},
+		{
+			title: __( 'Store Setup Checklist', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/woocommerce-setup-wizard/#section-9',
+		},
+	];
+}
+
 function getAppearanceItems() {
 	return [
 		{
@@ -270,7 +303,7 @@ function getItems( props ) {
 		case 'payments':
 			return getPaymentsItems( props );
 		default:
-			return [];
+			return getHomeItems();
 	}
 }
 

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -291,3 +291,12 @@
 .has-woocommerce-navigation .woocommerce-layout__activity-panel {
 	top: 0;
 }
+
+.has-woocommerce-navigation .woocommerce-layout__activity-panel-wrapper {
+	height: calc(100vh - #{$header-height + $header-height});
+	top: #{$header-height + $header-height};
+	@include breakpoint( '>782px' ) {
+		height: calc(100vh - #{$header-height});
+		top: #{$header-height};
+	}
+}

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -252,6 +252,14 @@
 		height: calc(100vh - #{$header-height + $adminbar-height});
 		top: #{$header-height + $adminbar-height};
 	}
+	.has-woocommerce-navigation & {
+		height: calc(100vh - #{$header-height + $header-height});
+		top: #{$header-height + $header-height};
+		@include breakpoint( '>782px' ) {
+			height: calc(100vh - #{$header-height});
+			top: #{$header-height};
+		}
+	}
 
 	&.is-open {
 		transform: initial;
@@ -290,13 +298,4 @@
 
 .has-woocommerce-navigation .woocommerce-layout__activity-panel {
 	top: 0;
-}
-
-.has-woocommerce-navigation .woocommerce-layout__activity-panel-wrapper {
-	height: calc(100vh - #{$header-height + $header-height});
-	top: #{$header-height + $header-height};
-	@include breakpoint( '>782px' ) {
-		height: calc(100vh - #{$header-height});
-		top: #{$header-height};
-	}
 }

--- a/client/header/activity-panel/tab/index.js
+++ b/client/header/activity-panel/tab/index.js
@@ -13,19 +13,11 @@ export const Tab = ( {
 	selected,
 	isPanelOpen,
 	onTabClick,
-	index,
 } ) => {
 	const className = classnames( 'woocommerce-layout__activity-panel-tab', {
 		'is-active': isPanelOpen && selected,
 		'has-unread': unread,
 	} );
-
-	let tabIndex = -1;
-
-	// Only make this item tabbable if it is the currently selected item, or the panel is closed and the item is the first item.
-	if ( selected || ( ! isPanelOpen && index === 0 ) ) {
-		tabIndex = null;
-	}
 
 	const tabKey = `activity-panel-tab-${ name }`;
 
@@ -33,7 +25,6 @@ export const Tab = ( {
 		<Button
 			role="tab"
 			className={ className }
-			tabIndex={ tabIndex }
 			aria-selected={ selected }
 			aria-controls={ `activity-panel-${ name }` }
 			key={ tabKey }

--- a/client/header/activity-panel/tab/test/index.js
+++ b/client/header/activity-panel/tab/test/index.js
@@ -76,7 +76,7 @@ describe( 'ActivityPanel Tab', () => {
 		expect( queryByText( 'unread activity' ) ).toBeNull();
 	} );
 
-	it( 'is tabbable if its selected or if its closed and the first item', () => {
+	it( 'is always tabbable even if active', () => {
 		const { getByRole, rerender } = render(
 			<Tab
 				icon={ <PagesIcon /> }
@@ -111,26 +111,6 @@ describe( 'ActivityPanel Tab', () => {
 		tab = getByRole( 'tab' );
 
 		expect( tab ).not.toHaveAttribute( 'tabindex' );
-	} );
-
-	it( 'is not tabbable if its not selected, or its open', () => {
-		const { getByRole, rerender } = render(
-			<Tab
-				icon={ <PagesIcon /> }
-				title={ 'Hello World' }
-				name={ 'overview' }
-				unread={ false }
-				selected={ false }
-				isPanelOpen={ false }
-				index={ 1 }
-				onTabClick={ () => {} }
-			/>
-		);
-
-		let tab = getByRole( 'tab' );
-
-		// Tab index is not set if its the currently selected item, or the panel is closed and the item is the first item.
-		expect( tab ).toHaveAttribute( 'tabindex', '-1' );
 
 		rerender(
 			<Tab
@@ -138,7 +118,7 @@ describe( 'ActivityPanel Tab', () => {
 				title={ 'Hello World' }
 				name={ 'overview' }
 				unread={ false }
-				selected={ false }
+				selected={ true }
 				isPanelOpen={ true }
 				index={ 1 }
 				onTabClick={ () => {} }
@@ -147,7 +127,7 @@ describe( 'ActivityPanel Tab', () => {
 
 		tab = getByRole( 'tab' );
 
-		expect( tab ).toHaveAttribute( 'tabindex', '-1' );
+		expect( tab ).not.toHaveAttribute( 'tabindex' );
 	} );
 
 	it( 'calls the onTabClick handler if a tab is clicked', () => {

--- a/client/header/activity-panel/test/help-panel.js
+++ b/client/header/activity-panel/test/help-panel.js
@@ -159,6 +159,28 @@ describe( 'Activity Panels', () => {
 			).toBeDefined();
 		} );
 
+		it( 'only shows links for home screen when supported', () => {
+			const homescreen = render(
+				<HelpPanel
+					activePlugins={ [ 'woocommerce-services' ] }
+					taskName=""
+				/>
+			);
+
+			const homescreenLinkTitles = [
+				'Get Support',
+				'Home Screen',
+				'Inbox',
+				'Stats Overview',
+				'Store Management',
+				'Store Setup Checklist',
+			];
+
+			homescreenLinkTitles.forEach( ( title ) => {
+				expect( homescreen.getByText( title ) ).toBeDefined();
+			} );
+		} );
+
 		describe( 'Filters', () => {
 			const testNamespace = 'wc/admin/tests';
 

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -48,29 +48,40 @@ describe( 'Activity Panel', () => {
 		expect( screen.queryByText( 'Inbox' ) ).toBeNull();
 	} );
 
+	it( 'should not render help tab if not on home screen', () => {
+		render(
+			<ActivityPanel
+				getHistory={ () => ( {
+					location: {
+						pathname: '/customers',
+					},
+				} ) }
+				query={ {} }
+			/>
+		);
+
+		expect( screen.queryByText( 'Help' ) ).toBeNull();
+	} );
+
+	it( 'should render help tab if on home screen', () => {
+		render(
+			<ActivityPanel
+				getHistory={ () => ( {
+					location: {
+						pathname: '/',
+					},
+				} ) }
+				query={ {} }
+			/>
+		);
+
+		expect( screen.getByText( 'Help' ) ).toBeDefined();
+	} );
+
 	it( 'should render help tab before options load', async () => {
 		render(
 			<ActivityPanel
 				requestingTaskListOptions
-				query={ {
-					task: 'products',
-				} }
-			/>
-		);
-
-		const tabs = await screen.findAllByRole( 'tab' );
-
-		// Expect that the only tab is "Help".
-		expect( tabs ).toHaveLength( 1 );
-		expect( screen.getByText( 'Help' ) ).toBeDefined();
-	} );
-
-	it( 'should render help tab when on single task', async () => {
-		render(
-			<ActivityPanel
-				requestingTaskListOptions={ false }
-				taskListComplete={ false }
-				taskListHidden={ false }
 				query={ {
 					task: 'products',
 				} }
@@ -90,41 +101,14 @@ describe( 'Activity Panel', () => {
 				requestingTaskListOptions={ false }
 				taskListComplete={ false }
 				taskListHidden={ false }
+				getHistory={ () => ( {
+					location: {
+						pathname: '/customers',
+					},
+				} ) }
 				query={ {
 					task: 'products',
 					path: '/customers',
-				} }
-			/>
-		);
-
-		// Expect that "Help" tab is absent.
-		expect( screen.queryByText( 'Help' ) ).toBeNull();
-	} );
-
-	it( 'should not render help tab when TaskList is hidden', () => {
-		render(
-			<ActivityPanel
-				requestingTaskListOptions={ false }
-				taskListComplete={ false }
-				taskListHidden
-				query={ {
-					task: 'products',
-				} }
-			/>
-		);
-
-		// Expect that "Help" tab is absent.
-		expect( screen.queryByText( 'Help' ) ).toBeNull();
-	} );
-
-	it( 'should not render help tab when TaskList is complete', () => {
-		render(
-			<ActivityPanel
-				requestingTaskListOptions={ false }
-				taskListComplete
-				taskListHidden={ false }
-				query={ {
-					task: 'products',
 				} }
 			/>
 		);


### PR DESCRIPTION
Fixes #5246 

Replaced the help lifesaver icon with the help icon as seen in the ticket wireframe.

Added home items list for the HelpPanel, this list is displayed as default when no taskName is defined.
Updated the help button display logic in the Activity Panel.
- Displays if on home screen or if isPerformingSetupTask is true (in the case where the setup tasks can be performed outside of the home screen).

Removed TabIndex logic for tabs to allow keyboard use (see comment below in Accessibility).

### Accessibility

- [✔︎]  I've tested using only a keyboard (no mouse) 
  Had to remove the [tabindex logic](https://github.com/woocommerce/woocommerce-admin/blob/main/client/header/activity-panel/tab/index.js#L25) to allow for keyboard use, I couldn't think of an exception where it would be useful given the current design (unless it turns into a dropdown) @samueljseay 
- [✔︎] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![woo-home-screen-help-icon](https://user-images.githubusercontent.com/2240960/98288744-aedca180-1f7d-11eb-9924-9e5bf6074d03.gif)

### Detailed test instructions:

- Open the WooCommerce home screen
- Click the help icon in the top right
- It should display the links listed in #5246 

- Open another page under WooCommerce (not homescreen)
- Help icon should not be present