### PR TITLE
Home screen - Fixed the orders not displaying bug

### DIFF
--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -304,12 +304,8 @@ export default withSelect( ( select, props ) => {
 		REPORTS_STORE_NAME
 	);
 
-	if ( countUnreadOrders === null ) {
-		return { isRequesting: true };
-	}
-
-	if ( countUnreadOrders === 0 ) {
-		return { isRequesting: false };
+	if ( ! countUnreadOrders ) {
+		return { isRequesting: countUnreadOrders !== 0 };
 	}
 
 	// Query the core Orders endpoint for the most up-to-date statuses.
@@ -344,6 +340,7 @@ export default withSelect( ( select, props ) => {
 		per_page: 5,
 		extended_info: true,
 		order_includes: map( actionableOrders, 'id' ),
+		status_is: orderStatuses,
 		_fields: [
 			'order_id',
 			'order_number',

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -346,7 +346,6 @@ export default withSelect( ( select, props ) => {
 			'order_id',
 			'order_number',
 			'status',
-			'data_created_gmt',
 			'total_sales',
 			'extended_info.customer',
 			'extended_info.products',

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -339,6 +339,7 @@ export default withSelect( ( select, props ) => {
 		page: 1,
 		per_page: 5,
 		extended_info: true,
+		match: 'any',
 		order_includes: map( actionableOrders, 'id' ),
 		status_is: orderStatuses,
 		_fields: [

--- a/client/homescreen/activity-panel/orders/utils.js
+++ b/client/homescreen/activity-panel/orders/utils.js
@@ -14,7 +14,7 @@ export function getUnreadOrders( select, orderStatuses ) {
 	);
 
 	if ( ! orderStatuses.length ) {
-		return false;
+		return 0;
 	}
 
 	const ordersQuery = {


### PR DESCRIPTION
Fixes #5567

This PR fixes the orders not displaying bug.

### Screenshots
![Screen Capture on 2020-11-10 at 15-20-46](https://user-images.githubusercontent.com/1314156/98715038-5f74e780-2368-11eb-846a-496759fef8e8.gif)

### Detailed test instructions:

- Create a few orders (manually or using the [Smooth generator](https://github.com/woocommerce/wc-smooth-generator)).
- Go to `Analytics` > `Settings` and select all the checkboxes under `Actionable Statuses` (**don't select unregistered statuses**).

![screenshot-one wordpress test-2020 11 10-15_08_26](https://user-images.githubusercontent.com/1314156/98713686-abbf2800-2366-11eb-8843-99822018eb6c.png)

- Go to the `Home` screen. Don't refresh the page in order to not lose the `Analytics > Settings` selection.
- Confirm that the total orders number is right.

![screenshot-one wordpress test-2020 11 10-15_14_30](https://user-images.githubusercontent.com/1314156/98714402-98608c80-2367-11eb-9698-ab5fc05b5afd.png)

- Go back to the Analytics settings and select only one status (or neither).
- Go to `Home` screen and verify that the orders panel has the selected ones.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Home screen - Fixed the orders not displaying bug
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
