### PR TITLE
Add a new note a day after adding the first product

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -142,11 +142,6 @@ class Events {
 		AddFirstProduct::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
 		CustomizingProductCatalog::possibly_add_note();
-
-		if ( $this->is_remote_inbox_notifications_enabled() ) {
-			DataSourcePoller::read_specs_from_data_sources();
-			RemoteInboxNotificationsEngine::run();
-		}
 	}
 
 	/**

--- a/src/Events.php
+++ b/src/Events.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\Notes\AddingAndManangingProducts;
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
+use \Automattic\WooCommerce\Admin\Notes\CustomizingProductCatalog;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
@@ -140,6 +141,12 @@ class Events {
 		InsightFirstProductAndPayment::possibly_add_note();
 		AddFirstProduct::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
+		CustomizingProductCatalog::possibly_add_note();
+
+		if ( $this->is_remote_inbox_notifications_enabled() ) {
+			DataSourcePoller::read_specs_from_data_sources();
+			RemoteInboxNotificationsEngine::run();
+		}
 	}
 
 	/**

--- a/src/Notes/CustomizingProductCatalog.php
+++ b/src/Notes/CustomizingProductCatalog.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WooCommerce Admin: How to customize your product catalog note provider
+ *
+ * Adds a note with a link to the customizer a day after adding the first product
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CustomizingProductCatalog
+ *
+ * @package Automattic\WooCommerce\Admin\Notes
+ */
+class CustomizingProductCatalog {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-customizing-product-catalog';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$query    = new \WC_Product_Query(
+			array(
+				'limit'    => 1,
+				'paginate' => true,
+				'status'   => array( 'publish' ),
+				'orderby'  => 'post_date',
+				'order'    => 'DESC',
+			)
+		);
+		$products = $query->get_products();
+
+		// we need at least 1 product.
+		if ( 0 === $products->total ) {
+			return;
+		}
+
+		$product           = $products->products[0];
+		$created_timestamp = $product->get_date_created()->getTimestamp();
+		$is_a_day_old      = ( time() - $created_timestamp ) > DAY_IN_SECONDS;
+		// the product must be at least 1 day old.
+		if ( ! $is_a_day_old ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'How to customize your product catalog', 'woocommerce-admin' ) );
+		$note->set_content( __( 'You want your product catalog and images to look great and align with your brand. This guide will give you all the tips you need to get your products looking great in your store.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'day-after-first-product',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/CustomizingProductCatalog.php
+++ b/src/Notes/CustomizingProductCatalog.php
@@ -31,7 +31,7 @@ class CustomizingProductCatalog {
 	 * @return Note
 	 */
 	public static function get_note() {
-		$query    = new \WC_Product_Query(
+		$query = new \WC_Product_Query(
 			array(
 				'limit'    => 1,
 				'paginate' => true,
@@ -40,6 +40,7 @@ class CustomizingProductCatalog {
 				'order'    => 'DESC',
 			)
 		);
+
 		$products = $query->get_products();
 
 		// we need at least 1 product.
@@ -49,9 +50,15 @@ class CustomizingProductCatalog {
 
 		$product           = $products->products[0];
 		$created_timestamp = $product->get_date_created()->getTimestamp();
-		$is_a_day_old      = ( time() - $created_timestamp ) > DAY_IN_SECONDS;
+		$is_a_day_old      = ( time() - $created_timestamp ) >= DAY_IN_SECONDS;
+
 		// the product must be at least 1 day old.
 		if ( ! $is_a_day_old ) {
+			return;
+		}
+
+		// store must not been active more than 14 days.
+		if ( self::wc_admin_active_for( DAY_IN_SECONDS * 14 ) ) {
 			return;
 		}
 

--- a/tests/notes/class-wc-tests-customizing-product-catalog.php
+++ b/tests/notes/class-wc-tests-customizing-product-catalog.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * CustomizingProductCatalog note tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Admin\Notes\CustomizingProductCatalog;
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+
+/**
+ * Class WC_Tests_Marketing_Notes
+ */
+class WC_Tests_Customizing_Product_Catalog extends WC_Unit_Test_Case {
+
+	/**
+	 * @var CustomizingProductCatalog
+	 */
+	private $instance;
+
+	/**
+	 * setUp
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->empty_posts();
+		$this->instance = new CustomizingProductCatalog();
+	}
+
+	/**
+	 * Empty wp_posts table
+	 */
+	private function empty_posts() {
+		global $wpdb;
+		$wpdb->query( "delete from {$wpdb->prefix}posts" );
+	}
+
+	/**
+	 * Given 0 products
+	 * When get_note() is called
+	 * Then it should return null
+	 */
+	public function test_it_does_not_add_note_if_product_count_is_zero() {
+		// Given -- setUp() takes care of it.
+		// When.
+		$note = $this->instance->get_note();
+
+		// Then.
+		$this->assertNull( $note );
+	}
+
+	/**
+	 * Given a fresh product
+	 * When get_note() is called
+	 * Then it should return null
+	 */
+	public function test_it_does_not_add_note_if_prouduct_is_less_than_a_day_old() {
+		// Given.
+		wp_insert_post(
+			array(
+				'post_title'   => 'a product',
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_content' => '',
+			)
+		);
+
+		// When.
+		$note = $this->instance->get_note();
+
+		// Then.
+		$this->assertNull( $note );
+	}
+
+	/**
+	 * Given a store that has been active for 14+ days
+	 * When get_note() is called
+	 * Then it should return null
+	 */
+	public function test_it_does_not_add_note_if_store_has_been_active_for_14_days_or_more() {
+		// Given.
+		update_option( 'woocommerce_admin_install_timestamp', time() - ( DAY_IN_SECONDS * 14 ) );
+		wp_insert_post(
+			array(
+				'post_title'   => 'a product',
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_content' => '',
+			)
+		);
+
+		// When.
+		$note = $this->instance->get_note();
+
+		// Then.
+		$this->assertNull( $note );
+	}
+
+	/**
+	 * Given a store that has been active for less than 14 days
+	 * and a product that is older than day
+	 *
+	 * When get_note() is called
+	 * Then it should return an instance of Note
+	 */
+	public function test_it_adds_note() {
+		// Given.
+		update_option( 'woocommerce_admin_install_timestamp', time() - ( DAY_IN_SECONDS * 13 ) );
+		$day_before = gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS );
+		$product    = new \WC_Product();
+		$product->set_props(
+			array(
+				'name' => 'test',
+			)
+		);
+		$product_id = $product->save();
+		wp_update_post(
+			array(
+				'ID'            => $product_id,
+				'post_date'     => $day_before,
+				'post_date_gmt' => get_gmt_from_date( $day_before ),
+			)
+		);
+
+		// When.
+		$note = $this->instance->get_note();
+		// Then.
+		$this->assertInstanceOf( Note::class, $note );
+	}
+}


### PR DESCRIPTION
Fixes #5956 

This PR adds a new note with a link to the customizer doc a day after adding the first product.

### Screenshots

![Screen Shot 2021-01-08 at 10 15 42 AM](https://user-images.githubusercontent.com/4723145/104049893-974ab080-519a-11eb-83de-16ad52be8081.jpg)

### Detailed test instructions:

Make sure your store is less than 14 days old. If it has been active for more than 14 days, run the following query.

```update wp_options set option_value = UNIX_TIMESTAMP() where option_name='woocommerce_admin_install_timestamp'```

1. Start with a fresh installation of WooCommerce or delete all published products.
2. Add a new product.
3. Open `wc_posts` and find the product you just added in step #2. Update the `post_date` and `post_date_gmt` to the past date (at least -1 day)
2. Install & activate "WP Crontrol" plugin
3. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
4. Navigate to WooCommerce -> Home and confirm a new note with the title "How to customize your product catalog"