### PR TITLE
Update custom post type menu item defaults

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -165,11 +165,11 @@ class CoreMenu {
 		return array_merge(
 			array(
 				$home_item,
-				$order_items[1],
-				$order_items[2],
-				$product_items[1],
-				$product_items[2],
-				$coupon_items[0],
+				$order_items['all'],
+				$order_items['new'],
+				$product_items['all'],
+				$product_items['new'],
+				$coupon_items['default'],
 				// Marketplace category.
 				array(
 					'title'        => __( 'Marketplace', 'woocommerce-admin' ),

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -348,7 +348,7 @@ class Menu {
 		}
 
 		return array(
-			array_merge(
+			'default' => array_merge(
 				array(
 					'title'      => esc_attr( $post_type_object->labels->menu_name ),
 					'capability' => $post_type_object->cap->edit_posts,
@@ -357,7 +357,7 @@ class Menu {
 				),
 				$menu_args
 			),
-			array_merge(
+			'all'     => array_merge(
 				array(
 					'parent'     => $post_type,
 					'title'      => esc_attr( $post_type_object->labels->all_items ),
@@ -368,7 +368,7 @@ class Menu {
 				),
 				$menu_args
 			),
-			array_merge(
+			'new'     => array_merge(
 				array(
 					'parent'     => $post_type,
 					'title'      => esc_attr( $post_type_object->labels->add_new ),

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -359,7 +359,6 @@ class Menu {
 			),
 			'all'     => array_merge(
 				array(
-					'parent'     => $post_type,
 					'title'      => esc_attr( $post_type_object->labels->all_items ),
 					'capability' => $post_type_object->cap->edit_posts,
 					'id'         => "{$post_type}-all-items",
@@ -370,7 +369,6 @@ class Menu {
 			),
 			'new'     => array_merge(
 				array(
-					'parent'     => $post_type,
 					'title'      => esc_attr( $post_type_object->labels->add_new ),
 					'capability' => $post_type_object->cap->create_posts,
 					'id'         => "{$post_type}-add-new",


### PR DESCRIPTION
Fixes #5588 

Returns an associative array for menu items and removes the default parent.

### Screenshots
<img width="342" alt="Screen Shot 2020-11-10 at 1 30 51 PM" src="https://user-images.githubusercontent.com/10561050/98716216-2f721800-2359-11eb-9701-d43ccab8ae9e.png">


### Detailed test instructions:

1. Enable the new navigation.
1. Check that Orders and Products menu items still work as expected.