### PR TITLE
Prevent adding duplicate queue item by checking action and label values

### DIFF
--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -220,6 +220,17 @@ class CustomerEffortScoreTracks {
 			array()
 		);
 
+		$has_duplicate = array_filter(
+			$queue,
+			function ( $queue_item ) use ( $item ) {
+				return $queue_item['action'] === $item['action']
+				&& $queue_item['label'] === $item['label'];
+			}
+		);
+		if ( $has_duplicate ) {
+			return;
+		}
+
 		$queue[] = $item;
 
 		update_option(

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -223,8 +223,7 @@ class CustomerEffortScoreTracks {
 		$has_duplicate = array_filter(
 			$queue,
 			function ( $queue_item ) use ( $item ) {
-				return $queue_item['action'] === $item['action']
-				&& $queue_item['label'] === $item['label'];
+				return $queue_item['action'] === $item['action'];
 			}
 		);
 		if ( $has_duplicate ) {

--- a/tests/features/class-wc-tests-ces-tracks.php
+++ b/tests/features/class-wc-tests-ces-tracks.php
@@ -49,4 +49,28 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$this->assertCount( 1, $expected_queue_item );
 	}
+
+	/**
+	 * Verify that the queue does not add duplicate item by cehcking
+	 * action and label values.
+	 */
+	public function test_the_queue_does_not_allow_duplicate() {
+		// Fire the action twice to trigger the queueing process twice.
+		do_action( 'woocommerce_update_options' );
+		do_action( 'woocommerce_update_options' );
+
+		$ces = $this->ces;
+
+		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+		$this->assertNotEmpty( $queue_items );
+
+		$expected_queue_item = array_filter(
+			$queue_items,
+			function ( $item ) use ( $ces ) {
+				return $ces::SETTINGS_CHANGE_ACTION_NAME === $item['action'];
+			}
+		);
+
+		$this->assertCount( 1, $expected_queue_item );
+	}
 }


### PR DESCRIPTION
Fixes #5670 

This PR fixes an edge case where duplicate snackbar notifications displayed as described in the original [issue](https://github.com/woocommerce/woocommerce-admin/issues/5670).


### Screenshots

![Screen Shot 2020-11-18 at 2 41 37 PMth_](https://user-images.githubusercontent.com/4723145/99597027-337ee500-29ac-11eb-8377-dd4715447e19.jpg)


### Detailed test instructions:

Make sure to delete the `woocommerce_ces_shown_for_actions` and the tracking option is turned on.

1. Click Products -> Add New
2. Enter the product name and click the [ Publish ] button. When you are redirected to the next page, close the tab immediately (timing is important) to prevent seeing the notification.
3. Navigate back to the admin area and click Products -> Add New to add a new product.
4. Make sure that you see only one snackbar notification.