### PR TITLE
CES: Update tests to fake that they are in wp-admin

### DIFF
--- a/tests/features/class-wc-tests-ces-tracks.php
+++ b/tests/features/class-wc-tests-ces-tracks.php
@@ -7,6 +7,9 @@
 
 use \Automattic\WooCommerce\Admin\Features\CustomerEffortScoreTracks;
 
+// CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
+define( 'WP_ADMIN', true );
+
 /**
  * Class WC_Tests_CES_Tracks
  */
@@ -34,7 +37,7 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$ces = $this->ces;
 
-		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME );
+		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
 		$this->assertNotEmpty( $queue_items );
 
 		$expected_queue_item = array_filter(


### PR DESCRIPTION
In #5540, we changed things so that Customer Effort Score (CES) action hook handlers are only setup if running in wp-admin. Unfortunately, this causes our CES unit tests to fail (we didn't catch this initially because the tests were not running properly, see #5650, #5656).

Before:

```
There was 1 failure:

1) WC_Tests_CES_Tracks::test_updating_options_triggers_ces
Failed asserting that a boolean is not empty.

/srv/www/woocommerce-dev/public_html/wp-content/plugins/woocommerce-admin/tests/features/class-wc-tests-ces-tracks.php:38

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

This PR updates the CES unit tests to fake that we are running in wp-admin.

### Detailed test instructions:

- Run CES unit tests:

```
composer test -- --filter="WC_Tests_CES_Tracks"
```

- Verify that test pass:

```
OK (1 test, 2 assertions)
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog entry required, as it is part of the larger CES feature being introduced.