### PR TITLE
Style updates to tax task

### DIFF
--- a/client/homescreen/activity-panel/style.scss
+++ b/client/homescreen/activity-panel/style.scss
@@ -64,17 +64,17 @@
 		}
 
 		&:hover {
-			background: $gray-200;
+			background-color: $gray-100;
 		}
 
 		&:active {
-			background: $gray-100;
+			background-color: $gray-100;
 		}
 
 		&:focus {
-			background: $gray-200;
+			background-color: $gray-100;
 			box-shadow: inset 0 0 0 1px $box-shadow-blue,
-				inset 0 0 0 2px $gray-200;
+				inset 0 0 0 2px $gray-100;
 		}
 
 		&:hover,

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -351,7 +351,7 @@
 
 .woocommerce-task-dashboard__container {
 	button.components-button.is-primary {
-		margin: 0;
+		margin: 0 8px 0 0;
 	}
 
 	button.components-button.is-link {

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -496,5 +496,5 @@
 
 .woocommerce-task__caption {
 	color: $gray-700;
-	margin-top: 12px;
+	margin-top: $gap;
 }

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -496,5 +496,5 @@
 
 .woocommerce-task__caption {
 	color: $gray-700;
-	margin-top: $gap;
+	margin-top: 12px;
 }

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -494,7 +494,7 @@
 	}
 }
 
-.woocommerce-task__caption {
+.woocommerce-task-dashboard__container .woocommerce-task__caption {
 	color: $gray-700;
 	margin-top: $gap;
 }

--- a/client/task-list/tasks/appearance.js
+++ b/client/task-list/tasks/appearance.js
@@ -309,6 +309,7 @@ class Appearance extends Component {
 							{ __( 'Create homepage', 'woocommerce-admin' ) }
 						</Button>
 						<Button
+							isTertiary
 							onClick={ () => {
 								recordEvent(
 									'tasklist_appearance_create_homepage',

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -258,12 +258,12 @@ class Tax extends Component {
 								this.manuallyConfigureTaxRates();
 							} }
 							skipText={ __(
-								'Set up tax rates manually',
+								'Set up manually',
 								'woocommerce-admin'
 							) }
 							onAbort={ () => this.doNotChargeSalesTax() }
 							abortText={ __(
-								"My business doesn't charge sales tax",
+								"I don't charge sales tax",
 								'woocommerce-admin'
 							) }
 						/>
@@ -425,6 +425,7 @@ class Tax extends Component {
 				</Button>
 				<Button
 					disabled={ isPending }
+					isTertiary
 					onClick={ () => {
 						recordEvent( 'tasklist_tax_setup_automated_proceed', {
 							setup_automatically: false,
@@ -433,18 +434,16 @@ class Tax extends Component {
 					} }
 				>
 					{ __(
-						"No thanks, I'll configure taxes manually",
+						"No thanks, I'll set up manually",
 						'woocommerce-admin'
 					) }
 				</Button>
 				<Button
 					disabled={ isPending }
+					isTertiary
 					onClick={ () => this.doNotChargeSalesTax() }
 				>
-					{ __(
-						"My business doesn't charge sales tax",
-						'woocommerce-admin'
-					) }
+					{ __( "I don't charge sales tax", 'woocommerce-admin' ) }
 				</Button>
 			</div>
 		);

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -130,11 +130,11 @@ export class Plugins extends Component {
 				>
 					{ __( 'Install & enable', 'woocommerce-admin' ) }
 				</Button>
-				<Button onClick={ this.skipInstaller }>
+				<Button isTertiary onClick={ this.skipInstaller }>
 					{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
 				</Button>
 				{ onAbort && (
-					<Button onClick={ onAbort }>
+					<Button isTertiary onClick={ onAbort }>
 						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
 					</Button>
 				) }

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -172,7 +172,7 @@
 		}
 
 		.woocommerce-stepper_content {
-			margin-top: $gap-smaller;
+			margin-top: $gap-medium;
 			margin-left: $gap-small + $step-icon-size;
 		}
 	}

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -172,7 +172,7 @@
 		}
 
 		.woocommerce-stepper_content {
-			margin-top: $gap-medium;
+			margin-top: $gap;
 			margin-left: $gap-small + $step-icon-size;
 		}
 	}


### PR DESCRIPTION
Fixes #

- Tweaked some styles and copy to make the tax task easier to read and understand
- Also updated the hover/focus/active state for the footer link in the Orders panel to be consistent with other button states on the home screen

### Screenshots
<img width="786" alt="Screen Shot 2020-11-20 at 2 48 33 PM" src="https://user-images.githubusercontent.com/5121465/99848584-a8365880-2b3f-11eb-97ac-ed5f21c70022.png">

<img width="608" alt="image" src="https://user-images.githubusercontent.com/5121465/99848681-d320ac80-2b3f-11eb-9b86-9bd866a0827b.png">

### Detailed test instructions:

- Open Set up tax step from Task list on Home screen
- See visual and copy updates

- Also, hover over "Manage all orders" link in Orders panel to see updates there

Note that I tried to change the buttons to tertiary buttons but not sure if that worked - feel free to comment and let me know anything that's off base.