### PR TITLE
Added support for custom actionable statuses

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -9,13 +9,14 @@ import { Accordion, AccordionPanel } from '@woocommerce/components';
  * Internal dependencies
  */
 import './style.scss';
-import { getUnreadOrders } from './orders/utils';
+import { getOrderStatuses, getUnreadOrders } from './orders/utils';
 import { getAllPanels } from './panels';
 
 export const ActivityPanel = () => {
 	const panels = useSelect( ( select ) => {
-		const countUnreadOrders = getUnreadOrders( select );
-		return getAllPanels( { countUnreadOrders } );
+		const orderStatuses = getOrderStatuses( select );
+		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
+		return getAllPanels( { countUnreadOrders, orderStatuses } );
 	} );
 	return (
 		<Accordion>

--- a/client/homescreen/activity-panel/orders/utils.js
+++ b/client/homescreen/activity-panel/orders/utils.js
@@ -8,14 +8,10 @@ import { SETTINGS_STORE_NAME, ITEMS_STORE_NAME } from '@woocommerce/data';
  */
 import { DEFAULT_ACTIONABLE_STATUSES } from '../../../analytics/settings/config';
 
-export function getUnreadOrders( select ) {
+export function getUnreadOrders( select, orderStatuses ) {
 	const { getItemsTotalCount, getItemsError, isResolving } = select(
 		ITEMS_STORE_NAME
 	);
-	const { getSetting: getMutableSetting } = select( SETTINGS_STORE_NAME );
-	const {
-		woocommerce_actionable_order_statuses: orderStatuses = DEFAULT_ACTIONABLE_STATUSES,
-	} = getMutableSetting( 'wc_admin', 'wcAdminSettings', {} );
 
 	if ( ! orderStatuses.length ) {
 		return false;
@@ -43,4 +39,12 @@ export function getUnreadOrders( select ) {
 	}
 
 	return totalOrders;
+}
+
+export function getOrderStatuses( select ) {
+	const { getSetting: getMutableSetting } = select( SETTINGS_STORE_NAME );
+	const {
+		woocommerce_actionable_order_statuses: orderStatuses = DEFAULT_ACTIONABLE_STATUSES,
+	} = getMutableSetting( 'wc_admin', 'wcAdminSettings', {} );
+	return orderStatuses;
 }

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -8,14 +8,19 @@ import { __ } from '@wordpress/i18n';
  */
 import OrdersPanel from './orders';
 
-export function getAllPanels( { countUnreadOrders } ) {
+export function getAllPanels( { countUnreadOrders, orderStatuses } ) {
 	return [
 		{
 			className: 'woocommerce-homescreen-card',
 			count: countUnreadOrders,
 			id: 'orders-panel',
 			initialOpen: true,
-			panel: <OrdersPanel countUnreadOrders={ countUnreadOrders } />,
+			panel: (
+				<OrdersPanel
+					countUnreadOrders={ countUnreadOrders }
+					orderStatuses={ orderStatuses }
+				/>
+			),
 			title: __( 'Orders', 'woocommerce-admin' ),
 		},
 		// Add another panel row here

--- a/client/homescreen/activity-panel/style.scss
+++ b/client/homescreen/activity-panel/style.scss
@@ -105,6 +105,14 @@
 	.woocommerce-layout__activity-panel-empty {
 		border-top: 1px solid $gray-200;
 	}
+
+	.woocommerce-activity-card__button {
+		&:focus {
+			box-shadow: unset;
+			outline: unset;
+			border: 1px solid $gray-200;
+		}
+	}
 }
 
 .components-panel__body-title {

--- a/client/homescreen/activity-panel/test/index.js
+++ b/client/homescreen/activity-panel/test/index.js
@@ -30,10 +30,11 @@ jest.mock( '../panels', () => {
 	};
 } );
 
-// Mock the orders.
+// Mock the orders and order statuses.
 jest.mock( '../orders/utils', () => {
 	return {
 		getUnreadOrders: jest.fn().mockImplementation( () => 100 ),
+		getOrderStatuses: jest.fn().mockImplementation( () => [ 'status' ] ),
 	};
 } );
 


### PR DESCRIPTION
Fixes #5545

This PR adds support for custom actionable statuses. A small refactor was added in order to call the setting that provides the `orderStatuses` only once. Also, a control was added in the `OrdersPanel` to confirm that the `reportOrders` and `actionableOrders` lists were filled before rendering.

### Screenshots
![Screen Capture on 2020-11-06 at 11-57-38](https://user-images.githubusercontent.com/1314156/98380530-75607080-2027-11eb-888e-d0cf1c989c92.gif)


### Detailed test instructions:

- Go to the `Home` screen.
- Verify the orders panel is visible.
- Create a few orders (manually or using the [Smooth generator](https://github.com/woocommerce/wc-smooth-generator)).
- Confirm that the orders in progress (and on hold) number is right.
- Verify that the order card looks like it should.
- Verify the buttons and links are working well.
- Verify there is no flickering when loading.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Added support for custom actionable statuses
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
