### PR TITLE
Add note for users coming from Calypso

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Welcome modal when coming from Calypso #6004
 - Enhancement: Add an a/b experiment for installing free business features #5786
 - Dev: Add `onChangeCallback` feature to the wc-admin <Form> component #5786 
+- Add: Note for users coming from Calypso. #6030
 
 == Changelog ==
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -21,6 +21,7 @@ use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificati
 use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
 use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
 use \Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses;
+use \Automattic\WooCommerce\Admin\Notes\WelcomeToWooCommerceForStoreUsers;
 
 /**
  * Feature plugin main class.
@@ -191,6 +192,7 @@ class FeaturePlugin {
 		new SetUpAdditionalPaymentTypes();
 		new TestCheckout();
 		new SellingOnlineCourses();
+		new WelcomeToWooCommerceForStoreUsers();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Notes/WelcomeToWooCommerceForStoreUsers.php
+++ b/src/Notes/WelcomeToWooCommerceForStoreUsers.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * WooCommerce Admin: Welcome to WooCommerce for store users.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Welcome to WooCommerce for store users.
+ */
+class WelcomeToWooCommerceForStoreUsers {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-welcome-to-woocommerce-for-store-users';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'possibly_add_note' ) );
+	}
+
+	/**
+	 * See if a mu plugin is installed.
+	 *
+	 * @param string $plugin_name The name of the mu plugin to check for.
+	 *
+	 * @return bool
+	 */
+	private static function is_mu_plugin_installed( $plugin_name ) {
+		$plugins = get_mu_plugins();
+
+		return isset( $plugins[ $plugin_name ] );
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		// Only add if coming from Calypso.
+		if ( ! isset( $_GET['from-calypso'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		// Only add if the WP.com Site Helper is installed.
+		if ( ! self::is_mu_plugin_installed( 'wpcomsh-loader.php' ) ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Welcome to your new store management experience', 'woocommerce-admin' ) );
+		$note->set_content( __( "We've designed your navigation and home screen to help you focus on the things that matter most in managing your online store.", 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://wordpress.com/support/store/"',
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/WelcomeToWooCommerceForStoreUsers.php
+++ b/src/Notes/WelcomeToWooCommerceForStoreUsers.php
@@ -29,19 +29,6 @@ class WelcomeToWooCommerceForStoreUsers {
 	}
 
 	/**
-	 * See if a mu plugin is installed.
-	 *
-	 * @param string $plugin_name The name of the mu plugin to check for.
-	 *
-	 * @return bool
-	 */
-	private static function is_mu_plugin_installed( $plugin_name ) {
-		$plugins = get_mu_plugins();
-
-		return isset( $plugins[ $plugin_name ] );
-	}
-
-	/**
 	 * Get the note.
 	 *
 	 * @return Note|null
@@ -49,11 +36,6 @@ class WelcomeToWooCommerceForStoreUsers {
 	public static function get_note() {
 		// Only add if coming from Calypso.
 		if ( ! isset( $_GET['from-calypso'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return;
-		}
-
-		// Only add if the WP.com Site Helper is installed.
-		if ( ! self::is_mu_plugin_installed( 'wpcomsh-loader.php' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #6008

This possibly creates a new note on page load if the user is coming from Calypso.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/103984338-a5b4be80-51d2-11eb-8783-289b5df10223.png)

### Detailed test instructions:

1. Refresh the WooCommerce dashboard. The new note should not appear.
2. Add `?from-calypso` to the URL. The new note should now be present.