### PR TITLE
Fixed Link component prop

### DIFF
--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -19,7 +19,7 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 			<Link
 				onClick={ onClick }
 				href={ href }
-				linkType={ linkType }
+				linktype={ linkType }
 				className="woocommerce-quick-links__item-link"
 			>
 				<Icon

--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -19,7 +19,7 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 			<Link
 				onClick={ onClick }
 				href={ href }
-				linktype={ linkType }
+				type={ linkType }
 				className="woocommerce-quick-links__item-link"
 			>
 				<Icon


### PR DESCRIPTION
Fixes #5651

This PR fixes an error with a Link component prop name. We were sending the Link component the prop name `linkType` instead of sending `linktype`.

### Detailed test instructions:

- Go to `Home` screen.
- Verify there aren't any console warnings.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Link component prop
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
