### PR TITLE
Highlight help panel with tooltip

### DIFF
--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 import {
 	Popover,
 	Card,
@@ -87,16 +88,19 @@ function HighlightTooltip( {
 			{ showHighlight ? (
 				<>
 					<IsolatedEventContainer className="highlight-tooltip__overlay" />
-					<div className="highlight-tooltip__highlighter"></div>
-					<Popover className="highlight-tooltip__popover">
+					<Popover
+						className="highlight-tooltip__popover"
+						noArrow={ false }
+						focusOnMount="container"
+					>
 						<Card
-							size="small"
+							size="medium"
 							className="woocommerce-task-card woocommerce-homescreen-card"
 						>
-							<CardHeader size="small">
+							<CardHeader>
 								{ title }
 								<Button
-									size="small"
+									isSmall
 									onClick={ triggerClose }
 									icon={ close }
 								/>
@@ -108,7 +112,7 @@ function HighlightTooltip( {
 									isPrimary
 									onClick={ triggerClose }
 								>
-									{ closeBtnText }
+									{ closeBtnText || __( 'Close' ) }
 								</Button>
 							</CardFooter>
 						</Card>

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import {
+	Popover,
+	Card,
+	CardBody,
+	CardHeader,
+	Button,
+	IsolatedEventContainer,
+} from '@wordpress/components';
+import { useState, useEffect, createPortal } from '@wordpress/element';
+import { close } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const SHOW_CLASS = 'highlight-tooltip__show';
+export function HighlightTooltipUncontrolled( {
+	title,
+	show,
+	id,
+	onClose,
+	delay,
+} ) {
+	const [ showHighlight, setShowHighlight ] = useState(
+		delay > 0 ? false : show
+	);
+	const [ node, setNode ] = useState( null );
+
+	useEffect( () => {
+		const element = document.getElementById( id );
+		if ( element && ! node ) {
+			const parent = element.parentElement;
+			const container = document.createElement( 'div' );
+			container.classList.add(
+				'highlight-tooltip__container',
+				SHOW_CLASS
+			);
+			parent.appendChild( container );
+			setNode( container );
+		}
+		let timeoutId;
+		if ( delay > 0 ) {
+			timeoutId = setTimeout( () => {
+				timeoutId = null;
+				setShowHighlight( show );
+			}, delay );
+		}
+		return () => {
+			if ( node ) {
+				const parent = node.parentElement;
+				parent.removeChild( node );
+			}
+			if ( timeoutId ) {
+				clearTimeout( timeoutId );
+			}
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( ! showHighlight && node ) {
+			node.classList.remove( SHOW_CLASS );
+		}
+	}, [ showHighlight ] );
+
+	const triggerClose = () => {
+		setShowHighlight( false );
+		if ( onClose ) {
+			onClose();
+		}
+	};
+
+	if ( ! node || ! showHighlight ) {
+		return null;
+	}
+
+	return createPortal(
+		<div className="highlight-tooltip__portal">
+			<IsolatedEventContainer className="highlight-tooltip__overlay" />
+			<div className="highlight-tooltip__highlighter"></div>
+			<Popover className="highlight-tooltip__popover">
+				<Card
+					size="small"
+					className="woocommerce-task-card woocommerce-homescreen-card"
+				>
+					<CardHeader size="small">
+						{ title }
+						<Button
+							size="small"
+							onClick={ triggerClose }
+							icon={ close }
+						/>
+					</CardHeader>
+					<CardBody></CardBody>
+				</Card>
+			</Popover>
+		</div>,
+		node
+	);
+}

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import {
 	Popover,
 	Card,
 	CardBody,
 	CardHeader,
+	CardFooter,
 	Button,
 	IsolatedEventContainer,
 } from '@wordpress/components';
@@ -18,9 +20,11 @@ import { close } from '@wordpress/icons';
 import './style.scss';
 
 const SHOW_CLASS = 'highlight-tooltip__show';
-export function HighlightTooltipUncontrolled( {
+function HighlightTooltip( {
 	title,
-	show,
+	closeBtnText,
+	content,
+	show = true,
 	id,
 	onClose,
 	delay,
@@ -32,9 +36,10 @@ export function HighlightTooltipUncontrolled( {
 
 	useEffect( () => {
 		const element = document.getElementById( id );
+		let container;
 		if ( element && ! node ) {
 			const parent = element.parentElement;
-			const container = document.createElement( 'div' );
+			container = document.createElement( 'div' );
 			container.classList.add(
 				'highlight-tooltip__container',
 				SHOW_CLASS
@@ -50,9 +55,9 @@ export function HighlightTooltipUncontrolled( {
 			}, delay );
 		}
 		return () => {
-			if ( node ) {
-				const parent = node.parentElement;
-				parent.removeChild( node );
+			if ( container ) {
+				const parent = container.parentElement;
+				parent.removeChild( container );
 			}
 			if ( timeoutId ) {
 				clearTimeout( timeoutId );
@@ -73,31 +78,77 @@ export function HighlightTooltipUncontrolled( {
 		}
 	};
 
-	if ( ! node || ! showHighlight ) {
+	if ( ! node ) {
 		return null;
 	}
 
 	return createPortal(
 		<div className="highlight-tooltip__portal">
-			<IsolatedEventContainer className="highlight-tooltip__overlay" />
-			<div className="highlight-tooltip__highlighter"></div>
-			<Popover className="highlight-tooltip__popover">
-				<Card
-					size="small"
-					className="woocommerce-task-card woocommerce-homescreen-card"
-				>
-					<CardHeader size="small">
-						{ title }
-						<Button
+			{ showHighlight ? (
+				<>
+					<IsolatedEventContainer className="highlight-tooltip__overlay" />
+					<div className="highlight-tooltip__highlighter"></div>
+					<Popover className="highlight-tooltip__popover">
+						<Card
 							size="small"
-							onClick={ triggerClose }
-							icon={ close }
-						/>
-					</CardHeader>
-					<CardBody></CardBody>
-				</Card>
-			</Popover>
+							className="woocommerce-task-card woocommerce-homescreen-card"
+						>
+							<CardHeader size="small">
+								{ title }
+								<Button
+									size="small"
+									onClick={ triggerClose }
+									icon={ close }
+								/>
+							</CardHeader>
+							<CardBody>{ content || null }</CardBody>
+							<CardFooter isBorderless={ true }>
+								<Button
+									size="small"
+									isPrimary
+									onClick={ triggerClose }
+								>
+									{ closeBtnText }
+								</Button>
+							</CardFooter>
+						</Card>
+					</Popover>
+				</>
+			) : null }
 		</div>,
 		node
 	);
 }
+
+HighlightTooltip.propTypes = {
+	/**
+	 * The id of the element it should highlight.
+	 */
+	id: PropTypes.string.isRequired,
+	/**
+	 * Title of the popup
+	 */
+	title: PropTypes.string.isRequired,
+	/**
+	 * Text of the close button.
+	 */
+	closeBtnText: PropTypes.string.isRequired,
+	/**
+	 * Content of the popup, can be either text or react element.
+	 */
+	content: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+	/**
+	 * If to show the popup, defaults to true.
+	 */
+	show: PropTypes.bool,
+	/**
+	 * Callback for when the user closes the popup.
+	 */
+	onClose: PropTypes.func,
+	/**
+	 * This will delay the popup from appearing by the number of ms.
+	 */
+	delay: PropTypes.number,
+};
+
+export { HighlightTooltip };

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { useState, useEffect, createPortal } from '@wordpress/element';
 import { close } from '@wordpress/icons';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ function HighlightTooltip( {
 	id,
 	onClose,
 	delay,
+	onShow = noop,
 } ) {
 	const [ showHighlight, setShowHighlight ] = useState(
 		delay > 0 ? null : show
@@ -85,12 +87,14 @@ function HighlightTooltip( {
 					container.classList.add( SHOW_CLASS );
 				}
 				setShowHighlight( show );
+				onShow();
 			}, delay );
 		} else if ( ! showHighlight ) {
 			if ( container ) {
 				container.classList.add( SHOW_CLASS );
 			}
 			setShowHighlight( true );
+			onShow();
 		}
 		return timeoutId;
 	};
@@ -174,6 +178,10 @@ HighlightTooltip.propTypes = {
 	 * This will delay the popup from appearing by the number of ms.
 	 */
 	delay: PropTypes.number,
+	/**
+	 * A callback for when the tooltip is shown.
+	 */
+	onShow: PropTypes.func,
 };
 
 export { HighlightTooltip };

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -93,10 +93,7 @@ function HighlightTooltip( {
 						noArrow={ false }
 						focusOnMount="container"
 					>
-						<Card
-							size="medium"
-							className="woocommerce-task-card woocommerce-homescreen-card"
-						>
+						<Card size="medium">
 							<CardHeader>
 								{ title }
 								<Button
@@ -112,7 +109,8 @@ function HighlightTooltip( {
 									isPrimary
 									onClick={ triggerClose }
 								>
-									{ closeButtonText || __( 'Close' ) }
+									{ closeButtonText ||
+										__( 'Close', 'woocommerce-admin' ) }
 								</Button>
 							</CardFooter>
 						</Card>

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -23,7 +23,7 @@ import './style.scss';
 const SHOW_CLASS = 'highlight-tooltip__show';
 function HighlightTooltip( {
 	title,
-	closeBtnText,
+	closeButtonText,
 	content,
 	show = true,
 	id,
@@ -112,7 +112,7 @@ function HighlightTooltip( {
 									isPrimary
 									onClick={ triggerClose }
 								>
-									{ closeBtnText || __( 'Close' ) }
+									{ closeButtonText || __( 'Close' ) }
 								</Button>
 							</CardFooter>
 						</Card>
@@ -136,7 +136,7 @@ HighlightTooltip.propTypes = {
 	/**
 	 * Text of the close button.
 	 */
-	closeBtnText: PropTypes.string.isRequired,
+	closeButtonText: PropTypes.string.isRequired,
 	/**
 	 * Content of the popup, can be either text or react element.
 	 */

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -31,7 +31,7 @@ function HighlightTooltip( {
 	delay,
 } ) {
 	const [ showHighlight, setShowHighlight ] = useState(
-		delay > 0 ? false : show
+		delay > 0 ? null : show
 	);
 	const [ node, setNode ] = useState( null );
 
@@ -42,14 +42,11 @@ function HighlightTooltip( {
 			// Add tooltip container
 			const parent = element.parentElement;
 			container = document.createElement( 'div' );
-			container.classList.add(
-				'highlight-tooltip__container',
-				SHOW_CLASS
-			);
+			container.classList.add( 'highlight-tooltip__container' );
 			parent.appendChild( container );
 			setNode( container );
 		}
-		const timeoutId = showTooltip();
+		const timeoutId = showTooltip( container );
 
 		return () => {
 			if ( container ) {
@@ -69,27 +66,30 @@ function HighlightTooltip( {
 	}, [ showHighlight ] );
 
 	useEffect( () => {
-		if ( show !== showHighlight ) {
+		if ( show !== showHighlight && showHighlight !== null && node ) {
 			setShowHighlight( show );
-			if ( ! show && node ) {
+			if ( ! show ) {
 				node.classList.remove( SHOW_CLASS );
 			} else if ( node ) {
-				showTooltip();
+				showTooltip( node );
 			}
 		}
 	}, [ show ] );
 
-	const showTooltip = () => {
+	const showTooltip = ( container ) => {
 		let timeoutId = null;
 		if ( delay > 0 ) {
 			timeoutId = setTimeout( () => {
 				timeoutId = null;
-				setShowHighlight( show );
-				if ( node ) {
-					node.classList.add( SHOW_CLASS );
+				if ( container ) {
+					container.classList.add( SHOW_CLASS );
 				}
+				setShowHighlight( show );
 			}, delay );
 		} else if ( ! showHighlight ) {
+			if ( container ) {
+				container.classList.add( SHOW_CLASS );
+			}
 			setShowHighlight( true );
 		}
 		return timeoutId;

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -39,6 +39,7 @@ function HighlightTooltip( {
 		const element = document.getElementById( id );
 		let container;
 		if ( element && ! node ) {
+			// Add tooltip container
 			const parent = element.parentElement;
 			container = document.createElement( 'div' );
 			container.classList.add(
@@ -48,13 +49,8 @@ function HighlightTooltip( {
 			parent.appendChild( container );
 			setNode( container );
 		}
-		let timeoutId;
-		if ( delay > 0 ) {
-			timeoutId = setTimeout( () => {
-				timeoutId = null;
-				setShowHighlight( show );
-			}, delay );
-		}
+		const timeoutId = showTooltip();
+
 		return () => {
 			if ( container ) {
 				const parent = container.parentElement;
@@ -71,6 +67,33 @@ function HighlightTooltip( {
 			node.classList.remove( SHOW_CLASS );
 		}
 	}, [ showHighlight ] );
+
+	useEffect( () => {
+		if ( show !== showHighlight ) {
+			setShowHighlight( show );
+			if ( ! show && node ) {
+				node.classList.remove( SHOW_CLASS );
+			} else if ( node ) {
+				showTooltip();
+			}
+		}
+	}, [ show ] );
+
+	const showTooltip = () => {
+		let timeoutId = null;
+		if ( delay > 0 ) {
+			timeoutId = setTimeout( () => {
+				timeoutId = null;
+				setShowHighlight( show );
+				if ( node ) {
+					node.classList.add( SHOW_CLASS );
+				}
+			}, delay );
+		} else if ( ! showHighlight ) {
+			setShowHighlight( true );
+		}
+		return timeoutId;
+	};
 
 	const triggerClose = () => {
 		setShowHighlight( false );
@@ -124,7 +147,7 @@ function HighlightTooltip( {
 
 HighlightTooltip.propTypes = {
 	/**
-	 * The id of the element it should highlight.
+	 * The id of the element it should highlight, should be unique per HighlightTooltip.
 	 */
 	id: PropTypes.string.isRequired,
 	/**

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -35,11 +35,6 @@
 		@include font-size( 16 );
 		font-weight: 600;
 		height: 60px;
-
-		.components-button {
-			position: absolute;
-			right: 10px;
-		}
 	}
 	.components-card__footer {
 		justify-content: flex-end;

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -34,3 +34,15 @@
 		z-index: z-index('.components-modal__screen-overlay');
 	}
 }
+
+.highlight-tooltip__popover {
+	.components-card__header {
+		.components-button {
+			position: absolute;
+			right: 10px;
+		}
+	}
+	.components-card__footer {
+		justify-content: flex-end;
+	}
+}

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -20,8 +20,8 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		background-color: rgba( $black, 0.35 );
-		z-index: z-index( '.components-modal__screen-overlay' );
+		background-color: rgba($black, 0.35);
+		z-index: z-index('.components-modal__screen-overlay');
 
 		@include edit-post__fade-in-animation();
 	}

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -1,0 +1,36 @@
+.highlight-tooltip__container {
+	position: absolute;
+	width: 0;
+	height: 0;
+	&.highlight-tooltip__show {
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+	}
+}
+.highlight-tooltip__portal {
+	width: 100%;
+	height: 100%;
+	position: relative;
+	.highlight-tooltip__highlighter {
+		left: 7%;
+		top: 5%;
+		width: 86%;
+		height: 90%;
+		position: absolute;
+		z-index: 1;
+		box-shadow: 0 0 0 100vw rgba(0, 0, 0, 0.7);
+		transition: box-shadow 0.2s ease-in-out;
+		border-radius: 50%;
+	}
+
+	.highlight-tooltip__overlay {
+		position: fixed;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		z-index: z-index('.components-modal__screen-overlay');
+	}
+}

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -13,17 +13,6 @@
 	width: 100%;
 	height: 100%;
 	position: relative;
-	.highlight-tooltip__highlighter {
-		left: 7%;
-		top: 5%;
-		width: 86%;
-		height: 90%;
-		position: absolute;
-		z-index: 1;
-		box-shadow: 0 0 0 100vw rgba(0, 0, 0, 0.7);
-		transition: box-shadow 0.2s ease-in-out;
-		border-radius: 50%;
-	}
 
 	.highlight-tooltip__overlay {
 		position: fixed;
@@ -31,12 +20,22 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		z-index: z-index('.components-modal__screen-overlay');
+		background-color: rgba( $black, 0.35 );
+		z-index: z-index( '.components-modal__screen-overlay' );
+
+		@include edit-post__fade-in-animation();
 	}
 }
 
 .highlight-tooltip__popover {
+	.components-card {
+		min-width: 360px;
+	}
 	.components-card__header {
+		@include font-size( 16 );
+		font-weight: 600;
+		height: 60px;
+
 		.components-button {
 			position: absolute;
 			right: 10px;

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -316,13 +316,6 @@ export class ActivityPanel extends Component {
 	render() {
 		const tabs = this.getTabs();
 		const { mobileOpen, currentTab, isPanelOpen } = this.state;
-		const {
-			trackedCompletedTasks,
-			trackedStartedTasks,
-			helpPanelHighlightShown,
-			query,
-		} = this.props;
-		const { task } = query;
 		const headerId = uniqueId( 'activity-panel-header_' );
 		const panelClasses = classnames( 'woocommerce-layout__activity-panel', {
 			'is-mobile-open': this.state.mobileOpen,

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -328,12 +328,7 @@ export class ActivityPanel extends Component {
 			'is-mobile-open': this.state.mobileOpen,
 		} );
 
-		const showHelpHighlightTooltip =
-			task &&
-			helpPanelHighlightShown !== 'yes' &&
-			( trackedStartedTasks || [] ).filter( ( t ) => t === task ).length >
-				1 &&
-			! trackedCompletedTasks.includes( task );
+		const showHelpHighlightTooltip = this.shouldShowHelpTooltip();
 		const hasUnread = tabs.some( ( tab ) => tab.unread );
 		const viewLabel = hasUnread
 			? __(

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -26,7 +26,7 @@ import { isWCAdmin } from '../../dashboard/utils';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
 import { DisplayOptions } from './display-options';
-import { HighlightTooltipUncontrolled } from './highlight-tooltip';
+import { HighlightTooltip } from './highlight-tooltip';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -360,9 +360,11 @@ export class ActivityPanel extends Component {
 					</div>
 				</Section>
 				{ showHelpHighlight ? (
-					<HighlightTooltipUncontrolled
-						show={ true }
-						title="test"
+					<HighlightTooltip
+						delay={ 500 }
+						title="We're here for help"
+						content="If you have any questions, feel free to explore the WooCommerce docs listed here."
+						closeBtnText="Got it"
 						id="activity-panel-tab-help"
 						onClose={ () => this.closedHelpPanelHighlight() }
 					/>

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -300,7 +300,7 @@ export class ActivityPanel extends Component {
 			'is-mobile-open': this.state.mobileOpen,
 		} );
 
-		const showHelpHighlight =
+		const showHelpHighlightTooltip =
 			task &&
 			helpPanelHighlightShown !== 'yes' &&
 			( trackedStartedTasks || [] ).filter( ( t ) => t === task ).length >
@@ -359,12 +359,14 @@ export class ActivityPanel extends Component {
 						{ this.renderPanel() }
 					</div>
 				</Section>
-				{ showHelpHighlight ? (
+				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
-						delay={ 500 }
-						title="We're here for help"
-						content="If you have any questions, feel free to explore the WooCommerce docs listed here."
-						closeBtnText="Got it"
+						delay={ 1000 }
+						title={ __( "We're here for help" ) }
+						content={ __(
+							'If you have any questions, feel free to explore the WooCommerce docs listed here.'
+						) }
+						closeBtnText={ __( 'Got it' ) }
 						id="activity-panel-tab-help"
 						onClose={ () => this.closedHelpPanelHighlight() }
 					/>

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -302,10 +302,10 @@ export class ActivityPanel extends Component {
 		const { task } = query;
 		const startedTasks =
 			userPreferencesData &&
-			userPreferencesData[ 'task_list_tracked_started_tasks' ];
+			userPreferencesData.task_list_tracked_started_tasks;
 		const highlightShown =
 			userPreferencesData &&
-			userPreferencesData[ 'help_panel_highlight_shown' ];
+			userPreferencesData.help_panel_highlight_shown;
 		if (
 			task &&
 			highlightShown !== 'yes' &&

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -48,9 +48,8 @@ export class ActivityPanel extends Component {
 			currentTab: '',
 			isPanelSwitching: false,
 		};
+		this.recordedHelpTooltip = false;
 	}
-
-	recordedHelpTooltip = false;
 
 	togglePanel( { name: tabName }, isTabOpen ) {
 		this.setState( ( state ) => {
@@ -282,26 +281,31 @@ export class ActivityPanel extends Component {
 	}
 
 	closedHelpPanelHighlight() {
-		const { updateOptions } = this.props;
-		recordEvent( 'wcadmin_help_tooltip_click' );
-		updateOptions( {
-			woocommerce_help_panel_highlight_shown: 'yes',
-		} );
+		const { userPreferencesData } = this.props;
+		recordEvent( 'help_tooltip_click' );
+		if (
+			userPreferencesData &&
+			userPreferencesData.updateUserPreferences
+		) {
+			userPreferencesData.updateUserPreferences( {
+				help_panel_highlight_shown: 'yes',
+			} );
+		}
 	}
 
 	shouldShowHelpTooltip() {
 		const {
+			userPreferencesData,
 			trackedCompletedTasks,
-			trackedStartedTasks,
-			helpPanelHighlightShown,
 			query,
 		} = this.props;
 		const { task } = query;
+		const { task_list_tracked_started_tasks, help_panel_highlight_shown } =
+			userPreferencesData || {};
 		if (
 			task &&
-			helpPanelHighlightShown !== 'yes' &&
-			( trackedStartedTasks || [] ).filter( ( t ) => t === task ).length >
-				1 &&
+			help_panel_highlight_shown !== 'yes' &&
+			( task_list_tracked_started_tasks || {} )[ task ] > 1 &&
 			! trackedCompletedTasks.includes( task )
 		) {
 			if ( ! this.recordedHelpTooltip ) {
@@ -415,12 +419,6 @@ export default compose(
 		const trackedCompletedTasks = getOption(
 			'woocommerce_task_list_tracked_completed_tasks'
 		);
-		const trackedStartedTasks = getOption(
-			'woocommerce_task_list_tracked_started_tasks'
-		);
-		const helpPanelHighlightShown = getOption(
-			'woocommerce_help_panel_highlight_shown'
-		);
 
 		return {
 			hasUnreadNotes,
@@ -428,8 +426,6 @@ export default compose(
 			taskListComplete,
 			taskListHidden,
 			trackedCompletedTasks,
-			trackedStartedTasks,
-			helpPanelHighlightShown,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -306,7 +306,7 @@ export class ActivityPanel extends Component {
 		) {
 			if ( ! this.recordedHelpTooltip ) {
 				this.recordedHelpTooltip = true;
-				recordEvent();
+				recordEvent( 'help_tooltip_view' );
 			}
 			return true;
 		}
@@ -378,11 +378,15 @@ export class ActivityPanel extends Component {
 				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
 						delay={ 1000 }
-						title={ __( "We're here for help" ) }
-						content={ __(
-							'If you have any questions, feel free to explore the WooCommerce docs listed here.'
+						title={ __(
+							"We're here for help",
+							'woocommerce-admin'
 						) }
-						closeBtnText={ __( 'Got it' ) }
+						content={ __(
+							'If you have any questions, feel free to explore the WooCommerce docs listed here.',
+							'woocommerce-admin'
+						) }
+						closeButtonText={ __( 'Got it', 'woocommerce-admin' ) }
 						id="activity-panel-tab-help"
 						onClose={ () => this.closedHelpPanelHighlight() }
 					/>

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -300,12 +300,16 @@ export class ActivityPanel extends Component {
 			query,
 		} = this.props;
 		const { task } = query;
-		const { task_list_tracked_started_tasks, help_panel_highlight_shown } =
-			userPreferencesData || {};
+		const startedTasks =
+			userPreferencesData &&
+			userPreferencesData[ 'task_list_tracked_started_tasks' ];
+		const highlightShown =
+			userPreferencesData &&
+			userPreferencesData[ 'help_panel_highlight_shown' ];
 		if (
 			task &&
-			help_panel_highlight_shown !== 'yes' &&
-			( task_list_tracked_started_tasks || {} )[ task ] > 1 &&
+			highlightShown !== 'yes' &&
+			( startedTasks || {} )[ task ] > 1 &&
 			! trackedCompletedTasks.includes( task )
 		) {
 			if ( ! this.recordedHelpTooltip ) {

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -48,7 +48,6 @@ export class ActivityPanel extends Component {
 			currentTab: '',
 			isPanelSwitching: false,
 		};
-		this.recordedHelpTooltip = false;
 	}
 
 	togglePanel( { name: tabName }, isTabOpen ) {
@@ -312,10 +311,6 @@ export class ActivityPanel extends Component {
 			( startedTasks || {} )[ task ] > 1 &&
 			! trackedCompletedTasks.includes( task )
 		) {
-			if ( ! this.recordedHelpTooltip ) {
-				this.recordedHelpTooltip = true;
-				recordEvent( 'help_tooltip_view' );
-			}
 			return true;
 		}
 		return false;
@@ -397,6 +392,7 @@ export class ActivityPanel extends Component {
 						closeButtonText={ __( 'Got it', 'woocommerce-admin' ) }
 						id="activity-panel-tab-help"
 						onClose={ () => this.closedHelpPanelHighlight() }
+						onShow={ () => recordEvent( 'help_tooltip_view' ) }
 					/>
 				) : null }
 			</div>

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -20,6 +20,10 @@ jest.mock( '../display-options', () => ( {
 	DisplayOptions: jest.fn().mockReturnValue( '[DisplayOptions]' ),
 } ) );
 
+jest.mock( '../highlight-tooltip', () => ( {
+	HighlightTooltip: jest.fn().mockReturnValue( '[HighlightTooltip]' ),
+} ) );
+
 describe( 'Activity Panel', () => {
 	it( 'should render inbox tab on embedded pages', () => {
 		render( <ActivityPanel isEmbedded query={ {} } /> );
@@ -192,5 +196,73 @@ describe( 'Activity Panel', () => {
 		);
 
 		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+	} );
+
+	describe( 'help panel tooltip', () => {
+		it( 'should render highlight tooltip when trackedStartedTasks includes task, task is not completed, and tooltip not shown yet', () => {
+			const { queryByText } = render(
+				<ActivityPanel
+					requestingTaskListOptions={ false }
+					taskListComplete={ false }
+					taskListHidden={ false }
+					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					trackedCompletedTasks={ [] }
+					helpPanelHighlightShown="no"
+					isEmbedded
+					query={ { task: 'payment' } }
+				/>
+			);
+
+			expect( queryByText( '[HighlightTooltip]' ) ).toBeDefined();
+		} );
+
+		it( 'should not render highlight tooltip when trackedStartedTasks does not include task more then once', () => {
+			const { queryByText } = render(
+				<ActivityPanel
+					requestingTaskListOptions={ false }
+					taskListComplete={ false }
+					taskListHidden={ false }
+					trackedStartedTasks={ [ 'payment' ] }
+					trackedCompletedTasks={ [] }
+					isEmbedded
+					query={ { task: 'payment' } }
+				/>
+			);
+
+			expect( queryByText( '[HighlightTooltip]' ) ).toBeNull();
+		} );
+
+		it( 'should not render highlight tooltip when trackedStartedTasks is included twice, but completed already', () => {
+			const { queryByText } = render(
+				<ActivityPanel
+					requestingTaskListOptions={ false }
+					taskListComplete={ false }
+					taskListHidden={ false }
+					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					trackedCompletedTasks={ [ 'payment' ] }
+					isEmbedded
+					query={ { task: 'payment' } }
+				/>
+			);
+
+			expect( queryByText( '[HighlightTooltip]' ) ).toBeNull();
+		} );
+
+		it( 'should not render highlight tooltip when trackedStartedTasks is included twice, not completed, but already shown', () => {
+			const { queryByText } = render(
+				<ActivityPanel
+					requestingTaskListOptions={ false }
+					taskListComplete={ false }
+					taskListHidden={ false }
+					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					trackedCompletedTasks={ [ 'payment' ] }
+					helpPanelHighlightShown="yes"
+					isEmbedded
+					query={ { task: 'payment' } }
+				/>
+			);
+
+			expect( queryByText( '[HighlightTooltip]' ) ).toBeNull();
+		} );
 	} );
 } );

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -255,7 +255,7 @@ describe( 'Activity Panel', () => {
 					taskListComplete={ false }
 					taskListHidden={ false }
 					trackedStartedTasks={ [ 'payment', 'payment' ] }
-					trackedCompletedTasks={ [ 'payment' ] }
+					trackedCompletedTasks={ [] }
 					helpPanelHighlightShown="yes"
 					isEmbedded
 					query={ { task: 'payment' } }

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -219,7 +219,7 @@ describe( 'Activity Panel', () => {
 		} );
 
 		it( 'should not render highlight tooltip when task is not visited more then once', () => {
-			const screen = render(
+			render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
@@ -234,7 +234,8 @@ describe( 'Activity Panel', () => {
 			);
 
 			expect( screen.queryByText( '[HighlightTooltip]' ) ).toBeNull();
-			const screen2 = render(
+
+			render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
@@ -248,7 +249,7 @@ describe( 'Activity Panel', () => {
 				/>
 			);
 
-			expect( screen2.queryByText( '[HighlightTooltip]' ) ).toBeNull();
+			expect( screen.queryByText( '[HighlightTooltip]' ) ).toBeNull();
 		} );
 
 		it( 'should not render highlight tooltip when task is visited twice, but completed already', () => {

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -185,7 +185,7 @@ describe( 'Activity Panel', () => {
 	} );
 
 	it( 'should render the store setup link when on embedded pages and TaskList is not complete', () => {
-		const { queryByText } = render(
+		const { getByText } = render(
 			<ActivityPanel
 				requestingTaskListOptions={ false }
 				taskListComplete={ false }
@@ -195,17 +195,19 @@ describe( 'Activity Panel', () => {
 			/>
 		);
 
-		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+		expect( getByText( 'Store Setup' ) ).toBeInTheDocument();
 	} );
 
 	describe( 'help panel tooltip', () => {
-		it( 'should render highlight tooltip when trackedStartedTasks includes task, task is not completed, and tooltip not shown yet', () => {
-			const { queryByText } = render(
+		it( 'should render highlight tooltip when task count is at-least 2, task is not completed, and tooltip not shown yet', () => {
+			const { getByText } = render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
 					taskListHidden={ false }
-					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					userPreferencesData={ {
+						task_list_tracked_started_tasks: { payment: 2 },
+					} }
 					trackedCompletedTasks={ [] }
 					helpPanelHighlightShown="no"
 					isEmbedded
@@ -213,32 +215,51 @@ describe( 'Activity Panel', () => {
 				/>
 			);
 
-			expect( queryByText( '[HighlightTooltip]' ) ).toBeDefined();
+			expect( getByText( '[HighlightTooltip]' ) ).toBeInTheDocument();
 		} );
 
-		it( 'should not render highlight tooltip when trackedStartedTasks does not include task more then once', () => {
-			const { queryByText } = render(
+		it( 'should not render highlight tooltip when task is not visited more then once', () => {
+			const screen = render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
 					taskListHidden={ false }
-					trackedStartedTasks={ [ 'payment' ] }
+					userPreferencesData={ {
+						task_list_tracked_started_tasks: { payment: 1 },
+					} }
 					trackedCompletedTasks={ [] }
 					isEmbedded
 					query={ { task: 'payment' } }
 				/>
 			);
 
-			expect( queryByText( '[HighlightTooltip]' ) ).toBeNull();
+			expect( screen.queryByText( '[HighlightTooltip]' ) ).toBeNull();
+			const screen2 = render(
+				<ActivityPanel
+					requestingTaskListOptions={ false }
+					taskListComplete={ false }
+					taskListHidden={ false }
+					userPreferencesData={ {
+						task_list_tracked_started_tasks: {},
+					} }
+					trackedCompletedTasks={ [] }
+					isEmbedded
+					query={ { task: 'payment' } }
+				/>
+			);
+
+			expect( screen2.queryByText( '[HighlightTooltip]' ) ).toBeNull();
 		} );
 
-		it( 'should not render highlight tooltip when trackedStartedTasks is included twice, but completed already', () => {
+		it( 'should not render highlight tooltip when task is visited twice, but completed already', () => {
 			const { queryByText } = render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
 					taskListHidden={ false }
-					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					userPreferencesData={ {
+						task_list_tracked_started_tasks: { payment: 2 },
+					} }
 					trackedCompletedTasks={ [ 'payment' ] }
 					isEmbedded
 					query={ { task: 'payment' } }
@@ -248,15 +269,17 @@ describe( 'Activity Panel', () => {
 			expect( queryByText( '[HighlightTooltip]' ) ).toBeNull();
 		} );
 
-		it( 'should not render highlight tooltip when trackedStartedTasks is included twice, not completed, but already shown', () => {
+		it( 'should not render highlight tooltip when task is visited twice, not completed, but already shown', () => {
 			const { queryByText } = render(
 				<ActivityPanel
 					requestingTaskListOptions={ false }
 					taskListComplete={ false }
 					taskListHidden={ false }
-					trackedStartedTasks={ [ 'payment', 'payment' ] }
+					userPreferencesData={ {
+						task_list_tracked_started_tasks: { payment: 2 },
+						help_panel_highlight_shown: 'yes',
+					} }
 					trackedCompletedTasks={ [] }
-					helpPanelHighlightShown="yes"
 					isEmbedded
 					query={ { task: 'payment' } }
 				/>

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -80,7 +80,14 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 				{ decodeEntities( pageTitle ) }
 			</Text>
 			{ window.wcAdminFeatures[ 'activity-panels' ] && (
-				<ActivityPanel isEmbedded={ isEmbedded } query={ query } />
+				<ActivityPanel
+					isEmbedded={ isEmbedded }
+					query={ query }
+					userPreferencesData={ {
+						...userData,
+						updateUserPreferences,
+					} }
+				/>
 			) }
 		</div>
 	);

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -113,7 +113,7 @@ export const Layout = ( {
 
 		return (
 			<Suspense fallback={ <TaskListPlaceholder /> }>
-				<TaskList query={ query } />
+				<TaskList query={ query } userPreferences={ userPrefs } />
 			</Suspense>
 		);
 	};

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -33,6 +33,29 @@ export class TaskDashboard extends Component {
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 	}
 
+	trackStartedTask = ( taskName ) => {
+		const { trackedStartedTasks, updateOptions } = this.props;
+		const taskStarted = trackedStartedTasks.filter(
+			( task ) => task === taskName
+		);
+		if ( taskStarted.length > 1 ) {
+			return;
+		}
+		updateOptions( {
+			woocommerce_task_list_tracked_started_tasks: [
+				...trackedStartedTasks,
+				taskName,
+			],
+		} );
+	};
+
+	onTaskSelect = ( taskName ) => {
+		recordEvent( 'tasklist_click', {
+			task_name: taskName,
+		} );
+		this.trackStartedTask( taskName );
+	};
+
 	getAllTasks() {
 		const {
 			activePlugins,
@@ -57,6 +80,7 @@ export class TaskDashboard extends Component {
 			profileItems,
 			query,
 			toggleCartModal: this.toggleCartModal.bind( this ),
+			onTaskSelect: this.onTaskSelect,
 		} );
 	}
 
@@ -132,6 +156,12 @@ export default compose(
 			isJetpackConnected,
 		} = select( PLUGINS_STORE_NAME );
 		const profileItems = getProfileItems();
+
+		const trackedCompletedTasks =
+			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
+		const trackedStartedTasks =
+			getOption( 'woocommerce_task_list_tracked_started_tasks' ) || [];
+
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const countryCode = getCountryCode(
 			generalSettings.woocommerce_default_country
@@ -162,6 +192,8 @@ export default compose(
 			trackedCompletedTasks:
 				getOption( 'woocommerce_task_list_tracked_completed_tasks' ) ||
 				[],
+			trackedCompletedTasks,
+			trackedStartedTasks,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -35,7 +35,7 @@ export class TaskDashboard extends Component {
 
 	trackStartedTask = ( taskName ) => {
 		const { trackedStartedTasks, updateOptions } = this.props;
-		const taskStarted = trackedStartedTasks.filter(
+		const taskStarted = ( trackedStartedTasks || [] ).filter(
 			( task ) => task === taskName
 		);
 		if ( taskStarted.length > 1 ) {
@@ -43,7 +43,7 @@ export class TaskDashboard extends Component {
 		}
 		updateOptions( {
 			woocommerce_task_list_tracked_started_tasks: [
-				...trackedStartedTasks,
+				...( trackedStartedTasks || [] ),
 				taskName,
 			],
 		} );
@@ -112,24 +112,24 @@ export class TaskDashboard extends Component {
 			<>
 				{ setupTasks && ! isSetupTaskListHidden && (
 					<TaskList
-						dismissedTasks={ dismissedTasks }
+						dismissedTasks={ dismissedTasks || [] }
 						isTaskListComplete={ isTaskListComplete }
 						isExtended={ false }
 						query={ query }
 						tasks={ allTasks }
-						trackedCompletedTasks={ trackedCompletedTasks }
+						trackedCompletedTasks={ trackedCompletedTasks || [] }
 					/>
 				) }
 				{ extensionTasks && ! isExtendedTaskListHidden && (
 					<TaskList
-						dismissedTasks={ dismissedTasks }
+						dismissedTasks={ dismissedTasks || [] }
 						isExtendedTaskListComplete={
 							isExtendedTaskListComplete
 						}
 						isExtended={ true }
 						query={ query }
 						tasks={ allTasks }
-						trackedCompletedTasks={ trackedCompletedTasks }
+						trackedCompletedTasks={ trackedCompletedTasks || [] }
 					/>
 				) }
 				{ isCartModalOpen && (
@@ -157,10 +157,12 @@ export default compose(
 		} = select( PLUGINS_STORE_NAME );
 		const profileItems = getProfileItems();
 
-		const trackedCompletedTasks =
-			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
-		const trackedStartedTasks =
-			getOption( 'woocommerce_task_list_tracked_started_tasks' ) || [];
+		const trackedCompletedTasks = getOption(
+			'woocommerce_task_list_tracked_completed_tasks'
+		);
+		const trackedStartedTasks = getOption(
+			'woocommerce_task_list_tracked_started_tasks'
+		);
 
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const countryCode = getCountryCode(
@@ -174,8 +176,9 @@ export default compose(
 		return {
 			activePlugins,
 			countryCode,
-			dismissedTasks:
-				getOption( 'woocommerce_task_list_dismissed_tasks' ) || [],
+			dismissedTasks: getOption(
+				'woocommerce_task_list_dismissed_tasks'
+			),
 			isExtendedTaskListComplete:
 				getOption( 'woocommerce_extended_task_list_complete' ) ===
 				'yes',
@@ -189,18 +192,17 @@ export default compose(
 			installedPlugins,
 			onboardingStatus,
 			profileItems,
-			trackedCompletedTasks:
-				getOption( 'woocommerce_task_list_tracked_completed_tasks' ) ||
-				[],
 			trackedCompletedTasks,
 			trackedStartedTasks,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
 
 		return {
+			updateOptions,
 			createNotice,
 			installAndActivatePlugins,
 		};

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -34,18 +34,22 @@ export class TaskDashboard extends Component {
 	}
 
 	trackStartedTask = ( taskName ) => {
-		const { trackedStartedTasks, updateOptions } = this.props;
-		const taskStarted = ( trackedStartedTasks || [] ).filter(
-			( task ) => task === taskName
-		);
-		if ( taskStarted.length > 1 ) {
+		const { userPreferences } = this.props;
+		const trackedStartedTasks =
+			userPreferences.task_list_tracked_started_tasks || {};
+		const currentTaskCount =
+			trackedStartedTasks && trackedStartedTasks[ taskName ]
+				? trackedStartedTasks[ taskName ]
+				: 0;
+		// Only record task visits up to 2 times
+		if ( currentTaskCount > 1 ) {
 			return;
 		}
-		updateOptions( {
-			woocommerce_task_list_tracked_started_tasks: [
-				...( trackedStartedTasks || [] ),
-				taskName,
-			],
+		userPreferences.updateUserPreferences( {
+			task_list_tracked_started_tasks: {
+				...( trackedStartedTasks || {} ),
+				[ taskName ]: currentTaskCount + 1,
+			},
 		} );
 	};
 
@@ -107,6 +111,7 @@ export class TaskDashboard extends Component {
 		const { isCartModalOpen } = this.state;
 		const allTasks = this.getAllTasks();
 		const { extension: extensionTasks, setup: setupTasks } = allTasks;
+		console.log( 'render task-list' );
 
 		return (
 			<>
@@ -160,9 +165,6 @@ export default compose(
 		const trackedCompletedTasks = getOption(
 			'woocommerce_task_list_tracked_completed_tasks'
 		);
-		const trackedStartedTasks = getOption(
-			'woocommerce_task_list_tracked_started_tasks'
-		);
 
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const countryCode = getCountryCode(
@@ -193,16 +195,13 @@ export default compose(
 			onboardingStatus,
 			profileItems,
 			trackedCompletedTasks,
-			trackedStartedTasks,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
 
 		return {
-			updateOptions,
 			createNotice,
 			installAndActivatePlugins,
 		};

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -33,31 +33,35 @@ export class TaskDashboard extends Component {
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 	}
 
-	trackStartedTask = ( taskName ) => {
+	getTaskStartedCount = ( taskName ) => {
+		const { userPreferences } = this.props;
+		const trackedStartedTasks =
+			userPreferences.task_list_tracked_started_tasks;
+		if ( ! trackedStartedTasks || ! trackedStartedTasks[ taskName ] ) {
+			return 0;
+		}
+		return trackedStartedTasks[ taskName ];
+	};
+
+	updateTrackStartedCount = ( taskName, newCount ) => {
 		const { userPreferences } = this.props;
 		const trackedStartedTasks =
 			userPreferences.task_list_tracked_started_tasks || {};
-		const currentTaskCount =
-			trackedStartedTasks && trackedStartedTasks[ taskName ]
-				? trackedStartedTasks[ taskName ]
-				: 0;
-		// Only record task visits up to 2 times
-		if ( currentTaskCount > 1 ) {
-			return;
-		}
 		userPreferences.updateUserPreferences( {
 			task_list_tracked_started_tasks: {
 				...( trackedStartedTasks || {} ),
-				[ taskName ]: currentTaskCount + 1,
+				[ taskName ]: newCount,
 			},
 		} );
 	};
 
 	onTaskSelect = ( taskName ) => {
+		const trackStartedCount = this.getTaskStartedCount( taskName );
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,
+			visit_count: trackStartedCount + 1,
 		} );
-		this.trackStartedTask( taskName );
+		this.updateTrackStartedCount( taskName, trackStartedCount + 1 );
 	};
 
 	getAllTasks() {

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -111,7 +111,6 @@ export class TaskDashboard extends Component {
 		const { isCartModalOpen } = this.state;
 		const allTasks = this.getAllTasks();
 		const { extension: extensionTasks, setup: setupTasks } = allTasks;
-		console.log( 'render task-list' );
 
 		return (
 			<>

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -51,6 +51,7 @@ export function getAllTasks( {
 	profileItems,
 	query,
 	toggleCartModal,
+	onTaskSelect,
 } ) {
 	const {
 		hasPaymentGateway,
@@ -101,9 +102,7 @@ export function getAllTasks( {
 			title: __( 'Store details', 'woocommerce-admin' ),
 			container: null,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'store_details',
-				} );
+				onTaskSelect( 'store_details' );
 				getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
 			},
 			completed: profilerCompleted,
@@ -116,9 +115,7 @@ export function getAllTasks( {
 			title: purchaseAndInstallText,
 			container: null,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'purchase',
-				} );
+				onTaskSelect( 'purchase' );
 				return remainingProducts.length ? toggleCartModal() : null;
 			},
 			visible: products.length,
@@ -132,9 +129,7 @@ export function getAllTasks( {
 			title: __( 'Add my products', 'woocommerce-admin' ),
 			container: <Products />,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'products',
-				} );
+				onTaskSelect( 'products' );
 				updateQueryString( { task: 'products' } );
 			},
 			completed: hasProducts,
@@ -163,9 +158,7 @@ export function getAllTasks( {
 						activePlugins,
 						installedPlugins
 					);
-					recordEvent( 'tasklist_click', {
-						task_name: 'woocommerce-payments',
-					} );
+					onTaskSelect( 'woocommerce-payments' );
 					return installActivateAndConnectWcpay(
 						resolve,
 						reject,
@@ -191,9 +184,7 @@ export function getAllTasks( {
 			container: <Payments />,
 			completed: hasPaymentGateway,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'payments',
-				} );
+				onTaskSelect( 'payments' );
 				updateQueryString( { task: 'payments' } );
 			},
 			visible: ! woocommercePaymentsInstalled || countryCode !== 'US',
@@ -205,9 +196,7 @@ export function getAllTasks( {
 			title: __( 'Set up tax', 'woocommerce-admin' ),
 			container: <Tax />,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'tax',
-				} );
+				onTaskSelect( 'tax' );
 				updateQueryString( { task: 'tax' } );
 			},
 			completed: isTaxComplete,
@@ -220,9 +209,7 @@ export function getAllTasks( {
 			title: __( 'Set up shipping', 'woocommerce-admin' ),
 			container: <Shipping />,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'shipping',
-				} );
+				onTaskSelect( 'shipping' );
 				updateQueryString( { task: 'shipping' } );
 			},
 			completed: shippingZonesCount > 0,
@@ -237,9 +224,7 @@ export function getAllTasks( {
 			title: __( 'Personalize my store', 'woocommerce-admin' ),
 			container: <Appearance />,
 			onClick: () => {
-				recordEvent( 'tasklist_click', {
-					task_name: 'appearance',
-				} );
+				onTaskSelect( 'appearance' );
 				updateQueryString( { task: 'appearance' } );
 			},
 			completed: isAppearanceComplete,

--- a/packages/data/src/user-preferences/use-user-preferences.js
+++ b/packages/data/src/user-preferences/use-user-preferences.js
@@ -137,7 +137,7 @@ export const useUserPreferences = () => {
 				hasStartedResolution( 'getCurrentUser' ) &&
 				! hasFinishedResolution( 'getCurrentUser' ),
 			user: getCurrentUser(),
-			getCurrentUser: getCurrentUser,
+			getCurrentUser,
 			getEntity,
 			getEntityRecord,
 			getLastEntitySaveError,

--- a/packages/data/src/user-preferences/use-user-preferences.js
+++ b/packages/data/src/user-preferences/use-user-preferences.js
@@ -56,6 +56,8 @@ async function updateUserPrefs(
 		'homepage_layout',
 		'homepage_stats',
 		'android_app_banner_dismissed',
+		'task_list_tracked_started_tasks',
+		'help_panel_highlight_shown',
 	];
 
 	// Prep valid fields for update.
@@ -130,14 +132,12 @@ export const useUserPreferences = () => {
 			hasFinishedResolution,
 		} = select( STORE_NAME );
 
-		// Use getCurrentUser() to get WooCommerce meta values.
-		const user = getCurrentUser();
-
 		return {
 			isRequesting:
 				hasStartedResolution( 'getCurrentUser' ) &&
 				! hasFinishedResolution( 'getCurrentUser' ),
-			user,
+			user: getCurrentUser(),
+			getCurrentUser: getCurrentUser,
 			getEntity,
 			getEntityRecord,
 			getLastEntitySaveError,
@@ -175,9 +175,11 @@ export const useUserPreferences = () => {
 				);
 			};
 		}
+		// Get most recent user before update.
+		const currentUser = userData.getCurrentUser();
 		return updateUserPrefs(
 			receiveCurrentUser,
-			userData.user,
+			currentUser,
 			saveUser,
 			userData.getLastEntitySaveError,
 			userPrefs

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Unreleased ==
 
 - Fix: Move collapsible config to panels object, to allow for more control. #5855
+- Enhancement: Show Help panel tooltip when user visits unfinished task more then once.
 - Tweak: Fix inconsistent REST API paramater name for customer type filtering.
 - Enhancement: Tasks extensibility in Home Screen. #5794
 - Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Unreleased ==
 
 - Fix: Move collapsible config to panels object, to allow for more control. #5855
-- Enhancement: Show Help panel tooltip when user visits unfinished task more then once.
+- Enhancement: Show Help panel tooltip when user visits unfinished task more then once. #5826
 - Tweak: Fix inconsistent REST API paramater name for customer type filtering.
 - Enhancement: Tasks extensibility in Home Screen. #5794
 - Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -60,7 +60,7 @@ class Homescreen {
 				'homepage_layout',
 				'homepage_stats',
 				'task_list_tracked_started_tasks',
-				'help_panel_highlight_shown'
+				'help_panel_highlight_shown',
 			)
 		);
 	}

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -59,6 +59,8 @@ class Homescreen {
 			array(
 				'homepage_layout',
 				'homepage_stats',
+				'task_list_tracked_started_tasks',
+				'help_panel_highlight_shown'
 			)
 		);
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -737,8 +737,6 @@ class Onboarding {
 		$options[] = 'woocommerce_woocommerce_payments_settings';
 		$options[] = 'woocommerce_eway_settings';
 		$options[] = 'woocommerce_razorpay_settings';
-		$options[] = 'woocommerce_help_panel_highlight_shown';
-		$options[] = 'woocommerce_task_list_tracked_started_tasks';
 
 		return $options;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -583,7 +583,7 @@ class Onboarding {
 			$files     = new \RegexIterator( $iterator, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH );
 
 			foreach ( $files as $file ) {
-				$content = file_get_contents( $file[0] );
+				$content = file_get_contents( $file[0] ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 				if ( preg_match( '/add_theme_support\(([^(]*)(\'|\")woocommerce(\'|\")([^(]*)/si', $content, $matches ) ) {
 					return true;
 				}
@@ -737,6 +737,8 @@ class Onboarding {
 		$options[] = 'woocommerce_woocommerce_payments_settings';
 		$options[] = 'woocommerce_eway_settings';
 		$options[] = 'woocommerce_razorpay_settings';
+		$options[] = 'woocommerce_help_panel_highlight_shown';
+		$options[] = 'woocommerce_task_list_tracked_started_tasks';
 
 		return $options;
 	}
@@ -996,7 +998,7 @@ class Onboarding {
 			$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
-			wp_redirect( $connect_url );
+			wp_save_redirect( $connect_url );
 			exit;
 		}
 
@@ -1039,7 +1041,7 @@ class Onboarding {
 
 			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
-			wp_redirect( $connect_url );
+			wp_save_redirect( $connect_url );
 			exit;
 		}
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -998,7 +998,7 @@ class Onboarding {
 			$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
-			wp_save_redirect( $connect_url );
+			wp_redirect( $connect_url );
 			exit;
 		}
 
@@ -1041,7 +1041,7 @@ class Onboarding {
 
 			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
-			wp_save_redirect( $connect_url );
+			wp_redirect( $connect_url );
 			exit;
 		}
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -583,7 +583,7 @@ class Onboarding {
 			$files     = new \RegexIterator( $iterator, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH );
 
 			foreach ( $files as $file ) {
-				$content = file_get_contents( $file[0] ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+				$content = file_get_contents( $file[0] );
 				if ( preg_match( '/add_theme_support\(([^(]*)(\'|\")woocommerce(\'|\")([^(]*)/si', $content, $matches ) ) {
 					return true;
 				}


### PR DESCRIPTION
Fixes #5082 

Added the `woocommerce_task_list_tracked_started_tasks` option as an object of { task_name: task_visit_count } to keep track of the tasks that where visited, and the `woocommerce_help_panel_highlight_shown` option to manage if the help panel tooltip was shown. The task_visit_count is increased everytime the task is clicked from the task list.

The tooltip will show when it is the second time an uncompleted task has been visited. The tooltip will **only** be hidden if a user has interacted with it. If a user refreshes without interacting it will show the tooltip again.

The tooltip is shown using a HighlightTooltip component, it makes use of an element id to target, and makes use of the wordpress `createPortal` function  and `Popover` component. This way it acts similar to the [Woo admin pointers](https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin-pointers.php#L228).

### Accessibility

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![helppanel-popup](https://user-images.githubusercontent.com/2240960/101396426-b0152d00-38a1-11eb-8a6f-a0feac22fa2b.gif)

### Detailed test instructions:

- Create a new WooCommerce store, and finish the initial Wizard
- Navigate to one of the unfinished tasks on the home screen and finish it (Ex: `Add my products` and add a product)
- Go to home screen and click on the finished task (no popup should appear)
- Go to home screen and click an unfinished task (not finishing it)
- Go to home screen again and click the same unfinished task
- A popup should appear now, highlighting the `Help` panel, like this:
<img width="352" alt="Screen Shot 2020-12-07 at 3 39 42 PM" src="https://user-images.githubusercontent.com/2240960/101396996-798be200-38a2-11eb-8345-53a904460bbb.png">
- Click `Got it` or the close button.
- Help panel button should still work correctly.
- If navigating back home and to the unfinished task again the popup should not show up (this goes for any other unfinished tasks as well).
- It should of logged the `wcadmin_help_tooltip_view` when the tooltip was viewed, and the `wcadmin_help_tooltip_click` when it was dismissed.
