### PR TITLE
Data: Verify we have an interval array before accessing.

### DIFF
--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -369,7 +369,13 @@ export function getReportChartData( options ) {
 		}
 
 		forEach( pagedData, function ( _data ) {
-			intervals = intervals.concat( _data.data.intervals );
+			if (
+				_data.data &&
+				_data.data.intervals &&
+				Array.isArray( _data.data.intervals )
+			) {
+				intervals = intervals.concat( _data.data.intervals );
+			}
 		} );
 	}
 


### PR DESCRIPTION
Fixes #5536

While testing the Variations report, I hit a bug today. This branch implements a fix by verifying we have a valid interval data array prior to attempting to use it.

### Detailed test instructions:

- Go to Variations Report on `main`
- Open the date range picker and select "Last Year" as the range, or just use this url `wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fvariations&period=last_year&compare=previous_year`
- There will likely be a few React warnings about required PropTypes to appear in your console, disregard those for now
- Then the exception should happen and the screen should go grey.
- Check out this branch, refresh the page, and verify all is well

@jeffstieler did mention that this might have been due to me not having sales data 3 years back on my test site. I didn't verify that myself, but figured this check would be good to have regardless.

### Changelog Note:

Dev: Add undefined check in intervals data util
