### PR TITLE
Update onboarding setup wizard to use WP Card component

### DIFF
--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button, Card, CardBody, CardFooter, __experimentalText as Text } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -255,7 +261,6 @@ class Benefits extends Component {
 					</Button>
 				</CardFooter>
 
-
 				<CardFooter isBorderless justify="center">
 					<p className="woocommerce-profile-wizard__benefits-install-notice">
 						{ isAcceptingTos
@@ -277,7 +282,7 @@ class Benefits extends Component {
 											/>
 										),
 									},
-							} )
+							  } )
 							: sprintf(
 									__(
 										'%s %s will be installed & activated for free.',
@@ -285,7 +290,7 @@ class Benefits extends Component {
 									),
 									pluginNamesString,
 									pluralizedPlugins
-							) }
+							  ) }
 					</p>
 				</CardFooter>
 			</Card>

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Button, __experimentalText as Text } from '@wordpress/components';
+import { Button, Card, CardBody, CardFooter, __experimentalText as Text } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { filter } from 'lodash';
 import interpolateComponents from 'interpolate-components';
-import { Card, H, Link } from '@woocommerce/components';
+import { H, Link } from '@woocommerce/components';
 import {
 	pluginNames,
 	ONBOARDING_STORE_NAME,
@@ -219,22 +219,23 @@ class Benefits extends Component {
 
 		return (
 			<Card className="woocommerce-profile-wizard__benefits-card">
-				<Logo />
-				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
-						{ sprintf(
-							__(
-								'Enhance your store with %s',
-								'woocommerce-admin'
-							),
-							pluginNamesString
-						) }
-					</Text>
-				</div>
+				<CardBody justify="center">
+					<Logo />
+					<div className="woocommerce-profile-wizard__step-header">
+						<Text variant="title.small" as="h2">
+							{ sprintf(
+								__(
+									'Enhance your store with %s',
+									'woocommerce-admin'
+								),
+								pluginNamesString
+							) }
+						</Text>
+					</div>
 
-				{ this.renderBenefits() }
-
-				<div className="woocommerce-profile-wizard__card-actions">
+					{ this.renderBenefits() }
+				</CardBody>
+				<CardFooter isBorderless justify="center">
 					<Button
 						isPrimary
 						isBusy={ isInstallAction }
@@ -252,38 +253,41 @@ class Benefits extends Component {
 					>
 						{ __( 'No thanks', 'woocommerce-admin' ) }
 					</Button>
-				</div>
+				</CardFooter>
 
-				<p className="woocommerce-profile-wizard__benefits-install-notice">
-					{ isAcceptingTos
-						? interpolateComponents( {
-								mixedString: sprintf(
+
+				<CardFooter isBorderless justify="center">
+					<p className="woocommerce-profile-wizard__benefits-install-notice">
+						{ isAcceptingTos
+							? interpolateComponents( {
+									mixedString: sprintf(
+										__(
+											'%s %s will be installed & activated for free, and you agree to our {{link}}Terms of Service{{/link}}.',
+											'woocommerce-admin'
+										),
+										pluginNamesString,
+										pluralizedPlugins
+									),
+									components: {
+										link: (
+											<Link
+												href="https://wordpress.com/tos/"
+												target="_blank"
+												type="external"
+											/>
+										),
+									},
+							} )
+							: sprintf(
 									__(
-										'%s %s will be installed & activated for free, and you agree to our {{link}}Terms of Service{{/link}}.',
+										'%s %s will be installed & activated for free.',
 										'woocommerce-admin'
 									),
 									pluginNamesString,
 									pluralizedPlugins
-								),
-								components: {
-									link: (
-										<Link
-											href="https://wordpress.com/tos/"
-											target="_blank"
-											type="external"
-										/>
-									),
-								},
-						  } )
-						: sprintf(
-								__(
-									'%s %s will be installed & activated for free.',
-									'woocommerce-admin'
-								),
-								pluginNamesString,
-								pluralizedPlugins
-						  ) }
-				</p>
+							) }
+					</p>
+				</CardFooter>
 			</Card>
 		);
 	}

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -464,7 +464,7 @@ class BusinessDetails extends Component {
 		];
 
 		return (
-			<Fragment>
+			<div>
 				{ extensionBenefits.map( ( benefit ) => (
 					<div
 						className="woocommerce-profile-wizard__benefit"
@@ -490,7 +490,7 @@ class BusinessDetails extends Component {
 						</div>
 					</div>
 				) ) }
-			</Fragment>
+			</div>
 		);
 	}
 
@@ -818,6 +818,16 @@ class BusinessDetails extends Component {
 				validate={ this.validate }
 			>
 				{ ( { getInputProps, handleSubmit, values, isValidForm } ) => {
+					const businessExtensions = this.bundleInstall
+						? this.renderBusinessExtensionsBundle(
+								values,
+								getInputProps
+						  )
+						: this.renderBusinessExtensions(
+								values,
+								getInputProps
+						  );
+
 					return (
 						<Fragment>
 							<div className="woocommerce-profile-wizard__step-header">
@@ -908,17 +918,12 @@ class BusinessDetails extends Component {
 											</div>
 										</Fragment>
 									) }
-
-									{ this.bundleInstall
-										? this.renderBusinessExtensionsBundle(
-												values,
-												getInputProps
-										  )
-										: this.renderBusinessExtensions(
-												values,
-												getInputProps
-										  ) }
 								</CardBody>
+								{ businessExtensions && (
+									<CardFooter>
+										{ businessExtensions }
+									</CardFooter>
+								) }
 								<CardFooter justify="center">
 									<Button
 										isPrimary
@@ -934,11 +939,11 @@ class BusinessDetails extends Component {
 											? __(
 													'Continue',
 													'woocommerce-admin'
-												)
+											  )
 											: __(
 													'Retry',
 													'woocommerce-admin'
-												) }
+											  ) }
 									</Button>
 									{ hasInstallActivateError && (
 										<Button

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -6,6 +6,9 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
 	Button,
+	Card,
+	CardBody,
+	CardFooter,
 	CheckboxControl,
 	FormToggle,
 	Popover,
@@ -16,7 +19,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { keys, get, pickBy } from 'lodash';
 import {
 	H,
-	Card,
 	Link,
 	SelectControl,
 	Form,
@@ -833,7 +835,7 @@ class BusinessDetails extends Component {
 								</Text>
 							</div>
 							<Card>
-								<Fragment>
+								<CardBody>
 									<SelectControl
 										label={ __(
 											'How many products do you plan to display?',
@@ -916,40 +918,39 @@ class BusinessDetails extends Component {
 												values,
 												getInputProps
 										  ) }
-
-									<div className="woocommerce-profile-wizard__card-actions">
-										<Button
-											isPrimary
-											onClick={ handleSubmit }
-											disabled={
-												! isValidForm ||
-												isUpdatingProfileItems ||
-												isInstallingActivating
-											}
-											isBusy={ isInstallingActivating }
-										>
-											{ ! hasInstallActivateError
-												? __(
-														'Continue',
-														'woocommerce-admin'
-												  )
-												: __(
-														'Retry',
-														'woocommerce-admin'
-												  ) }
-										</Button>
-										{ hasInstallActivateError && (
-											<Button
-												onClick={ () => goToNextStep() }
-											>
-												{ __(
-													'Continue without installing',
+								</CardBody>
+								<CardFooter justify="center">
+									<Button
+										isPrimary
+										onClick={ handleSubmit }
+										disabled={
+											! isValidForm ||
+											isUpdatingProfileItems ||
+											isInstallingActivating
+										}
+										isBusy={ isInstallingActivating }
+									>
+										{ ! hasInstallActivateError
+											? __(
+													'Continue',
+													'woocommerce-admin'
+												)
+											: __(
+													'Retry',
 													'woocommerce-admin'
 												) }
-											</Button>
-										) }
-									</div>
-								</Fragment>
+									</Button>
+									{ hasInstallActivateError && (
+										<Button
+											onClick={ () => goToNextStep() }
+										>
+											{ __(
+												'Continue without installing',
+												'woocommerce-admin'
+											) }
+										</Button>
+									) }
+								</CardFooter>
 							</Card>
 
 							{ this.renderBusinessExtensionHelpText( values ) }

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -5,6 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import {
 	Button,
+	Card,
+	CardBody,
+	CardFooter,
 	CheckboxControl,
 	__experimentalText as Text,
 } from '@wordpress/components';
@@ -13,7 +16,7 @@ import { filter, find, findIndex, get } from 'lodash';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { Card, TextControl } from '@woocommerce/components';
+import { TextControl } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -155,9 +158,39 @@ class Industry extends Component {
 		} );
 	}
 
+	renderIndustryLabel( slug, industry, selectedIndustry ) {
+		const { textInputListContent } = this.state;
+
+		return <>
+			{ industry.label }
+			{ industry.use_description && selectedIndustry && (
+				<TextControl
+					key={ `text-control-${ slug }` }
+					label={
+						industry.description_label
+					}
+					value={
+						selectedIndustry.detail ||
+						textInputListContent[
+							slug
+						] ||
+						''
+					}
+					onChange={ ( value ) =>
+						this.onDetailChange(
+							value,
+							slug
+						)
+					}
+					className="woocommerce-profile-wizard__text"
+				/> )
+			}
+		</>
+	}
+
 	render() {
 		const { industries } = onboarding;
-		const { error, selected, textInputListContent } = this.state;
+		const { error, selected } = this.state;
 		const { locationSettings, isProfileItemsRequesting } = this.props;
 		const region = getCurrencyRegion(
 			locationSettings.woocommerce_default_country
@@ -185,57 +218,31 @@ class Industry extends Component {
 					</Text>
 				</div>
 				<Card>
-					<div className="woocommerce-profile-wizard__checkbox-group">
-						{ filteredIndustryKeys.map( ( slug ) => {
-							const selectedIndustry = find( selected, { slug } );
+					<CardBody size={ null }>
+						<div className="woocommerce-profile-wizard__checkbox-group">
+							{ filteredIndustryKeys.map( ( slug ) => {
+								const selectedIndustry = find( selected, { slug } );
 
-							return (
-								<div key={ `div-${ slug }` }>
+								return (
 									<CheckboxControl
 										key={ `checkbox-control-${ slug }` }
-										label={ industries[ slug ].label }
+										label={ this.renderIndustryLabel( slug, industries[ slug ], selectedIndustry ) }
 										onChange={ () =>
 											this.onIndustryChange( slug )
 										}
 										checked={ selectedIndustry || false }
 										className="woocommerce-profile-wizard__checkbox"
 									/>
-									{ industries[ slug ].use_description &&
-										selectedIndustry && (
-											<TextControl
-												key={ `text-control-${ selectedIndustry.slug }` }
-												label={
-													industries[
-														selectedIndustry.slug
-													].description_label
-												}
-												value={
-													selectedIndustry.detail ||
-													textInputListContent[
-														slug
-													] ||
-													''
-												}
-												onChange={ ( value ) =>
-													this.onDetailChange(
-														value,
-														selectedIndustry.slug
-													)
-												}
-												className="woocommerce-profile-wizard__text"
-											/>
-										) }
-								</div>
-							);
-						} ) }
-						{ error && (
-							<span className="woocommerce-profile-wizard__error">
-								{ error }
-							</span>
-						) }
-					</div>
-
-					<div className="woocommerce-profile-wizard__card-actions">
+								);
+							} ) }
+							{ error && (
+								<span className="woocommerce-profile-wizard__error">
+									{ error }
+								</span>
+							) }
+						</div>
+					</CardBody>
+					<CardFooter isBorderless justify="center">
 						<Button
 							isPrimary
 							onClick={ this.onContinue }
@@ -245,7 +252,7 @@ class Industry extends Component {
 						>
 							{ __( 'Continue', 'woocommerce-admin' ) }
 						</Button>
-					</div>
+					</CardFooter>
 				</Card>
 			</Fragment>
 		);

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -161,31 +161,26 @@ class Industry extends Component {
 	renderIndustryLabel( slug, industry, selectedIndustry ) {
 		const { textInputListContent } = this.state;
 
-		return <>
-			{ industry.label }
-			{ industry.use_description && selectedIndustry && (
-				<TextControl
-					key={ `text-control-${ slug }` }
-					label={
-						industry.description_label
-					}
-					value={
-						selectedIndustry.detail ||
-						textInputListContent[
-							slug
-						] ||
-						''
-					}
-					onChange={ ( value ) =>
-						this.onDetailChange(
-							value,
-							slug
-						)
-					}
-					className="woocommerce-profile-wizard__text"
-				/> )
-			}
-		</>
+		return (
+			<>
+				{ industry.label }
+				{ industry.use_description && selectedIndustry && (
+					<TextControl
+						key={ `text-control-${ slug }` }
+						label={ industry.description_label }
+						value={
+							selectedIndustry.detail ||
+							textInputListContent[ slug ] ||
+							''
+						}
+						onChange={ ( value ) =>
+							this.onDetailChange( value, slug )
+						}
+						className="woocommerce-profile-wizard__text"
+					/>
+				) }
+			</>
+		);
 	}
 
 	render() {
@@ -221,12 +216,18 @@ class Industry extends Component {
 					<CardBody size={ null }>
 						<div className="woocommerce-profile-wizard__checkbox-group">
 							{ filteredIndustryKeys.map( ( slug ) => {
-								const selectedIndustry = find( selected, { slug } );
+								const selectedIndustry = find( selected, {
+									slug,
+								} );
 
 								return (
 									<CheckboxControl
 										key={ `checkbox-control-${ slug }` }
-										label={ this.renderIndustryLabel( slug, industries[ slug ], selectedIndustry ) }
+										label={ this.renderIndustryLabel(
+											slug,
+											industries[ slug ],
+											selectedIndustry
+										) }
 										onChange={ () =>
 											this.onIndustryChange( slug )
 										}

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -6,13 +6,15 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
 	Button,
+	Card,
+	CardBody,
+	CardFooter,
 	CheckboxControl,
 	FormToggle,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { includes, filter, get } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { Card } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
@@ -119,7 +121,7 @@ export class ProductTypes extends Component {
 				</div>
 
 				<Card>
-					<div className="woocommerce-profile-wizard__checkbox-group">
+					<CardBody size={ null }>
 						{ Object.keys( productTypes ).map( ( slug ) => {
 							return (
 								<CheckboxControl
@@ -154,21 +156,21 @@ export class ProductTypes extends Component {
 								{ error }
 							</span>
 						) }
-						<div className="woocommerce-profile-wizard__card-actions">
-							<Button
-								isPrimary
-								onClick={ this.onContinue }
-								disabled={
-									! selected.length ||
-									isProfileItemsRequesting
-								}
-							>
-								{ __( 'Continue', 'woocommerce-admin' ) }
-							</Button>
-						</div>
-					</div>
+					</CardBody>
+					<CardFooter isBorderless justify="center">
+						<Button
+							isPrimary
+							onClick={ this.onContinue }
+							disabled={
+								! selected.length ||
+								isProfileItemsRequesting
+							}
+						>
+							{ __( 'Continue', 'woocommerce-admin' ) }
+						</Button>
+					</CardFooter>
 				</Card>
-				<div className="woocommerce-profile-wizard__card-help-text">
+				<div className="woocommerce-profile-wizard__card-help-footnote">
 					<div className="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox">
 						<label htmlFor="woocommerce-product-types__pricing-toggle">
 							<Text variant="body">

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -162,8 +162,7 @@ export class ProductTypes extends Component {
 							isPrimary
 							onClick={ this.onContinue }
 							disabled={
-								! selected.length ||
-								isProfileItemsRequesting
+								! selected.length || isProfileItemsRequesting
 							}
 						>
 							{ __( 'Continue', 'woocommerce-admin' ) }

--- a/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -20,107 +20,103 @@ exports[`ProductTypes should render product types 1`] = `
       </p>
     </div>
     <div
-      class="woocommerce-card"
+      class="components-card is-size-medium css-1xs3c37-CardUI e1q7k77g0"
     >
       <div
-        class="woocommerce-card__body"
+        class="components-card__body css-xmjzce-BodyUI e1q7k77g3"
       >
         <div
-          class="woocommerce-profile-wizard__checkbox-group"
+          class="components-base-control woocommerce-profile-wizard__checkbox"
         >
           <div
-            class="components-base-control woocommerce-profile-wizard__checkbox"
+            class="components-base-control__field"
           >
-            <div
-              class="components-base-control__field"
+            <span
+              class="components-checkbox-control__input-container"
+            >
+              <input
+                class="components-checkbox-control__input"
+                id="inspector-checkbox-control-0"
+                type="checkbox"
+                value="1"
+              />
+            </span>
+            <label
+              class="components-checkbox-control__label"
+              for="inspector-checkbox-control-0"
             >
               <span
-                class="components-checkbox-control__input-container"
+                class="woocommerce-product-wizard__product-types-label"
               >
-                <input
-                  class="components-checkbox-control__input"
-                  id="inspector-checkbox-control-0"
-                  type="checkbox"
-                  value="1"
-                />
+                Paid product
               </span>
-              <label
-                class="components-checkbox-control__label"
-                for="inspector-checkbox-control-0"
+              <button
+                aria-label="Learn more about recommended free business features"
+                class="components-button is-tertiary"
+                type="button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="material-icons-outlined"
+                >
+                  info
+                </i>
+              </button>
+              
+              <span
+                class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
               >
                 <span
-                  class="woocommerce-product-wizard__product-types-label"
+                  class="screen-reader-text"
                 >
-                  Paid product
-                </span>
-                <button
-                  aria-label="Learn more about recommended free business features"
-                  class="components-button is-tertiary"
-                  type="button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="material-icons-outlined"
-                  >
-                    info
-                  </i>
-                </button>
-                
-                <span
-                  class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
-                >
-                  <span
-                    class="screen-reader-text"
-                  >
-                    This product type requires a paid extension.
+                  This product type requires a paid extension.
 We'll add this to a cart so that
 you can purchase and install it later.
-                  </span>
-                  $10 per month
                 </span>
-              </label>
-            </div>
-          </div>
-          <div
-            class="components-base-control woocommerce-profile-wizard__checkbox"
-          >
-            <div
-              class="components-base-control__field"
-            >
-              <span
-                class="components-checkbox-control__input-container"
-              >
-                <input
-                  class="components-checkbox-control__input"
-                  id="inspector-checkbox-control-1"
-                  type="checkbox"
-                  value="1"
-                />
+                $10 per month
               </span>
-              <label
-                class="components-checkbox-control__label"
-                for="inspector-checkbox-control-1"
-              >
-                Free product
-              </label>
-            </div>
+            </label>
           </div>
+        </div>
+        <div
+          class="components-base-control woocommerce-profile-wizard__checkbox"
+        >
           <div
-            class="woocommerce-profile-wizard__card-actions"
+            class="components-base-control__field"
           >
-            <button
-              class="components-button is-primary"
-              disabled=""
-              type="button"
+            <span
+              class="components-checkbox-control__input-container"
             >
-              Continue
-            </button>
+              <input
+                class="components-checkbox-control__input"
+                id="inspector-checkbox-control-1"
+                type="checkbox"
+                value="1"
+              />
+            </span>
+            <label
+              class="components-checkbox-control__label"
+              for="inspector-checkbox-control-1"
+            >
+              Free product
+            </label>
           </div>
         </div>
       </div>
+      <div
+        class="components-flex components-card__footer is-borderless is-size-medium e1q7k77g4 css-5hda2c-Flex-FooterUI eboqfv50"
+      >
+        <button
+          class="components-button is-primary"
+          disabled=""
+          type="button"
+        >
+          Continue
+        </button>
+      </div>
     </div>
     <div
-      class="woocommerce-profile-wizard__card-help-text"
+      class="woocommerce-profile-wizard__card-help-footnote"
     >
       <div
         class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"
@@ -181,107 +177,103 @@ exports[`ProductTypes should show annual prices on toggle 1`] = `
       </p>
     </div>
     <div
-      class="woocommerce-card"
+      class="components-card is-size-medium css-1xs3c37-CardUI e1q7k77g0"
     >
       <div
-        class="woocommerce-card__body"
+        class="components-card__body css-xmjzce-BodyUI e1q7k77g3"
       >
         <div
-          class="woocommerce-profile-wizard__checkbox-group"
+          class="components-base-control woocommerce-profile-wizard__checkbox"
         >
           <div
-            class="components-base-control woocommerce-profile-wizard__checkbox"
+            class="components-base-control__field"
           >
-            <div
-              class="components-base-control__field"
+            <span
+              class="components-checkbox-control__input-container"
+            >
+              <input
+                class="components-checkbox-control__input"
+                id="inspector-checkbox-control-2"
+                type="checkbox"
+                value="1"
+              />
+            </span>
+            <label
+              class="components-checkbox-control__label"
+              for="inspector-checkbox-control-2"
             >
               <span
-                class="components-checkbox-control__input-container"
+                class="woocommerce-product-wizard__product-types-label"
               >
-                <input
-                  class="components-checkbox-control__input"
-                  id="inspector-checkbox-control-2"
-                  type="checkbox"
-                  value="1"
-                />
+                Paid product
               </span>
-              <label
-                class="components-checkbox-control__label"
-                for="inspector-checkbox-control-2"
+              <button
+                aria-label="Learn more about recommended free business features"
+                class="components-button is-tertiary"
+                type="button"
+              >
+                <i
+                  aria-hidden="true"
+                  class="material-icons-outlined"
+                >
+                  info
+                </i>
+              </button>
+              
+              <span
+                class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
               >
                 <span
-                  class="woocommerce-product-wizard__product-types-label"
+                  class="screen-reader-text"
                 >
-                  Paid product
-                </span>
-                <button
-                  aria-label="Learn more about recommended free business features"
-                  class="components-button is-tertiary"
-                  type="button"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="material-icons-outlined"
-                  >
-                    info
-                  </i>
-                </button>
-                
-                <span
-                  class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
-                >
-                  <span
-                    class="screen-reader-text"
-                  >
-                    This product type requires a paid extension.
+                  This product type requires a paid extension.
 We'll add this to a cart so that
 you can purchase and install it later.
-                  </span>
-                  $120 per year
                 </span>
-              </label>
-            </div>
-          </div>
-          <div
-            class="components-base-control woocommerce-profile-wizard__checkbox"
-          >
-            <div
-              class="components-base-control__field"
-            >
-              <span
-                class="components-checkbox-control__input-container"
-              >
-                <input
-                  class="components-checkbox-control__input"
-                  id="inspector-checkbox-control-3"
-                  type="checkbox"
-                  value="1"
-                />
+                $120 per year
               </span>
-              <label
-                class="components-checkbox-control__label"
-                for="inspector-checkbox-control-3"
-              >
-                Free product
-              </label>
-            </div>
+            </label>
           </div>
+        </div>
+        <div
+          class="components-base-control woocommerce-profile-wizard__checkbox"
+        >
           <div
-            class="woocommerce-profile-wizard__card-actions"
+            class="components-base-control__field"
           >
-            <button
-              class="components-button is-primary"
-              disabled=""
-              type="button"
+            <span
+              class="components-checkbox-control__input-container"
             >
-              Continue
-            </button>
+              <input
+                class="components-checkbox-control__input"
+                id="inspector-checkbox-control-3"
+                type="checkbox"
+                value="1"
+              />
+            </span>
+            <label
+              class="components-checkbox-control__label"
+              for="inspector-checkbox-control-3"
+            >
+              Free product
+            </label>
           </div>
         </div>
       </div>
+      <div
+        class="components-flex components-card__footer is-borderless is-size-medium e1q7k77g4 css-5hda2c-Flex-FooterUI eboqfv50"
+      >
+        <button
+          class="components-button is-primary"
+          disabled=""
+          type="button"
+        >
+          Continue
+        </button>
+      </div>
     </div>
     <div
-      class="woocommerce-profile-wizard__card-help-text"
+      class="woocommerce-profile-wizard__card-help-footnote"
     >
       <div
         class="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox"

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -296,23 +296,15 @@ class StoreDetails extends Component {
 							</CardFooter>
 
 							<CardFooter justify="center">
-								<FlexItem align="center">
-									<div className="woocommerce-profile-wizard__submit">
-										<Button
-											isPrimary
-											onClick={ handleSubmit }
-											disabled={
-												! isValidForm ||
-												isUpdatingProfileItems
-											}
-										>
-											{ __(
-												'Continue',
-												'woocommerce-admin'
-											) }
-										</Button>
-									</div>
-								</FlexItem>
+								<Button
+									isPrimary
+									onClick={ handleSubmit }
+									disabled={
+										! isValidForm || isUpdatingProfileItems
+									}
+								>
+									{ __( 'Continue', 'woocommerce-admin' ) }
+								</Button>
 							</CardFooter>
 						</Card>
 					) }

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -9,12 +9,15 @@ import { decodeEntities } from '@wordpress/html-entities';
 import InfoIcon from 'gridicons/dist/info';
 import {
 	Button,
+	Card,
+	CardBody,
+	CardFooter,
 	TabPanel,
 	Tooltip,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Card, H } from '@woocommerce/components';
+import { H } from '@woocommerce/components';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -192,15 +195,17 @@ class Theme extends Component {
 
 		return (
 			<Card className="woocommerce-profile-wizard__theme" key={ slug }>
-				{ image && (
-					<div
-						className="woocommerce-profile-wizard__theme-image"
-						style={ { backgroundImage: `url(${ image })` } }
-						role="img"
-						aria-label={ title }
-					/>
-				) }
-				<div className="woocommerce-profile-wizard__theme-details">
+				<CardBody size={ null }>
+					{ image && (
+						<div
+							className="woocommerce-profile-wizard__theme-image"
+							style={ { backgroundImage: `url(${ image })` } }
+							role="img"
+							aria-label={ title }
+						/>
+					) }
+				</CardBody>
+				<CardBody className="woocommerce-profile-wizard__theme-details">
 					<H className="woocommerce-profile-wizard__theme-name">
 						{ title }
 						{ ! hasSupport && (
@@ -223,39 +228,39 @@ class Theme extends Component {
 					<p className="woocommerce-profile-wizard__theme-status">
 						{ this.getThemeStatus( theme ) }
 					</p>
-					<div className="woocommerce-profile-wizard__theme-actions">
-						{ slug === activeTheme ? (
-							<Button
-								isPrimary
-								onClick={ () => this.onChoose( theme, 'card' ) }
-								isBusy={ chosen === slug }
-								disabled={ chosen === slug }
-							>
-								{ __(
-									'Continue with my active theme',
-									'woocommerce-admin'
-								) }
-							</Button>
-						) : (
-							<Button
-								isSecondary
-								onClick={ () => this.onChoose( theme, 'card' ) }
-								isBusy={ chosen === slug }
-								disabled={ chosen === slug }
-							>
-								{ __( 'Choose', 'woocommerce-admin' ) }
-							</Button>
-						) }
-						{ demoUrl && (
-							<Button
-								isTertiary
-								onClick={ () => this.openDemo( theme ) }
-							>
-								{ __( 'Live demo', 'woocommerce-admin' ) }
-							</Button>
-						) }
-					</div>
-				</div>
+				</CardBody>
+				<CardFooter>
+					{ slug === activeTheme ? (
+						<Button
+							isPrimary
+							onClick={ () => this.onChoose( theme, 'card' ) }
+							isBusy={ chosen === slug }
+							disabled={ chosen === slug }
+						>
+							{ __(
+								'Continue with my active theme',
+								'woocommerce-admin'
+							) }
+						</Button>
+					) : (
+						<Button
+							isSecondary
+							onClick={ () => this.onChoose( theme, 'card' ) }
+							isBusy={ chosen === slug }
+							disabled={ chosen === slug }
+						>
+							{ __( 'Choose', 'woocommerce-admin' ) }
+						</Button>
+					) }
+					{ demoUrl && (
+						<Button
+							isTertiary
+							onClick={ () => this.openDemo( theme ) }
+						>
+							{ __( 'Live demo', 'woocommerce-admin' ) }
+						</Button>
+					) }
+				</CardFooter>
 			</Card>
 		);
 	}

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -44,18 +44,11 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	text-align: center;
 }
 
-.woocommerce-profile-wizard__body .woocommerce-profile-wizard__theme.woocommerce-card {
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__theme.components-card {
 	overflow: hidden;
 
 	@include breakpoint( '>782px' ) {
 		margin: 0;
-	}
-
-	.woocommerce-card__body {
-		padding: 0;
-		display: flex;
-		flex-direction: column;
-		height: 100%;
 	}
 
 	.woocommerce-profile-wizard__theme-image {
@@ -81,13 +74,6 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 		}
 	}
 
-	.woocommerce-profile-wizard__theme-details {
-		padding: $gap;
-		display: flex;
-		flex-direction: column;
-		margin-top: auto;
-	}
-
 	.woocommerce-profile-wizard__theme-status {
 		margin: 0;
 		font-size: 14px;
@@ -96,35 +82,11 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	.woocommerce-profile-wizard__theme-learn-more {
 		display: inline-block;
 	}
-
-	.woocommerce-profile-wizard__theme-actions {
-		button.components-button {
-			margin: 13px auto 0 auto;
-			display: block;
-			width: auto;
-			min-width: 106px;
-			height: 40px;
-			line-height: 1;
-
-			&.is-primary {
-				color: $studio-white;
-			}
-
-			&.is-tertiary {
-				font-size: 14px;
-				font-weight: 500;
-			}
-		}
-	}
 }
 
-.woocommerce-profile-wizard__body .woocommerce-theme-uploader.woocommerce-card {
+.woocommerce-profile-wizard__body .woocommerce-theme-uploader.components-card {
 	margin: 0;
 	position: relative;
-
-	.woocommerce-card__body {
-		height: 100%;
-	}
 
 	&.is-uploading .components-drop-zone__provider {
 		min-height: 382px;

--- a/client/profile-wizard/steps/theme/uploader.js
+++ b/client/profile-wizard/steps/theme/uploader.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
+	Card,
 	DropZoneProvider,
 	DropZone,
 	FormFileUpload,
@@ -15,7 +16,7 @@ import CloudUploadIcon from 'gridicons/dist/cloud-upload';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
-import { Card, H, Spinner } from '@woocommerce/components';
+import { H, Spinner } from '@woocommerce/components';
 
 class ThemeUploader extends Component {
 	constructor() {

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -401,13 +401,9 @@
 }
 
 .woocommerce-business-extensions {
-	margin-left: -$gap;
-	margin-right: -$gap;
-	padding: $gap $gap-large;
-	border-top: 1px solid $gray-100;
-	border-bottom: 1px solid $gray-100;
 	display: flex;
 	align-items: center;
+	width: 100%;
 
 	label {
 		display: flex;

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -20,45 +20,6 @@
 		}
 	}
 
-	.woocommerce-card {
-		margin-top: $gap;
-
-		h1,
-		h2,
-		h3 {
-			color: $gray-900;
-		}
-		color: $gray-700;
-		text-align: left;
-
-		button.is-button {
-			display: flex;
-			margin: $gap-smaller auto 0;
-			width: 310px;
-			max-width: 100%;
-			justify-content: center;
-		}
-
-		.business-competitors .woocommerce-select-control__listbox {
-			max-height: unset;
-		}
-	}
-
-	.woocommerce-profile-wizard__card-actions {
-		text-align: center;
-
-		.components-button {
-			margin-top: $gap-small;
-		}
-	}
-
-	.woocommerce-card + .woocommerce-profile-wizard__card-help-text {
-		font-size: 14px;
-		color: $gray-600;
-		text-align: center;
-		margin-top: $gap;
-	}
-
 	.woocommerce-profile-wizard__header {
 		height: $header-height;
 		border-bottom: 1px solid $studio-gray-5;
@@ -118,11 +79,6 @@
 			}
 		}
 
-		.woocommerce-card ~ p {
-			color: $gray-600;
-			text-align: center;
-		}
-
 		.woocommerce-profile-wizard__footer {
 			margin: 34px auto;
 			display: flex;
@@ -135,6 +91,9 @@
 		}
 
 		.woocommerce-profile-wizard__footnote {
+			margin-top: $gap;
+			text-align: center;
+
 			p {
 				color: $gray-700;
 				text-align: left;
@@ -155,7 +114,7 @@
 
 	.woocommerce-profile-wizard__error {
 		display: block;
-		padding: $gap;
+		padding: $gap $gap-large;
 		font-size: 12px;
 		color: $studio-red-50;
 	}
@@ -217,6 +176,7 @@
 	.woocommerce-profile-wizard__benefit-card {
 		display: flex;
 		flex-direction: column;
+		justify-self: center;
 		background: $studio-gray-0;
 		width: 100%;
 		max-width: 295px;
@@ -284,52 +244,41 @@
 		margin: $gap-smaller 0;
 	}
 
-	.woocommerce-profile-wizard__checkbox-group {
-		margin: #{-$gap} #{-$gap} 0 -#{$gap};
+	.woocommerce-profile-wizard__checkbox {
+		margin-top: 0;
+		margin-bottom: 0;
+		position: relative;
+		padding: $gap-small $gap-large;
+		min-height: 62px;
+		border-bottom: 1px solid $gray-100;
+		display: flex;
+		align-items: center;
 
-		.woocommerce-profile-wizard__checkbox {
-			margin-top: 0;
-			margin-bottom: 0;
+		.components-base-control {
 			position: relative;
-			padding: $gap-small $gap-large;
-			min-height: 46px;
-			border-bottom: 1px solid $gray-100;
-
-			.components-base-control {
-				position: relative;
-			}
-
-			.components-base-control__field {
-				margin: 0;
-			}
-
-			label.components-checkbox-control__label {
-				font-size: $gap;
-				margin-left: 0;
-			}
-
-			.components-base-control__help {
-				margin-left: $gap-largest + $gap-smaller;
-				font-style: normal;
-			}
-
-			.components-base-control__help {
-				color: $gray-600;
-				font-size: 14px;
-				line-height: 20px;
-				margin-top: 3px;
-				margin-bottom: 0;
-			}
-
-			&:last-of-type {
-				&::after {
-					display: none;
-				}
-			}
 		}
 
-		.woocommerce-profile-wizard__text {
-			margin: 0 16px 10px;
+		.components-base-control__field {
+			width: 100%;
+			margin: 0;
+		}
+
+		label.components-checkbox-control__label {
+			font-size: $gap;
+			margin-left: 0;
+		}
+
+		.components-base-control__help {
+			margin-left: $gap-largest + $gap-smaller;
+			font-style: normal;
+		}
+
+		.components-base-control__help {
+			color: $gray-600;
+			font-size: 14px;
+			line-height: 20px;
+			margin-top: 3px;
+			margin-bottom: 0;
 		}
 
 		svg.dashicon.components-checkbox-control__checked {
@@ -393,31 +342,12 @@
 	}
 }
 
-.woocommerce-profile-wizard__benefits-card.woocommerce-card {
+.woocommerce-profile-wizard__benefits-card.components-card {
 	display: inline-block;
 	max-width: 100%;
 	text-align: center;
 
-	.woocommerce-card__body {
-		padding: $gap-large * 2;
-	}
-
-	.woocommerce-profile-wizard__card-actions {
-		margin-top: $gap;
-		display: inline-flex;
-
-		.components-button {
-			width: auto;
-
-			&:first-child {
-				margin-right: $gap;
-			}
-		}
-	}
-
 	.woocommerce-profile-wizard__benefits-install-notice {
-		margin-top: $gap-large;
-		margin-bottom: 0;
 		font-size: 14px;
 		color: $studio-gray-40;
 	}
@@ -460,10 +390,6 @@
 	.woocommerce-stepper__steps {
 		margin: 0;
 	}
-}
-
-.woocommerce-profile-wizard__submit {
-	margin-bottom: $gap-small;
 }
 
 .woocommerce-profile-wizard__tooltip-icon {


### PR DESCRIPTION
Fixes (partialy) #4002

Uses the WP Card instead of WC Card for the setup wizard.

Styles here diverge slightly from the original, most notably:
* The business extensions have borders on top and bottom for both the bundled and non-bundled version.
* Theme card footers place buttons side-by-side as opposed to on top of each other.

My understanding was that the styles used here would more closely follow the default used in GB, so I left these as is, but happy to change to match the previous obw styling if we see fit.

### Screenshots
<img width="902" alt="Screen Shot 2020-12-16 at 6 31 57 PM" src="https://user-images.githubusercontent.com/10561050/102419328-86f54a80-3fcd-11eb-9c38-0f32237e30ee.png">
<img width="568" alt="Screen Shot 2020-12-16 at 6 31 21 PM" src="https://user-images.githubusercontent.com/10561050/102419330-878de100-3fcd-11eb-81f0-665fec33d818.png">
<img width="567" alt="Screen Shot 2020-12-16 at 6 24 13 PM" src="https://user-images.githubusercontent.com/10561050/102419332-88267780-3fcd-11eb-9523-3d608f87b7d8.png">
<img width="534" alt="Screen Shot 2020-12-16 at 6 21 03 PM" src="https://user-images.githubusercontent.com/10561050/102419333-88267780-3fcd-11eb-9c91-1da390e74195.png">
<img width="538" alt="Screen Shot 2020-12-16 at 6 20 52 PM" src="https://user-images.githubusercontent.com/10561050/102419334-88267780-3fcd-11eb-8d01-8912528ceed7.png">
<img width="565" alt="Screen Shot 2020-12-16 at 6 20 36 PM" src="https://user-images.githubusercontent.com/10561050/102419335-88267780-3fcd-11eb-9c47-5a14afaab9d8.png">


### Detailed test instructions:

1. Disconnect JP and/or WCS (to see benefits)
2. Go through the setup wizard.
2. Note the card styling is as expected.
3. Switch industries to show bundled/non-bundled extension styling.
