### PR TITLE
Test install script resets test environment

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -20,7 +20,7 @@ while [ $# -gt 0 ]; do
       RESET_FLAG=true
       ;;
   esac
-  shift
+	shift
 done
 
 TMPDIR=${TMPDIR-/tmp}
@@ -164,7 +164,7 @@ install_db() {
 
 	# drop existing database
 	if [ ${RESET_FLAG} = true ]; then
-		mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA 2>&1 | true
+		mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA || echo "Database $DB_NAME does not exist"
 	fi
 
 	# create database
@@ -185,8 +185,8 @@ install_deps() {
 
 	# delete existing wp-config and woocommerce repository
 	if [ ${RESET_FLAG} = true ]; then
-		rm wp-config.php | true
-		rm -rf wp-content/plugins/woocommerce | true
+		rm wp-config.php || echo "wp-config.php does not exist"
+		rm -rf wp-content/plugins/woocommerce || echo "wp-content/plugins/woocommerce does not exist"
 	fi
 
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -119,6 +119,11 @@ install_test_suite() {
 		local ioption='-i'
 	fi
 
+	# removes testing suite
+	if [ ${RESET_FLAG} = true ]; then
+		rm -rf $WP_TESTS_DIR
+	fi
+
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation] [-r, --reset]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -11,17 +11,6 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
-RESET_FLAG=false
-
-# get named arguments
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -r|--reset)
-      RESET_FLAG=true
-      ;;
-  esac
-	shift
-done
 
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
@@ -120,9 +109,7 @@ install_test_suite() {
 	fi
 
 	# removes testing suite
-	if [ ${RESET_FLAG} = true ]; then
-		rm -rf $WP_TESTS_DIR
-	fi
+	rm -rf $WP_TESTS_DIR
 
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d $WP_TESTS_DIR ]; then
@@ -168,9 +155,7 @@ install_db() {
 	fi
 
 	# drop existing database
-	if [ ${RESET_FLAG} = true ]; then
-		mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA || echo "Database $DB_NAME does not exist"
-	fi
+	mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA || echo "Database $DB_NAME does not exist"
 
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
@@ -189,10 +174,8 @@ install_deps() {
 	curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
 	# delete existing wp-config and woocommerce repository
-	if [ ${RESET_FLAG} = true ]; then
-		rm wp-config.php || echo "wp-config.php does not exist"
-		rm -rf wp-content/plugins/woocommerce || echo "wp-content/plugins/woocommerce does not exist"
-	fi
+	rm wp-config.php || echo "wp-config.php does not exist"
+	rm -rf wp-content/plugins/woocommerce || echo "wp-content/plugins/woocommerce does not exist"
 
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -155,7 +155,7 @@ install_db() {
 	fi
 
 	# drop existing database
-	mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA || echo "Database $DB_NAME does not exist"
+	mysqladmin drop -f $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA 2>/dev/null || true
 
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
@@ -174,8 +174,8 @@ install_deps() {
 	curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
 	# delete existing wp-config and woocommerce repository
-	rm wp-config.php || echo "wp-config.php does not exist"
-	rm -rf wp-content/plugins/woocommerce || echo "wp-content/plugins/woocommerce does not exist"
+	rm -f wp-config.php
+	rm -rf wp-content/plugins/woocommerce
 
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email


### PR DESCRIPTION
This PR changes `bin/install-wp-tests.sh` script to additionally do the following prior setting up:

- Drops test database.
- Deletes `wp-config.php`.
- Deletes test suite `/tmp/wordpress-tests-lib`
- Deletes `wp-content/plugins/woocommerce` folder.

The rationale is that I think our setup test script should reset on every run. Use cases:

- Setup ran halfway initially and then subsequently blocked because of existing files & database, thus unable to finish the whole setup.
- Potential intermittent issues due to persisting data that affects tests in between runs.
- Misbehaving tests and you're unsure whether it's your code or the environment.
- To apply updates from tests' dependencies

Note that this doesn't delete everything. Notably, the existing WordPress files will still be reused. 

### Detailed test instructions:

1. In your PHP test environment, run either the following:
    - `bin/install-wp-tests.sh wc-admin-tests root root`
2. Setup should be successful and finish at `Plugin 'woocommerce' activated.
Success: Activated 1 of 1 plugins.`
3. `./vendor/bin/phpunit` and see if it runs well.