### PR TITLE
Add changlog instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,6 @@ _Replace this with a good description of your changes & reasoning._
 
 <!--- Please add a Changelog note
 
-Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number--->
+Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.
+
+If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,21 +6,18 @@ _Replace this with a good description of your changes & reasoning._
 
 <!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->
 
-- [ ] I've tested using only a keyboard (no mouse)
-- [ ] I've tested using a screen reader
-- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
+-   [ ] I've tested using only a keyboard (no mouse)
+-   [ ] I've tested using a screen reader
+-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
 
 ### Screenshots
 
 ### Detailed test instructions:
 
-- Ex: Open page `url`
-- Click XYZ…
+-   Ex: Open page `url`
+-   Click XYZ…
 
-<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
-be sure to detail parts affected in Release Notes --->
+<!--- Please add a Changelog note
 
-### Changelog Note:
-
-<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
+Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number--->


### PR DESCRIPTION
Change the PR template to reflect a new process where PR creators are responsible for adding their own changelog entries.

### Detailed test instructions:

Make sure instructions makes sense. Anything missing?

### Changelog Note:

This is sooo meta
