### PR TITLE
Add wc-tracks as dependency for homepage notice admin script

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -252,7 +252,7 @@ class OnboardingTasks {
 	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
 		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
-			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
+			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data', 'wc-tracks' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #5554 

The homepage notice admin script code lives outside of the WooCommerce Admin context, and requires it's dependencies to be specifically defined. We were using woocommerce tracks in the code, but didn't import it as a dependency, thus causing `queueRecordEvent` to be `undefined`.
I added `wc-tracks` as a dependency, which fixed the issue.

### Screenshots

![customize-homepage](https://user-images.githubusercontent.com/2240960/99268298-5918bc80-27fb-11eb-9643-f8146c8e68d5.gif)

### Detailed test instructions:

- Go through and finish OBW
- In the _Finish setup_ list click _Personalize my store_, and create the homepage
- Then customize the home page, by click on the notification in the bottom left (see GIF)
- Change the homepage, and after saving the page, click on the link in the snackbar notif to take you back to the homescreen.
- There should be no error in the console as before, and it should correctly redirect back to the setup list
