### PR TITLE
Generate MD5 hashes without bundling all of Node crypto.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14734,6 +14734,12 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+			"dev": true
+		},
 		"check-node-version": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
@@ -16729,6 +16735,12 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+			"dev": true
 		},
 		"crypto-browserify": {
 			"version": "3.12.0",
@@ -26434,6 +26446,17 @@
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
 			"dev": true
+		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
 		},
 		"md5.js": {
 			"version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"jest-environment-jsdom-sixteen": "1.0.3",
 		"lerna": "3.22.1",
 		"lint-staged": "10.5.2",
+		"md5": "^2.3.0",
 		"merge-config": "2.0.0",
 		"moment-timezone-data-webpack-plugin": "1.3.0",
 		"node-sass": "4.14.1",

--- a/packages/components/src/gravatar/index.js
+++ b/packages/components/src/gravatar/index.js
@@ -6,7 +6,7 @@ import { parse, stringify } from 'qs';
 import PropTypes from 'prop-types';
 import url from 'url';
 import { isString } from 'lodash';
-import crypto from 'crypto';
+import md5 from 'md5';
 
 /**
  * Display a users Gravatar.
@@ -36,10 +36,7 @@ const Gravatar = ( { alt, title, size, user, className } ) => {
 	};
 
 	const getAvatarURLFromEmail = ( email ) => {
-		return (
-			'https://www.gravatar.com/avatar/' +
-			crypto.createHash( 'md5' ).update( email ).digest( 'hex' )
-		);
+		return 'https://www.gravatar.com/avatar/' + md5( email );
 	};
 
 	const altText = alt || ( user && ( user.display_name || user.name ) ) || '';

--- a/packages/data/src/export/utils.js
+++ b/packages/data/src/export/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import crypto from 'crypto';
+import md5 from 'md5';
 
 /**
  * Internal dependencies
@@ -9,8 +9,5 @@ import crypto from 'crypto';
 import { getResourceName } from '../utils';
 
 export const hashExportArgs = ( args ) => {
-	return crypto
-		.createHash( 'md5' )
-		.update( getResourceName( 'export', args ) )
-		.digest( 'hex' );
+	return md5( getResourceName( 'export', args ) );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,6 +221,9 @@ const webpackConfig = {
 			name: false,
 		},
 	},
+	node: {
+		crypto: 'empty',
+	},
 };
 
 if ( webpackConfig.mode !== 'production' && WC_ADMIN_PHASE !== 'core' ) {


### PR DESCRIPTION
While looking at https://github.com/woocommerce/woocommerce-admin/pull/5753, I noticed that `@woocommerce/data` was pretty bloated due to the `crypto-browserify` (really the `node-libs-browser`) package.

Since we're only using the `crypto` library to generate MD5 hashes, this seemed like an easy package to replace.

This change **reduces the build by 1.2MB** ❗ 

### Detailed test instructions:

- Smoke test WC-Admin, make sure functionality is working
- The two directly impacted areas are the Report Export and the Reviews card (Gravatar)
- `npm ci && npm run analyze` on `main` and this branch - see the size difference

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Performance: reduce bundle size by omitting Node crypto library.
