### PR TITLE
Adding body class for navigation to indicate when it is expanded, pre…

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -19,17 +19,35 @@ const Header = () => {
 	const siteTitle = getSetting( 'siteTitle', '' );
 	const siteUrl = getSetting( 'siteUrl', '' );
 	const isScrolled = useIsScrolled();
+	const navClasses = {
+		folded: 'is-folded',
+		expanded: 'is-expanded',
+	};
+
+	const foldNav = () => {
+		document.body.classList.add( navClasses.folded );
+		document.body.classList.remove( navClasses.expanded );
+	};
+
+	const expandNav = () => {
+		document.body.classList.remove( navClasses.folded );
+		document.body.classList.add( navClasses.expanded );
+	};
 
 	const toggleFolded = () => {
-		document.body.classList.toggle( 'is-folded' );
+		if ( document.body.classList.contains( navClasses.folded ) ) {
+			expandNav();
+		} else {
+			foldNav();
+		}
 	};
 
 	const foldOnMobile = ( screenWidth = document.body.clientWidth ) => {
-		const isSmallScreen = screenWidth <= 960;
-
-		document.body.classList[ isSmallScreen ? 'add' : 'remove' ](
-			'is-folded'
-		);
+		if ( screenWidth <= 960 ) {
+			foldNav();
+		} else {
+			expandNav();
+		}
 	};
 
 	useEffect( () => {

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -11,6 +11,15 @@
 		display: none !important;
 	}
 
+	#wpcontent,
+	#wpfooter {
+		margin-left: $navigation-width;
+
+		@media ( max-width: 960px ) {
+			margin-left: 0;
+		}
+	}
+
 	#woocommerce-embedded-navigation {
 		position: fixed;
 		top: 0;
@@ -20,6 +29,11 @@
 		box-sizing: border-box;
 		background-color: $gray-900;
 		z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
+
+		@media ( max-width: 960px ) {
+			width: $header-height;
+			height: $header-height;
+		}
 	}
 
 	.components-navigation {
@@ -28,14 +42,10 @@
 		box-sizing: border-box;
 	}
 
-	&:not(.is-folded) {
-		#wpcontent,
-		#wpfooter {
-			margin-left: $navigation-width;
-
-			@media ( max-width: 960px ) {
-				margin-left: 0;
-			}
+	&.is-expanded {
+		#woocommerce-embedded-navigation {
+			width: $navigation-width;
+			height: 100%;
 		}
 	}
 


### PR DESCRIPTION
Fixes #5580 

This is addressing the issue of the navigation placeholder (the container that is visible on page load) appearing as if the navigation is expanded before it's folded by default on mobile. It required adding a body class to indicate when the navigation is expanded (and loaded) in addition to the preexisting class that had been added when it was folded. 


### Screenshots

On mobile, how the navigation placeholder appears before change(s):
![image](https://user-images.githubusercontent.com/444632/98975586-21dc9f80-24cb-11eb-80bb-0ce2b5218e0c.png)


After changes:
![image](https://user-images.githubusercontent.com/444632/98975651-39b42380-24cb-11eb-867a-37f50dce88fb.png)


### Detailed test instructions:

- Checkout branch
- Ensure the navigation feature is enabled
- Go to WP-Admin -> WooCommerce to view new navigation
- Reduce width of viewport to less than 960 pixels
- Refresh the page
- While loading, you should observe the smaller placeholder as pictured in the second screenshot.
