### PR TITLE
Fix reference to navigation package and fix transient notices so it l…

### DIFF
--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -46,10 +46,11 @@ TransientNotices.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		// NOTE: This uses core/notices2, if this file is copied back upstream
-		// to Gutenberg this needs to be changed back to core/notices.
-		const notices = select( 'core/notices2' ).getNotices();
+		// to Gutenberg this needs to be changed back to just core/notices.
+		const notices = select( 'core/notices' ).getNotices();
+		const notices2 = select( 'core/notices2' ).getNotices();
 
-		return { notices };
+		return { notices: notices.concat( notices2 ) };
 	} ),
 	withDispatch( ( dispatch ) => ( {
 		// NOTE: This uses core/notices2, if this file is copied back upstream

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -241,7 +241,7 @@ class OnboardingTasks {
 			return;
 		}
 
-		wp_enqueue_script( 'onboarding-product-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
+		wp_enqueue_script( 'onboarding-product-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ), array( 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 	}
 
 	/**


### PR DESCRIPTION
…ooks at core/notices as well as core/notices2

NOTE this should *not* be cherry-picked, it includes a fix that isn't required (or possible) in the 1.7.0 cut. I'll make another PR for the cherry-pick.

Fixes #5553

There's two parts to this. For some reason including `wc-navigation` as a dependency to the script included when the first product is added causes seemingly non-related errors in Safari only, which killed the activity panel as well as the notification. The second part is that even after fixing the dependencies, the snackbar wasn't appearing due to the fork [added a couple of days ago](https://github.com/woocommerce/woocommerce-admin/pull/5532). This was fixed by referencing both data stores - `core/notices` and the newly added `core/notices2`.

Note that this second issue would have been affecting all existing usages of `core/notices` (only since Monday).

### Detailed test instructions:

- In Safari,
- delete all of your products. Yes even the ones you like.
- make sure your onboarding task list is visible on the WooCommerce home screen
- "Add my products"
- "Add manually"
- Add a product.
- When the page refreshes after adding the product the success message should appear and the activity panel should still be visible.

### Changelog Note:

Fix: First product script navigation dependency
Fix: Reference both core/notices and core/notices2