### PR TITLE
Localize regional currency information for use during onboarding setup

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -81,16 +81,16 @@ class StoreDetails extends Component {
 		}
 
 		const Currency = this.context;
-		const region = getCurrencyRegion( countryState );
+		const country = getCountryCode( countryState );
 		const { currencySymbols = {}, localeInfo = {} } = getSetting(
 			'onboarding',
 			{}
 		);
-		const regionInfo = localeInfo[ region ] || localeInfo.US;
+		const countryInfo = localeInfo[ country ] || localeInfo.US;
 		const symbol =
-			currencySymbols[ regionInfo.currency_code ] || currencySymbols.USD;
+			currencySymbols[ countryInfo.currency_code ] || currencySymbols.USD;
 
-		return Currency.formatPhpToJs( { ...regionInfo, symbol } );
+		return Currency.formatPhpToJs( { ...countryInfo, symbol } );
 	}
 
 	onSubmit() {

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -16,7 +16,7 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Form } from '@woocommerce/components';
-import { getCurrencyData } from '@woocommerce/currency';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -81,8 +81,8 @@ class StoreDetails extends Component {
 		}
 
 		const region = getCurrencyRegion( countryState );
-		const currencyData = getCurrencyData();
-		return currencyData[ region ] || currencyData.US;
+		const localeInfo = getSetting( 'localeInfo', {} );
+		return localeInfo[ region ] || localeInfo.US;
 	}
 
 	onSubmit() {
@@ -112,7 +112,7 @@ class StoreDetails extends Component {
 
 		recordEvent( 'storeprofiler_store_details_continue', {
 			store_country: getCountryCode( values.countryState ),
-			derived_currency: currencySettings.code,
+			derived_currency: currencySettings.currency_code,
 			setup_client: values.isClient,
 		} );
 
@@ -124,13 +124,11 @@ class StoreDetails extends Component {
 				woocommerce_default_country: values.countryState,
 				woocommerce_store_city: values.city,
 				woocommerce_store_postcode: values.postCode,
-				woocommerce_currency: currencySettings.code,
-				woocommerce_currency_pos: currencySettings.symbolPosition,
-				woocommerce_price_thousand_sep:
-					currencySettings.thousandSeparator,
-				woocommerce_price_decimal_sep:
-					currencySettings.decimalSeparator,
-				woocommerce_price_num_decimals: currencySettings.precision,
+				woocommerce_currency: currencySettings.currency_code,
+				woocommerce_currency_pos: currencySettings.currency_pos,
+				woocommerce_price_thousand_sep: currencySettings.thousand_sep,
+				woocommerce_price_decimal_sep: currencySettings.decimal_sep,
+				woocommerce_price_num_decimals: currencySettings.num_decimals,
 			},
 		} );
 

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -80,9 +80,17 @@ class StoreDetails extends Component {
 			return null;
 		}
 
+		const Currency = this.context;
 		const region = getCurrencyRegion( countryState );
-		const localeInfo = getSetting( 'localeInfo', {} );
-		return localeInfo[ region ] || localeInfo.US;
+		const { currencySymbols = {}, localeInfo = {} } = getSetting(
+			'onboarding',
+			{}
+		);
+		const regionInfo = localeInfo[ region ] || localeInfo.US;
+		const symbol =
+			currencySymbols[ regionInfo.currency_code ] || currencySymbols.USD;
+
+		return Currency.formatPhpToJs( { ...regionInfo, symbol } );
 	}
 
 	onSubmit() {
@@ -124,11 +132,13 @@ class StoreDetails extends Component {
 				woocommerce_default_country: values.countryState,
 				woocommerce_store_city: values.city,
 				woocommerce_store_postcode: values.postCode,
-				woocommerce_currency: currencySettings.currency_code,
-				woocommerce_currency_pos: currencySettings.currency_pos,
-				woocommerce_price_thousand_sep: currencySettings.thousand_sep,
-				woocommerce_price_decimal_sep: currencySettings.decimal_sep,
-				woocommerce_price_num_decimals: currencySettings.num_decimals,
+				woocommerce_currency: currencySettings.code,
+				woocommerce_currency_pos: currencySettings.symbolPosition,
+				woocommerce_price_thousand_sep:
+					currencySettings.thousandSeparator,
+				woocommerce_price_decimal_sep:
+					currencySettings.decimalSeparator,
+				woocommerce_price_num_decimals: currencySettings.precision,
 			},
 		} );
 

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -86,11 +86,11 @@ class StoreDetails extends Component {
 			'onboarding',
 			{}
 		);
-		const countryInfo = localeInfo[ country ] || localeInfo.US;
-		const symbol =
-			currencySymbols[ countryInfo.currency_code ] || currencySymbols.USD;
-
-		return Currency.formatPhpToJs( { ...countryInfo, symbol } );
+		return Currency.getDataForCountry(
+			country,
+			localeInfo,
+			currencySymbols
+		);
 	}
 
 	onSubmit() {

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -23,7 +23,8 @@
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.12.5",
 		"@woocommerce/number": "2.0.0",
-		"@wordpress/deprecated": "^2.9.0"
+		"@wordpress/deprecated": "^2.9.0",
+		"@wordpress/html-entities": "2.7.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -113,13 +113,10 @@ const CurrencyFactory = ( currencySetting ) => {
 		localeInfo = {},
 		currencySymbols = {}
 	) {
-		const countryInfo = localeInfo[ countryCode ] || {};
-		const symbol = currencySymbols[ countryInfo.currency_code ] || {};
+		const countryInfo = localeInfo[ countryCode ];
+		const symbol = currencySymbols[ countryInfo.currency_code ];
 
-		if (
-			! Object.keys( symbol ).length ||
-			! Object.keys( countryInfo ).length
-		) {
+		if ( ! symbol || ! countryInfo ) {
 			return {};
 		}
 

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -100,10 +100,44 @@ const CurrencyFactory = ( currencySetting ) => {
 		return '%1$s%2$s';
 	}
 
+	/**
+	 * Get formatted data for a country from supplied locale and symbol info.
+	 *
+	 * @param {string} countryCode Country code.
+	 * @param {Object} localeInfo Locale info by country code.
+	 * @param {Object} currencySymbols Currency symbols by symbol code.
+	 * @return {Object} Formatted currency data for country.
+	 */
+	function getDataForCountry(
+		countryCode,
+		localeInfo = {},
+		currencySymbols = {}
+	) {
+		const countryInfo = localeInfo[ countryCode ] || {};
+		const symbol = currencySymbols[ countryInfo.currency_code ] || {};
+
+		if (
+			! Object.keys( symbol ).length ||
+			! Object.keys( countryInfo ).length
+		) {
+			return {};
+		}
+
+		return {
+			code: countryInfo.currency_code,
+			symbol: decodeEntities( symbol ),
+			symbolPosition: countryInfo.currency_pos,
+			thousandSeparator: countryInfo.thousand_sep,
+			decimalSeparator: countryInfo.decimal_sep,
+			precision: countryInfo.num_decimals,
+		};
+	}
+
 	return {
 		getCurrencyConfig: () => {
 			return { ...currency };
 		},
+		getDataForCountry,
 		setCurrency,
 		formatAmount,
 		formatCurrency,
@@ -167,24 +201,134 @@ const CurrencyFactory = ( currencySetting ) => {
 			}
 			return formatAmount( number );
 		},
-
-		/**
-		 * Format currency from WooCommerce PHP version to WCA JS version.
-		 *
-		 * @param {Object} phpCurrency Currency to format
-		 * @return {Object} Formatted JS currency.
-		 */
-		formatPhpToJs( phpCurrency ) {
-			return {
-				code: phpCurrency.currency_code,
-				symbol: decodeEntities( phpCurrency.symbol ),
-				symbolPosition: phpCurrency.currency_pos,
-				thousandSeparator: phpCurrency.thousand_sep,
-				decimalSeparator: phpCurrency.decimal_sep,
-				precision: phpCurrency.num_decimals,
-			};
-		},
 	};
 };
 
 export default CurrencyFactory;
+
+/**
+ * Returns currency data by country/region. Contains code, symbol, position, thousands separator, decimal separator, and precision.
+ *
+ * Dev Note: When adding new currencies below, the exchange rate array should also be updated in WooCommerce Admin's `business-details.js`.
+ *
+ * @deprecated
+ *
+ * @return {Object} Curreny data.
+ */
+export function getCurrencyData() {
+	deprecated( 'getCurrencyData', {
+		version: '3.1.0',
+		alternative: 'CurrencyFactory.getDataForCountry',
+		plugin: 'WooCommerce Admin',
+		hint:
+			'Pass in the country, locale data, and symbol info to use getDataForCountry',
+	} );
+
+	// See https://github.com/woocommerce/woocommerce-admin/issues/3101.
+	return {
+		US: {
+			code: 'USD',
+			symbol: '$',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+		EU: {
+			code: 'EUR',
+			symbol: '€',
+			symbolPosition: 'left',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			precision: 2,
+		},
+		IN: {
+			code: 'INR',
+			symbol: '₹',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+		GB: {
+			code: 'GBP',
+			symbol: '£',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+		BR: {
+			code: 'BRL',
+			symbol: 'R$',
+			symbolPosition: 'left',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			precision: 2,
+		},
+		VN: {
+			code: 'VND',
+			symbol: '₫',
+			symbolPosition: 'right',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			precision: 1,
+		},
+		ID: {
+			code: 'IDR',
+			symbol: 'Rp',
+			symbolPosition: 'left',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			precision: 0,
+		},
+		BD: {
+			code: 'BDT',
+			symbol: '৳',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 0,
+		},
+		PK: {
+			code: 'PKR',
+			symbol: '₨',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+		RU: {
+			code: 'RUB',
+			symbol: '₽',
+			symbolPosition: 'right',
+			thousandSeparator: ' ',
+			decimalSeparator: ',',
+			precision: 2,
+		},
+		TR: {
+			code: 'TRY',
+			symbol: '₺',
+			symbolPosition: 'left',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			precision: 2,
+		},
+		MX: {
+			code: 'MXN',
+			symbol: '$',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+		CA: {
+			code: 'CAD',
+			symbol: '$',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+	};
+}

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -11,7 +11,14 @@ const CurrencyFactory = ( currencySetting ) => {
 	setCurrency( currencySetting );
 
 	function setCurrency( setting ) {
-		const defaultCurrency = getCurrencyData().US;
+		const defaultCurrency = {
+			code: 'USD',
+			symbol: '$',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		};
 		const config = { ...defaultCurrency, ...setting };
 		currency = {
 			code: config.code.toString(),
@@ -159,124 +166,24 @@ const CurrencyFactory = ( currencySetting ) => {
 			}
 			return formatAmount( number );
 		},
+
+		/**
+		 * Format currency from WooCommerce PHP version to WCA JS version.
+		 *
+		 * @param {Object} phpCurrency Currency to format
+		 * @return {Object} Formatted JS currency.
+		 */
+		formatPhpToJs( phpCurrency ) {
+			return {
+				code: phpCurrency.currency_code,
+				symbol: phpCurrency.symbol,
+				symbolPosition: phpCurrency.currency_pos,
+				thousandSeparator: phpCurrency.thousand_sep,
+				decimalSeparator: phpCurrency.decimal_sep,
+				precision: phpCurrency.num_decimals,
+			};
+		},
 	};
 };
 
 export default CurrencyFactory;
-
-/**
- * Returns currency data by country/region. Contains code, symbol, position, thousands separator, decimal separator, and precision.
- *
- * Dev Note: When adding new currencies below, the exchange rate array should also be updated in WooCommerce Admin's `business-details.js`.
- *
- * @return {Object} Curreny data.
- */
-export function getCurrencyData() {
-	// See https://github.com/woocommerce/woocommerce-admin/issues/3101.
-	return {
-		US: {
-			code: 'USD',
-			symbol: '$',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-		EU: {
-			code: 'EUR',
-			symbol: '€',
-			symbolPosition: 'left',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			precision: 2,
-		},
-		IN: {
-			code: 'INR',
-			symbol: '₹',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-		GB: {
-			code: 'GBP',
-			symbol: '£',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-		BR: {
-			code: 'BRL',
-			symbol: 'R$',
-			symbolPosition: 'left',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			precision: 2,
-		},
-		VN: {
-			code: 'VND',
-			symbol: '₫',
-			symbolPosition: 'right',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			precision: 1,
-		},
-		ID: {
-			code: 'IDR',
-			symbol: 'Rp',
-			symbolPosition: 'left',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			precision: 0,
-		},
-		BD: {
-			code: 'BDT',
-			symbol: '৳',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 0,
-		},
-		PK: {
-			code: 'PKR',
-			symbol: '₨',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-		RU: {
-			code: 'RUB',
-			symbol: '₽',
-			symbolPosition: 'right',
-			thousandSeparator: ' ',
-			decimalSeparator: ',',
-			precision: 2,
-		},
-		TR: {
-			code: 'TRY',
-			symbol: '₺',
-			symbolPosition: 'left',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			precision: 2,
-		},
-		MX: {
-			code: 'MXN',
-			symbol: '$',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-		CA: {
-			code: 'CAD',
-			symbol: '$',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		},
-	};
-}

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { decodeEntities } from '@wordpress/html-entities';
 import { sprintf } from '@wordpress/i18n';
 import { numberFormat } from '@woocommerce/number';
 import deprecated from '@wordpress/deprecated';
@@ -91,9 +92,9 @@ const CurrencyFactory = ( currencySetting ) => {
 			case 'right':
 				return '%2$s%1$s';
 			case 'left_space':
-				return '%1$s&nbsp;%2$s';
+				return '%1$s %2$s';
 			case 'right_space':
-				return '%2$s&nbsp;%1$s';
+				return '%2$s %1$s';
 		}
 
 		return '%1$s%2$s';
@@ -176,7 +177,7 @@ const CurrencyFactory = ( currencySetting ) => {
 		formatPhpToJs( phpCurrency ) {
 			return {
 				code: phpCurrency.currency_code,
-				symbol: phpCurrency.symbol,
+				symbol: decodeEntities( phpCurrency.symbol ),
 				symbolPosition: phpCurrency.currency_pos,
 				thousandSeparator: phpCurrency.thousand_sep,
 				decimalSeparator: phpCurrency.decimal_sep,

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -691,13 +691,14 @@ class Onboarding {
 		$wccom_auth                 = \WC_Helper_Options::get( 'auth' );
 		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
-		$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
-		$settings['onboarding']['euCountries']  = WC()->countries->get_european_union_countries();
-		$settings['onboarding']['industries']   = self::get_allowed_industries();
-		$settings['onboarding']['localeInfo']   = include WC()->plugin_path() . '/i18n/locale-info.php';
-		$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
-		$settings['onboarding']['profile']      = $profile;
-		$settings['onboarding']['themes']       = self::get_themes();
+		$settings['onboarding']['activeTheme']     = get_option( 'stylesheet' );
+		$settings['onboarding']['currencySymbols'] = get_woocommerce_currency_symbols();
+		$settings['onboarding']['euCountries']     = WC()->countries->get_european_union_countries();
+		$settings['onboarding']['industries']      = self::get_allowed_industries();
+		$settings['onboarding']['localeInfo']      = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$settings['onboarding']['productTypes']    = self::get_allowed_product_types();
+		$settings['onboarding']['profile']         = $profile;
+		$settings['onboarding']['themes']          = self::get_themes();
 
 		return $settings;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -694,6 +694,7 @@ class Onboarding {
 		$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
 		$settings['onboarding']['euCountries']  = WC()->countries->get_european_union_countries();
 		$settings['onboarding']['industries']   = self::get_allowed_industries();
+		$settings['onboarding']['localeInfo']   = include WC()->plugin_path() . '/i18n/locale-info.php';
 		$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
 		$settings['onboarding']['profile']      = $profile;
 		$settings['onboarding']['themes']       = self::get_themes();


### PR DESCRIPTION
Fixes #5760

Uses the WC region info to derive currency information during the obw.

Worth discussing: Is this too much data to preload and localize?  Should we be putting both updates and requests for info into a REST endpoint?

### Screenshots
<img width="550" alt="Screen Shot 2020-12-24 at 1 53 26 PM" src="https://user-images.githubusercontent.com/10561050/103103519-9426c080-45ef-11eb-9541-b9bc66b3add3.png">


### Detailed test instructions:

1. Go through the setup wizard.
2. Select a different currency than your store's existing currency.
3. Make sure that currency has been updated accordingly on your site. `wp-admin/admin.php?page=wc-settings&tab=general`