### PR TITLE
Update Jetpack Autoloader Dependency to 2.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	"require": {
 		"composer/installers": "^1.9.0",
 		"php": ">=7.0",
-		"automattic/jetpack-autoloader": "^2.2.0"
+		"automattic/jetpack-autoloader": "2.7.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33a135a8b9a5d43687b4b844109bd042",
+    "content-hash": "be2325a8d3371fcbab8739c0a1b7fac1",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.5.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "7945e862473e39f05e6f698f1598ea30a12e5965"
+                "reference": "5437697a56aefbdf707849b9833e1b36093d7a73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7945e862473e39f05e6f698f1598ea30a12e5965",
-                "reference": "7945e862473e39f05e6f698f1598ea30a12e5965",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/5437697a56aefbdf707849b9833e1b36093d7a73",
+                "reference": "5437697a56aefbdf707849b9833e1b36093d7a73",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+                "yoast/phpunit-polyfills": "0.2.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -44,9 +44,9 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.5.0"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.7.1"
             },
-            "time": "2020-10-08T19:51:11+00:00"
+            "time": "2020-12-18T22:33:59+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
Fixes #6145

WooCommerce core recently [bumped](https://github.com/woocommerce/woocommerce/pull/28630) the `automattic/jetpack-autoloader` version in Composer. This PR matches the version number to prevent conflicts running different versions at the same time.

### Detailed test instructions:

-   In Travis, ensure the "Latest WooCommerce" build job passes.
-   Perform a smoke test
