### PR TITLE
Add onsubmit_label string that can be used to create a snackbar upon …

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -48,6 +48,7 @@ function CustomerEffortScoreTracksContainer( {
 					key={ index }
 					action={ item.action }
 					label={ item.label }
+					onSubmitLabel={ item.onsubmit_label }
 					trackProps={ item.props || {} }
 				/>
 			) ) }

--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -22,21 +22,25 @@ const ALLOW_TRACKING_OPTION_NAME = 'woocommerce_allow_tracking';
  * @param {string}   props.action             The action name sent to Tracks.
  * @param {Object}   props.trackProps         Additional props sent to Tracks.
  * @param {string}   props.label              The label displayed in the modal.
+ * @param {string}   props.onSubmitLabel      The label displayed upon survey submission.
  * @param {Array}    props.cesShownForActions The array of actions that the CES modal has been shown for.
  * @param {boolean}  props.allowTracking      Whether tracking is allowed or not.
  * @param {boolean}  props.resolving          Are values still being resolved.
  * @param {number}   props.storeAge           The age of the store in months.
  * @param {Function} props.updateOptions      Function to update options.
+ * @param {Function} props.createNotice       Function to create a snackbar.
  */
 function CustomerEffortScoreTracks( {
 	action,
 	trackProps,
 	label,
+	onSubmitLabel,
 	cesShownForActions,
 	allowTracking,
 	resolving,
 	storeAge,
 	updateOptions,
+	createNotice,
 } ) {
 	const [ shown, setShown ] = useState( false );
 
@@ -76,6 +80,7 @@ function CustomerEffortScoreTracks( {
 			store_age: storeAge,
 			...trackProps,
 		} );
+		createNotice( 'success', onSubmitLabel );
 	};
 
 	return (
@@ -101,6 +106,10 @@ CustomerEffortScoreTracks.propTypes = {
 	 */
 	label: PropTypes.string.isRequired,
 	/**
+	 * The label for the snackbar that appears upon survey submission.
+	 */
+	onSubmitLabel: PropTypes.string,
+	/**
 	 * The array of actions that the CES modal has been shown for.
 	 */
 	cesShownForActions: PropTypes.arrayOf( PropTypes.string ).isRequired,
@@ -121,6 +130,10 @@ CustomerEffortScoreTracks.propTypes = {
 	 * Function to update options.
 	 */
 	updateOptions: PropTypes.func,
+	/**
+	 * Function to create a snackbar
+	 */
+	createNotice: PropTypes.func,
 };
 
 export default compose(
@@ -157,9 +170,11 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			updateOptions,
+			createNotice,
 		};
 	} )
 )( CustomerEffortScoreTracks );

--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -108,7 +108,7 @@ CustomerEffortScoreTracks.propTypes = {
 	/**
 	 * The label for the snackbar that appears upon survey submission.
 	 */
-	onSubmitLabel: PropTypes.string,
+	onSubmitLabel: PropTypes.string.isRequired,
 	/**
 	 * The array of actions that the CES modal has been shown for.
 	 */

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -41,6 +41,13 @@ class CustomerEffortScoreTracks {
 	const PRODUCT_UPDATE_ACTION_NAME = 'product_update';
 
 	/**
+	 * Label for the snackbar that appears when a user submits the survey.
+	 *
+	 * @var string
+	 */
+	private $onsubmit_label;
+
+	/**
 	 * Constructor. Sets up filters to hook into WooCommerce.
 	 */
 	public function __construct() {
@@ -60,6 +67,8 @@ class CustomerEffortScoreTracks {
 				'maybe_clear_ces_tracks_queue',
 			)
 		);
+
+		$this->onsubmit_label = __( 'Thank you for your feedback!', 'woocommerce-admin' );
 	}
 
 	/**
@@ -133,7 +142,7 @@ class CustomerEffortScoreTracks {
 	/**
 	 * Enqueue the item to the CES tracks queue.
 	 *
-	 * @param object $item The item to enqueue.
+	 * @param array $item The item to enqueue.
 	 */
 	private function enqueue_to_ces_tracks( $item ) {
 		$queue = get_option(
@@ -159,14 +168,15 @@ class CustomerEffortScoreTracks {
 
 		$this->enqueue_to_ces_tracks(
 			array(
-				'action'    => self::PRODUCT_ADD_PUBLISH_ACTION_NAME,
-				'label'     => __(
+				'action'         => self::PRODUCT_ADD_PUBLISH_ACTION_NAME,
+				'label'          => __(
 					'How easy was it to add a product?',
 					'woocommerce-admin'
 				),
-				'pagenow'   => 'product',
-				'adminpage' => 'post-php',
-				'props'     => array(
+				'onsubmit_label' => $this->onsubmit_label,
+				'pagenow'        => 'product',
+				'adminpage'      => 'post-php',
+				'props'          => array(
 					'product_count' => $this->get_product_count(),
 				),
 			)
@@ -183,14 +193,15 @@ class CustomerEffortScoreTracks {
 
 		$this->enqueue_to_ces_tracks(
 			array(
-				'action'    => self::PRODUCT_UPDATE_ACTION_NAME,
-				'label'     => __(
+				'action'         => self::PRODUCT_UPDATE_ACTION_NAME,
+				'label'          => __(
 					'How easy was it to edit your product?',
 					'woocommerce-admin'
 				),
-				'pagenow'   => 'product',
-				'adminpage' => 'post-php',
-				'props'     => array(
+				'onsubmit_label' => $this->onsubmit_label,
+				'pagenow'        => 'product',
+				'adminpage'      => 'post-php',
+				'props'          => array(
 					'product_count' => $this->get_product_count(),
 				),
 			)


### PR DESCRIPTION
Fixes #5469 

This PR adds a snackbar with "Thank you for your feedback!" message upon a CES submission.

### Screenshots
![Screen Shot 2020-11-05 at 3 49 21 PM](https://user-images.githubusercontent.com/4723145/98309118-886b3600-1f7e-11eb-8373-3dc9932e0742.jpg)

### Detailed test instructions:

1. Make sure both `woocommerce_ces_shown_for_actions` and `woocommerce_ces_tracks_queue` do not exist in the `wp_options` table.

2. Navigate to Products -> Add New
3. Fill out the form and click [ Publish ]. You should be redirected to "Edit product" page.
4. A snackbar should appear at the bottom left side. Click "Give feedback"
5. Click [ Click me ] button. (this is a test modal)
6. You should see a snackbar with "Thank you for your feedback!" label.

If you want to repeat the test, delete both `woocommerce_ces_shown_for_actions` and `woocommerce_ces_tracks_queue` from the `wp_options` table and repeat the steps.