### PR TITLE
Only show card placeholder for item that is updating, not the whole list

### DIFF
--- a/client/homescreen/activity-panel/reviews/index.js
+++ b/client/homescreen/activity-panel/reviews/index.js
@@ -149,7 +149,7 @@ class ReviewsPanel extends Component {
 				review._embedded.up[ 0 ] ) ||
 			null;
 
-		if ( review.isUpdating || this.props.isRequesting ) {
+		if ( review.isUpdating ) {
 			return (
 				<ActivityCardPlaceholder
 					key={ review.id }
@@ -160,7 +160,7 @@ class ReviewsPanel extends Component {
 				/>
 			);
 		}
-		if ( isNull( product ) ) {
+		if ( isNull( product ) || review.status !== reviewsQuery.status ) {
 			return null;
 		}
 
@@ -292,14 +292,15 @@ class ReviewsPanel extends Component {
 	}
 
 	renderReviews( reviews ) {
-		if ( reviews.length === 0 ) {
+		const renderedReviews = reviews.map( ( review ) =>
+			this.renderReview( review, this.props )
+		);
+		if ( renderedReviews.filter( Boolean ).length === 0 ) {
 			return <></>;
 		}
 		return (
 			<>
-				{ reviews.map( ( review ) =>
-					this.renderReview( review, this.props )
-				) }
+				{ renderedReviews }
 				<Link
 					href={ getAdminLink(
 						'edit-comments.php?comment_type=review'
@@ -351,7 +352,7 @@ class ReviewsPanel extends Component {
 							lines={ 1 }
 						/>
 					) : (
-						<>{ this.renderReviews( reviews, this.props ) }</>
+						<>{ this.renderReviews( reviews ) }</>
 					) }
 				</Section>
 			</Fragment>

--- a/packages/data/src/reviews/reducer.js
+++ b/packages/data/src/reviews/reducer.js
@@ -23,9 +23,16 @@ const reducer = (
 	switch ( type ) {
 		case TYPES.UPDATE_REVIEWS:
 			const ids = [];
+			const justFields =
+				query && query._fields && query._fields.length > 0;
 			const nextReviews = reviews.reduce( ( result, review ) => {
 				ids.push( review.id );
-				result[ review.id ] = review;
+				result[ review.id ] = {
+					...( justFields && state.data[ review.id ]
+						? state.data[ review.id ]
+						: {} ),
+					...review,
+				};
 				return result;
 			}, {} );
 			return {

--- a/packages/data/src/reviews/reducer.js
+++ b/packages/data/src/reviews/reducer.js
@@ -23,14 +23,10 @@ const reducer = (
 	switch ( type ) {
 		case TYPES.UPDATE_REVIEWS:
 			const ids = [];
-			const justFields =
-				query && query._fields && query._fields.length > 0;
 			const nextReviews = reviews.reduce( ( result, review ) => {
 				ids.push( review.id );
 				result[ review.id ] = {
-					...( justFields && state.data[ review.id ]
-						? state.data[ review.id ]
-						: {} ),
+					...( state.data[ review.id ] || {} ),
 					...review,
 				};
 				return result;

--- a/packages/data/src/reviews/test/reducer.js
+++ b/packages/data/src/reviews/test/reducer.js
@@ -46,8 +46,43 @@ describe( 'reviews reducer', () => {
 		).toBeTruthy();
 
 		expect( state.reviews[ stringifiedQuery ].totalCount ).toBe( 45 );
-		expect( state.data[ '1' ] ).toBe( reviews[ 0 ] );
-		expect( state.data[ '2' ] ).toBe( reviews[ 1 ] );
+		expect( state.data[ '1' ] ).toEqual( reviews[ 0 ] );
+		expect( state.data[ '2' ] ).toEqual( reviews[ 1 ] );
+	} );
+
+	it( 'should handle UPDATE_REVIEWS with _fields, only update updated fields', () => {
+		const reviews = [ { id: 1 }, { id: 2 } ];
+		const totalCount = 45;
+		const query = { status: 'flavortown', _fields: [ 'id' ] };
+		const state = reducer(
+			{
+				...defaultState,
+				data: {
+					1: { id: 1, review: 'Yum!' },
+					2: { id: 2, review: 'Dynamite!' },
+				},
+			},
+			{
+				type: TYPES.UPDATE_REVIEWS,
+				reviews,
+				query,
+				totalCount,
+			}
+		);
+
+		const stringifiedQuery = JSON.stringify( query );
+
+		expect( state.reviews[ stringifiedQuery ].data ).toHaveLength( 2 );
+		expect(
+			state.reviews[ stringifiedQuery ].data.includes( 1 )
+		).toBeTruthy();
+		expect(
+			state.reviews[ stringifiedQuery ].data.includes( 2 )
+		).toBeTruthy();
+
+		expect( state.reviews[ stringifiedQuery ].totalCount ).toBe( 45 );
+		expect( state.data[ '1' ].review ).toEqual( 'Yum!' );
+		expect( state.data[ '2' ].review ).toEqual( 'Dynamite!' );
 	} );
 
 	it( 'should handle SET_ERROR', () => {


### PR DESCRIPTION
Fixes #5706 

Remove the use of the loading placeholder on every item when the list is being updated. Also make sure the `Manage all reviews` disappears when no items are displayed. Both of these changes make the list updates look a lot smoother (see the difference between gif's).
Had to update the update reviews reducer action as well, to not overwrite a review if we are only retrieving an `id`.

### Screenshots

With stutter (old):
![update-review-with-stutter](https://user-images.githubusercontent.com/2240960/101505273-8e23b500-394a-11eb-96fb-2f04bc71b6ba.gif)

Without stutter (new):
![update-review-without-stutter](https://user-images.githubusercontent.com/2240960/101505294-94b22c80-394a-11eb-97fb-4e04ed64cde4.gif)


### Detailed test instructions:

- Create store with products and reviews enabled
- Add a couple reviews to a product (in incognito window, so it needs to be reviewed)
- Go to WC home screen, and open the review panel
- Update a review (approve, delete, or mark as spam), it should update correctly and not look jittery.