### PR TITLE
Change select control padding to match text-control inputs

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -1,5 +1,3 @@
-
-
 .woocommerce-select-control {
 	position: relative;
 
@@ -10,7 +8,7 @@
 		border: 1px solid $studio-gray-20;
 		border-radius: 3px;
 		background: $studio-white;
-		padding: $gap-small $gap;
+		padding: $gap-small;
 		position: relative;
 
 		.woocommerce-select-control__tags {
@@ -140,7 +138,7 @@
 
 	&.is-searchable {
 		.components-base-control__label {
-			left: 52px;
+			left: 48px;
 		}
 
 		.components-base-control.is-active .components-base-control__label {


### PR DESCRIPTION
Fixes #4254 

Updated the select control padding to use `$gap-small` for left/right padding (right is actually being overwritten already) to match the text control padding (the search control uses the same padding).

Updated the label `left` by `4px` to make up for the changed padding, this way the label also aligns with the input field.

### Screenshots

<img width="806" alt="Screen Shot 2020-11-10 at 12 22 48 PM" src="https://user-images.githubusercontent.com/2240960/98701738-ff724700-234f-11eb-8867-df278fb55cfc.png">

### Detailed test instructions:

- Have WooCommerce and WooCommerceAdmin enabled
- Go to the Woo setup wizard, can access using this url -> `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
- The magnifying glass for Country/Region field should align with the other text fields now.