### PR TITLE
Add key to the component to fix the warning and unexpected behavior

### DIFF
--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -66,6 +66,7 @@ export const filters = applyFilters( TAXES_REPORT_FILTERS_FILTER, [
 						NAMESPACE + '/taxes',
 						( tax ) => ( {
 							id: tax.id,
+							key: tax.id,
 							label: getTaxCode( tax ),
 						} )
 					),


### PR DESCRIPTION
Fixes #5659

This PR fixes unexpected behavior and warning when the comparison filter is used in WooCommerce -> Analytics -> Taxes as described in the issue https://github.com/woocommerce/woocommerce-admin/issues/5659

### Screenshots
![Screen Capture on 2020-11-17 at 16-11-34](https://user-images.githubusercontent.com/4723145/99465617-a70eec80-28ef-11eb-8d32-0e8f63454eee.gif)

### Detailed test instructions:

1. Set up a fresh installation of WordPress + WooCommerce and finish the onboarding process.
2. Check "Enable tax rates and calculation" in WooCommerce -> Settings and save the change.
3. Navigate back to WooCommerce -> Settings and click on the "Tax" tab.
4. Click the "Reduced rate rates" link.
5. Add two tax rates. I used the following tax codes for testing purposes.

|Country Code|State Code|Postcode/ZIP| City|Rate %|
|--------------|-----------|--------------|----|-------|
| US | CA|90020|LA|1|
|US|AZ|85007|PHOENIX|2|

6. Navigate to WooCommerce -> Analytics -> Taxes
7. Change `Show:` to `Comparison.`
8. Type 'US' in the search input box and select `US-CA-TAX-1`. Type 'US' again and select `US-AX-TAX-1.`
9. Click the [ Compare ] button.
10. Try to remove one of the tax codes by clicking the [X] button.
11. The tax code should be removed and there should not be a React warning in the browser console.

