### PR TITLE
Navigation: Some navigation menu items left out due to duplicate IDs

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -59,8 +59,7 @@ export const getPages = () => {
 			__( 'Home', 'woocommerce-admin' ),
 		],
 		wpOpenMenu: 'toplevel_page_woocommerce',
-		id: 'home',
-		navParent: 'woocommerce',
+		id: 'woocommerce/home',
 	} );
 
 	if ( window.wcAdminFeatures.analytics ) {
@@ -76,8 +75,7 @@ export const getPages = () => {
 				__( 'Overview', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
-			id: 'woocommerce-analytics-overview',
-			navParent: 'analytics',
+			id: 'analytics/woocommerce-analytics-overview',
 		} );
 		pages.push( {
 			container: AnalyticsSettings,
@@ -91,8 +89,7 @@ export const getPages = () => {
 				__( 'Settings', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
-			id: 'woocommerce-analytics-settings',
-			navParent: 'settings',
+			id: 'settings/woocommerce-analytics-settings',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -102,8 +99,7 @@ export const getPages = () => {
 				__( 'Customers', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			id: 'woocommerce-analytics-customers',
-			navParent: 'woocommerce',
+			id: 'woocommerce/woocommerce-analytics-customers',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -138,8 +134,7 @@ export const getPages = () => {
 				__( 'Overview', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-			id: 'woocommerce-marketing',
-			navParent: 'marketing',
+			id: 'marketing/woocommerce-marketing',
 		} );
 	}
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -60,6 +60,7 @@ export const getPages = () => {
 		],
 		wpOpenMenu: 'toplevel_page_woocommerce',
 		id: 'home',
+		navParent: 'woocommerce',
 	} );
 
 	if ( window.wcAdminFeatures.analytics ) {
@@ -76,6 +77,7 @@ export const getPages = () => {
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			id: 'woocommerce-analytics-overview',
+			navParent: 'analytics',
 		} );
 		pages.push( {
 			container: AnalyticsSettings,
@@ -90,6 +92,7 @@ export const getPages = () => {
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			id: 'woocommerce-analytics-settings',
+			navParent: 'settings',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -100,6 +103,7 @@ export const getPages = () => {
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 			id: 'woocommerce-analytics-customers',
+			navParent: 'woocommerce',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -135,6 +139,7 @@ export const getPages = () => {
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			id: 'woocommerce-marketing',
+			navParent: 'marketing',
 		} );
 	}
 

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -38,6 +38,15 @@ const NavigationPlugin = () => {
 				};
 			}
 			return page;
+		} )
+		.map( ( page ) => {
+			if ( ! page.navParent ) {
+				return page;
+			}
+			return {
+				...page,
+				id: `${ page.navParent }/${ page.id }`,
+			};
 		} );
 	const persistedQuery = getPersistedQuery( {} );
 	return (
@@ -54,7 +63,10 @@ const NavigationPlugin = () => {
 				</WooNavigationItem>
 			) ) }
 			{ reports.map( ( item ) => (
-				<WooNavigationItem item={ item.id } key={ item.report }>
+				<WooNavigationItem
+					item={ `analytics/${ item.id }` }
+					key={ item.report }
+				>
 					<Link
 						className="components-button"
 						href={ getNewPath(

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -31,23 +31,15 @@ const NavigationPlugin = () => {
 	const pages = getPages()
 		.filter( ( page ) => page.id )
 		.map( ( page ) => {
-			if ( page.id === 'woocommerce-analytics-settings' ) {
+			if ( page.id === 'settings/woocommerce-analytics-settings' ) {
 				return {
 					...page,
 					breadcrumbs: [ __( 'Analytics', 'woocommerce-admin' ) ],
 				};
 			}
 			return page;
-		} )
-		.map( ( page ) => {
-			if ( ! page.navParent ) {
-				return page;
-			}
-			return {
-				...page,
-				id: `${ page.navParent }/${ page.id }`,
-			};
 		} );
+
 	const persistedQuery = getPersistedQuery( {} );
 	return (
 		<>

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -66,6 +66,7 @@ Adding an item, much like a category, can be added directly to the menu or to an
         'title'      => 'Example Plugin',
         'capability' => 'view_woocommerce_reports',
         'url'        => 'https://www.google.com',
+        'parent'     => 'example-category',
     )
 );
 ```
@@ -89,10 +90,9 @@ You can also manually add a screen without registering an item.
 
 ### Slot/fill items
 
-Using slot fill we can update items on the front-end of the site using JavaScript.  This is useful for modern JavaScript routing, more intricate interactions with menu items, or updating URLs and hyperlink text without reloading the page.
+Using slot fill we can update items on the front-end of the site using JavaScript. This is useful for modern JavaScript routing, more intricate interactions with menu items, or updating URLs and hyperlink text without reloading the page.
 
-In order to use slot fill, you can import the `WooNavigationItem` component from `@woocommerce/navigation` and match the `item` prop with the ID of the item you'd like to modify the behavior of.
-
+In order to use slot fill, you can import the `WooNavigationItem` component from `@woocommerce/navigation` and match the `item` prop with a unique identifier of the item you'd like to modify the behavior of. This identifer needs to conform to the following format, given the `parent` and `id` properties that you used when registering the item in PHP: "`parent/item-id`".
 
 ```js
 import { __ } from '@wordpress/i18n';
@@ -102,20 +102,20 @@ import { useHistory } from "react-router-dom";
 import { WooNavigationItem } from "@woocommerce/navigation";
 
 const MyPlugin = () => {
-    const history = useHistory();
+	const history = useHistory();
 
-    const handleClick = () => {
-        history.push( '/my-plugin-path' );
-    }
+	const handleClick = () => {
+		history.push( '/my-plugin-path' );
+	};
 
-    return (
-        <WooNavigationItem item="example-plugin">
-            <Button onClick={ handleClick }>
-                { __( 'My Link', 'plugin-domain' ) }
-            </Button>
-        </WooNavigationItem>
-    );
+	return (
+		<WooNavigationItem item="example-category/example-plugin">
+			<Button onClick={ handleClick }>
+				{ __( 'My Link', 'plugin-domain' ) }
+			</Button>
+		</WooNavigationItem>
+	);
 };
 
-registerPlugin('my-plugin', { render: MyPlugin });
+registerPlugin( 'my-plugin', { render: MyPlugin } );
 ```

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -229,6 +229,7 @@ class CoreMenu {
 		$excluded_items = array(
 			'woocommerce',
 			'wc-reports',
+			'wc-settings',
 		);
 
 		return apply_filters( 'woocommerce_navigation_core_excluded_items', $excluded_items );

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -206,11 +206,12 @@ class Menu {
 	 *    ).
 	 */
 	private static function add_item( $args ) {
-		if ( ! isset( $args['id'] ) || isset( self::$menu_items[ $args['id'] ] ) ) {
+
+		if ( ! isset( $args['id'] ) ) {
 			return;
 		}
 
-		$defaults           = array(
+		$defaults = array(
 			'id'           => '',
 			'title'        => '',
 			'parent'       => self::DEFAULT_PARENT,
@@ -221,6 +222,7 @@ class Menu {
 			'menuId'       => 'primary',
 			'is_top_level' => false,
 		);
+
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
 		$menu_item['url']   = self::get_callback_url( $menu_item['url'] );
@@ -229,6 +231,12 @@ class Menu {
 			$menu_item['parent'] = 'woocommerce';
 		} else {
 			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
+		}
+
+		$menu_item['id'] = $menu_item['parent'] . '/' . $menu_item['id'];
+
+		if ( isset( self::$menu_items[ $menu_item['id'] ] ) ) {
+			return;
 		}
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -236,6 +236,13 @@ class Menu {
 		$menu_item['id'] = $menu_item['parent'] . '/' . $menu_item['id'];
 
 		if ( isset( self::$menu_items[ $menu_item['id'] ] ) ) {
+			error_log(  // phpcs:ignore
+				sprintf(
+					/* translators: 1: Duplicate menu item path. */
+					esc_html__( 'You have attempted to register a duplicate item with WooCommerce Navigation: %1$s', 'woocommerce-admin' ),
+					'`' . $menu_item['id'] . '`'
+				)
+			);
 			return;
 		}
 


### PR DESCRIPTION
Fixes #5626

This issue was noticed due to the "Products" menu item disappearing from the "Settings" category. On closer inspection, it looks like this stems from that use of fairly generic IDs (ie "products") resulting in conflicts that resulted in some items not being added as they should. For instance, in this case, a menu item had already been registered with the ID of "products," which resulted in the Settings page with the same ID being dismissed. 

To remedy this I've modified the code to identify each item in the context of their `parent` as well, so the resulting ID now follows this format: `parent-name/item-id`. 

This should allow similar items to be added without issue as long as they exist in a different level/category of the navigation hierarchy. 

This PR also includes updating how current slot-fill items are registered to support the new ID structure, as well as updating the documentation to reflect this change. 

Last, we're now printing a warning to the `error_log()` when a a duplicate item attempts registration. I'm not entirely confident of the suggested format for this since I could only find what example of it's use in the project.

### Screenshots

Settings -> Products item now visible:
![image](https://user-images.githubusercontent.com/444632/99320769-313c4f80-2821-11eb-988e-97cd37e98fd0.png)


### Detailed test instructions:

- Checkout branch
- Ensure navigation feature is enabled
- Navigation to WooCommerce -> Settings
- Ensure that the "Products" menu item is now visible in this category, as in the screenshot
- Click back and forth from a few react-based pages (Customer/Home/Analytics reports) and ensure there is still no page refresh.