### PR TITLE
Remove old debug code for connecting to Calypso / WordPress.com in help section

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,8 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Allowing users to create products by selecting a template. #5892
 - Dev: Add wait script for mysql to be ready for phpunit tests in docker. #6185
 - Update: Homescreen layout, moving Inbox panel for better interaction. #6122
+- Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
+
 
 == Changelog ==
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -106,7 +106,6 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
 		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_action( 'current_screen', array( $this, 'reset_extended_task_list' ) );
-		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
 	}
@@ -973,73 +972,6 @@ class Onboarding {
 		);
 
 		$screen->add_help_tab( $help_tab );
-	}
-
-	/**
-	 * Allows quick access to testing the calypso parts of onboarding.
-	 */
-	public static function calypso_tests() {
-		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
-
-		if ( Loader::is_admin_page() && class_exists( 'Jetpack' ) && isset( $_GET['test_wc_jetpack_connect'] ) && 1 === absint( $_GET['test_wc_jetpack_connect'] ) ) { // phpcs:ignore CSRF ok.
-			$redirect_url = esc_url_raw(
-				add_query_arg(
-					array(
-						'page' => 'wc-admin',
-					),
-					admin_url( 'admin.php' )
-				)
-			);
-
-			$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
-			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
-
-			wp_redirect( $connect_url );
-			exit;
-		}
-
-		if ( Loader::is_admin_page() && isset( $_GET['test_wc_helper_connect'] ) && 1 === absint( $_GET['test_wc_helper_connect'] ) ) { // phpcs:ignore CSRF ok.
-			include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
-
-			$redirect_uri = wc_admin_url( '&task=connect&wccom-connected=1' );
-
-			$request = \WC_Helper_API::post(
-				'oauth/request_token',
-				array(
-					'body' => array(
-						'home_url'     => home_url(),
-						'redirect_uri' => $redirect_uri,
-					),
-				)
-			);
-
-			$code = wp_remote_retrieve_response_code( $request );
-			if ( 200 !== $code ) {
-				wp_die( esc_html__( 'WooCommerce Helper was not able to connect to WooCommerce.com.', 'woocommerce-admin' ) );
-				exit;
-			}
-
-			$secret = json_decode( wp_remote_retrieve_body( $request ) );
-			if ( empty( $secret ) ) {
-				wp_die( esc_html__( 'WooCommerce Helper was not able to connect to WooCommerce.com.', 'woocommerce-admin' ) );
-				exit;
-			}
-
-			$connect_url = add_query_arg(
-				array(
-					'home_url'     => rawurlencode( home_url() ),
-					'redirect_uri' => rawurlencode( $redirect_uri ),
-					'secret'       => rawurlencode( $secret ),
-					'wccom-from'   => 'onboarding',
-				),
-				\WC_Helper_API::url( 'oauth/authorize' )
-			);
-
-			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
-
-			wp_redirect( $connect_url );
-			exit;
-		}
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -972,17 +972,6 @@ class Onboarding {
 			: '<p><a href="' . wc_admin_url( '&reset_extended_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
 		);
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$help_tab['content'] .= '<h3>' . __( 'Calypso / WordPress.com', 'woocommerce-admin' ) . '</h3>';
-			if ( class_exists( 'Jetpack' ) ) {
-				$help_tab['content'] .= '<p>' . __( 'Quickly access the Jetpack connection flow in Calypso.', 'woocommerce-admin' ) . '</p>';
-				$help_tab['content'] .= '<p><a href="' . wc_admin_url( '&test_wc_jetpack_connect=1' ) . '" class="button button-primary">' . __( 'Connect', 'woocommerce-admin' ) . '</a></p>';
-			}
-
-			$help_tab['content'] .= '<p>' . __( 'Quickly access the WooCommerce.com connection flow in Calypso.', 'woocommerce-admin' ) . '</p>';
-			$help_tab['content'] .= '<p><a href="' . wc_admin_url( '&test_wc_helper_connect=1' ) . '" class="button button-primary">' . __( 'Connect', 'woocommerce-admin' ) . '</a></p>';
-		}
-
 		$screen->add_help_tab( $help_tab );
 	}
 


### PR DESCRIPTION
Fixes #5918 

As suggested [here](https://github.com/woocommerce/woocommerce-admin/issues/5918#issuecomment-751910007) removing the `Calypso / Wordpress.com` connect help section, which was only displayed when WP_DEBUG was enabled.

### Screenshots

<img width="738" alt="Screen Shot 2021-01-19 at 2 43 46 PM" src="https://user-images.githubusercontent.com/2240960/105079077-49b92800-5a65-11eb-95eb-01831d6894b2.png">

### Detailed test instructions:

- Make sure you have WP_DEBUG set to `True`
- Go to a non-JS page, like WooCommerce > Orders (if you have orders!)
- Open the Help tab, go to "Setup wizard"
- Note it should not display the `Calypso / WordPress.com` section (see original ticket for how it looked originally - https://github.com/woocommerce/woocommerce-admin/issues/5918#issue-772361085)

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
