### PR TITLE
Hide shipping cost task if user has disabled shipping

### DIFF
--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -168,7 +168,7 @@ class Shipping extends Component {
 	}
 
 	getSteps() {
-		const { countryCode, isJetpackConnected } = this.props;
+		const { countryCode, isJetpackConnected, settings } = this.props;
 		const pluginsToActivate = this.getPluginsToActivate();
 		const requiresJetpackConnection =
 			! isJetpackConnected && countryCode === 'US';
@@ -217,7 +217,10 @@ class Shipping extends Component {
 						{ ...this.props }
 					/>
 				),
-				visible: true,
+				visible:
+					settings.woocommerce_ship_to_countries === 'disabled'
+						? false
+						: true,
 			},
 			{
 				key: 'label_printing',

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -23,7 +23,7 @@ import StoreLocation from '../steps/location';
 import ShippingRates from './rates';
 import { createNoticesFromResponse } from '../../../lib/notices';
 
-class Shipping extends Component {
+export class Shipping extends Component {
 	constructor( props ) {
 		super( props );
 

--- a/client/task-list/test/shipping.js
+++ b/client/task-list/test/shipping.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { Shipping } from '../tasks/shipping';
+
+describe( 'TaskList > Shipping', () => {
+	describe( 'Shipping', () => {
+		afterEach( () => jest.clearAllMocks() );
+
+		it( 'hides shipping setup when user has disabled shipping', () => {
+			render(
+				<Shipping
+					settings={ {
+						woocommerce_ship_to_countries: 'disabled',
+					} }
+				/>
+			);
+
+			expect( screen.queryByText( 'Set shipping costs' ) ).toBeNull();
+		} );
+	} );
+} );

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -63,6 +63,7 @@ global.wcSettings = {
 		woocommerce_excluded_report_order_statuses: [],
 	},
 	dataEndpoints: {
+    countries: [],
 		performanceIndicators: [
 			{
 				chart: 'total_sales',


### PR DESCRIPTION
Fixes #5562 

This PR checks general setting values and hide the shipping cost task if `settings.woocommerce_ship_to_countries` is disabled.

### Screenshots

**Original**
![Screen Shot 2020-12-08 at 5 41 07 PM](https://user-images.githubusercontent.com/4723145/101562955-3eaaac80-397d-11eb-92a7-e9a27c61aa45.jpg)


**Shipping location(s)**: Disable shipping and shipping calculations

![Screen Shot 2020-12-08 at 5 44 00 PM](https://user-images.githubusercontent.com/4723145/101562919-2b97dc80-397d-11eb-8b1c-c7af74b1e366.jpg)

### Detailed test instructions:

1. Complete the initial onboarding flow
2. Disable shipping: **WooCommerce > Settings > General > General options > Shipping location(s) > Select - Disable shipping and shipping Calculations**
3. Access: https://YOUR-DOMAIN/wp-admin/admin.php?page=wc-admin&task=shipping or navigate to WooCommerce -> Home and click "Set up shipping" under the `Finish setup`
4. Confirm that you have only 3 tasks and "Set shipping costs" task is missing.

