### PR TITLE
Send store age in weeks to tracks

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -7,7 +7,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import CustomerEffortScore from '@woocommerce/customer-effort-score';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME, MONTH } from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, WEEK } from '@woocommerce/data';
 import { __ } from '@wordpress/i18n';
 
 const SHOWN_FOR_ACTIONS_OPTION_NAME = 'woocommerce_ces_shown_for_actions';
@@ -27,7 +27,7 @@ const ALLOW_TRACKING_OPTION_NAME = 'woocommerce_allow_tracking';
  * @param {Array}    props.cesShownForActions The array of actions that the CES modal has been shown for.
  * @param {boolean}  props.allowTracking      Whether tracking is allowed or not.
  * @param {boolean}  props.resolving          Are values still being resolved.
- * @param {number}   props.storeAge           The age of the store in months.
+ * @param {number}   props.storeAgeInWeeks    The age of the store in weeks.
  * @param {Function} props.updateOptions      Function to update options.
  * @param {Function} props.createNotice       Function to create a snackbar.
  */
@@ -39,7 +39,7 @@ function CustomerEffortScoreTracks( {
 	cesShownForActions,
 	allowTracking,
 	resolving,
-	storeAge,
+	storeAgeInWeeks,
 	updateOptions,
 	createNotice,
 } ) {
@@ -68,7 +68,7 @@ function CustomerEffortScoreTracks( {
 	const onNoticeShown = () => {
 		recordEvent( 'ces_snackbar_view', {
 			action,
-			store_age: storeAge,
+			store_age: storeAgeInWeeks,
 			...trackProps,
 		} );
 	};
@@ -85,7 +85,7 @@ function CustomerEffortScoreTracks( {
 	const onNoticeDismissed = () => {
 		recordEvent( 'ces_snackbar_dismiss', {
 			action,
-			store_age: storeAge,
+			store_age: storeAgeInWeeks,
 			...trackProps,
 		} );
 
@@ -97,7 +97,7 @@ function CustomerEffortScoreTracks( {
 
 		recordEvent( 'ces_view', {
 			action,
-			store_age: storeAge,
+			store_age: storeAgeInWeeks,
 			...trackProps,
 		} );
 
@@ -109,7 +109,7 @@ function CustomerEffortScoreTracks( {
 			action,
 			score,
 			comments: comments || '',
-			store_age: storeAge,
+			store_age: storeAgeInWeeks,
 			...trackProps,
 		} );
 		createNotice( 'success', onSubmitLabel );
@@ -165,9 +165,9 @@ CustomerEffortScoreTracks.propTypes = {
 	 */
 	resolving: PropTypes.bool.isRequired,
 	/**
-	 * The age of the store in months.
+	 * The age of the store in weeks.
 	 */
-	storeAge: PropTypes.number,
+	storeAgeInWeeks: PropTypes.number,
 	/**
 	 * Function to update options.
 	 */
@@ -190,7 +190,7 @@ export default compose(
 		// Date.now() is ms since Unix epoch, adminInstallTimestamp is in
 		// seconds since Unix epoch.
 		const storeAgeInMs = Date.now() - adminInstallTimestamp * 1000;
-		const storeAge = Math.round( storeAgeInMs / MONTH );
+		const storeAgeInWeeks = Math.round( storeAgeInMs / WEEK );
 
 		const allowTrackingOption =
 			getOption( ALLOW_TRACKING_OPTION_NAME ) || 'no';
@@ -206,7 +206,7 @@ export default compose(
 		return {
 			cesShownForActions,
 			allowTracking,
-			storeAge,
+			storeAgeInWeeks,
 			resolving,
 		};
 	} ),

--- a/packages/data/src/constants.js
+++ b/packages/data/src/constants.js
@@ -10,6 +10,7 @@ export const SECOND = 1000;
 export const MINUTE = 60 * SECOND;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
+export const WEEK = 7 * DAY;
 export const MONTH = ( 365 * DAY ) / 12;
 
 export const DEFAULT_REQUIREMENT = {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -47,6 +47,7 @@ export {
 	MINUTE,
 	HOUR,
 	DAY,
+	WEEK,
 	MONTH,
 } from './constants';
 


### PR DESCRIPTION
This changes the store age sent to tracks as part of the Customer Effort Score so that it is in weeks, not months. Conversation here: https://woostartp2.wordpress.com/2020/09/25/customer-effort-score-2/#comment-1334.

### Detailed test instructions:

1. It's probably a good idea to see a track being sent before checking out this branch:
    1. Perform an action that will trigger a CES snackbar, such as adding a new product
    1. Note that in the console, a track is sent when the snackbar is displayed. The `store_age` property should be in months, rounded to the nearest month
1. Check out this branch
1. Perform a CES trigger action
1. Note that in the console, the track's `store_age` property is now in weeks, rounded to the nearest week.