### PR TITLE
Add navigation opt out modal

### DIFF
--- a/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+
+export default class NavigationOptOutContainer extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isModalOpen: true,
+		};
+	}
+
+	render() {
+		const { isModalOpen } = this.state;
+		if ( ! isModalOpen ) {
+			return null;
+		}
+
+		return (
+			<Modal
+				title={ __( 'Help us improve', 'woocommerce-admin' ) }
+				onRequestClose={ () => this.setState( { isModalOpen: false } ) }
+				className="woocommerce-navigation-opt-out-modal"
+			>
+				<p>
+					{ __(
+						"Take this 2-minute survey to share why you're opting out of the new navigation",
+						'woocommerce-admin'
+					) }
+				</p>
+
+				<div className="woocommerce-navigation-opt-out-modal__actions">
+					<Button
+						isDefault
+						onClick={ () =>
+							this.setState( { isModalOpen: false } )
+						}
+					>
+						{ __( 'No thanks', 'woocommerce-admin' ) }
+					</Button>
+
+					<Button
+						isPrimary
+						target="_blank"
+						href="https://automattic.survey.fm/new-navigation-opt-out"
+					>
+						{ __( 'Share feedback', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+}

--- a/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -46,6 +46,9 @@ export default class NavigationOptOutContainer extends Component {
 						isPrimary
 						target="_blank"
 						href="https://automattic.survey.fm/new-navigation-opt-out"
+						onClick={ () =>
+							this.setState( { isModalOpen: false } )
+						}
 					>
 						{ __( 'Share feedback', 'woocommerce-admin' ) }
 					</Button>

--- a/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Button, Modal } from '@wordpress/components';
 
-export default class NavigationOptOutContainer extends Component {
+export class NavigationOptOutContainer extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {

--- a/client/wp-admin-scripts/navigation-opt-out/index.js
+++ b/client/wp-admin-scripts/navigation-opt-out/index.js
@@ -7,6 +7,7 @@ import { render } from '@wordpress/element';
  * Internal dependencies
  */
 import NavigationOptOutContainer from './container';
+import './style.scss';
 
 const navigationOptOutRoot = document.createElement( 'div' );
 navigationOptOutRoot.setAttribute( 'id', 'navigation-opt-out-root' );

--- a/client/wp-admin-scripts/navigation-opt-out/index.js
+++ b/client/wp-admin-scripts/navigation-opt-out/index.js
@@ -6,7 +6,7 @@ import { render } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import NavigationOptOutContainer from './container';
+import { NavigationOptOutContainer } from './container';
 import './style.scss';
 
 const navigationOptOutRoot = document.createElement( 'div' );

--- a/client/wp-admin-scripts/navigation-opt-out/index.js
+++ b/client/wp-admin-scripts/navigation-opt-out/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import NavigationOptOutContainer from './container';
+
+const navigationOptOutRoot = document.createElement( 'div' );
+navigationOptOutRoot.setAttribute( 'id', 'navigation-opt-out-root' );
+
+render(
+	<NavigationOptOutContainer />,
+	document.body.appendChild( navigationOptOutRoot )
+);

--- a/client/wp-admin-scripts/navigation-opt-out/style.scss
+++ b/client/wp-admin-scripts/navigation-opt-out/style.scss
@@ -1,0 +1,8 @@
+.woocommerce-navigation-opt-out-modal__actions {
+	text-align: right;
+	margin-top: $gap-large;
+
+	.components-button.is-primary {
+		margin-left: $gap;
+	}
+}

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -23,7 +23,7 @@ class Init {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
 		add_action( 'update_option_woocommerce_navigation_enabled', array( $this, 'reload_page_on_toggle' ), 10, 2 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_opt_out_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_opt_out_scripts' ) );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
@@ -102,15 +102,24 @@ class Init {
 			return;
 		}
 
+		if ( 'yes' !== $value ) {
+			update_option( 'woocommerce_navigation_show_opt_out', 'yes' );
+		}
+
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			wp_safe_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+			exit();
 		}
 	}
 
 	/**
 	 * Enqueue the opt out scripts.
 	 */
-	public function enqueue_opt_out_scripts() {
+	public function maybe_enqueue_opt_out_scripts() {
+		if ( 'yes' !== get_option( 'woocommerce_navigation_show_opt_out', 'no' ) ) {
+			return;
+		}
+
 		$rtl = is_rtl() ? '.rtl' : '';
 		wp_enqueue_style(
 			'wc-admin-navigation-opt-out',
@@ -126,5 +135,7 @@ class Init {
 			Loader::get_file_version( 'js' ),
 			true
 		);
+
+		delete_option( 'woocommerce_navigation_show_opt_out' );
 	}
 }

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -23,6 +23,7 @@ class Init {
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
 		add_action( 'update_option_woocommerce_navigation_enabled', array( $this, 'reload_page_on_toggle' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_opt_out_scripts' ) );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
 			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
@@ -104,5 +105,26 @@ class Init {
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 			wp_safe_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		}
+	}
+
+	/**
+	 * Enqueue the opt out scripts.
+	 */
+	public function enqueue_opt_out_scripts() {
+		$rtl = is_rtl() ? '.rtl' : '';
+		wp_enqueue_style(
+			'wc-admin-navigation-opt-out',
+			Loader::get_url( "navigation-opt-out/style{$rtl}", 'css' ),
+			array( 'wp-components' ),
+			Loader::get_file_version( 'css' )
+		);
+
+		wp_enqueue_script(
+			'wc-admin-navigation-opt-out',
+			Loader::get_url( 'wp-admin-scripts/navigation-opt-out', 'js' ),
+			array( 'wp-i18n', 'wp-element', WC_ADMIN_APP ),
+			Loader::get_file_version( 'js' ),
+			true
+		);
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ wcAdminPackages.forEach( ( name ) => {
 
 const wpAdminScripts = [
 	'marketing-coupons',
+	'navigation-opt-out',
 	'onboarding-homepage-notice',
 	'onboarding-product-notice',
 	'onboarding-product-import-notice',


### PR DESCRIPTION
Fixes #5479

Adds a modal to request feedback after opting out of the navigation experience.

### Screenshots

<img width="580" alt="Screen Shot 2020-12-09 at 4 27 32 PM" src="https://user-images.githubusercontent.com/10561050/101690634-8ee84400-3a3b-11eb-9ff1-18ffb7813079.png">


### Detailed test instructions:

1. Enable the nav feature at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Make sure no modal is shown.
1. Disable the nav feature.
1. Make sure the modal is shown.
1. Check that "Share Feedback" opens the link as expected and the other actions (including clicking "Share Feedback") close the modal.
1. Check that the modal is not persisted upon refreshing the page or navigating to another page.