### PR TITLE
Fixed orders panel flickering

### DIFF
--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -304,7 +304,7 @@ export default withSelect( ( select, props ) => {
 		REPORTS_STORE_NAME
 	);
 
-	if ( ! orderStatuses.length && ! countUnreadOrders ) {
+	if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
 		return { isRequesting: false };
 	}
 

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -364,7 +364,6 @@ export default withSelect( ( select, props ) => {
 	if (
 		countUnreadOrders === null ||
 		typeof reportOrders === 'undefined' ||
-		typeof actionableOrders === 'undefined' ||
 		( reportOrders.length && ! actionableOrders.length ) ||
 		isRequesting
 	) {

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -304,8 +304,8 @@ export default withSelect( ( select, props ) => {
 		REPORTS_STORE_NAME
 	);
 
-	if ( ! countUnreadOrders ) {
-		return { isRequesting: countUnreadOrders !== 0 };
+	if ( ! orderStatuses.length && ! countUnreadOrders ) {
+		return { isRequesting: false };
 	}
 
 	// Query the core Orders endpoint for the most up-to-date statuses.
@@ -361,10 +361,17 @@ export default withSelect( ( select, props ) => {
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	let orders = [];
 
-	if ( reportOrders && reportOrders.length ) {
-		if ( actionableOrders && ! actionableOrders.length ) {
-			return { isRequesting: true };
-		}
+	if (
+		countUnreadOrders === null ||
+		typeof reportOrders === 'undefined' ||
+		typeof actionableOrders === 'undefined' ||
+		( reportOrders.length && ! actionableOrders.length ) ||
+		isRequesting
+	) {
+		return { isRequesting: true };
+	}
+
+	if ( reportOrders.length ) {
 		// Merge the core endpoint data with our reporting table.
 		const actionableOrdersById = keyBy( actionableOrders, 'id' );
 		orders = reportOrders.map( ( order ) =>

--- a/client/homescreen/activity-panel/orders/utils.js
+++ b/client/homescreen/activity-panel/orders/utils.js
@@ -24,14 +24,21 @@ export function getUnreadOrders( select, orderStatuses ) {
 		_fields: [ 'id' ],
 	};
 
+	const defaultValue = null;
+
 	// Disable eslint rule requiring `latestNote` to be defined below because the next two statements
 	// depend on `getItemsTotalCount` to have been called.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const totalOrders = getItemsTotalCount( 'orders', ordersQuery );
+	const totalOrders = getItemsTotalCount(
+		'orders',
+		ordersQuery,
+		defaultValue
+	);
 	const isError = Boolean( getItemsError( 'orders', ordersQuery ) );
 	const isRequesting = isResolving( 'getItemsTotalCount', [
 		'orders',
 		ordersQuery,
+		defaultValue,
 	] );
 
 	if ( isError || isRequesting ) {

--- a/packages/data/src/items/selectors.js
+++ b/packages/data/src/items/selectors.js
@@ -21,11 +21,10 @@ export const getItemsTotalCount = (
 	defaultValue = 0
 ) => {
 	const resourceName = getResourceName( itemType, query );
-	return (
-		( state.items[ resourceName ] &&
-			state.items[ resourceName ].totalCount ) ||
-		defaultValue
-	);
+	const totalCount = state.items[ resourceName ]
+		? state.items[ resourceName ].totalCount
+		: defaultValue;
+	return totalCount;
 };
 
 export const getItemsError = ( state, itemType, query ) => {

--- a/packages/data/src/items/selectors.js
+++ b/packages/data/src/items/selectors.js
@@ -14,12 +14,17 @@ export const getItems = ( state, itemType, query ) => {
 	}, new Map() );
 };
 
-export const getItemsTotalCount = ( state, itemType, query ) => {
+export const getItemsTotalCount = (
+	state,
+	itemType,
+	query,
+	defaultValue = 0
+) => {
 	const resourceName = getResourceName( itemType, query );
 	return (
 		( state.items[ resourceName ] &&
 			state.items[ resourceName ].totalCount ) ||
-		0
+		defaultValue
 	);
 };
 


### PR DESCRIPTION
Fixes #5609

This PR fixes the orders panel flickering when Gutenberg is activated.

### Screenshots
![Screen Capture on 2020-11-17 at 14-14-38](https://user-images.githubusercontent.com/1314156/99423458-55f6fc80-28df-11eb-8f1d-f738f43a947c.gif)

### Detailed test instructions:

- Be sure the `Gutenberg` plugin is installed and activated.
- Go to the `Home` screen.
- Verify no flickering happens in the order panel.
- Create a few orders (manually or using the [Smooth generator](https://github.com/woocommerce/wc-smooth-generator)).
- Go to `Analytics` > `Settings` and select different combinations of the checkboxes under `Actionable Statuses` (**don't select unregistered statuses**).
- Go back to the `Home` screen.
- Again, verify there isn't any flickering in the order panel.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Fixed orders panel flickering
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
