### PR TITLE
Navigation: Restoring Orders "Add->Order" menu item on new nav

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -166,6 +166,7 @@ class CoreMenu {
 			array(
 				$home_item,
 				$order_items[1],
+				$order_items[2],
 				$product_items[1],
 				$product_items[2],
 				$coupon_items[0],


### PR DESCRIPTION
Fixes #5539 

A recent change resulted in the "Add order" navigation item under the "Orders" category disappearing. This needs to be restored.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/98597380-cb365200-228d-11eb-9bc9-e753a882b4ba.png)


### Detailed test instructions:

- Checkout branch
- Ensure new navigation is enabled
- Navigate to WooCommerce to view new navigation
- Click on "Orders" category in navigation
- Ensure that the "Add Order" option is visible and functional
