### PR TITLE
Clean up menu callback methods

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -521,6 +521,13 @@ class Menu {
 	}
 
 	/**
+	 * Add a callback to identify and hide pages in the WP menu.
+	 */
+	public static function hide_page_in_wp_menu( $callback ) {
+		self::$callbacks[ $callback ] = true;
+	}
+
+	/**
 	 * Get registered menu items.
 	 *
 	 * @return array

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -448,6 +448,10 @@ class Menu {
 	 * @return bool
 	 */
 	public static function has_callback( $menu_item ) {
+		if ( ! $menu_item || ! isset( $menu_item[ self::CALLBACK ] ) ) {
+			return false;
+		}
+
 		$callback = $menu_item[ self::CALLBACK ];
 
 		if (
@@ -478,6 +482,14 @@ class Menu {
 
 		foreach ( $menu as $key => $menu_item ) {
 			if ( self::has_callback( $menu_item ) ) {
+				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+				continue;
+			}
+
+			// WordPress core menus make the parent item the same URL as the first child.
+			$has_children = isset( $submenu[ $menu_item[ self::CALLBACK ] ] ) && isset( $submenu[ $menu_item[ self::CALLBACK ] ][0] );
+			$first_child  = $has_children ? $submenu[ $menu_item[ self::CALLBACK ] ][0] : null;
+			if ( self::has_callback( $first_child ) ) {
 				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
 			}
 		}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -442,6 +442,32 @@ class Menu {
 	}
 
 	/**
+	 * Check if a menu item's callback is registered in the menu.
+	 *
+	 * @param array $menu_item Menu item args.
+	 * @return bool
+	 */
+	public static function has_callback( $menu_item ) {
+		$callback = $menu_item[ self::CALLBACK ];
+
+		if (
+			isset( self::$callbacks[ $callback ] ) &&
+			self::$callbacks[ $callback ]
+		) {
+			return true;
+		}
+
+		if (
+			isset( self::$callbacks[ self::get_callback_url( $callback ) ] ) &&
+			self::$callbacks[ self::get_callback_url( $callback ) ]
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Hides all WP admin menus items and adds screen IDs to check for new items.
 	 *
 	 * @param array $menu Menu items.
@@ -451,26 +477,14 @@ class Menu {
 		global $submenu;
 
 		foreach ( $menu as $key => $menu_item ) {
-			if (
-				isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
-				self::$callbacks[ $menu_item[ self::CALLBACK ] ]
-			) {
+			if ( self::has_callback( $menu_item ) ) {
 				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
 			}
 		}
 
 		foreach ( $submenu as $parent_key => $parent ) {
 			foreach ( $parent as $key => $menu_item ) {
-				if (
-					(
-						isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
-						self::$callbacks[ $menu_item[ self::CALLBACK ] ]
-					) ||
-					(
-						isset( self::$callbacks[ self::get_callback_url( $menu_item[ self::CALLBACK ] ) ] ) &&
-						self::$callbacks[ self::get_callback_url( $menu_item[ self::CALLBACK ] ) ]
-					)
-				) {
+				if ( self::has_callback( $menu_item ) ) {
 					// Disable phpcs since we need to override submenu classes.
 					// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.
 					// phpcs:disable

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -523,7 +523,7 @@ class Menu {
 	/**
 	 * Add a callback to identify and hide pages in the WP menu.
 	 */
-	public static function hide_page_in_wp_menu( $callback ) {
+	public static function hide_wp_menu_item( $callback ) {
 		self::$callbacks[ $callback ] = true;
 	}
 


### PR DESCRIPTION
Fixes #5618

Cleans up the callback check and allows items to be hidden in the wp menu manually.

Note that the Automatewoo issue is related to some CSS trickery and not directly related to the changes in this PR.

### Detailed test instructions:

1. Make sure the menu continues to work correctly.
1. Try hiding a menu item with the new method.  `Menu::hide_wp_menu_item( 'plugins.php' )`;