### PR TITLE
Add survey URL builder method

### DIFF
--- a/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -19,6 +19,10 @@ export class NavigationOptOutContainer extends Component {
 			return null;
 		}
 
+		if ( ! window.surveyData || ! window.surveyData.url ) {
+			return null;
+		}
+
 		return (
 			<Modal
 				title={ __( 'Help us improve', 'woocommerce-admin' ) }
@@ -45,7 +49,7 @@ export class NavigationOptOutContainer extends Component {
 					<Button
 						isPrimary
 						target="_blank"
-						href="https://automattic.survey.fm/new-navigation-opt-out"
+						href={ window.surveyData.url }
 						onClick={ () =>
 							this.setState( { isModalOpen: false } )
 						}

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\Features\Navigation;
 
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\Survey;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
@@ -201,6 +202,14 @@ class Init {
 			array( 'wp-i18n', 'wp-element', WC_ADMIN_APP ),
 			Loader::get_file_version( 'js' ),
 			true
+		);
+
+		wp_localize_script(
+			'wc-admin-navigation-opt-out',
+			'surveyData',
+			array(
+				'url' => Survey::get_url( '/new-navigation-opt-out' ),
+			)
 		);
 
 		delete_option( 'woocommerce_navigation_show_opt_out' );

--- a/src/Notes/GivingFeedbackNotes.php
+++ b/src/Notes/GivingFeedbackNotes.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Survey;
+
 /**
  * Giving_Feedback_Notes
  */
@@ -46,7 +48,7 @@ class GivingFeedbackNotes {
 		$note->add_action(
 			'share-feedback',
 			__( 'Share feedback', 'woocommerce-admin' ),
-			'https://automattic.survey.fm/store-setup-survey'
+			Survey::get_url( '/store-setup-survey' )
 		);
 		return $note;
 	}

--- a/src/Notes/NavigationFeedback.php
+++ b/src/Notes/NavigationFeedback.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Admin\Notes;
 
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\Survey;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -42,7 +43,7 @@ class NavigationFeedback {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), 'https://automattic.survey.fm/new-navigation' );
+		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), Survey::get_url( '/new-navigation' ) );
 		return $note;
 	}
 }

--- a/src/Notes/NavigationFeedbackFollowUp.php
+++ b/src/Notes/NavigationFeedbackFollowUp.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Admin\Notes;
 
 use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\Survey;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,7 +57,7 @@ class NavigationFeedbackFollowUp {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), 'https://automattic.survey.fm/new-navigation' );
+		$note->add_action( 'share-feedback', __( 'Share feedback', 'woocommerce-admin' ), Survey::get_url( '/new-navigation' ) );
 		return $note;
 	}
 }

--- a/src/Survey.php
+++ b/src/Survey.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Survey helper methods.
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Survey Class.
+ */
+class Survey {
+	/**
+	 * Get a survey's URL from a path.
+	 *
+	 * @param  string $path Path of the survey.
+	 * @param  array  $query Query arguments as key value pairs.
+	 * @return string Full URL to survey.
+	 */
+	public static function get_url( $path, $query = array() ) {
+		$url = 'https://automattic.survey.fm' . $path;
+
+		$source = self::get_source();
+		if ( $source ) {
+			$query['source'] = $source;
+		}
+
+		if ( ! empty( $query ) ) {
+			$query_string = http_build_query( $query );
+			$url          = $url . '?' . $query_string;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Get the source.
+	 *
+	 * @return string|null
+	 */
+	public static function get_source() {
+		return apply_filters( 'woocommerce_admin_survey_source', null );
+	}
+}

--- a/src/Survey.php
+++ b/src/Survey.php
@@ -12,6 +12,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class Survey {
 	/**
+	 * Survey URL.
+	 */
+	const SURVEY_URL = 'https://automattic.survey.fm';
+
+	/**
 	 * Get a survey's URL from a path.
 	 *
 	 * @param  string $path Path of the survey.
@@ -19,7 +24,7 @@ class Survey {
 	 * @return string Full URL to survey.
 	 */
 	public static function get_url( $path, $query = array() ) {
-		$url = 'https://automattic.survey.fm' . $path;
+		$url = self::SURVEY_URL . $path;
 
 		$query_args = apply_filters( 'woocommerce_admin_survey_query', $query );
 

--- a/src/Survey.php
+++ b/src/Survey.php
@@ -21,25 +21,13 @@ class Survey {
 	public static function get_url( $path, $query = array() ) {
 		$url = 'https://automattic.survey.fm' . $path;
 
-		$source = self::get_source();
-		if ( $source ) {
-			$query['source'] = $source;
-		}
+		$query_args = apply_filters( 'woocommerce_admin_survey_query', $query );
 
-		if ( ! empty( $query ) ) {
-			$query_string = http_build_query( $query );
+		if ( ! empty( $query_args ) ) {
+			$query_string = http_build_query( $query_args );
 			$url          = $url . '?' . $query_string;
 		}
 
 		return $url;
-	}
-
-	/**
-	 * Get the source.
-	 *
-	 * @return string|null
-	 */
-	public static function get_source() {
-		return apply_filters( 'woocommerce_admin_survey_source', null );
 	}
 }


### PR DESCRIPTION
Fixes (partially) #6051

Creates a method to build survey URLs so we can later filter the query and add in `source` to identify which plan users are coming from.

The `Survey` class may be slightly overkill, but didn't feel right tossing this into `core-functions.php`.

### Screenshots

<img width="441" alt="Screen Shot 2021-01-13 at 1 16 55 PM" src="https://user-images.githubusercontent.com/10561050/104492556-d5344400-55a1-11eb-97e4-76628270677f.png">
<img width="570" alt="Screen Shot 2021-01-13 at 1 16 45 PM" src="https://user-images.githubusercontent.com/10561050/104492557-d5344400-55a1-11eb-851c-140109b6ed38.png">


### Detailed test instructions:

1. Optionally add some arguments to the survey url.
```php
add_filter( 'woocommerce_admin_survey_query', function( $query ) {
	$query['source'] = 'ecomm-plan';
	return $query;
} );
```
2. Delete old navigation feedback and store setup notes.
2. Re-trigger those notes.
3. Make sure the URL for those items is correct.
4. Opt in to the navigation if not already opted in.
5. Opt out of the navigation and note the "Share Feedback" button URL in the modal is correct.