### PR TITLE
Add missing namespace for translation

### DIFF
--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -181,7 +181,7 @@ class Industry extends Component {
 						) }
 					</Text>
 					<Text variant="body">
-						{ __( 'Choose any that apply' ) }
+						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
 					</Text>
 				</div>
 				<Card>

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -114,7 +114,7 @@ export class ProductTypes extends Component {
 						) }
 					</Text>
 					<Text variant="body">
-						{ __( 'Choose any that apply' ) }
+						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
 					</Text>
 				</div>
 


### PR DESCRIPTION
Fixes #5902 

This PR fixes issue #5902 by adding the correct text-domain.

### Screenshots

![Screen Shot 2020-12-17 at 2 28 46 PM](https://user-images.githubusercontent.com/4723145/102551439-54525d00-4074-11eb-94ad-ee1170a04d3f.jpg)


### Detailed test instructions:



Before start testing, download this [language file](https://github.com/woocommerce/woocommerce-admin/files/5712491/woocommerce-admin-ko_KR-wc-admin-app.json.zip) -> unzip and place it in `wp-content/plugins/woocommerce-admin/languages` directory.

1. Login to the WordPress admin console (with the WooCommerce plugin installed)
2. Go to: Dashboard > Settings > General and change the Site language to Korean.
3. Go to:  Dashboard > Updates and click on the button to update translations (`{base-url}/wp-admin/update-core.php`)
4. Open the WooCommerce Setup Wizard and navigate through to the industry (`{base-url}/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`) and product types (`{base-url}/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`) pages
5. Confirm that "Choose any that apply" is translated correctly (refer to the screenshot)

