### PR TITLE
Replaced method `woocommerce_get_page_id` with `wc_get_page_id`

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1099,7 +1099,7 @@ class Loader {
 		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', dirname( __DIR__ ) . '/woocommerce-admin.php' );
 		$settings['wcVersion']       = WC_VERSION;
 		$settings['siteUrl']         = site_url();
-		$settings['shopUrl']         = get_permalink( woocommerce_get_page_id( 'shop' ) );
+		$settings['shopUrl']         = get_permalink( wc_get_page_id( 'shop' ) );
 		$settings['dateFormat']      = get_option( 'date_format' );
 		$settings['plugins']         = array(
 			'installedPlugins' => PluginsHelper::get_installed_plugin_slugs(),


### PR DESCRIPTION
This is a follow-up PR for [6200](https://github.com/woocommerce/woocommerce-admin/pull/6200)

This PR replaces method `woocommerce_get_page_id` with `wc_get_page_id` in `Loader.php`.
The method `woocommerce_get_page_id` has been deprecated since `WooCommerce 3.0`, so we are replacing it with the recommended one (`wc_get_page_id`).

### Screenshots
![screenshot-one wordpress test-2021 01 28-15_09_42](https://user-images.githubusercontent.com/1314156/106180784-8975c300-617b-11eb-98c5-3251c713b229.png)


### Detailed test instructions:

- Check out the `main` branch (`git checkout main`).
- Turn on the debug mode adding `define( 'WP_DEBUG', True );` in `wp-config.php`.
-  Confirm you see the deprecation warning.
- Check out this branch (`git checkout fix/6037_update`)
- Verify the warning is not present anymore.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
