### PR TITLE
Disable Customer Effort Score for Mobile Users

### DIFF
--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -73,6 +73,11 @@ class CustomerEffortScoreTracks {
 			return;
 		}
 
+		// Only hook up the action handlers if a desktop device is used.
+		if ( wp_is_mobile() ) {
+			return;
+		}
+
 		// Only enqueue a survey if tracking is allowed.
 		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
 		if ( ! $allow_tracking ) {

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -73,7 +73,7 @@ class CustomerEffortScoreTracks {
 			return;
 		}
 
-		// Only hook up the action handlers if a desktop device is used.
+		// Do not hook up the action handlers if a mobile device is used.
 		if ( wp_is_mobile() ) {
 			return;
 		}

--- a/tests/features/class-wc-tests-ces-tracks.php
+++ b/tests/features/class-wc-tests-ces-tracks.php
@@ -26,16 +26,15 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		update_option( 'woocommerce_allow_tracking', 'yes' );
-		$this->ces = new CustomerEffortScoreTracks();
 	}
 
 	/**
 	 * Verify that it adds correct action to the queue on woocommerce_update_options action.
 	 */
 	public function test_updating_options_triggers_ces() {
-		do_action( 'woocommerce_update_options' );
+		$ces = new CustomerEffortScoreTracks();
 
-		$ces = $this->ces;
+		do_action( 'woocommerce_update_options' );
 
 		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
 		$this->assertNotEmpty( $queue_items );
@@ -55,11 +54,11 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	 * action and label values.
 	 */
 	public function test_the_queue_does_not_allow_duplicate() {
+		$ces = new CustomerEffortScoreTracks();
+
 		// Fire the action twice to trigger the queueing process twice.
 		do_action( 'woocommerce_update_options' );
 		do_action( 'woocommerce_update_options' );
-
-		$ces = $this->ces;
 
 		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
 		$this->assertNotEmpty( $queue_items );
@@ -75,15 +74,17 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Verify that tasks performed using a mobile device do not get processed.
+	 * Verify that tasks performed using a mobile device are ignored.
 	 */
 	public function test_disabled_for_mobile() {
 		add_filter( 'wp_is_mobile', '__return_true' );
+
+		$ces = new CustomerEffortScoreTracks();
+
 		do_action( 'woocommerce_update_options' );
 
-		$ces = $this->ces;
-
 		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+
 		$this->assertEmpty( $queue_items );
 	}
 }

--- a/tests/features/class-wc-tests-ces-tracks.php
+++ b/tests/features/class-wc-tests-ces-tracks.php
@@ -73,4 +73,17 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$this->assertCount( 1, $expected_queue_item );
 	}
+
+	/**
+	 * Verify that tasks performed using a mobile device do not get processed.
+	 */
+	public function test_disabled_for_mobile() {
+		add_filter( 'wp_is_mobile', '__return_true' );
+		do_action( 'woocommerce_update_options' );
+
+		$ces = $this->ces;
+
+		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+		$this->assertEmpty( $queue_items );
+	}
 }


### PR DESCRIPTION
This PR disables the Customer Effort Score for mobile users. It does this by preventing items being added to the queue if a mobile device was used.

### Detailed test instructions:

- Delete the existing WP options state for Customer Effort Score, e.g.  in WP CLI 
`$ wp option delete woocommerce_ces_shown_for_actions`
- On a mobile device, update an existing product.
- Ensure no feedback notification appears.
- On a desktop computer, update an existing product.
- Ensure the feedback notification appears.
<img width="436" alt="Screen Shot 2020-11-19 at 2 10 13 pm" src="https://user-images.githubusercontent.com/9312929/99628369-f9c3e200-2a70-11eb-80a0-97cab1f0cdf2.png">

