### PR TITLE
Allow default link behavior when cmd or ctrl are used

### DIFF
--- a/packages/components/src/link/index.js
+++ b/packages/components/src/link/index.js
@@ -15,6 +15,11 @@ class Link extends Component {
 	// With React Router 5+, <RouterLink /> cannot be used outside of the main <Router /> elements,
 	// which seems to include components imported from @woocommerce/components. For now, we can use the history object directly.
 	wcAdminLinkHandler( onClick, event ) {
+		// If cmd or ctrl are used, use default behavior to allow opening in a new tab.
+		if ( event.ctrlKey || event.metaKey ) {
+			return;
+		}
+
 		event.preventDefault();
 
 		// If there is an onclick event, execute it.

--- a/packages/components/src/link/index.js
+++ b/packages/components/src/link/index.js
@@ -15,8 +15,13 @@ function Link( { children, href, type, ...props } ) {
 	// With React Router 5+, <RouterLink /> cannot be used outside of the main <Router /> elements,
 	// which seems to include components imported from @woocommerce/components. For now, we can use the history object directly.
 	const wcAdminLinkHandler = ( onClick, event ) => {
-		// If cmd or ctrl are used, use default behavior to allow opening in a new tab.
-		if ( event.ctrlKey || event.metaKey ) {
+		// If cmd, ctrl, alt, or shift are used, use default behavior to allow opening in a new tab.
+		if (
+			event.ctrlKey ||
+			event.metaKey ||
+			event.altKey ||
+			event.shiftKey
+		) {
 			return;
 		}
 

--- a/packages/components/src/link/index.js
+++ b/packages/components/src/link/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { partial } from 'lodash';
 import { getHistory } from '@woocommerce/navigation';
@@ -10,11 +9,12 @@ import { getHistory } from '@woocommerce/navigation';
  * Use `Link` to create a link to another resource. It accepts a type to automatically
  * create wp-admin links, wc-admin links, and external links.
  */
-class Link extends Component {
+
+function Link( { children, href, type, ...props } ) {
 	// @todo Investigate further if we can use <Link /> directly.
 	// With React Router 5+, <RouterLink /> cannot be used outside of the main <Router /> elements,
 	// which seems to include components imported from @woocommerce/components. For now, we can use the history object directly.
-	wcAdminLinkHandler( onClick, event ) {
+	const wcAdminLinkHandler = ( onClick, event ) => {
 		// If cmd or ctrl are used, use default behavior to allow opening in a new tab.
 		if ( event.ctrlKey || event.metaKey ) {
 			return;
@@ -31,29 +31,22 @@ class Link extends Component {
 		}
 
 		getHistory().push( event.target.closest( 'a' ).getAttribute( 'href' ) );
+	};
+
+	const passProps = {
+		...props,
+		'data-link-type': type,
+	};
+
+	if ( type === 'wc-admin' ) {
+		passProps.onClick = partial( wcAdminLinkHandler, passProps.onClick );
 	}
 
-	render() {
-		const { children, href, type, ...props } = this.props;
-
-		const passProps = {
-			...props,
-			'data-link-type': type,
-		};
-
-		if ( type === 'wc-admin' ) {
-			passProps.onClick = partial(
-				this.wcAdminLinkHandler,
-				passProps.onClick
-			);
-		}
-
-		return (
-			<a href={ href } { ...passProps }>
-				{ children }
-			</a>
-		);
-	}
+	return (
+		<a href={ href } { ...passProps }>
+			{ children }
+		</a>
+	);
 }
 
 Link.propTypes = {


### PR DESCRIPTION
Fixes #5916

Allows opening new tabs via default browser behavior when ctrl or cmd are used.

### Screenshots
<img width="263" alt="Screen Shot 2020-12-23 at 4 58 52 PM" src="https://user-images.githubusercontent.com/10561050/103040008-48690e00-4540-11eb-8808-619ac3400226.png">


### Detailed test instructions:

1. Try `cmd` + clicking (in OSX) or `ctrl` + clicking in Windows some `Link` components.
2. Make sure a new tab can be opened if a `href` exists.
3. Try clicking without holding keys.
4. Make sure the link still navigates normally via history update.