### PR TITLE
Remove header height

### DIFF
--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -57,7 +57,6 @@
 	}
 
 	.woocommerce-layout__header {
-		height: $header-height;
 		&.is-scrolled {
 			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
 		}


### PR DESCRIPTION
Fixes #5459 

Remove header height


### Screenshots
Before
<img width="383" alt="before" src="https://user-images.githubusercontent.com/56378160/106047416-975f1180-60b1-11eb-91ce-253ae238474d.png">

After
<img width="379" alt="after" src="https://user-images.githubusercontent.com/56378160/106047431-9c23c580-60b1-11eb-8f22-6ed3a764f8da.png">


### Detailed test instructions:
-  Go to `Header` and set ` ! isModalDismissed ` to `true`
-  Go to `MobileAppBanner` and set ` platform() === ANDROID_PLATFORM && ! isDismissed ` to `true`
-  Check if "w" button renders as expected.

