### PR TITLE
Always call onRemove when action is clicked in Snackbar

### DIFF
--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -62,9 +62,7 @@ function Snackbar(
 	function onActionClick( event, onClick ) {
 		event.stopPropagation();
 
-		if ( explicitDismiss ) {
-			onRemove();
-		}
+		onRemove();
 
 		if ( onClick ) {
 			onClick( event );


### PR DESCRIPTION
Whenever a Snackbar action is clicked, the snackbar should be removed.

### Detailed test instructions:

- Trigger snackbars with actions, such as removing an Inbox notice (click the "Undo" action in the snackbar).
- Trigger CES snackbars with action, such as editing a product (see #5700 for testing instructions on how to get a CES snackbar to appear).
- Verify that clicking a Snackbar action removes the Snackbar.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

No changelog entry needed.