### PR TITLE
Skip WC Payment plugin note if plugin not added through onboarding process

### DIFF
--- a/src/Notes/SetUpAdditionalPaymentTypes.php
+++ b/src/Notes/SetUpAdditionalPaymentTypes.php
@@ -45,11 +45,21 @@ class SetUpAdditionalPaymentTypes {
 	}
 
 	/**
-	 * Executes when the WooCommerce Payments plugin is activated. Possibly
-	 * adds the note if it isn't already in the database and if it matches any
-	 * criteria (see get_note()).
+	 * Executes when the WooCommerce Payments plugin is activated. It does nothing
+	 * if WooCommerce Payments plugin is not included in onboarding business extensions,
+	 * otherwise it possibly adds the note if it isn't already in the database and if
+	 * it matches any criteria (see get_note()).
 	 */
 	public static function on_activate_wcpay() {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		if ( is_array( $onboarding_profile ) && array_key_exists( 'business_extensions', $onboarding_profile ) ) {
+			if ( ! is_array( $onboarding_profile['business_extensions'] ) ||
+				! in_array( 'woocommerce-payments', $onboarding_profile['business_extensions'], true )
+			) {
+				return;
+			}
+		}
+
 		self::possibly_add_note();
 	}
 


### PR DESCRIPTION
Fixes #5601 

Add suggestion @timmyc mentioned in the ticket:
- Skip `possibly_add_note()` if WCPay is not part of the onboarding business extensions list
- Run `possibly_add_note()` if WCPay is part of the onboarding business extensions list

### Screenshots

Not Showing note:
![additional-payment-provider](https://user-images.githubusercontent.com/2240960/98985974-aabeff80-24fa-11eb-9169-24a0aa8b7a7d.gif)

Showing Note:
![additional-payment-provider-shown](https://user-images.githubusercontent.com/2240960/98986578-7ac42c00-24fb-11eb-9373-fdf4b834ce93.gif)

### Detailed test instructions:

1. Create a new store
2. Complete the store profiler with the US as location and Electronics and Computers as Industry
3. Install WooCommerce Payments through the Payments task
4. `Set up additional payment providers` note should not be shown on home screen or in inbox

Or the other case:
1. Create a new store
2. Complete the store profiler with the US as location and select 'Fashion, apparel, and accessories'
4. `Set up additional payment providers` note should be shown on home screen or in inbox

