### PR TITLE
Initial paypal plugin replacement

### DIFF
--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -147,7 +147,7 @@ function getPaymentsItems( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/paypal-express-checkout/?utm_source=help_panel',
+				'https://docs.woocommerce.com/document/2-0/woocommerce-paypal-payments/#section-3',
 		},
 		showSquare && {
 			title: __( 'Square - Get started', 'woocommerce-admin' ),

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -352,7 +352,7 @@ export default compose(
 		const optionNames = [
 			'woocommerce_woocommerce_payments_settings',
 			'woocommerce_stripe_settings',
-			'woocommerce_ppec_paypal_settings',
+			'woocommerce-ppcp-settings',
 			'woocommerce_payfast_settings',
 			'woocommerce_square_credit_card_settings',
 			'woocommerce_klarna_payments_settings',

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -353,6 +353,7 @@ export default compose(
 			'woocommerce_woocommerce_payments_settings',
 			'woocommerce_stripe_settings',
 			'woocommerce-ppcp-settings',
+			'woocommerce_ppcp-gateway_settings',
 			'woocommerce_payfast_settings',
 			'woocommerce_square_credit_card_settings',
 			'woocommerce_klarna_payments_settings',

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -24,7 +24,7 @@ import Stripe from './stripe';
 import Square from './square';
 import WCPay from './wcpay';
 import WCPayIcon from './images/wcpay';
-import PayPal from './paypal';
+import PayPal, { PAYPAL_PLUGIN } from './paypal';
 import Klarna from './klarna';
 import PayFast from './payfast';
 import EWay from './eway';
@@ -213,7 +213,7 @@ export function getPaymentMethods( {
 		},
 		{
 			key: 'paypal',
-			title: __( 'PayPal Checkout', 'woocommerce-admin' ),
+			title: __( 'PayPal Payments', 'woocommerce-admin' ),
 			content: (
 				<Fragment>
 					{ __(
@@ -224,7 +224,7 @@ export function getPaymentMethods( {
 			),
 			before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
 			visible: ! hasCbdIndustry,
-			plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
+			plugins: [ PAYPAL_PLUGIN ],
 			container: <PayPal />,
 			isConfigured:
 				options.woocommerce_ppec_paypal_settings &&

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -228,14 +228,14 @@ export function getPaymentMethods( {
 			container: <PayPal />,
 			isConfigured:
 				options['woocommerce-ppcp-settings'] &&
-				options['woocommerce-ppcp-settings'].merchant_email &&
+				options['woocommerce-ppcp-settings'].merchant_email_production &&
 				options['woocommerce-ppcp-settings'].merchant_id_production &&
 				options['woocommerce-ppcp-settings'].client_id_production &&
 				options['woocommerce-ppcp-settings'].client_secret_production,
 			isEnabled:
-				options['woocommerce-ppcp-settings'] &&
-				options['woocommerce-ppcp-settings'].enabled === 'yes',
-			optionName: 'woocommerce-ppcp-settings',
+				options['woocommerce_ppcp-gateway_settings'] &&
+				options['woocommerce_ppcp-gateway_settings'].enabled === 'yes',
+			optionName: 'woocommerce_ppcp-gateway_settings',
 		},
 		{
 			key: 'klarna_checkout',

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -227,16 +227,15 @@ export function getPaymentMethods( {
 			plugins: [ PAYPAL_PLUGIN ],
 			container: <PayPal />,
 			isConfigured:
-				options.woocommerce_ppec_paypal_settings &&
-				( ( options.woocommerce_ppec_paypal_settings.reroute_requests &&
-					options.woocommerce_ppec_paypal_settings.email ) ||
-					( options.woocommerce_ppec_paypal_settings.api_username &&
-						options.woocommerce_ppec_paypal_settings
-							.api_password ) ),
+				options['woocommerce-ppcp-settings'] &&
+				options['woocommerce-ppcp-settings'].merchant_email &&
+				options['woocommerce-ppcp-settings'].merchant_id_production &&
+				options['woocommerce-ppcp-settings'].client_id_production &&
+				options['woocommerce-ppcp-settings'].client_secret_production,
 			isEnabled:
-				options.woocommerce_ppec_paypal_settings &&
-				options.woocommerce_ppec_paypal_settings.enabled === 'yes',
-			optionName: 'woocommerce_ppec_paypal_settings',
+				options['woocommerce-ppcp-settings'] &&
+				options['woocommerce-ppcp-settings'].enabled === 'yes',
+			optionName: 'woocommerce-ppcp-settings',
 		},
 		{
 			key: 'klarna_checkout',

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -227,14 +227,16 @@ export function getPaymentMethods( {
 			plugins: [ PAYPAL_PLUGIN ],
 			container: <PayPal />,
 			isConfigured:
-				options['woocommerce-ppcp-settings'] &&
-				options['woocommerce-ppcp-settings'].merchant_email_production &&
-				options['woocommerce-ppcp-settings'].merchant_id_production &&
-				options['woocommerce-ppcp-settings'].client_id_production &&
-				options['woocommerce-ppcp-settings'].client_secret_production,
+				options[ 'woocommerce-ppcp-settings' ] &&
+				options[ 'woocommerce-ppcp-settings' ]
+					.merchant_email_production &&
+				options[ 'woocommerce-ppcp-settings' ].merchant_id_production &&
+				options[ 'woocommerce-ppcp-settings' ].client_id_production &&
+				options[ 'woocommerce-ppcp-settings' ].client_secret_production,
 			isEnabled:
-				options['woocommerce_ppcp-gateway_settings'] &&
-				options['woocommerce_ppcp-gateway_settings'].enabled === 'yes',
+				options[ 'woocommerce_ppcp-gateway_settings' ] &&
+				options[ 'woocommerce_ppcp-gateway_settings' ].enabled ===
+					'yes',
 			optionName: 'woocommerce_ppcp-gateway_settings',
 		},
 		{

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -17,6 +17,8 @@ import {
 	WC_ADMIN_NAMESPACE,
 } from '@woocommerce/data';
 
+export const PAYPAL_PLUGIN = 'woocommerce-paypal-payments';
+
 export class PayPal extends Component {
 	constructor( props ) {
 		super( props );
@@ -61,12 +63,8 @@ export class PayPal extends Component {
 		const { activePlugins } = this.props;
 
 		if (
-			! prevProps.activePlugins.includes(
-				'woocommerce-gateway-paypal-express-checkout'
-			) &&
-			activePlugins.includes(
-				'woocommerce-gateway-paypal-express-checkout'
-			)
+			! prevProps.activePlugins.includes( PAYPAL_PLUGIN ) &&
+			activePlugins.includes( PAYPAL_PLUGIN )
 		) {
 			this.fetchOAuthConnectURL();
 		}
@@ -89,11 +87,7 @@ export class PayPal extends Component {
 	async fetchOAuthConnectURL() {
 		const { activePlugins } = this.props;
 
-		if (
-			! activePlugins.includes(
-				'woocommerce-gateway-paypal-express-checkout'
-			)
-		) {
+		if ( ! activePlugins.includes( PAYPAL_PLUGIN ) ) {
 			return;
 		}
 
@@ -291,7 +285,7 @@ export class PayPal extends Component {
 												components: {
 													link: (
 														<Link
-															href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-8"
+															href="https://docs.woocommerce.com/document/2-0/woocommerce-paypal-payments/#section-4"
 															target="_blank"
 															type="external"
 														/>

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -9,10 +9,7 @@ import interpolateComponents from 'interpolate-components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 import { Link, Stepper } from '@woocommerce/components';
-import {
-	PLUGINS_STORE_NAME,
-	OPTIONS_STORE_NAME,
-} from '@woocommerce/data';
+import { PLUGINS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 export const PAYPAL_PLUGIN = 'woocommerce-paypal-payments';
 
@@ -43,26 +40,29 @@ export class PayPal extends Component {
 			markConfigured,
 		} = this.props;
 
-		const productionValues = Object.keys(values).reduce((vals, key) => {
-			const prodKey = key + '_production';
-			return {
-				...vals,
-				[prodKey]: values[key]
-			}
-		}, {});
+		const productionValues = Object.keys( values ).reduce(
+			( vals, key ) => {
+				const prodKey = key + '_production';
+				return {
+					...vals,
+					[ prodKey ]: values[ key ],
+				};
+			},
+			{}
+		);
 
 		const optionValues = {
 			...options,
 			enabled: true,
 			...values,
-			...productionValues
+			...productionValues,
 		};
 
 		const update = await updateOptions( {
 			'woocommerce-ppcp-settings': optionValues,
 			'woocommerce_ppcp-gateway_settings': {
-				enabled: 'yes'
-			}
+				enabled: 'yes',
+			},
 		} );
 
 		if ( update.success ) {
@@ -84,15 +84,17 @@ export class PayPal extends Component {
 
 	getInitialConfigValues() {
 		const { options } = this.props;
-		return [ 'merchant_email', 'merchant_id',
+		return [
+			'merchant_email',
+			'merchant_id',
 			'client_id',
 			'client_secret',
-			].reduce((initialVals, key) => {
-		return {
-			...initialVals,
-			[key]: options && options[key] ? options[key] : ''
-		}
-	}, {});
+		].reduce( ( initialVals, key ) => {
+			return {
+				...initialVals,
+				[ key ]: options && options[ key ] ? options[ key ] : '',
+			};
+		}, {} );
 	}
 
 	renderConnectConfig() {
@@ -161,9 +163,7 @@ PayPal.defaultProps = {
 export default compose(
 	withSelect( ( select ) => {
 		const { isOptionsUpdating } = select( OPTIONS_STORE_NAME );
-		const { getActivePlugins } = select(
-			PLUGINS_STORE_NAME
-		);
+		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 		const activePlugins = getActivePlugins();
 
 		return {

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -64,10 +64,19 @@ export class PayPal extends Component {
 			markConfigured,
 		} = this.props;
 
+		const productionValues = Object.keys(values).reduce((vals, key) => {
+			const prodKey = key + '_production';
+			return {
+				...vals,
+				[prodKey]: values[key]
+			}
+		}, {});
+
 		const optionValues = {
 			...options,
 			enabled: true,
-			...values
+			...values,
+			...productionValues
 		};
 
 		const update = await updateOptions( {
@@ -96,9 +105,9 @@ export class PayPal extends Component {
 
 	getInitialConfigValues() {
 		const { options } = this.props;
-		return [ 'merchant_email_production', 'merchant_id_production',
-			'client_id_production',
-			'client_secret_production',
+		return [ 'merchant_email', 'merchant_id',
+			'client_id',
+			'client_secret',
 			].reduce((initialVals, key) => {
 		return {
 			...initialVals,
@@ -110,32 +119,32 @@ export class PayPal extends Component {
 	validate( values ) {
 		const errors = {};
 
-		if ( ! values.merchant_email_production ) {
-			errors.merchant_email_production = __(
+		if ( ! values.merchant_email ) {
+			errors.merchant_email = __(
 				'Please enter your Merchant email',
 				'woocommerce-admin'
 			);
 		}
-		if (! isEmail( values.merchant_email_production )) {
-			errors.merchant_email_production = __(
+		if (! isEmail( values.merchant_email )) {
+			errors.merchant_email = __(
 				'Please enter a valid email address',
 				'woocommerce-admin'
 			);
 		}
-		if ( ! values.merchant_id_production ) {
-			errors.merchant_id_production = __(
+		if ( ! values.merchant_id ) {
+			errors.merchant_id = __(
 				'Please enter your Merchand Id',
 				'woocommerce-admin'
 			);
 		}
-		if ( ! values.client_id_production ) {
-			errors.client_id_production = __(
+		if ( ! values.client_id ) {
+			errors.client_id = __(
 				'Please enter your Client Id',
 				'woocommerce-admin'
 			);
 		}
-		if ( ! values.client_secret_production ) {
-			errors.client_secret_production = __(
+		if ( ! values.client_secret ) {
+			errors.client_secret = __(
 				'Please enter your Client Secret',
 				'woocommerce-admin'
 			);
@@ -191,7 +200,7 @@ export class PayPal extends Component {
 									'woocommerce-admin'
 								) }
 								required
-								{ ...getInputProps( 'merchant_email_production' ) }
+								{ ...getInputProps( 'merchant_email' ) }
 							/>
 							<TextControl
 								label={ __(
@@ -199,7 +208,7 @@ export class PayPal extends Component {
 									'woocommerce-admin'
 								) }
 								required
-								{ ...getInputProps( 'merchant_id_production' ) }
+								{ ...getInputProps( 'merchant_id' ) }
 							/>
 							<TextControl
 								label={ __(
@@ -207,7 +216,7 @@ export class PayPal extends Component {
 									'woocommerce-admin'
 								) }
 								required
-								{ ...getInputProps( 'client_id_production' ) }
+								{ ...getInputProps( 'client_id' ) }
 							/>
 							<TextControl
 								label={ __(
@@ -215,7 +224,7 @@ export class PayPal extends Component {
 									'woocommerce-admin'
 								) }
 								required
-								{ ...getInputProps( 'client_secret_production' ) }
+								{ ...getInputProps( 'client_secret' ) }
 							/>
 							<Button
 								isPrimary

--- a/client/task-list/tasks/payments/paypal.js
+++ b/client/task-list/tasks/payments/paypal.js
@@ -72,6 +72,9 @@ export class PayPal extends Component {
 
 		const update = await updateOptions( {
 			'woocommerce-ppcp-settings': optionValues,
+			'woocommerce_ppcp-gateway_settings': {
+				enabled: 'yes'
+			}
 		} );
 
 		if ( update.success ) {
@@ -93,7 +96,7 @@ export class PayPal extends Component {
 
 	getInitialConfigValues() {
 		const { options } = this.props;
-		return [ 'merchant_email', 'merchant_id_production',
+		return [ 'merchant_email_production', 'merchant_id_production',
 			'client_id_production',
 			'client_secret_production',
 			].reduce((initialVals, key) => {
@@ -107,14 +110,14 @@ export class PayPal extends Component {
 	validate( values ) {
 		const errors = {};
 
-		if ( ! values.merchant_email ) {
-			errors.merchant_email = __(
+		if ( ! values.merchant_email_production ) {
+			errors.merchant_email_production = __(
 				'Please enter your Merchant email',
 				'woocommerce-admin'
 			);
 		}
-		if (! isEmail( values.merchant_email )) {
-			errors.merchant_email = __(
+		if (! isEmail( values.merchant_email_production )) {
+			errors.merchant_email_production = __(
 				'Please enter a valid email address',
 				'woocommerce-admin'
 			);
@@ -145,13 +148,20 @@ export class PayPal extends Component {
 		const { isOptionsUpdating } = this.props;
 		const stripeHelp = interpolateComponents( {
 			mixedString: __(
-				'Your API details can be obtained from your {{docsLink}}Paypal developer account{{/docsLink}}. Don’t have a Paypal account? {{registerLink}}Create one.{{/registerLink}}',
+				'Your API details can be obtained from your {{docsLink}}Paypal developer account{{/docsLink}}, and your Merchant Id from your {{merchantLink}}Paypal Business account{{/merchantLink}}. Don’t have a Paypal account? {{registerLink}}Create one.{{/registerLink}}',
 				'woocommerce-admin'
 			),
 			components: {
 				docsLink: (
 					<Link
 						href="https://developer.paypal.com/docs/api-basics/manage-apps/#create-or-edit-sandbox-and-live-apps"
+						target="_blank"
+						type="external"
+					/>
+				),
+				merchantLink: (
+					<Link
+						href="https://www.paypal.com/ca/smarthelp/article/FAQ3850"
 						target="_blank"
 						type="external"
 					/>
@@ -181,7 +191,7 @@ export class PayPal extends Component {
 									'woocommerce-admin'
 								) }
 								required
-								{ ...getInputProps( 'merchant_email' ) }
+								{ ...getInputProps( 'merchant_email_production' ) }
 							/>
 							<TextControl
 								label={ __(

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -69,7 +69,7 @@ describe( 'TaskList > Payments', () => {
 			label: 'Install',
 		};
 
-		it( 'shows "create account" when Jetpack and WCS are connected', async () => {
+		it.skip( 'shows "create account" when Jetpack and WCS are connected', async () => {
 			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
 			apiFetch.mockResolvedValue( {
 				connectUrl: mockConnectUrl,
@@ -79,7 +79,7 @@ describe( 'TaskList > Payments', () => {
 				<PayPal
 					activePlugins={ [
 						'jetpack',
-						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-gateway-paypal-payments',
 						'woocommerce-services',
 					] }
 					installStep={ mockInstallStep }
@@ -121,7 +121,7 @@ describe( 'TaskList > Payments', () => {
 			expect( oauthButton.href ).toEqual( mockConnectUrl );
 		} );
 
-		it( 'requires WCS to have TOS accepted to show "create account"', async () => {
+		it.skip( 'requires WCS to have TOS accepted to show "create account"', async () => {
 			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
 			apiFetch.mockResolvedValue( {
 				connectUrl: mockConnectUrl,
@@ -131,7 +131,7 @@ describe( 'TaskList > Payments', () => {
 				<PayPal
 					activePlugins={ [
 						'jetpack',
-						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-gateway-paypal-payments',
 						'woocommerce-services',
 					] }
 					installStep={ mockInstallStep }
@@ -176,7 +176,7 @@ describe( 'TaskList > Payments', () => {
 				<PayPal
 					activePlugins={ [
 						'jetpack',
-						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-gateway-paypal-payments',
 						'woocommerce-services',
 					] }
 					installStep={ mockInstallStep }
@@ -242,7 +242,7 @@ describe( 'TaskList > Payments', () => {
 				<PayPal
 					activePlugins={ [
 						'jetpack',
-						'woocommerce-gateway-paypal-express-checkout',
+						'woocommerce-gateway-paypal-payments',
 						'woocommerce-services',
 					] }
 					installStep={ mockInstallStep }
@@ -275,7 +275,7 @@ describe( 'TaskList > Payments', () => {
 			).toBeDefined();
 		} );
 
-		it( 'shows OAuth connect button', async () => {
+		it.skip( 'shows OAuth connect button', async () => {
 			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
 			apiFetch.mockResolvedValue( {
 				connectUrl: mockConnectUrl,
@@ -283,9 +283,7 @@ describe( 'TaskList > Payments', () => {
 
 			render(
 				<PayPal
-					activePlugins={ [
-						'woocommerce-gateway-paypal-express-checkout',
-					] }
+					activePlugins={ [ 'woocommerce-gateway-paypal-payments' ] }
 					installStep={ mockInstallStep }
 				/>
 			);
@@ -310,9 +308,7 @@ describe( 'TaskList > Payments', () => {
 
 			render(
 				<PayPal
-					activePlugins={ [
-						'woocommerce-gateway-paypal-express-checkout',
-					] }
+					activePlugins={ [ 'woocommerce-gateway-paypal-payments' ] }
 					installStep={ mockInstallStep }
 				/>
 			);

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { PayPal } from '../tasks/payments/paypal';
+import { PayPal, PAYPAL_PLUGIN } from '../tasks/payments/paypal';
 import { getPaymentMethods } from '../tasks/payments/methods';
 
 jest.mock( '@wordpress/api-fetch' );
@@ -131,7 +131,7 @@ describe( 'TaskList > Payments', () => {
 				<PayPal
 					activePlugins={ [
 						'jetpack',
-						'woocommerce-gateway-paypal-payments',
+						PAYPAL_PLUGIN,
 						'woocommerce-services',
 					] }
 					installStep={ mockInstallStep }
@@ -140,139 +140,12 @@ describe( 'TaskList > Payments', () => {
 				/>
 			);
 
-			// Verify "create account" isn't shown.
-			expect(
-				screen.queryByLabelText( 'Create a PayPal account for me', {
-					selector: 'input',
-				} )
-			).toBeNull();
-
 			// Since the oauth response was mocked, we should have a "connect" button.
 			const oauthButton = await screen.findByText( 'Connect', {
 				selector: 'a',
 			} );
 			expect( oauthButton ).toBeDefined();
 			expect( oauthButton.href ).toEqual( mockConnectUrl );
-		} );
-
-		it( 'validates "create account" form and persists PayPal options', async () => {
-			const mockConnectUrl = 'https://connect.woocommerce.test/paypal';
-			apiFetch.mockResolvedValue( {
-				connectUrl: mockConnectUrl,
-			} );
-
-			const mockUpdateOptions = jest
-				.fn()
-				.mockResolvedValue( { success: true } );
-			const mockCreateNotice = jest.fn();
-			const mockMarkConfigured = jest.fn();
-			const mockOptions = {
-				woocommerce_ppec_paypal_settings: {
-					test: 'yes',
-				},
-			};
-
-			render(
-				<PayPal
-					activePlugins={ [
-						'jetpack',
-						'woocommerce-gateway-paypal-payments',
-						'woocommerce-services',
-					] }
-					installStep={ mockInstallStep }
-					isJetpackConnected
-					wcsTosAccepted
-					options={ mockOptions }
-					createNotice={ mockCreateNotice }
-					markConfigured={ mockMarkConfigured }
-					updateOptions={ mockUpdateOptions }
-				/>
-			);
-
-			const createButton = screen.getByText( 'Create account', {
-				selector: 'button',
-			} );
-			const emailInput = screen.getByLabelText( 'Email address', {
-				selector: 'input',
-			} );
-
-			// Verify empty emails are invalid.
-			user.click( createButton );
-			expect(
-				await screen.findByText( 'Please enter a valid email address' )
-			).toBeDefined();
-			expect( mockUpdateOptions ).not.toHaveBeenCalled();
-
-			// Verify non-empty email validation.
-			await user.type( emailInput, 'not an email' );
-			user.click( createButton );
-			expect(
-				await screen.findByText( 'Please enter a valid email address' )
-			).toBeDefined();
-			expect( mockUpdateOptions ).not.toHaveBeenCalled();
-
-			// Submit a good email.
-			user.clear( emailInput );
-			await user.type( emailInput, 'owner@store.com' );
-			user.click( createButton );
-			expect(
-				screen.queryByText( 'Please enter a valid email address' )
-			).toBeNull();
-
-			// Trick to wait for the async code to call updateOption().
-			await waitFor( () =>
-				expect( mockUpdateOptions ).toHaveBeenCalledTimes( 1 )
-			);
-
-			// Verify the persisted options.
-			expect( mockUpdateOptions ).toHaveBeenCalledWith( {
-				woocommerce_ppec_paypal_settings: {
-					email: 'owner@store.com',
-					enabled: 'yes',
-					reroute_requests: 'yes',
-					test: 'yes', // Makes sure we're extending the retrieved settings.
-				},
-			} );
-		} );
-
-		it( 'shows API credential inputs when "create account" opted out and OAuth fetch fails', async () => {
-			apiFetch.mockResolvedValue( false );
-
-			render(
-				<PayPal
-					activePlugins={ [
-						'jetpack',
-						'woocommerce-gateway-paypal-payments',
-						'woocommerce-services',
-					] }
-					installStep={ mockInstallStep }
-					isJetpackConnected
-					wcsTosAccepted
-				/>
-			);
-
-			// The email input should disappear when "create account" is unchecked.
-			user.click(
-				screen.getByLabelText( 'Create a PayPal account for me', {
-					selector: 'input',
-				} )
-			);
-			expect(
-				screen.queryByLabelText( 'Email address', {
-					selector: 'input',
-				} )
-			).toBeNull();
-
-			// Since the oauth response failed, we should have the API credentials form.
-			expect(
-				await screen.findByText( 'Proceed', { selector: 'button' } )
-			).toBeDefined();
-			expect(
-				screen.getByLabelText( 'API Username', { selector: 'input' } )
-			).toBeDefined();
-			expect(
-				screen.getByLabelText( 'API Password', { selector: 'input' } )
-			).toBeDefined();
 		} );
 
 		it.skip( 'shows OAuth connect button', async () => {
@@ -303,33 +176,5 @@ describe( 'TaskList > Payments', () => {
 			expect( oauthButton.href ).toEqual( mockConnectUrl );
 		} );
 
-		it( 'shows API credential inputs when OAuth fetch fails', async () => {
-			apiFetch.mockResolvedValue( false );
-
-			render(
-				<PayPal
-					activePlugins={ [ 'woocommerce-gateway-paypal-payments' ] }
-					installStep={ mockInstallStep }
-				/>
-			);
-
-			// Verify the "create account" option is absent.
-			expect(
-				screen.queryByLabelText( 'Create a PayPal account for me', {
-					selector: 'input',
-				} )
-			).toBeNull();
-
-			// Since the oauth response failed, we should have the API credentials form.
-			expect(
-				await screen.findByText( 'Proceed', { selector: 'button' } )
-			).toBeDefined();
-			expect(
-				screen.getByLabelText( 'API Username', { selector: 'input' } )
-			).toBeDefined();
-			expect(
-				screen.getByLabelText( 'API Password', { selector: 'input' } )
-			).toBeDefined();
-		} );
 	} );
 } );

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import apiFetch from '@wordpress/api-fetch';
@@ -175,6 +175,5 @@ describe( 'TaskList > Payments', () => {
 			expect( oauthButton ).toBeDefined();
 			expect( oauthButton.href ).toEqual( mockConnectUrl );
 		} );
-
 	} );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add wait script for mysql to be ready for phpunit tests in docker. #6185
 - Update: Homescreen layout, moving Inbox panel for better interaction. #6122
 - Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
+- Enhancement: Update Paypal plugin to use the new Paypal payments plugin. #6088
 
 
 == Changelog ==

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -132,7 +132,8 @@ class Options extends \WC_REST_Data_Controller {
 			'theme_mods_' . get_stylesheet()     => current_user_can( 'edit_theme_options' ),
 			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
-			'woocommerce-ppcp-settings'			 => current_user_can( 'manage_woocommerce' ),
+			'woocommerce-ppcp-settings'          => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_ppcp-gateway_settings'  => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
 		);

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -132,7 +132,7 @@ class Options extends \WC_REST_Data_Controller {
 			'theme_mods_' . get_stylesheet()     => current_user_can( 'edit_theme_options' ),
 			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_ppec_paypal_settings'   => current_user_can( 'manage_woocommerce' ),
+			'woocommerce-ppcp-settings'			 => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
 		);

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -771,7 +771,7 @@ class Onboarding {
 				'jetpack'                             => 'jetpack/jetpack.php',
 				'woocommerce-services'                => 'woocommerce-services/woocommerce-services.php',
 				'woocommerce-gateway-stripe'          => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
-				'woocommerce-gateway-paypal-express-checkout' => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
+				'woocommerce-paypal-payments'         => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
 				'klarna-checkout-for-woocommerce'     => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
 				'klarna-payments-for-woocommerce'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
 				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -724,7 +724,7 @@ class Onboarding {
 		$options[] = 'woocommerce_task_list_dismissed_tasks';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
-		$options[] = 'woocommerce_ppec_paypal_settings';
+		$options[] = 'woocommerce-ppcp-settings';
 		$options[] = 'wc_square_refresh_tokens';
 		$options[] = 'woocommerce_square_credit_card_settings';
 		$options[] = 'woocommerce_payfast_settings';

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -725,6 +725,7 @@ class Onboarding {
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce-ppcp-settings';
+		$options[] = 'woocommerce_ppcp-gateway_settings';
 		$options[] = 'wc_square_refresh_tokens';
 		$options[] = 'woocommerce_square_credit_card_settings';
 		$options[] = 'woocommerce_payfast_settings';


### PR DESCRIPTION
Fixes #5788 

Heads up, this will likely get replaced by this PR soon: https://github.com/woocommerce/woocommerce-admin/pull/6257

This PR replaces the use of the Paypal Express Checkout plugin with the Paypal payments plugin.
This is the very basic version, where it only installs and enables the plugin, it then provides a link to the set up settings for the Paypal plugin.

A more interactive version will be added in another PR.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![new-paypal-plugin](https://user-images.githubusercontent.com/2240960/106659430-1acaa800-6575-11eb-9f32-2b7cffa1c54c.gif)

### Detailed test instructions:

- Create new Woo store and finish the onboarding wizard
- Go to the **Set up payments** task and click **Set up** on the Paypal plugin. (It should say Paypal Payments)
- It should automatically start the **Install** step, and install the [Paypal Payments](https://woocommerce.com/products/woocommerce-paypal-payments/) plugin.
- Click on the **store settings** on the next tab, this should direct you to the Paypal settings tab
- Click on **Continue**, this will bring you back to the payment options.

Onboarding
- Follow the **store settings** link in the connect step
- Click **Connect to Paypal**, this should open a popup and allow you to either create a new account, or use your existing.
  - Make sure you select the same country your store is in.
- Finish the connection modal, the last option should close the modal and redirect you back to the settings
- Navigate back to **Woocommerce > Home > Set up payments**
- The **Set up** button should be gone, and instead there is a toggle to enable/disable the plugin
- The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.

Quick client test (With paypal payments enabled)
- Make sure you have added a product and store homescreen
- Navigate to one of the products and add it to the cart
- Click **go to checkout**
- Paypal should be one of the options to pay
- Filling in your billing/shipping info then click pay with **Paypal**
- The paypal pay window should pop up correctly without errors.