### PR TITLE
Allow extensions to order items in submenus

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -250,13 +250,17 @@ class Menu {
 	 *      'url'        => (string) URL or callback to be used. Required.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
 	 *      'menuId'     => (string) The ID of the menu to add the item to.
+	 *      'order'      => (int) Menu item order.
 	 *    ).
 	 */
 	public static function add_plugin_item( $args ) {
+		if ( ! isset( $args['parent'] ) ) {
+			unset( $args['order'] );
+		}
+
 		$item_args = array_merge(
 			$args,
 			array(
-				'order'        => null,
 				'menuId'       => 'plugins',
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
@@ -275,13 +279,17 @@ class Menu {
 	 *      'url'        => (string) URL or callback to be used. Required.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
 	 *      'menuId'     => (string) The ID of the menu to add the category to.
+	 *      'order'      => (int) Menu item order.
 	 *    ).
 	 */
 	public static function add_plugin_category( $args ) {
+		if ( ! isset( $args['parent'] ) ) {
+			unset( $args['order'] );
+		}
+
 		$category_args = array_merge(
 			$args,
 			array(
-				'order'        => null,
 				'menuId'       => 'plugins',
 				'is_top_level' => ! isset( $args['parent'] ),
 			)


### PR DESCRIPTION
Extensions by default cannot order top menu items, but this PR allows extensions to order submenu items.

### Screenshots
<img width="259" alt="Screen Shot 2020-11-11 at 4 12 12 PM" src="https://user-images.githubusercontent.com/10561050/98864965-acc08a00-2438-11eb-88f1-85f2f53bc6b6.png">


### Detailed test instructions:

1. Register an extension category with the navigation. (See https://github.com/woocommerce/woocommerce-memberships/pull/103 for an example)
1. Register some items.
1. Make sure you can add an `order` to submenu items.
1. Make sure top-level items cannot be re-ordered (should remain alphabetical).