### PR TITLE
Change rendering of homescreen layout so store links are last

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -69,11 +69,11 @@ export const Layout = ( {
 					/>
 					<ActivityPanel />
 					{ isTaskListEnabled && renderTaskList() }
-					{ ! isTaskListEnabled && <StoreManagementLinks /> }
 				</Column>
 				<Column shouldStick={ twoColumns }>
 					<StatsOverview />
 					<InboxPanel />
+					{ ! isTaskListEnabled && <StoreManagementLinks /> }
 				</Column>
 			</>
 		);

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { Suspense, lazy, useState } from '@wordpress/element';
+import {
+	Suspense,
+	lazy,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import classnames from 'classnames';
@@ -55,10 +62,26 @@ export const Layout = ( {
 		setShowInbox( true );
 	}
 
+	const isWideViewport = useRef( true );
+	const maybeToggleColumns = useCallback( () => {
+		isWideViewport.current = window.innerWidth >= 782;
+	}, [] );
+
+	useLayoutEffect( () => {
+		maybeToggleColumns();
+		window.addEventListener( 'resize', maybeToggleColumns );
+
+		return () => {
+			window.removeEventListener( 'resize', maybeToggleColumns );
+		};
+	}, [ maybeToggleColumns ] );
+
+	const shouldStickColumns = isWideViewport.current && twoColumns;
+
 	const renderColumns = () => {
 		return (
 			<>
-				<Column shouldStick={ twoColumns }>
+				<Column shouldStick={ shouldStickColumns }>
 					<ActivityHeader
 						className="your-store-today"
 						title={ __( 'Your store today', 'woocommerce-admin' ) }
@@ -69,14 +92,14 @@ export const Layout = ( {
 					/>
 					<ActivityPanel />
 					{ isTaskListEnabled && renderTaskList() }
-					{ ! isTaskListEnabled && twoColumns && (
+					{ ! isTaskListEnabled && shouldStickColumns && (
 						<StoreManagementLinks />
 					) }
 				</Column>
-				<Column shouldStick={ twoColumns }>
+				<Column shouldStick={ shouldStickColumns }>
 					<StatsOverview />
 					<InboxPanel />
-					{ ! isTaskListEnabled && ! twoColumns && (
+					{ ! isTaskListEnabled && ! shouldStickColumns && (
 						<StoreManagementLinks />
 					) }
 				</Column>

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -69,11 +69,16 @@ export const Layout = ( {
 					/>
 					<ActivityPanel />
 					{ isTaskListEnabled && renderTaskList() }
+					{ ! isTaskListEnabled && twoColumns && (
+						<StoreManagementLinks />
+					) }
 				</Column>
 				<Column shouldStick={ twoColumns }>
 					<StatsOverview />
 					<InboxPanel />
-					{ ! isTaskListEnabled && <StoreManagementLinks /> }
+					{ ! isTaskListEnabled && ! twoColumns && (
+						<StoreManagementLinks />
+					) }
 				</Column>
 			</>
 		);
@@ -150,12 +155,23 @@ export default compose(
 			getOption( 'woocommerce_task_list_welcome_modal_dismissed' ) ===
 			'yes';
 
+		console.log(
+			'raw opt value',
+			getOption( 'woocommerce_task_list_welcome_modal_dismissed' )
+		);
+
+		console.log( 'it equal yes?', welcomeModalDismissed );
+
 		const welcomeModalDismissedIsResolving = isResolving( 'getOption', [
 			'woocommerce_task_list_welcome_modal_dismissed',
 		] );
 
+		console.log( 'isresolve? ', welcomeModalDismissedIsResolving );
+
 		const shouldShowWelcomeModal =
 			! welcomeModalDismissedIsResolving && ! welcomeModalDismissed;
+
+		console.log( 'final value? ', shouldShowWelcomeModal );
 
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -155,23 +155,12 @@ export default compose(
 			getOption( 'woocommerce_task_list_welcome_modal_dismissed' ) ===
 			'yes';
 
-		console.log(
-			'raw opt value',
-			getOption( 'woocommerce_task_list_welcome_modal_dismissed' )
-		);
-
-		console.log( 'it equal yes?', welcomeModalDismissed );
-
 		const welcomeModalDismissedIsResolving = isResolving( 'getOption', [
 			'woocommerce_task_list_welcome_modal_dismissed',
 		] );
 
-		console.log( 'isresolve? ', welcomeModalDismissedIsResolving );
-
 		const shouldShowWelcomeModal =
 			! welcomeModalDismissedIsResolving && ! welcomeModalDismissed;
-
-		console.log( 'final value? ', shouldShowWelcomeModal );
 
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||


### PR DESCRIPTION
Fixes #5566

The store management link section should be displayed last in the homescreen. This places the links in the same column as the inbox, just after it as specified in #5566 

### Accessibility

n/a no accessibility changes here. 

### Screenshots

<img width="968" alt="Screenshot 2020-11-10 at 2 33 35 PM" src="https://user-images.githubusercontent.com/1281828/98616548-e1addd80-2361-11eb-9e20-a7408989c929.png">


### Detailed test instructions:

* Complete the task list
* Ensure that the store management links are displayed last on the homescreen, after the inbox.

### Changelog Note:

Fix:  Display the store management links last on the homescreen
