### PR TITLE
Add a new note when the store is 3+ days old and product count is 0

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\AddingAndManangingProducts;
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
@@ -117,6 +118,7 @@ class Events {
 		FilterByProductVariationsInReports::possibly_add_note();
 		ChoosingTheme::possibly_add_note();
 		InsightFirstProductAndPayment::possibly_add_note();
+		AddingAndManangingProducts::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/AddingAndManangingProducts.php
+++ b/src/Notes/AddingAndManangingProducts.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WooCommerce Admin adding and managing products note provider
+ *
+ * Adds a note with a link to the manging products doc if store has been active > 3 days and
+ * product count is 0
+ *
+ * @package WooCommerce\Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AddingAndManangingProducts
+ *
+ * @package Automattic\WooCommerce\Admin\Notes
+ */
+class AddingAndManangingProducts {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-adding-and-managing-products';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		// Store must have been at least 3 days.
+		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS * 3 ) ) {
+			return;
+		}
+
+		// Total # of products must be 0.
+		$query = new \WC_Product_Query(
+			array(
+				'limit'    => 1,
+				'paginate' => true,
+				'return'   => 'ids',
+				'status'   => array( 'publish' ),
+			)
+		);
+
+		$products = $query->get_products();
+		if ( 0 !== $products->total ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Adding and Managing Products', 'woocommerce-admin' ) );
+		$note->set_content(
+			__(
+				'Learn more about how to set up products in WooCommerce through our useful documentation about adding and managing products.',
+				'woocommerce-admin'
+			)
+		);
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://docs.woocommerce.com/document/managing-products/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5935 

This PR adds a new note with a link to the managing products doc when the store has been active for 3+ days and the product count is 0.

### Screenshots
![Screen Shot 2021-01-05 at 9 28 40 PM](https://user-images.githubusercontent.com/4723145/103732780-0064d500-4f9d-11eb-8a3a-9cefda21bb73.jpg)

### Detailed test instructions:

Make sure your store is 3+ days old by updating `woocommerce_admin_install_timestamp` option in `wp_options` table.

You can use this value `1608598121` (12/22/20)

1. Remove all products from WooCommerce -> Products
2. Install & activate "WP Crontrol" plugin
3. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
4. Navigate to WooCommerce -> Home and confirm a new note with the title "Adding and Managing Products"

