### PR TITLE
Add Product Attributes Endpoint

### DIFF
--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -63,6 +63,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Options',
 			'Automattic\WooCommerce\Admin\API\Orders',
 			'Automattic\WooCommerce\Admin\API\Products',
+			'Automattic\WooCommerce\Admin\API\ProductAttributes',
 			'Automattic\WooCommerce\Admin\API\ProductCategories',
 			'Automattic\WooCommerce\Admin\API\ProductVariations',
 			'Automattic\WooCommerce\Admin\API\ProductReviews',

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -64,6 +64,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Orders',
 			'Automattic\WooCommerce\Admin\API\Products',
 			'Automattic\WooCommerce\Admin\API\ProductAttributes',
+			'Automattic\WooCommerce\Admin\API\ProductAttributeTerms',
 			'Automattic\WooCommerce\Admin\API\ProductCategories',
 			'Automattic\WooCommerce\Admin\API\ProductVariations',
 			'Automattic\WooCommerce\Admin\API\ProductReviews',

--- a/src/API/ProductAttributeTerms.php
+++ b/src/API/ProductAttributeTerms.php
@@ -33,16 +33,19 @@ class ProductAttributeTerms extends \WC_REST_Product_Attribute_Terms_Controller 
 			$this->namespace,
 			'products/attributes/(?P<slug>[a-z0-9_\-]+)/terms',
 			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_item_by_slug' ),
-				'permission_callback' => array( $this, 'get_custom_attribute_permissions_check' ),
-				'args'                => array(
+				'args'   => array(
 					'slug' => array(
 						'description' => __( 'Slug identifier for the resource.', 'woocommerce-admin' ),
 						'type'        => 'string',
 					),
 				),
-				'schema'              => array( $this, 'get_public_item_schema' ),
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item_by_slug' ),
+					'permission_callback' => array( $this, 'get_custom_attribute_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 	}

--- a/src/API/ProductAttributeTerms.php
+++ b/src/API/ProductAttributeTerms.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * REST API Product Attribute Terms Controller
+ *
+ * Handles requests to /products/attributes/<slug>/terms
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product attribute terms controller.
+ *
+ * @extends WC_REST_Product_Attribute_Terms_Controller
+ */
+class ProductAttributeTerms extends \WC_REST_Product_Attribute_Terms_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-analytics';
+
+
+	/**
+	 * Register the routes for custom product attributes.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		register_rest_route(
+			$this->namespace,
+			'products/attributes/(?P<slug>[a-z0-9_\-]+)/terms',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item_by_slug' ),
+				'permission_callback' => array( $this, 'get_custom_attribute_permissions_check' ),
+				'args'                => array(
+					'slug' => array(
+						'description' => __( 'Slug identifier for the resource.', 'woocommerce-admin' ),
+						'type'        => 'string',
+					),
+				),
+				'schema'              => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read a custom attribute.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_custom_attribute_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'attributes', 'read' ) ) {
+			return new WP_Error(
+				'woocommerce_rest_cannot_view',
+				__( 'Sorry, you cannot view this resource.', 'woocommerce-admin' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the Attribute's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+		// Custom attributes substitute slugs for numeric IDs.
+		$schema['properties']['id']['type'] = array( 'integer', 'string' );
+
+		return $schema;
+	}
+
+	/**
+	 * Query custom attribute values by slug.
+	 *
+	 * @param string $slug Attribute slug.
+	 * @return array Attribute values, formatted for response.
+	 */
+	protected function get_custom_attribute_values( $slug ) {
+		global $wpdb;
+
+		if ( empty( $slug ) ) {
+			return array();
+		}
+
+		// Find all attribute values assigned to products.
+		$query_results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_value, COUNT(meta_id) AS product_count
+				FROM {$wpdb->postmeta}
+				WHERE meta_key = %s
+				GROUP BY meta_value",
+				'attribute_' . esc_sql( $slug )
+			),
+			ARRAY_A
+		);
+
+		$attribute_values = array();
+
+		foreach ( $query_results as $term ) {
+			// Mimic the structure of a taxonomy-backed attribute values for response.
+			$data = array(
+				'id'          => $term['meta_value'],
+				'name'        => $term['meta_value'],
+				'slug'        => $term['meta_value'],
+				'description' => '',
+				'menu_order'  => 0,
+				'count'       => (int) $term['product_count'],
+			);
+
+			$response = rest_ensure_response( $data );
+			$response->add_links(
+				array(
+					'collection' => array(
+						'href' => rest_url(
+							$this->namespace . '/products/attributes/' . $slug . '/terms'
+						),
+					),
+				)
+			);
+			$response = $this->prepare_response_for_collection( $response );
+
+			$attribute_values[] = $response;
+		}
+
+		return $attribute_values;
+	}
+
+	/**
+	 * Get a single custom attribute.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Request|WP_Error
+	 */
+	public function get_item_by_slug( $request ) {
+		return $this->get_custom_attribute_values( $request['slug'] );
+	}
+}

--- a/src/API/ProductAttributes.php
+++ b/src/API/ProductAttributes.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * REST API Product Attributes Controller
+ *
+ * Handles requests to /products/attributes.
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product categories controller.
+ *
+ * @extends WC_REST_Product_Attributes_Controller
+ */
+class ProductAttributes extends \WC_REST_Product_Attributes_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-analytics';
+
+	/**
+	 * Get the query params for collections
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params           = parent::get_collection_params();
+		$params['search'] = array(
+			'description'       => __( 'Search by similar attribute name.', 'woocommerce-admin' ),
+			'type'              => 'string',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Get the Attribute's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+		// Custom attributes substitute slugs for numeric IDs.
+		$schema['properties']['id']['type'] = array( 'integer', 'string' );
+
+		return $schema;
+	}
+
+	/**
+	 * Get all attributes, with support for searching (which includes custom attributes).
+	 *
+	 * @param WP_REST_Request $request The API request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		if ( empty( $request['search'] ) ) {
+			return parent::get_items( $request );
+		}
+
+		$search_string       = $request['search'];
+		$matching_attributes = $this->get_custom_attributes( $search_string );
+		$taxonomy_attributes = wc_get_attribute_taxonomies();
+
+		foreach ( $taxonomy_attributes as $attribute_obj ) {
+			// Skip taxonomy attributes that didn't match the query.
+			if ( false === stripos( $attribute_obj->attribute_label, $search_string ) ) {
+				continue;
+			}
+
+			$attribute             = $this->prepare_item_for_response( $attribute_obj, $request );
+			$matching_attributes[] = $this->prepare_response_for_collection( $attribute );
+		}
+
+		$response = rest_ensure_response( $matching_attributes );
+		$response->header( 'X-WP-Total', count( $matching_attributes ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
+	}
+
+	/**
+	 * Query custom attributes by name.
+	 *
+	 * @param string $search Search string.
+	 * @return array Matching attributes, formatted for response.
+	 */
+	protected function get_custom_attributes( $search ) {
+		global $wpdb;
+
+		if ( empty( $search ) ) {
+			return array();
+		}
+
+		// Get as close as we can to matching the name property of custom attributes using SQL.
+		$like = '%"name";s:%:"%' . $wpdb->esc_like( $search ) . '%"%';
+
+		// Find all serialized product attributes with names like the search string.
+		$query_results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_value
+				FROM {$wpdb->postmeta}
+				WHERE meta_key = '_product_attributes'
+				AND meta_value LIKE %s",
+				$like
+			),
+			ARRAY_A
+		);
+
+		$custom_attributes = array();
+
+		foreach ( $query_results as $raw_product_attributes ) {
+
+			$meta_attributes = maybe_unserialize( $raw_product_attributes['meta_value'] );
+
+			if ( empty( $meta_attributes ) || ! is_array( $meta_attributes ) ) {
+				continue;
+			}
+
+			foreach ( $meta_attributes as $meta_attribute_key => $meta_attribute_value ) {
+				$meta_value = array_merge(
+					array(
+						'name'        => '',
+						'is_taxonomy' => 0,
+					),
+					(array) $meta_attribute_value
+				);
+
+				// Skip non-custom attributes.
+				if ( ! empty( $meta_value['is_taxonomy'] ) ) {
+					continue;
+				}
+
+				// Skip custom attributes that didn't match the query.
+				// (There can be any number of attributes in the meta value).
+				if ( false === stripos( $meta_value['name'], $search ) ) {
+					continue;
+				}
+
+				// Skip already matched attributes.
+				if ( isset( $custom_attributes[ $meta_attribute_key ] ) ) {
+					continue;
+				}
+
+				// Mimic the structure of a taxonomy-backed attribute for response.
+				$data = array(
+					'id'           => $meta_attribute_key,
+					'name'         => $meta_value['name'],
+					'slug'         => $meta_attribute_key,
+					'type'         => 'select',
+					'order_by'     => 'menu_order',
+					'has_archives' => false,
+				);
+
+				$response = rest_ensure_response( $data );
+				$response->add_links( $this->prepare_links( (object) array( 'attribute_id' => $meta_attribute_key ) ) );
+				$response = $this->prepare_response_for_collection( $response );
+
+				$custom_attributes[ $meta_attribute_key ] = $response;
+			}
+		}
+
+		return array_values( $custom_attributes );
+	}
+}

--- a/src/API/ProductAttributes.php
+++ b/src/API/ProductAttributes.php
@@ -105,7 +105,8 @@ class ProductAttributes extends \WC_REST_Product_Attributes_Controller {
 				"SELECT meta_value
 				FROM {$wpdb->postmeta}
 				WHERE meta_key = '_product_attributes'
-				AND meta_value LIKE %s",
+				AND meta_value LIKE %s
+				LIMIT 100",
 				$like
 			),
 			ARRAY_A

--- a/tests/api/product-attributes.php
+++ b/tests/api/product-attributes.php
@@ -138,6 +138,35 @@ class WC_Tests_API_Product_Attributes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting a single attribute by slug.
+	 */
+	public function test_by_slug() {
+		wp_set_current_user( $this->user );
+
+		$request   = new WP_REST_Request( 'GET', $this->endpoint . '/numeric-size' );
+		$response  = $this->server->dispatch( $request );
+		$attribute = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'numeric-size', $attribute['id'] );
+		$this->assertEquals( 'numeric-size', $attribute['slug'] );
+		$this->assertEquals( 'Numeric Size', $attribute['name'] );
+	}
+
+	/**
+	 * Test not finding a single attribute by slug.
+	 */
+	public function test_by_slug_404() {
+		wp_set_current_user( $this->user );
+
+		$request   = new WP_REST_Request( 'GET', $this->endpoint . '/not-a-real-slug' );
+		$response  = $this->server->dispatch( $request );
+		$attribute = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
 	 * Test terms schema.
 	 */
 	public function test_terms_schema() {

--- a/tests/api/product-attributes.php
+++ b/tests/api/product-attributes.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Product Attributes REST API Test
+ *
+ * @package WooCommerce\Admin\Tests\API
+ */
+
+/**
+ * Class WC_Tests_API_Product_Attributes
+ */
+class WC_Tests_API_Product_Attributes extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-analytics/products/attributes';
+
+	/**
+	 * Setup test reports categories data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test request without valid permissions.
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test schema.
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 6, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertEquals( array( 'integer', 'string' ), $properties['id']['type'] );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'slug', $properties );
+		$this->assertArrayHasKey( 'type', $properties );
+		$this->assertArrayHasKey( 'order_by', $properties );
+		$this->assertArrayHasKey( 'has_archives', $properties );
+	}
+}


### PR DESCRIPTION
Partially implements #5560.

This PR enhances the `/products/attributes` and `/products/attributes/[term]/terms` endpoints to include custom (non-global, not taxonomy-backed) attributes.

A follow up PR will modify the Attribute report filter to use these endpoints for filter value selection.

### Detailed test instructions:

- Ensure your store has some global Product Attributes defined
- Create a variation that uses some custom attributes
- Search for your custom attribute using `/wc-analytics/products/attributes/?search=`
- Verify the custom attribute is in the results (and any taxonomy backed attributes that match the query)
- Retrieve all terms using `/wc-analytics/products/attributes/[slug]/terms` (substitute the slug of your custom term)
- Verify all terms are returned

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

Enhancement: Support Custom Product Attributes in REST API
