### PR TITLE
Fix/remove first product script navigation dependency

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -241,7 +241,7 @@ class OnboardingTasks {
 			return;
 		}
 
-		wp_enqueue_script( 'onboarding-product-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
+		wp_enqueue_script( 'onboarding-product-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ), array( 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 	}
 
 	/**


### PR DESCRIPTION
NOTE this PR's base is `release/1.7.0` so it can just be merged rather than cherry picked.

Fixes #5553

For some reason including `wc-navigation` as a dependency to the script included when the first product is added causes seemingly non-related errors in Safari only, which killed the activity panel as well as the notification.

### Detailed test instructions:

- In Safari,
- delete all of your products. Yes even the ones you like.
- make sure your onboarding task list is visible on the WooCommerce home screen
- "Add my products"
- "Add manually"
- Add a product.
- When the page refreshes after adding the product the success message should appear and the activity panel should still be visible.

### Changelog Note:

Fix: First product script navigation dependency
