### PR TITLE
Use client side filter on the CSV download

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -152,6 +152,32 @@ const ReportTable = ( props ) => {
 		} ) );
 	};
 
+	const applyTableFilters = ( data, totals, totalResults ) => {
+		const summary = getSummary ? getSummary( totals, totalResults ) : null;
+
+		/**
+		 * Filter report table for the CSV download.
+		 *
+		 * Enables manipulation of data used to create the report CSV.
+		 *
+		 * @param {Object} reportTableData - data used to create the table.
+		 * @param {string} reportTableData.endpoint - table api endpoint.
+		 * @param {Array} reportTableData.headers - table headers data.
+		 * @param {Array} reportTableData.rows - table rows data.
+		 * @param {Object} reportTableData.totals - total aggregates for request.
+		 * @param {Array} reportTableData.summary - summary numbers data.
+		 * @param {Object} reportTableData.items - response from api requerst.
+		 */
+		return applyFilters( TABLE_FILTER, {
+			endpoint,
+			headers: getHeadersContent(),
+			rows: getRowsContent( data ),
+			totals,
+			summary,
+			items,
+		} );
+	};
+
 	const onClickDownload = () => {
 		const { createNotice, startExport, title } = props;
 		const params = Object.assign( {}, query );
@@ -165,27 +191,7 @@ const ReportTable = ( props ) => {
 		}
 
 		if ( data && data.length === totalResults ) {
-			/**
-			 * Filter report table for the CSV download.
-			 *
-			 * Enables manipulation of data used to create the report CSV.
-			 *
-			 * @param {Object} reportTableData - data used to create the table.
-			 * @param {string} reportTableData.endpoint - table api endpoint.
-			 * @param {Array} reportTableData.headers - table headers data.
-			 * @param {Array} reportTableData.rows - table rows data.
-			 * @param {Object} reportTableData.totals - total aggregates for request.
-			 * @param {Array} reportTableData.summary - summary numbers data.
-			 * @param {Object} reportTableData.items - response from api requerst.
-			 */
-			const { headers, rows } = applyFilters( TABLE_FILTER, {
-				endpoint,
-				headers: getHeadersContent(),
-				rows: getRowsContent( data ),
-				totals,
-				summary: getSummary ? getSummary( totals, totalResults ) : null,
-				items,
-			} );
+			const { headers, rows } = applyTableFilters( data, totalResults );
 
 			downloadCSVFile(
 				generateCSVFileName( title, params ),
@@ -327,29 +333,14 @@ const ReportTable = ( props ) => {
 		label: v,
 	} ) );
 
-	/**
-	 * Filter report table.
-	 *
-	 * Enables manipulation of data used to create a report table.
-	 *
-	 * @param {Object} reportTableData - data used to create the table.
-	 * @param {string} reportTableData.endpoint - table api endpoint.
-	 * @param {Array} reportTableData.headers - table headers data.
-	 * @param {Array} reportTableData.rows - table rows data.
-	 * @param {Object} reportTableData.totals - total aggregates for request.
-	 * @param {Array} reportTableData.summary - summary numbers data.
-	 * @param {Object} reportTableData.items - response from api requerst.
-	 */
-	const filteredTableProps = applyFilters( TABLE_FILTER, {
-		endpoint,
-		headers: getHeadersContent(),
-		rows: getRowsContent( items.data ),
+	const { data } = items;
+	const applyTableFiltersResult = applyTableFilters(
+		data,
 		totals,
-		summary: getSummary ? getSummary( totals, totalResults ) : null,
-		items,
-	} );
-	let { headers, rows } = filteredTableProps;
-	const { summary } = filteredTableProps;
+		totalResults
+	);
+	let { headers, rows } = applyTableFiltersResult;
+	const { summary } = applyTableFiltersResult;
 
 	const onColumnsChange = ( shownColumns, toggledColumn ) => {
 		const columns = headers.map( ( header ) => header.key );

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -165,12 +165,31 @@ const ReportTable = ( props ) => {
 		}
 
 		if ( data && data.length === totalResults ) {
+			/**
+			 * Filter report table for the CSV download.
+			 *
+			 * Enables manipulation of data used to create the report CSV.
+			 *
+			 * @param {Object} reportTableData - data used to create the table.
+			 * @param {string} reportTableData.endpoint - table api endpoint.
+			 * @param {Array} reportTableData.headers - table headers data.
+			 * @param {Array} reportTableData.rows - table rows data.
+			 * @param {Object} reportTableData.totals - total aggregates for request.
+			 * @param {Array} reportTableData.summary - summary numbers data.
+			 * @param {Object} reportTableData.items - response from api requerst.
+			 */
+			const { headers, rows } = applyFilters( TABLE_FILTER, {
+				endpoint,
+				headers: getHeadersContent(),
+				rows: getRowsContent( data ),
+				totals,
+				summary: getSummary ? getSummary( totals, totalResults ) : null,
+				items,
+			} );
+
 			downloadCSVFile(
 				generateCSVFileName( title, params ),
-				generateCSVDataFromTable(
-					getHeadersContent(),
-					getRowsContent( data )
-				)
+				generateCSVDataFromTable( headers, rows )
 			);
 		} else {
 			downloadType = 'email';

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -19,7 +19,7 @@ import { getCurrentDates, defaultTableDateFormat } from '@woocommerce/date';
 import ReportTable from '../../components/report-table';
 import { CurrencyContext } from '../../../lib/currency-context';
 
-class CouponsReportTable extends Component {
+class DownloadsReportTable extends Component {
 	constructor() {
 		super();
 
@@ -203,11 +203,11 @@ class CouponsReportTable extends Component {
 	}
 }
 
-CouponsReportTable.contextType = CurrencyContext;
+DownloadsReportTable.contextType = CurrencyContext;
 
 export default withSelect( ( select ) => {
 	const { woocommerce_default_date_range: defaultDateRange } = select(
 		SETTINGS_STORE_NAME
 	).getSetting( 'wc_admin', 'wcAdminSettings' );
 	return { defaultDateRange };
-} )( CouponsReportTable );
+} )( DownloadsReportTable );


### PR DESCRIPTION
Fixes #5202

Kinda.

This takes the same client-side filter that currently allows changing the columns in the report table (`woocommerce_admin_report_table`) and uses it when generating the CSV on the client-side. So the CSV is in sync with the report table.

To test this: follow the instructions in this blog post: https://becdetat.home.blog/2020/12/02/adding-columns-to-analytics-reports-and-csv-downloads/

### Changelog Note:

Dev: Use woocommerce_admin_report_table client-side filter when generating a CSV