### PR TITLE
PHP Fatal: Fix classnames in mobile app inbox notes.

### DIFF
--- a/src/Notes/EditProductsOnTheMove.php
+++ b/src/Notes/EditProductsOnTheMove.php
@@ -36,16 +36,16 @@ class EditProductsOnTheMove {
 		}
 
 		// Check that the previous mobile app notes have not been actioned.
-		if ( Mobile_App::has_note_been_actioned() ) {
+		if ( MobileApp::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Real_Time_Order_Alerts::has_note_been_actioned() ) {
+		if ( RealTimeOrderAlerts::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Manage_Orders_On_The_Go::has_note_been_actioned() ) {
+		if ( ManageOrdersOnTheGo::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Performance_On_Mobile::has_note_been_actioned() ) {
+		if ( PerformanceOnMobile::has_note_been_actioned() ) {
 			return;
 		}
 

--- a/src/Notes/ManageOrdersOnTheGo.php
+++ b/src/Notes/ManageOrdersOnTheGo.php
@@ -36,10 +36,10 @@ class ManageOrdersOnTheGo {
 		}
 
 		// Check that the previous mobile app notes have not been actioned.
-		if ( Mobile_App::has_note_been_actioned() ) {
+		if ( MobileApp::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Real_Time_Order_Alerts::has_note_been_actioned() ) {
+		if ( RealTimeOrderAlerts::has_note_been_actioned() ) {
 			return;
 		}
 

--- a/src/Notes/PerformanceOnMobile.php
+++ b/src/Notes/PerformanceOnMobile.php
@@ -36,13 +36,13 @@ class PerformanceOnMobile {
 		}
 
 		// Check that the previous mobile app notes have not been actioned.
-		if ( Mobile_App::has_note_been_actioned() ) {
+		if ( MobileApp::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Real_Time_Order_Alerts::has_note_been_actioned() ) {
+		if ( RealTimeOrderAlerts::has_note_been_actioned() ) {
 			return;
 		}
-		if ( Manage_Orders_On_The_Go::has_note_been_actioned() ) {
+		if ( ManageOrdersOnTheGo::has_note_been_actioned() ) {
 			return;
 		}
 

--- a/src/Notes/RealTimeOrderAlerts.php
+++ b/src/Notes/RealTimeOrderAlerts.php
@@ -36,7 +36,7 @@ class RealTimeOrderAlerts {
 		}
 
 		// Check that the previous mobile app note was not actioned.
-		if ( Mobile_App::has_note_been_actioned() ) {
+		if ( MobileApp::has_note_been_actioned() ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR fixes some classnames that were missed in https://github.com/woocommerce/woocommerce-admin/pull/5462.

### Detailed test instructions:

- Run the `wc_admin_daily` cron job (use WP-Crontrol or similar plugin)
- Verify no PHP Fatals in log
- Remove store age check here: https://github.com/woocommerce/woocommerce-admin/blob/58679df60ddf5a94474b07e28343ea6a8ec786f3/src%2FNotes%2FPerformanceOnMobile.php#L34
- Run the `wc_admin_daily` cron job (use WP-Crontrol or similar plugin)
- Verify no PHP Fatals in log
- Remove store age check here: https://github.com/woocommerce/woocommerce-admin/blob/58679df60ddf5a94474b07e28343ea6a8ec786f3/src%2FNotes%2FRealTimeOrderAlerts.php#L34
- Run the `wc_admin_daily` cron job (use WP-Crontrol or similar plugin)
- Verify no PHP Fatals in log
- Remove store age check here: https://github.com/woocommerce/woocommerce-admin/blob/58679df60ddf5a94474b07e28343ea6a8ec786f3/src%2FNotes%2FEditProductsOnTheMove.php#L34
- Run the `wc_admin_daily` cron job (use WP-Crontrol or similar plugin)
- Verify no PHP Fatals in log
- Remove store age check here: https://github.com/woocommerce/woocommerce-admin/blob/58679df60ddf5a94474b07e28343ea6a8ec786f3/src%2FNotes%2FManageOrdersOnTheGo.php#L34
- Run the `wc_admin_daily` cron job (use WP-Crontrol or similar plugin)
- Verify no PHP Fatals in log

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug
