### PR TITLE
Move collapsible to panels config, fixing orders panel

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -52,6 +52,7 @@ export const ActivityPanel = () => {
 						initialOpen,
 						panel,
 						title,
+						collapsible,
 					} = panelData;
 					return (
 						<AccordionPanel
@@ -60,7 +61,7 @@ export const ActivityPanel = () => {
 							count={ count }
 							initialOpen={ initialOpen }
 							title={ title }
-							collapsible={ count !== 0 }
+							collapsible={ collapsible }
 						>
 							{ panel }
 						</AccordionPanel>

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -23,6 +23,7 @@ export function getAllPanels( {
 		totalOrderCount > 0 && {
 			className: 'woocommerce-homescreen-card',
 			count: countUnreadOrders,
+			collapsible: true,
 			id: 'orders-panel',
 			initialOpen: true,
 			panel: (
@@ -38,6 +39,7 @@ export function getAllPanels( {
 			count: countLowStockProducts,
 			id: 'stock-panel',
 			initialOpen: false,
+			collapsible: countLowStockProducts !== 0,
 			panel: (
 				<StockPanel countLowStockProducts={ countLowStockProducts } />
 			),
@@ -48,6 +50,7 @@ export function getAllPanels( {
 			id: 'reviews-panel',
 			count: countUnapprovedReviews,
 			initialOpen: false,
+			collapsible: countUnapprovedReviews !== 0,
 			panel: (
 				<ReviewsPanel
 					hasUnapprovedReviews={ countUnapprovedReviews > 0 }

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Move collapsible config to panels object, to allow for more control. #5855
 - Tweak: Fix inconsistent REST API paramater name for customer type filtering.
 - Enhancement: Tasks extensibility in Home Screen. #5794
 - Enhancement: Add page parameter to override default wc-admin page in Navigation API. #5821


### PR DESCRIPTION
Instead of setting the collapsible boolean on each activity panels count, I moved it to the panels config, so it can easily be toggled for different panels.
This fixes the 🎉 not showing up for the Orders panel.

### Screenshots

<img width="1433" alt="Screen Shot 2020-12-09 at 4 03 18 PM" src="https://user-images.githubusercontent.com/2240960/101681373-6f035100-3a38-11eb-9ef2-a049002db059.png">

### Detailed test instructions:

- Make sure you have a store with at-least one order
- Complete this order
- Navigate to the WC homescreen
- The orders panel should be collapsed with a 🎉  icon and saying - **You’ve fulfilled all your orders**
