### PR TITLE
Add link to update WordPress when min version not met

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -293,6 +293,7 @@ class Loader {
 					'desc'  => $description . $update_text,
 					'id'    => 'woocommerce_navigation_enabled',
 					'type'  => 'checkbox',
+					'class' => $needs_update ? 'disabled' : '',
 				),
 				array(
 					'type' => 'sectionend',

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -263,6 +263,22 @@ class Loader {
 			return $settings;
 		}
 
+		$description  = __(
+			'Adds the new WooCommerce navigation experience to the dashboard',
+			'woocommerce-admin'
+		);
+		$update_text  = '';
+		$needs_update = version_compare( get_bloginfo( 'version' ), '5.6', '<' );
+		if ( $needs_update && current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+			$update_text = sprintf(
+				/* translators: 1: line break tag, 2: open link to WordPress update link, 3: close link tag. */
+				__( '%1$s %2$sUpdate WordPress to enable the new navigation%3$s', 'woocommerce-admin' ),
+				'<br/>',
+				'<a href="' . self_admin_url( 'update-core.php' ) . '" target="_blank">',
+				'</a>'
+			);
+		}
+
 		return apply_filters(
 			'woocommerce_settings_features',
 			array(
@@ -274,7 +290,7 @@ class Loader {
 				),
 				array(
 					'title' => __( 'Navigation', 'woocommerce-admin' ),
-					'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
+					'desc'  => $description . $update_text,
 					'id'    => 'woocommerce_navigation_enabled',
 					'type'  => 'checkbox',
 				),


### PR DESCRIPTION
Fixes #5871

Adds a link to update the WP version for the new nav feature.

There does not appear to be a way to disable the input directly without JS, so this PR currently just styles the input as disabled.  Open to thoughts here if we think we should disable via JS as well.

### Screenshots
<img width="758" alt="Screen Shot 2020-12-15 at 11 52 39 AM" src="https://user-images.githubusercontent.com/10561050/102246415-bb351200-3ecc-11eb-991a-76563e25fcd3.png">


### Detailed test instructions:

1. Use a WP version < 5.6.
1. Visit the features settings `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Note the link if your user is able to update WP.
3. Update WP.
4. Make sure the link is no longer shown and the nav feature checkbox is full opacity (not disabled).