### PR TITLE
Fix column scroll collision after layout change.

### DIFF
--- a/client/header/activity-panel/display-options/index.js
+++ b/client/header/activity-panel/display-options/index.js
@@ -65,7 +65,7 @@ export const DisplayOptions = () => {
 				className: 'woocommerce-layout__activity-panel-popover',
 			} }
 		>
-			{ () => (
+			{ ( { onClose } ) => (
 				<MenuGroup
 					className="woocommerce-layout__homescreen-display-options"
 					label={ __( 'Layout', 'woocommerce-admin' ) }
@@ -76,6 +76,7 @@ export const DisplayOptions = () => {
 							updateUserPreferences( {
 								homepage_layout: newLayout,
 							} );
+							onClose();
 							recordEvent( 'homescreen_display_option', {
 								display_option: newLayout,
 							} );

--- a/client/homescreen/column.js
+++ b/client/homescreen/column.js
@@ -51,7 +51,7 @@ export const Column = ( { children, shouldStick = false } ) => {
 			className="woocommerce-homescreen-column"
 			ref={ content }
 			style={ {
-				position: isContentStuck ? 'sticky' : 'static',
+				position: shouldStick && isContentStuck ? 'sticky' : 'static',
 			} }
 		>
 			{ children }


### PR DESCRIPTION
Fixes #5585.

This PR fixes the column stickiness (and therefore scroll collision) when switching from two column to single column. Additionally, it dismisses the display options popover when a selection is made.

It **does not** address the focused element in the display options menu, as this is the behavior of the Gutenberg component. See: 
![Screen Shot 2020-11-10 at 10 01 07 AM](https://user-images.githubusercontent.com/63922/98699428-224b2e00-2345-11eb-8528-c4b4ff93c5d7.png)

### Screenshots

https://cldup.com/OH23zyR8my.gif

### Detailed test instructions:

- Go to WooCommerce > Home
- Select "two column" layout from Display Options
- Verify scrolling works as expected
- Select "single column" layout from Display Options
- Verify scrolling works as expected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
