### PR TITLE
Normalize installed WC Admin version

### DIFF
--- a/src/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/src/Notes/ManageStoreActivityFromHomeScreen.php
@@ -38,6 +38,10 @@ class ManageStoreActivityFromHomeScreen {
 	 */
 	public static function get_note() {
 		$installed_version = get_option( 'woocommerce_admin_version' );
+		// the value can be in 1.9.0-rc.3 format for RC or BETA releases
+		// get the version without -rc.3.
+		$version_segments  = explode( '-', $installed_version );
+		$installed_version = $version_segments[0];
 		if ( ! version_compare( $installed_version, '1.9.0', '=' ) ) {
 			return;
 		}


### PR DESCRIPTION
This is a follow-up PR for https://github.com/woocommerce/woocommerce-admin/pull/6072

RC or DEV versions of WC Admin release can have `-rc.*` or `-dev` suffix.

This PR normalizes `woocommerce_admin_version` value for comparison. 

Slack discussion: https://a8c.slack.com/archives/C011ENB20Q1/p1611303731013700. 

### Detailed test instructions:

Please refer to the original PR for the test instructions. 