### PR TITLE
Fix completed tasks tracking infinite loop

### DIFF
--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -111,18 +111,22 @@ export class TaskList extends Component {
 		);
 	}
 
-	isTrackingListUpdated( list, subList ) {
-		if ( subList.length === 0 ) {
+	shouldUpdateCompletedTasks( tasks, completedTasks ) {
+		if ( completedTasks.length === 0 ) {
 			return false;
 		}
-		return subList.every( ( taskName ) => list.indexOf( taskName ) >= 0 );
+		return ! completedTasks.every(
+			( taskName ) => tasks.indexOf( taskName ) >= 0
+		);
 	}
 
-	getIncludedTasks( list, subList ) {
-		if ( ! subList ) {
+	getTrackedCompletedTasks( completedTasks, trackedTasks ) {
+		if ( ! trackedTasks ) {
 			return [];
 		}
-		return list.filter( ( taskName ) => subList.includes( taskName ) );
+		return completedTasks.filter( ( taskName ) =>
+			trackedTasks.includes( taskName )
+		);
 	}
 
 	possiblyTrackCompletedTasks() {
@@ -131,13 +135,13 @@ export class TaskList extends Component {
 			updateOptions,
 		} = this.props;
 		const completedTaskKeys = this.getCompletedTaskKeys();
-		const trackedCompletedTasks = this.getIncludedTasks(
+		const trackedCompletedTasks = this.getTrackedCompletedTasks(
 			completedTaskKeys,
 			totalTrackedCompletedTasks
 		);
 
 		if (
-			! this.isTrackingListUpdated(
+			this.shouldUpdateCompletedTasks(
 				trackedCompletedTasks,
 				completedTaskKeys
 			)


### PR DESCRIPTION
Fixes #5894

Completed tasks were being updated infinitely when an empty array of completed tasks existed.  This PR prevents that and updates some of the method naming.

### Detailed test instructions:

1. Spin up a new site with no completed tasks.
2. Open your console.
3. Load up the homepage.
4. Make sure things don't blow up 🤞 💥 
5. Complete some tasks.
6. Make sure they are tracked in the `woocommerce_task_list_tracked_completed_tasks` option.