### PR TITLE
Use error_log() to log the deprecated class calls instead of _deprecated_function()

### DIFF
--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -40,16 +40,27 @@ class DeprecatedClassFacade {
 	}
 
 	/**
+	 * Log a deprecation to the error log.
+	 */
+	private static function log_deprecation() {
+		error_log( // phpcs:ignore
+			static::class
+			. ' is deprecated since version '
+			. static::$deprecated_in_version
+			. '. Make sure you are using the undeprecated equivalent which '
+			. 'this deprecation facade wraps.'
+		);
+	}
+
+	/**
 	 * Executes when calling any function on an instance of this class.
 	 *
 	 * @param string $name      The name of the function being called.
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public function __call( $name, $arguments ) {
-		_deprecated_function(
-			static::class . '::' . $name,
-			static::$deprecated_in_version
-		);
+		self::log_deprecation();
+
 		return call_user_func_array(
 			array(
 				$this->instance,
@@ -66,10 +77,8 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		_deprecated_function(
-			static::class . '::' . $name,
-			static::$deprecated_in_version
-		);
+		self::log_deprecation();
+
 		return call_user_func_array(
 			array(
 				static::$facade_over_classname,

--- a/src/DeprecatedClassFacade.php
+++ b/src/DeprecatedClassFacade.php
@@ -41,14 +41,17 @@ class DeprecatedClassFacade {
 
 	/**
 	 * Log a deprecation to the error log.
+	 *
+	 * @param string $function The name of the deprecated function being called.
 	 */
-	private static function log_deprecation() {
+	private static function log_deprecation( $function ) {
 		error_log( // phpcs:ignore
-			static::class
-			. ' is deprecated since version '
-			. static::$deprecated_in_version
-			. '. Make sure you are using the undeprecated equivalent which '
-			. 'this deprecation facade wraps.'
+			sprintf(
+				'%1$s is deprecated since version %2$s! Use %3$s instead.',
+				static::class . '::' . $function,
+				static::$deprecated_in_version,
+				static::$facade_over_classname . '::' . $function
+			)
 		);
 	}
 
@@ -59,7 +62,7 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public function __call( $name, $arguments ) {
-		self::log_deprecation();
+		self::log_deprecation( $name );
 
 		return call_user_func_array(
 			array(
@@ -77,7 +80,7 @@ class DeprecatedClassFacade {
 	 * @param array  $arguments An array of the arguments to the function call.
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		self::log_deprecation();
+		self::log_deprecation( $name );
 
 		return call_user_func_array(
 			array(


### PR DESCRIPTION
### Detailed test instructions:

1. Clone this plugin (https://github.com/becdetat/test-deprecated-notes-classes) in to your plugins folder
1. Activate the plugin
1. Navigate to any page
1. Find your site's error log (this might help: `@ini_set('error_log','/srv/www/wordpress-two/public_html/php-errors.log');` in your `wp-config.php` file)
1. Note that the usages of the deprecated classes in the plugin have caused errors in the log but not on screen.
