### PR TITLE
Add remote inbox notifications contains comparison and fix product count rule

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 - Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
 - Tweak: update the content and timing of the NeedSomeInspiration note. #6076
+- Add: Remote inbox notifications contains comparison and fix product rule. #6073
 
 
 == Changelog ==

--- a/src/RemoteInboxNotifications/ComparisonOperation.php
+++ b/src/RemoteInboxNotifications/ComparisonOperation.php
@@ -32,6 +32,10 @@ class ComparisonOperation {
 				return $left_operand >= $right_operand;
 			case '!=':
 				return $left_operand !== $right_operand;
+			case 'contains':
+				return in_array( $right_operand, $left_operand, true );
+			case '!contains':
+				return ! in_array( $right_operand, $left_operand, true );
 		}
 
 		return false;

--- a/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
+++ b/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
@@ -40,8 +40,11 @@ class ProductCountRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$products = $this->product_query->get_products();
-		$count    = $products->total + $stored_state->new_product_count;
+		$products          = $this->product_query->get_products();
+		$new_product_count = property_exists( $stored_state, 'new_product_count' )
+			? $stored_state->new_product_count
+			: 0;
+		$count             = $products->total + $new_product_count;
 
 		return ComparisonOperation::compare(
 			$count,

--- a/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
+++ b/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
@@ -40,8 +40,12 @@ class ProductCountRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$products = $this->product_query->get_products();
-		$count    = $products->total;
+		$products          = $this->product_query->get_products();
+		$new_product_count = get_option(
+			'wc_remote_inbox_notifications_new_product_count',
+			0
+		);
+		$count             = $products->total + $new_product_count;
 
 		return ComparisonOperation::compare(
 			$count,

--- a/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
+++ b/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
@@ -40,12 +40,8 @@ class ProductCountRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$products          = $this->product_query->get_products();
-		$new_product_count = get_option(
-			'wc_remote_inbox_notifications_new_product_count',
-			0
-		);
-		$count             = $products->total + $new_product_count;
+		$products = $this->product_query->get_products();
+		$count    = $products->total + $stored_state->new_product_count;
 
 		return ComparisonOperation::compare(
 			$count,

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -128,6 +128,34 @@ The `status` is what the status of the created note will be set to after interac
 ## Rule
 Rules in an array are executed as an AND operation. If there are no rules in the array the result is false and the specified notification is not shown.
 
+### Operations
+Some rule types support an `operation` value, which is used to compare two
+values. The following operations are implemented:
+
+- `=`
+- `<`
+- `<=`
+- `>`
+- `>=`
+- `!=`
+- `contains`
+- `!contains`
+
+`contains` and `!contains` allow checking if the provided value is present (or
+not present) in the haystack value. An example of this is using the
+`onboarding_profile` rule to match on a value in the `product_types` array -
+this rule matches if `physical` was selected as a product type in the
+onboarding profile:
+
+```json
+{
+	'type': 'onboarding_profile',
+	'index': 'product_types',
+	'operation': 'contains',
+	'value': 'physical'
+}
+```
+
 ### Plugins activated
 This passes if all of the listed plugins are installed and activated.
 

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -293,6 +293,7 @@ The currently available indices are:
 ```
 there_were_no_products
 there_are_now_products
+new_product_count
 ```
 
 `index`, `operation`, and `value` are required.

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -14,8 +14,6 @@ use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
  * Handles stored state setup for products.
  */
 class StoredStateSetupForProducts {
-	const NEW_PRODUCT_COUNT_OPTION_NAME = 'wc_remote_inbox_notifications_new_product_count';
-
 	/**
 	 * Initialize the class
 	 */
@@ -95,14 +93,20 @@ class StoredStateSetupForProducts {
 			return;
 		}
 
-		update_option( self::NEW_PRODUCT_COUNT_OPTION_NAME, 1 );
-
 		$stored_state                         = RemoteInboxNotificationsEngine::get_stored_state();
 		$stored_state->there_are_now_products = true;
+
+		// This is used to increment the product count yielded by the query,
+		// which is one less than the actual product count at this point in the
+		// product publish lifecycle. This is currently being used by
+		// ProductCountRuleProcessor.
+		$stored_state->new_product_count = 1;
+
 		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
 
 		RemoteInboxNotificationsEngine::run();
 
-		update_option( self::NEW_PRODUCT_COUNT_OPTION_NAME, 0 );
+		$stored_state->new_product_count = 0;
+		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
 	}
 }

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -14,6 +14,8 @@ use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
  * Handles stored state setup for products.
  */
 class StoredStateSetupForProducts {
+	const NEW_PRODUCT_COUNT_OPTION_NAME = 'wc_remote_inbox_notifications_new_product_count';
+
 	/**
 	 * Initialize the class
 	 */
@@ -93,10 +95,14 @@ class StoredStateSetupForProducts {
 			return;
 		}
 
+		update_option( self::NEW_PRODUCT_COUNT_OPTION_NAME, 1 );
+
 		$stored_state                         = RemoteInboxNotificationsEngine::get_stored_state();
 		$stored_state->there_are_now_products = true;
 		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
 
 		RemoteInboxNotificationsEngine::run();
+
+		update_option( self::NEW_PRODUCT_COUNT_OPTION_NAME, 0 );
 	}
 }


### PR DESCRIPTION
Fixes #5954 and completes #4223

This adds a `contains` (and `!contains`) comparison (so you can do a comparison operation on an array) and fixes the product count rule - it was being triggered at a point where the product count query was one less than the correct value on product add.

The note spec itself is here in the woocommerce.com feed: 9267-gh-woocommerce.com

Note that #5954 is just requesting a change to the URL, however when investigating I realised that the note in #4223 was never actually created, the (considerable) plumbing was designed but never put to use and ticket #4223 was closed and doesn't seem to have been tested.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/104553798-03d81a80-5687-11eb-9270-58f3f7ada43e.png)

### Detailed test instructions:

1. You'll need a woocommerce.com instance
2. Check out this branch (9267-gh-woocommerce.com) in your local woocommerce.com instance
3. Delete all of your products
3. Add `http://woocommerce.test/wp-json/wccom/inbox-notifications/1.0/notifications.json` to `DataSourcePoller.php`'s `DATA_SOURCES` arrray
4. `DELETE FROM wp_wc_admin_notes`
5. `DELETE FROM wp_options WHERE option_name IN ('wc_remote_inbox_notifications_specs', 'wc_remote_inbox_notifications_stored_state')`
6. Run the `wc_admin_daily` cron task
7. Check home screen that the new message _is not_ prosent
8. Add a product
9. Check home screen that the new message is now present