### PR TITLE
Add the "Getting started in Ecommerce" inbox note

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,7 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 - Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
 - Tweak: update the content and timing of the NeedSomeInspiration note. #6076
-
+- Add: new inbox message - Getting started in Ecommerce - watch this webinar. #6086
 
 == Changelog ==
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -46,6 +46,7 @@ use \Automattic\WooCommerce\Admin\Notes\NavigationFeedbackFollowUp;
 use \Automattic\WooCommerce\Admin\Notes\FilterByProductVariationsInReports;
 use \Automattic\WooCommerce\Admin\Notes\AddFirstProduct;
 use \Automattic\WooCommerce\Admin\Notes\DrawAttention;
+use \Automattic\WooCommerce\Admin\Notes\GettingStartedInEcommerceWebinar;
 
 /**
  * Events Class.
@@ -140,6 +141,7 @@ class Events {
 		InsightFirstProductAndPayment::possibly_add_note();
 		AddFirstProduct::possibly_add_note();
 		AddingAndManangingProducts::possibly_add_note();
+		GettingStartedInEcommerceWebinar::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/GettingStartedInEcommerceWebinar.php
+++ b/src/Notes/GettingStartedInEcommerceWebinar.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WooCommerce Admin: Getting started in ecommerce, watch a webinar.
+ *
+ * Adds a note to remind the client they can watch a webinar to get started
+ * with WooCommerce.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Getting started in ecommmerce note class.
+ */
+class GettingStartedInEcommerceWebinar {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Onboarding traits.
+	 */
+	use OnboardingTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-getting-started-ecommerce-webinar';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+
+		if ( ! self::onboarding_profile_started() ) {
+			return;
+		}
+
+		if ( self::store_setup_for_client() ) {
+			return;
+		}
+
+		if ( ! self::revenue_is_within( 0, 2500 ) ) {
+			return;
+		}
+
+		// Don't show if there are products.
+		$query    = new \WC_Product_Query(
+			array(
+				'limit'    => 1,
+				'paginate' => true,
+				'return'   => 'ids',
+				'status'   => array( 'publish' ),
+			)
+		);
+		$products = $query->get_products();
+		$count    = $products->total;
+
+		if ( 0 !== $count ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Getting Started in eCommerce - webinar', 'woocommerce-admin' ) );
+		$note->set_content( __( 'We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'getting-started-webinar',
+			__( 'Watch the webinar', 'woocommerce-admin' ),
+			'https://youtu.be/V_2XtCOyZ7o'
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/OnboardingTraits.php
+++ b/src/Notes/OnboardingTraits.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WC Admin Note Traits
+ *
+ * WC Admin Note Traits class that houses shared functionality across notes.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * OnboardingTraits class, encapsulates onboarding checks and functionality
+ * that are useful to determining whether to display notes or not.
+ */
+trait OnboardingTraits {
+	/**
+	 * Get access to the onboarding profile option.
+	 */
+	private static function get_onboarding_profile() {
+		return get_option( 'woocommerce_onboarding_profile', array() );
+	}
+
+	/**
+	 * Check if user has started the onboarding profile wizard.
+	 *
+	 * @return bool Whether or not the onboarding profile has been started.
+	 */
+	public static function onboarding_profile_started() {
+		$onboarding_profile = self::get_onboarding_profile();
+		return ! empty( $onboarding_profile );
+	}
+
+	/**
+	 * Check if onboarding profile revenue is between 2 amounts
+	 *
+	 * @param int $min_dollars Minimum amount the range must fall within (inclusive).
+	 * @param int $max_dollars Maximum amount the range must fall within (inclusive).
+	 * @return bool Whether the revenue falls within the min and max (inclusive).
+	 */
+	public static function revenue_is_within( $min_dollars, $max_dollars ) {
+		$onboarding_profile = self::get_onboarding_profile();
+
+		if ( empty( $onboarding_profile ) || ! isset( $onboarding_profile['revenue'] ) ) {
+			return false;
+		}
+
+		return $onboarding_profile['revenue'] >= $min_dollars && $onboarding_profile['revenue'] <= $max_dollars;
+	}
+
+	/**
+	 * Check if the store was marked as being setup for a client in onboarding. (Returns false if onboarding
+	 * was not completed).
+	 *
+	 * @return bool Whether or not the store is being setup for a client.
+	 */
+	public static function store_setup_for_client() {
+		$onboarding_profile = self::get_onboarding_profile();
+		return ! empty( $onboarding_profile ) && isset( $onboarding_profile['setup_client'] ) && $onboarding_profile['setup_client'];
+	}
+}

--- a/src/Notes/OnboardingTraits.php
+++ b/src/Notes/OnboardingTraits.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WC Admin Note Traits
+ * WC Admin Onboarding Traits
  *
- * WC Admin Note Traits class that houses shared functionality across notes.
+ * WC Admin Onboarding Traits class that houses shared functionality useful for checking status of onboarding.
  */
 
 namespace Automattic\WooCommerce\Admin\Notes;

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -16,31 +16,6 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	use OnboardingTraits;
 
 	/**
-	 * The options that we modify during this test suite.
-	 *
-	 * @var array
-	 */
-	private static $original_options;
-
-	/**
-	 * Setup for the whole test class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		self::$original_options = get_option( 'woocommerce_onboarding_profile', array() );
-	}
-
-		/**
-		 * Cleans up test data once all test have run.
-		 */
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
-
-		update_option( 'woocommerce_onboarding_profile', self::$original_options );
-	}
-
-	/**
 	 * Test revenue_is_within functionality.
 	 */
 	public function test_revenue_is_within() {

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -44,7 +44,7 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 * Test revenue_is_within functionality.
 	 */
 	public function test_revenue_is_within() {
-		update_option( 'woocommerce_onboarding_profile', (object) array( 'revenue' => 1500 ) );
+		update_option( 'woocommerce_onboarding_profile', array( 'revenue' => 1500 ) );
 
 		$this->assertEquals( self::revenue_is_within( 1200, 1500 ), true );
 		$this->assertEquals( self::revenue_is_within( 0, 1500 ), true );
@@ -67,13 +67,13 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 * Test store_setup_for_client functionality.
 	 */
 	public function test_store_setup_for_client() {
-		update_option( 'woocommerce_onboarding_profile', (object) array( 'setup_client' => true ) );
+		update_option( 'woocommerce_onboarding_profile', array( 'setup_client' => true ) );
 		$this->assertEquals( self::store_setup_for_client(), true );
 
 		update_option( 'woocommerce_onboarding_profile', null );
 		$this->assertEquals( self::store_setup_for_client(), false );
 
-		update_option( 'woocommerce_onboarding_profile', (object) array( 'setup_client' => false ) );
+		update_option( 'woocommerce_onboarding_profile', array( 'setup_client' => false ) );
 		$this->assertEquals( self::store_setup_for_client(), false );
 	}
 }

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -20,7 +20,7 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 * Test revenue_is_within functionality.
 	 */
 	public function test_revenue_is_within() {
-		update_option( 'onboarding_profile', array( 'revenue' => 1500 ) );
+		update_option( 'onboarding_profile', (object) array( 'revenue' => 1500 ) );
 
 		$this->assertEquals( self::revenue_is_within( 1200, 1500 ), true );
 		$this->assertEquals( self::revenue_is_within( 0, 1500 ), true );
@@ -33,23 +33,23 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 */
 	public function test_onboarding_started() {
 		update_option( 'onboarding_profile', null );
-		$this->assertEquals( self::onboarding_started(), false );
+		$this->assertEquals( self::onboarding_profile_started(), false );
 
 		update_option( 'onboarding_profile', array() );
-		$this->assertEquals( self::onboarding_started(), true );
+		$this->assertEquals( self::onboarding_profile_started(), true );
 	}
 
 	/**
 	 * Test store_setup_for_client functionality.
 	 */
 	public function test_store_setup_for_client() {
-		update_option( 'onboarding_profile', array( 'setup_client' => true ) );
+		update_option( 'onboarding_profile', (object) array( 'setup_client' => true ) );
 		$this->assertEquals( self::store_setup_for_client(), true );
 
 		update_option( 'onboarding_profile', null );
 		$this->assertEquals( self::store_setup_for_client(), false );
 
-		update_option( 'onboarding_profile', array( 'setup_client' => false ) );
+		update_option( 'onboarding_profile', (object) array( 'setup_client' => false ) );
 		$this->assertEquals( self::store_setup_for_client(), false );
 	}
 }

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Email notes tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Admin\Notes\OnboardingTraits;
+
+/**
+ * Class WC_Tests_Onboarding_Traits
+ */
+class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
+
+	/** Host the traits class we are testing */
+	use OnboardingTraits;
+
+
+	/**
+	 * Test revenue_is_within functionality.
+	 */
+	public function test_revenue_is_within() {
+		update_option( 'onboarding_profile', array( 'revenue' => 1500 ) );
+
+		$this->assertEquals( self::revenue_is_within( 1200, 1500 ), true );
+		$this->assertEquals( self::revenue_is_within( 0, 1500 ), true );
+		$this->assertEquals( self::revenue_is_within( 1600, 2000 ), false );
+		$this->assertEquals( self::revenue_is_within( 0, 100 ), false );
+	}
+
+	/**
+	 * Test onboarding_started functionality.
+	 */
+	public function test_onboarding_started() {
+		update_option( 'onboarding_profile', null );
+		$this->assertEquals( self::onboarding_started(), false );
+
+		update_option( 'onboarding_profile', array() );
+		$this->assertEquals( self::onboarding_started(), true );
+	}
+
+	/**
+	 * Test store_setup_for_client functionality.
+	 */
+	public function test_store_setup_for_client() {
+		update_option( 'onboarding_profile', array( 'setup_client' => true ) );
+		$this->assertEquals( self::store_setup_for_client(), true );
+
+		update_option( 'onboarding_profile', null );
+		$this->assertEquals( self::store_setup_for_client(), false );
+
+		update_option( 'onboarding_profile', array( 'setup_client' => false ) );
+		$this->assertEquals( self::store_setup_for_client(), false );
+	}
+}

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -15,12 +15,36 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	/** Host the traits class we are testing */
 	use OnboardingTraits;
 
+	/**
+	 * The options that we modify during this test suite.
+	 *
+	 * @var array
+	 */
+	private static $original_options;
+
+	/**
+	 * Setup for the whole test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		self::$original_options = get_option( 'woocommerce_onboarding_profile', array() );
+	}
+
+		/**
+		 * Cleans up test data once all test have run.
+		 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		update_option( 'woocommerce_onboarding_profile', self::$original_options );
+	}
 
 	/**
 	 * Test revenue_is_within functionality.
 	 */
 	public function test_revenue_is_within() {
-		update_option( 'onboarding_profile', (object) array( 'revenue' => 1500 ) );
+		update_option( 'woocommerce_onboarding_profile', (object) array( 'revenue' => 1500 ) );
 
 		$this->assertEquals( self::revenue_is_within( 1200, 1500 ), true );
 		$this->assertEquals( self::revenue_is_within( 0, 1500 ), true );
@@ -32,10 +56,10 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 * Test onboarding_started functionality.
 	 */
 	public function test_onboarding_started() {
-		update_option( 'onboarding_profile', null );
+		update_option( 'woocommerce_onboarding_profile', null );
 		$this->assertEquals( self::onboarding_profile_started(), false );
 
-		update_option( 'onboarding_profile', array() );
+		update_option( 'woocommerce_onboarding_profile', array() );
 		$this->assertEquals( self::onboarding_profile_started(), true );
 	}
 
@@ -43,13 +67,13 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 	 * Test store_setup_for_client functionality.
 	 */
 	public function test_store_setup_for_client() {
-		update_option( 'onboarding_profile', (object) array( 'setup_client' => true ) );
+		update_option( 'woocommerce_onboarding_profile', (object) array( 'setup_client' => true ) );
 		$this->assertEquals( self::store_setup_for_client(), true );
 
-		update_option( 'onboarding_profile', null );
+		update_option( 'woocommerce_onboarding_profile', null );
 		$this->assertEquals( self::store_setup_for_client(), false );
 
-		update_option( 'onboarding_profile', (object) array( 'setup_client' => false ) );
+		update_option( 'woocommerce_onboarding_profile', (object) array( 'setup_client' => false ) );
 		$this->assertEquals( self::store_setup_for_client(), false );
 	}
 }

--- a/tests/notes/class-wc-onboarding-traits.php
+++ b/tests/notes/class-wc-onboarding-traits.php
@@ -59,7 +59,7 @@ class WC_Tests_Onboarding_Traits extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_onboarding_profile', null );
 		$this->assertEquals( self::onboarding_profile_started(), false );
 
-		update_option( 'woocommerce_onboarding_profile', array() );
+		update_option( 'woocommerce_onboarding_profile', array( 'setup-client' => false ) );
 		$this->assertEquals( self::onboarding_profile_started(), true );
 	}
 


### PR DESCRIPTION
Fixes #5960 

Adds the new Getting started in Ecommerce inbox note. I evaluated using remote inbox, but I believe we can't do anything with the current rules to check things like values set in the onboarding profile?

I also had a go at DRY'ing up some of the checks we frequently do when adding notes, ideally these could be used in other notes to consolidate checking logic. I added these to a trait class so they could function like a mixin. I considered using a data store or something else, but that didn't feel correct here. At least if we decided this logic belongs elsewhere it would be trivial to move it later and I feel this is an improvement over the current state where we have a lot of repeated code.

### Detailed test instructions:

- First you'll need to make sure you meet the criteria for the note: 

   1. obw is done
   2. revenue is between 0-2500
   3. do not check "setting up for client" in obw
   4. store should have no products
- Next you need to install WP Crontrol, go to its list of cron events and click "run now" on "wc_admin_daily"
- Confirm the new note is displayed and that the content matches that specified in #5960 