### PR TITLE
Future proof experimental components

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -6,7 +6,8 @@ import {
 	Card,
 	CardBody,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -26,6 +27,8 @@ import {
 import ReportError from '../report-error';
 import sanitizeHTML from '../../../lib/sanitize-html';
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 export class Leaderboard extends Component {
 	getFormattedHeaders() {

--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { EmptyTable, TableCard } from '@woocommerce/components';
@@ -20,6 +14,7 @@ import {
 	getLeaderboard,
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -27,8 +22,6 @@ import {
 import ReportError from '../report-error';
 import sanitizeHTML from '../../../lib/sanitize-html';
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 export class Leaderboard extends Component {
 	getFormattedHeaders() {

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -4,27 +4,20 @@
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import {
 	getHistory,
 	getNewPath,
 	getPersistedQuery,
 } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import ReportChart from '../../analytics/components/report-chart';
 import './block.scss';
-
-const Text = TextComponent || __experimentalText;
 
 class ChartBlock extends Component {
 	handleChartClick = () => {

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -8,7 +8,8 @@ import {
 	Card,
 	CardBody,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import {
 	getHistory,
@@ -22,6 +23,8 @@ import { getAdminLink } from '@woocommerce/wc-admin-settings';
  */
 import ReportChart from '../../analytics/components/report-chart';
 import './block.scss';
+
+const Text = TextComponent || __experimentalText;
 
 class ChartBlock extends Component {
 	handleChartClick = () => {

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -4,13 +4,18 @@
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText,
+	Text as TextComponent,
+} from '@wordpress/components';
 import { EllipsisMenu } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 class ActivityHeader extends Component {
 	render() {

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -4,18 +4,13 @@
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import {
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 import { EllipsisMenu } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 class ActivityHeader extends Component {
 	render() {

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText,
+	Text as TextComponent,
+} from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
@@ -24,6 +27,8 @@ import { recordEvent } from '@woocommerce/tracks';
 import ActivityHeader from '../activity-header';
 import { getCountryCode } from '../../../dashboard/utils';
 import { getPaymentMethods } from '../../../task-list/tasks/payments/methods';
+
+const Text = TextComponent || __experimentalText;
 
 export const SETUP_TASK_HELP_ITEMS_FILTER =
 	'woocommerce_admin_setup_task_help_items';

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 import { withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
@@ -27,8 +24,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import ActivityHeader from '../activity-header';
 import { getCountryCode } from '../../../dashboard/utils';
 import { getPaymentMethods } from '../../../task-list/tasks/payments/methods';
-
-const Text = TextComponent || __experimentalText;
 
 export const SETUP_TASK_HELP_ITEMS_FILTER =
 	'woocommerce_admin_setup_task_help_items';

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -7,10 +7,7 @@ import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useUserPreferences } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import {
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -19,8 +16,6 @@ import './style.scss';
 import ActivityPanel from './activity-panel';
 import { MobileAppBanner } from '../mobile-banner';
 import useIsScrolled from '../hooks/useIsScrolled';
-
-const Text = TextComponent || __experimentalText;
 
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -7,7 +7,10 @@ import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useUserPreferences } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText,
+	Text as TextComponent,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,6 +19,8 @@ import './style.scss';
 import ActivityPanel from './activity-panel';
 import { MobileAppBanner } from '../mobile-banner';
 import useIsScrolled from '../hooks/useIsScrolled';
+
+const Text = TextComponent || __experimentalText;
 
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -10,8 +10,6 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { get, xor } from 'lodash';
 import {
@@ -24,6 +22,7 @@ import { useUserPreferences, PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -32,8 +31,6 @@ import './style.scss';
 import { DEFAULT_STATS, DEFAULT_HIDDEN_STATS } from './defaults';
 import StatsList from './stats-list';
 import { InstallJetpackCTA } from './install-jetpack-cta';
-
-const Text = TextComponent || __experimentalText;
 
 const { performanceIndicators } = getSetting( 'dataEndpoints', {
 	performanceIndicators: [],

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -10,7 +10,8 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { get, xor } from 'lodash';
 import {
@@ -31,6 +32,8 @@ import './style.scss';
 import { DEFAULT_STATS, DEFAULT_HIDDEN_STATS } from './defaults';
 import StatsList from './stats-list';
 import { InstallJetpackCTA } from './install-jetpack-cta';
+
+const Text = TextComponent || __experimentalText;
 
 const { performanceIndicators } = getSetting( 'dataEndpoints', {
 	performanceIndicators: [],

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -11,8 +11,6 @@ import {
 	CardHeader,
 	Dashicon,
 	SelectControl,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
@@ -23,6 +21,7 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -31,8 +30,6 @@ import sanitizeHTML from '../../lib/sanitize-html';
 import StoreAlertsPlaceholder from './placeholder';
 
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 export class StoreAlerts extends Component {
 	constructor( props ) {

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -11,7 +11,8 @@ import {
 	CardHeader,
 	Dashicon,
 	SelectControl,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
@@ -30,6 +31,8 @@ import sanitizeHTML from '../../lib/sanitize-html';
 import StoreAlertsPlaceholder from './placeholder';
 
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 export class StoreAlerts extends Component {
 	constructor( props ) {

--- a/client/marketing/components/card/index.js
+++ b/client/marketing/components/card/index.js
@@ -5,7 +5,8 @@ import {
 	Card as WPCard,
 	CardBody,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -14,6 +15,8 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 const Card = ( props ) => {
 	const { title, description, children, className } = props;

--- a/client/marketing/components/card/index.js
+++ b/client/marketing/components/card/index.js
@@ -1,22 +1,15 @@
 /**
  * External dependencies
  */
-import {
-	Card as WPCard,
-	CardBody,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Card as WPCard, CardBody, CardHeader } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 const Card = ( props ) => {
 	const { title, description, children, className } = props;

--- a/client/marketing/overview/installed-extensions/index.js
+++ b/client/marketing/overview/installed-extensions/index.js
@@ -6,12 +6,8 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import PropTypes from 'prop-types';
-import {
-	Card,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Card, CardHeader } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -19,8 +15,6 @@ import {
 import './style.scss';
 import InstalledExtensionRow from './row';
 import { STORE_KEY } from '../../data/constants';
-
-const Text = TextComponent || __experimentalText;
 
 class InstalledExtensions extends Component {
 	activatePlugin( pluginSlug ) {

--- a/client/marketing/overview/installed-extensions/index.js
+++ b/client/marketing/overview/installed-extensions/index.js
@@ -9,7 +9,8 @@ import PropTypes from 'prop-types';
 import {
 	Card,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 
 /**
@@ -18,6 +19,8 @@ import {
 import './style.scss';
 import InstalledExtensionRow from './row';
 import { STORE_KEY } from '../../data/constants';
+
+const Text = TextComponent || __experimentalText;
 
 class InstalledExtensions extends Component {
 	activatePlugin( pluginSlug ) {

--- a/client/navigation/components/Item/index.js
+++ b/client/navigation/components/Item/index.js
@@ -1,9 +1,14 @@
 /**
  * External dependencies
  */
-import { __experimentalNavigationItem as NavigationItem } from '@wordpress/components';
+import {
+	__experimentalNavigationItem,
+	NavigationItem as NavigationItemComponent,
+} from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { WooNavigationItem, useNavSlot } from '@woocommerce/navigation';
+
+const NavigationItem = NavigationItemComponent || __experimentalNavigationItem;
 
 const Item = ( { item } ) => {
 	const slot = useNavSlot( 'woocommerce_navigation_' + item.id );

--- a/client/navigation/components/Item/index.js
+++ b/client/navigation/components/Item/index.js
@@ -1,14 +1,9 @@
 /**
  * External dependencies
  */
-import {
-	__experimentalNavigationItem,
-	NavigationItem as NavigationItemComponent,
-} from '@wordpress/components';
+import { NavigationItem } from '@woocommerce/experimental';
 import { recordEvent } from '@woocommerce/tracks';
 import { WooNavigationItem, useNavSlot } from '@woocommerce/navigation';
-
-const NavigationItem = NavigationItemComponent || __experimentalNavigationItem;
 
 const Item = ( { item } ) => {
 	const slot = useNavSlot( 'woocommerce_navigation_' + item.id );

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -5,10 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
-	__experimentalNavigation as Navigation,
-	__experimentalNavigationBackButton as NavigationBackButton,
-	__experimentalNavigationMenu as NavigationMenu,
-	__experimentalNavigationGroup as NavigationGroup,
+	__experimentalNavigation,
+	__experimentalNavigationBackButton,
+	__experimentalNavigationMenu,
+	__experimentalNavigationGroup,
+	Navigation as NavigationComponent,
+	NavigationBackButton as NavigationBackButtonComponent,
+	NavigationMenu as NavigationMenuComponent,
+	NavigationGroup as NavigationGroupComponent,
 } from '@wordpress/components';
 import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -20,6 +24,13 @@ import { withSelect } from '@wordpress/data';
 import { addHistoryListener, getMatchingItem } from '../../utils';
 import Header from '../header';
 import Item from '../../components/Item';
+
+const Navigation = NavigationComponent || __experimentalNavigation;
+const NavigationBackButton =
+	NavigationBackButtonComponent || __experimentalNavigationBackButton;
+const NavigationMenu = NavigationMenuComponent || __experimentalNavigationMenu;
+const NavigationGroup =
+	NavigationGroupComponent || __experimentalNavigationGroup;
 
 const Container = ( { menuItems } ) => {
 	useEffect( () => {

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -5,15 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
-	__experimentalNavigation,
-	__experimentalNavigationBackButton,
-	__experimentalNavigationMenu,
-	__experimentalNavigationGroup,
-	Navigation as NavigationComponent,
-	NavigationBackButton as NavigationBackButtonComponent,
-	NavigationMenu as NavigationMenuComponent,
-	NavigationGroup as NavigationGroupComponent,
-} from '@wordpress/components';
+	Navigation,
+	NavigationBackButton,
+	NavigationMenu,
+	NavigationGroup,
+} from '@woocommerce/experimental';
 import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { withSelect } from '@wordpress/data';
@@ -24,13 +20,6 @@ import { withSelect } from '@wordpress/data';
 import { addHistoryListener, getMatchingItem } from '../../utils';
 import Header from '../header';
 import Item from '../../components/Item';
-
-const Navigation = NavigationComponent || __experimentalNavigation;
-const NavigationBackButton =
-	NavigationBackButtonComponent || __experimentalNavigationBackButton;
-const NavigationMenu = NavigationMenuComponent || __experimentalNavigationMenu;
-const NavigationGroup =
-	NavigationGroupComponent || __experimentalNavigationGroup;
 
 const Container = ( { menuItems } ) => {
 	useEffect( () => {

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -7,7 +7,8 @@ import {
 	Card,
 	CardBody,
 	CardFooter,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -32,6 +33,8 @@ import ManagementIcon from './images/management';
 import SalesTaxIcon from './images/sales_tax';
 import ShippingLabels from './images/shipping_labels';
 import SpeedIcon from './images/speed';
+
+const Text = TextComponent || __experimentalText;
 
 class Benefits extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -2,14 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardFooter,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Button, Card, CardBody, CardFooter } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -23,6 +16,7 @@ import {
 	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -33,8 +27,6 @@ import ManagementIcon from './images/management';
 import SalesTaxIcon from './images/sales_tax';
 import ShippingLabels from './images/shipping_labels';
 import SpeedIcon from './images/speed';
-
-const Text = TextComponent || __experimentalText;
 
 class Benefits extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/business-details/flows/bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/bundle/index.js
@@ -12,8 +12,6 @@ import {
 	CheckboxControl,
 	FormToggle,
 	Popover,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -35,6 +33,7 @@ import {
 	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -52,8 +51,6 @@ import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
 
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
-
-const Text = TextComponent || __experimentalText;
 
 class BusinessDetails extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/business-details/flows/bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/bundle/index.js
@@ -12,7 +12,8 @@ import {
 	CheckboxControl,
 	FormToggle,
 	Popover,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -51,6 +52,8 @@ import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
 
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
+
+const Text = TextComponent || __experimentalText;
 
 class BusinessDetails extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -9,7 +9,8 @@ import {
 	CardBody,
 	CardFooter,
 	CheckboxControl,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { filter, find, findIndex, get } from 'lodash';
@@ -25,6 +26,8 @@ import { recordEvent } from '@woocommerce/tracks';
 import { getCurrencyRegion } from '../../dashboard/utils';
 
 const onboarding = getSetting( 'onboarding', {} );
+
+const Text = TextComponent || __experimentalText;
 
 class Industry extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -9,8 +9,6 @@ import {
 	CardBody,
 	CardFooter,
 	CheckboxControl,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { filter, find, findIndex, get } from 'lodash';
@@ -19,6 +17,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { TextControl } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -26,8 +25,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import { getCurrencyRegion } from '../../dashboard/utils';
 
 const onboarding = getSetting( 'onboarding', {} );
-
-const Text = TextComponent || __experimentalText;
 
 class Industry extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -11,22 +11,19 @@ import {
 	CardFooter,
 	CheckboxControl,
 	FormToggle,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { includes, filter, get } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from '@woocommerce/tracks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import ProductTypeLabel from './label';
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 export class ProductTypes extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -11,7 +11,8 @@ import {
 	CardFooter,
 	CheckboxControl,
 	FormToggle,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { includes, filter, get } from 'lodash';
 import { getSetting } from '@woocommerce/wc-admin-settings';
@@ -24,6 +25,8 @@ import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
  */
 import ProductTypeLabel from './label';
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 export class ProductTypes extends Component {
 	constructor( props ) {

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -9,7 +9,8 @@ import {
 	CardFooter,
 	CheckboxControl,
 	FlexItem as MaybeFlexItem,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 	Popover,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -31,6 +32,8 @@ import {
 import UsageModal from '../usage-modal';
 import { CurrencyContext } from '../../../lib/currency-context';
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 // FlexItem is not available until WP version 5.5. This code is safe to remove
 // once the minimum WP supported version becomes 5.5.

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -9,8 +9,6 @@ import {
 	CardFooter,
 	CheckboxControl,
 	FlexItem as MaybeFlexItem,
-	__experimentalText,
-	Text as TextComponent,
 	Popover,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -20,6 +18,7 @@ import { Form } from '@woocommerce/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -32,8 +31,6 @@ import {
 import UsageModal from '../usage-modal';
 import { CurrencyContext } from '../../../lib/currency-context';
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 // FlexItem is not available until WP version 5.5. This code is safe to remove
 // once the minimum WP supported version becomes 5.5.

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -14,14 +14,13 @@ import {
 	CardFooter,
 	TabPanel,
 	Tooltip,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { H } from '@woocommerce/components';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -30,8 +29,6 @@ import './style.scss';
 import ThemeUploader from './uploader';
 import ThemePreview from './preview';
 import { getPriceValue } from '../../../dashboard/utils';
-
-const Text = TextComponent || __experimentalText;
 
 class Theme extends Component {
 	constructor() {

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -14,7 +14,8 @@ import {
 	CardFooter,
 	TabPanel,
 	Tooltip,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { H } from '@woocommerce/components';
@@ -29,6 +30,8 @@ import './style.scss';
 import ThemeUploader from './uploader';
 import ThemePreview from './preview';
 import { getPriceValue } from '../../../dashboard/utils';
+
+const Text = TextComponent || __experimentalText;
 
 class Theme extends Component {
 	constructor() {

--- a/client/store-management-links/index.js
+++ b/client/store-management-links/index.js
@@ -3,13 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import {
 	megaphone,
 	box,
@@ -22,6 +16,7 @@ import {
 } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -29,8 +24,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import './style.scss';
 import { QuickLinkCategory } from './quick-link-category';
 import { QuickLink } from './quick-link';
-
-const Text = TextComponent || __experimentalText;
 
 export function getItemsByCategory( siteUrl ) {
 	return [

--- a/client/store-management-links/index.js
+++ b/client/store-management-links/index.js
@@ -7,7 +7,8 @@ import {
 	Card,
 	CardBody,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import {
 	megaphone,
@@ -28,6 +29,8 @@ import { recordEvent } from '@woocommerce/tracks';
 import './style.scss';
 import { QuickLinkCategory } from './quick-link-category';
 import { QuickLink } from './quick-link';
+
+const Text = TextComponent || __experimentalText;
 
 export function getItemsByCategory( siteUrl ) {
 	return [

--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -3,13 +3,18 @@
  */
 import React from '@wordpress/element';
 import { external, Icon } from '@wordpress/icons';
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText,
+	Text as TextComponent,
+} from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+
+const Text = TextComponent || __experimentalText;
 
 export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 	const isExternal = linkType === 'external';

--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -3,18 +3,13 @@
  */
 import React from '@wordpress/element';
 import { external, Icon } from '@wordpress/icons';
-import {
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
 import { Link } from '@woocommerce/components';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-
-const Text = TextComponent || __experimentalText;
 
 export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 	const isExternal = linkType === 'external';

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -10,7 +10,8 @@ import {
 	Card,
 	CardBody,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
@@ -30,6 +31,8 @@ import { recordEvent } from '@woocommerce/tracks';
 import { recordTaskViewEvent } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
 import sanitizeHTML from '../lib/sanitize-html';
+
+const Text = TextComponent || __experimentalText;
 
 export class TaskList extends Component {
 	componentDidMount() {

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -5,14 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, cloneElement } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
 import { List, EllipsisMenu, Badge } from '@woocommerce/components';
@@ -24,6 +17,7 @@ import {
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -31,8 +25,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import { recordTaskViewEvent } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
 import sanitizeHTML from '../lib/sanitize-html';
-
-const Text = TextComponent || __experimentalText;
 
 export class TaskList extends Component {
 	componentDidMount() {

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -6,7 +6,8 @@ import {
 	Button,
 	Card,
 	CardBody,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -31,6 +32,8 @@ import Connect from '../../dashboard/components/connect';
 import { createNoticesFromResponse } from '../../lib/notices';
 import { getCountryCode } from '../../dashboard/utils';
 import StoreLocation from './steps/location';
+
+const Text = TextComponent || __experimentalText;
 
 class Tax extends Component {
 	constructor( props ) {

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Card,
-	CardBody,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { difference, filter } from 'lodash';
@@ -24,6 +18,7 @@ import {
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent, queueRecordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -32,8 +27,6 @@ import Connect from '../../dashboard/components/connect';
 import { createNoticesFromResponse } from '../../lib/notices';
 import { getCountryCode } from '../../dashboard/utils';
 import StoreLocation from './steps/location';
-
-const Text = TextComponent || __experimentalText;
 
 class Tax extends Component {
 	constructor( props ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8166,6 +8166,16 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "2.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
@@ -10933,6 +10943,156 @@
 					"requires": {
 						"isexe": "^2.0.0"
 					}
+				}
+			}
+		},
+		"@woocommerce/experimental": {
+			"version": "file:packages/experimental",
+			"dev": true,
+			"requires": {
+				"@babel/runtime-corejs2": "7.12.5",
+				"@wordpress/components": "10.0.0"
+			},
+			"dependencies": {
+				"@wordpress/components": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.0.0.tgz",
+					"integrity": "sha512-2iJw70xAhIQSjR7DLRbYTZx84OFqjGUZNE4U2fy7vg30z5TItP3KQ133VOW9uqQwl4U9gzovIAluq1nq8TuX1A==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@emotion/core": "^10.0.22",
+						"@emotion/css": "^10.0.22",
+						"@emotion/native": "^10.0.22",
+						"@emotion/styled": "^10.0.23",
+						"@wordpress/a11y": "^2.11.0",
+						"@wordpress/compose": "^3.19.0",
+						"@wordpress/deprecated": "^2.9.0",
+						"@wordpress/dom": "^2.13.0",
+						"@wordpress/element": "^2.16.0",
+						"@wordpress/hooks": "^2.9.0",
+						"@wordpress/i18n": "^3.14.0",
+						"@wordpress/icons": "^2.4.0",
+						"@wordpress/is-shallow-equal": "^2.1.0",
+						"@wordpress/keycodes": "^2.14.0",
+						"@wordpress/primitives": "^1.7.0",
+						"@wordpress/rich-text": "^3.20.0",
+						"@wordpress/warning": "^1.2.0",
+						"classnames": "^2.2.5",
+						"dom-scroll-into-view": "^1.2.1",
+						"downshift": "^5.4.0",
+						"gradient-parser": "^0.1.5",
+						"lodash": "^4.17.15",
+						"memize": "^1.1.0",
+						"moment": "^2.22.1",
+						"re-resizable": "^6.4.0",
+						"react-dates": "^17.1.1",
+						"react-resize-aware": "^3.0.1",
+						"react-spring": "^8.0.20",
+						"react-use-gesture": "^7.0.15",
+						"reakit": "^1.1.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^7.0.2"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.0.tgz",
+					"integrity": "sha512-IjXPfv9SuEkVbmxD4eaxn01zZmYUxp/4wrMcsHAHGym59k/bN6uJOQprrU/tTiSR4Zlf8Jmo22HWmuL654k8zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+					"integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.11.0",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.0.tgz",
+					"integrity": "sha512-f/jk3SpYRUp04+LzdonNWBpH8jlm8RXGjK2TimfLz+wRFzFFdF7i2dI9GX+4gea/UuV+WtXAWkfARyV0HVDXwQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.11.0.tgz",
+					"integrity": "sha512-TbvCrHcMiSZoyiflegEqVS3DDytDTpkms+yLUaGN4sMvNdR/Mv5s0WnNKyM0T49lbmZYPWlbWhwJ1F6hr/FQDg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+					"integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.9.0.tgz",
+					"integrity": "sha512-eQJQIaCLdmdo8iTjequNkB14Fzx3qLRbjzZTk26fnggG41L+uGRblIeheZDcHY/jPKDd2H4+v9c9/0LqfjuPCA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"@wordpress/element": "^2.19.0",
+						"@wordpress/primitives": "^1.11.0"
+					},
+					"dependencies": {
+						"@wordpress/primitives": {
+							"version": "1.11.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.11.0.tgz",
+							"integrity": "sha512-RjWKYITSBi4RaQchmswI1qTF3n3M3QoGFoItRSnCajOHyNti4K1chPaBpr52ithnentfblF3zquR3J6ZnAkPjA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.12.5",
+								"@wordpress/element": "^2.19.0",
+								"classnames": "^2.2.5"
+							}
+						}
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.17.0.tgz",
+					"integrity": "sha512-tV8Cjb1E0kXPTTQnqQu0VZZSncRB8d6KVckOJqwk/uSC7+RjLhGnQU+rUft7AJDaZgRH01xLOJD79mDj5/1FLA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"@wordpress/i18n": "^3.17.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"uuid": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
 		"@woocommerce/data": "file:packages/data",
 		"@woocommerce/date": "file:packages/date",
 		"@woocommerce/eslint-plugin": "file:packages/eslint-plugin",
+		"@woocommerce/experimental": "file:packages/experimental",
 		"@woocommerce/navigation": "file:packages/navigation",
 		"@woocommerce/notices": "file:packages/notices",
 		"@woocommerce/number": "file:packages/number",

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -10,15 +10,12 @@ import {
 	CardHeader,
 	Dropdown,
 	SelectControl,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { partial, difference, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import AddOutlineIcon from 'gridicons/dist/add-outline';
 import interpolateComponents from 'interpolate-components';
-
 import {
 	getActiveFiltersFromQuery,
 	getDefaultOptionValue,
@@ -26,6 +23,7 @@ import {
 	getQueryFromActiveFilters,
 	getHistory,
 } from '@woocommerce/navigation';
+import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -37,8 +35,6 @@ const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
 	{ value: 'any', label: __( 'Any', 'woocommerce-admin' ) },
 ];
-
-const Text = TextComponent || __experimentalText;
 
 /**
  * Displays a configurable set of filters which can modify query parameters.

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -10,7 +10,8 @@ import {
 	CardHeader,
 	Dropdown,
 	SelectControl,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { partial, difference, isEqual } from 'lodash';
@@ -36,6 +37,8 @@ const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
 	{ value: 'any', label: __( 'Any', 'woocommerce-admin' ) },
 ];
+
+const Text = TextComponent || __experimentalText;
 
 /**
  * Displays a configurable set of filters which can modify query parameters.

--- a/packages/components/src/compare-filter/index.js
+++ b/packages/components/src/compare-filter/index.js
@@ -9,7 +9,8 @@ import {
 	CardBody,
 	CardFooter,
 	CardHeader,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
@@ -21,6 +22,8 @@ import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import CompareButton from './button';
 import Search from '../search';
+
+const Text = TextComponent || __experimentalText;
 
 export { default as CompareButton } from './button';
 

--- a/packages/components/src/compare-filter/index.js
+++ b/packages/components/src/compare-filter/index.js
@@ -9,12 +9,10 @@ import {
 	CardBody,
 	CardFooter,
 	CardHeader,
-	__experimentalText,
-	Text as TextComponent,
 } from '@wordpress/components';
 import { isEqual, isFunction } from 'lodash';
 import PropTypes from 'prop-types';
-
+import { Text } from '@woocommerce/experimental';
 import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
@@ -22,8 +20,6 @@ import { getIdsFromQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import CompareButton from './button';
 import Search from '../search';
-
-const Text = TextComponent || __experimentalText;
 
 export { default as CompareButton } from './button';
 

--- a/packages/components/src/pill/pill.js
+++ b/packages/components/src/pill/pill.js
@@ -1,6 +1,6 @@
 /**
  * External dependencies
- */;
+ */
 import { Text } from '@woocommerce/experimental';
 
 export function Pill( { children } ) {

--- a/packages/components/src/pill/pill.js
+++ b/packages/components/src/pill/pill.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
- */
-import {
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
-
-const Text = TextComponent || __experimentalText;
+ */;
+import { Text } from '@woocommerce/experimental';
 
 export function Pill( { children } ) {
 	return (

--- a/packages/components/src/pill/pill.js
+++ b/packages/components/src/pill/pill.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalText,
+	Text as TextComponent,
+} from '@wordpress/components';
+
+const Text = TextComponent || __experimentalText;
+
 export function Pill( { children } ) {
 	return (
 		<Text className="woocommerce-pill" variant="caption" as="span">

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -1,23 +1,18 @@
 /**
  * External dependencies
  */
-import {
-	Button,
-	Tooltip,
-	__experimentalText,
-	Text as TextComponent,
-} from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import ChevronDownIcon from 'gridicons/dist/chevron-down';
 import { isNil, noop } from 'lodash';
 import PropTypes from 'prop-types';
+import { Text } from '@woocommerce/experimental';
+
 /**
  * Internal dependencies
  */
 import Link from '../link';
-
-const Text = TextComponent || __experimentalText;
 
 /**
  * A component to show a value, label, and an optional change percentage. Can also act as a link to a specific report focus.

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -4,7 +4,8 @@
 import {
 	Button,
 	Tooltip,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import classnames from 'classnames';
@@ -15,6 +16,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Link from '../link';
+
+const Text = TextComponent || __experimentalText;
 
 /**
  * A component to show a value, label, and an optional change percentage. Can also act as a link to a specific report focus.

--- a/packages/customer-effort-score/src/customer-feedback-modal/index.js
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.js
@@ -7,10 +7,13 @@ import {
 	Button,
 	Modal,
 	RadioControl,
-	__experimentalText as Text,
+	__experimentalText,
+	Text as TextComponent,
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+const Text = TextComponent || __experimentalText;
 
 /**
  * Provides a modal requesting customer feedback.

--- a/packages/customer-effort-score/src/customer-feedback-modal/index.js
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.js
@@ -7,13 +7,10 @@ import {
 	Button,
 	Modal,
 	RadioControl,
-	__experimentalText,
-	Text as TextComponent,
 	TextareaControl,
 } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 import { __ } from '@wordpress/i18n';
-
-const Text = TextComponent || __experimentalText;
 
 /**
  * Provides a modal requesting customer feedback.

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,6 +22,7 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
+			experimental: null,
 		};
 
 		if ( irregularExternalMap[ handle ] ) {

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,8 +22,12 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
-			experimental: null,
 		};
+
+		const excludedExternals = [ 'experimental' ];
+		if ( excludedExternals.includes( handle ) ) {
+			return;
+		}
 
 		if ( irregularExternalMap[ handle ] ) {
 			return irregularExternalMap[ handle ];

--- a/packages/experimental/.npmrc
+++ b/packages/experimental/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+-   Released package

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.0.0
 
--   Released package
+-   Initial package

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -1,0 +1,27 @@
+# Navigation
+
+A collection of component imports and exports that are aliases for components transitioning from experimental to non-experimental.  This package prevents the component from being undefined when the `@wordpress/components` library version is unclear.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @woocommerce/experimental --save
+```
+
+## Usage
+
+Simply import the component name with the `__experimental` prefix.  If found, the non-experimental version will be imported and if not, this will fallback to the experimental version.
+
+```jsx
+import { Text } from '@woocommerce/experimental';
+
+render() {
+	return (
+		<Text variant="title.small">
+			…
+		</Text>
+	);
+}
+```

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -1,5 +1,7 @@
 # Experimental
 
+This is a private package and will not be published for external use.
+
 A collection of component imports and exports that are aliases for components transitioning from experimental to non-experimental.  This package prevents the component from being undefined when the `@wordpress/components` library version is unclear.
 
 ## Installation

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -1,4 +1,4 @@
-# Navigation
+# Experimental
 
 A collection of component imports and exports that are aliases for components transitioning from experimental to non-experimental.  This package prevents the component from being undefined when the `@wordpress/components` library version is unclear.
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"private": true
 }

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@woocommerce/experimental",
+	"version": "1.0.0",
+	"description": "WooCommerce experimental components.",
+	"author": "Automattic",
+	"license": "GPL-3.0-or-later",
+	"keywords": [
+		"wordpress",
+		"woocommerce",
+		"experimental"
+	],
+	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/experimental/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+	},
+	"bugs": {
+		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@babel/runtime": "^7.11.2",
+		"@wordpress/components": "10.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -2,31 +2,33 @@
  * External dependencies
  */
 import {
-	__experimentalBackButton,
-	__experimentalGroup,
-	__experimentalMenu,
 	__experimentalNavigation,
+	__experimentalNavigationBackButton,
+	__experimentalNavigationGroup,
+	__experimentalNavigationMenu,
 	__experimentalNavigationItem,
 	__experimentalText,
 	__experimentalUseSlot,
-	BackButton as BackButtonComponent,
-	Group as GroupComponent,
-	Menu as MenuComponent,
 	Navigation as NavigationComponent,
+	NavigationBackButton as NavigationBackButtonComponent,
+	NavigationGroup as NavigationGroupComponent,
+	NavigationMenu as NavigationMenuComponent,
 	NavigationItem as NavigationItemComponent,
 	Text as TextComponent,
-	useNavSlot as useNavSlotHook,
+	useSlot as useSlotHook,
 } from '@wordpress/components';
 
 /**
  * Prioritize exports of non-experimental components over experimental.
  */
-export const BackButton = BackButtonComponent || __experimentalBackButton;
-export const Group = GroupComponent || __experimentalGroup;
-export const Menu = MenuComponent || __experimentalMenu;
 export const Navigation = NavigationComponent || __experimentalNavigation;
-export const NavigationItem = NavigationItemComponent || __experimentalNavigationItem;
+export const NavigationBackButton =
+	NavigationBackButtonComponent || __experimentalNavigationBackButton;
+export const NavigationGroup =
+	NavigationGroupComponent || __experimentalNavigationGroup;
+export const NavigationMenu =
+	NavigationMenuComponent || __experimentalNavigationMenu;
+export const NavigationItem =
+	NavigationItemComponent || __experimentalNavigationItem;
 export const Text = TextComponent || __experimentalText;
-export const useNavSlot = useNavSlotHook || __experimentalUseSlot;
-const Test = {};
-export default Test;
+export const useSlot = useSlotHook || __experimentalUseSlot;

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import {
+	__experimentalBackButton,
+	__experimentalGroup,
+	__experimentalMenu,
+	__experimentalNavigation,
+	__experimentalNavigationItem,
+	__experimentalText,
+	__experimentalUseSlot,
+	BackButton as BackButtonComponent,
+	Group as GroupComponent,
+	Menu as MenuComponent,
+	Navigation as NavigationComponent,
+	NavigationItem as NavigationItemComponent,
+	Text as TextComponent,
+	useNavSlot as useNavSlotHook,
+} from '@wordpress/components';
+
+/**
+ * Prioritize exports of non-experimental components over experimental.
+ */
+export const BackButton = BackButtonComponent || __experimentalBackButton;
+export const Group = GroupComponent || __experimentalGroup;
+export const Menu = MenuComponent || __experimentalMenu;
+export const Navigation = NavigationComponent || __experimentalNavigation;
+export const NavigationItem = NavigationItemComponent || __experimentalNavigationItem;
+export const Text = TextComponent || __experimentalText;
+export const useNavSlot = useNavSlotHook || __experimentalUseSlot;
+const Test = {};
+export default Test;

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -22,7 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.12.5",
-		"@woocommerce/experimental": "1.0.0",
+		"@woocommerce/experimental": "file:../experimental",
 		"history": "4.10.1",
 		"lodash": "4.17.15",
 		"qs": "6.9.4"

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -22,6 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.12.5",
+		"@woocommerce/experimental": "1.0.0",
 		"history": "4.10.1",
 		"lodash": "4.17.15",
 		"qs": "6.9.4"

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -5,7 +5,12 @@ import { addQueryArgs } from '@wordpress/url';
 import { parse } from 'qs';
 import { pick, uniq } from 'lodash';
 import { applyFilters } from '@wordpress/hooks';
-import { Slot, Fill } from '@wordpress/components';
+import {
+	Slot,
+	Fill,
+	__experimentalUseSlot,
+	useNavSlotHook,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -228,4 +233,4 @@ export { SlotFillProvider as NavSlotFillProvider } from '@wordpress/components';
  * in the /client folder. This problem is due to WC Admin bundling @wordpress/components
  * instead of enqueuing and using wp.components from the window.
  */
-export { __experimentalUseSlot as useNavSlot } from '@wordpress/components';
+export const useNavSlot = useNavSlotHook || __experimentalUseSlot;

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -5,12 +5,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { parse } from 'qs';
 import { pick, uniq } from 'lodash';
 import { applyFilters } from '@wordpress/hooks';
-import {
-	Slot,
-	Fill,
-	__experimentalUseSlot,
-	useNavSlotHook,
-} from '@wordpress/components';
+import { Slot, Fill } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -233,4 +228,4 @@ export { SlotFillProvider as NavSlotFillProvider } from '@wordpress/components';
  * in the /client folder. This problem is due to WC Admin bundling @wordpress/components
  * instead of enqueuing and using wp.components from the window.
  */
-export const useNavSlot = useNavSlotHook || __experimentalUseSlot;
+export { useSlot as useNavSlot } from '@woocommerce/experimental';

--- a/packages/navigation/src/test/index.js
+++ b/packages/navigation/src/test/index.js
@@ -1,23 +1,33 @@
 /**
  * Internal dependencies
  */
-import { getPersistedQuery, getSearchWords, getNewPath } from '../index';
-
-jest.mock( '../index', () => ( {
-	...require.requireActual( '../index' ),
-	getQuery: jest.fn().mockReturnValue( {
-		filter: 'advanced',
-		product_includes: 127,
-		period: 'year',
-		compare: 'previous_year',
-		after: '2018-02-01',
-		before: '2018-01-01',
-		interval: 'day',
-		search: 'lorem',
-	} ),
-} ) );
+import {
+	getHistory,
+	getPersistedQuery,
+	getSearchWords,
+	getNewPath,
+} from '../index';
 
 describe( 'getPersistedQuery', () => {
+	beforeEach( () => {
+		getHistory().push(
+			getNewPath(
+				{
+					filter: 'advanced',
+					product_includes: 127,
+					period: 'year',
+					compare: 'previous_year',
+					after: '2018-02-01',
+					before: '2018-01-01',
+					interval: 'day',
+					search: 'lorem',
+				},
+				'/',
+				{}
+			)
+		);
+	} );
+
 	it( "should return an empty object it the query doesn't contain any time related parameters", () => {
 		const query = {
 			filter: 'advanced',

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -399,7 +399,7 @@ class Loader {
 		wp_register_script(
 			'wc-navigation',
 			self::get_url( 'navigation/index', 'js' ),
-			array( 'wp-url', 'wp-hooks', 'wp-element', 'wp-data', 'moment', 'wp-components', 'wc-experimental' ),
+			array( 'wp-url', 'wp-hooks', 'wp-element', 'wp-data', 'moment', 'wp-components' ),
 			$js_file_version,
 			true
 		);
@@ -479,14 +479,6 @@ class Loader {
 
 		wp_set_script_translations( 'wc-components', 'woocommerce-admin' );
 
-		wp_register_script(
-			'wc-experimental',
-			self::get_url( 'experimental/index', 'js' ),
-			array( 'wp-components' ),
-			$js_file_version,
-			true
-		);
-
 		wp_register_style(
 			'wc-components',
 			self::get_url( 'components/style', 'css' ),
@@ -522,7 +514,6 @@ class Loader {
 				'wp-plugins',
 				'wc-tracks',
 				'wc-navigation',
-				'wc-experimental',
 			),
 			$js_file_version,
 			true

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -399,7 +399,7 @@ class Loader {
 		wp_register_script(
 			'wc-navigation',
 			self::get_url( 'navigation/index', 'js' ),
-			array( 'wp-url', 'wp-hooks', 'wp-element', 'wp-data', 'moment', 'wp-components' ),
+			array( 'wp-url', 'wp-hooks', 'wp-element', 'wp-data', 'moment', 'wp-components', 'wc-experimental' ),
 			$js_file_version,
 			true
 		);
@@ -479,6 +479,14 @@ class Loader {
 
 		wp_set_script_translations( 'wc-components', 'woocommerce-admin' );
 
+		wp_register_script(
+			'wc-experimental',
+			self::get_url( 'experimental/index', 'js' ),
+			array( 'wp-components' ),
+			$js_file_version,
+			true
+		);
+
 		wp_register_style(
 			'wc-components',
 			self::get_url( 'components/style', 'css' ),
@@ -514,6 +522,7 @@ class Loader {
 				'wp-plugins',
 				'wc-tracks',
 				'wc-navigation',
+				'wc-experimental',
 			),
 			$js_file_version,
 			true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ const wcAdminPackages = [
 	'currency',
 	'customer-effort-score',
 	'date',
-	'experimental',
 	'navigation',
 	'notices',
 	'number',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const wcAdminPackages = [
 	'currency',
 	'customer-effort-score',
 	'date',
+	'experimental',
 	'navigation',
 	'notices',
 	'number',


### PR DESCRIPTION
Fixes #5873

Use non experimental versions of components for future-proofing but fallback to experimental if they don't exist yet.

### Detailed test instructions:

1. Check out this branch.
2. Make sure things still run as expected, especially around `Text` and navigation components.
3. If you really want to check that things continue to work, optionally spin up a dev version of GB and update named exports in  `@wordpress/components`.