### PR TITLE
Skip checking WooCommerce theme support if stylesheet does not exist

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -574,7 +574,11 @@ class Onboarding {
 		}
 
 		foreach ( $themes as $theme ) {
-			$directory = new \RecursiveDirectoryIterator( $theme->theme_root . '/' . $theme->stylesheet );
+			$stylesheet_file = $theme->theme_root . '/' . $theme->stylesheet;
+			if ( ! file_exists( $stylesheet_file ) ) {
+				continue;
+			}
+			$directory = new \RecursiveDirectoryIterator( $stylesheet_file );
 			$iterator  = new \RecursiveIteratorIterator( $directory );
 			$files     = new \RegexIterator( $iterator, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH );
 


### PR DESCRIPTION
Fixes #5740 

This PR fixes a fatal error when a child theme is installed in a subdirectory and the subdirectory does not have a stylesheet file.

### Detailed test instructions:

Please enable both `WP_DEBUG` and `WP_DEBUG_LOG` from the `wp-config.php` before starting.


Confirm the error without this branch.

1. Create a fresh installation of WordPress + WooCommerce
2. Create `storefront-theme` directory in /wp-content/themes directory.
3. Create an empty child theme in the `storefront-theme`. I've attached a child theme for testing purposes.  [storefront-child-theme.zip](https://github.com/woocommerce/woocommerce-admin/files/5626451/storefront-child-theme.zip). Your themes folder should look like the following.
![Screen Shot 2020-12-02 at 1 49 22 PM](https://user-images.githubusercontent.com/4723145/100936162-f3d4f480-34a5-11eb-9d90-3cfde3964cc4.jpg)

4. Navigate to WooCommerce -> Home
5. Open a terminal and cd to WordPress. Check the error by running `tail -f wp-content/debug.log`

Change your branch to this PR and repeat the process. The fatal error should be gone.
