### PR TITLE
Adjust countries for Klarna checkout and payment

### DIFF
--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -249,7 +249,7 @@ export function getPaymentMethods( {
 				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
 			),
 			visible:
-				[ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ) &&
+				[ 'SE', 'FI', 'NO' ].includes( countryCode ) &&
 				! hasCbdIndustry,
 			plugins: [ 'klarna-checkout-for-woocommerce' ],
 			container: <Klarna plugin={ 'checkout' } />,
@@ -273,8 +273,19 @@ export function getPaymentMethods( {
 				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
 			),
 			visible:
-				[ 'DK', 'DE', 'AT' ].includes( countryCode ) &&
-				! hasCbdIndustry,
+				[
+					'DK',
+					'DE',
+					'AT',
+					'NL',
+					'CH',
+					'BE',
+					'SP',
+					'PL',
+					'FR',
+					'IT',
+					'UK',
+				].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'klarna-payments-for-woocommerce' ],
 			container: <Klarna plugin={ 'payments' } />,
 			// @todo This should check actual Klarna connection information.

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -10,10 +10,56 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { PayPal } from '../tasks/payments/paypal';
+import { getPaymentMethods } from '../tasks/payments/methods';
 
 jest.mock( '@wordpress/api-fetch' );
 
 describe( 'TaskList > Payments', () => {
+	describe( 'Methods', () => {
+		const params = {
+			activePlugins: [],
+			countryCode: 'SE',
+			onboardingStatus: {},
+			options: [],
+			profileItems: {},
+		};
+
+		it( 'includes Klarna Checkout for SE, NO, and FI', () => {
+			[ 'SE', 'NO', 'FI' ].forEach( ( countryCode ) => {
+				params.countryCode = countryCode;
+				const methods = getPaymentMethods( params );
+				expect(
+					methods.some(
+						( method ) => method.key === 'klarna_checkout'
+					)
+				).toBe( true );
+			} );
+		} );
+
+		it( 'includes Klarna Payment for EU countries', () => {
+			const supportedCountryCodes = [
+				'DK',
+				'DE',
+				'AT',
+				'NL',
+				'CH',
+				'BE',
+				'SP',
+				'PL',
+				'FR',
+				'IT',
+				'UK',
+			];
+			supportedCountryCodes.forEach( ( countryCode ) => {
+				params.countryCode = countryCode;
+				const methods = getPaymentMethods( params );
+				expect(
+					methods.some( ( e ) => e.key === 'klarna_payments' )
+				).toBe( true );
+			} );
+		} );
+	} );
+
 	describe( 'PayPal', () => {
 		afterEach( () => jest.clearAllMocks() );
 


### PR DESCRIPTION
Fixes #5838 

- This PR adjusts the country list for Klarna checkout and payments.
- Added a test case

### Detailed test instructions:

**Testing Checkout**

Supported countries: Sweden, Norway, Finland
1. Install a fresh WooCommerce.
2. Start OBW and choose one of Sweden, Norway, and Finland for the country and finish the wizard.
3. Choose "Set up payments" when you get redirected to WooCommerce -> Home
4. Confirm "Klarna Checkout" is available. 
5. Repeat the test for Norway and Finland.

**Testing Payments**

Supported countries: Denmark, Netherlands, Germany, Austria, Switzerland, Belgium, Spain, Poland, France, Italy, United Kingdom

1. Install a fresh WooCommerce.
2. Start OBW and choose one of Denmark, Netherlands, Germany, Austria, Switzerland, Belgium, Spain, Poland, France, Italy, United Kingdom.
3. Choose "Set up payments" when you get redirected to WooCommerce -> Home
4. Confirm "Klarna Payment" is available. 
5. Repeat the test for other supported countries.

