### PR TITLE
Fix/some outstanding CES bugs

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -98,10 +98,11 @@ function CustomerEffortScoreTracks( {
 		} );
 	};
 
-	const recordScore = ( score ) => {
+	const recordScore = ( score, comments ) => {
 		recordEvent( 'ces_feedback', {
 			action,
 			score,
+			comments,
 			store_age: storeAge,
 			...trackProps,
 		} );
@@ -153,7 +154,6 @@ CustomerEffortScoreTracks.propTypes = {
 	 * Whether tracking is allowed or not.
 	 */
 	allowTracking: PropTypes.bool,
-
 	/**
 	 * Whether props are still being resolved.
 	 */

--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -102,7 +102,7 @@ function CustomerEffortScoreTracks( {
 		recordEvent( 'ces_feedback', {
 			action,
 			score,
-			comments,
+			comments: comments || '',
 			store_age: storeAge,
 			...trackProps,
 		} );

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -364,14 +364,15 @@ class CustomerEffortScoreTracks {
 
 		$this->enqueue_to_ces_tracks(
 			array(
-				'action'    => self::SETTINGS_CHANGE_ACTION_NAME,
-				'label'     => __(
+				'action'         => self::SETTINGS_CHANGE_ACTION_NAME,
+				'label'          => __(
 					'How easy was it to update your settings?',
 					'woocommerce-admin'
 				),
-				'pagenow'   => 'woocommerce_page_wc-settings',
-				'adminpage' => 'woocommerce_page_wc-settings',
-				'props'     => array(),
+				'onsubmit_label' => $this->onsubmit_label,
+				'pagenow'        => 'woocommerce_page_wc-settings',
+				'adminpage'      => 'woocommerce_page_wc-settings',
+				'props'          => (object) array(),
 			)
 		);
 	}


### PR DESCRIPTION
This fixes 3 issues that were uncovered by early testing:

- a warning on the type of the `trackProps` prop coming from the settings update enqueue
- the submit label being undefined in the settings update enqueue
- comments not being included when recording the feedback

### Detailed test instructions:

1. go to the WooCommerce settings page
1. open the console to see any errors
1. change a setting
1. save the change
1. when the page reloads, the CES snackbar prompt should appear
1. click 'Give feedback'
1. note that no console errors appear
1. give a low rating, triggering the comments section to appear
1. enter a comment then send
1. note that the success snackbar content is not 'undefined'
1. there should be a tracks notice in the console, including the comments you provided
![image](https://user-images.githubusercontent.com/224531/100185412-76eacd80-2f2f-11eb-869f-4c186cf42a54.png)
