### PR TITLE
Add navigation determinant params

### DIFF
--- a/client/navigation/test/utils.js
+++ b/client/navigation/test/utils.js
@@ -145,6 +145,30 @@ describe( 'getMatchScore', () => {
 			)
 		).toBe( 0 );
 	} );
+
+	it( 'should return the match score if required params are found', () => {
+		expect(
+			getMatchScore(
+				new URL(
+					getAdminLink(
+						'admin.php?page=testpage&required_param=a&optional_param=b'
+					)
+				),
+				getAdminLink( 'admin.php?page=testpage&required_param=a' ),
+				[ 'required_param' ]
+			)
+		).toBe( 2 );
+	} );
+
+	it( "should return 0 for paths that don't contain the required params", () => {
+		expect(
+			getMatchScore(
+				new URL( getAdminLink( 'admin.php?page=testpage' ) ),
+				getAdminLink( 'admin.php?page=testpage&required_param=a' ),
+				[ 'required_param' ]
+			)
+		).toBe( 0 );
+	} );
 } );
 
 describe( 'getFullUrl', () => {

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -46,23 +46,14 @@ export const getFullUrl = ( url ) => {
  *
  * @param {Object} location Window location
  * @param {string} url URL to compare
- * @param {Array} itemDeterminantParams Params required to match this item.
+ * @param {Array} queryParams Params required to match this item.
  * @return {number} Number of matches or 0 if not matched.
  */
-export const getMatchScore = (
-	location,
-	url,
-	itemDeterminantParams = null
-) => {
+export const getMatchScore = ( location, url, queryParams = [] ) => {
 	if ( ! url ) {
 		return;
 	}
 
-	const determinantParams = itemDeterminantParams || [
-		'page',
-		'tab',
-		'path',
-	];
 	const fullUrl = getFullUrl( url );
 	const urlLocation = new URL( fullUrl );
 	const { origin: urlOrigin, pathname: urlPathname } = urlLocation;
@@ -96,7 +87,7 @@ export const getMatchScore = (
 		if ( urlParams[ key ] === locationParams[ key ] ) {
 			matchingParamCount++;
 		} else if (
-			determinantParams.includes( key ) &&
+			queryParams.includes( key ) &&
 			( urlParams[ key ] || locationParams[ key ] )
 		) {
 			// A determinant param was found and not matched.
@@ -163,7 +154,8 @@ export const getMatchingItem = ( items ) => {
 	items.forEach( ( item ) => {
 		const score = getMatchScore(
 			window.location,
-			getAdminLink( item.url )
+			getAdminLink( item.url ),
+			item.queryParams
 		);
 		if ( score >= highestMatch && score > 0 ) {
 			matchedItem = item;

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -46,13 +46,23 @@ export const getFullUrl = ( url ) => {
  *
  * @param {Object} location Window location
  * @param {string} url URL to compare
+ * @param {Array} itemDeterminantParams Params required to match this item.
  * @return {number} Number of matches or 0 if not matched.
  */
-export const getMatchScore = ( location, url ) => {
+export const getMatchScore = (
+	location,
+	url,
+	itemDeterminantParams = null
+) => {
 	if ( ! url ) {
 		return;
 	}
 
+	const determinantParams = itemDeterminantParams || [
+		'page',
+		'tab',
+		'path',
+	];
 	const fullUrl = getFullUrl( url );
 	const urlLocation = new URL( fullUrl );
 	const { origin: urlOrigin, pathname: urlPathname } = urlLocation;
@@ -82,11 +92,17 @@ export const getMatchScore = ( location, url ) => {
 	// Add points for each matching param.
 	let matchingParamCount = 0;
 	const locationParams = getParams( location );
-	Object.keys( urlParams ).forEach( ( key ) => {
+	for ( const key in urlParams ) {
 		if ( urlParams[ key ] === locationParams[ key ] ) {
 			matchingParamCount++;
+		} else if (
+			determinantParams.includes( key ) &&
+			( urlParams[ key ] || locationParams[ key ] )
+		) {
+			// A determinant param was found and not matched.
+			return 0;
 		}
-	} );
+	}
 
 	return origin === urlOrigin && pathname === urlPathname
 		? matchingParamCount

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -45,35 +45,35 @@ export const getFullUrl = ( url ) => {
  * Check to see if a URL matches a given window location.
  *
  * @param {Object} location Window location
- * @param {string} url URL to compare
+ * @param {string} itemUrl Item URL to compare
  * @param {Array} queryParams Params required to match this item.
  * @return {number} Number of matches or 0 if not matched.
  */
-export const getMatchScore = ( location, url, queryParams = [] ) => {
-	if ( ! url ) {
+export const getMatchScore = ( location, itemUrl, queryParams = [] ) => {
+	if ( ! itemUrl ) {
 		return;
 	}
 
-	const fullUrl = getFullUrl( url );
-	const urlLocation = new URL( fullUrl );
-	const { origin: urlOrigin, pathname: urlPathname } = urlLocation;
+	const fullItemUrl = getFullUrl( itemUrl );
+	const itemLocation = new URL( fullItemUrl );
+	const { origin: urlOrigin, pathname: urlPathname } = itemLocation;
 	const { hash, origin, pathname, search } = location;
 
 	// Exact match found.
-	if ( origin + pathname + search + hash === fullUrl ) {
+	if ( origin + pathname + search + hash === fullItemUrl ) {
 		return Number.MAX_SAFE_INTEGER;
 	}
 
 	// Matched URL without hash.
-	if ( hash.length && origin + pathname + search === fullUrl ) {
+	if ( hash.length && origin + pathname + search === fullItemUrl ) {
 		return Number.MAX_SAFE_INTEGER - 1;
 	}
 
-	const urlParams = getParams( urlLocation );
+	const itemParams = getParams( itemLocation );
 
 	// Post type match.
 	if (
-		window.wcNavigation.postType === urlParams.post_type &&
+		window.wcNavigation.postType === itemParams.post_type &&
 		urlPathname.indexOf( 'edit.php' ) >= 0 &&
 		origin === urlOrigin
 	) {
@@ -83,12 +83,12 @@ export const getMatchScore = ( location, url, queryParams = [] ) => {
 	// Add points for each matching param.
 	let matchingParamCount = 0;
 	const locationParams = getParams( location );
-	for ( const key in urlParams ) {
-		if ( urlParams[ key ] === locationParams[ key ] ) {
+	for ( const key in itemParams ) {
+		if ( itemParams[ key ] === locationParams[ key ] ) {
 			matchingParamCount++;
 		} else if (
 			queryParams.includes( key ) &&
-			( urlParams[ key ] || locationParams[ key ] )
+			( itemParams[ key ] || locationParams[ key ] )
 		) {
 			// A determinant param was found and not matched.
 			return 0;
@@ -149,7 +149,7 @@ export const addHistoryListener = ( listener ) => {
  */
 export const getMatchingItem = ( items ) => {
 	let matchedItem = null;
-	let highestMatch = 0;
+	let highestMatchScore = 0;
 
 	items.forEach( ( item ) => {
 		const score = getMatchScore(
@@ -157,9 +157,9 @@ export const getMatchingItem = ( items ) => {
 			getAdminLink( item.url ),
 			item.queryParams
 		);
-		if ( score >= highestMatch && score > 0 ) {
+		if ( score >= highestMatchScore && score > 0 ) {
 			matchedItem = item;
-			highestMatch = score;
+			highestMatchScore = score;
 		}
 	} );
 

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -54,12 +54,13 @@ class CoreMenu {
 			$order       += 10;
 			$menu_items[] = (
 				array(
-					'parent'     => 'woocommerce-settings',
-					'title'      => $setting,
-					'capability' => 'manage_woocommerce',
-					'id'         => 'settings-' . $key,
-					'url'        => 'admin.php?page=wc-settings&tab=' . $key,
-					'order'      => $order,
+					'parent'      => 'woocommerce-settings',
+					'title'       => $setting,
+					'capability'  => 'manage_woocommerce',
+					'id'          => 'settings-' . $key,
+					'url'         => 'admin.php?page=wc-settings&tab=' . $key,
+					'order'       => $order,
+					'queryParams' => array( 'page', 'tab' ),
 				)
 			);
 		}
@@ -137,10 +138,11 @@ class CoreMenu {
 			$path = isset( $page['path'] ) ? $page['path'] : null;
 			$item = array_merge(
 				array(
-					'id'         => 'wc_admin-' . $path,
-					'url'        => $path,
-					'title'      => $page['title'][0],
-					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
+					'id'          => 'wc_admin-' . $path,
+					'url'         => $path,
+					'title'       => $page['title'][0],
+					'capability'  => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
+					'queryParams' => array( 'page', 'path' ),
 				),
 				$page['nav_args']
 			);
@@ -156,20 +158,22 @@ class CoreMenu {
 		$home_item = array();
 		if ( defined( '\Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG' ) ) {
 			$home_item = array(
-				'id'    => 'wc_admin-wc-admin&path=/',
-				'title' => __( 'Home', 'woocommerce-admin' ),
-				'url'   => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
-				'order' => 0,
+				'id'          => 'wc_admin-wc-admin&path=/',
+				'title'       => __( 'Home', 'woocommerce-admin' ),
+				'url'         => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
+				'order'       => 0,
+				'queryParams' => array( 'page', 'path' ),
 			);
 		}
 
 		$customers_item = array();
 		if ( class_exists( '\Automattic\WooCommerce\Admin\Features\Analytics' ) ) {
 			$customers_item = array(
-				'id'    => 'woocommerce-analytics-customers',
-				'title' => __( 'Customers', 'woocommerce-admin' ),
-				'url'   => wc_admin_url( '/customers' ),
-				'order' => 50,
+				'id'          => 'woocommerce-analytics-customers',
+				'title'       => __( 'Customers', 'woocommerce-admin' ),
+				'url'         => 'wc-admin&path=/customers',
+				'order'       => 50,
+				'queryParams' => array( 'page', 'path' ),
 			);
 		}
 

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -184,14 +184,15 @@ class Menu {
 	 *
 	 * @param array $args Array containing the necessary arguments.
 	 *    $args = array(
-	 *      'id'         => (string) The unique ID of the menu item. Required.
-	 *      'title'      => (string) Title of the menu item. Required.
-	 *      'parent'     => (string) Parent menu item ID.
-	 *      'capability' => (string) Capability to view this menu item.
-	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'order'      => (int) Menu item order.
-	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'menuId'     => (string) The ID of the menu to add the item to.
+	 *      'id'          => (string) The unique ID of the menu item. Required.
+	 *      'title'       => (string) Title of the menu item. Required.
+	 *      'parent'      => (string) Parent menu item ID.
+	 *      'capability'  => (string) Capability to view this menu item.
+	 *      'url'         => (string) URL or callback to be used. Required.
+	 *      'order'       => (int) Menu item order.
+	 *      'migrate'     => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'      => (string) The ID of the menu to add the item to.
+	 *      'queryParams' => (array) Array of required params used to determine if this item should be active.
 	 *    ).
 	 */
 	private static function add_item( $args ) {
@@ -211,13 +212,14 @@ class Menu {
 		}
 
 		$defaults           = array(
-			'id'         => '',
-			'title'      => '',
-			'capability' => 'manage_woocommerce',
-			'url'        => '',
-			'order'      => 100,
-			'migrate'    => true,
-			'menuId'     => 'primary',
+			'id'          => '',
+			'title'       => '',
+			'capability'  => 'manage_woocommerce',
+			'url'         => '',
+			'order'       => 100,
+			'migrate'     => true,
+			'menuId'      => 'primary',
+			'queryParams' => array( 'page' ),
 		);
 		$menu_item          = wp_parse_args( $args, $defaults );
 		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
@@ -243,7 +245,7 @@ class Menu {
 	 * @return string
 	 */
 	public static function get_item_menu_id( $item ) {
-		if ( isset( self::$menu_items[ $item['parent'] ] ) ) {
+		if ( isset( $item['parent'] ) && isset( self::$menu_items[ $item['parent'] ] ) ) {
 			return self::$menu_items[ $item['parent'] ]['menuId'];
 		}
 
@@ -255,13 +257,14 @@ class Menu {
 	 *
 	 * @param array $args Array containing the necessary arguments.
 	 *    $args = array(
-	 *      'id'         => (string) The unique ID of the menu item. Required.
-	 *      'title'      => (string) Title of the menu item. Required.
-	 *      'parent'     => (string) Parent menu item ID.
-	 *      'capability' => (string) Capability to view this menu item.
-	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'order'      => (int) Menu item order.
+	 *      'id'          => (string) The unique ID of the menu item. Required.
+	 *      'title'       => (string) Title of the menu item. Required.
+	 *      'parent'      => (string) Parent menu item ID.
+	 *      'capability'  => (string) Capability to view this menu item.
+	 *      'url'         => (string) URL or callback to be used. Required.
+	 *      'migrate'     => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'order'       => (int) Menu item order.
+	 *      'queryParams' => (array) Array of required params used to determine if this item should be active.
 	 *    ).
 	 */
 	public static function add_plugin_item( $args ) {


### PR DESCRIPTION
Part 1 of a 2 part exploration to improve route detection.

This PR allows `queryParams` (up for discussion- `requiredParams`?) to be passed along with each individual item to help determine if this item should be marked active or not.  For example passing `'queryParams' => array( 'my_param' )` as a menu item argument means that the current URL location must match the menu item's `my_param` option.

This is useful since some pages are determined active by the `page` param, while others, like those in WCA, are determined by `page` and `path` and those in WC Settings are determined by `tab`.

The follow-up PR will explore a regex alternative.

### Screenshots
<img width="888" alt="Screen Shot 2020-12-02 at 5 39 05 PM" src="https://user-images.githubusercontent.com/10561050/100940071-4f62aa80-34c5-11eb-91b7-b6f79b963ee1.png">


### Detailed test instructions:

1. Add some items that have possible conflict in params due to a matching score being higher.  For example, you could register a new WCA page:

```php
wc_admin_register_page(
	array(
		'id'     => 'test-determinant-params',
		'title'  => __( 'Test Determinant Params', 'woocommerce-admin' ),
		'path'   => '/test-params&param1=a&param2=b',
		'nav_args' => array()
	)
);
```

2. Navigate to a URL where the match score should be higher for that item, but using a non-matching determinant param (`path` in the case of WCA).  `wp-admin/admin.php?page=wc-admin&param1=a&param2=b`
3. Note that the correct item is matched.