### PR TITLE
Add missing keys to activity panel on homescreen

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -71,7 +71,12 @@ export const ActivityPanel = () => {
 							<Text key={ title } variant="title.small">
 								{ title }
 							</Text>,
-							count !== null && <Badge count={ count } />,
+							count !== null && (
+								<Badge
+									key={ `${ title }-badge` }
+									count={ count }
+								/>
+							),
 						] }
 						key={ id }
 						className={ className }
@@ -82,7 +87,7 @@ export const ActivityPanel = () => {
 						<PanelRow>{ panel }</PanelRow>
 					</PanelBody>
 				) : (
-					<div className="components-panel__body">
+					<div className="components-panel__body" key={ id }>
 						<h2 className="components-panel__body-title">
 							<Button
 								className="components-panel__body-toggle"


### PR DESCRIPTION
Fixes up missing keys that weren't added in https://github.com/woocommerce/woocommerce-admin/pull/5970

### Detailed test instructions:

1. Fire up this branch.
2. Make sure no console warnings appear related to the activity panel on the homescreen.