### PR TITLE
Fix Deprecated Use of Jetpack in Shipping Label Banner

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Remove deprecated use of Jetpack in shipping label banner. #5929
 - Tweak: Remove visit_count from track, and update task count logic. #5996
 - Fix: Moved certified owner label for review to title. ##5877
 - Fix: Move collapsible config to panels object, to allow for more control. #5855

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -7,6 +7,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
+use \Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
 /**
  * Shows print shipping label banner on edit order page.
@@ -58,21 +59,18 @@ class ShippingLabelBanner {
 			$wcs_version       = null;
 			$wcs_tos_accepted  = null;
 
-			if ( class_exists( '\Jetpack_Data' ) ) {
+			if ( defined( 'JETPACK__VERSION' ) ) {
+				$jetpack_version = JETPACK__VERSION;
+			}
 
-				if ( defined( 'JETPACK_MASTER_USER' ) ) {
-					$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-					$jetpack_connected = isset( $user_token->external_user_id );
-				} else {
-					$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false );
-				}
-
-				$jetpack_version   = JETPACK__VERSION;
+			if ( class_exists( Jetpack_Connection_Manager::class ) ) {
+				$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
 			}
 
 			if ( class_exists( '\WC_Connect_Loader' ) ) {
 				$wcs_version = \WC_Connect_Loader::get_wcs_version();
 			}
+
 			if ( class_exists( '\WC_Connect_Options' ) ) {
 				$wcs_tos_accepted = \WC_Connect_Options::get_option( 'tos_accepted' );
 			}


### PR DESCRIPTION
Fixes #5910 

A shipping label banner should display when editing an order and certain conditions are met, including whether Jetpack is installed and connected.

![Screen Shot 2021-01-08 at 6 31 40 pm](https://user-images.githubusercontent.com/9312929/104005301-dcdd9c80-51df-11eb-91de-8e38ff00545b.png)

Previously, the logic determining if Jetpack is connected had the following deprecated items:

- The [`JETPACK_MASTER_USER`](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/jetpack.php#L21-L27) constant.
- The [`Jetpack_Data`](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/class.jetpack-data.php#L5-L8) class.

To prevent possible breakage in the future, these items have been replaced with [`\Automattic\Jetpack\Connection\Manager::is_active`,](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/packages/connection/src/class-manager.php#L524) which was recommended by Jetpack developers.

The `woocommerce_admin_is_jetpack_connected` filter has also been removed because its use-case was to work-around the usage of `JETPACK_MASTER_USER`, per https://github.com/woocommerce/woocommerce-admin/pull/5880#issuecomment-747925876. This filter has not made it into a release yet so I don't think there are backwards-compatibility concerns.

Ideally tests would be added in this PR, however the `ShippingLabelBanner` class needs improvements to make it testable with mock Jetpack classes. I hope to address that in a future PR.

### Detailed Testing Instructions

With a fresh installation capable of connecting to Jetpack,

-  Complete the onboarding wizard, using the following configuration:
    - US location
    - USD currency
    - **DO NOT** Install recommended free business features 
- Install and connect Jetpack
- Ensure [WooCommerce Shipping & Tax](https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/) plugin is not installed
- Create an order with shippable products
- Edit the order in WP-Admin
- Confirm the banner displays


