### PR TITLE
Fix WooCommerce mobile menu for new navigation

### DIFF
--- a/packages/navigation/src/style.scss
+++ b/packages/navigation/src/style.scss
@@ -7,5 +7,11 @@ body.js:not(.has-woocommerce-navigation) {
 
 	.toplevel_page_woocommerce ul.wp-submenu {
 		display: none;
+
+		@include breakpoint( '<782px' ) {
+			.wp-first-item.hide-if-js {
+				display: list-item;
+			}
+		}
 	}
 }

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -494,8 +494,15 @@ class Menu {
 			return;
 		}
 
-		foreach ( $submenu['woocommerce'] as $menu_item ) {
+		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 			if ( in_array( $menu_item[2], CoreMenu::get_excluded_items(), true ) ) {
+				// phpcs:disable
+				if ( ! isset( $menu_item[ self::CSS_CLASSES ] ) ) {
+					$submenu['woocommerce'][ $key ][] .= ' hide-if-js';
+				} else {
+					$submenu['woocommerce'][ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+				}
+				// phpcs:enable
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #6079

Shows the first menu item "Home" on mobile screens (<782px) and also fixes shown excluded items.

Note that we'll probably want to show a different set of items once the flyout menu feature is finalized.

### Screenshots

<img width="233" alt="Screen Shot 2021-01-19 at 12 18 12 PM" src="https://user-images.githubusercontent.com/10561050/105069850-7f074b00-5a50-11eb-8552-51cdbb0aa857.png">


### Detailed test instructions:

1. Narrow your viewport to <782px.
2. Click on "WooCommerce"
3. Note that "Home" is shown and the link works.
4. Make sure "Reports" is not shown.
5. Make sure the menu works as expected on larger screens.