### PR TITLE
Update store deprecation welcome modal support doc link

### DIFF
--- a/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
+++ b/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
@@ -32,7 +32,7 @@ const page = {
 				components: {
 					link: (
 						<Link
-							href="https://wordpress.com/support/store/"
+							href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
 							type="external"
 							target="_blank"
 						/>

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
 - Tweak: update the content and timing of the NeedSomeInspiration note. #6076
 - Add: Remote inbox notifications contains comparison and fix product rule. #6073
+- Update: store deprecation welcome modal support doc link #6094
 
 
 == Changelog ==

--- a/src/Notes/WelcomeToWooCommerceForStoreUsers.php
+++ b/src/Notes/WelcomeToWooCommerceForStoreUsers.php
@@ -48,7 +48,7 @@ class WelcomeToWooCommerceForStoreUsers {
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://wordpress.com/support/store/"',
+			'https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"',
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true
 		);


### PR DESCRIPTION
Fixes #6093

This PR updates the welcome modal support document link to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/

### Detailed test instructions:

- Starting with a fresh store (or by deleting the `woocommerce_task_list_welcome_modal_dismissed` option), visit `/wp-admin/admin.php?page=wc-admin`. You should see the standard welcome modal.
- Add `&from-calypso` to the URL. You should see the Calypso welcome modal.
- Notice "Learn more" links to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
