### PR TITLE
Add a note with a link to the optimizing WC checkout flow

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -15,6 +15,7 @@ use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
 use \Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
+use \Automattic\WooCommerce\Admin\Notes\OptimizingCheckoutFlow;
 use \Automattic\WooCommerce\Admin\Notes\TrackingOptIn;
 use \Automattic\WooCommerce\Admin\Notes\OnboardingEmailMarketing;
 use \Automattic\WooCommerce\Admin\Notes\OnboardingPayments;
@@ -140,6 +141,12 @@ class Events {
 		InsightFirstProductAndPayment::possibly_add_note();
 		AddFirstProduct::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
+		OptimizingCheckoutFlow::possibly_add_note();
+
+		if ( $this->is_remote_inbox_notifications_enabled() ) {
+			DataSourcePoller::read_specs_from_data_sources();
+			RemoteInboxNotificationsEngine::run();
+		}
 	}
 
 	/**

--- a/src/Notes/OptimizingCheckoutFlow.php
+++ b/src/Notes/OptimizingCheckoutFlow.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin: Optimizing the checkout flow note provider
+ *
+ * Adds a note with a link to optimizing checkout flow doc
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class OptimizingCheckoutFlow
+ *
+ * @package Automattic\WooCommerce\Admin\Notes
+ */
+class OptimizingCheckoutFlow {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-optimizing-the-checkout-flow';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		// We want to show the note after 3 days.
+		if ( ! self::wc_admin_active_for( 3 * DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		$completed_task_list = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
+
+		// 'payments' must have been completed
+		if ( ! in_array( 'payments', $completed_task_list, true ) ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Optimizing the checkout flow', 'woocommerce-admin' ) );
+		$note->set_content( __( 'It\'s crucial to get your store\'s checkout as smooth as possible to avoid losing sales. Let\'s take a look at how you can optimize the checkout experience for your shoppers.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'optimizing-the-checkout-flow',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/optimizing-woocommerce-checkout?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5959 

This PR adds a new note with a link to the optimizing checkout flow when the store is 3+ old and the user has completed the payments task.


### Screenshots

![Screen Shot 2021-01-08 at 11 30 04 AM](https://user-images.githubusercontent.com/4723145/104056345-31175b00-51a5-11eb-8181-4c808abd5af6.jpg)

### Detailed test instructions:


1. Make sure your store is at least 3+ days old. If you just installed WooCommerce, update `woocommerce_admin_install_timestamp` value in `wp_options` table. You can set the value to `1608598121`.

```
update wp_options set option_value = 1608598121 where option_name = 'woocommerce_admin_install_timestamp'
```

2. Navigate to WooCommerce -> Home and click on the "Set up payments" and enable one of the payments. I think "Cash on delivery" is good for testing purposes. 
3. Install & activate "WP Crontrol" plugin
4. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
5. Navigate to WooCommerce -> Home and confirm a new note with the title "Optimizing the checkout flow"

