### PR TITLE
Stripe - Remove redundant text

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -332,7 +332,7 @@
 			font-size: 14px;
 			color: $studio-gray-50;
 			font-weight: 400;
-			margin-top: 2px;
+			margin-top: 16px;
 			margin-bottom: $gap-smaller;
 		}
 	}

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -317,10 +317,6 @@ class Stripe extends Component {
 
 		return {
 			...connectStep,
-			description: __(
-				'Connect your store to your Stripe account.',
-				'woocommerce-admin'
-			),
 			content: this.renderManualConfig(),
 		};
 	}

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -318,7 +318,7 @@ class Stripe extends Component {
 		return {
 			...connectStep,
 			description: __(
-				'Connect your store to your Stripe account. Don’t have a Stripe account? Create one.',
+				'Connect your store to your Stripe account.',
 				'woocommerce-admin'
 			),
 			content: this.renderManualConfig(),


### PR DESCRIPTION
Fixes #5654 

This PR removes redundant stripe help text as described in the original issue #5654 

### Screenshots
**Before:**
<img width="712" alt="Screen Shot 2020-11-17 at 10 54 17 AM" src="https://user-images.githubusercontent.com/10561050/99415412-c42ec580-28c5-11eb-9ebd-2f8e9f688a7d.png">

**After:**
![Screen Shot 2020-11-19 at 2 21 06 PM](https://user-images.githubusercontent.com/4723145/99731437-bff3db00-2a72-11eb-8a15-bb09aa64536e.jpg)

**After removing the subtext entirely:**

![Screen Shot 2020-11-20 at 12 53 50 PM](https://user-images.githubusercontent.com/4723145/99849090-bf6d4a00-2b2f-11eb-901c-7b78f3c4827f.jpg)


### Detailed test instructions:

1. Create a new jurassic ninja site.
2. Navigate to the admin area.
3. Add WooCommerce plugin and upload [woocommerce-admin.zip](https://github.com/woocommerce/woocommerce-admin/files/5576042/woocommerce-admin.zip)

4. Go to the plugin page and activate both WooCommerce and WooCommerce Admin
5. Navigate to WooCommerce -> Home and click "Set up payments"
6. Click [ Set up ] button for the stripe.
7. Click "manually enter your Stripe API details" link.
