### PR TITLE
Navigation: Fix homescreen id on client

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -59,7 +59,7 @@ export const getPages = () => {
 			__( 'Home', 'woocommerce-admin' ),
 		],
 		wpOpenMenu: 'toplevel_page_woocommerce',
-		id: 'woocommerce-home',
+		id: 'home',
 	} );
 
 	if ( window.wcAdminFeatures.analytics ) {


### PR DESCRIPTION
The homescreen id on page registration changed from `woocommerce-home` to `home`. This made the router aware link in the Nav stop working because a mismatched slot/fill.

### Detailed test instructions:

1. Turn on the new Nav `woocommerce_navigation_enabled` set to "yes" if you haven't already.
1. Visit any Analytics report or wc-admin page other than Homescreen.
2. Click on "Home" in the Nav.
3. See the page navigate without a page refresh.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

none: Change to unreleased feature
