### PR TITLE
Allow WCA registered pages to register plugin items and categories

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -235,14 +235,10 @@ class Analytics {
 				),
 			) : null,
 			array(
-				'id'       => 'woocommerce-analytics-customers',
-				'title'    => __( 'Customers', 'woocommerce-admin' ),
-				'parent'   => 'woocommerce',
-				'path'     => '/customers',
-				'nav_args' => array(
-					'is_top_level' => true,
-					'order'        => 50,
-				),
+				'id'     => 'woocommerce-analytics-customers',
+				'title'  => __( 'Customers', 'woocommerce-admin' ),
+				'parent' => 'woocommerce',
+				'path'   => '/customers',
 			),
 			array(
 				'id'       => 'woocommerce-analytics-settings',

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -69,12 +69,11 @@ class Homescreen {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'           => 'woocommerce-home',
-				'title'        => __( 'Home', 'woocommerce-admin' ),
-				'parent'       => 'woocommerce',
-				'path'         => self::MENU_SLUG,
-				'is_top_level' => true,
-				'order'        => 0,
+				'id'     => 'woocommerce-home',
+				'title'  => __( 'Home', 'woocommerce-admin' ),
+				'parent' => 'woocommerce',
+				'path'   => self::MENU_SLUG,
+				'order'  => 0,
 			)
 		);
 	}

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -143,9 +143,9 @@ class CoreMenu {
 			$wca_items[] = array_merge(
 				array(
 					'id'         => 'wc_admin-' . $page['path'],
-					'url'        => $page['path'],
+					'url'        => isset( $page['path'] ) ? $page['path'] : null,
 					'title'      => $page['title'][0],
-					'capability' => $page['capability'],
+					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
 				),
 				$page['nav_args']
 			);

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -75,49 +75,43 @@ class CoreMenu {
 	public static function get_categories() {
 		return array(
 			array(
-				'title'        => __( 'Orders', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-orders',
-				'order'        => 10,
-				'is_top_level' => true,
+				'title'      => __( 'Orders', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-orders',
+				'order'      => 10,
 			),
 			array(
-				'title'        => __( 'Products', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-products',
-				'order'        => 20,
-				'is_top_level' => true,
+				'title'      => __( 'Products', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-products',
+				'order'      => 20,
 			),
 			array(
-				'title'        => __( 'Analytics', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-analytics',
-				'order'        => 30,
-				'is_top_level' => true,
+				'title'      => __( 'Analytics', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-analytics',
+				'order'      => 30,
 			),
 			array(
-				'title'        => __( 'Marketing', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-marketing',
-				'order'        => 40,
-				'is_top_level' => true,
+				'title'      => __( 'Marketing', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-marketing',
+				'order'      => 40,
 			),
 			array(
-				'title'        => __( 'Settings', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-settings',
-				'menuId'       => 'secondary',
-				'order'        => 10,
-				'url'          => 'admin.php?page=wc-settings',
-				'is_top_level' => true,
+				'title'      => __( 'Settings', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-settings',
+				'menuId'     => 'secondary',
+				'order'      => 10,
+				'url'        => 'admin.php?page=wc-settings',
 			),
 			array(
-				'title'        => __( 'Tools', 'woocommerce-admin' ),
-				'capability'   => 'manage_woocommerce',
-				'id'           => 'woocommerce-tools',
-				'menuId'       => 'secondary',
-				'order'        => 30,
-				'is_top_level' => true,
+				'title'      => __( 'Tools', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'woocommerce-tools',
+				'menuId'     => 'secondary',
+				'order'      => 30,
 			),
 		);
 	}
@@ -146,17 +140,12 @@ class CoreMenu {
 					'url'        => isset( $page['path'] ) ? $page['path'] : null,
 					'title'      => $page['title'][0],
 					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
-					'menuId'     => 'primary',
 				),
 				$page['nav_args']
 			);
 
 			// Don't allow top-level items to be added to the primary menu.
-			if (
-				isset( $item['is_top_level'] ) &&
-				$item['is_top_level'] &&
-				'primary' === $item['menuId']
-			) {
+			if ( ! isset( $item['parent'] ) ) {
 				$item['menuId'] = 'plugins';
 			}
 
@@ -166,22 +155,20 @@ class CoreMenu {
 		$home_item = array();
 		if ( defined( '\Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG' ) ) {
 			$home_item = array(
-				'id'           => 'wc_admin-wc-admin&path=/',
-				'title'        => __( 'Home', 'woocommerce-admin' ),
-				'url'          => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
-				'is_top_level' => true,
-				'order'        => 0,
+				'id'    => 'wc_admin-wc-admin&path=/',
+				'title' => __( 'Home', 'woocommerce-admin' ),
+				'url'   => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
+				'order' => 0,
 			);
 		}
 
 		$customers_item = array();
 		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Analytics' ) ) {
 			$customers_item = array(
-				'id'           => 'woocommerce-analytics-customers',
-				'title'        => __( 'Customers', 'woocommerce-admin' ),
-				'url'          => wc_admin_url( '/customers' ),
-				'is_top_level' => true,
-				'order'        => 50,
+				'id'    => 'woocommerce-analytics-customers',
+				'title' => __( 'Customers', 'woocommerce-admin' ),
+				'url'   => wc_admin_url( '/customers' ),
+				'order' => 50,
 			);
 		}
 
@@ -196,13 +183,12 @@ class CoreMenu {
 				$coupon_items['default'],
 				// Marketplace category.
 				array(
-					'title'        => __( 'Marketplace', 'woocommerce-admin' ),
-					'capability'   => 'manage_woocommerce',
-					'id'           => 'woocommerce-marketplace',
-					'url'          => 'wc-addons',
-					'menuId'       => 'secondary',
-					'order'        => 20,
-					'is_top_level' => true,
+					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'woocommerce-marketplace',
+					'url'        => 'wc-addons',
+					'menuId'     => 'secondary',
+					'order'      => 20,
 				),
 				// Tools category.
 				array(

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -134,10 +134,11 @@ class CoreMenu {
 				continue;
 			}
 
+			$path = isset( $page['path'] ) ? $page['path'] : null;
 			$item = array_merge(
 				array(
-					'id'         => 'wc_admin-' . $page['path'],
-					'url'        => isset( $page['path'] ) ? $page['path'] : null,
+					'id'         => 'wc_admin-' . $path,
+					'url'        => $path,
 					'title'      => $page['title'][0],
 					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
 				),
@@ -145,7 +146,7 @@ class CoreMenu {
 			);
 
 			// Don't allow top-level items to be added to the primary menu.
-			if ( ! isset( $item['parent'] ) ) {
+			if ( ! isset( $item['parent'] ) || 'woocommerce' === $item['parent'] ) {
 				$item['menuId'] = 'plugins';
 			}
 

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -140,15 +140,27 @@ class CoreMenu {
 				continue;
 			}
 
-			$wca_items[] = array_merge(
+			$item = array_merge(
 				array(
 					'id'         => 'wc_admin-' . $page['path'],
 					'url'        => isset( $page['path'] ) ? $page['path'] : null,
 					'title'      => $page['title'][0],
 					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
+					'menuId'     => 'primary',
 				),
 				$page['nav_args']
 			);
+
+			// Don't allow top-level items to be added to the primary menu.
+			if (
+				isset( $item['is_top_level'] ) &&
+				$item['is_top_level'] &&
+				'primary' === $item['menuId']
+			) {
+				$item['menuId'] = 'plugins';
+			}
+
+			$wca_items[] = $item;
 		}
 
 		$home_item = array();
@@ -162,9 +174,21 @@ class CoreMenu {
 			);
 		}
 
+		$customers_item = array();
+		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Analytics' ) ) {
+			$customers_item = array(
+				'id'           => 'woocommerce-analytics-customers',
+				'title'        => __( 'Customers', 'woocommerce-admin' ),
+				'url'          => wc_admin_url( '/customers' ),
+				'is_top_level' => true,
+				'order'        => 50,
+			);
+		}
+
 		return array_merge(
 			array(
 				$home_item,
+				$customers_item,
 				$order_items['all'],
 				$order_items['new'],
 				$product_items['all'],

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -412,14 +412,11 @@ class Menu {
 
 		$items = CoreMenu::get_items();
 		foreach ( $items as $item ) {
-			if ( ! isset( $item['is_top_level'] ) && ! isset( $item['parent'] ) ) {
-				if ( isset( $item['is_category'] ) && $item['is_category'] ) {
-					self::add_plugin_category( $item );
-				} else {
-					self::add_plugin_item( $item );
-				}
+			if ( isset( $item['is_category'] ) && $item['is_category'] ) {
+				self::add_category( $item );
+			} else {
+				self::add_item( $item );
 			}
-			self::add_item( $item );
 		}
 	}
 

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -50,13 +50,6 @@ class Menu {
 	const CSS_CLASSES = 4;
 
 	/**
-	 * Default parent menu
-	 *
-	 * @var string
-	 */
-	const DEFAULT_PARENT = 'woocommerce-settings';
-
-	/**
 	 * Store menu items.
 	 *
 	 * @var array
@@ -159,28 +152,24 @@ class Menu {
 		}
 
 		$defaults           = array(
-			'id'           => '',
-			'title'        => '',
-			'capability'   => 'manage_woocommerce',
-			'order'        => 100,
-			'migrate'      => true,
-			'menuId'       => 'primary',
-			'isCategory'   => true,
-			'parent'       => self::DEFAULT_PARENT,
-			'is_top_level' => false,
+			'id'         => '',
+			'title'      => '',
+			'capability' => 'manage_woocommerce',
+			'order'      => 100,
+			'migrate'    => true,
+			'menuId'     => 'primary',
+			'isCategory' => true,
 		);
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
 		unset( $menu_item['url'] );
 
-		if ( true === $menu_item['is_top_level'] ) {
+		if ( ! isset( $menu_item['parent'] ) ) {
 			$menu_item['parent']          = 'woocommerce';
 			$menu_item['backButtonLabel'] = __(
 				'WooCommerce Home',
 				'woocommerce-admin'
 			);
-		} else {
-			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		}
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
@@ -222,24 +211,20 @@ class Menu {
 		}
 
 		$defaults           = array(
-			'id'           => '',
-			'title'        => '',
-			'parent'       => self::DEFAULT_PARENT,
-			'capability'   => 'manage_woocommerce',
-			'url'          => '',
-			'order'        => 100,
-			'migrate'      => true,
-			'menuId'       => 'primary',
-			'is_top_level' => false,
+			'id'         => '',
+			'title'      => '',
+			'capability' => 'manage_woocommerce',
+			'url'        => '',
+			'order'      => 100,
+			'migrate'    => true,
+			'menuId'     => 'primary',
 		);
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
 		$menu_item['url']   = self::get_callback_url( $menu_item['url'] );
 
-		if ( true === $menu_item['is_top_level'] ) {
+		if ( ! isset( $menu_item['parent'] ) ) {
 			$menu_item['parent'] = 'woocommerce';
-		} else {
-			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		}
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
@@ -260,7 +245,6 @@ class Menu {
 	 *      'capability' => (string) Capability to view this menu item.
 	 *      'url'        => (string) URL or callback to be used. Required.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'menuId'     => (string) The ID of the menu to add the item to.
 	 *      'order'      => (int) Menu item order.
 	 *    ).
 	 */
@@ -272,8 +256,7 @@ class Menu {
 		$item_args = array_merge(
 			$args,
 			array(
-				'menuId'       => 'plugins',
-				'is_top_level' => ! isset( $args['parent'] ),
+				'menuId' => 'plugins',
 			)
 		);
 		self::add_item( $item_args );
@@ -289,7 +272,6 @@ class Menu {
 	 *      'capability' => (string) Capability to view this menu item.
 	 *      'url'        => (string) URL or callback to be used. Required.
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'menuId'     => (string) The ID of the menu to add the category to.
 	 *      'order'      => (int) Menu item order.
 	 *    ).
 	 */
@@ -301,55 +283,10 @@ class Menu {
 		$category_args = array_merge(
 			$args,
 			array(
-				'menuId'       => 'plugins',
-				'is_top_level' => ! isset( $args['parent'] ),
+				'menuId' => 'plugins',
 			)
 		);
 		self::add_category( $category_args );
-	}
-
-	/**
-	 * Adds a post type as a menu category.
-	 *
-	 * @param string $post_type Post type.
-	 * @param array  $args Array of menu item args.
-	 */
-	public static function add_post_type_category( $post_type, $args = array() ) {
-		$post_type_object = get_post_type_object( $post_type );
-
-		if ( ! $post_type_object ) {
-			return;
-		}
-
-		self::add_category(
-			array_merge(
-				array(
-					'title'        => esc_attr( $post_type_object->labels->menu_name ),
-					'capability'   => $post_type_object->cap->edit_posts,
-					'id'           => $post_type,
-					'is_top_level' => true,
-				),
-				$args
-			)
-		);
-		self::add_item(
-			array(
-				'parent'     => $post_type,
-				'title'      => esc_attr( $post_type_object->labels->all_items ),
-				'capability' => $post_type_object->cap->edit_posts,
-				'id'         => "{$post_type}-all-items",
-				'url'        => "edit.php?post_type={$post_type}",
-			)
-		);
-		self::add_item(
-			array(
-				'parent'     => $post_type,
-				'title'      => esc_attr( $post_type_object->labels->add_new ),
-				'capability' => $post_type_object->cap->create_posts,
-				'id'         => "{$post_type}-add-new",
-				'url'        => "post-new.php?post_type={$post_type}",
-			)
-		);
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -412,6 +412,13 @@ class Menu {
 
 		$items = CoreMenu::get_items();
 		foreach ( $items as $item ) {
+			if ( ! isset( $item['is_top_level'] ) && ! isset( $item['parent'] ) ) {
+				if ( isset( $item['is_category'] ) && $item['is_category'] ) {
+					self::add_plugin_category( $item );
+				} else {
+					self::add_plugin_item( $item );
+				}
+			}
 			self::add_item( $item );
 		}
 	}


### PR DESCRIPTION
This PR allows items that register with WCA to easily add nav args to add to core menus or create new plugin items/categories.

Note that this does not address issues with locking categories or top-level items which will need a follow-up PR.

### Screenshots
<img width="789" alt="Screen Shot 2020-11-23 at 4 36 17 PM" src="https://user-images.githubusercontent.com/10561050/100018140-06ff0a80-2daa-11eb-91d8-3dd3df8eaa42.png">


### Detailed test instructions:

1. Register some items via `wc_admin_register_page` or `wc_admin_connect_page` with `nav_args`.  This WC Pay PR is a good example - https://github.com/Automattic/woocommerce-payments/pull/1067
1. Note that the items are correctly added to either the core menu or plugins menu when the navigation is enabled.
1. Make sure categories can also be added via the `is_category` property.
1. Make sure no regressions have occurred with other WCA registered items.