### PR TITLE
Fix issue where store age is 0 while isResolving for the option is returning false

### DIFF
--- a/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -178,6 +178,19 @@ CustomerEffortScoreTracks.propTypes = {
 	createNotice: PropTypes.func,
 };
 
+function getStoreAgeInWeeks( adminInstallTimestamp ) {
+	if ( adminInstallTimestamp === 0 ) {
+		return null;
+	}
+
+	// Date.now() is ms since Unix epoch, adminInstallTimestamp is in
+	// seconds since Unix epoch.
+	const storeAgeInMs = Date.now() - adminInstallTimestamp * 1000;
+	const storeAgeInWeeks = Math.round( storeAgeInMs / WEEK );
+
+	return storeAgeInWeeks;
+}
+
 export default compose(
 	withSelect( ( select ) => {
 		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
@@ -187,10 +200,7 @@ export default compose(
 
 		const adminInstallTimestamp =
 			getOption( ADMIN_INSTALL_TIMESTAMP_OPTION_NAME ) || 0;
-		// Date.now() is ms since Unix epoch, adminInstallTimestamp is in
-		// seconds since Unix epoch.
-		const storeAgeInMs = Date.now() - adminInstallTimestamp * 1000;
-		const storeAgeInWeeks = Math.round( storeAgeInMs / WEEK );
+		const storeAgeInWeeks = getStoreAgeInWeeks( adminInstallTimestamp );
 
 		const allowTrackingOption =
 			getOption( ALLOW_TRACKING_OPTION_NAME ) || 'no';
@@ -198,6 +208,7 @@ export default compose(
 
 		const resolving =
 			isResolving( 'getOption', [ SHOWN_FOR_ACTIONS_OPTION_NAME ] ) ||
+			storeAgeInWeeks === null ||
 			isResolving( 'getOption', [
 				ADMIN_INSTALL_TIMESTAMP_OPTION_NAME,
 			] ) ||


### PR DESCRIPTION
Upgrading to WordPress 5.6 caused an issue where the CES snackbar was displayed twice for an action.

![image](https://user-images.githubusercontent.com/224531/101733094-01275a00-3b0a-11eb-8cc6-01538263fbc8.png)

This seems to be because `isResolving` for the `woocommerce_admin_install_timestamp` option was returning false while `getOption` was returning zero, which rendered the `CustomerEffortScore` component, showing the snackbar. `getOption` later returning the correct timestamp again rendered the `CustomerEffortScore` component, this time correctly showing the snackbar again.

This PR adds an extra check that the timestamp is a valid value to the `resolving` value, which stops the first incorrect render.

### Detailed test instructions:

- on a site with WordPress 5.6 installed
- add a new product
- check that the CES snackbar only appears once
