### PR TITLE
Add deprecation notice to wc card component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Add product attributes support to `<Search />`.
 -   Allow single-selection support to `<Search />`.
 -   Improve handling of `multiple` and `inlineTags` in `<SelectControl />`.
+-   Deprecate use of `<Card>` in favor of the `<Card>` component in `@wordpress/components`.
 
 # 5.1.2
 

--- a/packages/components/src/card/index.js
+++ b/packages/components/src/card/index.js
@@ -3,6 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import classnames from 'classnames';
+import deprecated from '@wordpress/deprecated';
 import PropTypes from 'prop-types';
 
 /**
@@ -14,8 +15,20 @@ import { validateComponent } from '../lib/proptype-validator';
 
 /**
  * A basic card component with a header. The header can contain a title, an action, and an `EllipsisMenu` menu.
+ *
+ * @deprecated
  */
 class Card extends Component {
+	constructor() {
+		super();
+		deprecated( 'Card', {
+			version: '5.2.0',
+			alternative: '@wordpress/components Card',
+			plugin: 'WooCommerce',
+			hint: 'Use `import { Card } from "@wordpress/components"`',
+		} );
+	}
+
 	render() {
 		const {
 			action,


### PR DESCRIPTION
Fixes #4002 

Adds a notice that the WC Card component will be deprecated.

### Screenshots
<img width="802" alt="Screen Shot 2020-12-18 at 8 58 33 AM" src="https://user-images.githubusercontent.com/10561050/102622590-3be35080-410f-11eb-82d3-df8ce032db55.png">


### Detailed test instructions:

1. Make sure a WC Card exists somewhere (still present on most analytics pages if other PRs have not yet been merged) or add one.
2. Open your console.
3. Check that the deprecation notice exists.