### PR TITLE
Pin WooCommerce Version in Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ services:
     - mysql
     - docker
 
+env:
+    - WC_VERSION=4.5.0
+
 matrix:
     include:
         - name: 'PHP 7.3 unit tests, PHP Coding standards check and JS tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
     - docker
 
 env:
-    - WC_VERSION=4.5.0
+    - global:
+          - WC_VERSION=4.5.0
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
         - name: 'PHP 7.3 unit tests, PHP Coding standards check and JS tests'
           php: 7.3
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_PHPCS=1 RUN_JS=1 COMPOSER_DEV=1
+        - name: 'Latest WooCommerce'
+          php: 7.3
+          env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress COMPOSER_DEV=1 WC_VERSION=
         - name: 'PHP 7.3 unit tests, run in random order'
           php: 7.3
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_RANDOM=1 COMPOSER_DEV=1
@@ -34,7 +37,7 @@ matrix:
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress WC_VERSION=3.8.1
     allow_failures:
         php: 7.3
-        env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_RANDOM=1 COMPOSER_DEV=1
+        env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress COMPOSER_DEV=1 WC_VERSION=
 
 before_install:
     - nvm install 'lts/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,9 @@ matrix:
           php: 5.6
           env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress WC_VERSION=3.8.1
     allow_failures:
-        php: 7.3
-        env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress COMPOSER_DEV=1 WC_VERSION=
+        - php: 7.3
+          env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_RANDOM=1 COMPOSER_DEV=1
+        - env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress COMPOSER_DEV=1 WC_VERSION=
 
 before_install:
     - nvm install 'lts/*'


### PR DESCRIPTION
The current Travis builds are broken after the release of WooCommerce `4.9.1`, which is preventing PR checks from passing.

This PR pins the Travis build to WooCommerce `4.5.0`, our minimum supported version. 

To continue testing against the latest version of WooCommerce, a new build for it is added to the matrix and allowed to fail. This will prevent PR checks being blocked by issues with new versions of WooCommerce, whilst still providing visibility about the issue.

### Detailed test instructions:

-   Ensure that all Travis builds pass, except for "Latest WooCommerce".
