### PR TITLE
Hide Inventory and Reviews panels if store setup task list is visible

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -26,7 +26,7 @@ import { getAllPanels } from './panels';
 import { getUnapprovedReviews } from './reviews/utils';
 
 export const ActivityPanel = () => {
-	const settings = useSelect( () => {
+	const settingsData = useSelect( () => {
 		const manageStock = getSetting( 'manageStock', 'no' );
 		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
 		const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
@@ -65,9 +65,9 @@ export const ActivityPanel = () => {
 	} );
 
 	const panels = getAllPanels( {
-		...settings,
 		...ordersData,
 		...reviewsData,
+		...settingsData,
 		...taskListData,
 	} );
 

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -11,6 +11,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -46,8 +47,14 @@ export const ActivityPanel = () => {
 			publishedProductCount,
 		};
 	} );
+	const setupTaskListData = useSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		return {
+			isTaskListHidden: getOption( 'woocommerce_task_list_hidden' ),
+		};
+	} );
 
-	const panels = getAllPanels( panelsData );
+	const panels = getAllPanels( { ...panelsData, ...setupTaskListData } );
 
 	if ( panels.length === 0 ) {
 		return null;

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -26,35 +26,50 @@ import { getAllPanels } from './panels';
 import { getUnapprovedReviews } from './reviews/utils';
 
 export const ActivityPanel = () => {
-	const panelsData = useSelect( ( select ) => {
-		const totalOrderCount = getSetting( 'orderCount', 0 );
-		const orderStatuses = getOrderStatuses( select );
-		const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
-		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
+	const settings = useSelect( () => {
 		const manageStock = getSetting( 'manageStock', 'no' );
-		const countLowStockProducts = getLowStockCount( select );
-		const countUnapprovedReviews = getUnapprovedReviews( select );
 		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
+		const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
+		const totalOrderCount = getSetting( 'orderCount', 0 );
+		return {
+			manageStock,
+			publishedProductCount,
+			reviewsEnabled,
+			totalOrderCount,
+		};
+	} );
 
+	const ordersData = useSelect( ( select ) => {
+		const orderStatuses = getOrderStatuses( select );
+		const countLowStockProducts = getLowStockCount( select );
+		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
 		return {
 			countLowStockProducts,
 			countUnreadOrders,
-			manageStock,
 			orderStatuses,
-			totalOrderCount,
-			reviewsEnabled,
-			countUnapprovedReviews,
-			publishedProductCount,
 		};
 	} );
-	const setupTaskListData = useSelect( ( select ) => {
+
+	const reviewsData = useSelect( ( select ) => {
+		const countUnapprovedReviews = getUnapprovedReviews( select );
+		return {
+			countUnapprovedReviews,
+		};
+	} );
+
+	const taskListData = useSelect( ( select ) => {
 		const { getOption } = select( OPTIONS_STORE_NAME );
 		return {
 			isTaskListHidden: getOption( 'woocommerce_task_list_hidden' ),
 		};
 	} );
 
-	const panels = getAllPanels( { ...panelsData, ...setupTaskListData } );
+	const panels = getAllPanels( {
+		...settings,
+		...ordersData,
+		...reviewsData,
+		...taskListData,
+	} );
 
 	if ( panels.length === 0 ) {
 		return null;

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -26,50 +26,31 @@ import { getAllPanels } from './panels';
 import { getUnapprovedReviews } from './reviews/utils';
 
 export const ActivityPanel = () => {
-	const settingsData = useSelect( () => {
-		const manageStock = getSetting( 'manageStock', 'no' );
-		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
-		const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
+	const panelsData = useSelect( ( select ) => {
 		const totalOrderCount = getSetting( 'orderCount', 0 );
+		const orderStatuses = getOrderStatuses( select );
+		const reviewsEnabled = getSetting( 'reviewsEnabled', 'no' );
+		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
+		const manageStock = getSetting( 'manageStock', 'no' );
+		const countLowStockProducts = getLowStockCount( select );
+		const countUnapprovedReviews = getUnapprovedReviews( select );
+		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		const isTaskListHidden = getOption( 'woocommerce_task_list_hidden' );
 		return {
+			countLowStockProducts,
+			countUnapprovedReviews,
+			countUnreadOrders,
+			isTaskListHidden,
 			manageStock,
 			publishedProductCount,
 			reviewsEnabled,
 			totalOrderCount,
-		};
-	} );
-
-	const ordersData = useSelect( ( select ) => {
-		const orderStatuses = getOrderStatuses( select );
-		const countLowStockProducts = getLowStockCount( select );
-		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
-		return {
-			countLowStockProducts,
-			countUnreadOrders,
 			orderStatuses,
 		};
 	} );
 
-	const reviewsData = useSelect( ( select ) => {
-		const countUnapprovedReviews = getUnapprovedReviews( select );
-		return {
-			countUnapprovedReviews,
-		};
-	} );
-
-	const taskListData = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
-		return {
-			isTaskListHidden: getOption( 'woocommerce_task_list_hidden' ),
-		};
-	} );
-
-	const panels = getAllPanels( {
-		...ordersData,
-		...reviewsData,
-		...settingsData,
-		...taskListData,
-	} );
+	const panels = getAllPanels( panelsData );
 
 	if ( panels.length === 0 ) {
 		return null;

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -14,6 +14,7 @@ export function getAllPanels( {
 	countLowStockProducts,
 	countUnapprovedReviews,
 	countUnreadOrders,
+	isTaskListHidden,
 	manageStock,
 	orderStatuses,
 	publishedProductCount,
@@ -37,6 +38,7 @@ export function getAllPanels( {
 		},
 		totalOrderCount > 0 &&
 			publishedProductCount > 0 &&
+			isTaskListHidden !== 'yes' &&
 			manageStock === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				count: countLowStockProducts,
@@ -51,6 +53,7 @@ export function getAllPanels( {
 				title: __( 'Stock', 'woocommerce-admin' ),
 			},
 		publishedProductCount > 0 &&
+			isTaskListHidden !== 'yes' &&
 			reviewsEnabled === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				id: 'reviews-panel',

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -38,7 +38,7 @@ export function getAllPanels( {
 		},
 		totalOrderCount > 0 &&
 			publishedProductCount > 0 &&
-			isTaskListHidden !== 'yes' &&
+			isTaskListHidden === 'yes' &&
 			manageStock === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				count: countLowStockProducts,
@@ -53,7 +53,7 @@ export function getAllPanels( {
 				title: __( 'Stock', 'woocommerce-admin' ),
 			},
 		publishedProductCount > 0 &&
-			isTaskListHidden !== 'yes' &&
+			isTaskListHidden === 'yes' &&
 			reviewsEnabled === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				id: 'reviews-panel',

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -33,6 +33,30 @@ describe( 'ActivityPanel', () => {
 			publishedProductCount: 0,
 			manageStock: 'yes',
 			reviewsEnabled: 'yes',
+			isTaskListHidden: 'yes',
+		} );
+
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'reviews-panel' } ),
+			] )
+		);
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'stock-panel' } ),
+			] )
+		);
+	} );
+
+	it( 'should exclude the reviews and stock panels when the setup task list is visible', () => {
+		const panels = getAllPanels( {
+			countUnreadOrders: 0,
+			orderStatuses: [],
+			totalOrderCount: 1, // Yes, I realize this isn't "possible".
+			publishedProductCount: 0,
+			manageStock: 'yes',
+			reviewsEnabled: 'yes',
+			isTaskListHidden: 'no',
 		} );
 
 		expect( panels ).toEqual(
@@ -68,7 +92,7 @@ describe( 'ActivityPanel', () => {
 			totalOrderCount: 10,
 			publishedProductCount: 2,
 			manageStock: 'yes',
-			isTaskListHidden: 'no',
+			isTaskListHidden: 'yes',
 		} );
 
 		expect( panels ).toEqual(
@@ -82,7 +106,7 @@ describe( 'ActivityPanel', () => {
 		const panels = getAllPanels( {
 			publishedProductCount: 5,
 			reviewsEnabled: 'yes',
-			isTaskListHidden: 'no',
+			isTaskListHidden: 'yes',
 		} );
 
 		expect( panels ).toEqual(

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -68,6 +68,7 @@ describe( 'ActivityPanel', () => {
 			totalOrderCount: 10,
 			publishedProductCount: 2,
 			manageStock: 'yes',
+			isTaskListHidden: 'no',
 		} );
 
 		expect( panels ).toEqual(
@@ -81,6 +82,7 @@ describe( 'ActivityPanel', () => {
 		const panels = getAllPanels( {
 			publishedProductCount: 5,
 			reviewsEnabled: 'yes',
+			isTaskListHidden: 'no',
 		} );
 
 		expect( panels ).toEqual(

--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -25,6 +25,11 @@ jest.mock( '@woocommerce/data', () => ( {
 	useUserPreferences: jest.fn().mockReturnValue( {} ),
 } ) );
 
+// We aren't testing the <ActivityPanel /> component here.
+jest.mock( '../activity-panel', () => ( {
+	ActivityPanel: jest.fn().mockReturnValue( '[ActivityPanel]' ),
+} ) );
+
 describe( 'Homescreen Layout', () => {
 	it( 'should show TaskList placeholder when loading', () => {
 		const { container } = render(
@@ -42,7 +47,7 @@ describe( 'Homescreen Layout', () => {
 		expect( placeholder ).not.toBeNull();
 	} );
 
-	it( 'should show TaskList inline', async () => {
+	it( 'should show TaskList inline', () => {
 		const { container } = render(
 			<Layout
 				requestingTaskList={ false }
@@ -59,11 +64,11 @@ describe( 'Homescreen Layout', () => {
 		expect( columns ).not.toBeNull();
 
 		// Expect that the <TaskList /> is there too.
-		const taskList = await screen.findByText( '[TaskList]' );
+		const taskList = screen.queryByText( '[TaskList]' );
 		expect( taskList ).toBeDefined();
 	} );
 
-	it( 'should render TaskList alone when on task', async () => {
+	it( 'should render TaskList alone when on task', () => {
 		const { container } = render(
 			<Layout
 				requestingTaskList={ false }
@@ -82,7 +87,7 @@ describe( 'Homescreen Layout', () => {
 		expect( columns ).toBeNull();
 
 		// Expect that the <TaskList /> is there though.
-		const taskList = await screen.findByText( '[TaskList]' );
+		const taskList = screen.queryByText( '[TaskList]' );
 		expect( taskList ).toBeDefined();
 	} );
 


### PR DESCRIPTION
Fixes #6095

This PR adds the code to hide the `Inventory` and `Reviews` panels if the store setup task list is visible.

### Screenshots
![Screen Capture on 2021-01-26 at 12-14-52](https://user-images.githubusercontent.com/1314156/105864428-ac17a880-5fd0-11eb-9bcf-b9bf6e49b0cf.gif)

### Detailed test instructions:

- Create a brand new site (e.g.: using Jurassic Ninja)
- Upload a test version of this branch (you can get it by running `npm run test:zip`).
- Finish the OBW.
- Add a new product.
- Hide the task list named "Finish setup".
- Verify the `Reviews` panel is visible now.
- Go to a non-js page (e.g.: `/wp-admin/admin.php?page=wc-settings`).
- Click on `Help` > `Setup wizard` and enable the `Task list`.
- Go to the `Home` screen.
- Verify the `Reviews` panel is not visible anymore.

cc: @pmcpinto

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
