### PR TITLE
Don't show the Orders panel on the homescreen with the Task List

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -4,6 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { Accordion, AccordionPanel } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -14,9 +15,14 @@ import { getAllPanels } from './panels';
 
 export const ActivityPanel = () => {
 	const panels = useSelect( ( select ) => {
+		const totalOrderCount = getSetting( 'orderCount', 0 );
 		const orderStatuses = getOrderStatuses( select );
 		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
-		return getAllPanels( { countUnreadOrders, orderStatuses } );
+		return getAllPanels( {
+			countUnreadOrders,
+			orderStatuses,
+			totalOrderCount,
+		} );
 	} );
 	return (
 		<Accordion>

--- a/client/homescreen/activity-panel/orders/test/index.js
+++ b/client/homescreen/activity-panel/orders/test/index.js
@@ -16,6 +16,7 @@ describe( 'OrdersPanel', () => {
 				isError={ false }
 				isRequesting={ false }
 				orderStatuses={ [] }
+				totalOrderCount={ 10 }
 			/>
 		);
 		expect(

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -8,9 +8,13 @@ import { __ } from '@wordpress/i18n';
  */
 import OrdersPanel from './orders';
 
-export function getAllPanels( { countUnreadOrders, orderStatuses } ) {
+export function getAllPanels( {
+	countUnreadOrders,
+	orderStatuses,
+	totalOrderCount,
+} ) {
 	return [
-		{
+		totalOrderCount > 0 && {
 			className: 'woocommerce-homescreen-card',
 			count: countUnreadOrders,
 			id: 'orders-panel',
@@ -24,5 +28,5 @@ export function getAllPanels( { countUnreadOrders, orderStatuses } ) {
 			title: __( 'Orders', 'woocommerce-admin' ),
 		},
 		// Add another panel row here
-	];
+	].filter( Boolean );
 }

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { getAllPanels } from '../panels';
+
+describe( 'ActivityPanel', () => {
+	it( 'should exclude the orders panel when there are no orders', () => {
+		const panels = getAllPanels( {
+			countUnreadOrders: 0,
+			orderStatuses: [],
+			totalOrderCount: 0,
+		} );
+
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'orders-panel' } ),
+			] )
+		);
+	} );
+
+	it( 'should include the orders panel when there are orders', () => {
+		const panels = getAllPanels( {
+			countUnreadOrders: 1,
+			orderStatuses: [],
+			totalOrderCount: 10,
+		} );
+
+		expect( panels ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 'orders-panel' } ),
+			] )
+		);
+	} );
+} );

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -44,6 +44,7 @@ class Homescreen {
 		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 	}
 
 	/**
@@ -133,5 +134,18 @@ class Homescreen {
 		$options[] = 'woocommerce_default_homepage_layout';
 
 		return $options;
+	}
+
+	/**
+	 * Add data to the shared component settings.
+	 *
+	 * @param array $settings Shared component settings.
+	 */
+	public function component_settings( $settings ) {
+		$allowed_statuses       = array( 'pending', 'processing', 'completed' );
+		$status_counts          = array_map( 'wc_orders_count', $allowed_statuses );
+		$settings['orderCount'] = array_sum( $status_counts );
+
+		return $settings;
 	}
 }

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -142,8 +142,12 @@ class Homescreen {
 	 * @param array $settings Shared component settings.
 	 */
 	public function component_settings( $settings ) {
-		$allowed_statuses       = array( 'pending', 'processing', 'completed' );
-		$status_counts          = array_map( 'wc_orders_count', $allowed_statuses );
+		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
+
+		// Remove the Draft Order status (from the Checkout Block).
+		unset( $allowed_statuses['checkout-draft'] );
+
+		$status_counts          = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
 		$settings['orderCount'] = array_sum( $status_counts );
 
 		return $settings;


### PR DESCRIPTION
This PR is a result of a Slack conversation - we decided that the Orders panel should not be shown if the store has yet to receive an order.

### Detailed test instructions:

- On a store with no orders, verify the Orders panel is not visible
- Either place an order, or switch to a test store with orders
- Verify the Orders panel is visible

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: hide the Orders panel before the store has received orders.