### PR TITLE
Fix missing border around the emojis on the CES survey

### DIFF
--- a/packages/customer-effort-score/src/style.scss
+++ b/packages/customer-effort-score/src/style.scss
@@ -16,6 +16,7 @@
 		&:not(:last-child) {
 			// Override package component style.
 			margin-bottom: 0;
+			margin-right: 4px;
 		}
 
 		input {

--- a/packages/customer-effort-score/src/style.scss
+++ b/packages/customer-effort-score/src/style.scss
@@ -45,6 +45,7 @@
 		}
 
 		input:checked + label {
+			outline: 2px solid $studio-wordpress-blue;
 			background-color: $studio-wordpress-blue-0;
 		}
 


### PR DESCRIPTION
Fixes #5962 

This PR adds the missing border around the emojis on the CES survey.

- The border was missing in Safari when user clicks one of the emojis.
- The border did not stay highlighted when user changes input focus. 

### Screenshots

Before -- No border
![Untitled](https://user-images.githubusercontent.com/4723145/103240488-597d9a80-4905-11eb-8bee-3347e603d89f.png)

After:

![Screen Shot 2020-12-28 at 12 01 00 PM](https://user-images.githubusercontent.com/4723145/103240439-394ddb80-4905-11eb-99fe-ff16c8d3dcf1.jpg)

### Detailed test instructions:

Make sure both `woocommerce_ces_shown_for_actions` and `woocommerce_ces_tracks_queue` config values are deleted.

 1. Complete the Onboarding setup wizard.
 1. Go to WooCommerce > Settings > Advanced > WooCommerce.com
 1. Enable Usage Tracking 
 1. Go to Products->Add New
 1. Click on Publish
 1. Note feedback dialog is triggered, click on "Give Feedback" option
 1. Click on any one of the emojis or options say Neutral
 1. Confirm the border around the emoji

The test should be performed on Safari, Chrome, and Firefox.
