### PR TITLE
Fix a bug where wc-tracks was not loaded as a dependency.

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -252,7 +252,7 @@ class OnboardingTasks {
 	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
 		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
-			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
+			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data', 'wc-tracks' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #5644 

Just as was done in #5638 this adds the `wc-tracks` dependency to this script so that it does not crash when trying to record tracks. (This happens because the script is loaded outside the context of wc-admin).

### Detailed test instructions:

Instructions copy/pasted from the original issue:

Steps to reproduce the behavior:

1. On a fresh store,
2. Complete the OBW
3. Select the "Personalize my store" task
4. Do the first step. When the snackbar appears, click the action to get to the store home page customisation page
5. Make a change and click Update
6. In the snackbar that appears, click the "Continue setup" action
7. A JS error will *NOT* appear in the console and a redirect to the WC home page will happen

### Changelog Note:

Fix: a crash when continuing store setup from editing home page.
