### PR TITLE
Fix/5831 nav add plugin settings

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -330,14 +330,14 @@ class Menu {
 	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
 	 *    ).
 	 */
-	public static function add_plugin_setting_item( $args ) {
+	public static function add_setting_item( $args ) {
 		unset( $args['order'] );
 
 		if ( isset( $args['parent'] ) || isset( $args['menuId'] ) ) {
 			error_log(  // phpcs:ignore
 				sprintf(
 					/* translators: 1: Duplicate menu item path. */
-					esc_html__( 'The item ID %1$s attempted to register using an invalid option. The arguments `menuId` and `parent` are not allowed for add_plugin_setting_item()', 'woocommerce-admin' ),
+					esc_html__( 'The item ID %1$s attempted to register using an invalid option. The arguments `menuId` and `parent` are not allowed for add_setting_item()', 'woocommerce-admin' ),
 					'`' . $args['id'] . '`'
 				)
 			);

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -333,13 +333,23 @@ class Menu {
 	public static function add_plugin_setting_item( $args ) {
 		unset( $args['order'] );
 
-			$item_args = array_merge(
-				$args,
-				array(
-					'menuId' => 'secondary',
-					'parent' => 'woocommerce-settings',
+		if ( isset( $args['parent'] ) || isset( $args['menuId'] ) ) {
+			error_log(  // phpcs:ignore
+				sprintf(
+					/* translators: 1: Duplicate menu item path. */
+					esc_html__( 'The item ID %1$s attempted to register using an invalid option. The arguments `menuId` and `parent` are not allowed for add_plugin_setting_item()', 'woocommerce-admin' ),
+					'`' . $args['id'] . '`'
 				)
 			);
+		}
+
+		$item_args = array_merge(
+			$args,
+			array(
+				'menuId' => 'secondary',
+				'parent' => 'woocommerce-settings',
+			)
+		);
 
 		self::add_item( $item_args );
 	}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -251,40 +251,6 @@ class Menu {
 	}
 
 	/**
-	 * Adds a plugin item.
-	 *
-	 * @param array $args Array containing the necessary arguments.
-	 *    $args = array(
-	 *      'id'         => (string) The unique ID of the menu item. Required.
-	 *      'title'      => (string) Title of the menu item. Required.
-	 *      'parent'     => (string) Parent menu item ID.
-	 *      'capability' => (string) Capability to view this menu item.
-	 *      'url'        => (string) URL or callback to be used. Required.
-	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
-	 *      'order'      => (int) Menu item order.
-	 *    ).
-	 */
-	public static function add_plugin_item( $args ) {
-		if ( ! isset( $args['parent'] ) ) {
-			unset( $args['order'] );
-		}
-
-		$item_args = array_merge(
-			$args,
-			array(
-				'menuId' => 'plugins',
-			)
-		);
-
-		$menu_id = self::get_item_menu_id( $item_args );
-		if ( 'plugins' !== $menu_id ) {
-			return;
-		}
-
-		self::add_item( $item_args );
-	}
-
-	/**
 	 * Adds a plugin category.
 	 *
 	 * @param array $args Array containing the necessary arguments.
@@ -316,6 +282,69 @@ class Menu {
 
 		self::add_category( $category_args );
 	}
+
+	/**
+	 * Adds a plugin item.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'parent'     => (string) Parent menu item ID.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'order'      => (int) Menu item order.
+	 *    ).
+	 */
+	public static function add_plugin_item( $args ) {
+		if ( ! isset( $args['parent'] ) ) {
+			unset( $args['order'] );
+		}
+
+		$item_args = array_merge(
+			$args,
+			array(
+				'menuId' => 'plugins',
+			)
+		);
+
+		$menu_id = self::get_item_menu_id( $item_args );
+
+		if ( 'plugins' !== $menu_id ) {
+			return;
+		}
+
+		self::add_item( $item_args );
+	}
+
+	/**
+	 * Adds a plugin setting item.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *    ).
+	 */
+	public static function add_plugin_setting_item( $args ) {
+		unset( $args['order'] );
+
+			$item_args = array_merge(
+				$args,
+				array(
+					'menuId' => 'secondary',
+					'parent' => 'woocommerce-settings',
+				)
+			);
+
+		self::add_item( $item_args );
+	}
+
+
 
 	/**
 	 * Get menu item templates for a given post type.


### PR DESCRIPTION
Fixes #5831

This is addressing the inability to add a Settings item to the nav via the `add_plugin_item()`. This is disallowed as that hook intentionally only supports adding items to the "Plugins" menu. Since the use case of plugins adding a "settings" page is a common one, this PR adds a similar hook that clearly allows for adding to Settings while still walling off unexpected behavior.

Notes:
- The `menuId` option is discarded for this hook, as it should only add to the `Settings` category in the `secondary` menu.
- The `parent` argument is also discarded, as we're only supporting singular items, not categories, under Settings.
- Right now if a plugin provides either of those two arguments, a warning is printed out via `error_log()`. If this is thought to be too noisy we can remove this bit.
- If we decide to go this route I'll also add notes for this function to the documentation.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/101421122-81e71b80-38a8-11eb-8fb7-2298e2164cd1.png)

### Detailed test instructions:

- Check out branch
- Ensure navigation feature is enabled
- Attempt to add an item to the Settings like this:
```
\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_setting_item(
	array(
		'id'     => 'example-item-settings',
		'title'  => 'Example Item Settings',
		'url'    => '/notreallythere/settings',
	)
);
```
You should see the page appear under the _Settings_ menu as expected.

- Add a dummy `parent` argument to that call, and refresh the page. You should still see the option present under _Settings_, but it should print out a warning to the `error_log`

- Do the same with `menuId`.  You should see the same behavior, while the item still displays as it should under _Settings_.