### PR TITLE
Adding checkbox role to chart legend component to make it compatible with screen readers

### DIFF
--- a/packages/components/src/chart/d3chart/legend.js
+++ b/packages/components/src/chart/d3chart/legend.js
@@ -105,6 +105,8 @@ class D3Legend extends Component {
 							onFocus={ handleLegendHover }
 						>
 							<button
+								role="checkbox"
+								aria-checked={ row.visible ? 'true' : 'false' }
 								onClick={ handleLegendToggle }
 								id={ `woocommerce-legend-${ instanceId }__item-button__${ row.key }` }
 								disabled={

--- a/packages/components/src/chart/d3chart/test/legend.js
+++ b/packages/components/src/chart/d3chart/test/legend.js
@@ -30,8 +30,8 @@ describe( 'Legend', () => {
 			<D3Legend colorScheme={ colorScheme } data={ data } />
 		);
 
-		expect( getByRole( 'button', { name: /Lorem/ } ) ).toBeEnabled();
-		expect( getByRole( 'button', { name: /Ipsum/ } ) ).toBeEnabled();
+		expect( getByRole( 'checkbox', { name: /Lorem/ } ) ).toBeEnabled();
+		expect( getByRole( 'checkbox', { name: /Ipsum/ } ) ).toBeEnabled();
 	} );
 
 	test( 'should prevent toggling off of last active dataset', () => {
@@ -43,7 +43,7 @@ describe( 'Legend', () => {
 			<D3Legend colorScheme={ colorScheme } data={ data } />
 		);
 
-		expect( getByRole( 'button', { name: /Lorem/ } ) ).toBeDisabled();
-		expect( getByRole( 'button', { name: /Ipsum/ } ) ).toBeEnabled();
+		expect( getByRole( 'checkbox', { name: /Lorem/ } ) ).toBeDisabled();
+		expect( getByRole( 'checkbox', { name: /Ipsum/ } ) ).toBeEnabled();
 	} );
 } );


### PR DESCRIPTION
Fixes #6206 

The legend component used within the Analytics charts functions as a checkbox, but uses non-semantic markup to implement the functionality. This results in screen readers not giving audio feedback to indicate that it is a checkbox, and whether it's checked or not. 

This PR takes the minimal approach of adding aria labelling to provide this information. Another approach would be to replace the markup with more semantic options, but doesn't seem necessary in this case. 

### Accessibility

:+1: 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/106209949-cdb49380-617a-11eb-8b09-3334219067e9.png)


### Detailed test instructions:

-  Enable a screen reader (I'm using NVDA)
-  Navigate to Analytics -> Products
- Navigate to the pictured checkbox above the chart, used for toggling the comparison periods on the chart below. They're also pictured in the screenshots section
- The screen reader should indicate that it is a checkbox. 
- Hit the `spacebar` key to toggle the checkbox. The screen reader should indicate that it is either checked or unchecked.