### PR TITLE
Update core menu item order in navigation

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -75,30 +75,30 @@ class CoreMenu {
 	public static function get_categories() {
 		return array(
 			array(
-				'title'        => __( 'Analytics', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'analytics',
-				'order'        => 10,
-				'is_top_level' => true,
-			),
-			array(
 				'title'        => __( 'Orders', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'orders',
-				'order'        => 20,
-				'is_top_level' => true,
-			),
-			array(
-				'title'        => __( 'Marketing', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'marketing',
-				'order'        => 30,
+				'order'        => 10,
 				'is_top_level' => true,
 			),
 			array(
 				'title'        => __( 'Products', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'products',
+				'order'        => 20,
+				'is_top_level' => true,
+			),
+			array(
+				'title'        => __( 'Analytics', 'woocommerce-admin' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'analytics',
+				'order'        => 30,
+				'is_top_level' => true,
+			),
+			array(
+				'title'        => __( 'Marketing', 'woocommerce-admin' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'marketing',
 				'order'        => 40,
 				'is_top_level' => true,
 			),


### PR DESCRIPTION
Fixes #5693 

Reorganizes menu items.

### Screenshots
<img width="443" alt="Screen Shot 2020-11-19 at 3 01 51 PM" src="https://user-images.githubusercontent.com/10561050/99718121-67274100-2a78-11eb-84ed-24a44a3349f1.png">


### Detailed test instructions:

1. Enable the new nav feature.
1. Make sure the menu item order matches:

```
Home
Orders
Products
Analytics
Marketing
Customers
```