### PR TITLE
Add nav item route regex matching

### DIFF
--- a/client/navigation/test/utils.js
+++ b/client/navigation/test/utils.js
@@ -81,6 +81,26 @@ describe( 'getMatchingItem', () => {
 		const matchingItem = getMatchingItem( sampleMenuItems );
 		expect( matchingItem.id ).toBe( 'multiple-args' );
 	} );
+
+	it( 'should match an item with irrelevant query parameters', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?page=wc-admin&path=/test-path&section=section-name&foo=bar'
+			)
+		);
+		const matchingItem = getMatchingItem( sampleMenuItems );
+		expect( matchingItem.id ).toBe( 'multiple-args' );
+	} );
+
+	it( 'should match an item with query parameters in mixed order', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?foo=bar&page=wc-admin&path=/test-path&section=section-name'
+			)
+		);
+		const matchingItem = getMatchingItem( sampleMenuItems );
+		expect( matchingItem.id ).toBe( 'multiple-args' );
+	} );
 } );
 
 describe( 'getDefaultMatchExpression', () => {

--- a/client/navigation/test/utils.js
+++ b/client/navigation/test/utils.js
@@ -10,8 +10,7 @@ import {
 	addHistoryListener,
 	getFullUrl,
 	getMatchingItem,
-	getMatchScore,
-	getParams,
+	isMatch,
 } from '../utils';
 
 const originalLocation = window.location;
@@ -83,7 +82,7 @@ describe( 'getMatchingItem', () => {
 	} );
 } );
 
-describe( 'getMatchScore', () => {
+describe( 'isMatch', () => {
 	beforeAll( () => {
 		delete window.location;
 		window.location = new URL( getAdminLink( '/' ) );
@@ -93,57 +92,59 @@ describe( 'getMatchScore', () => {
 		window.location = originalLocation;
 	} );
 
-	it( 'should return the largest integer for an exact match', () => {
+	it( 'should retur true if the URL is the same', () => {
 		expect(
-			getMatchScore(
+			isMatch(
 				new URL( getAdminLink( 'admin.php?page=testpage' ) ),
 				getAdminLink( 'admin.php?page=testpage' )
 			)
-		).toBe( Number.MAX_SAFE_INTEGER );
+		).toBe( true );
 	} );
 
-	it( 'should return the largest integer for an exact match with a partial URL', () => {
+	it( 'should return true if the URL starts with the same string', () => {
 		expect(
-			getMatchScore(
-				new URL( getFullUrl( '/wp-admin/admin.php?page=testpage' ) ),
+			isMatch(
+				new URL(
+					getFullUrl(
+						'/wp-admin/admin.php?page=testpage&extra_param=a'
+					)
+				),
 				'/wp-admin/admin.php?page=testpage'
 			)
-		).toBe( Number.MAX_SAFE_INTEGER );
+		).toBe( true );
 	} );
 
-	it( 'should return the largest integer - 1 for an exact match without a hash', () => {
+	it( 'should return false if the URL is not the same', () => {
 		expect(
-			getMatchScore(
-				new URL( getAdminLink( 'admin.php?page=testpage#hash' ) ),
+			isMatch(
+				new URL( getAdminLink( 'admin.php?page=different-page' ) ),
 				getAdminLink( 'admin.php?page=testpage' )
 			)
-		).toBe( Number.MAX_SAFE_INTEGER - 1 );
+		).toBe( false );
 	} );
 
-	it( 'should return a score equal to the number of arguments matched', () => {
+	it( 'should return true for a location matching the expression', () => {
 		expect(
-			getMatchScore(
+			isMatch(
 				new URL(
-					getAdminLink(
-						'admin.php?page=testpage&param1=a&param2=b&param3=c'
-					)
+					getAdminLink( 'admin.php?page=different-page&param1=a' )
 				),
-				getAdminLink( 'admin.php?page=testpage&param1=a&param2=b' )
+				getAdminLink( 'admin.php?page=testpage' ),
+				'param1=a'
 			)
-		).toBe( 3 );
+		).toBe( true );
 	} );
 
-	it( "should return 0 for paths that don't match", () => {
+	it( 'should return false for a location not matching the expression', () => {
 		expect(
-			getMatchScore(
+			isMatch(
 				new URL(
-					getAdminLink(
-						'admin.php?page=testpage&param1=a&param2=b&param3=c'
-					)
+					getAdminLink( 'admin.php?page=different-page&param1=b' )
 				),
-				getAdminLink( 'plugins.php?page=testpage&param1=a&param2=b' )
+				getAdminLink( 'admin.php?page=testpage' ),
+				'param1=a'
 			)
-		).toBe( 0 );
+		).toBe( false );
 	} );
 } );
 
@@ -169,18 +170,6 @@ describe( 'getFullUrl', () => {
 		expect( getFullUrl( getAdminLink( 'admin.php?page=testpage' ) ) ).toBe(
 			getAdminLink( 'admin.php?page=testpage' )
 		);
-	} );
-} );
-
-describe( 'getParams', () => {
-	it( 'should get the params from a location', () => {
-		const location = new URL(
-			getAdminLink( 'admin.php?page=testpage&param1=a' )
-		);
-		const params = getParams( location );
-		expect( Object.keys( params ).length ).toBe( 2 );
-		expect( params.page ).toBe( 'testpage' );
-		expect( params.param1 ).toBe( 'a' );
 	} );
 } );
 

--- a/client/navigation/test/utils.js
+++ b/client/navigation/test/utils.js
@@ -39,7 +39,93 @@ const sampleMenuItems = [
 		title: 'Page with multiple arguments',
 		url: 'admin.php?page=wc-admin&path=/test-path&section=section-name',
 	},
+	{
+		id: 'multiple-args-plus-one',
+		title: 'Page with same multiple arguments plus an additional one',
+		url:
+			'admin.php?page=wc-admin&path=/test-path&section=section-name&version=22',
+	},
+	{
+		id: 'hash-and-multiple-args',
+		title: 'Page with multiple arguments and a hash',
+		url:
+			'admin.php?page=wc-admin&path=/test-path&section=section-name#anchor',
+	},
 ];
+
+const runGetMatchingItemTests = ( items ) => {
+	it( 'should get the closest matched item', () => {
+		window.location = new URL( getAdminLink( 'admin.php?page=wc-admin' ) );
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'main' );
+	} );
+
+	it( 'should match the item without hash if a better match does not exist', () => {
+		window.location = new URL(
+			getAdminLink( 'admin.php?page=wc-admin#hash' )
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'main' );
+	} );
+
+	it( 'should exactly match the item with a hash if it exists', () => {
+		window.location = new URL(
+			getAdminLink( 'admin.php?page=wc-admin&path=/test-path#anchor' )
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'hash' );
+	} );
+
+	it( 'should roughly match the item if all menu item arguments exist', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?page=wc-admin&path=/test-path&section=section-name'
+			)
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'multiple-args' );
+	} );
+
+	it( 'should match an item with irrelevant query parameters', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?page=wc-admin&path=/test-path&section=section-name&foo=bar'
+			)
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'multiple-args' );
+	} );
+
+	it( 'should match an item with similar query args plus one additional arg', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?page=wc-admin&path=/test-path&section=section-name&version=22'
+			)
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'multiple-args-plus-one' );
+	} );
+
+	it( 'should match an item with query parameters in mixed order', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?foo=bar&page=wc-admin&path=/test-path&section=section-name'
+			)
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'multiple-args' );
+	} );
+
+	it( 'should match an item with query parameters and a hash', () => {
+		window.location = new URL(
+			getAdminLink(
+				'admin.php?foo=bar&page=wc-admin&path=/test-path&section=section-name#anchor'
+			)
+		);
+		const matchingItem = getMatchingItem( items );
+		expect( matchingItem.id ).toBe( 'hash-and-multiple-args' );
+	} );
+};
 
 describe( 'getMatchingItem', () => {
 	beforeAll( () => {
@@ -50,57 +136,9 @@ describe( 'getMatchingItem', () => {
 		window.location = originalLocation;
 	} );
 
-	it( 'should get the closest matched item', () => {
-		window.location = new URL( getAdminLink( 'admin.php?page=wc-admin' ) );
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'main' );
-	} );
-
-	it( 'should match the item without hash if a better match does not exist', () => {
-		window.location = new URL(
-			getAdminLink( 'admin.php?page=wc-admin#hash' )
-		);
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'main' );
-	} );
-
-	it( 'should exactly match the item with a hash if it exists', () => {
-		window.location = new URL(
-			getAdminLink( 'admin.php?page=wc-admin&path=/test-path#anchor' )
-		);
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'hash' );
-	} );
-
-	it( 'should roughly match the item if all menu item arguments exist', () => {
-		window.location = new URL(
-			getAdminLink(
-				'admin.php?page=wc-admin&path=/test-path&section=section-name'
-			)
-		);
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'multiple-args' );
-	} );
-
-	it( 'should match an item with irrelevant query parameters', () => {
-		window.location = new URL(
-			getAdminLink(
-				'admin.php?page=wc-admin&path=/test-path&section=section-name&foo=bar'
-			)
-		);
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'multiple-args' );
-	} );
-
-	it( 'should match an item with query parameters in mixed order', () => {
-		window.location = new URL(
-			getAdminLink(
-				'admin.php?foo=bar&page=wc-admin&path=/test-path&section=section-name'
-			)
-		);
-		const matchingItem = getMatchingItem( sampleMenuItems );
-		expect( matchingItem.id ).toBe( 'multiple-args' );
-	} );
+	runGetMatchingItemTests( sampleMenuItems );
+	// re-run the tests with sampleMenuItems in reverse order.
+	runGetMatchingItemTests( sampleMenuItems.reverse() );
 } );
 
 describe( 'getDefaultMatchExpression', () => {

--- a/client/navigation/test/utils.js
+++ b/client/navigation/test/utils.js
@@ -11,7 +11,7 @@ import {
 	getDefaultMatchExpression,
 	getFullUrl,
 	getMatchingItem,
-	isMatch,
+	getMatchScore,
 } from '../utils';
 
 const originalLocation = window.location;
@@ -131,7 +131,7 @@ describe( 'getDefaultMatchExpression', () => {
 	} );
 } );
 
-describe( 'isMatch', () => {
+describe( 'getMatchScore', () => {
 	beforeAll( () => {
 		delete window.location;
 		window.location = new URL( getAdminLink( '/' ) );
@@ -141,18 +141,18 @@ describe( 'isMatch', () => {
 		window.location = originalLocation;
 	} );
 
-	it( 'should return true if the URL is the same', () => {
+	it( 'should return max safe integer if the url is an exact match', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL( getAdminLink( 'admin.php?page=testpage' ) ),
 				getAdminLink( 'admin.php?page=testpage' )
 			)
-		).toBe( true );
+		).toBe( Number.MAX_SAFE_INTEGER );
 	} );
 
-	it( 'should return true if the URL starts with the same string', () => {
+	it( 'should return matching path and parameter count', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL(
 					getFullUrl(
 						'/wp-admin/admin.php?page=testpage&extra_param=a'
@@ -160,62 +160,60 @@ describe( 'isMatch', () => {
 				),
 				'/wp-admin/admin.php?page=testpage'
 			)
-		).toBe( true );
+		).toBe( 2 );
 	} );
 
-	it( 'should return false if the URL is not the same', () => {
+	it( 'should return 0 if the URL does not meet match criteria', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL( getAdminLink( 'admin.php?page=different-page' ) ),
 				getAdminLink( 'admin.php?page=testpage' )
 			)
-		).toBe( false );
+		).toBe( 0 );
 	} );
 
-	it( 'should return true for a location matching the expression', () => {
+	it( 'should return match count for a custom match expression', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL(
 					getAdminLink( 'admin.php?page=different-page&param1=a' )
 				),
 				getAdminLink( 'admin.php?page=testpage' ),
 				'param1=a'
 			)
-		).toBe( true );
+		).toBe( 1 );
 	} );
 
-	it( 'should return false for a location not matching the expression', () => {
+	it( 'should return 0 for custom match expression that does not match', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL(
 					getAdminLink( 'admin.php?page=different-page&param1=b' )
 				),
 				getAdminLink( 'admin.php?page=testpage' ),
 				'param1=a'
 			)
-		).toBe( false );
+		).toBe( 0 );
 	} );
 
-	it( 'should return true if params match but are out of order', () => {
+	it( 'should return match count if params match but are out of order', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL( getAdminLink( 'admin.php?param1=a&page=testpage' ) ),
-				getAdminLink( 'admin.php?page=testpage' ),
-				'param1=a'
+				getAdminLink( 'admin.php?page=testpage' )
 			)
-		).toBe( true );
+		).toBe( 2 );
 	} );
 
-	it( 'should return true if multiple params match but are out of order', () => {
+	it( 'should return match count if multiple params match but are out of order', () => {
 		expect(
-			isMatch(
+			getMatchScore(
 				new URL(
 					getAdminLink( 'admin.php?param1=a&page=testpage&param2=b' )
 				),
-				getAdminLink( 'admin.php?page=testpage&param1=a' ),
-				'param1=a'
+				getAdminLink( 'admin.php?page=testpage&param1=a' )
 			)
-		).toBe( true );
+		).toBe( 3 );
 	} );
 } );
 

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -4,24 +4,6 @@
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 /**
- * Get the params from a location as a key/value pair object.
- *
- * @param {Object} location Window location
- * @return {Object} Params
- */
-export const getParams = ( location ) => {
-	const params = {};
-	if ( location.search ) {
-		new URLSearchParams( location.search.substring( 1 ) ).forEach(
-			( value, key ) => {
-				params[ key ] = value;
-			}
-		);
-	}
-	return params;
-};
-
-/**
  * Get the full URL if a relative path is passed.
  *
  * @param {string} url URL
@@ -57,7 +39,8 @@ export const isMatch = ( location, itemUrl, itemExpression = null ) => {
 	const fullUrl = getFullUrl( itemUrl );
 	const { href } = location;
 
-	const defaultExpression = '^' + fullUrl.replace( /[-\/\\^$*+?.()|[\]{}]/g, '\\$&' );
+	const defaultExpression =
+		'^' + fullUrl.replace( /[-\/\\^$*+?.()|[\]{}]/g, '\\$&' );
 	const regexp = new RegExp( itemExpression || defaultExpression );
 	return Boolean( decodeURIComponent( href ).match( regexp ) );
 };
@@ -113,7 +96,13 @@ export const getMatchingItem = ( items ) => {
 	let matchedItem = null;
 
 	items.forEach( ( item ) => {
-		if ( isMatch( window.location, getAdminLink( item.url ), item.matchExpression ) ) {
+		if (
+			isMatch(
+				window.location,
+				getAdminLink( item.url ),
+				item.matchExpression
+			)
+		) {
 			matchedItem = item;
 		}
 	} );

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -38,6 +38,12 @@ export const getMatchScore = ( location, itemUrl, itemExpression = null ) => {
 
 	const fullUrl = getFullUrl( itemUrl );
 	const { href } = location;
+
+	// Return highest possible score for exact match.
+	if ( fullUrl === href ) {
+		return Number.MAX_SAFE_INTEGER;
+	}
+
 	const defaultExpression = getDefaultMatchExpression( fullUrl );
 	const regexp = new RegExp( itemExpression || defaultExpression, 'i' );
 	return ( decodeURIComponent( href ).match( regexp ) || [] ).length;

--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -24,14 +24,14 @@ export const getFullUrl = ( url ) => {
 };
 
 /**
- * Check to see if a URL matches a given window location.
+ * Get a match score for a menu item given a location.
  *
  * @param {Object} location Window location
  * @param {string} itemUrl	 URL to compare
  * @param {string} itemExpression Custom match expression
  * @return {number} Number of matches or 0 if not matched.
  */
-export const isMatch = ( location, itemUrl, itemExpression = null ) => {
+export const getMatchScore = ( location, itemUrl, itemExpression = null ) => {
 	if ( ! itemUrl ) {
 		return;
 	}
@@ -40,7 +40,7 @@ export const isMatch = ( location, itemUrl, itemExpression = null ) => {
 	const { href } = location;
 	const defaultExpression = getDefaultMatchExpression( fullUrl );
 	const regexp = new RegExp( itemExpression || defaultExpression, 'i' );
-	return Boolean( decodeURIComponent( href ).match( regexp ) );
+	return ( decodeURIComponent( href ).match( regexp ) || [] ).length;
 };
 
 /**
@@ -110,15 +110,16 @@ export const addHistoryListener = ( listener ) => {
  */
 export const getMatchingItem = ( items ) => {
 	let matchedItem = null;
+	let highestMatchScore = 0;
 
 	items.forEach( ( item ) => {
-		if (
-			isMatch(
-				window.location,
-				getAdminLink( item.url ),
-				item.matchExpression
-			)
-		) {
+		const score = getMatchScore(
+			window.location,
+			getAdminLink( item.url ),
+			item.matchExpression
+		);
+		if ( score > 0 && score >= highestMatchScore ) {
+			highestMatchScore = score;
 			matchedItem = item;
 		}
 	} );

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -58,6 +58,7 @@ Adding an item, much like a category, can be added directly to the menu or to an
 * `capability` - (string) Capability to view this menu item.
 * `url` - (string) URL or callback to be used. Required.
 * `migrate` - (bool) Whether or not to hide the item in the wp admin menu.
+* `matchExpression` - (string) An optional regex string to compare against the current location and mark the item active.
 
 ```php
 \Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -156,10 +156,11 @@ class CoreMenu {
 		$home_item = array();
 		if ( defined( '\Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG' ) ) {
 			$home_item = array(
-				'id'    => 'woocommerce-home',
-				'title' => __( 'Home', 'woocommerce-admin' ),
-				'url'   => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
-				'order' => 0,
+				'id'              => 'woocommerce-home',
+				'title'           => __( 'Home', 'woocommerce-admin' ),
+				'url'             => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
+				'order'           => 0,
+				'matchExpression' => 'page=wc-admin((?!path=).)*$',
 			);
 		}
 

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -372,25 +372,30 @@ class Menu {
 			return;
 		}
 
-		$parent = isset( $menu_args['parent'] ) ? $menu_args['parent'] . '-' : '';
+		$parent           = isset( $menu_args['parent'] ) ? $menu_args['parent'] . '-' : '';
+		$match_expression = isset( $_GET['post'] ) && get_post_type( intval( $_GET['post'] ) ) === $post_type // phpcs:ignore WordPress.Security.NonceVerification
+			? '(edit.php|post.php)'
+			: null;
 
 		return array(
 			'default' => array_merge(
 				array(
-					'title'      => esc_attr( $post_type_object->labels->menu_name ),
-					'capability' => $post_type_object->cap->edit_posts,
-					'id'         => $parent . $post_type,
-					'url'        => "edit.php?post_type={$post_type}",
+					'title'           => esc_attr( $post_type_object->labels->menu_name ),
+					'capability'      => $post_type_object->cap->edit_posts,
+					'id'              => $parent . $post_type,
+					'url'             => "edit.php?post_type={$post_type}",
+					'matchExpression' => $match_expression,
 				),
 				$menu_args
 			),
 			'all'     => array_merge(
 				array(
-					'title'      => esc_attr( $post_type_object->labels->all_items ),
-					'capability' => $post_type_object->cap->edit_posts,
-					'id'         => "{$parent}{$post_type}-all-items",
-					'url'        => "edit.php?post_type={$post_type}",
-					'order'      => 10,
+					'title'           => esc_attr( $post_type_object->labels->all_items ),
+					'capability'      => $post_type_object->cap->edit_posts,
+					'id'              => "{$parent}{$post_type}-all-items",
+					'url'             => "edit.php?post_type={$post_type}",
+					'order'           => 10,
+					'matchExpression' => $match_expression,
 				),
 				$menu_args
 			),
@@ -600,7 +605,6 @@ class Menu {
 
 		$data = array(
 			'menuItems' => self::get_prepared_menu_item_data(),
-			'postType'  => isset( $_GET['post'] ) ? get_post_type( $_GET['post'] ) : null,
 		);
 
 		$paul = wp_add_inline_script( WC_ADMIN_APP, 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -184,14 +184,15 @@ class Menu {
 	 *
 	 * @param array $args Array containing the necessary arguments.
 	 *    $args = array(
-	 *      'id'         => (string) The unique ID of the menu item. Required.
-	 *      'title'      => (string) Title of the menu item. Required.
-	 *      'parent'     => (string) Parent menu item ID.
-	 *      'capability' => (string) Capability to view this menu item.
-	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'order'      => (int) Menu item order.
-	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'menuId'     => (string) The ID of the menu to add the item to.
+	 *      'id'              => (string) The unique ID of the menu item. Required.
+	 *      'title'           => (string) Title of the menu item. Required.
+	 *      'parent'          => (string) Parent menu item ID.
+	 *      'capability'      => (string) Capability to view this menu item.
+	 *      'url'             => (string) URL or callback to be used. Required.
+	 *      'order'           => (int) Menu item order.
+	 *      'migrate'         => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'          => (string) The ID of the menu to add the item to.
+	 *      'matchExpression' => (string) A regular expression used to identify if the menu item is active.
 	 *    ).
 	 */
 	private static function add_item( $args ) {
@@ -288,13 +289,14 @@ class Menu {
 	 *
 	 * @param array $args Array containing the necessary arguments.
 	 *    $args = array(
-	 *      'id'         => (string) The unique ID of the menu item. Required.
-	 *      'title'      => (string) Title of the menu item. Required.
-	 *      'parent'     => (string) Parent menu item ID.
-	 *      'capability' => (string) Capability to view this menu item.
-	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'order'      => (int) Menu item order.
+	 *      'id'              => (string) The unique ID of the menu item. Required.
+	 *      'title'           => (string) Title of the menu item. Required.
+	 *      'parent'          => (string) Parent menu item ID.
+	 *      'capability'      => (string) Capability to view this menu item.
+	 *      'url'             => (string) URL or callback to be used. Required.
+	 *      'migrate'         => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'order'           => (int) Menu item order.
+	 *      'matchExpression' => (string) A regular expression used to identify if the menu item is active.
 	 *    ).
 	 */
 	public static function add_plugin_item( $args ) {


### PR DESCRIPTION
Part 2 of route detection exploration.  Part 1 - https://github.com/woocommerce/woocommerce-admin/pull/5798

* This PR adds the ability for nav items to determine active status via regular expressions.
* By default a nav item will be matched if the current location begins with this nav item's URL.
* Matching will still cycle through all registered items and use the last matched item.  This is optional, but may be slightly safer if a catch-all page is registered prior to other items.  For example, the WCA homepage `admin.php?page=wc-admin` would match before any others if an expression had not been added).

While I was pretty opposed to this approach, I'm starting to lean heavily in favor of this approach for a few reasons.
1. The default expression works for 90% of use cases without any fancy logic.
1. It opens up the possibility for negative lookaheads to prevent matching on items even if the path matches.
1. It resolves issues we have with matching both post types and taxonomies.
1. It allows a catch-all page if a plugin wants to mark a different page active.
1. Less logic to test.

### Detailed test instructions:

1. Register a page in WCA without registering in the nav:

```php
wc_admin_register_page(
    array(
        'id'     => 'unregistered-page',
        'title'  => __( 'Unregistered Page', 'woocommerce-admin' ),
        'path'   => '/unregistered-page',
    )
);
```

2. Navigate to `wp-admin/admin.php?page=wc-admin&path=/unregistered-page`
2. Note the home item is not marked active despite a matching path and start of URL.
3. Navigate to `Home` and its subpages (tasks).
4. Make sure `Home` is now marked active.
5. Navigate to various post type pages (orders and products).
6. Make sure items are correctly marked active.
7. Make sure no other regressions have occurred with active status on items.