### PR TITLE
Remove visit count on track and only count uncompleted task visits

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -64,7 +64,6 @@ export class TaskDashboard extends Component {
 	};
 
 	onTaskSelect = ( taskName ) => {
-		const { trackedCompletedTasks } = this.props;
 		const trackStartedCount = this.getTaskStartedCount( taskName );
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -55,13 +55,23 @@ export class TaskDashboard extends Component {
 		} );
 	};
 
+	isTaskCompleted = ( taskName ) => {
+		const { trackedCompletedTasks } = this.props;
+		if ( ! trackedCompletedTasks ) {
+			return false;
+		}
+		return trackedCompletedTasks.includes( taskName );
+	};
+
 	onTaskSelect = ( taskName ) => {
+		const { trackedCompletedTasks } = this.props;
 		const trackStartedCount = this.getTaskStartedCount( taskName );
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,
-			visit_count: trackStartedCount + 1,
 		} );
-		this.updateTrackStartedCount( taskName, trackStartedCount + 1 );
+		if ( ! this.isTaskCompleted( taskName ) ) {
+			this.updateTrackStartedCount( taskName, trackStartedCount + 1 );
+		}
 	};
 
 	getAllTasks() {

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Remove visit_count from track, and update task count logic. #5996
 - Fix: Moved certified owner label for review to title. ##5877
 - Fix: Move collapsible config to panels object, to allow for more control. #5855
 - Enhancement: Show Help panel tooltip when user visits unfinished task more then once. #5826


### PR DESCRIPTION
Fixes #5082 

Small fix from the changes merged in https://github.com/woocommerce/woocommerce-admin/pull/5826, removing the visit_count as mentioned here: https://github.com/woocommerce/woocommerce-admin/pull/5826#issuecomment-749115364
Given we don't need the visit_count, I changed the logic to only increase if the task is uncompleted.

### Detailed test instructions:

- Test the help tooltip by following test instructions in the original PR: https://github.com/woocommerce/woocommerce-admin/pull/5826
- After completing a task open the redux devtools and look at the `core` State.
  - You can find the meta data under **root > currentUser > woocommerce_meta > task_list_tracked_started_tasks**
- Visit a completed task multiple times, the count in the meta field **should not** increase
- Visit a uncompleted task multiple times, the count in the meta field **should** increase

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
