### PR TITLE
Remove WooCommerce Tax copies if it is already installed

### DIFF
--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -192,6 +192,24 @@ class Tax extends Component {
 			updateOptions,
 		} = this.props;
 		const { cachedPluginsToActivate } = this.state;
+		let step2Label, agreementText;
+
+		if ( cachedPluginsToActivate.includes( 'woocommerce-services' ) ) {
+			step2Label = __(
+				'Install Jetpack and WooCommerce Tax',
+				'woocommerce-admin'
+			);
+			agreementText = __(
+				'By installing Jetpack and WooCommerce Tax you agree to the {{link}}Terms of Service{{/link}}.',
+				'woocommerce-admin'
+			);
+		} else {
+			step2Label = __( 'Install Jetpack', 'woocommerce-admin' );
+			agreementText = __(
+				'By installing Jetpack you agree to the {{link}}Terms of Service{{/link}}.',
+				'woocommerce-admin'
+			);
+		}
 
 		const steps = [
 			{
@@ -221,10 +239,7 @@ class Tax extends Component {
 			},
 			{
 				key: 'plugins',
-				label: __(
-					'Install Jetpack and WooCommerce Tax',
-					'woocommerce-admin'
-				),
+				label: step2Label,
 				description: __(
 					'Jetpack and WooCommerce Tax allow you to automate sales tax calculations',
 					'woocommerce-admin'
@@ -273,10 +288,7 @@ class Tax extends Component {
 								className="woocommerce-task__caption"
 							>
 								{ interpolateComponents( {
-									mixedString: __(
-										'By installing Jetpack and WooCommerce Tax you agree to the {{link}}Terms of Service{{/link}}.',
-										'woocommerce-admin'
-									),
+									mixedString: agreementText,
 									components: {
 										link: (
 											<Link


### PR DESCRIPTION
Fixes #5712 

This PR removes WC Shipping & Tax copies if it is already installed.

### Detailed test instructions:

**Without WooCommerce Shipping & Tax installed:**

1. Install & Activate WooCommerce
2. Navigate to WooCommerce -> Home and click "Set up tax"
3. Set store location and move to step 2.
4. You should see "Install Jetpack and WooCommerce Tax"

![Screen Shot 2020-11-24 at 3 07 38 PMth_](https://user-images.githubusercontent.com/4723145/100161771-f8c2f400-2e66-11eb-997e-9d64284dd465.jpg)


**With WooCommerce Shipping & Tax installed:**
1. Install & Activate WooCommerce
2. Navigate to WooCommerce -> Home and click "Set up tax"
3. Set store location and move to step 2.
4. You should see "Install Jetpack" without any mention of WooCommerce Tax.

![Screen Shot 2020-11-24 at 3 08 28 PMth_](https://user-images.githubusercontent.com/4723145/100161799-02e4f280-2e67-11eb-8e02-eb75336f07c4.jpg)
