### PR TITLE
Add filter for root back URL

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -10,7 +10,6 @@ import {
 	__experimentalNavigationMenu as NavigationMenu,
 	__experimentalNavigationGroup as NavigationGroup,
 } from '@wordpress/components';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { withSelect } from '@wordpress/data';
@@ -29,7 +28,7 @@ const Container = ( { menuItems } ) => {
 		adminMenu.classList.add( 'folded' );
 	}, [] );
 
-	const dashboardUrl = getAdminLink( '' );
+	const { rootBackUrl } = window.wcNavigation;
 
 	const parentCategory = {
 		capability: 'manage_woocommerce',
@@ -130,10 +129,10 @@ const Container = ( { menuItems } ) => {
 						setActiveLevel( ...args );
 					} }
 				>
-					{ activeLevel === 'woocommerce' && dashboardUrl && (
+					{ activeLevel === 'woocommerce' && rootBackUrl && (
 						<NavigationBackButton
 							className="woocommerce-navigation__back-to-dashboard"
-							href={ dashboardUrl }
+							href={ rootBackUrl }
 							backButtonLabel={ __(
 								'WordPress Dashboard',
 								'woocommerce-navigation'

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -28,7 +28,7 @@ const Container = ( { menuItems } ) => {
 		adminMenu.classList.add( 'folded' );
 	}, [] );
 
-	const { rootBackUrl } = window.wcNavigation;
+	const { rootBackLabel, rootBackUrl } = window.wcNavigation;
 
 	const parentCategory = {
 		capability: 'manage_woocommerce',
@@ -133,10 +133,7 @@ const Container = ( { menuItems } ) => {
 						<NavigationBackButton
 							className="woocommerce-navigation__back-to-dashboard"
 							href={ rootBackUrl }
-							backButtonLabel={ __(
-								'WordPress Dashboard',
-								'woocommerce-navigation'
-							) }
+							backButtonLabel={ rootBackLabel }
 							onClick={ () => trackBackClick( 'woocommerce' ) }
 						></NavigationBackButton>
 					) }

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -602,8 +602,9 @@ class Menu {
 	 */
 	public function enqueue_data( $menu ) {
 		$data = array(
-			'menuItems'   => self::get_prepared_menu_item_data(),
-			'rootBackUrl' => apply_filters( 'woocommerce_navigation_root_back_url', get_dashboard_url() ),
+			'menuItems'     => self::get_prepared_menu_item_data(),
+			'rootBackUrl'   => apply_filters( 'woocommerce_navigation_root_back_url', get_dashboard_url() ),
+			'rootBackLabel' => apply_filters( 'woocommerce_navigation_root_back_label', __( 'WordPress Dashboard', 'woocommerce-admin' ) ),
 		);
 
 		wp_add_inline_script( WC_ADMIN_APP, 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -601,14 +601,11 @@ class Menu {
 	 * @return array
 	 */
 	public function enqueue_data( $menu ) {
-		global $submenu, $parent_file, $typenow, $self;
-
 		$data = array(
-			'menuItems' => self::get_prepared_menu_item_data(),
+			'menuItems'   => self::get_prepared_menu_item_data(),
+			'rootBackUrl' => apply_filters( 'woocommerce_navigation_root_back_url', get_dashboard_url() ),
 		);
 
-		$paul = wp_add_inline_script( WC_ADMIN_APP, 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );
-
-		return $menu;
+		wp_add_inline_script( WC_ADMIN_APP, 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );
 	}
 }


### PR DESCRIPTION
Fixes #5866 

Adds a filter to allow changing the root back button URL.

### Screenshots
<img width="271" alt="Screen Shot 2020-12-14 at 4 02 39 PM" src="https://user-images.githubusercontent.com/10561050/102135334-d436b800-3e25-11eb-8934-bc04f45cb157.png">


### Detailed test instructions:

1. Filter the URL and label:
```php
add_filter( 'woocommerce_navigation_root_back_url', function() {
  return 'http://wordpress.com';
} );
add_filter( 'woocommerce_navigation_root_back_label', function() {
  return 'Retreat!';
} );
```
2. Enable the navigation.
1. Navigate to the root.
1. Make sure the back button text is updated and goes to the specified URL.