### PR TITLE
Try: Use settings tabs filter to get setting pages for nav

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -42,15 +42,11 @@ class CoreMenu {
 	 * Add registered admin settings as menu items.
 	 */
 	public static function get_setting_items() {
-		$setting_pages = \WC_Admin_Settings::get_settings_pages();
-		$settings      = array();
-		foreach ( $setting_pages as $setting_page ) {
-			$settings = $setting_page->add_settings_page( $settings );
-		}
+		$tabs = apply_filters( 'woocommerce_settings_tabs_array', array() );
 
 		$menu_items = array();
 		$order      = 0;
-		foreach ( $settings as $key => $setting ) {
+		foreach ( $tabs as $key => $setting ) {
 			$order       += 10;
 			$menu_items[] = (
 				array(


### PR DESCRIPTION
Uses the tabs hook instead of the settings page hook to get settings item.

While the official docs and naming implies, I would expect the pages hook to be the right way to register pages.  However, most unofficial WooCommerce how-tos seem to use the tabs hook and this at least works with all the current use cases.

See p2-p7DVsv-ae2#comment-33691 for discussion around this.

### Screenshots
<img width="677" alt="Screen Shot 2021-01-20 at 6 41 27 PM" src="https://user-images.githubusercontent.com/10561050/105254745-3b940600-5b50-11eb-9033-e09ce791a012.png">


### Detailed test instructions:

1. Install and activate Collisimo ( https://wordpress.org/plugins/colissimo-shipping-methods-for-woocommerce/ )
2. Check that the settings tabs includes all default WC setting tabs as well as Collisimo.
3. Note that an additional Collisimo menu item will exist due to migrating un-migrated WooCommerce menu items from the old menu (discussion on whether or not we want to change this in above p2).