### PR TITLE
Use wp cards in store alerts

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -3,14 +3,22 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, Dashicon, SelectControl } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	Dashicon,
+	SelectControl,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import moment from 'moment';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
-import { Card } from '@woocommerce/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -190,7 +198,6 @@ class StoreAlerts extends Component {
 		const type = alert.type;
 		const className = classnames(
 			'woocommerce-store-alerts',
-			'woocommerce-analytics__card',
 			{
 				'is-alert-error': type === 'error',
 				'is-alert-update': type === 'update',
@@ -198,14 +205,13 @@ class StoreAlerts extends Component {
 		);
 
 		return (
-			<Card
-				title={ [
-					alert.icon && <Dashicon key="icon" icon={ alert.icon } />,
-					<Fragment key="title">{ alert.title }</Fragment>,
-				] }
-				className={ className }
-				action={
-					numberOfAlerts > 1 && (
+			<Card className={ className } size={ null }>
+				<CardHeader isBorderless>
+					<Text variant="title.medium" as="h2">
+						{ alert.icon && <Dashicon key="icon" icon={ alert.icon } /> }
+						{ alert.title }
+					</Text>
+					{ numberOfAlerts > 1 && (
 						<div className="woocommerce-store-alerts__pagination">
 							<Button
 								onClick={ this.previousAlert }
@@ -252,14 +258,17 @@ class StoreAlerts extends Component {
 								<Icon icon={ chevronRight } />
 							</Button>
 						</div>
-					)
-				}
-			>
-				<div
-					className="woocommerce-store-alerts__message"
-					dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
-				/>
-				{ this.renderActions( alert ) }
+					) }
+				</CardHeader>
+				<CardBody>
+					<div
+						className="woocommerce-store-alerts__message"
+						dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
+					/>
+				</CardBody>
+				<CardFooter isBorderless>
+					{ this.renderActions( alert ) }
+				</CardFooter>
 			</Card>
 		);
 	}

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -31,7 +31,7 @@ import StoreAlertsPlaceholder from './placeholder';
 
 import './style.scss';
 
-class StoreAlerts extends Component {
+export class StoreAlerts extends Component {
 	constructor( props ) {
 		super( props );
 		const { alerts } = this.props;
@@ -196,19 +196,18 @@ class StoreAlerts extends Component {
 		const numberOfAlerts = alerts.length;
 		const alert = alerts[ currentIndex ];
 		const type = alert.type;
-		const className = classnames(
-			'woocommerce-store-alerts',
-			{
-				'is-alert-error': type === 'error',
-				'is-alert-update': type === 'update',
-			}
-		);
+		const className = classnames( 'woocommerce-store-alerts', {
+			'is-alert-error': type === 'error',
+			'is-alert-update': type === 'update',
+		} );
 
 		return (
 			<Card className={ className } size={ null }>
 				<CardHeader isBorderless>
 					<Text variant="title.medium" as="h2">
-						{ alert.icon && <Dashicon key="icon" icon={ alert.icon } /> }
+						{ alert.icon && (
+							<Dashicon key="icon" icon={ alert.icon } />
+						) }
 						{ alert.title }
 					</Text>
 					{ numberOfAlerts > 1 && (
@@ -263,7 +262,9 @@ class StoreAlerts extends Component {
 				<CardBody>
 					<div
 						className="woocommerce-store-alerts__message"
-						dangerouslySetInnerHTML={ sanitizeHTML( alert.content ) }
+						dangerouslySetInnerHTML={ sanitizeHTML(
+							alert.content
+						) }
 					/>
 				</CardBody>
 				<CardFooter isBorderless>

--- a/client/layout/store-alerts/placeholder.js
+++ b/client/layout/store-alerts/placeholder.js
@@ -10,7 +10,7 @@ class StoreAlertsPlaceholder extends Component {
 
 		return (
 			<div
-				className="woocommerce-card woocommerce-store-alerts is-loading"
+				className="woocommerce-store-alerts is-loading"
 				aria-hidden
 			>
 				<div className="woocommerce-card__header">

--- a/client/layout/store-alerts/placeholder.js
+++ b/client/layout/store-alerts/placeholder.js
@@ -3,36 +3,32 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 
 class StoreAlertsPlaceholder extends Component {
 	render() {
 		const { hasMultipleAlerts } = this.props;
 
 		return (
-			<div
+			<Card
 				className="woocommerce-store-alerts is-loading"
 				aria-hidden
+				size={ null }
 			>
-				<div className="woocommerce-card__header">
-					<div className="woocommerce-card__title woocommerce-card__header-item">
-						<span className="is-placeholder" />
-					</div>
-					{ hasMultipleAlerts && (
-						<div className="woocommerce-card__action woocommerce-card__header-item">
-							<span className="is-placeholder" />
-						</div>
-					) }
-				</div>
-				<div className="woocommerce-card__body">
+				<CardHeader isBorderless>
+					<span className="is-placeholder" />
+					{ hasMultipleAlerts && <span className="is-placeholder" /> }
+				</CardHeader>
+				<CardBody>
 					<div className="woocommerce-store-alerts__message">
 						<span className="is-placeholder" />
 						<span className="is-placeholder" />
 					</div>
-					<div className="woocommerce-store-alerts__actions">
-						<span className="is-placeholder" />
-					</div>
-				</div>
-			</div>
+				</CardBody>
+				<CardFooter isBorderless>
+					<span className="is-placeholder" />
+				</CardFooter>
+			</Card>
 		);
 	}
 }

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -155,10 +155,14 @@
 		height: 16px;
 	}
 
-	.components-card__header h2 {
-		.is-placeholder {
+	.components-card__header {
+		.is-placeholder:nth-child(1) {
 			width: 340px;
-			height: 20px;
+			height: 32px;
+		}
+		.is-placeholder:nth-child(2) {
+			width: 137px;
+			height: 38px;
 		}
 	}
 
@@ -169,7 +173,7 @@
 		}
 	}
 
-	.woocommerce-store-alerts__message {
+	.components-card__body {
 		.is-placeholder {
 			&:nth-child(1) {
 				width: 75%;

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -16,22 +16,12 @@
 		background: transparent;
 	}
 
-	.woocommerce-card__header {
-		padding: 0;
-		border: 0;
+	.components-card__header {
 		margin-bottom: 12px;
-	}
-
-	.woocommerce-card__title {
-		display: inline-flex;
 
 		svg {
 			margin-right: 6px;
 		}
-	}
-
-	.woocommerce-card__body {
-		padding: 0;
 	}
 
 	a.components-button {
@@ -58,7 +48,7 @@
 		margin-bottom: $gap-large;
 		padding: $gap;
 
-		.woocommerce-card__header {
+		.components-card__header {
 			display: flex;
 			flex-direction: column-reverse;
 			align-items: flex-start;
@@ -82,7 +72,7 @@
 		background-color: $alert-color;
 	}
 
-	.woocommerce-card__title {
+	.components-card__header h2 {
 		svg {
 			color: $alert-color;
 		}
@@ -96,7 +86,7 @@
 		background-color: $alert-color;
 	}
 
-	.woocommerce-card__title {
+	.components-card__header h2 {
 		svg {
 			color: $alert-color;
 		}
@@ -165,14 +155,14 @@
 		height: 16px;
 	}
 
-	.woocommerce-card__title {
+	.components-card__header h2 {
 		.is-placeholder {
 			width: 340px;
 			height: 20px;
 		}
 	}
 
-	.woocommerce-card__action {
+	.components-card__footer {
 		.is-placeholder {
 			min-width: 120px;
 			height: 30px;
@@ -199,7 +189,7 @@
 	}
 
 	@include breakpoint( '<782px' ) {
-		.woocommerce-card__title {
+		.components-card__header h2 {
 			width: 100%;
 
 			.is-placeholder {
@@ -207,7 +197,7 @@
 			}
 		}
 
-		.woocommerce-card__action {
+		.components-card__footer {
 			margin-bottom: 14px;
 		}
 	}

--- a/client/layout/store-alerts/test/index.js
+++ b/client/layout/store-alerts/test/index.js
@@ -1,0 +1,143 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import { setSetting } from '@woocommerce/wc-admin-settings';
+
+/**
+ * Internal dependencies
+ */
+import { StoreAlerts } from '../';
+
+const alerts = [
+	{
+		title: 'Alert title 1',
+		content: 'Alert content 1',
+		actions: [],
+	},
+	{
+		title: 'Alert title 2',
+		content: 'Alert content 2',
+		actions: [
+			{
+				id: 'action-1',
+				name: 'action-1',
+				label: 'Click me!',
+				url: '#',
+			},
+		],
+	},
+];
+
+describe( 'StoreAlerts', () => {
+	it( 'should return null when no alerts exist', () => {
+		const { container } = render( <StoreAlerts alerts={ [] } /> );
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should show the placeholder when loading and preloaded alerts exist', () => {
+		setSetting( 'alertCount', 2 );
+		const { container } = render(
+			<StoreAlerts isLoading alerts={ alerts } />
+		);
+
+		expect(
+			container.querySelector( '.is-placeholder' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should show the alert title and content', () => {
+		const { container } = render( <StoreAlerts alerts={ alerts } /> );
+
+		expect( container.querySelector( 'h2' ).textContent ).toBe(
+			'Alert title 1'
+		);
+		expect(
+			container.querySelector( '.woocommerce-store-alerts__message' )
+				.textContent
+		).toBe( 'Alert content 1' );
+	} );
+
+	it( 'should not show the pagination for a single alert', () => {
+		const { container } = render(
+			<StoreAlerts alerts={ [ alerts[ 0 ] ] } />
+		);
+
+		expect(
+			container.querySelector( '.woocommerce-store-alerts__pagination' )
+		).toBeNull();
+	} );
+
+	it( 'should show the pagination for multiple alerts', () => {
+		const { container } = render( <StoreAlerts alerts={ alerts } /> );
+
+		expect(
+			container.querySelector( '.woocommerce-store-alerts__pagination' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should show the actions for an alert that contains actions', () => {
+		const { container } = render(
+			<StoreAlerts alerts={ [ alerts[ 1 ] ] } />
+		);
+
+		expect(
+			container.querySelector( '.components-button' ).textContent
+		).toBe( 'Click me!' );
+		expect(
+			container
+				.querySelector( '.components-button' )
+				.getAttribute( 'href' )
+		).toBe( '#' );
+		expect(
+			container.querySelector( '.woocommerce-store-alerts__snooze' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should show the actions and snooze actions for snoozable alerts', () => {
+		const { container } = render(
+			<StoreAlerts
+				alerts={ [ { ...alerts[ 1 ], is_snoozable: true } ] }
+			/>
+		);
+
+		expect(
+			container.querySelector( '.components-button' ).textContent
+		).toBe( 'Click me!' );
+		expect(
+			container
+				.querySelector( '.components-button' )
+				.getAttribute( 'href' )
+		).toBe( '#' );
+		expect(
+			container.querySelector( '.woocommerce-store-alerts__snooze' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should show different alerts when clicking the pagination buttons', () => {
+		const { container, getByLabelText, rerender } = render(
+			<StoreAlerts alerts={ alerts } />
+		);
+
+		expect( container.querySelector( 'h2' ).textContent ).toBe(
+			'Alert title 1'
+		);
+
+		fireEvent.click( getByLabelText( 'Next Alert' ) );
+
+		rerender( <StoreAlerts alerts={ alerts } /> );
+
+		expect( container.querySelector( 'h2' ).textContent ).toBe(
+			'Alert title 2'
+		);
+
+		fireEvent.click( getByLabelText( 'Previous Alert' ) );
+
+		rerender( <StoreAlerts alerts={ alerts } /> );
+
+		expect( container.querySelector( 'h2' ).textContent ).toBe(
+			'Alert title 1'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes (partially) #4002

Updates store alerts to use GB cards and adds tests for the store alerts.

Styles are pretty much identical to pre-existing styles with the exception of some updated placeholder styles.

### Screenshots

**Before**
<img width="1059" alt="Screen Shot 2020-12-16 at 7 03 47 PM" src="https://user-images.githubusercontent.com/10561050/102423811-cd4fa700-3fd7-11eb-941e-4508ae1d5d05.png">

**After**
<img width="1055" alt="Screen Shot 2020-12-16 at 7 33 09 PM" src="https://user-images.githubusercontent.com/10561050/102423809-ccb71080-3fd7-11eb-89e8-9c5b9b04286d.png">
<img width="1047" alt="Screen Shot 2020-12-16 at 7 07 56 PM" src="https://user-images.githubusercontent.com/10561050/102423810-cd4fa700-3fd7-11eb-95a8-c8c705b2a5ba.png">

### Detailed test instructions:

1. Trigger at least 2 store alerts (or just add `return true;` to the top of  `CouponsPageMoved::can_be_added()` and refresh a couple times)
2. Check that styles match.
3. Refresh and make sure that the loading (placeholder) style is correct.