### PR TITLE
Adding wrapper class around navigation to implement scroll styles/logic

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
 	__experimentalNavigation as Navigation,
@@ -83,82 +83,93 @@ const Container = ( { menuItems } ) => {
 		[ menuItems ]
 	);
 
+	const navDomRef = useRef( null );
+
 	return (
 		<div className="woocommerce-navigation">
 			<Header />
-			<Navigation
-				activeItem={ activeItem ? activeItem.id : null }
-				activeMenu={ activeLevel }
-				onActivateMenu={ ( ...args ) => {
-					const navDomRef = document.querySelector(
-						'.components-navigation'
-					);
+			<div className="woocommerce-navigation__wrapper" ref={ navDomRef }>
+				<Navigation
+					activeItem={ activeItem ? activeItem.id : null }
+					activeMenu={ activeLevel }
+					onActivateMenu={ ( ...args ) => {
+						if ( navDomRef && navDomRef.current ) {
+							navDomRef.current.scrollTop = 0;
+						}
 
-					if ( navDomRef ) {
-						navDomRef.scrollTop = 0;
-					}
-
-					setActiveLevel( ...args );
-				} }
-			>
-				{ activeLevel === 'woocommerce' && dashboardUrl && (
-					<NavigationBackButton
-						className="woocommerce-navigation__back-to-dashboard"
-						href={ dashboardUrl }
-						backButtonLabel={ __(
-							'WordPress Dashboard',
-							'woocommerce-navigation'
-						) }
-					></NavigationBackButton>
-				) }
-				{ categories.map( ( category ) => {
-					const [
-						primaryItems,
-						secondaryItems,
-						pluginItems,
-					] = categorizedItems[ category.id ] || [ [], [], [] ];
-					return (
-						<NavigationMenu
-							key={ category.id }
-							title={ category.title }
-							menu={ category.id }
-							parentMenu={ category.parent }
-							backButtonLabel={ category.backButtonLabel || null }
-						>
-							{ !! primaryItems.length && (
-								<NavigationGroup>
-									{ primaryItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
-								</NavigationGroup>
+						setActiveLevel( ...args );
+					} }
+				>
+					{ activeLevel === 'woocommerce' && dashboardUrl && (
+						<NavigationBackButton
+							className="woocommerce-navigation__back-to-dashboard"
+							href={ dashboardUrl }
+							backButtonLabel={ __(
+								'WordPress Dashboard',
+								'woocommerce-navigation'
 							) }
-							{ !! pluginItems.length && (
-								<NavigationGroup
-									title={
-										category.id === 'woocommerce'
-											? __(
-													'Extensions',
-													'woocommerce-admin'
-											  )
-											: null
-									}
-								>
-									{ pluginItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
-								</NavigationGroup>
-							) }
-							{ !! secondaryItems.length && (
-								<NavigationGroup>
-									{ secondaryItems.map( ( item ) => (
-										<Item key={ item.id } item={ item } />
-									) ) }
-								</NavigationGroup>
-							) }
-						</NavigationMenu>
-					);
-				} ) }
-			</Navigation>
+						></NavigationBackButton>
+					) }
+					{ categories.map( ( category ) => {
+						const [
+							primaryItems,
+							secondaryItems,
+							pluginItems,
+						] = categorizedItems[ category.id ] || [ [], [], [] ];
+						return (
+							<NavigationMenu
+								key={ category.id }
+								title={ category.title }
+								menu={ category.id }
+								parentMenu={ category.parent }
+								backButtonLabel={
+									category.backButtonLabel || null
+								}
+							>
+								{ !! primaryItems.length && (
+									<NavigationGroup>
+										{ primaryItems.map( ( item ) => (
+											<Item
+												key={ item.id }
+												item={ item }
+											/>
+										) ) }
+									</NavigationGroup>
+								) }
+								{ !! pluginItems.length && (
+									<NavigationGroup
+										title={
+											category.id === 'woocommerce'
+												? __(
+														'Extensions',
+														'woocommerce-admin'
+												  )
+												: null
+										}
+									>
+										{ pluginItems.map( ( item ) => (
+											<Item
+												key={ item.id }
+												item={ item }
+											/>
+										) ) }
+									</NavigationGroup>
+								) }
+								{ !! secondaryItems.length && (
+									<NavigationGroup>
+										{ secondaryItems.map( ( item ) => (
+											<Item
+												key={ item.id }
+												item={ item }
+											/>
+										) ) }
+									</NavigationGroup>
+								) }
+							</NavigationMenu>
+						);
+					} ) }
+				</Navigation>
+			</div>
 		</div>
 	);
 };

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -22,9 +22,12 @@
 		z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
 	}
 
-	.components-navigation {
+	.woocommerce-navigation__wrapper {
 		overflow-y: auto;
 		height: calc(100vh - #{$header-height});
+	}
+
+	.components-navigation {
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
Fixes #5568

Currently the styles and logic that implement scrolling behavior for the navigation feature are attached directly to the experimentat `<Navigation>` component imported from Gutenberg. Since these are specific to the current implementation of the nav, it makes sense for them to instead be applied to a wrapper class to avoid future conflicts, as put by @joshuatf in [this previous PR](https://github.com/woocommerce/woocommerce-admin/pull/5524/files#r519804713).

### Screenshots

No visual change

### Detailed test instructions:

No change, although we should ensure that this behavior is retained:

- Check out branch
- Enable new navigation feature
- Go into WooCommerce menu
- If your viewport is larger than the navigation menu, no scroll bar should appear
- Shrink your viewport window to a smaller screensize, and ensure that scrollbar appears
- Simulate or use on mobile, ensure behavior still meets requirements. 
