### PR TITLE
Add new note for the first product and payment setup insight

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
+use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
 use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
 use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
@@ -115,6 +116,7 @@ class Events {
 		NavigationFeedback::possibly_add_note();
 		NavigationFeedbackFollowUp::possibly_add_note();
 		FilterByProductVariationsInReports::possibly_add_note();
+		InsightFirstProductAndPayment::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -192,7 +192,6 @@ class FeaturePlugin {
 		new SetUpAdditionalPaymentTypes();
 		new TestCheckout();
 		new SellingOnlineCourses();
-		new InsightFirstProductAndPayment();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\OrderMilestones;
 use \Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes;
@@ -191,6 +192,7 @@ class FeaturePlugin {
 		new SetUpAdditionalPaymentTypes();
 		new TestCheckout();
 		new SellingOnlineCourses();
+		new InsightFirstProductAndPayment();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/InsightFirstProductAndPayment.php
+++ b/src/Notes/InsightFirstProductAndPayment.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * WooCommerce Admin: Insight - First product and payment setup
+ *
+ * Adds a note to give insight about the first product and payment setup
+ *
+ * @package WooCommerce\Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insight_First_Sale.
+ */
+class InsightFirstProductAndPayment {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-insight-first-product-and-payment';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		// We want to show the note after 1 day.
+		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Insight', 'woocommerce-admin' ) );
+		$note->set_content( __( 'More than 80% of new merchants add the first product and have at least one payment method set up during the first week. We\'re here to help your business succeed! Do you find this type of insight useful?', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_SURVEY );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'affirm-insight-first-product-and-payment',
+			__( 'Yes', 'woocommerce-admin' ),
+			false,
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
+			__( 'Thanks for your feedback', 'woocommerce-admin' )
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5937 

This PR adds a new note about the first product and payment setup.

### Screenshots

![Screen Shot 2021-01-05 at 5 59 43 PM](https://user-images.githubusercontent.com/4723145/103720670-b968e680-4f80-11eb-991b-c52963389985.jpg)


### Detailed test instructions:

1. Navigate to WordPress -> Plugins
2. Deactivate WooCommerce Admin and activate it again
3. Open `wp_wc_admin_notes` table and confirm a new note with name `wc-admin-insight-first-product-and-payment`
4. Navigate to WooCommerce -> Home and confirm that you have a new note with the title `Insight` (refer to the screenshot)
