### PR TITLE
CES: Add Tracks events for showing notice and modal

### DIFF
--- a/packages/customer-effort-score/src/index.js
+++ b/packages/customer-effort-score/src/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import { useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { noop } from 'lodash';
 
 /**
  * Use `CustomerEffortScore` to gather a customer effort score.
@@ -14,18 +14,22 @@ import { noop } from 'lodash';
  * NOTE: This should live in @woocommerce/customer-effort-score to allow
  * reuse.
  *
- * @param {Object}   props                Component props.
- * @param {Function} props.trackCallback  Function to call when the results should be tracked.
- * @param {string}   props.label          The label displayed in the modal.
- * @param {Function} props.createNotice   Create a notice (snackbar).
- * @param {Function} props.openedCallback Function to call when the modal is opened.
- * @param {Object}   props.icon           Icon (React component) to be shown on the notice.
+ * @param {Object} props                             Component props.
+ * @param {Function} props.recordScoreCallback       Function to call when the score should be recorded.
+ * @param {string} props.label                       The label displayed in the modal.
+ * @param {Function} props.createNotice              Create a notice (snackbar).
+ * @param {Function} props.onNoticeShownCallback     Function to call when the notice is shown.
+ * @param {Function} props.onNoticeDismissedCallback Function to call when the notice is dismissed.
+ * @param {Function} props.onModalShownCallback      Function to call when the modal is shown.
+ * @param {Object} props.icon                        Icon (React component) to be shown on the notice.
  */
 function CustomerEffortScore( {
-	trackCallback,
+	recordScoreCallback,
 	label,
 	createNotice,
-	openedCallback = noop,
+	onNoticeShownCallback = noop,
+	onNoticeDismissedCallback = noop,
+	onModalShownCallback = noop,
 	icon,
 } ) {
 	const [ score, setScore ] = useState( 0 );
@@ -39,17 +43,18 @@ function CustomerEffortScore( {
 					label: __( 'Give feedback', 'woocommerce-admin' ),
 					onClick: () => {
 						setVisible( true );
-
-						openedCallback();
+						onModalShownCallback();
 					},
 				},
 			],
 			icon,
 			explicitDismiss: true,
-			onDismiss: openedCallback,
+			onDismiss: onNoticeDismissedCallback,
 		} );
 
 		setShouldCreateNotice( false );
+
+		onNoticeShownCallback();
 
 		return null;
 	}
@@ -62,7 +67,7 @@ function CustomerEffortScore( {
 		setScore( 3 ); // TODO let this happen in the UI
 
 		setVisible( false );
-		trackCallback( score );
+		recordScoreCallback( score );
 	}
 
 	return (
@@ -74,9 +79,9 @@ function CustomerEffortScore( {
 
 CustomerEffortScore.propTypes = {
 	/**
-	 * The function to call when the modal is actioned.
+	 * The function to call to record the score.
 	 */
-	trackCallback: PropTypes.func.isRequired,
+	recordScoreCallback: PropTypes.func.isRequired,
 	/**
 	 * The label displayed in the modal.
 	 */
@@ -86,9 +91,17 @@ CustomerEffortScore.propTypes = {
 	 */
 	createNotice: PropTypes.func.isRequired,
 	/**
-	 * Callback executed when the modal is opened.
+	 * The function to call when the notice is shown.
 	 */
-	openedCallback: PropTypes.func,
+	onNoticeShownCallback: PropTypes.func,
+	/**
+	 * The function to call when the notice is dismissed.
+	 */
+	onNoticeDismissedCallback: PropTypes.func,
+	/**
+	 * The function to call when the modal is shown.
+	 */
+	onModalShownCallback: PropTypes.func,
 	/**
 	 * Icon (React component) to be displayed.
 	 */


### PR DESCRIPTION
Fixes #5341

This PR adds Tracks events for the following:

- Snackbar (notice) shown: `wcadmin_ces_snackbar_view`
- Snackbar (notice) dismissed: `wcadmin_ces_snackbar_dismiss` (Note: this won't be functional until #5623 lands)
- Modal shown: `wcadmin_ces_view`

All events have an `action` property that corresponds to the action that triggered things.

### Detailed test instructions:

- Make sure tracking is enabled: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
- Clear out the options tracking whether the survey has been shown:

```
/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
```

- Enable the logging of Tracks events to your browser dev console:

```
localStorage.setItem( 'debug', 'wc-admin:tracks' );
```

- Keep your browser dev console open, so you can verify the Tracks events.
- Add or edit a product in wp-admin.
- When the snackbar/notice is shown, verify that the following Tracks event is logged:

```
wcadmin_ces_snackbar_view
```

- When `Provide feedback` is clicked and the modal is shown, verify that the following Tracks event is logged:

```
wcadmin_ces_view
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

Other things to test:

This PR also refactored things a bit to rename some props and state variables in the CES code, so make sure that basic CES functionality works (this is a bit of a moving target, as we still have a number of PRs open).

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog note required (part of larger CES feature being introduced).