### PR TITLE
Add exclusion on getOptions and method renaming

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -264,6 +264,7 @@ class BusinessDetails extends Component {
 							<Card>
 								<>
 									<SelectControl
+										excludeSelectedOptions={ false }
 										label={ __(
 											'How many products do you plan to display?',
 											'woocommerce-admin'
@@ -274,6 +275,7 @@ class BusinessDetails extends Component {
 									/>
 
 									<SelectControl
+										excludeSelectedOptions={ false }
 										label={ __(
 											'Currently selling elsewhere?',
 											'woocommerce-admin'
@@ -290,6 +292,7 @@ class BusinessDetails extends Component {
 										'other-woocommerce',
 									].includes( values.selling_venues ) && (
 										<SelectControl
+											excludeSelectedOptions={ false }
 											label={ __(
 												"What's your current annual revenue?",
 												'woocommerce-admin'
@@ -311,6 +314,9 @@ class BusinessDetails extends Component {
 										<>
 											<div className="business-competitors">
 												<SelectControl
+													excludeSelectedOptions={
+														false
+													}
 													label={ __(
 														'Which platform is the store using?',
 														'woocommerce-admin'

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -42,14 +42,14 @@ class Control extends Component {
 			isSearchable,
 			setExpanded,
 			showAllOnFocus,
-			updateFilteredOptions,
+			updateSearchOptions,
 		} = this.props;
 
 		return ( event ) => {
 			this.setState( { isActive: true } );
 			if ( isSearchable && showAllOnFocus ) {
 				event.target.select();
-				updateFilteredOptions( '' );
+				updateSearchOptions( '' );
 			} else if ( isSearchable ) {
 				onSearch( event.target.value );
 			} else {

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -218,13 +218,19 @@ export class SelectControl extends Component {
 				? cacheSearchOptions
 				: this.getOptionsByQuery( cacheSearchOptions, query );
 
-		this.setState( {
-			query,
-			isFocused: true,
-			selectedIndex: 0,
-			searchOptions,
-			isExpanded: Boolean( searchOptions.length ),
-		} );
+		this.setState(
+			{
+				query,
+				isFocused: true,
+				selectedIndex: 0,
+				searchOptions,
+			},
+			() => {
+				this.setState( {
+					isExpanded: Boolean( this.getOptions().length ),
+				} );
+			}
+		);
 
 		this.updateSearchOptions( query );
 	}
@@ -253,9 +259,13 @@ export class SelectControl extends Component {
 				{
 					selectedIndex: 0,
 					searchOptions,
-					isExpanded: Boolean( searchOptions.length ),
 				},
-				() => this.announce( searchOptions )
+				() => {
+					this.setState( {
+						isExpanded: Boolean( this.getOptions().length ),
+					} );
+					this.announce( searchOptions );
+				}
 			);
 		} ) );
 	}

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -157,19 +157,21 @@ export class SelectControl extends Component {
 	}
 
 	getOptions() {
-		const { isSearchable, options } = this.props;
+		const { isSearchable, options, excludeSelectedOptions } = this.props;
 		const { filteredOptions } = this.state;
-		return isSearchable ? filteredOptions : options;
+		const selectedKeys = this.getSelected().map( ( option ) => option.key );
+		const shownOptions = isSearchable ? filteredOptions : options;
+
+		if ( excludeSelectedOptions ) {
+			return shownOptions.filter(
+				( option ) => ! selectedKeys.includes( option.key )
+			);
+		}
+		return shownOptions;
 	}
 
 	getFilteredOptions( options, query ) {
-		const {
-			excludeSelectedOptions,
-			getSearchExpression,
-			maxResults,
-			onFilter,
-		} = this.props;
-		const selectedKeys = this.getSelected().map( ( option ) => option.key );
+		const { getSearchExpression, maxResults, onFilter } = this.props;
 		const filtered = [];
 
 		// Create a regular expression to filter the options.
@@ -180,13 +182,6 @@ export class SelectControl extends Component {
 
 		for ( let i = 0; i < options.length; i++ ) {
 			const option = options[ i ];
-
-			if (
-				excludeSelectedOptions &&
-				selectedKeys.includes( option.key )
-			) {
-				continue;
-			}
 
 			// Merge label into keywords
 			let { keywords = [] } = option;


### PR DESCRIPTION
Fixes #6005 

Add selected exclusion on getOptions and rename `filteredOptions` to `searchOptions`

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [X] I've tested using only a keyboard (no mouse)
-   [X] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
Before
<img width="551" alt="before" src="https://user-images.githubusercontent.com/56378160/105253745-13a3a300-5b4e-11eb-9cae-d315feb41583.png">
After
<img width="581" alt="after" src="https://user-images.githubusercontent.com/56378160/105253767-1d2d0b00-5b4e-11eb-95c9-53008f2417c5.png">

### Detailed test instructions:
-   npm run storybook
-   Find `selectControl` and check check that already selected options are excluded from the list.

