### PR TITLE
Fix updating WC customer without wordpress user (if multiple orders are present)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Tasks extensibility in Home Screen. #5794
 - Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821
 - Fix: Invalidate product count if the last product was updated in the list. #5790
+- Fix: Updating (non wordpress user) customer with order data
 
 == Changelog ==
 

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -132,6 +132,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Only updates customer if it is the customers last order.
 	 *
 	 * @param int $post_id of order.
+	 * @return true|-1
 	 */
 	public static function sync_order_customer( $post_id ) {
 		global $wpdb;
@@ -643,8 +644,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				ORDER BY date_created_gmt DESC, order_id DESC LIMIT 1",
 				// phpcs:enable
 				$customer_id
-			),
-			0
+			)
 		);
 		if ( ! $last_order ) {
 			return false;

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -142,7 +142,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$order       = wc_get_order( $post_id );
 		$customer_id = self::get_existing_customer_id_from_order( $order );
-		if ( ! $customer_id ) {
+		if ( false === $customer_id ) {
 			return -1;
 		}
 		$last_order = self::get_last_order( $customer_id );
@@ -629,23 +629,22 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Retrieve the last order made by a customer.
 	 *
 	 * @param int $customer_id Customer ID.
-	 * @return object Order|false.
+	 * @return object WC_Order|false.
 	 */
 	public static function get_last_order( $customer_id ) {
 		global $wpdb;
-		$orders_table                = $wpdb->prefix . 'wc_order_stats';
-		$excluded_statuses_condition = "AND status IN ( '" . implode( "','", array_map( 'esc_sql', array_keys( wc_get_order_statuses() ) ) ) . "' )";
+		$orders_table = $wpdb->prefix . 'wc_order_stats';
 
 		$last_order = $wpdb->get_var(
 			$wpdb->prepare(
 				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT order_id FROM {$orders_table}
+				"SELECT order_id, date_created_gmt FROM {$orders_table}
 				WHERE customer_id = %d
-				{$excluded_statuses_condition}
-				ORDER BY order_id DESC LIMIT 1",
+				ORDER BY date_created_gmt DESC, order_id DESC LIMIT 1",
 				// phpcs:enable
 				$customer_id
-			)
+			),
+			0
 		);
 		if ( ! $last_order ) {
 			return false;

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -545,7 +545,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		WC_Helper_Queue::run_all_pending();
 
 		// Didn't update anything.
-		$this->assertEquals( -1, $result );
+		$this->assertTrue( -1 === $result );
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
 		$reports  = $response->get_data();
@@ -597,7 +597,7 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		WC_Helper_Queue::run_all_pending();
 
 		// Didn't update anything.
-		$this->assertEquals( -1, $result );
+		$this->assertTrue( $result );
 		$request  = new WP_REST_Request( 'GET', $this->endpoint );
 		$response = $this->server->dispatch( $request );
 		$reports  = $response->get_data();

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -602,15 +602,17 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$reports  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
+		$first_customer_index  = array_search( 'admin@example.org', array_column( $reports, 'email' ), true );
+		$second_customer_index = array_search( 'different@example.org', array_column( $reports, 'email' ), true );
 		// First customer.
-		$this->assertEquals( 'admin@example.org', $reports[0]['email'] );
-		$this->assertNotEquals( 'Random', $reports[0]['city'] );
-		$this->assertNotEquals( 'FL', $reports[0]['state'] );
-		$this->assertNotEquals( '54321', $reports[0]['postcode'] );
+		$this->assertEquals( 'admin@example.org', $reports[ $first_customer_index ]['email'] );
+		$this->assertNotEquals( 'Random', $reports[ $first_customer_index ]['city'] );
+		$this->assertNotEquals( 'FL', $reports[ $first_customer_index ]['state'] );
+		$this->assertNotEquals( '54321', $reports[ $first_customer_index ]['postcode'] );
 		// Latest customer that should be updated.
-		$this->assertEquals( 'different@example.org', $reports[1]['email'] );
-		$this->assertEquals( 'Random', $reports[1]['city'] );
-		$this->assertEquals( 'FL', $reports[1]['state'] );
-		$this->assertEquals( '54321', $reports[1]['postcode'] );
+		$this->assertEquals( 'different@example.org', $reports[ $second_customer_index ]['email'] );
+		$this->assertEquals( 'Random', $reports[ $second_customer_index ]['city'] );
+		$this->assertEquals( 'FL', $reports[ $second_customer_index ]['state'] );
+		$this->assertEquals( '54321', $reports[ $second_customer_index ]['postcode'] );
 	}
 }


### PR DESCRIPTION
Fixes #4152

Added a `get_last_order` function to the customer datastore that uses the customer_id instead of making use of the Wordpress user id.

### Screenshots

![update-customer-order](https://user-images.githubusercontent.com/2240960/101204487-ae016300-3642-11eb-856d-b60ea6585820.gif)

### Detailed test instructions:

- Create two orders with an unregistered user (use incognito window)
- Create another order with a new unregistered user (use different email)
- Update this last order in **WooCommerce -> Orders** (billing info/name).
- Go to **WooCommerce -> Customers** the data of the newest customer/order should be updated.