### PR TITLE
Update WooCommerce Dropdown Button Styles

### DIFF
--- a/packages/components/src/dropdown-button/style.scss
+++ b/packages/components/src/dropdown-button/style.scss
@@ -17,7 +17,6 @@
 		right: 14px;
 		width: 32px;
 		height: 48px;
-		@include animate-transform;
 	}
 
 	&.is-open {
@@ -30,6 +29,7 @@
 	&:active,
 	&.is-open {
 		background-color: $gray-100;
+		border-color: $gray-700;
 	}
 
 	&.is-multi-line .woocommerce-dropdown-button__labels {


### PR DESCRIPTION
Small update to re-introduce the border around the button when it's active / open:

Before:

<img width="849" alt="Screen Shot 2020-12-17 at 3 51 42 PM" src="https://user-images.githubusercontent.com/4500952/102557425-ffb4df00-407f-11eb-9519-88d4d78da921.png">

After:

<img width="879" alt="Screen Shot 2020-12-17 at 3 50 25 PM" src="https://user-images.githubusercontent.com/4500952/102557435-080d1a00-4080-11eb-8ad5-13d3ef2ffe9d.png">

I've also removed the animation that was added to the chevron, since it was pivoting the chevron around a strange point, and generally felt distracting / unnecessary. 

To test, load up an analytics screen, click the date picker or show menu. Note the border now remains around the button when it's active / open. 