### PR TITLE
Composer 2: Update release scripts

### DIFF
--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -88,7 +88,12 @@ status "Here are the changes so far. Make sure the following changes are reflect
 
 echo "- docs/: folder will have changes to documentation, if any."
 echo "- package.json: new version number."
-echo "- woocommerce-admin.php: new version numbers."
+echo "- woocommerce-admin.php: new version number."
+echo "- composer.json: new version number."
+echo "- readme.txt: new version number."
+echo "- src/FeaturePlugin.php: new version number."
+echo "- src/Composer/Package.php: new version number."
+echo "- package-lock.json: dependencies updated."
 echo -e "\n"
 echo -e "\n"
 

--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -35,6 +35,6 @@ function replace_version( $filename, $package_json ) {
 
 replace_version( 'woocommerce-admin.php', $package );
 replace_version( 'src/FeaturePlugin.php', $package );
-replace_version( 'src/Package.php', $package );
+replace_version( 'src/Composer/Package.php', $package );
 replace_version( 'readme.txt', $package );
 replace_version( 'composer.json', $package );


### PR DESCRIPTION
`src/Package.php` was renamed to `src/Composer/Package.php` in https://github.com/woocommerce/woocommerce-admin/pull/5512. Our scripts to update version numbers were still using the old path. Besides updating that, I added some logs to the pre-release script to reflect all the changes if anyone is actually reading those logs.

### Detailed test instructions:

1. `npm run pre-release`.
2. Use this branch when asked which branch to base off of, `fix/pre-release-scripts`.
3. Enter a new version number like 99.0.0 to avoid future confusion.
4. Ensure that `src/Composer/Package.php` is updated with the correct version number.

### Changelog Note:

- Dev: Update pre-release scripts to reflect Composer 2 changes
