### PR TITLE
Using the router to implement persisted queries

### DIFF
--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -98,15 +98,6 @@ const Settings = ( { createNotice, query } ) => {
 	const saveChanges = () => {
 		persistSettings();
 		recordEvent( 'analytics_settings_save', wcAdminSettings );
-
-		// On save, reset persisted query properties of Nav Menu links to default
-		query.period = undefined;
-		query.compare = undefined;
-		query.before = undefined;
-		query.after = undefined;
-		query.interval = undefined;
-		query.type = undefined;
-		window.wpNavMenuUrlUpdate( query );
 	};
 
 	const handleInputChange = ( e ) => {

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -9,6 +9,7 @@ import { withDispatch } from '@wordpress/data';
 import { SectionHeader, ScrollTo } from '@woocommerce/components';
 import { useSettings } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { resetPersistedQueries } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -98,6 +99,8 @@ const Settings = ( { createNotice, query } ) => {
 	const saveChanges = () => {
 		persistSettings();
 		recordEvent( 'analytics_settings_save', wcAdminSettings );
+
+		resetPersistedQueries();
 	};
 
 	const handleInputChange = ( e ) => {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -245,7 +245,7 @@ window.wpNavMenuClassChange = function ( page, url ) {
 	const pageUrl =
 		url === '/'
 			? 'admin.php?page=wc-admin'
-			: 'admin.php?page=wc-admin&path=' + encodeURIComponent( url );
+			: 'admin.php?page=wc-admin&path=' + url;
 	const currentItemsSelector =
 		url === '/'
 			? `li > a[href$="${ pageUrl }"], li > a[href*="${ pageUrl }?"]`

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -85,6 +85,7 @@ class ReportFilters extends Component {
 
 	onRangeSelect( data ) {
 		const { query, path, onDateSelect } = this.props;
+		data.updatePersistedQueries = true;
 		updateQueryString( data, path, query );
 		onDateSelect( data );
 	}

--- a/packages/navigation/src/history.js
+++ b/packages/navigation/src/history.js
@@ -50,6 +50,11 @@ function getHistory() {
 			createHref: ( ...args ) =>
 				browserHistory.createHref.apply( browserHistory, args ),
 			push( ...args ) {
+				if ( args.length !== 1 ) {
+					browserHistory.push.apply( browserHistory, args );
+					return;
+				}
+
 				const [ href ] = args;
 				const search = href.split( '?' )[
 					href.indexOf( '?' ) >= 0 ? 1 : 0

--- a/packages/navigation/src/history.js
+++ b/packages/navigation/src/history.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { createBrowserHistory } from 'history';
-import { parse } from 'qs';
+import { parse, stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import { patchPersistedQueries } from './index';
 
 // See https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
 
@@ -44,8 +49,17 @@ function getHistory() {
 			},
 			createHref: ( ...args ) =>
 				browserHistory.createHref.apply( browserHistory, args ),
-			push: ( ...args ) =>
-				browserHistory.push.apply( browserHistory, args ),
+			push( ...args ) {
+				const [ href ] = args;
+				const search = href.split( '?' )[
+					href.indexOf( '?' ) >= 0 ? 1 : 0
+				];
+				const query = patchPersistedQueries( parse( search ) );
+
+				browserHistory.push.apply( browserHistory, [
+					'admin.php?' + stringify( query ),
+				] );
+			},
 			replace: ( ...args ) =>
 				browserHistory.replace.apply( browserHistory, args ),
 			go: ( ...args ) => browserHistory.go.apply( browserHistory, args ),

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -14,7 +14,7 @@ import { getHistory } from './history';
 import * as navUtils from './index';
 // For the above, import the module into itself. Functions consumed from this import can be mocked in tests.
 
-const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
+const PERSISTED_QUERIES_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
 
 // Expose history so all uses get the same history object.
 export { getHistory };
@@ -56,12 +56,10 @@ export const getPersistedQuery = ( query = navUtils.getQuery() ) => {
  * @return {Object} Modified query object
  */
 export const patchPersistedQueries = ( query ) => {
-	const excludedScreens = applyFilters( TIME_EXCLUDED_SCREENS_FILTER, [
-		'stock',
-		'settings',
-		'customers',
-		'homescreen',
-	] );
+	const excludedScreens = applyFilters(
+		PERSISTED_QUERIES_EXCLUDED_SCREENS_FILTER,
+		[ 'stock', 'settings', 'customers', 'homescreen' ]
+	);
 
 	const path = query.path || 'homescreen';
 	const screen = path.replace( '/analytics', '' ).replace( '/', '' );


### PR DESCRIPTION
Fixes #5684

Exploring the possibility of relocating the logic governing persisted queries to the router, primarily to address the fact that they don't function as is in the new nav. This does, however, change how this is controlled for the old navigation as well, which is intentional so that we don't have to duplicate logic. 

**Benefits**
- No DOM manipulation required
- Cleaner (somewhat less code required)
- Consolidated all logic governing persisted queries into `navigation` package; works with old and new navigation (and future iterations)

**Known Issues**
- ~~Right now if you navigate to an excluded page (ie Customers), and then back to a non-excluded page, the persisted queries will be lost (since they're only stored in the url for now). There are a number of ways we could address this if it's considered an issue.~~
- Need to fix/add tests (will do if we decide to go this route)

**Other Notes**
- ~~I've only implemented this for basic filters as a PoC, but it should be simple to add to advanced/etc filters if those are supported (need to explore this a bit more)~~ I don't believe this is a problem?

### Detailed test instructions:

-  Check out branch
- Ensure that the new navigation is enabled.
- Go to an _Analytics_ report page and apply a different date range.
- Then navigate to a different report page (without a refresh), and ensure that the new date range persists.
- Disable the new navigation and do the same, ensuring that the old nav works as always.