### PR TITLE
Fix nav group titles showing in child menus

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -161,10 +161,14 @@ const Container = ( { menuItems } ) => {
 								) }
 								{ !! pluginItems && (
 									<NavigationGroup
-										title={ __(
-											'Extensions',
-											'woocommerce-admin'
-										) }
+										title={
+											category.id === 'woocommerce'
+												? __(
+														'Extensions',
+														'woocommerce-admin'
+												  )
+												: null
+										}
 									>
 										{ pluginItems.map( ( item ) => (
 											<Item

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -243,7 +243,7 @@ class Menu {
 	 * @return string
 	 */
 	public static function get_item_menu_id( $item ) {
-		if ( isset( self::$menu_items[ $item['parent'] ] ) ) {
+		if ( isset( $item['parent'] ) && isset( self::$menu_items[ $item['parent'] ] ) ) {
 			return self::$menu_items[ $item['parent'] ]['menuId'];
 		}
 


### PR DESCRIPTION
Fixes nav group title showing in child menus as well as item menu checks without parents.

### Screenshots

### Before
<img width="269" alt="Screen Shot 2020-12-02 at 12 40 55 PM" src="https://user-images.githubusercontent.com/10561050/100910192-a6538a00-349b-11eb-94bb-6bb963e6e57b.png">


### After

<img width="263" alt="Screen Shot 2020-12-02 at 12 39 22 PM" src="https://user-images.githubusercontent.com/10561050/100910081-7a380900-349b-11eb-909a-fe7ecb4cea42.png">


### Detailed test instructions:

1. Enable the nav feature.
1. Make sure no errors occur in your error log.
1. Navigate to a child menu group in the extensions menu.
1. Make sure the title "Extensions" is not shown.