### PR TITLE
Try: Add initial setting options render

### DIFF
--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -1,3 +1,24 @@
-export default ( {} ) => {
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { Spinner } from '@wordpress/components';
+
+export default ( { params } ) => {
+	const { settings, isLoading } = useSelect( ( select ) => {
+		return {
+			isLoading: ! select(
+				SETTINGS_STORE_NAME
+			).hasFinishedResolution( 'getSettings', [ params.page ] ),
+			settings:
+				select( SETTINGS_STORE_NAME ).getSettings( params.page ) || {},
+		};
+	} );
+
+	if ( isLoading ) {
+		return <Spinner />;
+	}
+
 	return <div>Settings page</div>;
 };

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -5,14 +5,21 @@ import { useSelect } from '@wordpress/data';
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { Spinner } from '@wordpress/components';
 
-export default ( { params } ) => {
-	const { settings, isLoading } = useSelect( ( select ) => {
+/**
+ * Internal dependencies
+ */
+import { SettingOptions } from './setting-options';
+import './style.scss';
+
+export const SettingsPage = ( { params } ) => {
+	const group = params.page;
+	const { settingOptions, isLoading } = useSelect( ( select ) => {
 		return {
 			isLoading: ! select(
 				SETTINGS_STORE_NAME
-			).hasFinishedResolution( 'getSettings', [ params.page ] ),
-			settings:
-				select( SETTINGS_STORE_NAME ).getSettings( params.page ) || {},
+			).hasFinishedResolution( 'getSettingOptions', [ group ] ),
+			settingOptions:
+				select( SETTINGS_STORE_NAME ).getSettingOptions( group ) || {},
 		};
 	} );
 
@@ -20,5 +27,7 @@ export default ( { params } ) => {
 		return <Spinner />;
 	}
 
-	return <div>Settings page</div>;
+	return <SettingOptions options={ settingOptions[ group ] } />;
 };
+
+export default SettingsPage;

--- a/client/settings/setting-option.js
+++ b/client/settings/setting-option.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import {
+	CheckboxControl,
+	SelectControl,
+	TextareaControl,
+	TextControl,
+} from '@wordpress/components';
+import { NumberControl } from '@woocommerce/experimental';
+
+export const SettingOption = ( {
+	description,
+	label,
+	onChange = () => {},
+	options,
+	placeholder,
+	type,
+	value,
+} ) => {
+	if ( ! type ) {
+		return null;
+	}
+
+	const renderControl = () => {
+		if ( type === 'text' || type === 'password' ) {
+			return (
+				<TextControl
+					value={ value }
+					onChange={ onChange }
+					placeholder={ placeholder }
+					type={ type }
+				/>
+			);
+		}
+
+		if ( type === 'password' ) {
+			return (
+				<TextControl
+					value={ value }
+					onChange={ onChange }
+					placeholder={ placeholder }
+				/>
+			);
+		}
+
+		if ( type === 'textarea' ) {
+			return (
+				<TextareaControl
+					help={ description }
+					value={ value }
+					onChange={ onChange }
+					rows="5"
+				/>
+			);
+		}
+
+		if ( type === 'checkbox' ) {
+			return (
+				<CheckboxControl
+					label={ description }
+					onChange={ onChange }
+					checked={ value === 'yes' }
+				/>
+			);
+		}
+
+		if ( type === 'select' ) {
+			return (
+				<SelectControl
+					value={ value }
+					onChange={ onChange }
+					options={ Object.keys( options ).map( ( option ) => {
+						return {
+							label: options[ option ],
+							value: option,
+						};
+					} ) }
+					multiple={ type === 'multiselect' }
+				/>
+			);
+		}
+
+		if ( type === 'number' ) {
+			return <NumberControl value={ value } onChange={ onChange } />;
+		}
+
+		return null;
+	};
+
+	return (
+		<div className="woocommerce-admin-setting-option">
+			<div className="woocommerce-admin-setting-option__label">
+				{ label }
+			</div>
+			<div className="woocommerce-admin-setting-option__description">
+				{ description }
+			</div>
+			<div className="woocommerce-admin-setting-option__control">
+				{ renderControl() }
+			</div>
+		</div>
+	);
+};
+
+export default SettingOption;

--- a/client/settings/setting-option.js
+++ b/client/settings/setting-option.js
@@ -34,16 +34,6 @@ export const SettingOption = ( {
 			);
 		}
 
-		if ( type === 'password' ) {
-			return (
-				<TextControl
-					value={ value }
-					onChange={ onChange }
-					placeholder={ placeholder }
-				/>
-			);
-		}
-
 		if ( type === 'textarea' ) {
 			return (
 				<TextareaControl

--- a/client/settings/setting-options.js
+++ b/client/settings/setting-options.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { SettingOption } from './setting-option';
+
+export const SettingOptions = ( { options } ) => {
+	if ( ! options.length ) {
+		return null;
+	}
+
+	return (
+		<div className="woocommerce-admin-setting-options">
+			{ options.map( ( option ) => {
+				return <SettingOption key={ option.id } { ...option } />;
+			} ) }
+		</div>
+	);
+};
+
+export default SettingOptions;

--- a/client/settings/style.scss
+++ b/client/settings/style.scss
@@ -1,0 +1,3 @@
+.woocommerce-admin-setting-option {
+	margin-bottom: $gap;
+}

--- a/packages/data/src/settings/resolvers.js
+++ b/packages/data/src/settings/resolvers.js
@@ -10,13 +10,6 @@ import { NAMESPACE } from '../constants';
 import { STORE_NAME } from './constants';
 import { updateSettingsForGroup, updateErrorForGroup } from './actions';
 
-function settingsToSettingsResource( settings ) {
-	return settings.reduce( ( resource, setting ) => {
-		resource[ setting.id ] = setting.value;
-		return resource;
-	}, {} );
-}
-
 export function* getSettings( group ) {
 	yield dispatch( STORE_NAME, 'setIsRequesting', group, true );
 
@@ -27,12 +20,14 @@ export function* getSettings( group ) {
 			method: 'GET',
 		} );
 
-		const resource = settingsToSettingsResource( results );
-
-		return updateSettingsForGroup( group, { [ group ]: resource } );
+		return updateSettingsForGroup( group, { [ group ]: results } );
 	} catch ( error ) {
 		return updateErrorForGroup( group, null, error.message );
 	}
+}
+
+export function* getSettingOptions( group ) {
+	yield getSettings( group );
 }
 
 export function* getSettingsForGroup( group ) {

--- a/packages/data/src/settings/selectors.js
+++ b/packages/data/src/settings/selectors.js
@@ -18,6 +18,30 @@ export const getSettings = ( state, group ) => {
 	if ( settingIds.length === 0 ) {
 		return settings;
 	}
+
+	settingIds.forEach( ( id ) => {
+		settings[ id ] = getSettingValues(
+			state[ getResourceName( group, id ) ].data
+		);
+	} );
+	return settings;
+};
+
+const getSettingValues = ( settings ) => {
+	return settings.reduce( ( resource, setting ) => {
+		resource[ setting.id ] = setting.value;
+		return resource;
+	}, {} );
+};
+
+export const getSettingOptions = ( state, group ) => {
+	const settings = {};
+
+	const settingIds = ( state[ group ] && state[ group ].data ) || [];
+	if ( settingIds.length === 0 ) {
+		return settings;
+	}
+
 	settingIds.forEach( ( id ) => {
 		settings[ id ] = state[ getResourceName( group, id ) ].data;
 	} );

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -7,6 +7,7 @@ import {
 	__experimentalNavigationGroup,
 	__experimentalNavigationMenu,
 	__experimentalNavigationItem,
+	__experimentalNumberControl,
 	__experimentalText,
 	__experimentalUseSlot,
 	Navigation as NavigationComponent,
@@ -14,6 +15,7 @@ import {
 	NavigationGroup as NavigationGroupComponent,
 	NavigationMenu as NavigationMenuComponent,
 	NavigationItem as NavigationItemComponent,
+	NumberControl as NumberControlComponent,
 	Text as TextComponent,
 	useSlot as useSlotHook,
 } from '@wordpress/components';
@@ -30,5 +32,7 @@ export const NavigationMenu =
 	NavigationMenuComponent || __experimentalNavigationMenu;
 export const NavigationItem =
 	NavigationItemComponent || __experimentalNavigationItem;
+export const NumberControl =
+	NumberControlComponent || __experimentalNumberControl;
 export const Text = TextComponent || __experimentalText;
 export const useSlot = useSlotHook || __experimentalUseSlot;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1076,12 +1076,8 @@ class Loader {
 		if ( ! empty( $preload_settings ) ) {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
-				$group_settings   = $setting_options->get_group_settings( $group );
-				$preload_settings = [];
-				foreach ( $group_settings as $option ) {
-					$preload_settings[ $option['id'] ] = $option['value'];
-				}
-				$settings['preloadSettings'][ $group ] = $preload_settings;
+				$group_settings                        = $setting_options->get_group_settings( $group );
+				$settings['preloadSettings'][ $group ] = $group_settings;
 			}
 		}
 


### PR DESCRIPTION
* Adds initial setting options rendering for `text|password|select|multiselect|number|textarea`
* Adds data store selector to get setting options

This PR requires follow-ups and DOES NOT:

* Address insufficient preloading of "General" settings
* Handle option styling
* Rendering HTML segments in options
* Option changes/state and saving

### Screenshots

<img width="552" alt="Screen Shot 2021-01-19 at 5 08 47 PM" src="https://user-images.githubusercontent.com/10561050/105099330-82fb9300-5a79-11eb-8d00-2d5a83fcf679.png">


### Detailed test instructions:

1. Navigate to any settings page that uses the Settings API  to create controls (except General due to pre-existing preloaded settings issues)
2. Check that the above Setting types render (unstyled)
3. Smoke test other areas in the app to make sure no setting regressions have occurred