### PR TITLE
Update content and timing of NeedSomeInspiration.php.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: update the content for the ChooseNiche note. #6048
 - Fix: Generate JSON translation chunks on plugin activation #6028
 - Dev: Update travis CI distribution. #6067
+- Tweak: update the content and timing of the NeedSomeInspiration note. #6076
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: update the content for the ChooseNiche note. #6048
 - Fix: Generate JSON translation chunks on plugin activation #6028
 - Dev: Update travis CI distribution. #6067
+- Add: Manage activity from home screen inbox message. #6072
 
 == 1.8.3 1/5/2021 ==
 

--- a/src/Notes/NeedSomeInspiration.php
+++ b/src/Notes/NeedSomeInspiration.php
@@ -29,8 +29,8 @@ class NeedSomeInspiration {
 	 * @return Note
 	 */
 	public static function get_note() {
-		// We want to show the note after five days.
-		if ( ! self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
+		// We want to show the note after 4 days.
+		if ( ! self::wc_admin_active_for( 4 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 
@@ -56,8 +56,8 @@ class NeedSomeInspiration {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Do you need some inspiration?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Check some of our favorite customer stories from entrepreneurs, agencies, and developers in our global community.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Browse our success stories', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Learn more about how other entrepreneurs used WooCommerce to build successful businesses.', 'woocommerce-admin' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );


### PR DESCRIPTION
Fixes #5924 

This updates the timing of this note from 5 days to 4 and tweaks the content as specified on the issue.

### Detailed test instructions:

- Set the `woocommerce_admin_install_timestamp` option to a timestamp approx 4 days before today but not older than 30 days 
-  Make sure you completed OBW and didn't choose "setting up for client" in OBW
- Install WP Crontrol plugin, go to the plugin's list of cron jobs and "run now" on the job `wc_admin_daily`.
- Confirm that the note shows up with the new content in your inbox.