### PR TITLE
Add a new note about the variable product when the owner adds the fir…

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -12,6 +12,7 @@ use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
+use \Automattic\WooCommerce\Admin\Notes\LearnMoreAboutVariableProducts;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
 use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
 use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
@@ -117,6 +118,7 @@ class Events {
 		FilterByProductVariationsInReports::possibly_add_note();
 		ChoosingTheme::possibly_add_note();
 		InsightFirstProductAndPayment::possibly_add_note();
+		LearnMoreAboutVariableProducts::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Events.php
+++ b/src/Events.php
@@ -12,7 +12,6 @@ use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
-use \Automattic\WooCommerce\Admin\Notes\LearnMoreAboutVariableProducts;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
 use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
 use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
@@ -118,7 +117,6 @@ class Events {
 		FilterByProductVariationsInReports::possibly_add_note();
 		ChoosingTheme::possibly_add_note();
 		InsightFirstProductAndPayment::possibly_add_note();
-		LearnMoreAboutVariableProducts::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -7,8 +7,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
-use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
+use \Automattic\WooCommerce\Admin\Notes\LearnMoreAboutVariableProducts;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\OrderMilestones;
 use \Automattic\WooCommerce\Admin\Notes\WooSubscriptionsNotes;
@@ -16,7 +15,6 @@ use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
 use \Automattic\WooCommerce\Admin\Notes\WooCommercePayments;
 use \Automattic\WooCommerce\Admin\Notes\InstallJPAndWCSPlugins;
 use \Automattic\WooCommerce\Admin\Notes\DrawAttention;
-use \Automattic\WooCommerce\Admin\Notes\CouponPageMoved;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
 use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
 use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
@@ -191,6 +189,7 @@ class FeaturePlugin {
 		new SetUpAdditionalPaymentTypes();
 		new TestCheckout();
 		new SellingOnlineCourses();
+		new LearnMoreAboutVariableProducts();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/LearnMoreAboutVariableProducts.php
+++ b/src/Notes/LearnMoreAboutVariableProducts.php
@@ -28,27 +28,35 @@ class LearnMoreAboutVariableProducts {
 	const NOTE_NAME = 'wc-admin-learn-more-about-variable-products';
 
 	/**
+	 * Add save_post action.
+	 *
+	 * LearnMoreAboutVariableProducts constructor.
+	 */
+	public function __construct() {
+		add_action( 'save_post', array( $this, 'maybe_add_new_note' ), 10, 3 );
+	}
+
+	/**
+	 * Maybe attempt to add a new note if product is published
+	 *
+	 * @param int    $post_id post id.
+	 * @param object $post WordPress post object.
+	 * @param bool   $update true if post is being updated.
+	 */
+	public function maybe_add_new_note( $post_id, $post, $update ) {
+		if ( 'publish' !== $post->post_status || 'product' !== $post->post_type || $update ) {
+			return;
+		}
+
+		static::possibly_add_note();
+	}
+
+	/**
 	 * Get the note.
 	 *
 	 * @return Note|null
 	 */
 	public static function get_note() {
-
-		$query = new \WC_Product_Query(
-			array(
-				'limit'    => 1,
-				'paginate' => true,
-				'return'   => 'ids',
-				'status'   => array( 'publish' ),
-			)
-		);
-
-		// The store must have at least one product.
-		$products = $query->get_products();
-		if ( 0 === $products->total ) {
-			return;
-		}
-
 		$note = new Note();
 		$note->set_title( __( 'Learn more about variable products', 'woocommerce-admin' ) );
 		$note->set_content(

--- a/src/Notes/LearnMoreAboutVariableProducts.php
+++ b/src/Notes/LearnMoreAboutVariableProducts.php
@@ -41,14 +41,9 @@ class LearnMoreAboutVariableProducts {
 	 *
 	 * @param int    $post_id post id.
 	 * @param object $post WordPress post object.
-	 * @param bool   $update true if post is being updated.
 	 */
-	public function maybe_add_new_note( $post_id, $post, $update ) {
-		if ( 'publish' !== $post->post_status || 'product' !== $post->post_type || $update ) {
-			return;
-		}
-
-		static::possibly_add_note();
+	public function maybe_add_new_note( $post_id, $post ) {
+		'publish' === $post->post_status && 'product' === $post->post_type && static::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/LearnMoreAboutVariableProducts.php
+++ b/src/Notes/LearnMoreAboutVariableProducts.php
@@ -28,22 +28,30 @@ class LearnMoreAboutVariableProducts {
 	const NOTE_NAME = 'wc-admin-learn-more-about-variable-products';
 
 	/**
-	 * Add save_post action.
+	 * Add transition_post_status action.
 	 *
 	 * LearnMoreAboutVariableProducts constructor.
 	 */
 	public function __construct() {
-		add_action( 'save_post', array( $this, 'maybe_add_new_note' ), 10, 3 );
+		add_action( 'transition_post_status', array( $this, 'maybe_add_new_note' ), 10, 3 );
 	}
 
 	/**
-	 * Maybe attempt to add a new note if product is published
+	 * Maybe attempt to add a new note if product is published.
 	 *
-	 * @param int    $post_id post id.
-	 * @param object $post WordPress post object.
+	 * @param string $new_status new status.
+	 * @param string $old_status old status.
+	 * @param object $post post object.
 	 */
-	public function maybe_add_new_note( $post_id, $post ) {
-		'publish' === $post->post_status && 'product' === $post->post_type && static::possibly_add_note();
+	public function maybe_add_new_note( $new_status, $old_status, $post ) {
+		if ( 'publish' === $new_status && 'publish' !== $old_status && 'product' === $post->post_type ) {
+			$product = wc_get_product( $post->ID );
+			if ( ! $product ) {
+				return;
+			}
+
+			$product->is_type( 'simple' ) && static::possibly_add_note();
+		}
 	}
 
 	/**

--- a/src/Notes/LearnMoreAboutVariableProducts.php
+++ b/src/Notes/LearnMoreAboutVariableProducts.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * WooCommerce Admin learn more about variable products note provider
+ *
+ * Adds a note when the store owner adds the first product.
+ *
+ * @package WooCommerce\Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AddingAndManangingProducts
+ *
+ * @package Automattic\WooCommerce\Admin\Notes
+ */
+class LearnMoreAboutVariableProducts {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-learn-more-about-variable-products';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+
+		$query = new \WC_Product_Query(
+			array(
+				'limit'    => 1,
+				'paginate' => true,
+				'return'   => 'ids',
+				'status'   => array( 'publish' ),
+			)
+		);
+
+		// The store must have at least one product.
+		$products = $query->get_products();
+		if ( 0 === $products->total ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Learn more about variable products', 'woocommerce-admin' ) );
+		$note->set_content(
+			__(
+				'Variable products are a powerful product type that lets you offer a set of variations on a product, with control over prices, stock, image and more for each variation. They can be used for a product like a shirt, where you can offer a large, medium and small and in different colors.',
+				'woocommerce-admin'
+			)
+		);
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://docs.woocommerce.com/document/variable-product/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}

--- a/tests/notes/class-wc-tests-learn-more-about-variable-product.php
+++ b/tests/notes/class-wc-tests-learn-more-about-variable-product.php
@@ -14,11 +14,19 @@ use \Automattic\WooCommerce\Admin\Notes\Notes;
 class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
 
 	/**
+	 * Reset the notes table for each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		global $wpdb;
+
+		$wpdb->query( "delete from {$wpdb->prefix}wc_admin_notes" );
+	}
+
+	/**
 	 * Tests LearnMoreAboutVariableProducts gets created when a products gets published
 	 */
 	public function test_adding_note_when_product_gets_published() {
-		Notes::delete_all_notes();
-
 		// Given a new product.
 		$product = array(
 			'post_title'   => 'a product',
@@ -53,12 +61,12 @@ class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
 	 * @param string $product product from provider.
 	 */
 	public function test_adding_draft_product_and_non_product_post_does_not_add_note( $product ) {
-		Notes::delete_all_notes();
 		wp_insert_post( $product );
 
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( LearnMoreAboutVariableProducts::NOTE_NAME );
-		$this->assertEmpty( $note_ids );
+		$note_count = count( $note_ids );
+		$this->assertEmpty( $note_ids, "{$note_count} notes found." );
 	}
 
 	/**

--- a/tests/notes/class-wc-tests-learn-more-about-variable-product.php
+++ b/tests/notes/class-wc-tests-learn-more-about-variable-product.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * LearnMoreAboutVariableProducts note tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use Automattic\WooCommerce\Admin\Notes\LearnMoreAboutVariableProducts;
+use \Automattic\WooCommerce\Admin\Notes\Notes;
+
+/**
+ * Class WC_Tests_Marketing_Notes
+ */
+class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests LearnMoreAboutVariableProducts gets created when a products gets published
+	 */
+	public function test_adding_note_when_product_gets_published() {
+		// Given a new product.
+		$product = array(
+			'post_title'   => 'a product',
+			'post_type'    => 'product',
+			'post_status'  => 'publish',
+			'post_content' => '',
+		);
+
+		// When it is published.
+		wp_insert_post( $product );
+
+		// Then we should have LearnMoreAboutVariableProducts note.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( LearnMoreAboutVariableProducts::NOTE_NAME );
+		$this->assertNotEmpty( $note_ids );
+		$this->assertCount( 1, $note_ids );
+
+		$note = Notes::get_note( $note_ids[0] );
+		$this->assertEquals( $note->get_name(), LearnMoreAboutVariableProducts::NOTE_NAME );
+
+		// Adding a second product does not create an additional note.
+		wp_insert_post( $product );
+		$note_ids = $data_store->get_notes_with_name( LearnMoreAboutVariableProducts::NOTE_NAME );
+		$this->assertNotEmpty( $note_ids );
+		$this->assertCount( 1, $note_ids );
+	}
+}

--- a/tests/notes/class-wc-tests-learn-more-about-variable-product.php
+++ b/tests/notes/class-wc-tests-learn-more-about-variable-product.php
@@ -43,4 +43,40 @@ class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
 		$this->assertNotEmpty( $note_ids );
 		$this->assertCount( 1, $note_ids );
 	}
+
+
+	/**
+	 * @dataProvider postProvider
+	 *
+	 * @param string $product product from provider.
+	 */
+	public function test_adding_draft_product_and_non_product_post_does_not_add_note( $product ) {
+		wp_insert_post( $product );
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( LearnMoreAboutVariableProducts::NOTE_NAME );
+		$this->assertEmpty( $note_ids );
+	}
+
+	/**
+	 * Post provider for draft product and non-product post type
+	 *
+	 * @return array a set of posts.
+	 */
+	public function postProvider() {
+		return array(
+			array(
+				'post_title'   => 'a product',
+				'post_type'    => 'not a product',
+				'post_status'  => 'publish',
+				'post_content' => '',
+			),
+			array(
+				'post_title'   => 'a product',
+				'post_type'    => 'product',
+				'post_status'  => 'draft',
+				'post_content' => '',
+			),
+		);
+	}
 }

--- a/tests/notes/class-wc-tests-learn-more-about-variable-product.php
+++ b/tests/notes/class-wc-tests-learn-more-about-variable-product.php
@@ -17,6 +17,8 @@ class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
 	 * Tests LearnMoreAboutVariableProducts gets created when a products gets published
 	 */
 	public function test_adding_note_when_product_gets_published() {
+		Notes::delete_all_notes();
+
 		// Given a new product.
 		$product = array(
 			'post_title'   => 'a product',
@@ -51,6 +53,7 @@ class WC_Tests_Learn_More_About_Variable_Product extends WC_Unit_Test_Case {
 	 * @param string $product product from provider.
 	 */
 	public function test_adding_draft_product_and_non_product_post_does_not_add_note( $product ) {
+		Notes::delete_all_notes();
 		wp_insert_post( $product );
 
 		$data_store = \WC_Data_Store::load( 'admin-note' );


### PR DESCRIPTION
Fixes #5934 

This PR adds a note with a link to the variable product documentation when the store owner adds his/her first product.

### Screenshots

![Screen Shot 2021-01-06 at 2 37 17 PM](https://user-images.githubusercontent.com/4723145/103827051-f1c5fe80-502c-11eb-9fdd-46dee0a271c5.jpg)


### Detailed test instructions:

1. Add a new product if you don't have any yet.
2. Install & activate "WP Crontrol" plugin
3. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
4. Navigate to WooCommerce -> Home and confirm a new note with the title "Learn more about variable products" 