### PR TITLE
Position transient notices based on nav width

### DIFF
--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -1,7 +1,9 @@
+@import '../../navigation/stylesheets/variables';
+
 .woocommerce-transient-notices {
 	position: fixed;
 	bottom: $gap-small;
-	left: 176px;
+	left: $admin-menu-width + $gap;
 	z-index: 99999;
 
 	@media ( max-width: 960px ) {
@@ -19,6 +21,12 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
+	}
+}
+
+.has-woocommerce-navigation {
+	.woocommerce-transient-notices {
+		left: $navigation-width + $gap;
 	}
 }
 

--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -24,12 +24,6 @@
 	}
 }
 
-.has-woocommerce-navigation {
-	.woocommerce-transient-notices {
-		left: $navigation-width + $gap;
-	}
-}
-
 .components-snackbar {
 	&.components-snackbar-explicit-dismiss {
 		cursor: default;

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -96,5 +96,17 @@
 				display: none;
 			}
 		}
+
+		.woocommerce-transient-notices {
+			left: $gap;
+		}
+	}
+
+	.woocommerce-transient-notices {
+		left: $navigation-width + $gap;
+
+		@include breakpoint( '<782px' ) {
+			left: $gap;
+		}
 	}
 }

--- a/client/navigation/stylesheets/_variables.scss
+++ b/client/navigation/stylesheets/_variables.scss
@@ -3,6 +3,7 @@ $navigation-width: 240px;
 $navigation-x-padding: 30px;
 
 // WordPress defaults.
+$admin-menu-width: 160px;
 $admin-bar-height: 32px;
 $admin-bar-height-mobile: 46px;
 


### PR DESCRIPTION
Fixes #5622 

Moves the transient notices when using the new wc nav width.

### Screenshots
<img width="493" alt="Screen Shot 2020-11-13 at 1 55 25 PM" src="https://user-images.githubusercontent.com/10561050/99110227-10bd8c80-25b8-11eb-9060-703ecd032435.png">


### Detailed test instructions:

1. Add a fake notice to test.  This can be done in `transient-notices/index.js` on line 53 with this line `return { notices: notices.concat( [ { id: 1232, content: 'hello, Im a notice' } ] ) };`
1. Check that without the wc nav, the notice is correctly positioned.
1. Check that with the nav enabled, the notice is correctly positioned and not overlapping the nav.