### PR TITLE
Disable the continue button while requests are being made

### DIFF
--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -198,7 +198,7 @@ class Benefits extends Component {
 		const {
 			activePlugins,
 			isInstallingActivating,
-			isRequesting,
+			isUpdatingProfileItems,
 		} = this.props;
 
 		const pluginNamesString = this.pluginsToInstall
@@ -238,15 +238,15 @@ class Benefits extends Component {
 					<Button
 						isPrimary
 						isBusy={ isInstallAction }
-						disabled={ isRequesting || isInstallAction }
+						disabled={ isUpdatingProfileItems || isInstallAction }
 						onClick={ this.startPluginInstall }
 					>
 						{ __( 'Yes please!', 'woocommerce-admin' ) }
 					</Button>
 					<Button
 						isSecondary
-						isBusy={ isRequesting && ! isInstallAction }
-						disabled={ isRequesting || isInstallAction }
+						isBusy={ isUpdatingProfileItems && ! isInstallAction }
+						disabled={ isUpdatingProfileItems || isInstallAction }
 						className="woocommerce-profile-wizard__skip"
 						onClick={ this.skipPluginInstall }
 					>
@@ -307,7 +307,9 @@ export default compose(
 				getOnboardingError( 'updateProfileItems' )
 			),
 			profileItems: getProfileItems(),
-			isRequesting: isOnboardingRequesting( 'updateProfileItems' ),
+			isUpdatingProfileItems: isOnboardingRequesting(
+				'updateProfileItems'
+			),
 			isInstallingActivating:
 				isPluginsRequesting( 'installPlugins' ) ||
 				isPluginsRequesting( 'activatePlugins' ) ||

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -658,6 +658,7 @@ class BusinessDetails extends Component {
 			goToNextStep,
 			isInstallingActivating,
 			hasInstallActivateError,
+			isUpdateRequesting,
 		} = this.props;
 		const { formatAmount } = this.context;
 		const productCountOptions = [
@@ -920,7 +921,11 @@ class BusinessDetails extends Component {
 										<Button
 											isPrimary
 											onClick={ handleSubmit }
-											disabled={ ! isValidForm }
+											disabled={
+												! isValidForm ||
+												isUpdateRequesting ||
+												isInstallingActivating
+											}
 											isBusy={ isInstallingActivating }
 										>
 											{ ! hasInstallActivateError
@@ -960,10 +965,16 @@ BusinessDetails.contextType = CurrencyContext;
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getSettings, getSettingsError } = select( SETTINGS_STORE_NAME );
-		const { getProfileItems, getOnboardingError } = select(
-			ONBOARDING_STORE_NAME
-		);
+		const {
+			getSettings,
+			getSettingsError,
+			isUpdateSettingsRequesting,
+		} = select( SETTINGS_STORE_NAME );
+		const {
+			getProfileItems,
+			getOnboardingError,
+			isOnboardingRequesting,
+		} = select( ONBOARDING_STORE_NAME );
 		const { getPluginsError, isPluginsRequesting } = select(
 			PLUGINS_STORE_NAME
 		);
@@ -977,6 +988,9 @@ export default compose(
 			profileItems: getProfileItems(),
 			isSettingsError: Boolean( getSettingsError( 'general' ) ),
 			settings,
+			isUpdateRequesting:
+				isOnboardingRequesting( 'updateProfileItems' ) ||
+				isUpdateSettingsRequesting( 'general' ),
 			isInstallingActivating:
 				isPluginsRequesting( 'installPlugins' ) ||
 				isPluginsRequesting( 'activatePlugins' ) ||

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -658,7 +658,7 @@ class BusinessDetails extends Component {
 			goToNextStep,
 			isInstallingActivating,
 			hasInstallActivateError,
-			isUpdateRequesting,
+			isUpdatingProfileItems,
 		} = this.props;
 		const { formatAmount } = this.context;
 		const productCountOptions = [
@@ -923,7 +923,7 @@ class BusinessDetails extends Component {
 											onClick={ handleSubmit }
 											disabled={
 												! isValidForm ||
-												isUpdateRequesting ||
+												isUpdatingProfileItems ||
 												isInstallingActivating
 											}
 											isBusy={ isInstallingActivating }
@@ -988,7 +988,7 @@ export default compose(
 			profileItems: getProfileItems(),
 			isSettingsError: Boolean( getSettingsError( 'general' ) ),
 			settings,
-			isUpdateRequesting:
+			isUpdatingProfileItems:
 				isOnboardingRequesting( 'updateProfileItems' ) ||
 				isUpdateSettingsRequesting( 'general' ),
 			isInstallingActivating:

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -158,7 +158,7 @@ class Industry extends Component {
 	render() {
 		const { industries } = onboarding;
 		const { error, selected, textInputListContent } = this.state;
-		const { locationSettings } = this.props;
+		const { locationSettings, isProfileItemsRequesting } = this.props;
 		const region = getCurrencyRegion(
 			locationSettings.woocommerce_default_country
 		);
@@ -239,7 +239,9 @@ class Industry extends Component {
 						<Button
 							isPrimary
 							onClick={ this.onContinue }
-							disabled={ ! selected.length }
+							disabled={
+								! selected.length || isProfileItemsRequesting
+							}
 						>
 							{ __( 'Continue', 'woocommerce-admin' ) }
 						</Button>
@@ -252,9 +254,11 @@ class Industry extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getProfileItems, getOnboardingError } = select(
-			ONBOARDING_STORE_NAME
-		);
+		const {
+			getProfileItems,
+			getOnboardingError,
+			isOnboardingRequesting,
+		} = select( ONBOARDING_STORE_NAME );
 		const { getSettings } = select( SETTINGS_STORE_NAME );
 		const { general: locationSettings = {} } = getSettings( 'general' );
 
@@ -262,6 +266,9 @@ export default compose(
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),
 			profileItems: getProfileItems(),
 			locationSettings,
+			isProfileItemsRequesting: isOnboardingRequesting(
+				'updateProfileItems'
+			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -102,6 +102,7 @@ export class ProductTypes extends Component {
 	render() {
 		const { productTypes = {} } = getSetting( 'onboarding', {} );
 		const { error, isMonthlyPricing, selected } = this.state;
+		const { isProfileItemsRequesting } = this.props;
 
 		return (
 			<div className="woocommerce-profile-wizard__product-types">
@@ -176,7 +177,10 @@ export class ProductTypes extends Component {
 							<Button
 								isPrimary
 								onClick={ this.onContinue }
-								disabled={ ! selected.length }
+								disabled={
+									! selected.length ||
+									isProfileItemsRequesting
+								}
 							>
 								{ __( 'Continue', 'woocommerce-admin' ) }
 							</Button>
@@ -198,13 +202,18 @@ export class ProductTypes extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getProfileItems, getOnboardingError } = select(
-			ONBOARDING_STORE_NAME
-		);
+		const {
+			getProfileItems,
+			getOnboardingError,
+			isOnboardingRequesting,
+		} = select( ONBOARDING_STORE_NAME );
 
 		return {
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),
 			profileItems: getProfileItems(),
+			isProfileItemsRequesting: isOnboardingRequesting(
+				'updateProfileItems'
+			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -172,7 +172,7 @@ class StoreDetails extends Component {
 			isStoreDetailsPopoverVisible,
 			isSkipSetupPopoverVisible,
 		} = this.state;
-		const { skipProfiler } = this.props;
+		const { skipProfiler, isUpdateRequesting } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 		const skipSetupText = __(
@@ -290,7 +290,10 @@ class StoreDetails extends Component {
 										<Button
 											isPrimary
 											onClick={ handleSubmit }
-											disabled={ ! isValidForm }
+											disabled={
+												! isValidForm ||
+												isUpdateRequesting
+											}
 										>
 											{ __(
 												'Continue',
@@ -357,10 +360,16 @@ StoreDetails.contextType = CurrencyContext;
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getSettings, getSettingsError } = select( SETTINGS_STORE_NAME );
-		const { getOnboardingError, getProfileItems } = select(
-			ONBOARDING_STORE_NAME
-		);
+		const {
+			getSettings,
+			getSettingsError,
+			isUpdateSettingsRequesting,
+		} = select( SETTINGS_STORE_NAME );
+		const {
+			getOnboardingError,
+			getProfileItems,
+			isOnboardingRequesting,
+		} = select( ONBOARDING_STORE_NAME );
 
 		const profileItems = getProfileItems();
 		const isProfileItemsError = Boolean(
@@ -369,11 +378,14 @@ export default compose(
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );
-
+		const isUpdateRequesting =
+			isOnboardingRequesting( 'updateProfileItems' ) ||
+			isUpdateSettingsRequesting( 'general' );
 		return {
 			isProfileItemsError,
 			isSettingsError,
 			profileItems,
+			isUpdateRequesting,
 			settings,
 		};
 	} ),

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -172,7 +172,7 @@ class StoreDetails extends Component {
 			isStoreDetailsPopoverVisible,
 			isSkipSetupPopoverVisible,
 		} = this.state;
-		const { skipProfiler, isUpdateRequesting } = this.props;
+		const { skipProfiler, isUpdatingProfileItems } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 		const skipSetupText = __(
@@ -292,7 +292,7 @@ class StoreDetails extends Component {
 											onClick={ handleSubmit }
 											disabled={
 												! isValidForm ||
-												isUpdateRequesting
+												isUpdatingProfileItems
 											}
 										>
 											{ __(
@@ -378,14 +378,14 @@ export default compose(
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );
-		const isUpdateRequesting =
+		const isUpdatingProfileItems =
 			isOnboardingRequesting( 'updateProfileItems' ) ||
 			isUpdateSettingsRequesting( 'general' );
 		return {
 			isProfileItemsError,
 			isSettingsError,
 			profileItems,
-			isUpdateRequesting,
+			isUpdatingProfileItems,
 			settings,
 		};
 	} ),

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -241,6 +241,7 @@ class Theme extends Component {
 								isSecondary
 								onClick={ () => this.onChoose( theme, 'card' ) }
 								isBusy={ chosen === slug }
+								disabled={ chosen === slug }
 							>
 								{ __( 'Choose', 'woocommerce-admin' ) }
 							</Button>

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -189,6 +189,7 @@ class Theme extends Component {
 		} = theme;
 		const { chosen } = this.state;
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
+		const { isUpdatingProfileItems } = this.props;
 
 		return (
 			<Card className="woocommerce-profile-wizard__theme" key={ slug }>
@@ -229,6 +230,7 @@ class Theme extends Component {
 								isPrimary
 								onClick={ () => this.onChoose( theme, 'card' ) }
 								isBusy={ chosen === slug }
+								disabled={ isUpdatingProfileItems }
 							>
 								{ __(
 									'Continue with my active theme',

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -189,7 +189,6 @@ class Theme extends Component {
 		} = theme;
 		const { chosen } = this.state;
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
-		const { isUpdatingProfileItems } = this.props;
 
 		return (
 			<Card className="woocommerce-profile-wizard__theme" key={ slug }>
@@ -230,7 +229,7 @@ class Theme extends Component {
 								isPrimary
 								onClick={ () => this.onChoose( theme, 'card' ) }
 								isBusy={ chosen === slug }
-								disabled={ isUpdatingProfileItems }
+								disabled={ chosen === slug }
 							>
 								{ __(
 									'Continue with my active theme',


### PR DESCRIPTION
Fixes #5643 

This PR fixes an edge case where a user can click the "Continue" button multiple times as described in the original issue #5643.

### Detailed test instructions:

1. Start the OBW
2. Click the "Continue" button a few times in quick succession.
3. The button should be disabled and your mouse pointer should be changed to pointer after the first click. 

Pointer:
![cursor_feature_imgth_](https://user-images.githubusercontent.com/4723145/99752136-8fbf3300-2a98-11eb-820f-f80691960f40.jpg)

