### PR TITLE
Convert before and after dates to UTC in Analytics queries

### DIFF
--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -692,6 +692,8 @@ class DataStore extends SqlQuery {
 				$datetime_str = $query_args['before']->date( TimeInterval::$sql_datetime_format );
 			} else {
 				$datetime_str = $query_args['before']->format( TimeInterval::$sql_datetime_format );
+				$datetime_str = TimeInterval::convert_local_datetime_to_gmt( $datetime_str )
+											->format( TimeInterval::$sql_datetime_format );
 			}
 			if ( isset( $this->subquery ) ) {
 				$this->subquery->add_sql_clause( 'where_time', "AND {$table_name}.date_created <= '$datetime_str'" );
@@ -705,6 +707,8 @@ class DataStore extends SqlQuery {
 				$datetime_str = $query_args['after']->date( TimeInterval::$sql_datetime_format );
 			} else {
 				$datetime_str = $query_args['after']->format( TimeInterval::$sql_datetime_format );
+				$datetime_str = TimeInterval::convert_local_datetime_to_gmt( $datetime_str )
+											->format( TimeInterval::$sql_datetime_format );
 			}
 			if ( isset( $this->subquery ) ) {
 				$this->subquery->add_sql_clause( 'where_time', "AND {$table_name}.date_created >= '$datetime_str'" );


### PR DESCRIPTION
Fixes #5810 

This PR fixes issue #5810 by converting `before` and `after` dates into UTC (GMT to be exact). More details are in the issue.

I think the fix is reasonable, but I want to be extra careful since this is how it has been working from the beginning. I would appreciate any inputs/suggestions or alternative solutions.


### Detailed test instructions:

- Make sure that your server timezone is set to UTC by navigating to WooCommerce -> Status. Check for the `Default timezone is UTC` setting. UTC is the default setting unless you have modified `wp-settings.php` for some reason.
- Set a user timezone either by selecting a city or an offset on Settings -> General page. Let's use "Los Angeles" or "UTC-8" for testing purposes. 
- Enable debug mode in `wp-config.php` by setting `WP_DEBUG` and `WP_DEBUG_LOG` constants to `true`.

1. Make a test order and confirm that the order is in the `wp_wc_order_status` table and both `date_created` and `date_created_gmt` are in UTC time.
2. Open [Orders/DataStore.php](https://github.com/woocommerce/woocommerce-admin/blob/ea83f9ba690329cbfc65f373c4a51ccc6dc88066/src/API/Reports/Orders/DataStore.php#L253) and add `error_log($this->subquery->get_query_statement());`
3. Open a terminal and cd to your WordPress directory. Start watching debug file by executing `tail -f wp-content/debug.log`
4. Navigate to Analytics -> Orders and select "Today" from the datepicker. Selecting "Today" will request YYYY-MM-DD 00:00:00 and YYYY-MM-DD 23:59:59 to the backend.
5. Check the terminal log. You should see a log that contains the following line.
`wp_wc_order_stats.date_created <= '2020-12-04 07:59:59' AND wp_wc_order_stats.date_created >= '2020-12-01 08:00:00'`
6. Confirm that the dates have values of +-(UTC offset of your timezone).

If you don't see anything from the console log, try clearing Analytics cache from WooCommerce -> Status -> Tools -> Clear analytics cache
