### PR TITLE
Fix fatal error on homescreen when clicking add products task

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -416,9 +416,8 @@ export default compose(
 		const requestingTaskListOptions =
 			isResolving( 'getOption', [ 'woocommerce_task_list_complete' ] ) ||
 			isResolving( 'getOption', [ 'woocommerce_task_list_hidden' ] );
-		const trackedCompletedTasks = getOption(
-			'woocommerce_task_list_tracked_completed_tasks'
-		);
+		const trackedCompletedTasks =
+			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 
 		return {
 			hasUnreadNotes,

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -175,9 +175,8 @@ export default compose(
 		} = select( PLUGINS_STORE_NAME );
 		const profileItems = getProfileItems();
 
-		const trackedCompletedTasks = getOption(
-			'woocommerce_task_list_tracked_completed_tasks'
-		);
+		const trackedCompletedTasks =
+			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
 
 		const { general: generalSettings = {} } = getSettings( 'general' );
 		const countryCode = getCountryCode(


### PR DESCRIPTION
Fixes #6111 

Fixing fatal error when navigating to Homescreen after clicking add product task twice. 

### Detailed test instructions:

* Checkout branch
* Ensure you have no products in your store (and all onboarding tasks are incomplete)
* Go to WooCommerce->home
* Click on “Add my products”
* Click on WooCommerce->home again
* Click on “Add my products” again. 
* Ensure no error is thrown and no blank screen is displayed. 