### PR TITLE
Home Screen: Do not show store setup activity panel.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -145,7 +145,10 @@ export class ActivityPanel extends Component {
 			! isEmbedded && this.isHomescreen() && ! isPerformingSetupTask;
 
 		const showStoreSetup =
-			! taskListComplete && ! taskListHidden && ! isPerformingSetupTask;
+			! taskListComplete &&
+			! taskListHidden &&
+			! isPerformingSetupTask &&
+			( ! this.isHomescreen() || isEmbedded );
 
 		const inbox = showInbox
 			? {

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -159,4 +159,38 @@ describe( 'Activity Panel', () => {
 
 		expect( queryByText( 'Store Setup' ) ).toBeNull();
 	} );
+
+	it( 'should not render the store setup link when on the home screen and TaskList is not complete', () => {
+		const { queryByText } = render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden={ false }
+				getHistory={ () => ( {
+					location: {
+						pathname: '/',
+					},
+				} ) }
+				query={ {
+					task: '',
+				} }
+			/>
+		);
+
+		expect( queryByText( 'Store Setup' ) ).toBeNull();
+	} );
+
+	it( 'should render the store setup link when on embedded pages and TaskList is not complete', () => {
+		const { queryByText } = render(
+			<ActivityPanel
+				requestingTaskListOptions={ false }
+				taskListComplete={ false }
+				taskListHidden={ false }
+				isEmbedded
+				query={ {} }
+			/>
+		);
+
+		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+	} );
 } );


### PR DESCRIPTION
Fixes #5792

@elizaan36 pointed out that it would be good to remove the Store Setup activity panel link from being shown on the home screen ahead of the final 4.8 release. This branch adds the logic, and some tests, to do that.
### Screenshots

__Before__
<img width="1054" alt="home-store-setup-before" src="https://user-images.githubusercontent.com/22080/100944452-31407e80-34b4-11eb-84cd-93813fe6567f.png">

__After__
<img width="1054" alt="home-store-setup-after" src="https://user-images.githubusercontent.com/22080/100944465-39002300-34b4-11eb-8aa1-2e7c3ac0ecdf.png">

### Detailed test instructions:

- Either reset site options to a state where the Setup Checklist is being shown, or run this branch on a new site.
- Navigate to the home screen and verify the setup link in the activity panel/header area is not shown
- Navigate to another wc-admin powered page like Customers and verify that it **is shown**
- Navigate to an embedded page, like Orders, and verify that it is still shown there also
