### PR TITLE
Changed price toggle placement

### DIFF
--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -148,25 +148,6 @@ export class ProductTypes extends Component {
 								/>
 							);
 						} ) }
-						<div className="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox">
-							<label htmlFor="woocommerce-product-types__pricing-toggle">
-								<Text variant="body">
-									{ __(
-										'Display monthly prices',
-										'woocommerce-admin'
-									) }
-								</Text>
-								<FormToggle
-									id="woocommerce-product-types__pricing-toggle"
-									checked={ isMonthlyPricing }
-									onChange={ () =>
-										this.setState( {
-											isMonthlyPricing: ! isMonthlyPricing,
-										} )
-									}
-								/>
-							</label>
-						</div>
 						{ error && (
 							<span className="woocommerce-profile-wizard__error">
 								{ error }
@@ -184,6 +165,25 @@ export class ProductTypes extends Component {
 					</div>
 				</Card>
 				<div className="woocommerce-profile-wizard__card-help-text">
+					<div className="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox">
+						<label htmlFor="woocommerce-product-types__pricing-toggle">
+							<Text variant="body">
+								{ __(
+									'Display monthly prices',
+									'woocommerce-admin'
+								) }
+							</Text>
+							<FormToggle
+								id="woocommerce-product-types__pricing-toggle"
+								checked={ isMonthlyPricing }
+								onChange={ () =>
+									this.setState( {
+										isMonthlyPricing: ! isMonthlyPricing,
+									} )
+								}
+							/>
+						</label>
+					</div>
 					<Text variant="caption">
 						{ __(
 							'Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.',

--- a/client/profile-wizard/steps/product-types/style.scss
+++ b/client/profile-wizard/steps/product-types/style.scss
@@ -52,7 +52,7 @@
 			label {
 				display: inline-flex;
 				align-items: center;
-				margin: 0 auto;
+				margin: auto;
 			}
 
 			.components-form-toggle {

--- a/client/profile-wizard/steps/product-types/style.scss
+++ b/client/profile-wizard/steps/product-types/style.scss
@@ -47,10 +47,12 @@
 			align-items: center;
 			justify-content: flex-end;
 			color: $gray-600;
+			margin-bottom: $gap;
 
 			label {
 				display: inline-flex;
 				align-items: center;
+				margin: 0 auto;
 			}
 
 			.components-form-toggle {

--- a/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -106,35 +106,6 @@ you can purchase and install it later.
             </div>
           </div>
           <div
-            class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"
-          >
-            <label
-              for="woocommerce-product-types__pricing-toggle"
-            >
-              <p
-                class="css-1f0yw52-Text e15wbhsk0"
-              >
-                Display monthly prices
-              </p>
-              <span
-                class="components-form-toggle is-checked"
-              >
-                <input
-                  checked=""
-                  class="components-form-toggle__input"
-                  id="woocommerce-product-types__pricing-toggle"
-                  type="checkbox"
-                />
-                <span
-                  class="components-form-toggle__track"
-                />
-                <span
-                  class="components-form-toggle__thumb"
-                />
-              </span>
-            </label>
-          </div>
-          <div
             class="woocommerce-profile-wizard__card-actions"
           >
             <button
@@ -151,6 +122,35 @@ you can purchase and install it later.
     <div
       class="woocommerce-profile-wizard__card-help-text"
     >
+      <div
+        class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"
+      >
+        <label
+          for="woocommerce-product-types__pricing-toggle"
+        >
+          <p
+            class="css-1f0yw52-Text e15wbhsk0"
+          >
+            Display monthly prices
+          </p>
+          <span
+            class="components-form-toggle is-checked"
+          >
+            <input
+              checked=""
+              class="components-form-toggle__input"
+              id="woocommerce-product-types__pricing-toggle"
+              type="checkbox"
+            />
+            <span
+              class="components-form-toggle__track"
+            />
+            <span
+              class="components-form-toggle__thumb"
+            />
+          </span>
+        </label>
+      </div>
       <p
         class="css-1qmnemh-Text e15wbhsk0"
       >
@@ -267,35 +267,6 @@ you can purchase and install it later.
             </div>
           </div>
           <div
-            class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"
-          >
-            <label
-              for="woocommerce-product-types__pricing-toggle"
-            >
-              <p
-                class="css-1f0yw52-Text e15wbhsk0"
-              >
-                Display monthly prices
-              </p>
-              <span
-                class="components-form-toggle"
-              >
-                <input
-                  checked=""
-                  class="components-form-toggle__input"
-                  id="woocommerce-product-types__pricing-toggle"
-                  type="checkbox"
-                />
-                <span
-                  class="components-form-toggle__track"
-                />
-                <span
-                  class="components-form-toggle__thumb"
-                />
-              </span>
-            </label>
-          </div>
-          <div
             class="woocommerce-profile-wizard__card-actions"
           >
             <button
@@ -312,6 +283,35 @@ you can purchase and install it later.
     <div
       class="woocommerce-profile-wizard__card-help-text"
     >
+      <div
+        class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"
+      >
+        <label
+          for="woocommerce-product-types__pricing-toggle"
+        >
+          <p
+            class="css-1f0yw52-Text e15wbhsk0"
+          >
+            Display monthly prices
+          </p>
+          <span
+            class="components-form-toggle"
+          >
+            <input
+              checked=""
+              class="components-form-toggle__input"
+              id="woocommerce-product-types__pricing-toggle"
+              type="checkbox"
+            />
+            <span
+              class="components-form-toggle__track"
+            />
+            <span
+              class="components-form-toggle__thumb"
+            />
+          </span>
+        </label>
+      </div>
       <p
         class="css-1qmnemh-Text e15wbhsk0"
       >


### PR DESCRIPTION
Fixes #5295

This PR changes the price toggle placement.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 11 20-16_29_58](https://user-images.githubusercontent.com/1314156/99841995-cefb8b80-2b4d-11eb-833f-545eb0085f12.png)

### Detailed test instructions:

- Go to the 3rd OBW step (`/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`)
- Verify the price toggle looks as expected. 

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Changed price toggle placement
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
