### PR TITLE
Add an unread indicator to inbox messages based on existing logic.

### DIFF
--- a/client/inbox-panel/card.js
+++ b/client/inbox-panel/card.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, createRef, Fragment } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { Button, Dropdown, Modal } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import VisibilitySensor from 'react-visibility-sensor';
@@ -207,11 +207,7 @@ class InboxNoteCard extends Component {
 	renderDismissConfirmationModal() {
 		return (
 			<Modal
-				title={
-					<Fragment>
-						{ __( 'Are you sure?', 'woocommerce-admin' ) }
-					</Fragment>
-				}
+				title={ <>{ __( 'Are you sure?', 'woocommerce-admin' ) }</> }
 				onRequestClose={ () => this.closeDismissModal() }
 				className="woocommerce-inbox-dismiss-confirmation_modal"
 			>
@@ -249,7 +245,7 @@ class InboxNoteCard extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ noteActions.map( ( action, index ) => (
 					<NoteAction
 						key={ index }
@@ -258,7 +254,7 @@ class InboxNoteCard extends Component {
 						onClick={ () => this.onActionClicked( action ) }
 					/>
 				) ) }
-			</Fragment>
+			</>
 		);
 	}
 
@@ -310,6 +306,9 @@ class InboxNoteCard extends Component {
 					) }
 					<div className="woocommerce-inbox-message__wrapper">
 						<div className="woocommerce-inbox-message__content">
+							{ unread && (
+								<div className="woocommerce-inbox-message__unread-indicator" />
+							) }
 							{ date && (
 								<span className="woocommerce-inbox-message__date">
 									{ moment.utc( date ).fromNow() }

--- a/client/inbox-panel/style.scss
+++ b/client/inbox-panel/style.scss
@@ -49,6 +49,15 @@
 }
 
 .woocommerce-inbox-message__content {
+	.woocommerce-inbox-message__unread-indicator {
+		height: 8px;
+		width: 8px;
+		background-color: var(--wp-admin-theme-color);
+		border-radius: 100px;
+		display: inline-block;
+		margin-right: $gap-smaller;
+	}
+
 	.woocommerce-inbox-message__title {
 		color: $gray-900;
 		@include font-size( 16 );

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Add an a/b experiment for installing free business features #5786
 - Dev: Add `onChangeCallback` feature to the wc-admin <Form> component #5786 
 - Add: Note for users coming from Calypso. #6030
+- Enhancement: Add an "unread" indicator to inbox messages. #6047 
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes #5627 by adding a "unread" indicator to unread messages based on existing logic (`unread = date created > activity_panel_inbox_last_read`)

Also note I haven't added tests, there is already test coverage of unread being correctly applied in an existing test.

### Screenshots

<img width="520" alt="Screenshot 2021-01-12 at 7 54 47 PM" src="https://user-images.githubusercontent.com/1281828/104280251-7e325e80-5510-11eb-9a2a-391df5905b29.png">


### Detailed test instructions:

-  Trigger an inbox notification (the easiest way is via WP-Crontrol and running `wc_admin_daily` job on a fresh site. This usually shows at least a couple of new user inbox messages.

- Note that the message is initially shown with an unread symbol as in the linked screenshot.

- `activity_panel_inbox_last_read` is updated when the component remounts, so a page refresh should be enough to clear out the unread indicator for your messages. Note that the unread indicator no longer displays.

@elizaan36 Could you take a look at this and review the design? I couldn't find an actual design with measurements etc in Figma so I approximated it from the screenshot provided in the original issue.
