### PR TITLE
Add onboarding settings only for the home and setup wizard pages

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -507,9 +507,8 @@ class Onboarding {
 			$active_theme     = get_option( 'stylesheet' );
 
 			foreach ( $installed_themes as $slug => $theme ) {
-				$theme_data       = self::get_theme_data( $theme );
-				$installed_themes = wp_get_themes();
-				$themes[ $slug ]  = $theme_data;
+				$theme_data      = self::get_theme_data( $theme );
+				$themes[ $slug ] = $theme_data;
 			}
 
 			// Add the WooCommerce support tag for default themes that don't explicitly declare support.
@@ -645,9 +644,26 @@ class Onboarding {
 	}
 
 	/**
+	 * Check if the current page is one of the WC Admin pages.
+	 *
+	 * @return bool
+	 */
+	public static function is_woocommerce_admin_page() {
+		$is_wc_admin_page = false;
+		$current_screen   = get_current_screen();
+		if ( null !== $current_screen ) {
+			$is_wc_admin_page = 'woocommerce_page_wc-admin' === $current_screen->id;
+		}
+
+		return $is_wc_admin_page;
+	}
+
+	/**
 	 * Add profiler items to component settings.
 	 *
 	 * @param array $settings Component settings.
+	 *
+	 * @return array
 	 */
 	public function component_settings( $settings ) {
 		$profile                = (array) get_option( self::PROFILE_DATA_OPTION, array() );
@@ -655,8 +671,14 @@ class Onboarding {
 			'profile' => $profile,
 		);
 
-		// Only fetch if the onboarding wizard OR the task list is incomplete or currently shown.
-		if ( ! self::should_show_profiler() && ! self::should_show_tasks() ) {
+		// Only fetch if the onboarding wizard OR the task list is incomplete or currently shown
+		// or the current page is one of the WooCommerce Admin pages.
+		if (
+			( ! self::should_show_profiler() && ! self::should_show_tasks()
+			||
+			! self::is_woocommerce_admin_page()
+		)
+		) {
 			return $settings;
 		}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -645,6 +645,21 @@ class Onboarding {
 	}
 
 	/**
+	 * Determine if the current page is home or setup wizard.
+	 *
+	 * @return bool
+	 */
+	protected function is_home_or_setup_wizard_page() {
+		$allowed_paths = array( 'wc-admin', 'wc-admin&path=/setup-wizard' );
+		$current_page  = PageController::get_instance()->get_current_page();
+		if ( ! $current_page ) {
+			return false;
+		}
+
+		return in_array( $current_page['path'], $allowed_paths );
+	}
+
+	/**
 	 * Add profiler items to component settings.
 	 *
 	 * @param array $settings Component settings.
@@ -662,7 +677,7 @@ class Onboarding {
 		if (
 			( ! self::should_show_profiler() && ! self::should_show_tasks()
 			||
-			! PageController::get_instance()->get_current_page()
+			! $this->is_home_or_setup_wizard_page()
 		)
 		) {
 			return $settings;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -7,6 +7,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\PageController;
 use \Automattic\WooCommerce\Admin\PluginsHelper;
 use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
 
@@ -644,21 +645,6 @@ class Onboarding {
 	}
 
 	/**
-	 * Check if the current page is one of the WC Admin pages.
-	 *
-	 * @return bool
-	 */
-	public static function is_woocommerce_admin_page() {
-		$is_wc_admin_page = false;
-		$current_screen   = get_current_screen();
-		if ( null !== $current_screen ) {
-			$is_wc_admin_page = 'woocommerce_page_wc-admin' === $current_screen->id;
-		}
-
-		return $is_wc_admin_page;
-	}
-
-	/**
 	 * Add profiler items to component settings.
 	 *
 	 * @param array $settings Component settings.
@@ -676,7 +662,7 @@ class Onboarding {
 		if (
 			( ! self::should_show_profiler() && ! self::should_show_tasks()
 			||
-			! self::is_woocommerce_admin_page()
+			! PageController::get_instance()->get_current_page()
 		)
 		) {
 			return $settings;


### PR DESCRIPTION
Fixes #5702 

This PR improves the performance of non-WooCommerce pages by skipping [Onboarding::component_settings](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/Onboarding.php#L652) method for the non-WooCommerce pages.

- Removed unnecessary call to **wp_get_themes** at https://github.com/woocommerce/woocommerce-admin/blob/6fba36c4082a915cb4ef4af49caa6ec6313aa504/src/Features/Onboarding.php#L511 Notice that the call is inside a loop.
- Uses screen object to check for the WC Admin pages.

### Detailed test instructions:

1. Install a fresh WordPress and WooCommerce.
2. Navigate to WooCommerce -> Home or WooCommerce -> Home -> click one of the onboarding items.
3. Open browser console and type`wcSettings.onboarding` and make sure that the object contains onboarding properties such as `themes` and `tasksStatus`
4. Navigate to any pages, except home or setup wizard.
5. Open browser console and type `wcSettings.onboarding` and make sure that the object is missing onboarding properties such as `themes` and `tasksStatus`