### PR TITLE
CES: Remove CSS transition from CES modal when comments appear

### DIFF
--- a/packages/customer-effort-score/src/customer-feedback-modal/index.js
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.js
@@ -11,8 +11,6 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import classnames from 'classnames';
 
 /**
  * Provides a modal requesting customer feedback.
@@ -57,9 +55,6 @@ function CustomerFeedbackModal( { recordScoreCallback, label } ) {
 	const [ comments, setComments ] = useState();
 	const [ showNoScoreMessage, setShowNoScoreMessage ] = useState( false );
 	const [ isOpen, setOpen ] = useState( true );
-	const [ isCommentsTransitioning, setCommentsTransitioning ] = useState(
-		false
-	);
 
 	const closeModal = () => setOpen( false );
 
@@ -78,23 +73,13 @@ function CustomerFeedbackModal( { recordScoreCallback, label } ) {
 		recordScoreCallback( score, comments );
 	};
 
-	const onCommentsTransitionStart = () => {
-		setCommentsTransitioning( true );
-	};
-
-	const onCommentsTransitionEnd = () => {
-		setCommentsTransitioning( false );
-	};
-
 	if ( ! isOpen ) {
 		return null;
 	}
 
 	return (
 		<Modal
-			className={ classnames( 'woocommerce-customer-effort-score', {
-				'woocommerce-customer-effort-score-comments-transitioning': isCommentsTransitioning,
-			} ) }
+			className="woocommerce-customer-effort-score"
 			title={ __( 'Please share your feedback', 'woocommerce-admin' ) }
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ false }
@@ -111,35 +96,23 @@ function CustomerFeedbackModal( { recordScoreCallback, label } ) {
 				/>
 			</div>
 
-			<TransitionGroup>
-				{ ( score === 1 || score === 2 ) && (
-					<CSSTransition
-						key={ 'woocommerce-customer-effort-score__comments' }
-						timeout={ 250 }
-						classNames="woocommerce-customer-effort-score__comments"
-						onEnter={ onCommentsTransitionStart }
-						onEntered={ onCommentsTransitionEnd }
-						onExit={ onCommentsTransitionStart }
-						onExited={ onCommentsTransitionEnd }
-					>
-						<div className="woocommerce-customer-effort-score__comments">
-							<TextareaControl
-								label={ __(
-									'Comments (Optional)',
-									'woocommerce-admin'
-								) }
-								help={ __(
-									'Your feedback will go to the WooCommerce development team',
-									'woocommerce-admin'
-								) }
-								value={ comments }
-								onChange={ ( value ) => setComments( value ) }
-								rows="5"
-							/>
-						</div>
-					</CSSTransition>
-				) }
-			</TransitionGroup>
+			{ ( score === 1 || score === 2 ) && (
+				<div className="woocommerce-customer-effort-score__comments">
+					<TextareaControl
+						label={ __(
+							'Comments (Optional)',
+							'woocommerce-admin'
+						) }
+						help={ __(
+							'Your feedback will go to the WooCommerce development team',
+							'woocommerce-admin'
+						) }
+						value={ comments }
+						onChange={ ( value ) => setComments( value ) }
+						rows="5"
+					/>
+				</div>
+			) }
 
 			{ showNoScoreMessage && (
 				<div

--- a/packages/customer-effort-score/src/style.scss
+++ b/packages/customer-effort-score/src/style.scss
@@ -1,7 +1,3 @@
-.components-modal__frame.woocommerce-customer-effort-score-comments-transitioning {
-	overflow: hidden;
-}
-
 .woocommerce-customer-effort-score__selection {
 	margin: 1em 0;
 
@@ -93,34 +89,6 @@
 	textarea {
 		width: 100%;
 	}
-}
-
-.woocommerce-customer-effort-score__comments-enter {
-	opacity: 0;
-	max-height: 0;
-	transform: translateY(50%);
-}
-
-.woocommerce-customer-effort-score__comments-enter-active {
-	opacity: 1;
-	max-height: 100vh;
-	transform: translateY(0%);
-	transition: opacity 250ms ease-out, transform 250ms ease-out,
-		max-height 250ms ease-out;
-}
-
-.woocommerce-customer-effort-score__comments-exit {
-	opacity: 1;
-	max-height: 100vh;
-	transform: translateY(0%);
-}
-
-.woocommerce-customer-effort-score__comments-exit-active {
-	opacity: 0;
-	max-height: 0;
-	transform: translateY(50%);
-	transition: opacity 250ms ease-out, transform 250ms ease-out,
-		max-height 250ms ease-out;
 }
 
 .woocommerce-customer-effort-score__buttons {


### PR DESCRIPTION
@elizaan36 has requested (pbIJXs-m0-p2) that the transition when showing/hiding the comments field on the CES modal be removed for now, since we do not have a holistic set of transitions/animations for our design system. This can be revisited in the future. 


### Detailed test instructions:

- delete the `woocommerce_ces_shown_for_actions` option to reset the feature if you've tested it before
- Add a product. When the snackbar appears, click 'Give Feedback'.
- Select "Somewhat difficult".
- Verify that when the comments field is shown/hidden on the CES modal, that it instantly appears/disappears (no transition/animation) 

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

Fix: Remove CES modal comments transition.