### PR TITLE
Fix typo in Variation Stats Datastore context variable.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 = vnext =
 - Fix: Add Customer Type column to the Orders report table. #5820
 - Fix: Product exclusion filter on Orders Report.
+- Fix: Typo in Variation Stats DataStore context filter value.
 
 = 1.7.0 11/11/2020 =
 - Enhancement: Variations report.  #5167

--- a/src/API/Reports/Variations/Stats/DataStore.php
+++ b/src/API/Reports/Variations/Stats/DataStore.php
@@ -34,7 +34,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'variatons_stats';
+	protected $context = 'variations_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.


### PR DESCRIPTION
Fixes #5674.

This PR fixes a typo in the `$context` variable in the Variation Stats Datastore.

### Detailed test instructions:

- Verify the spelling is correct
- Smoke test Variations Report

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
