### PR TITLE
Move inbox panel to left column, to increase user interaction

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -96,16 +96,11 @@ export const Layout = ( {
 					/>
 					<ActivityPanel />
 					{ isTaskListEnabled && renderTaskList() }
-					{ ! isTaskListEnabled && shouldStickColumns && (
-						<StoreManagementLinks />
-					) }
+					<InboxPanel />
 				</Column>
 				<Column shouldStick={ shouldStickColumns }>
 					<StatsOverview />
-					<InboxPanel />
-					{ ! isTaskListEnabled && ! shouldStickColumns && (
-						<StoreManagementLinks />
-					) }
+					{ ! isTaskListEnabled && <StoreManagementLinks /> }
 				</Column>
 			</>
 		);

--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -208,7 +208,7 @@ describe( 'Homescreen Layout', () => {
 		const { container } = render(
 			<Layout
 				requestingTaskList={ false }
-				taskListHidden={ false }
+				bothTaskListsHidden={ false }
 				query={ {} }
 				updateOptions={ () => {} }
 			/>

--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { useUserPreferences } from '@woocommerce/data';
 
 /**
@@ -11,7 +11,7 @@ import { Layout } from '../layout';
 
 // Rendering <StatsOverview /> breaks tests.
 jest.mock( 'homescreen/stats-overview', () =>
-	jest.fn().mockReturnValue( null )
+	jest.fn().mockReturnValue( '[StatsOverview]' )
 );
 
 // We aren't testing the <TaskList /> component here.
@@ -64,7 +64,7 @@ describe( 'Homescreen Layout', () => {
 		expect( columns ).not.toBeNull();
 
 		// Expect that the <TaskList /> is there too.
-		const taskList = screen.queryByText( '[TaskList]' );
+		const taskList = screen.queryByText( /\[TaskList\]/ );
 		expect( taskList ).toBeDefined();
 	} );
 
@@ -199,5 +199,46 @@ describe( 'Homescreen Layout', () => {
 				'woocommerce-homescreen two-columns'
 			)
 		).toHaveLength( 1 );
+	} );
+
+	it( 'should display the correct blocks in each column', () => {
+		useUserPreferences.mockReturnValue( {
+			homepage_layout: 'two_columns',
+		} );
+		const { container } = render(
+			<Layout
+				requestingTaskList={ false }
+				taskListHidden={ false }
+				query={ {} }
+				updateOptions={ () => {} }
+			/>
+		);
+
+		const columns = container.getElementsByClassName(
+			'woocommerce-homescreen-column'
+		);
+		expect( columns ).toHaveLength( 2 );
+		const firstColumn = columns[ 0 ];
+		const secondColumn = columns[ 1 ];
+
+		expect(
+			within( firstColumn ).getByText( /\[TaskList\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( firstColumn ).getByText( /\[InboxPanel\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( secondColumn ).queryByText( /\[TaskList\]/ )
+		).toBeNull();
+		expect(
+			within( secondColumn ).queryByText( /\[InboxPanel\]/ )
+		).toBeNull();
+
+		expect(
+			within( secondColumn ).getByText( /\[StatsOverview\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( firstColumn ).queryByText( /\[StatsOverview\]/ )
+		).toBeNull();
 	} );
 } );

--- a/client/inbox-panel/placeholder.js
+++ b/client/inbox-panel/placeholder.js
@@ -12,9 +12,6 @@ class InboxNotePlaceholder extends Component {
 				className={ `woocommerce-inbox-message is-placeholder ${ className }` }
 				aria-hidden
 			>
-				<div className="woocommerce-inbox-message__image">
-					<div className="banner-block" />
-				</div>
 				<div className="woocommerce-inbox-message__wrapper">
 					<div className="woocommerce-inbox-message__content">
 						<div className="woocommerce-inbox-message__date">

--- a/client/inbox-panel/style.scss
+++ b/client/inbox-panel/style.scss
@@ -174,16 +174,6 @@
 	}
 }
 
-.woocommerce-inbox-message__image {
-	.banner-block {
-		.is-placeholder & {
-			@include placeholder();
-			width: 100%;
-			height: 120px;
-		}
-	}
-}
-
 .woocommerce-homepage-notes-wrapper {
 	padding-top: $gap-large;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: store deprecation welcome modal support doc link #6094
 - Enhancement: Allowing users to create products by selecting a template. #5892
 - Dev: Add wait script for mysql to be ready for phpunit tests in docker. #6185
+- Update: Homescreen layout, moving Inbox panel for better interaction. #6122
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes #5931 

There was a drop in user interaction with the inbox panel, this PR moves the inbox panel to the left column (in two column format), and below setup tasks in the single column format.

### Screenshots

![homescreen-rearangement](https://user-images.githubusercontent.com/2240960/105362698-93268600-5bd1-11eb-9af3-651776369ccc.gif)

### Detailed test instructions:

- Create a new woo store, and finish the onboarding wizard.
- Go to the home screen, and make sure the panels follow this order:
- Two column:
  - Left column: store setup and/or management tasks + inbox panel
  - Right column: stats overview + store management shortcuts (only shows when setup tasks is hidden)
- Single column:
  - store setup tasks, inbox panel, stats overview, store management links (only visible when setup tasks is hidden).
- Hide the setup tasks list, and see if the store management links show up in the right place.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
