### PR TITLE
Addressing 'sort by undefined' issue with screen readers in reports t…

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Allow single-selection support to `<Search />`.
 -   Improve handling of `multiple` and `inlineTags` in `<SelectControl />`.
 -   Deprecate use of `<Card>` in favor of the `<Card>` component in `@wordpress/components`.
+-   Fixing screen reader text being undefined for report `<Table>`
 
 # 5.1.2
 

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -214,14 +214,14 @@ class Table extends Component {
 													'Sort by %s in ascending order',
 													'woocommerce-admin'
 												),
-												screenReaderLabel
+												screenReaderLabel || label
 										  )
 										: sprintf(
 												__(
 													'Sort by %s in descending order',
 													'woocommerce-admin'
 												),
-												screenReaderLabel
+												screenReaderLabel || label
 										  );
 
 								const textLabel = (


### PR DESCRIPTION
Fixes #6207 

This is addressing an issue with screen reader text explicitly provided that reads "sort by undefined" when tabbing through the report table, for each cell.

It looks like this stems from the fact that a `screenReaderText` variable is provided and utilized from the `headers` object, but it's meant to fallback to the standard label when not present. This fallback was not in place.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/106321102-afa56c80-6228-11eb-9f9d-9cd276bf6d14.png)


### Detailed test instructions:

- Checkout branch
-   Enable a screen reader
-   Navigate to Analytics -> Products
- Navigate via keyboard to the report table, and tab through the cells.
- Each cell should cause the screen reader to recite "sort by -name of column," instead of "sort by undefined." Among other things.