### PR TITLE
Decode entities in titles

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, wordpress } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { useSelect } from '@wordpress/data';
@@ -109,7 +110,7 @@ const Header = () => {
 				className="woocommerce-navigation-header__site-title"
 				as="span"
 			>
-				{ siteTitle }
+				{ decodeEntities( siteTitle ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
Fixes #5893

Allows special characters in site titles in the new nav.

### Screenshots

**Before**
<img width="273" alt="Screen Shot 2020-12-23 at 4 43 08 PM" src="https://user-images.githubusercontent.com/10561050/103039102-03dc7300-453e-11eb-8a9e-37d4a84c61a7.png">


**After**
<img width="260" alt="Screen Shot 2020-12-23 at 4 42 23 PM" src="https://user-images.githubusercontent.com/10561050/103039104-05a63680-453e-11eb-9823-d03aa1ed8ae4.png">


### Detailed test instructions:

1. Add some special html characters like `<` or `&` to your site title.
2. Load up the new nav.
3. Make sure the title displays correctly in the nav.