### PR TITLE
Remove loading state (isBusy) from the links

### DIFF
--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -425,7 +425,6 @@ class Tax extends Component {
 				</Button>
 				<Button
 					disabled={ isPending }
-					isBusy={ isPending }
 					onClick={ () => {
 						recordEvent( 'tasklist_tax_setup_automated_proceed', {
 							setup_automatically: false,
@@ -440,7 +439,6 @@ class Tax extends Component {
 				</Button>
 				<Button
 					disabled={ isPending }
-					isBusy={ isPending }
 					onClick={ () => this.doNotChargeSalesTax() }
 				>
 					{ __(


### PR DESCRIPTION
Fixes #5711 

This PR removes the loading state (isBusy) from the two links.

### Screenshots

**Before:**
![Screen Shot 2020-11-23 at 1 55 09 PMth_](https://user-images.githubusercontent.com/4723145/100019889-acf34a80-2d93-11eb-8ec3-33c447cb1254.jpg)

**After:**
![Screen Shot 2020-11-23 at 1 54 26 PMth_](https://user-images.githubusercontent.com/4723145/100019897-b086d180-2d93-11eb-8b11-414f22c04922.jpg)


### Detailed test instructions:

Open a new site with Jetpack connected and the task list on the home screen.

1. Navigate to WooCommerce -> Home
2. Click on 'Set up tax'
3. Click on 'Yes please'