### PR TITLE
Compile debug module and remove use of flat

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,15 +1,18 @@
-const { babelConfig: e2eBabelConfig } = require( '@woocommerce/e2e-environment' );
+const {
+	babelConfig: e2eBabelConfig,
+} = require( '@woocommerce/e2e-environment' );
 
-module.exports = function( api ) {
+module.exports = function ( api ) {
 	api.cache( true );
 
 	return {
-        ...e2eBabelConfig,
-        presets: [
-              ...e2eBabelConfig.presets,
-              '@wordpress/babel-preset-default',
-        ],
-        plugins: [
+		...e2eBabelConfig,
+		presets: [
+			...e2eBabelConfig.presets,
+			'@wordpress/babel-preset-default',
+		],
+		sourceType: 'unambiguous',
+		plugins: [
 			/**
 			 * This allows arrow functions as class methods so that binding
 			 * methods to `this` in the constructor isn't required.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ const webpackConfig = {
 			},
 			{
 				test: /\.js?$/,
-				exclude: /node_modules/,
+				exclude: /node_modules(\/|\\)(?!(debug))/,
 				use: {
 					loader: 'babel-loader',
 					options: {


### PR DESCRIPTION
Fixes #5968 

Compiles the debug module using babel and remove use of `.flat()` since IE11 does not support it.  Fixes WCA not loading in IE11.

### Screenshots
**Before**
<img width="724" alt="Screen Shot 2020-12-30 at 7 07 43 PM" src="https://user-images.githubusercontent.com/10561050/103387525-4f5cc700-4ad2-11eb-8ff9-7d0d25f43936.png">


**After**
<img width="1130" alt="Screen Shot 2020-12-30 at 7 05 03 PM" src="https://user-images.githubusercontent.com/10561050/103387489-1886b100-4ad2-11eb-9210-ecf336abd22b.png">

### Detailed test instructions:

1. Fire up IE11 🔥 
2. Smoke test WCA pages.
3. Make sure things load.
4. Check other browsers to make sure no regressions have occurred.