### PR TITLE
Customers: Update column heading for date registered.

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -47,7 +47,7 @@ class CustomersReportTable extends Component {
 				isSortable: true,
 			},
 			{
-				label: __( 'Sign Up', 'woocommerce-admin' ),
+				label: __( 'Date Registered', 'woocommerce-admin' ),
 				key: 'date_registered',
 				isSortable: true,
 			},


### PR DESCRIPTION
Fixes #5414 

The existing column header for the `date_registered` value of a customer is "Sign Up" which I guess kind of means "Sign Up Date" - but regardless it is conflicting with the "Sign Up" string that is used on the front-end of sites, and resulting in oddities with translations ( as reported in the issue linked above ).

The proposed fix here is to just label the column "Date Registered" so we have a unique key for this context, and to me it reads a bit better overall.

<img width="1228" alt="customers-column-change" src="https://user-images.githubusercontent.com/22080/98308248-75effd00-1f7c-11eb-9049-3221d70c1e8e.png">

This can be tested by viewing the Customers page.