### PR TITLE
Onboarding - Empty spaces should not be allowed as a valid input

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -18,22 +18,22 @@ const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 export function validateStoreAddress( values ) {
 	const errors = {};
 
-	if ( ! values.addressLine1.length ) {
+	if ( ! values.addressLine1.trim().length ) {
 		errors.addressLine1 = __(
 			'Please add an address',
 			'woocommerce-admin'
 		);
 	}
-	if ( ! values.countryState.length ) {
+	if ( ! values.countryState.trim().length ) {
 		errors.countryState = __(
 			'Please select a country / region',
 			'woocommerce-admin'
 		);
 	}
-	if ( ! values.city.length ) {
+	if ( ! values.city.trim().length ) {
 		errors.city = __( 'Please add a city', 'woocommerce-admin' );
 	}
-	if ( ! values.postCode.length ) {
+	if ( ! values.postCode.trim().length ) {
 		errors.postCode = __( 'Please add a post code', 'woocommerce-admin' );
 	}
 


### PR DESCRIPTION
Fixes #5747 

This PR fixes input validation on the Setup Wizard -> Store Details where empty spaces are allowed as a valid input by trimming the input value before checking the length.

### Detailed test instructions:

1. Install a fresh WordPress + WooCommerce
2. Navigate to WooCommerce -> Home. It should start the Setup Wizard.
3. Try adding only spaces for each input.
4. You should get a red border around the inputs with an error message.

