### PR TITLE
Navigation: Renaming navigation body classes to be less generic

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -20,8 +20,8 @@ const Header = () => {
 	const siteUrl = getSetting( 'siteUrl', '' );
 	const isScrolled = useIsScrolled();
 	const navClasses = {
-		folded: 'is-folded',
-		expanded: 'is-expanded',
+		folded: 'is-wc-nav-folded',
+		expanded: 'is-wc-nav-expanded',
 	};
 
 	const foldNav = () => {

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -45,14 +45,14 @@
 		box-sizing: border-box;
 	}
 
-	&.is-expanded {
+	&.is-wc-nav-expanded {
 		#woocommerce-embedded-navigation {
 			width: $navigation-width;
 			height: 100%;
 		}
 	}
 
-	&.is-folded {
+	&.is-wc-nav-folded {
 		#wpcontent,
 		#wpfooter {
 			margin-left: 0;


### PR DESCRIPTION
Fixes #5658

Quick PR to rename the body classes used for navigation from `is-folded` & `is-expanded` to `is-wc-nav-folded` & `is-wc-nav-expanded` as mentioned (and missed) in [this earlier PR](https://github.com/woocommerce/woocommerce-admin/pull/5616#discussion_r523135657).


### Detailed test instructions:

- Check out branch
- Ensure navigation feature is enabled
- Navigation to WP-Admin -> WooCommerce
- Click top-left logo to fold and expand navigation
- Ensure behavior is still as expected
