### PR TITLE
Store setup task list - purchase flow copy changes

### DIFF
--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -126,7 +126,7 @@ class CartModal extends Component {
 		return (
 			<Modal
 				title={ __(
-					'Would you like to purchase and install the following features now?',
+					'Would you like to add the following paid features to your store now?',
 					'woocommerce-admin'
 				) }
 				onRequestClose={ () => this.onClose() }
@@ -155,7 +155,7 @@ class CartModal extends Component {
 						isBusy={ purchaseNowButtonBusy }
 						onClick={ () => this.onClickPurchaseNow() }
 					>
-						{ __( 'Purchase & install now', 'woocommerce-admin' ) }
+						{ __( 'Buy now', 'woocommerce-admin' ) }
 					</Button>
 				</div>
 			</Modal>

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -83,14 +83,14 @@ export function getAllTasks( {
 		product_types: productTypes,
 	} = profileItems;
 
-	let purchaseAndInstallText = __( 'Purchase & install extensions' );
+	let purchaseAndInstallText = __( 'Add paid extensions to my store' );
 
 	if ( uniqueItemsList.length === 1 ) {
-		const { name: itemName, type: itemType } = uniqueItemsList[ 0 ];
-		const purchaseAndInstallFormat =
-			itemType === 'theme'
-				? __( 'Purchase & install %s theme', 'woocommerce-admin' )
-				: __( 'Purchase & install %s extension', 'woocommerce-admin' );
+		const { name: itemName } = uniqueItemsList[ 0 ];
+		const purchaseAndInstallFormat = __(
+			'Add %s to my store',
+			'woocommerce-admin'
+		);
 		purchaseAndInstallText = sprintf( purchaseAndInstallFormat, itemName );
 	}
 


### PR DESCRIPTION
Fixes #5315

This PR modifies the copy of the purchase extension flow.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)


### Detailed test instructions:

#### Extensions
- Go to the 3rd step of the OBW (URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fprofiler&step=product-types`).
- Select only one paid extension. Be sure you don't have a paid theme selected too. 
- Go back to the `Home` screen (URL: `/wp-admin/admin.php?page=wc-admin`).
- Now the item `Add [extension_name] to my store` should be visible in the task list.
![Captura de ecrã 2020-10-09, às 11.43.01.png](https://images.zenhubusercontent.com/5d84fe8e1201de0001b6ab61/d333cd43-d9a9-49ef-a633-7de7170dd2d9)

#### Themes
- Now unselect the paid extension and go to the 5th step of the OBW and select a paid theme.
- When you go back to the `Home` screen, the text `Add [theme_name] to my store` should be visible in the task list.

#### More than one item
- Try adding a paid extension and a paid theme, or two paid extensions.
- The message `Add paid extensions to my store` should be visible.
![Captura de ecrã 2020-10-09, às 11.45.29.png](https://images.zenhubusercontent.com/5d84fe8e1201de0001b6ab61/73a88952-1ca9-48c7-9fa2-8cdd7d734564)

#### Modal
- Press `Add paid extensions to my store`.
- The modal title should say `Would you like to add the following paid features to your store now?`
- The CTA button should say `Buy now`.
![Captura de ecrã 2020-10-09, às 11.51.25.png](https://images.zenhubusercontent.com/5d84fe8e1201de0001b6ab61/8f43f11b-b192-4177-b948-e9e6fa625e5f)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Add: Store setup task list - purchase flow copy changes
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
