### PR TITLE
Enable CES in core and plugin configs

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
-		"customer-effort-score-tracks": false,
+		"customer-effort-score-tracks": true,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": false,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
-		"customer-effort-score-tracks": false,
+		"customer-effort-score-tracks": true,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": true,


### PR DESCRIPTION
This enables CES in the core and plugin configs.

It's pretty straightforward but if you wanted to test it you could `npm run test:zip` and upload the generated zip to a JN site and verify that the CES snackbars get displayed.