### PR TITLE
embedded activity panels - Add 24px padding top to the container

### DIFF
--- a/client/inbox-panel/style.scss
+++ b/client/inbox-panel/style.scss
@@ -176,6 +176,10 @@
 	}
 }
 
+.woocommerce-layout__activity-panel-content {
+	padding-top: $gap-large;
+}
+
 #activity-panel-inbox {
 	margin: 0 $gap-large;
 }


### PR DESCRIPTION
Fixes #5699 

This PR fixes issue 5699 by adding 24px padding-top to the container.

This ticket might be related: https://github.com/woocommerce/woocommerce-admin/pull/4632/files#diff-df7d27b4ebc30d4a4d81884234868bda73e2ec29498d85bb6477e4725f28f46fR9

I applied `padding-top` to `.woocommerce-layout__activity-panel-content` class name in order to avoid any conflict as it is not being used by any other pages.

### Screenshots

**Before:**
![Screen Shot 2020-11-23 at 1 22 04 PMth_](https://user-images.githubusercontent.com/4723145/100016949-0442ec00-2d8f-11eb-8024-6f6f8494e1b9.jpg)

**After
![Screen Shot 2020-11-23 at 1 22 13 PMth_](https://user-images.githubusercontent.com/4723145/100016964-0a38cd00-2d8f-11eb-8210-85b140adf2fb.jpg)
:**


### Detailed test instructions:

1. With 4.8-beta.1 installed
2. Visit the orders listing page, and click on the inbox activity panel
