### PR TITLE
Update travis CI to use a new distribution - xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: php
 
-dist: trusty
+dist: xenial
 
 services:
     - xvfb
@@ -25,7 +25,7 @@ matrix:
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress COMPOSER_DEV=1
         - name: 'PHP 7.0 unit tests'
           php: 7.0
-          env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
+          env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress PHPUNIT=6
         - name: 'PHP 5.6 unit tests'
           php: 5.6
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress WC_VERSION=3.8.1

--- a/bin/travis.sh
+++ b/bin/travis.sh
@@ -14,4 +14,8 @@ if [ "$1" == 'before' ]; then
 	else
 		composer install --no-dev
 	fi
+	# phpunit ^7 is not supported in php 7.0
+	if [[ "$PHPUNIT" == "6" ]]; then
+		curl -fsSL -o vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.5.9.phar --create-dirs && chmod +x vendor/bin/phpunit
+	fi
 fi

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Add an "unread" indicator to inbox messages. #6047 
 - Tweak: update the content for the ChooseNiche note. #6048
 - Fix: Generate JSON translation chunks on plugin activation #6028
+- Dev: Update travis CI distribution. #6067
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes an issue with php unit tests caused by an older minor version of PHP.

Updated dist to 'xenial', and added some logic for running phpunit on PHP 7.0, which required the latest version of phpunit 6.

### Detailed test instructions:

-   Make sure the Travis CI runs successfully on this PR

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
