### PR TITLE
Restore Autoloading of WooCommerce Classes in PHP Tests

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -180,8 +180,10 @@ install_deps() {
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
 	# Bring in WooCommerce Core dependencies
- 	cd "woocommerce"
+ 	composer self-update --1
+	cd "woocommerce"
  	composer install --no-dev
+	composer self-update --2
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -179,6 +179,10 @@ install_deps() {
 	# As zip file does not include tests, we have to get it from git repo.
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
+	# Bring in WooCommerce Core dependencies
+ 	cd "woocommerce"
+ 	composer install --no-dev
+
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,9 +54,6 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
-		// load the wc installer.
-		require_once $this->wc_core_dir . '/includes/class-wc-install.php';
-
 		// load WC.
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
 


### PR DESCRIPTION
When running PHPUnit locally, the [early exit call](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-install.php#L12) in the `class-wc-install.php` is triggered and prevents the tests from running.

This PR restores autoloading of WooCommerce classes in the tests to remove the need to directly require `class-wc-install.php`. 

### Additional information

WooCommerce class autoloading was stopped in PR https://github.com/woocommerce/woocommerce-admin/pull/5462 when `composer install` was removed from the WooCommerce build in `install-wp-tests.sh`.

In PR https://github.com/woocommerce/woocommerce-admin/pull/5603 a change was made to `bootstrap.php ` to require `class-wc-install.php` directly.

### Testing instructions

- Run PHPUnit tests locally and ensure test results are output.