### PR TITLE
Prevent unnecessary re-renders when using useSelect

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -18,21 +18,24 @@ import {
 import { getAllPanels } from './panels';
 
 export const ActivityPanel = () => {
-	const panels = useSelect( ( select ) => {
+	const panelsData = useSelect( ( select ) => {
 		const totalOrderCount = getSetting( 'orderCount', 0 );
 		const orderStatuses = getOrderStatuses( select );
 		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
 		const manageStock = getSetting( 'manageStock', 'no' );
 		const countLowStockProducts = getLowStockCount( select );
 
-		return getAllPanels( {
+		return {
 			countLowStockProducts,
 			countUnreadOrders,
 			manageStock,
 			orderStatuses,
 			totalOrderCount,
-		} );
+		};
 	} );
+
+	const panels = getAllPanels( panelsData );
+
 	return (
 		<Accordion>
 			<Fragment>

--- a/packages/data/src/user-preferences/test/use-user-preferences.js
+++ b/packages/data/src/user-preferences/test/use-user-preferences.js
@@ -14,6 +14,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {} ),
 				getLastEntitySaveError: jest.fn().mockReturnValue( {} ),
 				hasStartedResolution: jest.fn().mockReturnValue( false ),
@@ -34,6 +35,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {} ),
 				getLastEntitySaveError: jest.fn().mockReturnValue( {} ),
 				hasStartedResolution: jest.fn().mockReturnValue( true ),
@@ -54,6 +56,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {} ),
 				getLastEntitySaveError: jest.fn().mockReturnValue( {} ),
 				hasStartedResolution: jest.fn().mockReturnValue( true ),
@@ -74,6 +77,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {
 					woocommerce_meta: {
 						dashboard_chart_type: '"line"',
@@ -116,6 +120,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {
 					id: 1,
 				} ),
@@ -174,6 +179,7 @@ describe( 'useUserPreferences() hook', () => {
 		registerStore( 'core', {
 			reducer: () => ( {} ),
 			selectors: {
+				getEntity: jest.fn().mockReturnValue( undefined ),
 				getCurrentUser: jest.fn().mockReturnValue( {
 					id: 1,
 				} ),


### PR DESCRIPTION
Make sure we don't create either a new function/object/array within a `useSelect` function and return this as part of the data.
`useSelect` only does a [shallowEqual](https://github.com/WordPress/gutenberg/blob/master/packages/data/src/components/use-select/index.js#L148) which would cause new functions/objects/arrays to be different every time (despite the data within being the same).

This in turn would trigger unnecessary [forceRender()](https://github.com/WordPress/gutenberg/blob/master/packages/data/src/components/use-select/index.js#L156) for the components where it used this.
I didn't go through the entire code to check for occurrences of this, I fixed it for the `useUserPreferences` hook, and the home screen `ActivityPanel` component.
I couldn't see a huge visual difference, as we aren't doing anything compute heavy within the components, but you can see the scripting time difference in the screenshots below.

### Screenshots
Before the fix, you can see that scripting time is `~5616ms`.
<img width="1438" alt="Screen Shot 2020-11-27 at 10 18 12 AM" src="https://user-images.githubusercontent.com/2240960/100460268-49239700-309d-11eb-8e6a-ef26130dc716.png">

After the change: (scripting time: `~3621ms`).
<img width="1442" alt="Screen Shot 2020-11-26 at 5 05 59 PM" src="https://user-images.githubusercontent.com/2240960/100459570-0c0ad500-309c-11eb-88f5-127297d31855.png">


### Detailed test instructions:

- Open Woo-commerce home page
- It should all the default panels correctly
- Try updating the display layout, it should correctly update (without error) and be persistent on refresh
- Smoke test places where `useUserPreferences` is being used
  - ReportsTable in every analytics page