### PR TITLE
Fix visual glitches on OBW when viewport is small

### DIFF
--- a/client/profile-wizard/steps/product-types/style.scss
+++ b/client/profile-wizard/steps/product-types/style.scss
@@ -67,3 +67,23 @@
 		}
 	}
 }
+
+@media screen and (max-width: 438px) {
+	.woocommerce-profile-wizard__body {
+		.woocommerce-profile-wizard__product-types {
+			.woocommerce-product-wizard__product-types-label {
+				width: min-content;
+			}
+		}
+	}
+}
+
+@media screen and (max-width: 375px) {
+	.woocommerce-profile-wizard__body {
+		.woocommerce-profile-wizard__product-types {
+			.woocommerce-pill {
+				white-space: nowrap;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5979 

This PR addresses visual glitches when the user's viewport is less than 438px and 375px (iPhone 6/7/8)

We still have visual glitches for devices with a viewport less than 354px. I think the ultimate solution would be reducing the overall font-size to adapt to the viewport size, but that requires more tests and discussions. I will open a new PR if we decide to go that route.

The changes in this PR fix the visual glitches for any major mobile phones, except for the iPhone 5 and SE (the first edition).

### Screenshots

Before:

![Screen Shot 2021-01-04 at 4 31 52 PM](https://user-images.githubusercontent.com/4723145/103593314-63297400-4eaa-11eb-9661-9e331e6f568d.jpg)

After:

![Screen Shot 2021-01-04 at 4 00 50 PM](https://user-images.githubusercontent.com/4723145/103593331-6ae91880-4eaa-11eb-87e1-2b111ae70bb8.jpg)



### Detailed test instructions:

1. Install WooCommerce and start OBW
2. Start OBW and continue to the Product Types 
3. Open your browser console and change the view mode to mobile
4. Test with pre-defined mobile devices.
5. Confirm the fix.