### PR TITLE
Remove unnecessary color override for the primary button

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -41,14 +41,8 @@
 
 body.woocommerce-page {
 	.components-button.is-primary {
-		color: $studio-white;
-
 		&:not(:disabled) {
-			&:hover,
-			&:active,
-			&:focus {
-				color: $studio-white;
-			}
+			color: $studio-white;
 		}
 	}
 


### PR DESCRIPTION
Fixes #5912 

This PR fixes text color for the disabled primary button.

### Screenshots

Before:
![Screen Shot 2021-01-04 at 5 18 26 PM](https://user-images.githubusercontent.com/4723145/103595798-39278000-4eb1-11eb-9734-d1bcb812c057.jpg)

After:
![Screen Shot 2021-01-04 at 5 18 11 PM](https://user-images.githubusercontent.com/4723145/103595804-3cbb0700-4eb1-11eb-8894-c4d7c1c954a6.jpg)


### Detailed test instructions:

1. Navigate to WooCommerce and start OBW
2. Confirm the "Continue" button has disabled look (Refer to the screenshot section)
3. Fill out the input values and confirm the "Continue" button is enabled. 

