### PR TITLE
Allow actionable statuses in orders endpoint(s) filters.

### DIFF
--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin\API;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+
 /**
  * Orders controller.
  *
@@ -37,6 +39,10 @@ class Orders extends \WC_REST_Orders_Controller {
 		);
 		// Fix the default 'status' value until it can be patched in core.
 		$params['status']['default'] = array( 'any' );
+
+		// Analytics settings may affect the allowed status list.
+		$params['status']['items']['enum'] = ReportsController::get_order_statuses();
+
 		return $params;
 	}
 

--- a/src/API/Reports/Categories/Controller.php
+++ b/src/API/Reports/Categories/Controller.php
@@ -285,7 +285,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);
@@ -295,7 +295,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -390,7 +390,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);
@@ -400,7 +400,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -403,7 +403,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 			'default'           => null,
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);
@@ -413,7 +413,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
-				'enum' => $this->get_order_statuses(),
+				'enum' => self::get_order_statuses(),
 				'type' => 'string',
 			),
 		);

--- a/tests/api/orders.php
+++ b/tests/api/orders.php
@@ -6,6 +6,7 @@
  */
 
 use \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
+use Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 
 /**
  * WC Tests API Orders
@@ -30,6 +31,24 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+	}
+
+	/**
+	 * Test the order status (it should allow all actionable statuses).
+	 */
+	public function test_order_status() {
+		// Add a status to the actionable list.
+		$actionable_statuses = get_option( 'woocommerce_actionable_order_statuses', array() );
+		update_option( 'woocommerce_actionable_order_statuses', array( 'test-status' ) );
+
+		// Ideally this would be a test using an endpoint, but the option value is used
+		// at `rest_api_init` time to create the collection param schema. It's too late
+		// here to test with the actual endpoint code. Instantiating a new WP_REST_Server
+		// didn't seem to work either.
+		$this->assertContains( 'test-status', ReportsController::get_order_statuses() );
+
+		// Restore the actionable statuses.
+		update_option( 'woocommerce_actionable_order_statuses', $actionable_statuses );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5592.

This PR allows all "actionable" order statuses to be used in the `status`, `status_is`, and `status_is_not` filters available on Orders endpoints.

### Detailed test instructions:

- Create a few orders (manually or using the Smooth generator).
- Create an unregistered status.
- Go to Analytics > Settings and select the unregistered status under Actionable Statuses.
- Go to the Home screen
- Verify the orders HTTP requests return with `200` status

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Orders panel breaking with unregistered statuses being marked as actionable.
