### PR TITLE
Update task list to use wp card component

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -89,6 +89,11 @@
 .woocommerce-task-dashboard__body {
 	.woocommerce-task-dashboard__container {
 		.woocommerce-task-card {
+			max-width: 680px;
+			margin-left: auto;
+			margin-right: auto;
+			margin-bottom: $gap-large;
+
 			.components-card__header.is-size-large {
 				padding-bottom: 12px;
 

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -52,12 +52,6 @@
 		font-size: 12px;
 	}
 
-	.woocommerce-card.is-narrow {
-		max-width: 680px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-
 	#wpbody-content {
 		position: relative;
 	}
@@ -202,13 +196,11 @@
 }
 
 .woocommerce-task-payment {
-	.woocommerce-card__body {
-		display: flex;
-		padding: $gap-large $gap-larger;
-		align-items: center;
-		position: relative;
-		overflow: hidden;
-	}
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	position: relative;
+	overflow: hidden;
 
 	.woocommerce-task-payment__recommended-ribbon {
 		position: absolute;
@@ -244,7 +236,7 @@
 		}
 	}
 
-	.woocommerce-task-payment__before {
+	.components-card__header {
 		margin-right: $gap-larger;
 
 		img {
@@ -275,7 +267,7 @@
 		}
 	}
 
-	.woocommerce-task-payment__after {
+	.components-card__footer {
 		margin-left: auto;
 
 		.components-button.is-button {
@@ -284,9 +276,7 @@
 	}
 
 	@include breakpoint( '<600px' ) {
-		.woocommerce-card__body {
-			flex-direction: column;
-		}
+		flex-direction: column;
 
 		.woocommerce-task-payment__recommended-ribbon {
 			display: none;
@@ -296,13 +286,13 @@
 			display: none;
 		}
 
-		.woocommerce-task-payment__before {
+		.components-card__header {
 			order: 1;
 			margin-right: auto;
 			margin-bottom: $gap-large;
 		}
 
-		.woocommerce-task-payment__after {
+		.components-card__footer {
 			position: absolute;
 			right: $gap-larger;
 			top: $gap-large;
@@ -312,7 +302,7 @@
 			}
 		}
 
-		.woocommerce-task-payment__text {
+		.components-card__body {
 			order: 3;
 			margin-top: $gap;
 		}
@@ -320,21 +310,17 @@
 }
 
 .woocommerce-task-payment-method {
-	.woocommerce-card__body {
-		padding: $gap-large;
+	> h3 {
+		margin: 0;
+		color: $studio-gray-90;
+	}
 
-		> h3 {
-			margin: 0;
-			color: $studio-gray-90;
-		}
-
-		p {
-			font-size: 14px;
-			color: $studio-gray-50;
-			font-weight: 400;
-			margin-top: 16px;
-			margin-bottom: $gap-smaller;
-		}
+	p {
+		font-size: 14px;
+		color: $studio-gray-50;
+		font-weight: 400;
+		margin-top: 16px;
+		margin-bottom: $gap-smaller;
 	}
 }
 

--- a/client/task-list/tasks/appearance.js
+++ b/client/task-list/tasks/appearance.js
@@ -3,14 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { filter } from 'lodash';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 import {
-	Card,
 	Stepper,
 	TextControl,
 	ImageUpload,
@@ -403,15 +402,17 @@ class Appearance extends Component {
 
 		return (
 			<div className="woocommerce-task-appearance">
-				<Card className="is-narrow">
-					<Stepper
-						isPending={
-							isUpdatingNotice || isUpdatingLogo || isPending
-						}
-						isVertical
-						currentStep={ currentStep }
-						steps={ this.getSteps() }
-					/>
+				<Card className="woocommerce-task-card">
+					<CardBody>
+						<Stepper
+							isPending={
+								isUpdatingNotice || isUpdatingLogo || isPending
+							}
+							isVertical
+							currentStep={ currentStep }
+							steps={ this.getSteps() }
+						/>
+					</CardBody>
 				</Card>
 			</div>
 		);

--- a/client/task-list/tasks/appearance.js
+++ b/client/task-list/tasks/appearance.js
@@ -9,11 +9,7 @@ import { compose } from '@wordpress/compose';
 import { filter } from 'lodash';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-import {
-	Stepper,
-	TextControl,
-	ImageUpload,
-} from '@woocommerce/components';
+import { Stepper, TextControl, ImageUpload } from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import {
 	OPTIONS_STORE_NAME,

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -11,7 +11,7 @@ import {
 	CardBody,
 	CardFooter,
 	CardHeader,
-	FormToggle
+	FormToggle,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { H, Plugins } from '@woocommerce/components';

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -5,9 +5,16 @@ import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { cloneElement, Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { Button, FormToggle } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	FormToggle
+} from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, H, Plugins } from '@woocommerce/components';
+import { H, Plugins } from '@woocommerce/components';
 import {
 	getHistory,
 	getNewPath,
@@ -199,13 +206,15 @@ class Payments extends Component {
 
 		if ( currentMethod ) {
 			return (
-				<Card className="woocommerce-task-payment-method is-narrow">
-					{ cloneElement( currentMethod.container, {
-						query,
-						installStep: this.getInstallStep(),
-						markConfigured: this.markConfigured,
-						hasCbdIndustry: currentMethod.hasCbdIndustry,
-					} ) }
+				<Card className="woocommerce-task-payment-method woocommerce-task-card">
+					<CardBody>
+						{ cloneElement( currentMethod.container, {
+							query,
+							installStep: this.getInstallStep(),
+							markConfigured: this.markConfigured,
+							hasCbdIndustry: currentMethod.hasCbdIndustry,
+						} ) }
+					</CardBody>
 				</Card>
 			);
 		}
@@ -229,7 +238,7 @@ class Payments extends Component {
 
 					const classes = classnames(
 						'woocommerce-task-payment',
-						'is-narrow',
+						'woocommerce-task-card',
 						! isConfigured &&
 							'woocommerce-task-payment-not-configured',
 						'woocommerce-task-payment-' + key
@@ -244,7 +253,7 @@ class Payments extends Component {
 
 					return (
 						<Card key={ key } className={ classes }>
-							<div className="woocommerce-task-payment__before">
+							<CardHeader isBorderless>
 								{ showRecommendedRibbon && (
 									<div className="woocommerce-task-payment__recommended-ribbon">
 										<span>
@@ -256,8 +265,8 @@ class Payments extends Component {
 									</div>
 								) }
 								{ before }
-							</div>
-							<div className="woocommerce-task-payment__text">
+							</CardHeader>
+							<CardBody>
 								<H className="woocommerce-task-payment__title">
 									{ title }
 									{ showRecommendedPill && (
@@ -272,8 +281,8 @@ class Payments extends Component {
 								<div className="woocommerce-task-payment__content">
 									{ content }
 								</div>
-							</div>
-							<div className="woocommerce-task-payment__after">
+							</CardBody>
+							<CardFooter isBorderless>
 								{ container && ! isConfigured ? (
 									<Button
 										isPrimary={ key === recommendedMethod }
@@ -297,7 +306,7 @@ class Payments extends Component {
 										onClick={ ( e ) => e.stopPropagation() }
 									/>
 								) }
-							</div>
+							</CardFooter>
 						</Card>
 					);
 				} ) }

--- a/client/task-list/tasks/products.js
+++ b/client/task-list/tasks/products.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { Card, List } from '@woocommerce/components';
+import { Card, CardBody } from '@wordpress/components';
+import { List } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -61,7 +62,9 @@ export default class Products extends Component {
 		return (
 			<Fragment>
 				<Card className="woocommerce-task-card">
-					<List items={ subTasks } />
+					<CardBody size={ null }>
+						<List items={ subTasks } />
+					</CardBody>
 				</Card>
 			</Fragment>
 		);

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -314,7 +314,9 @@ export class Shipping extends Component {
 				<Card className="woocommerce-task-card">
 					<CardBody>
 						<Stepper
-							isPending={ isPending || isUpdateSettingsRequesting }
+							isPending={
+								isPending || isUpdateSettingsRequesting
+							}
 							isVertical
 							currentStep={ step }
 							steps={ this.getSteps() }

--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -4,11 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
+import { Card, CardBody } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { difference, filter } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, Link, Stepper, Plugins } from '@woocommerce/components';
+import { Link, Stepper, Plugins } from '@woocommerce/components';
 import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { SETTINGS_STORE_NAME, PLUGINS_STORE_NAME } from '@woocommerce/data';
@@ -310,13 +311,15 @@ export class Shipping extends Component {
 
 		return (
 			<div className="woocommerce-task-shipping">
-				<Card className="is-narrow">
-					<Stepper
-						isPending={ isPending || isUpdateSettingsRequesting }
-						isVertical
-						currentStep={ step }
-						steps={ this.getSteps() }
-					/>
+				<Card className="woocommerce-task-card">
+					<CardBody>
+						<Stepper
+							isPending={ isPending || isUpdateSettingsRequesting }
+							isVertical
+							currentStep={ step }
+							steps={ this.getSteps() }
+						/>
+					</CardBody>
 				</Card>
 			</div>
 		);

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	Card,
 	CardBody,
-	__experimentalText as Text
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -2,13 +2,18 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	__experimentalText as Text
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { difference, filter } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, H, Link, Stepper, Plugins } from '@woocommerce/components';
+import { H, Link, Stepper, Plugins } from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
@@ -468,17 +473,19 @@ class Tax extends Component {
 
 		return (
 			<div className="woocommerce-task-tax">
-				<Card className="is-narrow">
-					{ this.shouldShowSuccessScreen() ? (
-						this.renderSuccessScreen()
-					) : (
-						<Stepper
-							isPending={ isPending || isResolving }
-							isVertical={ true }
-							currentStep={ step.key }
-							steps={ this.getSteps() }
-						/>
-					) }
+				<Card className="woocommerce-task-card">
+					<CardBody>
+						{ this.shouldShowSuccessScreen() ? (
+							this.renderSuccessScreen()
+						) : (
+							<Stepper
+								isPending={ isPending || isResolving }
+								isVertical={ true }
+								currentStep={ step.key }
+								steps={ this.getSteps() }
+							/>
+						) }
+					</CardBody>
 				</Card>
 			</div>
 		);

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -48,7 +48,7 @@ const markTaskIncomplete = () => {
 
 const Task = () => {
 	return (
-		<Card className="is-narrow">
+		<Card className="woocommerce-task-card">
 			{ __( 'Example task card content.', 'plugin-domain' ) }
 			<br />
 			<br />


### PR DESCRIPTION
Fixes (partially) #4002

Replace cards used in task list with WP `Card` component and style accordingly.

Styling here mostly stays true to the previous task list with the exception of card changes, such as border, box shadow, and default padding.

### Screenshots
<img width="714" alt="Screen Shot 2020-12-16 at 6 09 03 PM" src="https://user-images.githubusercontent.com/10561050/102417991-df771880-3fca-11eb-817b-41c8324048aa.png">
<img width="720" alt="Screen Shot 2020-12-16 at 6 08 58 PM" src="https://user-images.githubusercontent.com/10561050/102417992-e00faf00-3fca-11eb-9bb8-73bb7270d7ed.png">
<img width="721" alt="Screen Shot 2020-12-16 at 6 08 53 PM" src="https://user-images.githubusercontent.com/10561050/102417993-e00faf00-3fca-11eb-84f8-2b115f653ec7.png">
<img width="698" alt="Screen Shot 2020-12-16 at 6 08 48 PM" src="https://user-images.githubusercontent.com/10561050/102417994-e00faf00-3fca-11eb-9b14-b0b017422d27.png">


### Detailed test instructions:

1. Go through the task list.
2. Make sure that tasks are styled as expected.