### PR TITLE
Home Screen - Small refactor to tasks extensibility 

### DIFF
--- a/client/lib/lists/index.js
+++ b/client/lib/lists/index.js
@@ -1,0 +1,28 @@
+/**
+ * Returns an object with items grouped by the sent key.
+ *
+ * @param {Array} array array of objects.
+ * @param {string} key the object prop that will be used to group elements.
+ * @param {string} defaultKey if the key is not found in the object, it will use this value.
+ * @return {Object} Object that contains the grouped elements.
+ */
+export const groupListOfObjectsBy = (
+	array,
+	key,
+	defaultKey = 'undefined'
+) => {
+	if ( array && Array.isArray( array ) && array.length ) {
+		if ( ! key ) {
+			return array;
+		}
+		return array.reduce( ( result, currentValue ) => {
+			if ( ! currentValue[ key ] ) {
+				currentValue[ key ] = defaultKey;
+			}
+			( result[ currentValue[ key ] ] =
+				result[ currentValue[ key ] ] || [] ).push( currentValue );
+			return result;
+		}, {} );
+	}
+	return {};
+};

--- a/client/lib/lists/test/index.js
+++ b/client/lib/lists/test/index.js
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import { groupListOfObjectsBy } from '../index.js';
+
+describe( 'groupListOfObjectsBy', () => {
+	const objectList = [
+		{
+			id: '1',
+			name: 'Object name 1',
+			type: 'type1',
+		},
+		{
+			id: '2',
+			name: 'Object name 2',
+			type: 'type1',
+		},
+		{
+			id: '3',
+			name: 'Object name 3',
+			type: 'type1',
+		},
+		{
+			id: '4',
+			name: 'Object name 4',
+			type: 'type2',
+		},
+	];
+
+	it( 'handles different params', () => {
+		// Using these params should return an empty object.
+		const emptyObject = groupListOfObjectsBy();
+		const otherEmptyObject = groupListOfObjectsBy( [] );
+		const anotherEmptyObject = groupListOfObjectsBy( 'not an array' );
+		expect( emptyObject ).toMatchObject( {} );
+		expect( otherEmptyObject ).toMatchObject( {} );
+		expect( anotherEmptyObject ).toMatchObject( {} );
+
+		// Not sending a key to use for grouping the elements will return the sent list
+		const ungroupedList = groupListOfObjectsBy( objectList );
+		expect( ungroupedList.length ).toBe( 4 );
+	} );
+
+	it( 'groups objects by type', () => {
+		const { type1, type2 } = groupListOfObjectsBy( objectList, 'type' );
+		expect( type1.length ).toBe( 3 );
+		expect( type2.length ).toBe( 1 );
+	} );
+
+	it( 'groups objects without type', () => {
+		const objectWithoutType = {
+			id: '5',
+			name: 'Object name 5',
+		};
+		objectList.push( objectWithoutType );
+		const { type1, type2 } = groupListOfObjectsBy(
+			objectList,
+			'type',
+			'type2'
+		);
+		expect( type1.length ).toBe( 3 );
+		expect( type2.length ).toBe( 2 );
+	} );
+
+	it( 'groups objects with a new type', () => {
+		const objectWithNewType = {
+			id: '6',
+			name: 'Object name 4',
+			type: 'type3',
+		};
+		objectList.push( objectWithNewType );
+		const { type1, type2, type3 } = groupListOfObjectsBy(
+			objectList,
+			'type',
+			'type2'
+		);
+		expect( type1.length ).toBe( 3 );
+		expect( type2.length ).toBe( 2 );
+		expect( type3.length ).toBe( 1 );
+	} );
+} );

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -60,14 +60,6 @@ export class TaskDashboard extends Component {
 		} );
 	}
 
-	groupBy( array, key ) {
-		return array.reduce( ( result, currentValue ) => {
-			( result[ currentValue[ key ] ] =
-				result[ currentValue[ key ] ] || [] ).push( currentValue );
-			return result;
-		}, {} );
-	}
-
 	toggleCartModal() {
 		const { isCartModalOpen } = this.state;
 
@@ -90,34 +82,29 @@ export class TaskDashboard extends Component {
 		} = this.props;
 		const { isCartModalOpen } = this.state;
 		const allTasks = this.getAllTasks();
-		const { extension: extensionTasks, setup: setupTasks } = this.groupBy(
-			allTasks,
-			'type'
-		);
+		const { extension: extensionTasks, setup: setupTasks } = allTasks;
 
 		return (
 			<>
 				{ setupTasks && ! isSetupTaskListHidden && (
 					<TaskList
-						allTasks={ allTasks }
 						dismissedTasks={ dismissedTasks }
 						isTaskListComplete={ isTaskListComplete }
 						isExtended={ false }
 						query={ query }
-						specificTasks={ setupTasks }
+						tasks={ allTasks }
 						trackedCompletedTasks={ trackedCompletedTasks }
 					/>
 				) }
 				{ extensionTasks && ! isExtendedTaskListHidden && (
 					<TaskList
-						allTasks={ allTasks }
 						dismissedTasks={ dismissedTasks }
 						isExtendedTaskListComplete={
 							isExtendedTaskListComplete
 						}
 						isExtended={ true }
 						query={ query }
-						specificTasks={ extensionTasks }
+						tasks={ allTasks }
 						trackedCompletedTasks={ trackedCompletedTasks }
 					/>
 				) }

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -54,6 +54,24 @@ export class TaskList extends Component {
 		this.possiblyTrackCompletedTasks();
 	}
 
+	getUngroupedTasks() {
+		const { tasks: groupedTasks } = this.props;
+		return [].concat(
+			...Object.keys( groupedTasks ).map(
+				( taskType ) => groupedTasks[ taskType ]
+			)
+		);
+	}
+
+	getSpecificTasks() {
+		const { isExtended, tasks: groupedTasks } = this.props;
+		const { extension, setup } = groupedTasks;
+		if ( isExtended ) {
+			return extension;
+		}
+		return setup;
+	}
+
 	possiblyCompleteTaskList() {
 		const {
 			isExtended,
@@ -61,8 +79,8 @@ export class TaskList extends Component {
 			isExtendedTaskListComplete,
 			updateOptions,
 		} = this.props;
-		const isSetupTaskListInComplete = ! isExtended && ! isTaskListComplete;
-		const isExtendedTaskListInComplete =
+		const isSetupTaskListIncomplete = ! isExtended && ! isTaskListComplete;
+		const isExtendedTaskListIncomplete =
 			isExtended && ! isExtendedTaskListComplete;
 		const taskListToComplete = isExtended
 			? { woocommerce_extended_task_list_complete: 'yes' }
@@ -73,7 +91,7 @@ export class TaskList extends Component {
 
 		if (
 			! this.getIncompleteTasks().length &&
-			( isSetupTaskListInComplete || isExtendedTaskListInComplete )
+			( isSetupTaskListIncomplete || isExtendedTaskListIncomplete )
 		) {
 			updateOptions( {
 				...taskListToComplete,
@@ -88,8 +106,8 @@ export class TaskList extends Component {
 	}
 
 	getIncompleteTasks() {
-		const { dismissedTasks, specificTasks } = this.props;
-		return specificTasks.filter(
+		const { dismissedTasks } = this.props;
+		return this.getSpecificTasks().filter(
 			( task ) =>
 				task.visible &&
 				! task.completed &&
@@ -169,8 +187,9 @@ export class TaskList extends Component {
 	}
 
 	getVisibleTasks( type ) {
-		const { allTasks, specificTasks, dismissedTasks } = this.props;
-		const tasks = type === 'all' ? allTasks : specificTasks;
+		const { dismissedTasks } = this.props;
+		const tasks =
+			type === 'all' ? this.getUngroupedTasks() : this.getSpecificTasks();
 
 		return tasks.filter(
 			( task ) => task.visible && ! dismissedTasks.includes( task.key )
@@ -235,9 +254,11 @@ export class TaskList extends Component {
 	}
 
 	getCurrentTask() {
-		const { specificTasks, query } = this.props;
+		const { query } = this.props;
 		const { task } = query;
-		const currentTask = specificTasks.find( ( s ) => s.key === task );
+		const currentTask = this.getSpecificTasks().find(
+			( s ) => s.key === task
+		);
 
 		if ( ! currentTask ) {
 			return null;

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -56,11 +56,7 @@ export class TaskList extends Component {
 
 	getUngroupedTasks() {
 		const { tasks: groupedTasks } = this.props;
-		return [].concat(
-			...Object.keys( groupedTasks ).map(
-				( taskType ) => groupedTasks[ taskType ]
-			)
-		);
+		return Object.values( groupedTasks ).flat();
 	}
 
 	getSpecificTasks() {

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -39,6 +39,14 @@ export function recordTaskViewEvent(
 	} );
 }
 
+const groupBy = ( array, key ) => {
+	return array.reduce( ( result, currentValue ) => {
+		( result[ currentValue[ key ] ] =
+			result[ currentValue[ key ] ] || [] ).push( currentValue );
+		return result;
+	}, {} );
+};
+
 export function getAllTasks( {
 	activePlugins,
 	countryCode,
@@ -247,10 +255,8 @@ export function getAllTasks( {
 			type: 'setup',
 		},
 	];
-
-	return applyFilters(
-		'woocommerce_admin_onboarding_task_list',
-		tasks,
-		query
+	return groupBy(
+		applyFilters( 'woocommerce_admin_onboarding_task_list', tasks, query ),
+		'type'
 	);
 }

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -41,6 +41,9 @@ export function recordTaskViewEvent(
 
 const groupBy = ( array, key ) => {
 	return array.reduce( ( result, currentValue ) => {
+		if ( ! currentValue[ key ] ) {
+			currentValue[ key ] = 'extension';
+		}
 		( result[ currentValue[ key ] ] =
 			result[ currentValue[ key ] ] || [] ).push( currentValue );
 		return result;

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -22,6 +22,7 @@ import Shipping from './tasks/shipping';
 import Tax from './tasks/tax';
 import Payments from './tasks/payments';
 import { installActivateAndConnectWcpay } from './tasks/payments/methods';
+import { groupListOfObjectsBy } from '../lib/lists';
 
 export function recordTaskViewEvent(
 	taskName,
@@ -38,17 +39,6 @@ export function recordTaskViewEvent(
 		jetpack_connected: isJetpackConnected,
 	} );
 }
-
-const groupBy = ( array, key ) => {
-	return array.reduce( ( result, currentValue ) => {
-		if ( ! currentValue[ key ] ) {
-			currentValue[ key ] = 'extension';
-		}
-		( result[ currentValue[ key ] ] =
-			result[ currentValue[ key ] ] || [] ).push( currentValue );
-		return result;
-	}, {} );
-};
 
 export function getAllTasks( {
 	activePlugins,
@@ -258,8 +248,9 @@ export function getAllTasks( {
 			type: 'setup',
 		},
 	];
-	return groupBy(
+	return groupListOfObjectsBy(
 		applyFilters( 'woocommerce_admin_onboarding_task_list', tasks, query ),
-		'type'
+		'type',
+		'extension'
 	);
 }

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -17,49 +17,52 @@ jest.mock( '../tasks' );
 
 describe( 'TaskDashboard and TaskList', () => {
 	afterEach( () => jest.clearAllMocks() );
-
-	const tasks = [
-		{
-			key: 'optional',
-			title: 'This task is optional',
-			container: null,
-			completed: false,
-			visible: true,
-			time: '1 minute',
-			isDismissable: true,
-			type: 'setup',
-		},
-		{
-			key: 'required',
-			title: 'This task is required',
-			container: null,
-			completed: false,
-			visible: true,
-			time: '1 minute',
-			isDismissable: false,
-			type: 'setup',
-		},
-		{
-			key: 'completed',
-			title: 'This task is completed',
-			container: null,
-			completed: true,
-			visible: true,
-			time: '1 minute',
-			isDismissable: true,
-			type: 'setup',
-		},
-		{
-			key: 'extension',
-			title: 'This task is an extension',
-			container: null,
-			completed: false,
-			visible: true,
-			time: '1 minute',
-			isDismissable: true,
-			type: 'extension',
-		},
-	];
+	const tasks = {
+		setup: [
+			{
+				key: 'optional',
+				title: 'This task is optional',
+				container: null,
+				completed: false,
+				visible: true,
+				time: '1 minute',
+				isDismissable: true,
+				type: 'setup',
+			},
+			{
+				key: 'required',
+				title: 'This task is required',
+				container: null,
+				completed: false,
+				visible: true,
+				time: '1 minute',
+				isDismissable: false,
+				type: 'setup',
+			},
+			{
+				key: 'completed',
+				title: 'This task is completed',
+				container: null,
+				completed: true,
+				visible: true,
+				time: '1 minute',
+				isDismissable: true,
+				type: 'setup',
+			},
+		],
+		extension: [
+			{
+				key: 'extension',
+				title: 'This task is an extension',
+				container: null,
+				completed: false,
+				visible: true,
+				time: '1 minute',
+				isDismissable: true,
+				type: 'extension',
+			},
+		],
+	};
 	const shorterTasksList = [
 		{
 			key: 'completed-1',
@@ -141,8 +144,7 @@ describe( 'TaskDashboard and TaskList', () => {
 				query={ {} }
 				trackedCompletedTasks={ shorterTasksList }
 				updateOptions={ updateOptions }
-				allTasks={ shorterTasksList }
-				specificTasks={ shorterTasksList }
+				tasks={ { setup: shorterTasksList } }
 			/>
 		);
 
@@ -167,8 +169,7 @@ describe( 'TaskDashboard and TaskList', () => {
 					query={ {} }
 					trackedCompletedTasks={ shorterTasksList }
 					updateOptions={ updateOptions }
-					allTasks={ shorterTasksList }
-					specificTasks={ shorterTasksList }
+					tasks={ { setup: shorterTasksList } }
 				/>
 			);
 		} );
@@ -191,8 +192,7 @@ describe( 'TaskDashboard and TaskList', () => {
 					query={ {} }
 					trackedCompletedTasks={ shorterTasksList }
 					updateOptions={ updateOptions }
-					allTasks={ shorterTasksList }
-					specificTasks={ shorterTasksList }
+					tasks={ { extension: shorterTasksList } }
 				/>
 			);
 		} );
@@ -208,14 +208,13 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
-					allTasks={ tasks }
+					tasks={ tasks }
 					dismissedTasks={ [] }
 					isTaskListComplete={ true }
 					profileItems={ {} }
 					query={ {} }
 					trackedCompletedTasks={ shorterTasksList }
 					updateOptions={ updateOptions }
-					specificTasks={ shorterTasksList }
 				/>
 			);
 		} );

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -87,7 +87,6 @@ addFilter(
 				time: __( '2 minutes', 'woocommerce-admin' ),
 				isDismissable: true,
 				onDismiss: () => console.log( "The task was dismissed" ),
-				type: 'extension'
 			},
 		];
 	}

--- a/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
+++ b/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
@@ -8,7 +8,7 @@
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 
 /**
- * Register the JS.
+ * Register the task list item and the JS.
  */
 function add_task_register_script() {
 
@@ -41,3 +41,12 @@ function add_task_register_script() {
 	do_action( 'add_woocommerce_extended_task_list_item', 'woocommerce_admin_add_task_example_name' );
 }
 add_action( 'admin_enqueue_scripts', 'add_task_register_script' );
+
+/**
+ * Unregister task list item.
+ */
+function pluginprefix_deactivate() {
+	do_action( 'remove_woocommerce_extended_task_list_item', 'woocommerce_admin_add_task_example_name' );
+}
+
+register_deactivation_hook( __FILE__, 'pluginprefix_deactivate' );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -47,6 +47,7 @@ class OnboardingTasks {
 		add_action( 'add_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'update_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'add_woocommerce_extended_task_list_item', array( $this, 'add_extended_task_list_item' ), 10, 2 );
+		add_action( 'remove_woocommerce_extended_task_list_item', array( $this, 'remove_extended_task_list_item' ), 10, 2 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -390,6 +391,22 @@ class OnboardingTasks {
 				array_push( $extended_tasks_list_items, $new_task_name );
 				update_option( 'woocommerce_extended_task_list_items', $extended_tasks_list_items );
 				update_option( 'woocommerce_extended_task_list_hidden', 'no' );
+			}
+		}
+	}
+
+	/**
+	 * Removes item to the extended task list.
+	 *
+	 * @param mixed $task_name Task name to remove.
+	 */
+	public static function remove_extended_task_list_item( $task_name ) {
+		if ( $task_name ) {
+			$extended_tasks_list_items = get_option( 'woocommerce_extended_task_list_items', array() );
+			if ( in_array( $task_name, $extended_tasks_list_items, true ) ) {
+				array_push( $extended_tasks_list_items, $task_name );
+				$tasks_list_items = array_diff( $extended_tasks_list_items, array( $task_name ) );
+				update_option( 'woocommerce_extended_task_list_items', $tasks_list_items );
 			}
 		}
 	}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -396,7 +396,7 @@ class OnboardingTasks {
 	}
 
 	/**
-	 * Removes item to the extended task list.
+	 * Removes an item from the extended task list.
 	 *
 	 * @param mixed $task_name Task name to remove.
 	 */


### PR DESCRIPTION
Related issue #5242
This PR adds a few modifications [related to the changes](https://github.com/woocommerce/woocommerce-admin/pull/5794) to the task extensibility. 

The modifications in this PR are:
* a small refactor related to the list handling
* a method to [unregister the extended tasks](https://github.com/woocommerce/woocommerce-admin/pull/5794#pullrequestreview-544454521)
* a default extended task type (`extension`)


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2020 12 02-17_01_48](https://user-images.githubusercontent.com/1314156/100925052-3c99a700-34c0-11eb-9a32-f0eda5c7c75a.png)

### Detailed test instructions:
0. Checkout `add/5242_update`.
1. Run `npm run example -- --ext=add-task`.
2. Activate the plugin `WooCommerce Admin Add Task Example`.
3. Be sure the setup task list is not hidden
```
UPDATE `wp_options` SET `option_value` = 'no' WHERE `wp_options`.`option_name` = 'woocommerce_task_list_hidden';
```
4. Go to the `Home` screen.
5. Verify the task list `Extensions setup` is visible.
6. Verify the task list was added to `woocommerce_extended_task_list_items`. You can do it with a sentence like this:
```
SELECT * FROM `wp_options` WHERE `option_name` = 'woocommerce_extended_task_list_items'
```
7. Deactivate the plugin: `WooCommerce Admin Add Task Example`
8. Verify the task list was removed from `woocommerce_extended_task_list_items`.

<!--- Please add a Changelog note
Enhancement: Small tasks extensibility refactor in Home Screen.
Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
