### PR TITLE
Add page parameter to getNewPath to override default page wc-admin

### DIFF
--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -93,14 +93,16 @@ export function getSearchWords( query = navUtils.getQuery() ) {
  * @param {Object} query object of params to be updated.
  * @param {string} path Relative path (defaults to current path).
  * @param {Object} currentQuery object of current query params (defaults to current querystring).
+ * @param {string} page Page key (defaults to "wc-admin")
  * @return {string}  Updated URL merging query params into existing params.
  */
 export function getNewPath(
 	query,
 	path = getPath(),
-	currentQuery = getQuery()
+	currentQuery = getQuery(),
+	page = 'wc-admin'
 ) {
-	const args = { page: 'wc-admin', ...currentQuery, ...query };
+	const args = { page, ...currentQuery, ...query };
 	if ( path !== '/' ) {
 		args.path = path;
 	}
@@ -156,13 +158,15 @@ export function onQueryChange( param, path = getPath(), query = getQuery() ) {
  * @param {Object} query object of params to be updated.
  * @param {string} path Relative path (defaults to current path).
  * @param {Object} currentQuery object of current query params (defaults to current querystring).
+ * @param {string} page Page key (defaults to "wc-admin")
  */
 export function updateQueryString(
 	query,
 	path = getPath(),
-	currentQuery = getQuery()
+	currentQuery = getQuery(),
+	page = 'wc-admin'
 ) {
-	const newPath = getNewPath( query, path, currentQuery );
+	const newPath = getNewPath( query, path, currentQuery, page );
 	getHistory().push( newPath );
 }
 

--- a/packages/navigation/src/test/index.js
+++ b/packages/navigation/src/test/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getPersistedQuery, getSearchWords } from '../index';
+import { getPersistedQuery, getSearchWords, getNewPath } from '../index';
 
 jest.mock( '../index', () => ( {
 	...require.requireActual( '../index' ),
@@ -106,5 +106,32 @@ describe( 'getSearchWords', () => {
 		};
 
 		expect( () => getSearchWords( query ) ).toThrow( Error );
+	} );
+} );
+
+describe( 'getNewPath', () => {
+	it( 'should have default page as "wc-admin"', () => {
+		const path = getNewPath( {}, '', {} );
+
+		expect( path ).toEqual( 'admin.php?page=wc-admin&path=' );
+	} );
+
+	it( 'should override default page when page parameter is specified', () => {
+		const path = getNewPath( {}, '', {}, 'custom-page' );
+
+		expect( path ).toEqual( 'admin.php?page=custom-page&path=' );
+	} );
+
+	it( 'should override default page by query parameter over page parameter', () => {
+		const path = getNewPath(
+			{
+				page: 'custom-page',
+			},
+			'',
+			{},
+			'default-page'
+		);
+
+		expect( path ).toEqual( 'admin.php?page=custom-page&path=' );
 	} );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Unreleased ==
 
 - Enhancement: Tasks extensibility in Home Screen. #5794
+- Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821
 - Fix: Invalidate product count if the last product was updated in the list. #5790
 
 == Changelog ==


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5077

This PR adds `page` parameter to `getNewPath` and `updateQueryString` in Navigation API to provide the option for developers to override the default page. Previously it was possible to override the default page through `query` parameter but does so implicitly. This PR aims to improve the developer experience.

### Detailed test instructions:
Unit tests are added to verify that it should not change previous behavior.

- Run tests `npm run test`
- Run e2e tests `npm run test:e2e`

### Changelog Note:
Enhancement: Add page parameter to override default `wc-admin` page in Navigation API