### PR TITLE
Update customer data on order update

### DIFF
--- a/src/Schedulers/OrdersScheduler.php
+++ b/src/Schedulers/OrdersScheduler.php
@@ -11,6 +11,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\Coupons\DataStore as CouponsDataSt
 use \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Taxes\DataStore as TaxesDataStore;
+use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 use \Automattic\WooCommerce\Admin\Schedulers\CustomersScheduler;
 
@@ -86,7 +87,7 @@ class OrdersScheduler extends ImportScheduler {
 			WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
 			AND post_status NOT IN ( 'wc-auto-draft', 'auto-draft', 'trash' )
 			{$where_clause}"
-		); // WPCS: unprepared SQL ok.
+		); // phpcs:ignore unprepared SQL ok.
 
 		$order_ids = absint( $count ) > 0 ? $wpdb->get_col(
 			$wpdb->prepare(
@@ -161,6 +162,7 @@ class OrdersScheduler extends ImportScheduler {
 			ProductsDataStore::sync_order_products( $order_id ),
 			CouponsDataStore::sync_order_coupons( $order_id ),
 			TaxesDataStore::sync_order_taxes( $order_id ),
+			CustomersDataStore::sync_order_customer( $order_id ),
 		);
 
 		ReportsCache::invalidate();


### PR DESCRIPTION
Fixes #4152 

Added `sync_order_customer` functionality to the _on save order_ scheduler. This gets triggered after an order gets updated.
It gets the latest order billing info and customer info, and updates the customer.


### Screenshots

![update-order-and-customer](https://user-images.githubusercontent.com/2240960/100775921-49dc6600-33da-11eb-8ea7-e78b7c58b490.gif)

### Detailed test instructions:

- Create store with at-least one product
- Submit order for that product and add dummy customer info
- Go to **WP Admin -> WooCommerce -> Orders**
- Edit the billing info of the customer in the order and click **Update**
- Navigate to **WP Admin -> WooCommerce -> Customers**
- Customer from order should reflect updated billing info from order (might have to refresh once - mine was slow locally)
- Create another order with the same customer (use the same email address)
- Go to **WP Admin -> WooCommerce -> Orders** and update the **old** order
- Navigate to **WP Admin -> WooCommerce -> Customers**
- Customers info should be the same as the newer order, not the older order that was changed again.

### Changelog Note:

Syncs the customer with the latest billing info of the order edited on `save_post` for `shop_order` type.