### PR TITLE
Refactor WCA plugin outdated version check to run on 'woocommerce_init' hook

### DIFF
--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -49,14 +49,9 @@ class Package {
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
-			$update_version       = new DeactivatePlugin();
-			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
-				if ( method_exists( $update_version, 'possibly_add_note' ) ) {
-					$update_version::possibly_add_note();
-				}
-			} else {
-				$update_version::delete_note();
-			}
+
+			// Check version after WooCommerce is initialized.
+			add_action( 'woocommerce_init', array( __CLASS__, 'check_outdated_wca_plugin' ) );
 
 			// Register a deactivation hook for the feature plugin.
 			register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( __CLASS__, 'on_deactivation' ) );
@@ -125,5 +120,21 @@ class Package {
 	public static function on_deactivation() {
 		$update_version = new DeactivatePlugin();
 		$update_version::delete_note();
+	}
+
+	/**
+	 * Checks if embedded WCA version is newer than standalone WCA
+	 * and adds/removes DeactivatePlugin note as necessary.
+	 */
+	public static function check_outdated_wca_plugin() {
+		$update_version = new DeactivatePlugin();
+
+		if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
+			if ( method_exists( $update_version, 'possibly_add_note' ) ) {
+				$update_version::possibly_add_note();
+			}
+		} else {
+			$update_version::delete_note();
+		}
 	}
 }


### PR DESCRIPTION
This PR refactors WCA version check in `src/Composer/Package.php` to run after WooCommerce is initialized. Previously `$update_version::delete_note();` is run way too early (the case with PHP test suite - before database schema is set up). I can confirm that the change of execution order does not change the behaviour from user's perspective.

Fixes #5879

### Detailed test instructions:

#### Testing phpunit in docker:
1. Remove existing docker instance: `docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml down`
2. Run `npm run test:php`
2. Observe the following error does not appear:
```
WordPress database error Table 'wordpress_test.wptests_wc_admin_notes' doesn't exist for query SELECT note_id FROM wptests_wc_admin_notes WHERE name = 'wc-admin-deactivate-plugin' ORDER BY note_id ASC made by PHPUnit\TextUI\Command::main, PHPUnit\TextUI\Command->run, PHPUnit\TextUI\Command->handleArguments, PHPUnit\TextUI\Command->handleBootstrap, PHPUnit\Util\FileLoader::checkAndLoad, PHPUnit\Util\FileLoader::load, include_once('/plugin/tests/bootstrap.php'), WC_Admin_Unit_Tests_Bootstrap::instance, WC_Admin_Unit_Tests_Bootstrap->__construct, require_once('/tmp/wordpress-tests-lib/includes/bootstrap.php'), require_once('wp-settings.php'), do_action('plugins_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, Automattic\WooCommerce\Packages::on_init, Automattic\WooCommerce\Packages::load_packages, call_user_func, Automattic\WooCommerce\Admin\Composer\Package::init, Automattic\WooCommerce\Admin\Notes\DeactivatePlugin::delete_note, Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name, WC_Data_Store->__call, Automattic\WooCommerce\Admin\Notes\DataStore->get_notes_with_name
<div id="error"><p class="wpdberror"><strong>WordPress database error:</strong> [Table &#039;wordpress_test.wptests_wc_admin_notes&#039; doesn&#039;t exist]<br /><code>SELECT note_id FROM wptests_wc_admin_notes WHERE name = &#039;wc-admin-deactivate-plugin&#039; ORDER BY note_id ASC</code></p></div>Installing WooCommerce and WooCommerce Admin...
```

#### Testing original behaviour from user's perspective:
1. Manually edit the following line to a version higher, example: `2.0.0-dev` to `3.0.0-dev` so that it emulates an outdated WCA plugin: https://github.com/woocommerce/woocommerce-admin/blob/407571c08775669e9afee3e475446ef02029047e/src/Composer/Package.php#L27
2. Navigate to WooCommerce, and see the note added: ![image](https://user-images.githubusercontent.com/3747241/106140321-94474c80-61a9-11eb-9d9d-b4bcb02d4d61.png)
4. Change back to the original version, and reload WooCommerce
5. Observe the note is deleted