### PR TITLE
Display the task components regardless of woocommerce_task_list_hidde…

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -55,7 +55,7 @@ export const Layout = ( {
 	const [ showInbox, setShowInbox ] = useState( true );
 
 	const isTaskListEnabled = taskListHidden === false;
-	const isDashboardShown = ! isTaskListEnabled || ! query.task;
+	const isDashboardShown = ! query.task;
 
 	if ( isBatchUpdating && ! showInbox ) {
 		setShowInbox( true );
@@ -124,9 +124,7 @@ export const Layout = ( {
 				'two-columns': twoColumns,
 			} ) }
 		>
-			{ isDashboardShown
-				? renderColumns()
-				: isTaskListEnabled && renderTaskList() }
+			{ isDashboardShown ? renderColumns() : renderTaskList() }
 			{ shouldShowWelcomeModal && (
 				<WelcomeModal
 					onClose={ () => {

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -116,7 +116,6 @@ export class TaskDashboard extends Component {
 			dismissedTasks,
 			isExtendedTaskListComplete,
 			isExtendedTaskListHidden,
-			isSetupTaskListHidden,
 			isTaskListComplete,
 			query,
 			trackedCompletedTasks,
@@ -127,7 +126,7 @@ export class TaskDashboard extends Component {
 
 		return (
 			<>
-				{ setupTasks && ! isSetupTaskListHidden && (
+				{ setupTasks && (
 					<TaskList
 						dismissedTasks={ dismissedTasks || [] }
 						isTaskListComplete={ isTaskListComplete }


### PR DESCRIPTION
Fixes #6023 

This PR disregards `woocommerce_task_list_hidden` value when a task component is requested by appending &task={task name}.

As [noted](https://github.com/woocommerce/woocommerce-admin/issues/6023#issuecomment-756365282) by Timmy in the original issue, this is probably going to be a temporary fix.


### Detailed test instructions:

1. Navigate to WooCommerce -> Home
2. Hide the "Finish setup" panel.
![Screen Shot 2021-01-07 at 1 40 39 PMth_](https://user-images.githubusercontent.com/4723145/103948041-f7374d80-50ed-11eb-9150-5ab567d9edb0.jpg)

3. Confirm you can still access `http://{Your WP URL}/wp-admin/admin.php?page=wc-admin&task=payments`