### PR TITLE
Support custom product attributes in advanced filter

### DIFF
--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -38,6 +38,14 @@ export function getRequestByIdString( path, handleData = identity ) {
 	};
 }
 
+export const getAttributeLabels = getRequestByIdString(
+	NAMESPACE + '/products/attributes',
+	( attribute ) => ( {
+		key: attribute.id,
+		label: attribute.name,
+	} )
+);
+
 export const getCategoryLabels = getRequestByIdString(
 	NAMESPACE + '/products/categories',
 	( category ) => ( {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Unreleased
 
--   Change styling of `<ProductImage />`
+-   Change styling of `<ProductImage />`.
 -   Add new `<Accordion>` component.
 -   Remove the `showCount` prop from `<SearchListItem>`. Count will always be displayed if any of those props is not undefined/null: `countLabel` and `item.count`.
 -   Fix alignment of `<SearchListItem>` count bubble in newest versions of `@wordpress/components`.
+-   Support custom attributes in `<AttributeFilter />`.
+-   Add product attributes support to `<Search />`.
+-   Allow single-selection support to `<Search />`.
+-   Improve handling of `multiple` and `inlineTags` in `<SelectControl />`.
 
 # 5.1.2
 

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -27,7 +27,8 @@ const getScreenReaderText = ( {
 	if (
 		! attributeTerms ||
 		attributeTerms.length === 0 ||
-		selectedAttribute === false ||
+		! selectedAttribute ||
+		selectedAttribute.length === 0 ||
 		selectedAttributeTerm === ''
 	) {
 		return '';
@@ -39,8 +40,11 @@ const getScreenReaderText = ( {
 		  ) || {}
 		: {};
 
-	const attributeName = selectedAttribute.label;
-	const attributeTerm = selectedAttributeTerm.label;
+	const attributeName = selectedAttribute[ 0 ].label;
+	const termObject = attributeTerms.find(
+		( { key } ) => key === selectedAttributeTerm
+	);
+	const attributeTerm = termObject && termObject.label;
 
 	if ( ! attributeName || ! attributeTerm ) {
 		return '';

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -13,11 +13,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Search from '../search';
 import SelectControl from '../select-control';
 import { textContent } from './utils';
 
 const getScreenReaderText = ( {
-	attributes,
 	attributeTerms,
 	config,
 	filter,
@@ -25,11 +25,9 @@ const getScreenReaderText = ( {
 	selectedAttributeTerm,
 } ) => {
 	if (
-		! attributes ||
-		attributes.length === 0 ||
 		! attributeTerms ||
 		attributeTerms.length === 0 ||
-		selectedAttribute === '' ||
+		selectedAttribute === false ||
 		selectedAttributeTerm === ''
 	) {
 		return '';
@@ -41,11 +39,8 @@ const getScreenReaderText = ( {
 		  ) || {}
 		: {};
 
-	const { label: attributeName } =
-		attributes.find( ( attr ) => attr.key === selectedAttribute ) || {};
-	const { label: attributeTerm } =
-		attributeTerms.find( ( term ) => term.key === selectedAttributeTerm ) ||
-		{};
+	const attributeName = selectedAttribute.label;
+	const attributeTerm = selectedAttributeTerm.label;
 
 	if ( ! attributeName || ! attributeTerm ) {
 		return '';
@@ -82,43 +77,38 @@ const AttributeFilter = ( props ) => {
 	const { rule, value } = filter;
 	const { labels, rules } = config;
 
-	const [ attributes, setAttributes ] = useState( [] );
-
-	// Fetch all product attributes on mount.
-	useEffect( () => {
-		apiFetch( {
-			path: '/wc/v3/products/attributes',
-		} )
-			.then( ( attrs ) =>
-				attrs.map( ( { id, name } ) => ( {
-					key: id.toString(),
-					label: name,
-				} ) )
-			)
-			.then( setAttributes );
-	}, [] );
-
-	const [ selectedAttribute, setSelectedAttribute ] = useState(
-		Array.isArray( value ) ? value[ 0 ] : ''
-	);
+	const [ selectedAttribute, setSelectedAttribute ] = useState( [] );
 
 	// Set selected attribute from filter value (in query string).
 	useEffect( () => {
-		if ( Array.isArray( value ) ) {
-			setSelectedAttribute( value[ 0 ] );
+		if (
+			! selectedAttribute.length &&
+			Array.isArray( value ) &&
+			value[ 0 ]
+		) {
+			apiFetch( {
+				path: `/wc-analytics/products/attributes/${ value[ 0 ] }`,
+			} )
+				.then( ( { id, name } ) => [
+					{
+						key: id.toString(),
+						label: name,
+					},
+				] )
+				.then( setSelectedAttribute );
 		}
-	}, [ value ] );
+	}, [ value, selectedAttribute ] );
 
-	const [ attributeTerms, setAttributeTerms ] = useState( false );
+	const [ attributeTerms, setAttributeTerms ] = useState( [] );
 
 	// Fetch all product attributes on mount.
 	useEffect( () => {
-		if ( ! selectedAttribute ) {
+		if ( ! selectedAttribute.length ) {
 			return;
 		}
 		setAttributeTerms( false );
 		apiFetch( {
-			path: `/wc/v3/products/attributes/${ selectedAttribute }/terms`,
+			path: `/wc-analytics/products/attributes/${ selectedAttribute[ 0 ].key }/terms`,
 		} )
 			.then( ( terms ) =>
 				terms.map( ( { id, name } ) => ( {
@@ -134,7 +124,6 @@ const AttributeFilter = ( props ) => {
 	);
 
 	const screenReaderText = getScreenReaderText( {
-		attributes,
 		attributeTerms,
 		config,
 		filter,
@@ -180,63 +169,71 @@ const AttributeFilter = ( props ) => {
 									'woocommerce-filters-advanced__attribute-fieldset'
 								) }
 							>
-								{ attributes.length > 0 ? (
-									<SelectControl
+								{ ! Array.isArray( value ) ||
+								! value.length ||
+								selectedAttribute.length ? (
+									<Search
 										className="woocommerce-filters-advanced__input woocommerce-search"
-										label={ __(
+										onChange={ ( [ attr ] ) => {
+											setSelectedAttribute(
+												attr ? [ attr ] : []
+											);
+											setSelectedAttributeTerm( '' );
+											onFilterChange(
+												'value',
+												[ attr && attr.key ].filter(
+													Boolean
+												)
+											);
+										} }
+										type="attributes"
+										placeholder={ __(
 											'Attribute name',
 											'woocommerce-admin'
 										) }
-										isSearchable
-										showAllOnFocus
-										options={ attributes }
+										multiple={ false }
 										selected={ selectedAttribute }
-										onChange={ ( attr ) => {
-											// Clearing the input using delete/backspace causes an empty array to be passed here.
-											if ( typeof attr !== 'string' ) {
-												attr = '';
-											}
-											setSelectedAttribute( attr );
-											setSelectedAttributeTerm( '' );
-											onFilterChange( 'value', [ attr ] );
-										} }
+										inlineTags
+										aria-label={ __(
+											'Attribute name',
+											'woocommerce-admin'
+										) }
 									/>
 								) : (
 									<Spinner />
 								) }
-								{ attributes.length > 0 &&
-									selectedAttribute !== '' &&
-									( attributeTerms !== false ? (
+								{ selectedAttribute.length > 0 &&
+									( attributeTerms.length ? (
 										<Fragment>
 											<span className="woocommerce-filters-advanced__attribute-field-separator">
 												=
 											</span>
 											<SelectControl
 												className="woocommerce-filters-advanced__input woocommerce-search"
-												label={ __(
+												placeholder={ __(
 													'Attribute value',
 													'woocommerce-admin'
 												) }
+												inlineTags
 												isSearchable
+												multiple={ false }
 												showAllOnFocus
 												options={ attributeTerms }
 												selected={
 													selectedAttributeTerm
 												}
 												onChange={ ( term ) => {
-													// Clearing the input using delete/backspace causes an empty array to be passed here.
-													if (
-														typeof term !== 'string'
-													) {
-														term = '';
-													}
 													setSelectedAttributeTerm(
 														term
 													);
-													onFilterChange( 'value', [
-														selectedAttribute,
-														term,
-													] );
+													onFilterChange(
+														'value',
+														[
+															selectedAttribute[ 0 ]
+																.key,
+															term,
+														].filter( Boolean )
+													);
 												} }
 											/>
 										</Fragment>

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -227,6 +227,12 @@ const AttributeFilter = ( props ) => {
 													selectedAttributeTerm
 												}
 												onChange={ ( term ) => {
+													// Clearing the input using delete/backspace causes an empty array to be passed here.
+													if (
+														typeof term !== 'string'
+													) {
+														term = '';
+													}
 													setSelectedAttributeTerm(
 														term
 													);

--- a/packages/components/src/search/autocompleters/attributes.js
+++ b/packages/components/src/search/autocompleters/attributes.js
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * Internal dependencies
+ */
+import { computeSuggestionMatch } from './utils';
+
+/**
+ * A raw completer option.
+ *
+ * @typedef {*} CompleterOption
+ */
+
+/**
+ * @callback FnGetOptions
+ *
+ * @return {(CompleterOption[]|Promise.<CompleterOption[]>)} The completer options or a promise for them.
+ */
+
+/**
+ * @callback FnGetOptionKeywords
+ * @param {CompleterOption} option a completer option.
+ *
+ * @return {string[]} list of key words to search.
+ */
+
+/**
+ * @callback FnIsOptionDisabled
+ * @param {CompleterOption} option a completer option.
+ *
+ * @return {string[]} whether or not the given option is disabled.
+ */
+
+/**
+ * @callback FnGetOptionLabel
+ * @param {CompleterOption} option a completer option.
+ *
+ * @return {(string|Array.<(string|Node)>)} list of react components to render.
+ */
+
+/**
+ * @callback FnAllowContext
+ * @param {string} before the string before the auto complete trigger and query.
+ * @param {string} after  the string after the autocomplete trigger and query.
+ *
+ * @return {boolean} true if the completer can handle.
+ */
+
+/**
+ * @typedef {Object} OptionCompletion
+ * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
+ * @property {OptionCompletionValue} value the completion value.
+ */
+
+/**
+ * A completion value.
+ *
+ * @typedef {(string|WPElement|Object)} OptionCompletionValue
+ */
+
+/**
+ * @callback FnGetOptionCompletion
+ * @param {CompleterOption} value the value of the completer option.
+ * @param {string} query the text value of the autocomplete query.
+ *
+ * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
+ * 													   OptionCompletionValue is returned, the
+ * 													   completion action defaults to `insert-at-caret`.
+ */
+
+/**
+ * @typedef {Object} WPCompleter
+ * @property {string} name a way to identify a completer, useful for selective overriding.
+ * @property {?string} className A class to apply to the popup menu.
+ * @property {string} triggerPrefix the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
+ * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
+ * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ */
+
+/**
+ * A product attributes completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {WPCompleter}
+ */
+export default {
+	name: 'attributes',
+	className: 'woocommerce-search__product-result',
+	options( search ) {
+		const query = search
+			? {
+					search,
+					per_page: 10,
+					orderby: 'count',
+			  }
+			: {};
+		return apiFetch( {
+			path: addQueryArgs( '/wc-analytics/products/attributes', query ),
+		} );
+	},
+	isDebounced: true,
+	getOptionIdentifier( attribute ) {
+		return attribute.id;
+	},
+	getOptionKeywords( attribute ) {
+		return [ attribute.name ];
+	},
+	getFreeTextOptions( query ) {
+		const label = (
+			<span key="name" className="woocommerce-search__result-name">
+				{ interpolateComponents( {
+					mixedString: __(
+						'All attributes with names that include {{query /}}',
+						'woocommerce-admin'
+					),
+					components: {
+						query: (
+							<strong className="components-form-token-field__suggestion-match">
+								{ query }
+							</strong>
+						),
+					},
+				} ) }
+			</span>
+		);
+		const nameOption = {
+			key: 'name',
+			label,
+			value: { id: query, name: query },
+		};
+
+		return [ nameOption ];
+	},
+	getOptionLabel( attribute, query ) {
+		const match = computeSuggestionMatch( attribute.name, query ) || {};
+
+		return (
+			<span
+				key="name"
+				className="woocommerce-search__result-name"
+				aria-label={ attribute.name }
+			>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>
+		);
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( attribute ) {
+		const value = {
+			key: attribute.id,
+			label: attribute.name,
+		};
+		return value;
+	},
+};

--- a/packages/components/src/search/autocompleters/index.js
+++ b/packages/components/src/search/autocompleters/index.js
@@ -1,6 +1,7 @@
 /**
  * Export all autocompleters
  */
+export { default as attributes } from './attributes';
 export { default as productCategory } from './categories';
 export { default as countries } from './countries';
 export { default as coupons } from './coupons';

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -154,6 +154,7 @@ export class Search extends Component {
 			showClearButton,
 			staticResults,
 			disabled,
+			multiple,
 		} = this.props;
 		const { options } = this.state;
 		const inputType = autocompleter.inputType
@@ -172,7 +173,7 @@ export class Search extends Component {
 					isSearchable
 					label={ placeholder }
 					getSearchExpression={ autocompleter.getSearchExpression }
-					multiple
+					multiple={ multiple }
 					placeholder={ placeholder }
 					onChange={ this.updateSelected }
 					onFilter={ this.appendFreeTextSearch }
@@ -266,6 +267,7 @@ Search.defaultProps = {
 	showClearButton: false,
 	staticResults: false,
 	disabled: false,
+	multiple: true,
 };
 
 export default Search;

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -11,6 +11,7 @@ import classnames from 'classnames';
  */
 import SelectControl from '../select-control';
 import {
+	attributes,
 	countries,
 	coupons,
 	customers,
@@ -42,6 +43,8 @@ export class Search extends Component {
 
 	getAutocompleter() {
 		switch ( this.props.type ) {
+			case 'attributes':
+				return attributes;
 			case 'categories':
 				return productCategory;
 			case 'countries':
@@ -202,6 +205,7 @@ Search.propTypes = {
 	 * The object type to be used in searching.
 	 */
 	type: PropTypes.oneOf( [
+		'attributes',
 		'categories',
 		'countries',
 		'coupons',

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -171,7 +171,6 @@ export class Search extends Component {
 					hideBeforeSearch
 					inlineTags={ inlineTags }
 					isSearchable
-					label={ placeholder }
 					getSearchExpression={ autocompleter.getSearchExpression }
 					multiple={ multiple }
 					placeholder={ placeholder }

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -229,17 +229,22 @@ Search.propTypes = {
 	 */
 	placeholder: PropTypes.string,
 	/**
-	 * An array of objects describing selected values. If the label of the selected
-	 * value is omitted, the Tag of that value will not be rendered inside the
-	 * search box.
+	 * An array of objects describing selected values or optionally a string for a single value.
+	 * If the label of the selected value is omitted, the Tag of that value will not
+	 * be rendered inside the search box.
 	 */
-	selected: PropTypes.arrayOf(
-		PropTypes.shape( {
-			key: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] )
-				.isRequired,
-			label: PropTypes.string,
-		} )
-	),
+	selected: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.arrayOf(
+			PropTypes.shape( {
+				key: PropTypes.oneOfType( [
+					PropTypes.number,
+					PropTypes.string,
+				] ).isRequired,
+				label: PropTypes.string,
+			} )
+		),
+	] ),
 	/**
 	 * Render tags inside input, otherwise render below input.
 	 */

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -126,6 +126,7 @@ class Control extends Component {
 			selected,
 		} = this.props;
 		const { isActive } = this.state;
+		const disabled = ! multiple && inlineTags && selected.length > 0;
 
 		return (
 			<input
@@ -134,9 +135,9 @@ class Control extends Component {
 				id={ `woocommerce-select-control-${ instanceId }__control-input` }
 				ref={ this.input }
 				type={ isSearchable ? searchInputType : 'button' }
-				disabled={ ! multiple && inlineTags && selected.length > 0 }
+				disabled={ disabled }
 				value={ this.getInputValue() }
-				placeholder={ isActive ? placeholder : '' }
+				placeholder={ isActive && ! disabled ? placeholder : '' }
 				onChange={ this.updateSearch( onSearch ) }
 				onFocus={ this.onFocus( onSearch ) }
 				onBlur={ this.onBlur }
@@ -191,8 +192,11 @@ class Control extends Component {
 			isSearchable,
 			label,
 			query,
+			multiple,
+			selected,
 		} = this.props;
 		const { isActive } = this.state;
+		const disabled = ! multiple && inlineTags && selected.length > 0;
 
 		return (
 			// Disable reason: The div below visually simulates an input field. Its
@@ -208,7 +212,7 @@ class Control extends Component {
 					className,
 					{
 						empty: ! query || query.length === 0,
-						'is-active': isActive,
+						'is-active': isActive && ! disabled,
 						'has-tags': inlineTags && hasTags,
 						'with-value': this.getInputValue().length,
 						'has-error': !! help,

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -122,6 +122,8 @@ class Control extends Component {
 			onSearch,
 			placeholder,
 			searchInputType,
+			multiple,
+			selected,
 		} = this.props;
 		const { isActive } = this.state;
 
@@ -132,6 +134,7 @@ class Control extends Component {
 				id={ `woocommerce-select-control-${ instanceId }__control-input` }
 				ref={ this.input }
 				type={ isSearchable ? searchInputType : 'button' }
+				disabled={ ! multiple && inlineTags && selected.length > 0 }
 				value={ this.getInputValue() }
 				placeholder={ isActive ? placeholder : '' }
 				onChange={ this.updateSearch( onSearch ) }
@@ -156,6 +159,7 @@ class Control extends Component {
 
 	getInputValue() {
 		const {
+			inlineTags,
 			isFocused,
 			isSearchable,
 			multiple,
@@ -165,7 +169,7 @@ class Control extends Component {
 		const selectedValue = selected.length ? selected[ 0 ].label : '';
 
 		// Show the selected value for simple select dropdowns.
-		if ( ! multiple && ! isFocused ) {
+		if ( ! multiple && ! isFocused && ! inlineTags ) {
 			return selectedValue;
 		}
 

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -122,11 +122,8 @@ class Control extends Component {
 			onSearch,
 			placeholder,
 			searchInputType,
-			multiple,
-			selected,
 		} = this.props;
 		const { isActive } = this.state;
-		const disabled = ! multiple && inlineTags && selected.length > 0;
 
 		return (
 			<input
@@ -135,9 +132,8 @@ class Control extends Component {
 				id={ `woocommerce-select-control-${ instanceId }__control-input` }
 				ref={ this.input }
 				type={ isSearchable ? searchInputType : 'button' }
-				disabled={ disabled }
 				value={ this.getInputValue() }
-				placeholder={ isActive && ! disabled ? placeholder : '' }
+				placeholder={ isActive ? placeholder : '' }
 				onChange={ this.updateSearch( onSearch ) }
 				onFocus={ this.onFocus( onSearch ) }
 				onBlur={ this.onBlur }
@@ -192,11 +188,8 @@ class Control extends Component {
 			isSearchable,
 			label,
 			query,
-			multiple,
-			selected,
 		} = this.props;
 		const { isActive } = this.state;
-		const disabled = ! multiple && inlineTags && selected.length > 0;
 
 		return (
 			// Disable reason: The div below visually simulates an input field. Its
@@ -212,7 +205,7 @@ class Control extends Component {
 					className,
 					{
 						empty: ! query || query.length === 0,
-						'is-active': isActive && ! disabled,
+						'is-active': isActive,
 						'has-tags': inlineTags && hasTags,
 						'with-value': this.getInputValue().length,
 						'has-error': !! help,

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -16,23 +16,17 @@ import List from './list';
 import Tags from './tags';
 import Control from './control';
 
+const initialState = { isExpanded: false, isFocused: false, query: '' };
+
 /**
  * A search box which filters options while typing,
  * allowing a user to select from an option from a filtered list.
  */
 export class SelectControl extends Component {
-	static getInitialState() {
-		return {
-			isExpanded: false,
-			isFocused: false,
-			query: '',
-		};
-	}
-
 	constructor( props ) {
 		super( props );
 		this.state = {
-			...this.constructor.getInitialState(),
+			...initialState,
 			filteredOptions: [],
 			selectedIndex: 0,
 		};
@@ -55,15 +49,14 @@ export class SelectControl extends Component {
 	}
 
 	reset( selected = this.getSelected() ) {
-		const { multiple } = this.props;
-		const initialState = this.constructor.getInitialState();
-
+		const { inlineTags } = this.props;
+		const newState = { ...initialState };
 		// Reset to the option label if not using tags.
-		if ( ! multiple && selected.length && selected[ 0 ].label ) {
-			initialState.query = selected[ 0 ].label;
+		if ( ! inlineTags && selected.length && selected[ 0 ].label ) {
+			newState.query = selected[ 0 ].label;
 		}
 
-		this.setState( initialState );
+		this.setState( newState );
 	}
 
 	handleFocusOutside() {

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -64,13 +64,17 @@ export class SelectControl extends Component {
 	}
 
 	hasTags() {
-		const { multiple, selected } = this.props;
+		const { inlineTags, selected } = this.props;
 
-		if ( ! multiple ) {
+		if ( ! inlineTags ) {
 			return false;
 		}
 
-		return selected.some( ( item ) => Boolean( item.label ) );
+		if ( Array.isArray( selected ) ) {
+			return selected.some( ( item ) => Boolean( item.label ) );
+		}
+
+		return Boolean( selected );
 	}
 
 	getSelected() {

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Add Customer Type column to the Orders report table. #5820
 - Fix: Product exclusion filter on Orders Report.
 - Fix: Typo in Variation Stats DataStore context filter value.
+- Fix: support custom attributes in Attribute advanced report filter.
 
 = 1.7.0 11/11/2020 =
 - Enhancement: Variations report.  #5167

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1330,7 +1330,7 @@ class DataStore extends SqlQuery {
 		 * @param string $field      The object type.
 		 * @param string $context    The data store context.
 		 */
-		$ids = apply_filters( 'woocommerce_analytics_ ' . $field, $ids, $query_args, $field, $this->context );
+		$ids = apply_filters( 'woocommerce_analytics_' . $field, $ids, $query_args, $field, $this->context );
 
 		if ( ! empty( $ids ) ) {
 			$ids_str = implode( $separator, $ids );

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1233,34 +1233,42 @@ class DataStore extends SqlQuery {
 				continue;
 			}
 			foreach ( $query_args[ $arg ] as $attribute_term ) {
-				// We expect tuples of IDs.
+				// We expect tuples.
 				if ( ! is_array( $attribute_term ) || 2 !== count( $attribute_term ) ) {
 					continue;
 				}
 
-				$attribute_id = intval( $attribute_term[0] );
-				$term_id      = intval( $attribute_term[1] );
+				// If the tuple is numeric, assume these are IDs.
+				if ( is_numeric( $attribute_term[0] ) && is_numeric( $attribute_term[1] ) ) {
+					$attribute_id = intval( $attribute_term[0] );
+					$term_id      = intval( $attribute_term[1] );
 
-				// Tuple, but non-numeric.
-				if ( 0 === $attribute_id || 0 === $term_id ) {
-					continue;
+					// Invalid IDs.
+					if ( 0 === $attribute_id || 0 === $term_id ) {
+						continue;
+					}
+
+					// @todo: Use wc_get_attribute() instead ?
+					$attr_taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
+					// Invalid attribute ID.
+					if ( empty( $attr_taxonomy ) ) {
+						continue;
+					}
+
+					$attr_term = get_term_by( 'id', $term_id, $attr_taxonomy );
+					// Invalid term ID.
+					if ( false === $attr_term ) {
+						continue;
+					}
+
+					$meta_key   = wc_variation_attribute_name( $attr_taxonomy );
+					$meta_value = $attr_term->slug;
+				} else {
+					// Assume these are a custom attribute slug/value pair.
+					$meta_key   = 'attribute_' . esc_sql( $attribute_term[0] );
+					$meta_value = esc_sql( $attribute_term[1] );
 				}
 
-				// @todo: Use wc_get_attribute() instead ?
-				$attr_taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
-				// Invalid attribute ID.
-				if ( empty( $attr_taxonomy ) ) {
-					continue;
-				}
-
-				$attr_term = get_term_by( 'id', $term_id, $attr_taxonomy );
-				// Invalid term ID.
-				if ( false === $attr_term ) {
-					continue;
-				}
-
-				$meta_key   = wc_variation_attribute_name( $attr_taxonomy );
-				$meta_value = $attr_term->slug;
 				$join_alias = 'wpm1';
 
 				// If we're matching all filters (AND), we'll need multiple JOINs on postmeta.

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -137,10 +137,29 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		WC_Helper_Reports::reset_stats_dbs();
 
 		// Create a variable product.
-		$variable_product   = WC_Helper_Product::create_variation_product( new WC_Product_Variable() );
+		$variable_product = WC_Helper_Product::create_variation_product( new WC_Product_Variable() );
+
+		// Add a custom attribute.
+		$attributes  = $variable_product->get_attributes();
+		$custom_attr = new WC_Product_Attribute();
+		$custom_attr->set_name( 'Numeric Size' );
+		$custom_attr->set_options( array( '1', '2', '3', '4', '5' ) );
+		$custom_attr->set_visible( true );
+		$custom_attr->set_variation( true );
+		$attributes[] = $custom_attr;
+		$variable_product->set_attributes( $attributes );
+		$variable_product->save();
+
+		// Custom attribute terms can only be found once assigned to variations.
+		$data_store = $variable_product->get_data_store();
+		$data_store->create_all_product_variations( $variable_product );
+
+		// Fetch the product to get new variations.
+		$variable_product   = wc_get_product( $variable_product->get_id() );
 		$product_variations = $variable_product->get_children();
-		$order_variation_1  = wc_get_product( $product_variations[0] ); // Variation: size = small.
-		$order_variation_2  = wc_get_product( $product_variations[2] ); // Variation: size = huge, colour = red, number = 0.
+
+		$order_variation_1 = wc_get_product( $product_variations[0] ); // Variation: size = small.
+		$order_variation_2 = wc_get_product( end( $product_variations ) ); // Variation: size = huge, colour = blue, number = 1, numeric-size = 5.
 
 		// Create orders for variations.
 		$variation_order_1 = WC_Helper_Order::create_order( $this->user, $order_variation_1 );
@@ -177,8 +196,6 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$bad_args = array(
 			'not an array!',                   // Not an array.
 			array( 1, 2, 3 ),                  // Not a tuple.
-			array( 'a', 1 ),                   // Non-numeric attribute ID.
-			array( 1, 'a' ),                   // Non-numeric term ID.
 			array( -1, $small_term->term_id ), // Invaid attribute ID.
 			array( $size_attr_id, -1 ),        // Invaid term ID.
 		);
@@ -223,6 +240,22 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 					array( $size_attr_id, $small_term->term_id ),
 				),
 				'per_page'         => 15,
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $response_orders ) );
+		$this->assertEquals( $response_orders[0]['order_id'], $variation_order_2->get_id() );
+
+		// Filter by the "Numeric Size" custom attribute, with value "1".
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'attribute_is' => array(
+					array( 'numeric-size', '5' ),
+				),
 			)
 		);
 		$response        = $this->server->dispatch( $request );


### PR DESCRIPTION
Fixes #5560, along with https://github.com/woocommerce/woocommerce-admin/pull/5840.

This PR hooks up the product attribute advanced filter to the new endpoints that support custom attributes.

To support that end:
* A new `attributes` autocompleter was added to the `<Search>` component
* The `<Search>` component `selected` prop was updated to match the inner `<SelectControl>` that it gets passed to
* The passthough `multiple` prop can be defined on the `<Search>` component
* The attribute filter now uses the "inline tag" style for chosen values
* Some UX tweaks were made for `<SelectControl>` for combinations of `multiple` and `inlineTags`
* The reports datastore `get_attribute_subqueries()` method had custom attribute support added

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2020-12-09 at 9 55 48 AM](https://user-images.githubusercontent.com/63922/101660918-b0363980-3a15-11eb-9ffc-53f05f5e9026.png)

Searching returns both custom and global product attributes.

![Screen Shot 2020-12-09 at 9 56 43 AM](https://user-images.githubusercontent.com/63922/101660968-bc21fb80-3a15-11eb-82ab-ccd02a49b9fa.png)

Selecting a custom attribute.

![Screen Shot 2020-12-09 at 9 56 57 AM](https://user-images.githubusercontent.com/63922/101661015-c80dbd80-3a15-11eb-9af9-226ad2710b6b.png)


### Detailed test instructions:

- Create an order using Woo's sample product data variable Hoodie /product/hoodie/?attribute_pa_color=green&attribute_logo=No.
- Confirm the Hoodie has variations "Logo" and "Color" in the Edit Product screen.
- See the data from the purchase available in the Orders Report.
- Advanced Filters > Add a filter > Attribute
- See the "logo" attribute available in the dropdown
- Select "no" for the value
- Click "Filter"
- Verify the order is in the results
- Refresh the page
- Verify the filter values are restored from the URL querystring

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
