### PR TITLE
Reduce Unnecessary Re-renders in Revenue Report

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -567,6 +567,9 @@ ReportTable.defaultProps = {
 	baseSearchQuery: {},
 };
 
+const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+
 export default compose(
 	withSelect( ( select, props ) => {
 		const {
@@ -587,7 +590,7 @@ export default compose(
 			( query.search &&
 				! ( query[ endpoint ] && query[ endpoint ].length ) )
 		) {
-			return {};
+			return EMPTY_OBJECT;
 		}
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			SETTINGS_STORE_NAME
@@ -603,11 +606,10 @@ export default compose(
 					select,
 					filters,
 					advancedFilters,
-					tableQuery,
 					defaultDateRange,
 					fields: summaryFields,
 			  } )
-			: {};
+			: EMPTY_OBJECT;
 		const queriedTableData =
 			tableData ||
 			getReportTableData( {
@@ -632,9 +634,9 @@ export default compose(
 					? extendedTableData.items.data.map(
 							( item ) => item[ itemIdField ]
 					  )
-					: [],
+					: EMPTY_ARRAY,
 			tableData: extendedTableData,
-			query: { ...tableQuery, ...query },
+			query,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/data/src/reports/selectors.js
+++ b/packages/data/src/reports/selectors.js
@@ -3,6 +3,8 @@
  */
 import { getResourceName } from '../utils';
 
+const EMPTY_OBJECT = {};
+
 export const getReportItemsError = ( state, endpoint, query ) => {
 	const resourceName = getResourceName( endpoint, query );
 	return state.itemErrors[ resourceName ] || false;
@@ -10,12 +12,12 @@ export const getReportItemsError = ( state, endpoint, query ) => {
 
 export const getReportItems = ( state, endpoint, query ) => {
 	const resourceName = getResourceName( endpoint, query );
-	return state.items[ resourceName ] || {};
+	return state.items[ resourceName ] || EMPTY_OBJECT;
 };
 
 export const getReportStats = ( state, endpoint, query ) => {
 	const resourceName = getResourceName( endpoint, query );
-	return state.stats[ resourceName ] || {};
+	return state.stats[ resourceName ] || EMPTY_OBJECT;
 };
 
 export const getReportStatsError = ( state, endpoint, query ) => {

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, forEach, isNull, get, includes } from 'lodash';
+import { find, forEach, isNull, get, includes, memoize } from 'lodash';
 import moment from 'moment';
 import {
 	appendTimestamp,
@@ -20,6 +20,7 @@ import {
 import * as reportsUtils from './utils';
 import { MAX_PER_PAGE, QUERY_DEFAULTS } from '../constants';
 import { STORE_NAME } from './constants';
+import { getResourceName } from '../utils';
 
 /**
  * Add filters and advanced filters values to a query object.
@@ -284,6 +285,55 @@ export function getSummaryNumbers( options ) {
 }
 
 /**
+ * Static responses object to avoid returning new references each call.
+ */
+const reportChartDataResponses = {
+	requesting: {
+		isEmpty: false,
+		isError: false,
+		isRequesting: true,
+		data: {
+			totals: {},
+			intervals: [],
+		},
+	},
+	error: {
+		isEmpty: false,
+		isError: true,
+		isRequesting: false,
+		data: {
+			totals: {},
+			intervals: [],
+		},
+	},
+	empty: {
+		isEmpty: true,
+		isError: false,
+		isRequesting: false,
+		data: {
+			totals: {},
+			intervals: [],
+		},
+	},
+};
+
+const EMPTY_ARRAY = [];
+
+/**
+ * Cache helper for returning the full chart dataset after multiple
+ * requests. Memoized on the request query (string), only called after
+ * all the requests have resolved successfully.
+ */
+const getReportChartDataResponse = memoize(
+	( requestString, totals, intervals ) => ( {
+		isEmpty: false,
+		isError: false,
+		isRequesting: false,
+		data: { totals, intervals },
+	} )
+);
+
+/**
  * Returns all of the data needed to render a chart with summary numbers on a report page.
  *
  * @param  {Object} options           arguments
@@ -301,16 +351,6 @@ export function getReportChartData( options ) {
 		STORE_NAME
 	);
 
-	const response = {
-		isEmpty: false,
-		isError: false,
-		isRequesting: false,
-		data: {
-			totals: {},
-			intervals: [],
-		},
-	};
-
 	const requestQuery = getRequestQuery( options );
 	// Disable eslint rule requiring `stats` to be defined below because the next two if statements
 	// depend on `getReportStats` to have been called.
@@ -318,19 +358,20 @@ export function getReportChartData( options ) {
 	const stats = getReportStats( endpoint, requestQuery );
 
 	if ( isResolving( 'getReportStats', [ endpoint, requestQuery ] ) ) {
-		return { ...response, isRequesting: true };
+		return reportChartDataResponses.requesting;
 	}
 
 	if ( getReportStatsError( endpoint, requestQuery ) ) {
-		return { ...response, isError: true };
+		return reportChartDataResponses.error;
 	}
 
 	if ( isReportDataEmpty( stats, endpoint ) ) {
-		return { ...response, isEmpty: true };
+		return reportChartDataResponses.empty;
 	}
 
 	const totals = ( stats && stats.data && stats.data.totals ) || null;
-	let intervals = ( stats && stats.data && stats.data.intervals ) || [];
+	let intervals =
+		( stats && stats.data && stats.data.intervals ) || EMPTY_ARRAY;
 
 	// If we have more than 100 results for this time period,
 	// we need to make additional requests to complete the response.
@@ -363,9 +404,9 @@ export function getReportChartData( options ) {
 		}
 
 		if ( isFetching ) {
-			return { ...response, isRequesting: true };
+			return reportChartDataResponses.requesting;
 		} else if ( isError ) {
-			return { ...response, isError: true };
+			return reportChartDataResponses.error;
 		}
 
 		forEach( pagedData, function ( _data ) {
@@ -379,7 +420,11 @@ export function getReportChartData( options ) {
 		} );
 	}
 
-	return { ...response, data: { totals, intervals } };
+	return getReportChartDataResponse(
+		getResourceName( endpoint, requestQuery ),
+		totals,
+		intervals
+	);
 }
 
 /**

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -330,7 +330,9 @@ const getReportChartDataResponse = memoize(
 		isError: false,
 		isRequesting: false,
 		data: { totals, intervals },
-	} )
+	} ),
+	( requestString, totals, intervals ) =>
+		[ requestString, totals.length, intervals.length ].join( ':' )
 );
 
 /**


### PR DESCRIPTION
This PR seeks to reduce the number of unnecessary re-renders in the Revenue Report and serve as an example for reducing renders in other reports.

It primarily focuses on reducing the number of objects that are equivalent (same data), but fail a strict equals (`===`) comparison because they are new instances/references.

Lodash's `memoize` was used because it was there. It should be easily replaced if we want to remove the dependency on Lodash.

In order to discover/diagnose props that were considered changing (but not changing equivalent values) I used the React DevTools Profile with the "record why" option: 
![Screen Shot 2020-12-30 at 9 37 37 AM](https://user-images.githubusercontent.com/63922/103367641-a0999600-4a93-11eb-98bd-80b94f63ef6f.png)

I noticed that props like `headers` and `summaryFields` were causing renders, but inspection/logging showed the logical values weren't changing. The exercise then was to stop the references from changing by returning the same object where possible. This required varying strategies of common object references (like `EMPTY_OBJECT`, as seen in Gutenberg) and memoization of selectors / data manipulation functions where possible.

Much, much more can be done here. I think the biggest opportunities are in memoizing our selectors where possible.

### Screenshots

Reduction in `ReportTable` renders, using React DevTools Profiler:

| Before | After |
| --- | --- |
| ![Screen Shot 2020-12-30 at 9 20 07 AM](https://user-images.githubusercontent.com/63922/103367130-4cda7d00-4a92-11eb-9e69-edae481ba506.png) | ![Screen Shot 2020-12-30 at 9 23 59 AM](https://user-images.githubusercontent.com/63922/103367144-5663e500-4a92-11eb-8c3b-9c3d153333b3.png) |
| | Scripting, Rendering, System, and blocking time are all down so I think this is an improvement |
| ![Screen Shot 2020-12-30 at 8 57 41 AM](https://user-images.githubusercontent.com/63922/103366104-b442fd80-4a8f-11eb-87b5-ded9f3167ed7.png) | ![Screen Shot 2020-12-30 at 9 07 56 AM](https://user-images.githubusercontent.com/63922/103366117-bd33cf00-4a8f-11eb-9329-deb424be1e3a.png) |
| 35 renders, 342.7 ms | 6 renders, 139.7 ms |

### Detailed test instructions:

- Ensure your test store has `WP_DEBUG` and `SCRIPT_DEBUG` on in `wp-config.php`
- Use `npm start` so you're using a development build of React (needed to support Profiling)
- Thoroughly test the Revenue Report (and another report of your choosing)
- Test changing date ranges, all report modes (single,comparison,advanced)
- Test comparison using checkboxes in the table
- Test table search
- Test table pagination
- Test table sorting

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
