### PR TITLE
[WIP] Add error handling logic for WP_Error

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1082,7 +1082,7 @@ class Loader {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
 				$group_settings = $setting_options->get_group_settings( $group );
-				if ( $group_settings instanceof \WP_Error ) {
+				if ( is_wp_error( $group_settings ) ) {
 					continue;
 				}
 				$preload_settings = [];

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1081,7 +1081,10 @@ class Loader {
 		if ( ! empty( $preload_settings ) ) {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
-				$group_settings   = $setting_options->get_group_settings( $group );
+				$group_settings = $setting_options->get_group_settings( $group );
+				if ( $group_settings instanceof \WP_Error ) {
+					continue;
+				}
 				$preload_settings = [];
 				foreach ( $group_settings as $option ) {
 					$preload_settings[ $option['id'] ] = $option['value'];


### PR DESCRIPTION
Fixes #5631 

This PR fixes PHP notices when an invalid group setting I.D is given to `woocommerce_admin_preload_settings` filter.

The `get_group_settings` method returns either an instance of `WP_Error` or array.

Added if statement to check `WP_Error` error.

### Detailed test instructions:

It's a little bit tricky as this is not reproducible with a fresh installation of WooCommerce.

1. Turn on WP_DEBUG in `wp-config.php` 
```
define('WP_DEBUG', true);
```
2. Open `src/Loader.php` and locate `add_component_settings` method.
3. Scroll down to `$preload_settings = apply_filters( 'woocommerce_admin_preload_settings', array() )` line and add an invalid value.

```php
$preload_settings[] = "I am an invalid I.D";
```
4. Navigate to one of the WooCommerce admin pages. Let's use the Analytics overview page for testing purposes.
5. Check `wp-content/debug.log` and make sure that there is no PHP notice regarding undefined index.