### PR TITLE
Disable CES

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
-		"customer-effort-score-tracks": true,
+		"customer-effort-score-tracks": false,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": false,

--- a/config/development.json
+++ b/config/development.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
-		"customer-effort-score-tracks": true,
+		"customer-effort-score-tracks": false,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
-		"customer-effort-score-tracks": true,
+		"customer-effort-score-tracks": false,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": true,


### PR DESCRIPTION
This PR disables CES in an effort to fix the ongoing issue with the WC Admin 1.8.3. [Link](https://a8c.slack.com/archives/C0E1AV8T0/p1611571234078600) to slack message.

### Detailed test instructions:

Make sure both woocommerce_ces_shown_for_actions and woocommerce_ces_tracks_queue config values are deleted.

 1. Complete the Onboarding setup wizard.
 1. Go to WooCommerce > Settings > Advanced > WooCommerce.com
 1. Enable Usage Tracking 
 1. Go to Products->Add New
 1. Click on Publish
 2. Confirm that you do not see the CES survey popup. 