### PR TITLE
Add wait for mysql script to php unit entrypoint

### DIFF
--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Wait for MySQL to be up and running
+until mysqladmin ping -h"$DB_HOST" --silent; do
+  >&2 echo "MySQL is unavailable - sleeping"
+  sleep 2
+done
+  
+>&2 echo "MySQL is up - executing tests"
+
 # Run the install script if the WordPress directory is not found.
 if [ ! -d /tmp/wordpress-tests-lib ]; then
 	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST latest true

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"test": "./node_modules/jest-24.9.0/bin/jest.js --config tests/js/jest.config.json",
 		"test-staged": "./node_modules/jest-24.9.0/bin/jest.js --bail --config tests/js/jest.config.json --findRelatedTests",
 		"test:help": "wp-scripts test-unit-js --help",
-		"test:php": "docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml run --rm phpunit",
+		"test:php": "docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml run --rm phpunit ; docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml down",
 		"test:update-snapshots": "jest --updateSnapshot --config tests/js/jest.config.json",
 		"test:watch": "npm run test -- --watch",
 		"test:zip": "npm run clean && composer i && ./bin/build-test-zip.sh",

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Remote inbox notifications contains comparison and fix product rule. #6073
 - Update: store deprecation welcome modal support doc link #6094
 - Enhancement: Allowing users to create products by selecting a template. #5892
+- Dev: Add wait script for mysql to be ready for phpunit tests in docker. #6185
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes #5907 

Add script that sleeps for 2seconds if the mysql container isn't up yet. Also added a `docker-compose down`, so the containers are removed after running.

### Screenshots

<img width="1186" alt="Screen Shot 2021-01-26 at 2 58 31 PM" src="https://user-images.githubusercontent.com/2240960/105891399-fd329700-5fe6-11eb-9d90-724ed22762ae.png">

### Detailed test instructions:

- If you have run this script before, run:
  - `docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml down`
  - `docker image rm wc-admin-php-test-suite_phpunit` (removing the original docker image it created)
- Run `npm run test:php`
- This should pass successfully, or at-least run the tests successfully.