### PR TITLE
Fix snackbar dismissal bug

### DIFF
--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -15,7 +15,7 @@ import './style.scss';
 
 class TransientNotices extends Component {
 	render() {
-		const { className, notices, onRemove } = this.props;
+		const { className, notices, onRemove, onRemove2 } = this.props;
 		const classes = classnames(
 			'woocommerce-transient-notices',
 			'components-notices__snackbar',
@@ -27,6 +27,7 @@ class TransientNotices extends Component {
 				notices={ notices }
 				className={ classes }
 				onRemove={ onRemove }
+				onRemove2={ onRemove2 }
 			/>
 		);
 	}

--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -55,6 +55,7 @@ export default compose(
 	withDispatch( ( dispatch ) => ( {
 		// NOTE: This uses core/notices2, if this file is copied back upstream
 		// to Gutenberg this needs to be changed back to core/notices.
-		onRemove: dispatch( 'core/notices2' ).removeNotice,
+		onRemove: dispatch( 'core/notices' ).removeNotice,
+		onRemove2: dispatch( 'core/notices2' ).removeNotice,
 	} ) )
 )( TransientNotices );

--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -83,7 +83,7 @@ function Snackbar(
 		}, NOTICE_TIMEOUT );
 
 		return () => clearTimeout( timeoutHandle );
-	}, [ onDismiss, onRemove ] );
+	}, [ explicitDismiss, onDismiss, onRemove ] );
 
 	const classes = classnames( className, 'components-snackbar', {
 		'components-snackbar-explicit-dismiss': !! explicitDismiss,

--- a/client/layout/transient-notices/snackbar/list.js
+++ b/client/layout/transient-notices/snackbar/list.js
@@ -18,11 +18,18 @@ import Snackbar from './';
  * @param  {Object}   $0           Props passed to the component.
  * @param  {Array}    $0.notices   Array of notices to render.
  * @param  {Function} $0.onRemove  Function called when a notice should be removed / dismissed.
+ * @param  {Function} $0.onRemove2 Function called when a notice should be removed / dismissed.
  * @param  {Object}   $0.className Name of the class used by the component.
  * @param  {Object}   $0.children  Array of children to be rendered inside the notice list.
  * @return {Object}                The rendered notices list.
  */
-function SnackbarList( { notices, className, children, onRemove = noop } ) {
+function SnackbarList( {
+	notices,
+	className,
+	children,
+	onRemove = noop,
+	onRemove2 = noop,
+} ) {
 	const isReducedMotion = useReducedMotion();
 	const [ refMap ] = useState( () => new WeakMap() );
 	const transitions = useTransition( notices, ( notice ) => notice.id, {
@@ -40,7 +47,11 @@ function SnackbarList( { notices, className, children, onRemove = noop } ) {
 	} );
 
 	className = classnames( 'components-snackbar-list', className );
-	const removeNotice = ( notice ) => () => onRemove( notice.id );
+	const removeNotice = ( notice ) => () => {
+		onRemove( notice.id );
+		// To be removed when we're no longer using core/notices2.
+		onRemove2( notice.id );
+	};
 
 	return (
 		<div className={ className }>


### PR DESCRIPTION
This PR seeks to restore the dismissal functionality of notices that are in the `core/notices` store. When the component was [copied from Gutenberg](https://github.com/woocommerce/woocommerce-admin/commit/8e0a6cf8f1ea850fd4f324e82197d2825dab5687), only the `core/notices2` store was [having dismissal actions dispatched](https://github.com/woocommerce/woocommerce-admin/blob/a1237ed49636c751fedac1d4574ea49b2d6019ab/client/layout/transient-notices/index.js#L58).

### Detailed test instructions:

- Trigger a snackbar notice - I used the Stock panel (update quantity)
- Verify the snackbar appears and auto dismisses after 10 seconds
- Trigger another
- Click the snackbar before 10 seconds elapses
- Verify it is dismissed

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug