### PR TITLE
Invalidate product count if the last product was updated in the list

### DIFF
--- a/client/homescreen/activity-panel/orders/utils.js
+++ b/client/homescreen/activity-panel/orders/utils.js
@@ -56,38 +56,43 @@ export function getOrderStatuses( select ) {
 	return orderStatuses;
 }
 
+export const getLowStockCountQuery = {
+	page: 1,
+	per_page: 1,
+	low_in_stock: true,
+	status: 'publish',
+	_fields: [ 'id' ],
+};
+
 export function getLowStockCount( select ) {
 	const { getItemsTotalCount, getItemsError, isResolving } = select(
 		ITEMS_STORE_NAME
 	);
 
-	const productsQuery = {
-		page: 1,
-		per_page: 1,
-		low_in_stock: true,
-		status: 'publish',
-		_fields: [ 'id' ],
-	};
-
-	const defaultValue = 0;
+	const defaultValue = null;
 
 	// Disable eslint rule requiring `totalLowStockProducts` to be defined below because the next two statements
 	// depend on `getItemsTotalCount` to have been called.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const totalLowStockProducts = getItemsTotalCount(
 		'products',
-		productsQuery,
+		getLowStockCountQuery,
 		defaultValue
 	);
 
-	const isError = Boolean( getItemsError( 'products', productsQuery ) );
+	const isError = Boolean(
+		getItemsError( 'products', getLowStockCountQuery )
+	);
 	const isRequesting = isResolving( 'getItemsTotalCount', [
 		'products',
-		productsQuery,
+		getLowStockCountQuery,
 		defaultValue,
 	] );
 
-	if ( isError || isRequesting ) {
+	if (
+		isError ||
+		( isRequesting && totalLowStockProducts === defaultValue )
+	) {
 		return null;
 	}
 

--- a/client/homescreen/activity-panel/stock/index.js
+++ b/client/homescreen/activity-panel/stock/index.js
@@ -14,6 +14,7 @@ import { ITEMS_STORE_NAME } from '@woocommerce/data';
  */
 import { ActivityCardPlaceholder } from '../../../header/activity-panel/activity-card';
 import { ProductStockCard } from './card';
+import { getLowStockCountQuery } from '../orders/utils';
 
 const productsQuery = {
 	page: 1,
@@ -40,13 +41,24 @@ export class StockPanel extends Component {
 	}
 
 	async updateStock( product, quantity ) {
-		const { invalidateResolution, updateProductStock } = this.props;
+		const {
+			invalidateResolution,
+			updateProductStock,
+			products,
+		} = this.props;
 
 		const success = await updateProductStock( product, quantity );
 
 		if ( success ) {
 			// Request more low stock products.
 			invalidateResolution( 'getItems', [ 'products', productsQuery ] );
+			if ( products.length < 2 ) {
+				invalidateResolution( 'getItemsTotalCount', [
+					'products',
+					getLowStockCountQuery,
+					null,
+				] );
+			}
 		}
 
 		return success;

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,10 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 2. Activity Panels
 3. Analytics
 
+== unreleased ==
+
+- Fix: Invalidate product count if the last product was updated in the list. #5790
+
 == Changelog ==
 
 = 1.7.0 11/11/2020 =


### PR DESCRIPTION
Fixes #5239

Invalidate product count if the last product was updated in the list fixing stock panel refresh, by making use of the `invalidateResolution` action, and the same product count query object.

### Screenshots

![stock-refresh](https://user-images.githubusercontent.com/2240960/100883610-e5c3ab80-3486-11eb-965e-26bad18a62bd.gif)

### Detailed test instructions:

- Create store with at-least one product
- Enable stock management at product level for that product (**Product > Inventory > Manage stock?**)
- Set Low stock threshold and set Stock quantity below the low stock threshold.
- Go to **WooCommerce -> Home** and open the Stock dropdown 
- Make sure a single item is listed, and Update the stock.
- After the stock is updated it should collapse and not show a dropdown arrow
- Click undo on the bottom left popup
- It should update the Stock header showing a single item, and the dropdown arrow should appear again.