### PR TITLE
Don't show Stock or Reviews panels before there are Products and/or Orders.

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -27,6 +27,7 @@ export const ActivityPanel = () => {
 		const manageStock = getSetting( 'manageStock', 'no' );
 		const countLowStockProducts = getLowStockCount( select );
 		const countUnapprovedReviews = getUnapprovedReviews( select );
+		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
 
 		return {
 			countLowStockProducts,
@@ -36,10 +37,15 @@ export const ActivityPanel = () => {
 			totalOrderCount,
 			reviewsEnabled,
 			countUnapprovedReviews,
+			publishedProductCount,
 		};
 	} );
 
 	const panels = getAllPanels( panelsData );
+
+	if ( panels.length === 0 ) {
+		return null;
+	}
 
 	return (
 		<Accordion>

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -12,12 +12,13 @@ import ReviewsPanel from './reviews';
 
 export function getAllPanels( {
 	countLowStockProducts,
+	countUnapprovedReviews,
 	countUnreadOrders,
 	manageStock,
 	orderStatuses,
-	totalOrderCount,
+	publishedProductCount,
 	reviewsEnabled,
-	countUnapprovedReviews,
+	totalOrderCount,
 } ) {
 	return [
 		totalOrderCount > 0 && {
@@ -34,30 +35,35 @@ export function getAllPanels( {
 			),
 			title: __( 'Orders', 'woocommerce-admin' ),
 		},
-		manageStock === 'yes' && {
-			className: 'woocommerce-homescreen-card',
-			count: countLowStockProducts,
-			id: 'stock-panel',
-			initialOpen: false,
-			collapsible: countLowStockProducts !== 0,
-			panel: (
-				<StockPanel countLowStockProducts={ countLowStockProducts } />
-			),
-			title: __( 'Stock', 'woocommerce-admin' ),
-		},
-		reviewsEnabled === 'yes' && {
-			className: 'woocommerce-homescreen-card',
-			id: 'reviews-panel',
-			count: countUnapprovedReviews,
-			initialOpen: false,
-			collapsible: countUnapprovedReviews !== 0,
-			panel: (
-				<ReviewsPanel
-					hasUnapprovedReviews={ countUnapprovedReviews > 0 }
-				/>
-			),
-			title: __( 'Reviews', 'woocommerce-admin' ),
-		},
+		totalOrderCount > 0 &&
+			publishedProductCount > 0 &&
+			manageStock === 'yes' && {
+				className: 'woocommerce-homescreen-card',
+				count: countLowStockProducts,
+				id: 'stock-panel',
+				initialOpen: false,
+				collapsible: countLowStockProducts !== 0,
+				panel: (
+					<StockPanel
+						countLowStockProducts={ countLowStockProducts }
+					/>
+				),
+				title: __( 'Stock', 'woocommerce-admin' ),
+			},
+		publishedProductCount > 0 &&
+			reviewsEnabled === 'yes' && {
+				className: 'woocommerce-homescreen-card',
+				id: 'reviews-panel',
+				count: countUnapprovedReviews,
+				initialOpen: false,
+				collapsible: countUnapprovedReviews !== 0,
+				panel: (
+					<ReviewsPanel
+						hasUnapprovedReviews={ countUnapprovedReviews > 0 }
+					/>
+				),
+				title: __( 'Reviews', 'woocommerce-admin' ),
+			},
 		// Add another panel row here
 	].filter( Boolean );
 }

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -4,16 +4,45 @@
 import { getAllPanels } from '../panels';
 
 describe( 'ActivityPanel', () => {
-	it( 'should exclude the orders panel when there are no orders', () => {
+	it( 'should exclude the orders and stock panels when there are no orders', () => {
 		const panels = getAllPanels( {
 			countUnreadOrders: 0,
 			orderStatuses: [],
 			totalOrderCount: 0,
+			publishedProductCount: 1,
+			manageStock: 'yes',
 		} );
 
 		expect( panels ).toEqual(
 			expect.not.arrayContaining( [
 				expect.objectContaining( { id: 'orders-panel' } ),
+			] )
+		);
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'stock-panel' } ),
+			] )
+		);
+	} );
+
+	it( 'should exclude the reviews and stock panels when there are no published products', () => {
+		const panels = getAllPanels( {
+			countUnreadOrders: 0,
+			orderStatuses: [],
+			totalOrderCount: 1, // Yes, I realize this isn't "possible".
+			publishedProductCount: 0,
+			manageStock: 'yes',
+			reviewsEnabled: 'yes',
+		} );
+
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'reviews-panel' } ),
+			] )
+		);
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'stock-panel' } ),
 			] )
 		);
 	} );
@@ -28,6 +57,35 @@ describe( 'ActivityPanel', () => {
 		expect( panels ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( { id: 'orders-panel' } ),
+			] )
+		);
+	} );
+
+	it( 'should include the stock panel when there are orders, products, and inventory management is enabled', () => {
+		const panels = getAllPanels( {
+			countUnreadOrders: 1,
+			orderStatuses: [],
+			totalOrderCount: 10,
+			publishedProductCount: 2,
+			manageStock: 'yes',
+		} );
+
+		expect( panels ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 'stock-panel' } ),
+			] )
+		);
+	} );
+
+	it( 'should include the reviews panel when there are products and reviews are enabled', () => {
+		const panels = getAllPanels( {
+			publishedProductCount: 5,
+			reviewsEnabled: 'yes',
+		} );
+
+		expect( panels ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 'reviews-panel' } ),
 			] )
 		);
 	} );

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Product exclusion filter on Orders Report.
 - Fix: Typo in Variation Stats DataStore context filter value.
 - Fix: support custom attributes in Attribute advanced report filter.
+- Fix: Don't show Stock and Reviews Homescreen panels too early.
 
 == 1.8.2 12/22/2020 ==
 

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -148,8 +148,10 @@ class Homescreen {
 		// Remove the Draft Order status (from the Checkout Block).
 		unset( $allowed_statuses['checkout-draft'] );
 
-		$status_counts          = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
-		$settings['orderCount'] = array_sum( $status_counts );
+		$status_counts                     = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
+		$product_counts                    = wp_count_posts( 'product' );
+		$settings['orderCount']            = array_sum( $status_counts );
+		$settings['publishedProductCount'] = $product_counts->publish;
 
 		return $settings;
 	}


### PR DESCRIPTION
Fixes #5952

This PR seeks to fix the issue observed in #5952 where empty Stock and Reviews panels were displayed on the Homescreen of a brand new store.

It changes the logic of when to include the Stock and Reviews panels to the following:

Stock: inventory management is enabled, total order count is 1 or more, published product count is 1 or more

Reviews: reviews are enabled, published product count is 1 or more

### Detailed test instructions:

* Create a new store
* Complete or skip the store profiler
* Visit the home screen
* Verify that the Stock and Reviews panels are not visible
* Switch to an existing store with products + orders, with reviews and inventory enabled
* Visit the home screen
* Verify that the Stock and Reviews panels are visible

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
