### PR TITLE
Fix task list toggle logic in help tab.

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -948,7 +948,10 @@ class Onboarding {
 			'id'    => 'woocommerce_onboard_tab',
 		);
 
-		$task_list_hidden = get_option( 'woocommerce_task_list_hidden', 'no' ) || get_option( 'woocommerce_extended_task_list_hidden', 'no' );
+		$task_list_hidden = (
+			'yes' === get_option( 'woocommerce_task_list_hidden', 'no' ) ||
+			'yes' === get_option( 'woocommerce_extended_task_list_hidden', 'no' )
+		);
 
 		$help_tab['content'] = '<h2>' . __( 'WooCommerce Onboarding', 'woocommerce-admin' ) . '</h2>';
 
@@ -958,7 +961,7 @@ class Onboarding {
 
 		$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce-admin' ) . '</h3>';
 		$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-		( 'yes' === $task_list_hidden
+		( $task_list_hidden
 			? '<p><a href="' . wc_admin_url( '&reset_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
 			: '<p><a href="' . wc_admin_url( '&reset_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
 		);


### PR DESCRIPTION
Partially addresses #5918.

This PR fixes a logic error when checking the status of the Task List - there was JS syntax in place that doesn't work the same way in PHP.

### Screenshots

![](https://user-images.githubusercontent.com/343847/102806925-1ca92500-4394-11eb-9ac7-eb53a426716a.png)

### Detailed test instructions:

- Hide your Task List from the home screen 
- Go to a non-JS page, like WooCommerce > Orders (if you have orders!)
- Open the Help tab, go to "Setup wizard"
- Note that the Task List toggle button says "enable"
- Click to enable the task list
- Go to the homescreen
- Verify your Task List is visible again
- Go to a non-JS page, like WooCommerce > Orders (if you have orders!)
- Open the Help tab, go to "Setup wizard"
- Note that the Task List toggle button says "disable"

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

Fix: Task List toggle in help panel.
