### PR TITLE
Fix empty space between the header and the search meta links when the…

### DIFF
--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -26,6 +26,7 @@ $gap-smallest: 4px;
 
 // Header
 $header-height: 60px;
+$header-height-with-new-nav: 46px;
 $header-scroll-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);
 
 // Sidebar

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -123,5 +123,13 @@
 		a.components-button:not(.is-primary) {
 			color: $gray-text;
 		}
-	}
+    }
+}
+
+// for the embed page with the new navigation enabled
+.woocommerce-feature-enabled-navigation.woocommerce-embed-page {
+    #screen-meta,
+    #screen-meta-links {
+        top: $header-height-with-new-nav;
+    }
 }

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -123,13 +123,19 @@
 		a.components-button:not(.is-primary) {
 			color: $gray-text;
 		}
-    }
+	}
 }
 
 // for the embed page with the new navigation enabled
 .woocommerce-feature-enabled-navigation.woocommerce-embed-page {
-    #screen-meta,
-    #screen-meta-links {
-        top: $header-height-with-new-nav;
-    }
+	@include breakpoint( '<782px' ) {
+		#screen-meta,
+		#screen-meta-links {
+			top: $header-height-with-new-nav;
+		}
+
+		#screen-meta-links {
+			margin-bottom: 77px;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #6148 

This PR removes unnecessary empty space between the header and the search meta links when the new nav is enabled. Please take a look at the screenshots in the linked [issue](https://github.com/woocommerce/woocommerce-admin/issues/6148).

### Screenshots

![Screen Shot 2021-01-21 at 9 27 35 PM](https://user-images.githubusercontent.com/4723145/105450536-80429e80-5c2f-11eb-91ef-8b5c28f88fd8.jpg)
![Screen Shot 2021-01-21 at 9 27 28 PM](https://user-images.githubusercontent.com/4723145/105450539-8173cb80-5c2f-11eb-8061-6d2829c6b6ea.jpg)


### Detailed test instructions:

1. Make sure `woocommerce_marketplace_suggestions` option is not set in the `wp_options` table.
2. Enable the new navigation feature by navigating to WooCommerce -> Settings -> Advanced -> Features.
3. Navigate to WooCommerce -> Orders
4. Open the browser inspector and change the view to a small device such as Pixel 2
5. Confirm that the search meta link is aligned correctly.
6. Click one of the search meta links and confirm that the expanded panel is aligned correctly.
