### PR TITLE
Fix payment task styling, to match old format

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -201,6 +201,7 @@
 	align-items: center;
 	position: relative;
 	overflow: hidden;
+	box-shadow: $muriel-box-shadow-1dp;
 
 	.woocommerce-task-payment__recommended-ribbon {
 		position: absolute;
@@ -236,8 +237,8 @@
 		}
 	}
 
-	.components-card__header {
-		margin-right: $gap-larger;
+	.components-card__media {
+		margin: $gap-large $gap-larger;
 
 		img {
 			max-width: 100px;
@@ -267,8 +268,14 @@
 		}
 	}
 
+	.components-card__body {
+		padding: $gap-large 0;
+		flex: 1;
+	}
+
 	.components-card__footer {
 		margin-left: auto;
+		width: auto;
 
 		.components-button.is-button {
 			margin: 0;
@@ -286,7 +293,7 @@
 			display: none;
 		}
 
-		.components-card__header {
+		.components-card__media {
 			order: 1;
 			margin-right: auto;
 			margin-bottom: $gap-large;
@@ -336,8 +343,10 @@
 }
 
 .woocommerce-task-dashboard__container {
-	button.components-button.is-primary {
-		margin: 0 8px 0 0;
+	.woocommerce-stepper {
+		button.components-button.is-primary {
+			margin: 0 8px 0 0;
+		}
 	}
 
 	button.components-button.is-link {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -9,8 +9,8 @@ import {
 	Button,
 	Card,
 	CardBody,
+	CardMedia,
 	CardFooter,
-	CardHeader,
 	FormToggle,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -253,7 +253,7 @@ class Payments extends Component {
 
 					return (
 						<Card key={ key } className={ classes }>
-							<CardHeader isBorderless>
+							<CardMedia isBorderless>
 								{ showRecommendedRibbon && (
 									<div className="woocommerce-task-payment__recommended-ribbon">
 										<span>
@@ -265,7 +265,7 @@ class Payments extends Component {
 									</div>
 								) }
 								{ before }
-							</CardHeader>
+							</CardMedia>
 							<CardBody>
 								<H className="woocommerce-task-payment__title">
 									{ title }


### PR DESCRIPTION
Fixes #6126 

Make use of the CardMedia component instead of the CardHeader, and make some minor styling changes to correctly display a vertical card.

### Screenshots

<img width="1453" alt="Screen Shot 2021-01-21 at 2 54 33 PM" src="https://user-images.githubusercontent.com/2240960/105398502-d3e5c580-5bf8-11eb-8896-d0304f6b35d7.png">

### Detailed test instructions:

- Start new Woo store, and finish the onboarding wizard
- Click on the `Set up payments` task
- The different payment options should look good, and the text not pressed together. See the difference [in this image](https://user-images.githubusercontent.com/22080/105375746-d4ad3600-5bbd-11eb-9e80-03646f8d6a63.png) of the bug ticket.
