### PR TITLE
Update ce4wp_referred_by option when Creative Mail gets activated dur…

### DIFF
--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -31,6 +31,7 @@ import {
 	PLUGINS_STORE_NAME,
 	pluginNames,
 	SETTINGS_STORE_NAME,
+	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -100,6 +101,25 @@ class BusinessDetails extends Component {
 		this.validate = this.validate.bind( this );
 		this.getNumberRangeString = this.getNumberRangeString.bind( this );
 		this.numberFormat = this.numberFormat.bind( this );
+	}
+
+	onCreativeMailInstallAndActivated() {
+		const { updateOptions } = this.props;
+		updateOptions( {
+			ce4wp_referred_by: {
+				plugin: 'woocommerce',
+				version: getSetting( 'wcVersion' ),
+				time: Math.floor( new Date().getTime() / 1000 ),
+				source: 'onboarding',
+			},
+		} );
+	}
+
+	onPostInstallAndActivePlugins( response ) {
+		const activated = response.data.activated;
+		if ( activated.includes( 'creative-mail-by-constant-contact' ) ) {
+			this.onCreativeMailInstallAndActivated();
+		}
 	}
 
 	async onContinue( values ) {
@@ -176,6 +196,7 @@ class BusinessDetails extends Component {
 				installAndActivatePlugins( businessExtensions )
 					.then( ( response ) => {
 						createNoticesFromResponse( response );
+						this.onPostInstallAndActivePlugins( response );
 					} )
 					.catch( ( error ) => {
 						createNoticesFromResponse( error );
@@ -1007,11 +1028,13 @@ export default compose(
 		const { updateProfileItems } = dispatch( ONBOARDING_STORE_NAME );
 		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
 		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
 
 		return {
 			createNotice,
 			installAndActivatePlugins,
 			updateProfileItems,
+			updateOptions,
 		};
 	} )
 )( BusinessDetails );


### PR DESCRIPTION
Fixes #5841 

This PR updates option `ce4wp_referred_by` when a user opts to install Creative.mail during the OBW.

### Detailed test instructions:

1. Install a fresh WordPress & WooCommerce
2. Start OBW and ensure to choose Creative.mail on the "Business Details" step.
3. Finish OBW
4. Confirm `ce4wp_referred_by` from the `wp_options` table.

The `ce4wp_referred_by` option should have the following values.

|Name| Expected Value|
|------|----------------|
|plugin|woocommerce|
|version| value of wcSettings.wcVersion|
|time| time() value |
|source|onboarding|
