### PR TITLE
Add a note with a link to the first things to customize doc

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\Notes\AddingAndManangingProducts;
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
+use \Automattic\WooCommerce\Admin\Notes\FirstFiveThingsToCustomize;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
@@ -121,6 +122,7 @@ class Events {
 		ChoosingTheme::possibly_add_note();
 		InsightFirstProductAndPayment::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
+		FirstFiveThingsToCustomize::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/FirstFiveThingsToCustomize.php
+++ b/src/Notes/FirstFiveThingsToCustomize.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin: The first 5 things to customize in your store note provider
+ *
+ * Adds a note with a link to first things to customize doc
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class FirstFiveThingsToCustomize
+ *
+ * @package Automattic\WooCommerce\Admin\Notes
+ */
+class FirstFiveThingsToCustomize {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-first-five-things-to-customize';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		// We want to show the note after 2 days.
+		if ( ! self::wc_admin_active_for( 2 * DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		$completed_task_list = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
+
+		// skip if the user has finished at least one task.
+		if ( 0 !== count( $completed_task_list ) ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'The first 5 things to customize in your store', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Deciding what to start with first is tricky. To help you properly prioritize, we’ve put together this short list of the first few things you should customize in WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'first-five-things-to-customize',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/first-things-customize-woocommerce/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5958 

This PR adds a new note with a link to the first things to customize doc when the user hasn't finished any task after 2 days of installing the plugin.

### Screenshots

![Screen Shot 2021-01-08 at 10 33 37 AM](https://user-images.githubusercontent.com/4723145/104051605-3ec8e280-519d-11eb-93af-3b450c482bb2.jpg)


### Detailed test instructions:

1. Make sure your store is at least 2+ days old. If you just installed WooCommerce, update `woocommerce_admin_install_timestamp` value in `wp_options` table. You can set the value to `1608598121`.

```
update wp_options set option_value = 1608598121 where option_name = 'woocommerce_admin_install_timestamp'
```

2. Make sure you don't have `woocommerce_task_list_tracked_completed_tasks` in `wp_options` table. 
3. Install & activate "WP Crontrol" plugin
4. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
5. Navigate to WooCommerce -> Home and confirm a new note with the title "The first 5 things to customize in your store"
