### PR TITLE
Fix/5872 nav back btn color

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -114,6 +114,8 @@ const Container = ( { menuItems } ) => {
 		} );
 	};
 
+	const isRootBackVisible = activeLevel === 'woocommerce' && rootBackUrl;
+
 	return (
 		<div className="woocommerce-navigation">
 			<Header />
@@ -129,7 +131,7 @@ const Container = ( { menuItems } ) => {
 						setActiveLevel( ...args );
 					} }
 				>
-					{ activeLevel === 'woocommerce' && rootBackUrl && (
+					{ isRootBackVisible && (
 						<NavigationBackButton
 							className="woocommerce-navigation__back-to-dashboard"
 							href={ rootBackUrl }
@@ -152,8 +154,10 @@ const Container = ( { menuItems } ) => {
 								backButtonLabel={
 									category.backButtonLabel || null
 								}
-								onBackButtonClick={ () =>
-									trackBackClick( category.id )
+								onBackButtonClick={
+									isRootBackVisible
+										? null
+										: () => trackBackClick( category.id )
 								}
 							>
 								{ !! primaryItems && (


### PR DESCRIPTION
Fixes #5872

~~The issue appears in this branch, which this PR is based off of: `fix/wp-components-unbundle`, from [this PR.](https://github.com/woocommerce/woocommerce-admin/pull/5753)~~

Due to recent changes in the `Navigation` component within gutenberg, we're now seeing two back buttons on root level. The original issue also reports an incorrect color for the nav links, although I haven't been able to reproduce that part. 

This PR fixes the duplicate back button.

### Screenshots

Before Fix:
![image](https://user-images.githubusercontent.com/444632/102676950-cd28e600-4154-11eb-97cd-c269068a3cfb.png)


### Detailed test instructions:

-  Check out this branch
-  Navigation to `Woocommerce -> Home`
- Ensure that only a single backbtn is displayed (unlike the screenshot above)
- Observe that the text for the back btn is "WordPress Dashboard", and it works as expected.
