### PR TITLE
Update panel icon order - moving help tab far right

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -212,15 +212,19 @@ export class ActivityPanel extends Component {
 			  }
 			: null;
 
-		const displayOption = showDisplayOptions
+		const displayOptions = showDisplayOptions
 			? {
 					component: DisplayOptions,
 			  }
 			: null;
 
-		return [ inbox, ...stockAndReviews, setup, displayOption, help ].filter(
-			Boolean
-		);
+		return [
+			inbox,
+			...stockAndReviews,
+			setup,
+			displayOptions,
+			help,
+		].filter( Boolean );
 	}
 
 	getPanelContent( tab ) {

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -29,6 +29,7 @@ import {
 import { isWCAdmin } from '../../dashboard/utils';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
+import { DisplayOptions } from './display-options';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -154,6 +155,9 @@ export class ActivityPanel extends Component {
 		const showHelp =
 			( this.isHomescreen() && ! isEmbedded ) || isPerformingSetupTask;
 
+		const showDisplayOptions =
+			! isEmbedded && this.isHomescreen() && ! isPerformingSetupTask;
+
 		const showStockAndReviews =
 			( taskListComplete || taskListHidden ) && ! isPerformingSetupTask;
 
@@ -208,7 +212,15 @@ export class ActivityPanel extends Component {
 			  }
 			: null;
 
-		return [ inbox, ...stockAndReviews, setup, help ].filter( Boolean );
+		const displayOption = showDisplayOptions
+			? {
+					component: DisplayOptions,
+			  }
+			: null;
+
+		return [ inbox, ...stockAndReviews, setup, displayOption, help ].filter(
+			Boolean
+		);
 	}
 
 	getPanelContent( tab ) {
@@ -314,7 +326,6 @@ export class ActivityPanel extends Component {
 
 	render() {
 		const tabs = this.getTabs();
-		const { isEmbedded } = this.props;
 		const { mobileOpen, currentTab, isPanelOpen } = this.state;
 		const headerId = uniqueId( 'activity-panel-header_' );
 		const panelClasses = classnames( 'woocommerce-layout__activity-panel', {
@@ -328,10 +339,6 @@ export class ActivityPanel extends Component {
 					'woocommerce-admin'
 			  )
 			: __( 'View Activity Panel', 'woocommerce-admin' );
-
-		const isPerformingSetupTask = this.isPerformingSetupTask();
-		const showDisplayOptions =
-			! isEmbedded && this.isHomescreen() && ! isPerformingSetupTask;
 
 		return (
 			<div>
@@ -374,7 +381,6 @@ export class ActivityPanel extends Component {
 							onTabClick={ ( tab, tabOpen ) => {
 								this.togglePanel( tab, tabOpen );
 							} }
-							showDisplayOptions={ showDisplayOptions }
 						/>
 						{ this.renderPanel() }
 					</div>

--- a/client/header/activity-panel/tabs/index.js
+++ b/client/header/activity-panel/tabs/index.js
@@ -9,13 +9,11 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { Tab } from '../tab';
-import { DisplayOptions } from '../display-options';
 
 export const Tabs = ( {
 	tabs,
 	onTabClick,
 	selectedTab: selectedTabName,
-	showDisplayOptions,
 	tabOpen = false,
 } ) => {
 	const [ { tabOpen: tabIsOpenState, currentTab }, setTabState ] = useState( {
@@ -38,35 +36,40 @@ export const Tabs = ( {
 			className="woocommerce-layout__activity-panel-tabs"
 		>
 			{ tabs &&
-				tabs.map( ( tab, i ) => (
-					<Tab
-						key={ i }
-						index={ i }
-						isPanelOpen={ tabIsOpenState }
-						selected={ currentTab === tab.name }
-						{ ...tab }
-						onTabClick={ () => {
-							const isTabOpen =
-								currentTab === tab.name || currentTab === ''
-									? ! tabIsOpenState
-									: true;
+				tabs.map( ( tab, i ) => {
+					if ( tab.component ) {
+						const { component: Comp, options } = tab;
+						return <Comp key={ i } { ...options } />;
+					}
+					return (
+						<Tab
+							key={ i }
+							index={ i }
+							isPanelOpen={ tabIsOpenState }
+							selected={ currentTab === tab.name }
+							{ ...tab }
+							onTabClick={ () => {
+								const isTabOpen =
+									currentTab === tab.name || currentTab === ''
+										? ! tabIsOpenState
+										: true;
 
-							// If a panel is being opened, or if an existing panel is already open and a different one is being opened, record a track.
-							if ( ! isTabOpen || currentTab !== tab.name ) {
-								recordEvent( 'activity_panel_open', {
-									tab: tab.name,
+								// If a panel is being opened, or if an existing panel is already open and a different one is being opened, record a track.
+								if ( ! isTabOpen || currentTab !== tab.name ) {
+									recordEvent( 'activity_panel_open', {
+										tab: tab.name,
+									} );
+								}
+
+								setTabState( {
+									tabOpen: isTabOpen,
+									currentTab: tab.name,
 								} );
-							}
-
-							setTabState( {
-								tabOpen: isTabOpen,
-								currentTab: tab.name,
-							} );
-							onTabClick( tab, isTabOpen );
-						} }
-					/>
-				) ) }
-			{ showDisplayOptions && <DisplayOptions /> }
+								onTabClick( tab, isTabOpen );
+							} }
+						/>
+					);
+				} ) }
 		</NavigableMenu>
 	);
 };

--- a/client/header/activity-panel/tabs/test/index.js
+++ b/client/header/activity-panel/tabs/test/index.js
@@ -19,6 +19,10 @@ const generateTabs = () => {
 	} ) );
 };
 
+const CustomTab = () => {
+	return <div>Custom Tab</div>;
+};
+
 describe( 'Activity Panel Tabs', () => {
 	it( 'correctly tracks the selected tab', () => {
 		const { getAllByRole } = render(
@@ -95,5 +99,17 @@ describe( 'Activity Panel Tabs', () => {
 		expect( recordEvent ).toHaveBeenCalledWith( 'activity_panel_open', {
 			tab: generatedTabs[ 3 ].name,
 		} );
+	} );
+
+	it( 'should render tabs with a custom component defined in tab config', () => {
+		const generatedTabs = generateTabs();
+		generatedTabs.push( {
+			component: CustomTab,
+		} );
+
+		const { getByText } = render(
+			<Tabs tabs={ generatedTabs } onTabClick={ () => {} } />
+		);
+		expect( getByText( 'Custom Tab' ) ).toBeDefined();
 	} );
 } );

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -117,6 +117,21 @@ describe( 'Activity Panel', () => {
 		expect( screen.queryByText( 'Help' ) ).toBeNull();
 	} );
 
+	it( 'should render display options if on home screen', () => {
+		render(
+			<ActivityPanel
+				getHistory={ () => ( {
+					location: {
+						pathname: '/',
+					},
+				} ) }
+				query={ {} }
+			/>
+		);
+
+		expect( screen.getByText( '[DisplayOptions]' ) ).toBeDefined();
+	} );
+
 	it( 'should only render the store setup link when TaskList is not complete', () => {
 		const { queryByText, rerender } = render(
 			<ActivityPanel


### PR DESCRIPTION
Fixes #5589 

Allowed the Tabs component to render custom components if passed in through the tab object, this way we can handle
the order more easily without making explicit exceptions (like we did for Display Options tab).
The display options component is now passed in as a tab object in the Activity Panel component.

Extra thoughts:
- Could add support for the onTabClick in the Display options component, so other tabs are closed if `Display` is active.
- A tab config could contain an (optional) order integer field, but that didn't seem necessary atm.

### Accessibility

- [✔︎] I've tested using only a keyboard (no mouse)

### Screenshots

<img width="581" alt="Screen Shot 2020-11-13 at 11 25 16 AM" src="https://user-images.githubusercontent.com/2240960/99090680-502ead80-25a5-11eb-8fc1-7974b551af54.png">

### Detailed test instructions:

- Have a new WooCommerce store setup
- Go to **WooCommerce > Home**
- Help tab should now be far right
