### PR TITLE
Continue showing task list even if entire list is complete

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -44,7 +44,6 @@ export const Layout = ( {
 	isBatchUpdating,
 	query,
 	requestingTaskList,
-	taskListComplete,
 	taskListHidden,
 	shouldShowWelcomeModal,
 	updateOptions,
@@ -55,7 +54,7 @@ export const Layout = ( {
 		'two_columns';
 	const [ showInbox, setShowInbox ] = useState( true );
 
-	const isTaskListEnabled = taskListHidden === false && ! taskListComplete;
+	const isTaskListEnabled = taskListHidden === false;
 	const isDashboardShown = ! isTaskListEnabled || ! query.task;
 
 	if ( isBatchUpdating && ! showInbox ) {
@@ -196,8 +195,6 @@ export default compose(
 			defaultHomescreenLayout,
 			isBatchUpdating: isNotesRequesting( 'batchUpdateNotes' ),
 			shouldShowWelcomeModal,
-			taskListComplete:
-				getOption( 'woocommerce_task_list_complete' ) === 'yes',
 			taskListHidden:
 				getOption( 'woocommerce_task_list_hidden' ) === 'yes',
 			requestingTaskList:

--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -90,23 +90,7 @@ describe( 'Homescreen Layout', () => {
 		render(
 			<Layout
 				requestingTaskList={ false }
-				taskListComplete={ false }
 				taskListHidden
-				query={ {} }
-				updateOptions={ () => {} }
-			/>
-		);
-
-		const taskList = screen.queryByText( '[TaskList]' );
-		expect( taskList ).toBeNull();
-	} );
-
-	it( 'should not show TaskList when it is complete', () => {
-		render(
-			<Layout
-				requestingTaskList={ false }
-				taskListComplete
-				taskListHidden={ false }
 				query={ {} }
 				updateOptions={ () => {} }
 			/>
@@ -120,7 +104,6 @@ describe( 'Homescreen Layout', () => {
 		render(
 			<Layout
 				requestingTaskList={ false }
-				taskListComplete={ false }
 				taskListHidden
 				query={ {} }
 				updateOptions={ () => {} }
@@ -135,7 +118,6 @@ describe( 'Homescreen Layout', () => {
 		render(
 			<Layout
 				requestingTaskList={ false }
-				taskListComplete
 				taskListHidden={ false }
 				query={ {} }
 				updateOptions={ () => {} }


### PR DESCRIPTION
Fixes #5303 

Removed logic that hides the task list upon completion, we only hide the task list now if `woocommerce_task_list_hidden` is set.

### Screenshots

![hide-task-list](https://user-images.githubusercontent.com/2240960/99540746-50a0bd00-2986-11eb-98a1-f922cbf13ec4.gif)

### Detailed test instructions:

- Create new store and complete the onboarding wizard
- Go to the home screen and walk through and finish the list under _Finish setup_
- Once all items are completed the task list should still be present on the home screen
- If you click the 3 dots and select _hide this_ it should hide the task list