### PR TITLE
Do not show snackbar for action after it has been dismissed

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -73,12 +73,23 @@ function CustomerEffortScoreTracks( {
 		} );
 	};
 
+	const addActionToShownOption = () => {
+		updateOptions( {
+			[ SHOWN_FOR_ACTIONS_OPTION_NAME ]: [
+				action,
+				...cesShownForActions,
+			],
+		} );
+	};
+
 	const onNoticeDismissed = () => {
 		recordEvent( 'ces_snackbar_dismiss', {
 			action,
 			store_age: storeAge,
 			...trackProps,
 		} );
+
+		addActionToShownOption();
 	};
 
 	const onModalShown = () => {
@@ -90,12 +101,7 @@ function CustomerEffortScoreTracks( {
 			...trackProps,
 		} );
 
-		updateOptions( {
-			[ SHOWN_FOR_ACTIONS_OPTION_NAME ]: [
-				action,
-				...cesShownForActions,
-			],
-		} );
+		addActionToShownOption();
 	};
 
 	const recordScore = ( score, comments ) => {


### PR DESCRIPTION
Per conversation [here](https://woostartp2.wordpress.com/2020/09/25/customer-effort-score-2/#comment-1302) the snackbar shouldn't be displayed again for the current action if it has been manually dismissed.

This _was_ working but something along the development trail has changed the code. This PR addresses this by adding hte action to the shown option when the snackbar is dismissed.

### Detailed test instructions:

1. clear the `woocommerce_ces_shown_for_actions` option
1. create a new product. Note that the snackbar is shown.
1. create another new product. Note that the snackbar is still shown.
1. manually dismiss the snackbar using the cross icon
1. create another new product. Note that the snackbar is no longer shown.

### Changelog Note:

Fix: Do not show snackbar for action after it has been dismissed