### PR TITLE
Fix non-matching items and post type matching

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -47,8 +47,10 @@ const Container = ( { menuItems } ) => {
 
 	useEffect( () => {
 		const initialMatchedItem = getMatchingItem( menuItems );
-		setActiveItem( initialMatchedItem );
-		setActiveLevel( initialMatchedItem.parent );
+		if ( initialMatchedItem ) {
+			setActiveItem( initialMatchedItem );
+			setActiveLevel( initialMatchedItem.parent );
+		}
 
 		const removeListener = addHistoryListener( () => {
 			setTimeout( () => {

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -69,9 +69,19 @@ export const getMatchScore = ( location, url ) => {
 	}
 
 	const urlParams = getParams( urlLocation );
-	const locationParams = getParams( location );
-	let matchingParamCount = 0;
 
+	// Post type match.
+	if (
+		window.wcNavigation.postType === urlParams.post_type &&
+		urlPathname.indexOf( 'edit.php' ) >= 0 &&
+		origin === urlOrigin
+	) {
+		return Number.MAX_SAFE_INTEGER - 2;
+	}
+
+	// Add points for each matching param.
+	let matchingParamCount = 0;
+	const locationParams = getParams( location );
 	Object.keys( urlParams ).forEach( ( key ) => {
 		if ( urlParams[ key ] === locationParams[ key ] ) {
 			matchingParamCount++;

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -139,11 +139,11 @@ export const getMatchingItem = ( items ) => {
 			window.location,
 			getAdminLink( item.url )
 		);
-		if ( score >= highestMatch ) {
+		if ( score >= highestMatch && score > 0 ) {
 			matchedItem = item;
 			highestMatch = score;
 		}
 	} );
 
-	return matchedItem ? matchedItem : null;
+	return matchedItem || null;
 };

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -538,6 +538,7 @@ class Menu {
 
 		$data = array(
 			'menuItems' => self::get_prepared_menu_item_data(),
+			'postType'  => isset( $_GET['post'] ) ? get_post_type( $_GET['post'] ) : null,
 		);
 
 		$paul = wp_add_inline_script( WC_ADMIN_APP, 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );


### PR DESCRIPTION
Fixes #5575 

* Avoids matching the last item if no matches exist.
* Matches post type edit pages to the respective post type "all" menu item.

### Screenshots
<img width="861" alt="Screen Shot 2020-11-10 at 3 52 11 PM" src="https://user-images.githubusercontent.com/10561050/98732296-f5ab0c80-236c-11eb-9c83-59fc79271146.png">


### Detailed test instructions:

1. Enable the navigation feature.
1. Create or edit an existing order.
1. Note the active menu item is correct.
1. Check that no regressions have occurred with other menu item's active status.