### PR TITLE
Packages: Fix dependencies

### DIFF
--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -5,12 +5,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { parse } from 'qs';
 import { pick, uniq } from 'lodash';
 import { applyFilters } from '@wordpress/hooks';
-import {
-	Slot,
-	Fill,
-	SlotFillProvider,
-	__experimentalUseSlot as useSlot,
-} from '@wordpress/components';
+import { Slot, Fill } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -193,20 +188,13 @@ WooNavigationItem.Slot = ( { name } ) => (
  * the same `context` as those created in the /client folder. This problem is due
  * to WC Admin bundling @wordpress/components instead of enqueuing and using
  * wp.components from the window.
- *
- * @param {Object} param0
- * @param {Array} param0.children - Node children.
  */
-export const NavSlotFillProvider = ( { children } ) => (
-	<SlotFillProvider>{ children }</SlotFillProvider>
-);
+export { SlotFillProvider as NavSlotFillProvider } from '@wordpress/components';
 
 /**
  * Similar to NavSlotFillProvider above, this is a workaround because components
  * exported from this package do not have the same `context` as those created
  * in the /client folder. This problem is due to WC Admin bundling @wordpress/components
  * instead of enqueuing and using wp.components from the window.
- *
- * @param {string} name - slot name.
  */
-export const useNavSlot = ( name ) => useSlot( name );
+export { __experimentalUseSlot as useNavSlot } from '@wordpress/components';

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -375,7 +375,7 @@ class Loader {
 		wp_register_script(
 			'wc-navigation',
 			self::get_url( 'navigation/index', 'js' ),
-			array( 'wp-url', 'wp-hooks' ),
+			array( 'wp-url', 'wp-hooks', 'wp-element', 'wp-data', 'moment' ),
 			$js_file_version,
 			true
 		);
@@ -417,7 +417,7 @@ class Loader {
 		wp_register_script(
 			'wc-store-data',
 			self::get_url( 'data/index', 'js' ),
-			array(),
+			array( 'wp-data' ),
 			$js_file_version,
 			true
 		);


### PR DESCRIPTION
A lack of declared dependencies has been causing problems in extensions, see p90Yrv-1ZJ

The core issue is the lack of Dependency Extraction Webpack Plugin to handle this for us, so we continue to have these issues.

### Fix

The fix is to add dependencies. 

### Wait, hang on

Why are `'wp-data', 'moment'` added to the `wc-navigation` script when those dependencies aren't used in the code? 

I'm not sure, but it points a bigger problem of those dependencies being improperly declared elsewhere. I tried placing them in different package dependencies, but no luck. Adding Dependency Extraction Webpack Plugin will analyze the code and solve this for us. 

### Detailed test instructions:

1. Create an extension to use `@woocommerce/navigation` or use this one https://github.com/psealock/aaa
2. Activate the plugin and `npm install && npm start`
3. Navigate to a wc-admin screen and see check the console for no errors and this:

![Screen Shot 2020-11-24 at 12 30 21 PM](https://user-images.githubusercontent.com/1922453/100027048-da51fe00-2e50-11eb-805b-096398d080ac.png)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- Dev: Add correct script dependencies to packages
