### PR TITLE
Make sure current_page has path index

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -652,7 +652,7 @@ class Onboarding {
 	protected function is_home_or_setup_wizard_page() {
 		$allowed_paths = array( 'wc-admin', 'wc-admin&path=/setup-wizard' );
 		$current_page  = PageController::get_instance()->get_current_page();
-		if ( ! $current_page ) {
+		if ( ! $current_page || ! isset( $current_page['path'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #6113 

This PR fixes `PHP Error: Undefined index: path` issue by making sure `path` index exists in the array.

I would like to investigate it a little further and find out why the `path` index is missing on some pages, but this PR should fix the error for the release.

### Detailed test instructions:

1. Turn on `WP_DEBUG` and `WP_DEBUG_LOG` in `wp-config.php`
2. Navigate to Products -> Add New
3. Check wordpress/wp-content/debug.log and make sure you don't see PHP error with `Undefined index: path` message.