### PR TITLE
Landmark link display is cut off when new navigation is enabled

### DIFF
--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -5,6 +5,10 @@
 .has-woocommerce-navigation {
 	margin-top: -$admin-bar-height;
 
+	.screen-reader-shortcut:focus {
+		top: 7px;
+	}
+
 	#wpadminbar,
 	#adminmenuwrap,
 	#adminmenuback {


### PR DESCRIPTION
Fixes #6202 

Landmark links are displayed for users navigating via the keyboard, and possibly via a screen reader. When the navigation feature is enabled, the admin bar is hidden, which is resulting in these links being obscured. 

This is a quick CSS fix that is conditional on the navigation being enabled via body class.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/106204505-ec625c80-6171-11eb-88c1-7d4162c236f4.png)

### Detailed test instructions:

-   Checkout branch
-   Enable navigation feature and navigate within WooCommerce
- Use the `tab` key to focus the landmark links (towards the start of the page)
- They should display correct and not be obscured