### PR TITLE
Use an empty queue if CES feature is not enabled

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -75,6 +75,12 @@ CustomerEffortScoreTracksContainer.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
+		if (
+			window.wcAdminFeatures &&
+			window.wcAdminFeatures[ 'customer-effort-score-tracks' ] !== true
+		) {
+			return { queue: [], resolving: false };
+		}
 		const { getCesSurveyQueue, isResolving } = select( STORE_KEY );
 		const queue = getCesSurveyQueue();
 		const resolving = isResolving( 'getOption', [ QUEUE_OPTION_NAME ] );

--- a/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -75,12 +75,6 @@ CustomerEffortScoreTracksContainer.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
-		if (
-			window.wcAdminFeatures &&
-			window.wcAdminFeatures[ 'customer-effort-score-tracks' ] !== true
-		) {
-			return { queue: [], resolving: false };
-		}
 		const { getCesSurveyQueue, isResolving } = select( STORE_KEY );
 		const queue = getCesSurveyQueue();
 		const resolving = isResolving( 'getOption', [ QUEUE_OPTION_NAME ] );

--- a/client/index.js
+++ b/client/index.js
@@ -83,12 +83,19 @@ if ( navigationRoot ) {
 	render( <Navigation />, navigationRoot );
 }
 
-// Set up customer effort score survey.
-( function () {
-	const root = appRoot || embeddedRoot;
+// Render the CustomerEffortScoreTracksContainer only if
+// the feature flag is enabled.
+if (
+	window.wcAdminFeatures &&
+	window.wcAdminFeatures[ 'customer-effort-score-tracks' ] === true
+) {
+	// Set up customer effort score survey.
+	( function () {
+		const root = appRoot || embeddedRoot;
 
-	render(
-		<CustomerEffortScoreTracksContainer />,
-		root.insertBefore( document.createElement( 'div' ), null )
-	);
-} )();
+		render(
+			<CustomerEffortScoreTracksContainer />,
+			root.insertBefore( document.createElement( 'div' ), null )
+		);
+	} )();
+}


### PR DESCRIPTION
Fixes #5797 

This PR respects the feature flag for the CES on the Analytics pages.

I considered two approaches at first.

1.  Check the feature flag in https://github.com/woocommerce/woocommerce-admin/blob/a0187bc0adbd0c8428475292c4466a8ad810229d/client/index.js#L86 and conditionally load `CustomerEffortScoreTracksContainer.`
2. Check the feature flag in [customer-effort-score-tracks-container.js](https://github.com/woocommerce/woocommerce-admin/blob/main/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js) and return an empty array for the `queue` value so that any subsequent `ADD_CES_SURVEY` calls would be ignored.

~~I took approach #2 since it's simple and API consumers don't have to check for the feature flag. If we choose approach #1, which does not include `CustomerEffortScoreTracksContainer` then the API consumers must check for the feature flag before calling the `ADD_CES_SURVEY` action.~~

Updated to use the first approach and left a [comment](https://github.com/woocommerce/woocommerce-admin/pull/5800#issuecomment-737672828) about it.


I would appreciate any suggestions on other approaches.

### Detailed test instructions:

1. Turn off `customer-effort-score-tracks` in `config/development.json.`
2. Run `npm run dev` to apply the change.
3. Navigate to WooCommerce -> Analytics and change a filter.
4. You should not see a CES survey snackbar. 

