### PR TITLE
Update Woo tested and min versions.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,7 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 
 		$wc_tests_framework_base_dir = $this->wc_core_dir . '/tests';
+
 		if ( ! is_dir( $wc_tests_framework_base_dir . '/framework' ) ) {
 			$wc_tests_framework_base_dir .= '/legacy';
 		}
@@ -52,6 +53,9 @@ class WC_Admin_Unit_Tests_Bootstrap {
 
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';
+
+		// load the wc installer.
+		require_once $this->wc_core_dir . '/includes/class-wc-install.php';
 
 		// load WC.
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -11,8 +11,8 @@
  * Requires at least: 5.3
  * Requires PHP: 5.6.20
  *
- * WC requires at least: 3.6.0
- * WC tested up to: 4.3.0
+ * WC requires at least: 4.5.0
+ * WC tested up to: 4.7.0
  *
  * @package WooCommerce\Admin
  */


### PR DESCRIPTION
Fixes #5561

Per the conversation in the above issue, this branch updates our min supported Woo version to be the current release ( this will be 4.8 when this ships ) -3, so 4.5, and also updated the tested up to to match the latest Woo version.