### PR TITLE
Only show menu items from same parent menu 

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -137,7 +137,7 @@ const Container = ( { menuItems } ) => {
 						const {
 							primary: primaryItems,
 							secondary: secondaryItems,
-							plugin: pluginItems,
+							plugins: pluginItems,
 						} = categorizedItems[ category.id ] || {};
 						return (
 							<NavigationMenu

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -79,7 +79,7 @@ const Container = ( { menuItems } ) => {
 		return items.reduce( ( acc, item ) => {
 			// Set up the category if it doesn't yet exist.
 			if ( ! acc[ item.parent ] ) {
-				acc[ item.parent ] = [ [], [], [] ];
+				acc[ item.parent ] = {};
 			}
 
 			// Check if parent category is in the same menu.
@@ -91,13 +91,12 @@ const Container = ( { menuItems } ) => {
 				return acc;
 			}
 
-			let index = 0;
-			if ( item.menuId === 'secondary' ) {
-				index = 1;
-			} else if ( item.menuId === 'plugins' ) {
-				index = 2;
+			// Create the menu object if it doesn't exist in this category.
+			if ( ! acc[ item.parent ][ item.menuId ] ) {
+				acc[ item.parent ][ item.menuId ] = [];
 			}
-			acc[ item.parent ][ index ].push( item );
+
+			acc[ item.parent ][ item.menuId ].push( item );
 			return acc;
 		}, {} );
 	};
@@ -135,11 +134,11 @@ const Container = ( { menuItems } ) => {
 						></NavigationBackButton>
 					) }
 					{ categories.map( ( category ) => {
-						const [
-							primaryItems,
-							secondaryItems,
-							pluginItems,
-						] = categorizedItems[ category.id ] || [ [], [], [] ];
+						const {
+							primary: primaryItems,
+							secondary: secondaryItems,
+							plugin: pluginItems,
+						} = categorizedItems[ category.id ] || {};
 						return (
 							<NavigationMenu
 								key={ category.id }
@@ -150,7 +149,7 @@ const Container = ( { menuItems } ) => {
 									category.backButtonLabel || null
 								}
 							>
-								{ !! primaryItems.length && (
+								{ !! primaryItems && (
 									<NavigationGroup>
 										{ primaryItems.map( ( item ) => (
 											<Item
@@ -160,7 +159,7 @@ const Container = ( { menuItems } ) => {
 										) ) }
 									</NavigationGroup>
 								) }
-								{ !! pluginItems.length && (
+								{ !! pluginItems && (
 									<NavigationGroup
 										title={ __(
 											'Extensions',
@@ -175,7 +174,7 @@ const Container = ( { menuItems } ) => {
 										) ) }
 									</NavigationGroup>
 								) }
-								{ !! secondaryItems.length && (
+								{ !! secondaryItems && (
 									<NavigationGroup>
 										{ secondaryItems.map( ( item ) => (
 											<Item

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -87,6 +87,26 @@ const Container = ( { menuItems } ) => {
 
 	const navDomRef = useRef( null );
 
+	const renderNavigationGroup = ( category, items, topLevelTitle = null ) => {
+		if ( ! items.length ) {
+			return null;
+		}
+
+		const isTopLevel = category.id === 'woocommerce';
+
+		if ( ! isTopLevel && items[ 0 ].menuId !== category.menuId ) {
+			return null;
+		}
+
+		return (
+			<NavigationGroup title={ isTopLevel ? topLevelTitle : null }>
+				{ items.map( ( item ) => (
+					<Item key={ item.id } item={ item } />
+				) ) }
+			</NavigationGroup>
+		);
+	};
+
 	return (
 		<div className="woocommerce-navigation">
 			<Header />
@@ -128,44 +148,18 @@ const Container = ( { menuItems } ) => {
 									category.backButtonLabel || null
 								}
 							>
-								{ !! primaryItems.length && (
-									<NavigationGroup>
-										{ primaryItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
+								{ renderNavigationGroup(
+									category,
+									primaryItems
 								) }
-								{ !! pluginItems.length && (
-									<NavigationGroup
-										title={
-											category.id === 'woocommerce'
-												? __(
-														'Extensions',
-														'woocommerce-admin'
-												  )
-												: null
-										}
-									>
-										{ pluginItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
+								{ renderNavigationGroup(
+									category,
+									pluginItems,
+									__( 'Extensions', 'woocommerce-admin' )
 								) }
-								{ !! secondaryItems.length && (
-									<NavigationGroup>
-										{ secondaryItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
+								{ renderNavigationGroup(
+									category,
+									secondaryItems
 								) }
 							</NavigationMenu>
 						);

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -231,6 +231,8 @@ class Menu {
 			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		}
 
+		$menu_item['menuId'] = isset( self::$menu_items[ $menu_item['parent'] ] ) ? self::$menu_items[ $menu_item['parent'] ]['menuId'] : $menu_item['menuId'];
+
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
 
 		if ( isset( $args['url'] ) ) {

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -231,13 +231,27 @@ class Menu {
 			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
 		}
 
-		$menu_item['menuId'] = isset( self::$menu_items[ $menu_item['parent'] ] ) ? self::$menu_items[ $menu_item['parent'] ]['menuId'] : $menu_item['menuId'];
+		$menu_item['menuId'] = self::get_item_menu_id( $menu_item );
 
 		self::$menu_items[ $menu_item['id'] ] = $menu_item;
 
 		if ( isset( $args['url'] ) ) {
 			self::$callbacks[ $args['url'] ] = $menu_item['migrate'];
 		}
+	}
+
+	/**
+	 * Get an item's menu ID from its parent.
+	 *
+	 * @param array $item Item args.
+	 * @return string
+	 */
+	public static function get_item_menu_id( $item ) {
+		if ( isset( self::$menu_items[ $item['parent'] ] ) ) {
+			return self::$menu_items[ $item['parent'] ]['menuId'];
+		}
+
+		return $item['menuId'];
 	}
 
 	/**
@@ -267,6 +281,12 @@ class Menu {
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
 		);
+
+		$menu_id = self::get_item_menu_id( $item_args );
+		if ( 'plugins' !== $menu_id ) {
+			return;
+		}
+
 		self::add_item( $item_args );
 	}
 
@@ -296,6 +316,12 @@ class Menu {
 				'is_top_level' => ! isset( $args['parent'] ),
 			)
 		);
+
+		$menu_id = self::get_item_menu_id( $category_args );
+		if ( 'plugins' !== $menu_id ) {
+			return;
+		}
+
 		self::add_category( $category_args );
 	}
 


### PR DESCRIPTION
Fixes #5718

Fixes an issue where menu items could have the same parent, but different menu IDs and still be shown together.

### Detailed test instructions:

1. Register a menu item in the plugins menu, but using a parent ID from the main menu:
```php

		\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
			array(
				'id'     => 'wrong-menu-item',
				'parent' => 'analytics',
				'title'  => 'I should not be shown',
				'url'    => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
			)
		);
```
2. Navigate to that category.
3. Make sure the item is not shown.
4. Make sure no other regressions occur with items showing across various menu categories.