### PR TITLE
Add a add new note with a link to getting started in ecommerce webinar

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\Notes\AddingAndManangingProducts;
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
+use \Automattic\WooCommerce\Admin\Notes\GettingStartedInEcommerce;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
@@ -29,7 +30,6 @@ use \Automattic\WooCommerce\Admin\Notes\LaunchChecklist;
 use \Automattic\WooCommerce\Admin\Notes\RealTimeOrderAlerts;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
-use \Automattic\WooCommerce\Admin\Loader;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstSale;
 use \Automattic\WooCommerce\Admin\Notes\NeedSomeInspiration;
 use \Automattic\WooCommerce\Admin\Notes\OnlineClothingStore;
@@ -121,6 +121,7 @@ class Events {
 		ChoosingTheme::possibly_add_note();
 		InsightFirstProductAndPayment::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
+		GettingStartedInEcommerce::possibly_add_note();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/GettingStartedInEcommerce.php
+++ b/src/Notes/GettingStartedInEcommerce.php
@@ -39,23 +39,23 @@ class GettingStartedInEcommerce {
 		// Make sure that the person who filled out the OBW was not setting up
 		// the store for their customer/client.
 		if (
-			! isset( $onboarding_profile['setup_client'] ) ||
-			$onboarding_profile['setup_client']
+			isset( $onboarding_profile['setup_client'] ) &&
+			true === $onboarding_profile['setup_client']
 		) {
 			return;
 		}
 
 		// Set default values for product_count and revenue if they are missing.
 		$onboarding_profile = array_merge(
-			[
+			array(
 				'product_count' => false,
 				'revenue'       => false,
-			],
+			),
 			$onboarding_profile
 		);
 
 		if (
-			0 === $onboarding_profile['product_count'] ||
+			'0' === $onboarding_profile['product_count'] ||
 			'none' === $onboarding_profile['revenue'] ||
 			'up-to-2500' === $onboarding_profile['revenue']
 		) {

--- a/src/Notes/GettingStartedInEcommerce.php
+++ b/src/Notes/GettingStartedInEcommerce.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WooCommerce Admin: Getting Started in eCommerce note provider
+ *
+ * Add a new note with a link to a webinar
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * GettingStartedInEcommerce.
+ */
+class GettingStartedInEcommerce {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-getting-started-in-ecommerce';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Confirm that $onboarding_profile is set.
+		if ( empty( $onboarding_profile ) ) {
+			return;
+		}
+
+		// Make sure that the person who filled out the OBW was not setting up
+		// the store for their customer/client.
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
+			return;
+		}
+
+		// Set default values for product_count and revenue if they are missing.
+		$onboarding_profile = array_merge(
+			[
+				'product_count' => false,
+				'revenue'       => false,
+			],
+			$onboarding_profile
+		);
+
+		if (
+			0 === $onboarding_profile['product_count'] ||
+			'none' === $onboarding_profile['revenue'] ||
+			'up-to-2500' === $onboarding_profile['revenue']
+		) {
+			$note = new Note();
+			$note->set_title( __( 'Getting Started in eCommerce - webinar', 'woocommerce-admin' ) );
+			$note->set_content( __( 'We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.', 'woocommerce-admin' ) );
+			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_name( self::NOTE_NAME );
+			$note->set_content_data( (object) array() );
+			$note->set_source( 'woocommerce-admin' );
+			$note->add_action(
+				'watch-the-webinar',
+				__( 'Watch the webinar', 'woocommerce-admin' ),
+				'https://youtu.be/V_2XtCOyZ7o'
+			);
+
+			return $note;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5960 

This PR adds a new note with a link to the "Getting Started in eCommerce" webinar when product_number =0 or revenue = none or revenue = up to 2500 from the business_details in OBW

### Screenshots

![Screen Shot 2021-01-08 at 12 23 27 PM](https://user-images.githubusercontent.com/4723145/104061154-e8fc3680-51ac-11eb-8a27-a76ef6af93c3.jpg)


### Detailed test instructions:

1. Start OBW and proceed to the "Business Details" step.
2. Choose "I don't have any products yet" for the "How many products do you plan to display?" and complete the OBW.
3. Install & activate "WP Crontrol" plugin
4. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
5. Navigate to WooCommerce -> Home and confirm a new note with the title "Getting Started in eCommerce - webinar"

Repeat the steps, but choose "Yes, on another platform" for the "Currently selling elsewhere?" and select revenue. 
