### PR TITLE
Fix Inconsistent Customer Type Parameter in REST endpoints

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Fix inconsistent REST API paramater name for customer type filtering.
 - Enhancement: Tasks extensibility in Home Screen. #5794
 - Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821
 - Fix: Invalidate product count if the last product was updated in the list. #5790

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1196,10 +1196,10 @@ class DataStore extends SqlQuery {
 		global $wpdb;
 
 		$customer_filter = '';
-		if ( isset( $query_args['customer'] ) ) {
-			if ( 'new' === strtolower( $query_args['customer'] ) ) {
+		if ( isset( $query_args['customer_type'] ) ) {
+			if ( 'new' === strtolower( $query_args['customer_type'] ) ) {
 				$customer_filter = " {$wpdb->prefix}wc_order_stats.returning_customer = 0";
-			} elseif ( 'returning' === strtolower( $query_args['customer'] ) ) {
+			} elseif ( 'returning' === strtolower( $query_args['customer_type'] ) ) {
 				$customer_filter = " {$wpdb->prefix}wc_order_stats.returning_customer = 1";
 			}
 		}

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -59,12 +59,17 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$args['coupon_excludes']    = (array) $request['coupon_excludes'];
 		$args['tax_rate_includes']  = (array) $request['tax_rate_includes'];
 		$args['tax_rate_excludes']  = (array) $request['tax_rate_excludes'];
-		$args['customer']           = $request['customer'];
+		$args['customer_type']      = $request['customer_type'];
 		$args['refunds']            = $request['refunds'];
 		$args['attribute_is']       = (array) $request['attribute_is'];
 		$args['attribute_is_not']   = (array) $request['attribute_is_not'];
 		$args['category_includes']  = (array) $request['categories'];
 		$args['segmentby']          = $request['segmentby'];
+
+		// For backwards compatibility, `customer` is aliased to `customer_type`.
+		if ( empty( $request['customer_type'] ) && ! empty( $request['customer'] ) ) {
+			$args['customer_type'] = $request['customer'];
+		}
 
 		return $args;
 	}
@@ -495,6 +500,15 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['customer']           = array(
+			'description'       => __( 'Alias for customer_type (deprecated).', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'enum'              => array(
+				'new',
+				'returning',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['customer_type']      = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'enum'              => array(

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -509,7 +509,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['customer_type']      = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that have the specified customer_type', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'new',

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -280,7 +280,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'coupon_excludes'   => array(),
 			'tax_rate_includes' => array(),
 			'tax_rate_excludes' => array(),
-			'customer'          => '',
+			'customer_type'     => '',
 			'category_includes' => array(),
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -2108,10 +2108,10 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 		// * Customer filters
 		// ** Customer new
 		$query_args = array(
-			'after'    => $current_hour_start->format( TimeInterval::$sql_datetime_format ),
-			'before'   => $current_hour_end->format( TimeInterval::$sql_datetime_format ),
-			'interval' => 'hour',
-			'customer' => 'new',
+			'after'         => $current_hour_start->format( TimeInterval::$sql_datetime_format ),
+			'before'        => $current_hour_end->format( TimeInterval::$sql_datetime_format ),
+			'interval'      => 'hour',
+			'customer_type' => 'new',
 		);
 
 		$orders_count   = 2;
@@ -2173,10 +2173,10 @@ class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 
 		// ** Customer returning
 		$query_args = array(
-			'after'    => $current_hour_start->format( TimeInterval::$sql_datetime_format ), // I don't think this makes sense.... gmdate( 'Y-m-d H:i:s', $orders[0]->get_date_created()->getOffsetTimestamp() + 1 ), // Date after initial order to get a returning customer.
-			'before'   => $current_hour_end->format( TimeInterval::$sql_datetime_format ),
-			'interval' => 'hour',
-			'customer' => 'returning',
+			'after'         => $current_hour_start->format( TimeInterval::$sql_datetime_format ), // I don't think this makes sense.... gmdate( 'Y-m-d H:i:s', $orders[0]->get_date_created()->getOffsetTimestamp() + 1 ), // Date after initial order to get a returning customer.
+			'before'        => $current_hour_end->format( TimeInterval::$sql_datetime_format ),
+			'interval'      => 'hour',
+			'customer_type' => 'returning',
 		);
 
 		$total_orders_count     = 144;


### PR DESCRIPTION
The `wc-analytics/reports/orders` and `/wc-analytics/reports/orders/stats` endpoints have inconsistent parameter names for filtering the customer type: `customer_type` vs `customer`.

This was affecting the Customer Type filter in the orders analytics, reported in issue #5803, where the component expects the parameter names to be the same. This is because it uses a paramater name based on the [key in the filter configuration](https://github.com/woocommerce/woocommerce-admin/blob/831c9ff13a862f22cf53d3ae676daeabbefe90ad/client/analytics/report/orders/config.js#L247) (`customer_type`). 

![Screen Shot 2020-12-04 at 1 29 41 pm](https://user-images.githubusercontent.com/9312929/101156463-98506580-3663-11eb-83a2-5d11f30c223b.png)

To resolve this, this PR updates `/wc-analytics/reports/orders/stats` to accept both `customer_type` and `customer` as parameter names for this filter.  I have however deprecated the `customer` parameter in its description to discourage usage.

### Alternative approach

An alternative approach is to keep the inconsistent names, and modify the filter component(s) to use a different parameter name depending on the endpoint being fetched. I think this is less ideal because the inconsistency can add confusion.

### Detailed test instructions:

-   For the the `/wc-analytics/reports/orders/stats` REST API endpoint, check that the `customer` and `customer_type` parameters return identical results for values of `new` and `returning`.