### PR TITLE
Add Customer Type column to the Orders report table

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -17,6 +17,9 @@ import ReportTable from '../../components/report-table';
 import { CurrencyContext } from '../../../lib/currency-context';
 import './style.scss';
 
+const capitalizeFirstLetter = ( expr ) =>
+	expr.charAt( 0 ).toUpperCase() + expr.slice( 1 );
+
 class OrdersReportTable extends Component {
 	constructor() {
 		super();
@@ -51,6 +54,12 @@ class OrdersReportTable extends Component {
 			{
 				label: __( 'Customer', 'woocommerce-admin' ),
 				key: 'customer_id',
+				required: false,
+				isSortable: false,
+			},
+			{
+				label: __( 'Customer Type', 'woocommerce-admin' ),
+				key: 'customer_type',
 				required: false,
 				isSortable: false,
 			},
@@ -112,6 +121,7 @@ class OrdersReportTable extends Component {
 				order_number: orderNumber,
 				parent_id: parentId,
 				status,
+				customer_type: customerType,
 			} = row;
 			const extendedInfo = row.extended_info || {};
 			const { coupons, customer, products } = extendedInfo;
@@ -174,6 +184,10 @@ class OrdersReportTable extends Component {
 				{
 					display: this.getCustomerName( customer ),
 					value: this.getCustomerName( customer ),
+				},
+				{
+					display: capitalizeFirstLetter( customerType ),
+					value: customerType,
 				},
 				{
 					display: this.renderList(

--- a/readme.txt
+++ b/readme.txt
@@ -78,8 +78,10 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
-= 1.7.0 11/11/2020 =
+= vnext =
+- Fix: Add Customer Type column to the Orders report table. #5820
 
+= 1.7.0 11/11/2020 =
 - Enhancement: Variations report.  #5167
 - Enhancement: Add ability to toggle homescreen layouts. #5429
 - Enhancement: Accordion component  #5474


### PR DESCRIPTION
Fixes #5181

This adds the customer type to the orders table. The data was being generated and sent on the server, this PR just maps the data to the UI.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/101115497-31b15480-362f-11eb-86b8-cf46920a887b.png)

### Detailed test instructions:

1. have some orders in the system
1. go to Analytics/Orders
1. note that the "Customer Type" column is present and populated

