### PR TITLE
Skip failing tests in WP 5.3 and 5.4

### DIFF
--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -134,7 +134,7 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 	public function test_product_attributes_filter() {
 		global $wp_version;
 		if ( version_compare( $wp_version, '5.5', '<' ) ) {
-			$this->markTestSkipped();
+			$this->markTestSkipped( 'Skipped in older versions of WordPress due to a bug in WP when validating arrays.' );
 		}
 
 		global $wpdb;

--- a/tests/api/reports-orders-stats.php
+++ b/tests/api/reports-orders-stats.php
@@ -132,6 +132,11 @@ class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
 	 * Test filtering by product attribute(s).
 	 */
 	public function test_product_attributes_filter() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.5', '<' ) ) {
+			$this->markTestSkipped();
+		}
+
 		global $wpdb;
 		wp_set_current_user( $this->user );
 		WC_Helper_Reports::reset_stats_dbs();

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -135,7 +135,7 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 	public function test_product_attributes_filter() {
 		global $wp_version;
 		if ( version_compare( $wp_version, '5.5', '<' ) ) {
-			$this->markTestSkipped();
+			$this->markTestSkipped( 'Skipped in older versions of WordPress due to a bug in WP when validating arrays.' );
 		}
 
 		wp_set_current_user( $this->user );
@@ -243,7 +243,7 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 	public function test_custom_product_attributes_filter() {
 		global $wp_version;
 		if ( version_compare( $wp_version, '5.5', '<' ) ) {
-			$this->markTestSkipped();
+			$this->markTestSkipped( 'Skipped in older versions of WordPress due to a bug in WP when validating arrays.' );
 		}
 
 		wp_set_current_user( $this->user );

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -133,6 +133,11 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 	 * Test filtering by taxonomy-backed product attribute(s).
 	 */
 	public function test_product_attributes_filter() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.5', '<' ) ) {
+			$this->markTestSkipped();
+		}
+
 		wp_set_current_user( $this->user );
 		WC_Helper_Reports::reset_stats_dbs();
 
@@ -236,6 +241,11 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 	 * Test filtering by custom product attribute(s).
 	 */
 	public function test_custom_product_attributes_filter() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '5.5', '<' ) ) {
+			$this->markTestSkipped();
+		}
+
 		wp_set_current_user( $this->user );
 		WC_Helper_Reports::reset_stats_dbs();
 


### PR DESCRIPTION
Fixes #6194 

This PR skips the tests that fail only in WP 5.3 and 5.4 due to the difference in how rest-api.php handles schema validation.

More details on here https://github.com/woocommerce/woocommerce-admin/issues/6194#issuecomment-768052452

### Detailed test instructions:


1. Remove the existing phpunit volume `docker volume rm -f wc-admin-php-test-suite_test-suite`
2. Open docker/wc-admin-php-test-suite/entrypoint.sh
2. Change the following line.

Before: `	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST latest true`
After: `	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST 5.3 true`

3. Run the test normally and confirm three tests are skipped.

