### PR TITLE
Allow navigation feature in plugin and core builds

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -10,7 +10,7 @@
 		"marketing": true,
 		"minified-js": false,
 		"mobile-app-banner": true,
-		"navigation": false,
+		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -10,7 +10,7 @@
 		"marketing": true,
 		"minified-js": true,
 		"mobile-app-banner": true,
-		"navigation": false,
+		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,


### PR DESCRIPTION
Fixes #5692 

Allows the navigation feature to be toggled on/off in all builds.  By default, this feature is still off and behind a feature flag.

### Screenshots
<img width="805" alt="Screen Shot 2020-11-19 at 12 54 49 PM" src="https://user-images.githubusercontent.com/10561050/99717707-c173d200-2a77-11eb-9ffa-08c1ee81cfec.png">


### Detailed test instructions:

1. Build a non-dev version of WCA.
1. Navigate to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Turn on the feature.
1. Note that the new nav feature loads (you may need to refresh the page once).