### PR TITLE
Refactoring logic handling auto-folding navigation to support resize …

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -8,6 +8,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import classnames from 'classnames';
+import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ const Header = () => {
 		document.body.classList.toggle( 'is-folded' );
 	};
 
-	const foldOnMobile = ( screenWidth ) => {
+	const foldOnMobile = ( screenWidth = document.body.clientWidth ) => {
 		if ( screenWidth <= 960 ) {
 			document.body.classList.add( 'is-folded' );
 		}
@@ -31,12 +32,20 @@ const Header = () => {
 
 	useEffect( () => {
 		foldOnMobile( document.body.clientWidth );
+		const foldEvents = [
+			{
+				eventName: 'orientationchange',
+				handler: ( e ) => foldOnMobile( e.target.screen.availWidth ),
+			},
+			{
+				eventName: 'resize',
+				handler: debounce( () => foldOnMobile(), 200 ),
+			},
+		];
 
-		window.addEventListener(
-			'orientationchange',
-			( e ) => foldOnMobile( e.target.screen.availWidth ),
-			false
-		);
+		for ( const { eventName, handler } of foldEvents ) {
+			window.addEventListener( eventName, handler, false );
+		}
 	}, [] );
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;

--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -25,13 +25,15 @@ const Header = () => {
 	};
 
 	const foldOnMobile = ( screenWidth = document.body.clientWidth ) => {
-		if ( screenWidth <= 960 ) {
-			document.body.classList.add( 'is-folded' );
-		}
+		const isSmallScreen = screenWidth <= 960;
+
+		document.body.classList[ isSmallScreen ? 'add' : 'remove' ](
+			'is-folded'
+		);
 	};
 
 	useEffect( () => {
-		foldOnMobile( document.body.clientWidth );
+		foldOnMobile();
 		const foldEvents = [
 			{
 				eventName: 'orientationchange',


### PR DESCRIPTION
Fixes #5557 

Right now the navigation will auto-collapse in response to an `orientationchange` event if the viewport is less than 960px. According to the referenced issue we need to apply this logic to the resize event as well. This change will also add behavior that will auto-extend the nav when the viewport is resized to be greater than the mentioned threshold. 

### Detailed test instructions:

- Check out branch
- Ensure the navigation feature is enabled
- Navigate to Wp Admin -> WooCommerce to view the new navigation
- With the navigation displayed, resize the viewport to less than 960px
- Ensure that the navigation collapses.
- Resize the viewport again to be greater than 960px
- Ensure that the navigation extends.