### PR TITLE
Navigation should fold automattically after clicking link in mobile

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -15,6 +15,7 @@ import { debounce } from 'lodash';
  * Internal dependencies
  */
 import useIsScrolled from '../../../hooks/useIsScrolled';
+import { addHistoryListener } from '../../utils';
 
 const Header = () => {
 	const siteTitle = getSetting( 'siteTitle', '' );
@@ -67,6 +68,8 @@ const Header = () => {
 		for ( const { eventName, handler } of foldEvents ) {
 			window.addEventListener( eventName, handler, false );
 		}
+
+		addHistoryListener( () => foldOnMobile() );
 	}, [] );
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;


### PR DESCRIPTION
Fixes #6100 

As per the [recent nav revisions P2](pbIJXs-xY-p2), the navigation should fold after clicking a link on mobile. Currently this behavior doesn't happen when navigating between React-based pages. This PR addresses that.

### Detailed test instructions:

-   Checkout branch
-   Ensure navigation is enabled
-  Navigate to _WooCommerce > Home_
- Resize viewport to < 960 px
- Expand navigation and navigate to _WooCommerce -> Customers_
- Navigation should fold automatically