### PR TITLE
Use callback for customers URL in navigation

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -168,7 +168,7 @@ class CoreMenu {
 			$customers_item = array(
 				'id'    => 'woocommerce-analytics-customers',
 				'title' => __( 'Customers', 'woocommerce-admin' ),
-				'url'   => wc_admin_url( '/customers' ),
+				'url'   => 'wc-admin&path=/customers',
 				'order' => 50,
 			);
 		}


### PR DESCRIPTION
Fixes #5782

Uses the callback for the customers URL to avoid double registration.

### Detailed test instructions:

1. Enable the nav feature.
1. Check that `Customers` works from the main menu.
1. Check that `Customers` does not exist under the `Settings` menu.