### PR TITLE
Fix WCS slug when building Tracks data.

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -126,7 +126,7 @@ class BusinessDetails extends Component {
 			used_platform: otherPlatform,
 			used_platform_name: otherPlatformName,
 			install_woocommerce_services: businessExtensions.includes(
-				'facebook-for-woocommerce'
+				'woocommerce-services'
 			),
 			install_jetpack: businessExtensions.includes( 'jetpack' ),
 			install_facebook: businessExtensions.includes(


### PR DESCRIPTION
Tracks data was checking FB install instead. Props @dechov - https://github.com/woocommerce/woocommerce-admin/pull/4695#discussion_r521565942.

Fixes https://github.com/woocommerce/woocommerce-admin/pull/4695#discussion_r521565942
