### PR TITLE
Update dashboard charts to use WP Card

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -71,7 +71,9 @@ export class Leaderboard extends Component {
 			return (
 				<Card className={ classes }>
 					<CardHeader>
-						<Text variant="title.small" as="h3">{ title }</Text>
+						<Text variant="title.small" as="h3">
+							{ title }
+						</Text>
 					</CardHeader>
 					<CardBody size={ null }>
 						<EmptyTable>

--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -2,11 +2,17 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import { EmptyTable, TableCard } from '@woocommerce/components';
 import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
-import { Card, EmptyTable, TableCard } from '@woocommerce/components';
 import { getPersistedQuery } from '@woocommerce/navigation';
 import {
 	getFilterQuery,
@@ -63,13 +69,18 @@ export class Leaderboard extends Component {
 
 		if ( ! isRequesting && rows.length === 0 ) {
 			return (
-				<Card title={ title } className={ classes }>
-					<EmptyTable>
-						{ __(
-							'No data recorded for the selected time period.',
-							'woocommerce-admin'
-						) }
-					</EmptyTable>
+				<Card className={ classes }>
+					<CardHeader>
+						<Text variant="title.small" as="h3">{ title }</Text>
+					</CardHeader>
+					<CardBody size={ null }>
+						<EmptyTable>
+							{ __(
+								'No data recorded for the selected time period.',
+								'woocommerce-admin'
+							) }
+						</EmptyTable>
+					</CardBody>
 				</Card>
 			);
 		}

--- a/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
+++ b/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
@@ -255,11 +255,17 @@ exports[`Leaderboard should render correct data in the table 1`] = `
 exports[`Leaderboard should render empty message when there are no rows 1`] = `
 <div>
   <div
-    class="woocommerce-card woocommerce-leaderboard"
+    class="components-card is-size-medium woocommerce-leaderboard css-1xs3c37-CardUI e1q7k77g0"
   >
-    
     <div
-      class="woocommerce-card__body"
+      class="components-flex components-card__header is-size-medium e1q7k77g1 css-jsa6v9-Flex-HeaderUI eboqfv50"
+    >
+      <h3
+        class="css-1ahfdc3-Text e15wbhsk0"
+      />
+    </div>
+    <div
+      class="components-card__body css-xmjzce-BodyUI e1q7k77g3"
     >
       <div
         class="woocommerce-table is-empty"

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -4,7 +4,12 @@
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card } from '@woocommerce/components';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import {
 	getHistory,
 	getNewPath,
@@ -53,35 +58,37 @@ class ChartBlock extends Component {
 				className="woocommerce-dashboard__chart-block-wrapper"
 				onClick={ this.handleChartClick }
 			>
-				<Card
-					className="woocommerce-dashboard__chart-block woocommerce-analytics__card"
-					title={ selectedChart.label }
-				>
-					<a
-						className="screen-reader-text"
-						href={ getAdminLink(
-							this.getChartPath( selectedChart )
-						) }
-					>
-						{
-							/* translators: %s is the chart type */
-							sprintf(
-								__( '%s Report', 'woocommerce-admin' ),
-								selectedChart.label
-							)
-						}
-					</a>
-					<ReportChart
-						charts={ charts }
-						endpoint={ endpoint }
-						query={ query }
-						interactiveLegend={ false }
-						legendPosition="bottom"
-						path={ path }
-						selectedChart={ selectedChart }
-						showHeaderControls={ false }
-						filters={ filters }
-					/>
+				<Card className="woocommerce-dashboard__chart-block">
+					<CardHeader>
+						<Text variant="title.small" as="h3">{ selectedChart.label }</Text>
+					</CardHeader>
+					<CardBody size={ null }>
+						<a
+							className="screen-reader-text"
+							href={ getAdminLink(
+								this.getChartPath( selectedChart )
+							) }
+						>
+							{
+								/* translators: %s is the chart type */
+								sprintf(
+									__( '%s Report', 'woocommerce-admin' ),
+									selectedChart.label
+								)
+							}
+						</a>
+						<ReportChart
+							charts={ charts }
+							endpoint={ endpoint }
+							query={ query }
+							interactiveLegend={ false }
+							legendPosition="bottom"
+							path={ path }
+							selectedChart={ selectedChart }
+							showHeaderControls={ false }
+							filters={ filters }
+						/>
+					</CardBody>
 				</Card>
 			</div>
 		);

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -60,7 +60,9 @@ class ChartBlock extends Component {
 			>
 				<Card className="woocommerce-dashboard__chart-block">
 					<CardHeader>
-						<Text variant="title.small" as="h3">{ selectedChart.label }</Text>
+						<Text variant="title.small" as="h3">
+							{ selectedChart.label }
+						</Text>
 					</CardHeader>
 					<CardBody size={ null }>
 						<a

--- a/client/dashboard/dashboard-charts/block.scss
+++ b/client/dashboard/dashboard-charts/block.scss
@@ -9,6 +9,11 @@
 			background: transparent;
 		}
 	}
+	.woocommerce-chart {
+		margin-top: 0;
+		margin-bottom: 0;
+		border: 0;
+	}
 	.woocommerce-chart__footer {
 		position: relative;
 		&::after {


### PR DESCRIPTION
Fixes (partially) #4002

Updates the dashboard charts and leaderboards to use the GB imported card.

Styles stay pretty consistent to previous design with exception of default card styling changes.  Title sizes now use `Text`.

### Screenshots
<img width="1052" alt="Screen Shot 2020-12-16 at 6 52 52 PM" src="https://user-images.githubusercontent.com/10561050/102420805-ea34ac00-3fd0-11eb-9ac8-83ea60078fac.png">


### Detailed test instructions:

1. Navigate to the dashboard.
2. Check that card styling and titles are as expected.