### PR TITLE
Add feature toggle and extensibility

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -10,7 +10,7 @@
 		"marketing": true,
 		"minified-js": false,
 		"mobile-app-banner": true,
-		"navigation": true,
+		"navigation": false,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -43,11 +43,28 @@ class Init {
 	 * @return array
 	 */
 	public static function add_feature_toggle( $features ) {
+		$description  = __(
+			'Adds the new WooCommerce navigation experience to the dashboard',
+			'woocommerce-admin'
+		);
+		$update_text  = '';
+		$needs_update = version_compare( get_bloginfo( 'version' ), '5.6', '<' );
+		if ( $needs_update && current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+			$update_text = sprintf(
+				/* translators: 1: line break tag, 2: open link to WordPress update link, 3: close link tag. */
+				__( '%1$s %2$sUpdate WordPress to enable the new navigation%3$s', 'woocommerce-admin' ),
+				'<br/>',
+				'<a href="' . self_admin_url( 'update-core.php' ) . '" target="_blank">',
+				'</a>'
+			);
+		}
+
 		$features[] = array(
 			'title' => __( 'Navigation', 'woocommerce-admin' ),
-			'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
+			'desc'  => $description . $update_text,
 			'id'    => 'woocommerce_navigation_enabled',
 			'type'  => 'checkbox',
+			'class' => $needs_update ? 'disabled' : '',
 		);
 
 		return $features;

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -20,6 +20,7 @@ class Init {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
+		add_filter( 'woocommerce_settings_features', array( $this, 'add_feature_toggle' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
 		add_action( 'update_option_woocommerce_navigation_enabled', array( $this, 'reload_page_on_toggle' ), 10, 2 );
@@ -33,6 +34,23 @@ class Init {
 			CoreMenu::instance()->init();
 			Screen::instance()->init();
 		}
+	}
+
+	/**
+	 * Add the feature toggle to the features settings.
+	 *
+	 * @param array $features Feature sections.
+	 * @return array
+	 */
+	public static function add_feature_toggle( $features ) {
+		$features[] = array(
+			'title' => __( 'Navigation', 'woocommerce-admin' ),
+			'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
+			'id'    => 'woocommerce_navigation_enabled',
+			'type'  => 'checkbox',
+		);
+
+		return $features;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -263,24 +263,16 @@ class Loader {
 			return $settings;
 		}
 
-		$description  = __(
-			'Adds the new WooCommerce navigation experience to the dashboard',
-			'woocommerce-admin'
+		$features = apply_filters(
+			'woocommerce_settings_features',
+			array()
 		);
-		$update_text  = '';
-		$needs_update = version_compare( get_bloginfo( 'version' ), '5.6', '<' );
-		if ( $needs_update && current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-			$update_text = sprintf(
-				/* translators: 1: line break tag, 2: open link to WordPress update link, 3: close link tag. */
-				__( '%1$s %2$sUpdate WordPress to enable the new navigation%3$s', 'woocommerce-admin' ),
-				'<br/>',
-				'<a href="' . self_admin_url( 'update-core.php' ) . '" target="_blank">',
-				'</a>'
-			);
+
+		if ( empty( $features ) ) {
+			return $settings;
 		}
 
-		return apply_filters(
-			'woocommerce_settings_features',
+		return array_merge(
 			array(
 				array(
 					'title' => __( 'Features', 'woocommerce-admin' ),
@@ -288,13 +280,9 @@ class Loader {
 					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
 					'id'    => 'features_options',
 				),
-				array(
-					'title' => __( 'Navigation', 'woocommerce-admin' ),
-					'desc'  => $description . $update_text,
-					'id'    => 'woocommerce_navigation_enabled',
-					'type'  => 'checkbox',
-					'class' => $needs_update ? 'disabled' : '',
-				),
+			),
+			$features,
+			array(
 				array(
 					'type' => 'sectionend',
 					'id'   => 'features_options',

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -247,6 +247,15 @@ class Loader {
 	 * @return array
 	 */
 	public static function add_features_section( $sections ) {
+		$features = apply_filters(
+			'woocommerce_settings_features',
+			array()
+		);
+
+		if ( empty( $features ) ) {
+			return $sections;
+		}
+
 		$sections['features'] = __( 'Features', 'woocommerce-admin' );
 		return $sections;
 	}


### PR DESCRIPTION
Adds the ability to extend the features list from within features.

Also turns off the nav feature in core. /cc @psealock to verify that this is correct.

### Screenshots

<img width="779" alt="Screen Shot 2021-01-05 at 5 31 24 PM" src="https://user-images.githubusercontent.com/10561050/103707091-06968980-4f7c-11eb-8a97-53b3464d1b56.png">

### Detailed test instructions:

1. Run the dev version of WCA.
2. Make sure you can see the features section and navigation toggle at `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Build a test plugin version from this branch.
4. Make sure that the nav toggle can be seen.
5. Build the core version of this branch.
6. Make sure the feature section does not exist.