### PR TITLE
Fix Orders Report Product/Variation Exclusion Filters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 = vnext =
 - Fix: Add Customer Type column to the Orders report table. #5820
+- Fix: Product exclusion filter on Orders Report.
 
 = 1.7.0 11/11/2020 =
 - Enhancement: Variations report.  #5167

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -140,27 +140,25 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$included_products = $this->get_included_products( $query_args );
 		$excluded_products = $this->get_excluded_products( $query_args );
 		if ( $included_products || $excluded_products ) {
-			$have_joined_products_table = true;
-			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id" );
+			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} product_lookup ON {$order_stats_lookup_table}.order_id = product_lookup.order_id" );
 		}
 		if ( $included_products ) {
-			$where_subquery[] = "{$order_product_lookup_table}.product_id IN ({$included_products})";
+			$where_subquery[] = "product_lookup.product_id IN ({$included_products})";
 		}
 		if ( $excluded_products ) {
-			$where_subquery[] = "{$order_product_lookup_table}.product_id NOT IN ({$excluded_products})";
+			$where_subquery[] = "product_lookup.product_id NOT IN ({$excluded_products})";
 		}
 
 		$included_variations = $this->get_included_variations( $query_args );
 		$excluded_variations = $this->get_excluded_variations( $query_args );
-		if ( ! $have_joined_products_table && ( $included_variations || $excluded_variations ) ) {
-			$have_joined_products_table = true;
-			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id" );
+		if ( $included_variations || $excluded_variations ) {
+			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} variation_lookup ON {$order_stats_lookup_table}.order_id = variation_lookup.order_id" );
 		}
 		if ( $included_variations ) {
-			$where_subquery[] = "{$order_product_lookup_table}.variation_id IN ({$included_variations})";
+			$where_subquery[] = "variation_lookup.variation_id IN ({$included_variations})";
 		}
 		if ( $excluded_variations ) {
-			$where_subquery[] = "{$order_product_lookup_table}.variation_id NOT IN ({$excluded_variations})";
+			$where_subquery[] = "variation_lookup.variation_id NOT IN ({$excluded_variations})";
 		}
 
 		$included_tax_rates = ! empty( $query_args['tax_rate_includes'] ) ? implode( ',', $query_args['tax_rate_includes'] ) : false;
@@ -177,11 +175,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$attribute_subqueries = $this->get_attribute_subqueries( $query_args );
 		if ( $attribute_subqueries['join'] && $attribute_subqueries['where'] ) {
-			// JOIN on product lookup if we haven't already.
-			if ( ! $have_joined_products_table ) {
-				$have_joined_products_table = true;
-				$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id" );
-			}
+			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id" );
+
 			// Add JOINs for matching attributes.
 			foreach ( $attribute_subqueries['join'] as $attribute_join ) {
 				$this->subquery->add_sql_clause( 'join', $attribute_join );

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -140,25 +140,31 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$included_products = $this->get_included_products( $query_args );
 		$excluded_products = $this->get_excluded_products( $query_args );
 		if ( $included_products || $excluded_products ) {
-			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} product_lookup ON {$order_stats_lookup_table}.order_id = product_lookup.order_id" );
+			$this->subquery->add_sql_clause( 'join', "LEFT JOIN {$order_product_lookup_table} product_lookup" );
+			$this->subquery->add_sql_clause( 'join', "ON {$order_stats_lookup_table}.order_id = product_lookup.order_id" );
 		}
 		if ( $included_products ) {
-			$where_subquery[] = "product_lookup.product_id IN ({$included_products})";
+			$this->subquery->add_sql_clause( 'join', "AND product_lookup.product_id IN ({$included_products})" );
+			$where_subquery[] = 'product_lookup.order_id IS NOT NULL';
 		}
 		if ( $excluded_products ) {
-			$where_subquery[] = "product_lookup.product_id NOT IN ({$excluded_products})";
+			$this->subquery->add_sql_clause( 'join', "AND product_lookup.product_id IN ({$excluded_products})" );
+			$where_subquery[] = 'product_lookup.order_id IS NULL';
 		}
 
 		$included_variations = $this->get_included_variations( $query_args );
 		$excluded_variations = $this->get_excluded_variations( $query_args );
 		if ( $included_variations || $excluded_variations ) {
-			$this->subquery->add_sql_clause( 'join', "JOIN {$order_product_lookup_table} variation_lookup ON {$order_stats_lookup_table}.order_id = variation_lookup.order_id" );
+			$this->subquery->add_sql_clause( 'join', "LEFT JOIN {$order_product_lookup_table} variation_lookup" );
+			$this->subquery->add_sql_clause( 'join', "ON {$order_stats_lookup_table}.order_id = variation_lookup.order_id" );
 		}
 		if ( $included_variations ) {
-			$where_subquery[] = "variation_lookup.variation_id IN ({$included_variations})";
+			$this->subquery->add_sql_clause( 'join', "AND variation_lookup.variation_id IN ({$included_variations})" );
+			$where_subquery[] = 'variation_lookup.order_id IS NOT NULL';
 		}
 		if ( $excluded_variations ) {
-			$where_subquery[] = "variation_lookup.variation_id NOT IN ({$excluded_variations})";
+			$this->subquery->add_sql_clause( 'join', "AND variation_lookup.variation_id IN ({$excluded_variations})" );
+			$where_subquery[] = 'variation_lookup.order_id IS NULL';
 		}
 
 		$included_tax_rates = ! empty( $query_args['tax_rate_includes'] ) ? implode( ',', $query_args['tax_rate_includes'] ) : false;


### PR DESCRIPTION
Fixes (in part) #5803. It addresses the issues pointed out by @joelclimbsthings in https://github.com/woocommerce/woocommerce-admin/issues/5803#issuecomment-738403405.

This PR fixes two issues with the Orders Report filters:
* Stacking Product, Variation, and Attribute filters would try to apply all filters to the same product in the table query (summary numbers were correct, based on an matching the **order** having these items)
* Excluding a Product or Variation resulted in many duplicate orders in the table

### Detailed test instructions:

- Go to the Orders Report, using a date range with many orders
- Add a Product filter, exclude a product seen in the results
- Verify the table has no duplicates
- Change the Product filter to "includes"
- Add a Variation filter, include a variation seen in the results (requires variable products that have been ordered)
- Verify that the table count matches the summary numbers

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
