### PR TITLE
Add Line-Ending Normalization to Text Files in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# default
+* text=auto
+
 /.* export-ignore
 /*.md export-ignore
 /node_modules* export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# default
+# Line-ending normalization
 * text=auto
 
 /.* export-ignore


### PR DESCRIPTION
Fixes #5285 

Adds [line-ending](https://stackoverflow.com/questions/1552749/difference-between-cr-lf-lf-and-cr-line-break-types/1552770#1552770) normalization to text files in Git. 

This aims to ensure consistent line-endings in the repo to prevent cross-platform issues in text files. An example of this can be seen in issue #5118 where commits were made with unexpected line-endings.

Git can be used to automatically normalize line-endings in text files using `.gitignore` rules. This is a strategy employed by the [WooCommerce](https://github.com/woocommerce/woocommerce/blob/aac4db94b2ff060d9b889132e7ff50779f52f819/.gitattributes#L1-L5) and [Gutenberg](https://github.com/WordPress/gutenberg/blob/35bd1cbb9308ab38b580b6e05b93b85f2ba906bc/.gitattributes#L1-L2) repos, and also also suggested in [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings#per-repository-settings).

Since all text files in this repo use `LF` line-endings, only a single rule applying to all text files needs to be added here. 

### Detailed test instructions:

-   In Git, stage a change containing containing CRLF line-endings,  such as the `wp-config-sample.php` file found in WordPress.
-   Confirm a warning message about CRLF being replaced:

>warning: CRLF will be replaced by LF in wp-config-sample.php.
The file will have its original line endings in your working directory

For example, in macOS:

```shell
curl -O https://raw.githubusercontent.com/WordPress/WordPress/master/wp-config-sample.php
git add wp-config-sample.php
```