### PR TITLE
Add core settings redirection to new settings pages

### DIFF
--- a/src/Features/Settings.php
+++ b/src/Features/Settings.php
@@ -53,6 +53,7 @@ class Settings {
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'add_component_settings' ) );
 		// Run this after the original WooCommerce settings have been added.
 		add_action( 'admin_menu', array( $this, 'register_pages' ), 60 );
+		add_action( 'init', array( $this, 'redirect_core_settings_pages' ) );
 	}
 
 	/**
@@ -152,5 +153,27 @@ class Settings {
 				$item[2] = wc_admin_url( "&path={$page['path']}" );
 			}
 		}
+	}
+
+	/**
+	 * Redirect the old settings page URLs to the new ones.
+	 */
+	public function redirect_core_settings_pages() {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if ( ! isset( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$setting_pages   = \WC_Admin_Settings::get_settings_pages();
+		$default_setting = isset( $setting_pages[0] ) ? $setting_pages[0]->get_id() : '';
+		$setting         = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : $default_setting;
+		/* phpcs:enable */
+
+		wp_safe_redirect( wc_admin_url( "&path=/settings/$setting" ) );
+		exit;
 	}
 }


### PR DESCRIPTION
Adds redirection from old core pages to new ones when setting feature is enabled.

### Screenshots

![vIADO8a](https://user-images.githubusercontent.com/10561050/104969830-8dedef00-59b7-11eb-89f9-85169cee790b.gif)

### Detailed test instructions:

1. Try to navigate to an old settings page URL `/wp-admin/admin.php?page=wc-settings&tab=advanced`
2. Make sure you're taken to the WCA version `/wp-admin/admin.php?page=wc-admin&path=%2Fsettings%2Fadvanced`
3. Try to navigate to a URL without the `tab` param. `/wp-admin/admin.php?page=wc-settings`
4. Make sure you're taken to the first settings page (typically `general`).