### PR TITLE
Adding role to focusable elements in analytics charts for screen reader accessibility

### DIFF
--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -170,6 +170,7 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'cx', ( d ) => scales.xScale( moment( d.date ).toDate() ) )
 			.attr( 'cy', ( d ) => scales.yScale( d.value ) )
 			.attr( 'tabindex', '0' )
+			.attr( 'role', 'graphics-symbol' )
 			.attr( 'aria-label', ( d ) => {
 				const label = formats.screenReaderFormat(
 					d.date instanceof Date ? d.date : moment( d.date ).toDate()


### PR DESCRIPTION
Fixes #6204 

Using some screen readers, such as NVDA, tabbing through the analytics charts results in every data point being read as "blank," providing no useful information and possibly endangering the sanity of our users. 

This took a while to track down. It appears that it was only an issue with the particular screen reader I was using (and potentially others), and is something of a known issue:

https://github.com/nvaccess/nvda/issues/7807

Despite that, it seems to be expected and intended behavior for now. I did find that adding a `role` of `graphics-symbol` to the focusable elements actually does trigger the screen reader to read out the aria label (which was already defined). I've added this, although it's a bit debatable on whether this is our issue or NVDA's. 


### Detailed test instructions:

- Checkout branch
-   Enable NVDA as a screen reader
-   Navigate to Analytics -> Products
- Navigate via keyboard (tab key) to the chart, and you'll find that each data point has intentionally been made focusable. When focusing each data point, you should hear the data and number read, and not just the world "blank" as it previously was.