### PR TITLE
Show CES survey after editing an order

### DIFF
--- a/packages/customer-effort-score/src/style.scss
+++ b/packages/customer-effort-score/src/style.scss
@@ -3,6 +3,6 @@
 	top: 300px;
 	left: 300px;
 	background: #faa;
-	z-index: 999;
+	z-index: 99999;
 	padding: 2em;
 }

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -73,6 +73,11 @@ class CustomerEffortScoreTracks {
 	 * Add actions that require woocommerce_allow_tracking.
 	 */
 	private function enable_survey_enqueing_if_tracking_is_enabled() {
+		// Only hook up the action handlers if in wp-admin.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		// Only enqueue a survey if tracking is allowed.
 		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
 		if ( ! $allow_tracking ) {
@@ -87,15 +92,20 @@ class CustomerEffortScoreTracks {
 			)
 		);
 
-		add_action(
-			'transition_post_status',
-			array(
-				$this,
-				'run_on_transition_post_status',
-			),
-			10,
-			3
-		);
+		// Only hook up the transition_post_status action handler
+		// if on the edit page.
+		global $pagenow;
+		if ( 'post.php' === $pagenow ) {
+			add_action(
+				'transition_post_status',
+				array(
+					$this,
+					'run_on_transition_post_status',
+				),
+				10,
+				3
+			);
+		}
 
 		add_action(
 			'woocommerce_update_options',
@@ -165,11 +175,6 @@ class CustomerEffortScoreTracks {
 		$new_status,
 		$old_status
 	) {
-
-		if ( 'auto-draft' === $new_status ) {
-			return;
-		}
-
 		$this->enqueue_ces_survey_for_edited_shop_order();
 	}
 

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -30,11 +30,6 @@ class CustomerEffortScoreTracks {
 	const SHOWN_FOR_ACTIONS_OPTION_NAME = 'woocommerce_ces_shown_for_actions';
 
 	/**
-	 * The post types that we show CES surveys for.
-	 */
-	const TRACKED_POST_TYPES = array( 'product', 'shop_order' );
-
-	/**
 	 * Action name for product add/publish.
 	 */
 	const PRODUCT_ADD_PUBLISH_ACTION_NAME = 'product_add_publish';
@@ -133,14 +128,10 @@ class CustomerEffortScoreTracks {
 		$old_status,
 		$post
 	) {
-		if ( ! in_array( $post->post_type, self::TRACKED_POST_TYPES, true ) ) {
-			return;
-		}
-
 		if ( 'product' === $post->post_type ) {
 			$this->maybe_enqueue_ces_survey_for_product( $new_status, $old_status );
 		} elseif ( 'shop_order' === $post->post_type ) {
-			$this->maybe_enqueue_ces_survey_for_shop_order( $new_status, $old_status );
+			$this->enqueue_ces_survey_for_edited_shop_order();
 		}
 	}
 
@@ -163,19 +154,6 @@ class CustomerEffortScoreTracks {
 		} else {
 			$this->enqueue_ces_survey_for_edited_product();
 		}
-	}
-
-	/**
-	 * Maybe enqueue the CES survey, if shop order is being edited.
-	 *
-	 * @param string $new_status The new status.
-	 * @param string $old_status The old status.
-	 */
-	private function maybe_enqueue_ces_survey_for_shop_order(
-		$new_status,
-		$old_status
-	) {
-		$this->enqueue_ces_survey_for_edited_shop_order();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5347 

This PR triggers the display of the Customer Effort Score survey modal after editing an order. It only displays if tracking is enabled and the survey has not already been shown.

### Detailed test instructions:

Note: Depending on other outstanding PRs, you may need to make sure that...

- Tracking is enabled: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
- The options tracking whether the survey has been shown is cleared out: `delete from wp_options where option_name = 'woocommerce_ces_shown_for_actions'` executed

Steps:

- Enable the debugging of Tracks events in your browser console: `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
- Add an order (checkout from cart) on store frontend of site.
- Click on an order in wp-admin.
- Verify that the CES survey snackbar is not shown.
- Go back to the list of orders.
- Bulk modify some orders.
- Click on an order in wp-admin.
- Verify that the CES survey snackbar is not shown.
- Go back to the list of orders.
- Edit an order in wp-admin.
- Verify the CES survey snackbar is displayed.
- Click "Provide Feedback" in the snackbar.
- Verify that the "How easy was it to update an order?" survey modal is shown (how this modal looks will depend on what other PRs related to this have been merged; this PR is not concerned with how the modal looks)
- Verify that if you complete the survey (again, how this is done depends on the state of other open PRs), a Tracks event for `wcadmin_ces_feedback` is logged, with:
    - `action` set to `shop_order_update` 
    - `order_count` set to the number of orders in the store

Other things to test:

- Make sure that the CES modal is shown as expected when adding and editing Products, according to the test instructions in #5352

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog note required, as this is part of the larger Customer Effort Score feature being added.