### PR TITLE
CES: Fix dismissal button (X) style in notice/snackbar

### DIFF
--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -1,16 +1,14 @@
-
-
 .woocommerce-transient-notices {
 	position: fixed;
 	bottom: $gap-small;
 	left: 176px;
 	z-index: 99999;
 
-	@media (max-width: 960px) {
+	@media ( max-width: 960px ) {
 		left: 50px;
 	}
 
-	@media (max-width: 782px) {
+	@media ( max-width: 782px ) {
 		left: $gap;
 	}
 
@@ -39,7 +37,7 @@
 		left: 26px;
 	}
 
-	.components-snackbar__dismiss_button {
+	.components-snackbar__dismiss-button {
 		margin-left: 32px;
 		cursor: pointer;
 	}


### PR DESCRIPTION
This PR fixes the dismissal button (X) style in the CES notice/snackbar.

### Screenshots

Before:

<img width="451" alt="Screen Shot 2020-11-19 at 15 41 36" src="https://user-images.githubusercontent.com/2098816/99723232-e704d980-2a7f-11eb-86c1-6b5efb6db2fd.png">

After:

<img width="487" alt="Screen Shot 2020-11-19 at 15 47 01" src="https://user-images.githubusercontent.com/2098816/99723256-f126d800-2a7f-11eb-8b7c-6f6b8fb99900.png">

### Detailed test instructions:

- Make sure tracking is enabled: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
- Clear out the options tracking whether the survey has been shown:

```
/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
```

- Add or edit a product in wp-admin.
- When the snackbar/notice is shown, verify that the dismissal button is styled correctly (left margin and cursor).


### Changelog Note:

No changelog entry needed.
