### PR TITLE
Customer Effort Score Package: Downgrade @wordpress/components to 11.0.0

### DIFF
--- a/packages/customer-effort-score/package.json
+++ b/packages/customer-effort-score/package.json
@@ -21,7 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.12.5",
-		"@wordpress/components": "^11.1.1",
+		"@wordpress/components": "11.0.0",
 		"@wordpress/compose": "^3.22.0",
 		"@wordpress/data": "^4.25.0",
 		"@wordpress/notices": "^2.11.0"


### PR DESCRIPTION
This aligns the `@wordpress/components ` version with the root `package.json`. It fixes error reported by `lerna bootstrap`  currently blocking PR https://github.com/woocommerce/woocommerce-admin/pull/5714

### Detailed test instructions:

- Run lerna bootstrap and confirm no errors.

```
$ npx lerna bootstrap
```