### PR TITLE
Hide Home screen panels if store setup task list is visible

### DIFF
--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -21,6 +21,10 @@ export function getAllPanels( {
 	reviewsEnabled,
 	totalOrderCount,
 } ) {
+	if ( isTaskListHidden !== 'yes' ) {
+		return [];
+	}
+
 	return [
 		totalOrderCount > 0 && {
 			className: 'woocommerce-homescreen-card',
@@ -38,7 +42,6 @@ export function getAllPanels( {
 		},
 		totalOrderCount > 0 &&
 			publishedProductCount > 0 &&
-			isTaskListHidden === 'yes' &&
 			manageStock === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				count: countLowStockProducts,
@@ -53,7 +56,6 @@ export function getAllPanels( {
 				title: __( 'Stock', 'woocommerce-admin' ),
 			},
 		publishedProductCount > 0 &&
-			isTaskListHidden === 'yes' &&
 			reviewsEnabled === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				id: 'reviews-panel',

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -11,6 +11,7 @@ describe( 'ActivityPanel', () => {
 			totalOrderCount: 0,
 			publishedProductCount: 1,
 			manageStock: 'yes',
+			isTaskListHidden: 'yes',
 		} );
 
 		expect( panels ).toEqual(
@@ -48,17 +49,22 @@ describe( 'ActivityPanel', () => {
 		);
 	} );
 
-	it( 'should exclude the reviews and stock panels when the setup task list is visible', () => {
+	it( 'should exclude any panel when the setup task list is visible', () => {
 		const panels = getAllPanels( {
 			countUnreadOrders: 0,
 			orderStatuses: [],
-			totalOrderCount: 1, // Yes, I realize this isn't "possible".
+			totalOrderCount: 1,
 			publishedProductCount: 0,
 			manageStock: 'yes',
 			reviewsEnabled: 'yes',
 			isTaskListHidden: 'no',
 		} );
 
+		expect( panels ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { id: 'orders-panel' } ),
+			] )
+		);
 		expect( panels ).toEqual(
 			expect.not.arrayContaining( [
 				expect.objectContaining( { id: 'reviews-panel' } ),
@@ -76,6 +82,7 @@ describe( 'ActivityPanel', () => {
 			countUnreadOrders: 1,
 			orderStatuses: [],
 			totalOrderCount: 10,
+			isTaskListHidden: 'yes',
 		} );
 
 		expect( panels ).toEqual(


### PR DESCRIPTION
This is a follow-up PR of [6182](https://github.com/woocommerce/woocommerce-admin/pull/6182). Related issue [6095](https://github.com/woocommerce/woocommerce-admin/issues/6095)

This PR adds the code to hide the `Orders` panel if the store setup task list is visible.
Currently, we're hiding the `Inventory` and `Reviews` panels. With this change, any panel will be shown if the setup task list is not hidden.

### Screenshots
![Screen Capture on 2021-01-28 at 11-49-51](https://user-images.githubusercontent.com/1314156/106155046-021a5680-615f-11eb-8b52-4544ef2fd956.gif)

### Detailed test instructions:

- Create a brand new site (e.g.: using Jurassic Ninja)
- Upload a test version of this branch (you can get it by running `npm run test:zip`).
- Finish the OBW.
- Add a new product and enable stock management.
- Add an order.
- Go to `Home` screen.
- No panel should be visible (either Orders, Reviews, or Inventory panels).
- Hide the task list named "Finish setup".
- Verify the panels are visible now.
- Go to a non-js page (e.g.: `/wp-admin/admin.php?page=wc-settings`).
- Click on `Help` > `Setup wizard` and enable the `Task list`.
- Go to the `Home` screen.
- Verify the panels aren't visible anymore.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
