### PR TITLE
Home Screen: Add missing text domain on home screen stats.

### DIFF
--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -162,7 +162,7 @@ export const StatsOverview = () => {
 						} );
 					} }
 				>
-					{ __( 'View detailed stats' ) }
+					{ __( 'View detailed stats', 'woocommerce-admin' ) }
 				</Link>
 			</CardFooter>
 		</Card>


### PR DESCRIPTION
Fixes #5391

This branch adds in a missing text domain on the "View Detailed Stats" link on the home screen

No testing needed, just verify the translation call looks good.