### PR TITLE
Remove Inbox message is read styling

### DIFF
--- a/client/inbox-panel/style.scss
+++ b/client/inbox-panel/style.scss
@@ -1,7 +1,7 @@
 .woocommerce-inbox-message {
 	position: relative;
 	color: $gray-text;
-	background: $gray-100;
+	background: $studio-white;
 	border-radius: 2px;
 	@include font-size( 13 );
 	margin: 0 0 $gap-large;
@@ -32,10 +32,6 @@
 		border: 1px solid $gray-200;
 	}
 
-	&.message-is-unread {
-		background: $studio-white;
-	}
-
 	.line {
 		width: 100%;
 	}
@@ -59,12 +55,8 @@
 		@include font-size( 16 );
 		font-style: normal;
 		line-height: 1.5;
-		font-weight: normal;
+		font-weight: bold;
 		margin: $gap-smaller 0;
-
-		.message-is-unread & {
-			font-weight: bold;
-		}
 
 		.is-placeholder & {
 			& > div {


### PR DESCRIPTION
Fixes #5247 

Replaced the default inbox message styling (which was the `read` styling) with the `message-is-unread` styling.
Removed the scss cases where `message-is-unread` was used, as it wasn't necessary.
I left the JS logic that add's the `message-is-unread` class.

### Accessibility

- [✔︎] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="553" alt="Screen Shot 2020-11-09 at 4 58 31 PM" src="https://user-images.githubusercontent.com/2240960/98595804-da78c800-22ac-11eb-97fa-ff8b926b620b.png">

### Detailed test instructions:

- Open **WooCommerce > Orders**
- Click **Inbox** in the top right
- All messages should now have white background and bold titles, previously the **read** messages had a grey background, and titles weren't bold.