### PR TITLE
Adding text labels to elements that were previously invisible to screen readers

### DIFF
--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -73,6 +73,7 @@ const renderIntervalSelector = ( { chartInterval, setInterval, query } ) => {
 				value: allowedInterval,
 				label: intervalLabels[ allowedInterval ],
 			} ) ) }
+			aria-label="Chart period"
 			onChange={ setInterval }
 		/>
 	);

--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -105,6 +105,7 @@ const Header = () => {
 			<Button
 				onClick={ () => toggleFolded() }
 				className="woocommerce-navigation-header__site-icon"
+				aria-label="Toggle navigation"
 			>
 				{ buttonIcon }
 			</Button>

--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -7,7 +7,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, wordpress } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 
@@ -21,6 +21,9 @@ const Header = () => {
 	const siteTitle = getSetting( 'siteTitle', '' );
 	const siteUrl = getSetting( 'siteUrl', '' );
 	const isScrolled = useIsScrolled();
+	const [ isFolded, setIsFolded ] = useState(
+		document.body.classList.contains( false )
+	);
 	const navClasses = {
 		folded: 'is-wc-nav-folded',
 		expanded: 'is-wc-nav-expanded',
@@ -29,11 +32,13 @@ const Header = () => {
 	const foldNav = () => {
 		document.body.classList.add( navClasses.folded );
 		document.body.classList.remove( navClasses.expanded );
+		setIsFolded( true );
 	};
 
 	const expandNav = () => {
 		document.body.classList.remove( navClasses.folded );
 		document.body.classList.add( navClasses.expanded );
+		setIsFolded( false );
 	};
 
 	const toggleFolded = () => {
@@ -105,7 +110,9 @@ const Header = () => {
 			<Button
 				onClick={ () => toggleFolded() }
 				className="woocommerce-navigation-header__site-icon"
-				aria-label="Toggle navigation"
+				aria-label="Fold navigation"
+				role="switch"
+				aria-checked={ isFolded ? 'true' : 'false' }
 			>
 				{ buttonIcon }
 			</Button>


### PR DESCRIPTION
Fixes #6201 

Adding text-readable labels to components within `wc-admin` that are currently invisible to screen readers.

### Accessibility

Oh yes.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/106198636-2418d680-6169-11eb-8bb6-c4d5e3376606.png)

![image](https://user-images.githubusercontent.com/444632/106198673-2f6c0200-6169-11eb-941d-18d0499bf206.png)


### Detailed test instructions:

-   Enable screen reader
-   Enable new navigation
- Bring WC logo within navigation sidebar into focus. 
- The screenreader should recite "toggle navigation button," or something like that.
- Go to Analytics -> Overview
- Focus select box above charts, as pictured in screenshots section. 
- Screen reader should recite "chart period"
