### PR TITLE
Do a refresh when redirecting to homescreen after completing OBW

### DIFF
--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -234,20 +234,26 @@ class ProfileWizard extends Component {
 		updateProfileItems( { completed: true } ).then( () => {
 			clearTaskCache();
 
+			const homescreenUrl = new URL(
+				getNewPath( {}, '/', {} ),
+				window.location.href
+			).href;
+
 			if ( shouldConnectJetpack ) {
 				document.body.classList.add( 'woocommerce-admin-is-loading' );
 
-				connectToJetpack(
-					getHistory().push( getNewPath( {}, '/', {} ) )
-				);
+				connectToJetpack( () => {
+					return homescreenUrl;
+				} );
 			} else {
-				getHistory().push( getNewPath( {}, '/', {} ) );
+				window.location.href = homescreenUrl;
 			}
 		} );
 	}
 
 	skipProfiler() {
 		const { createNotice, updateProfileItems } = this.props;
+
 		updateProfileItems( { skipped: true } )
 			.then( () => {
 				recordEvent( 'storeprofiler_store_details_skip' );


### PR DESCRIPTION
Fixes #5521

The inbox notification related to installing wc payments was not showing after completing the OBW. This was due to the fact that we don't do a refresh between installing it and going back to the homescreen.

This changes the `completeProfiler` behaviour to do a full refresh at the end to always ensure that **any relevant inbox notifications are loaded when arriving on this screen.**

### Detailed test instructions:

To test the original bug is fixed:

1. Go through OBW, choosing US for country and Fashion for industry
2. Keep the "install business features" checkbox checked
3. Finish the OBW
4. It should do a refresh when going to the homescreen and the "Set up additional payment providers" inbox notification should be shown

It would also be a good idea to test the redirect functionality of the "connect to jetpack" flow in the OBW to ensure that it does redirect to the correct URL on completion.

### Changelog Note:

Fix: ensure the "Set up additional payment providers" inbox notification is shown when relevant after completing the OBW.