### PR TITLE
Onboarding: Fix new business step error

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -106,7 +106,7 @@ class BusinessDetails extends Component {
 				],
 		} );
 
-		const _updates = {
+		const updates = {
 			other_platform: otherPlatform,
 			other_platform_name:
 				otherPlatform === 'other' ? otherPlatformName : '',
@@ -117,9 +117,9 @@ class BusinessDetails extends Component {
 		};
 
 		// Remove possible empty values like `revenue` and `other_platform`.
-		const updates = Object.entries( _updates ).filter( ( { value } ) => {
-			return value !== '';
-		} );
+		Object.keys( updates ).forEach(
+			( key ) => updates[ key ] === '' && delete updates[ key ]
+		);
 
 		const promises = [
 			updateProfileItems( updates ).catch( () => {


### PR DESCRIPTION
Fixes #6127

This PR fixes the empty string filtering in OBW.

There was a problem when filtering empty values before updating `woocommerce_onboarding_profile `, in the new business step of the OBW. The filtering was changing the object structure.
With this fix, the filtering of empty values should work normally. 

### Screenshots
![screenshot-five wordpress test-2021 01 21-15_36_38](https://user-images.githubusercontent.com/1314156/105396351-8c623800-5bfe-11eb-8bf8-b912fa72b7c6.png)


### Detailed test instructions:
1. Follow the test instructions [here](https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-5.0#business-features-install-free-extensions)
2. Be sure to either accept all default extensions or make sure you have Mailchimp selected.
3. Finish the OBW.
4. Verify you're not being redirected to the Mailchimp setup during the Woo OBW.
5. Confirm that all extensions installed as part of the business step in the OBW populate the `business_extensions` array. You can check that using `wp-cli`:
```
wp option get woocommerce_onboarding_profile
```
or executing the SQL statement:
```
SELECT * FROM `wp_options` WHERE `option_name` = 'woocommerce_onboarding_profile';
```

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
