### PR TITLE
Changing headings on report tables to use semantic tags

### DIFF
--- a/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
+++ b/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ exports[`Leaderboard should render correct data in the table 1`] = `
     <div
       class="components-flex components-card__header is-size-medium e1q7k77g1 css-aafj2m-Flex-HeaderUI eboqfv50"
     >
-      <p
+      <h2
         class="css-1ahfdc3-Text e15wbhsk0"
       />
       <div

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -166,7 +166,9 @@ class TableCard extends Component {
 		return (
 			<Card className={ classes }>
 				<CardHeader>
-					<Text variant="title.small">{ title }</Text>
+					<Text variant="title.small" as="h2">
+						{ title }
+					</Text>
 					<div className="woocommerce-table__actions">
 						{ actions }
 					</div>


### PR DESCRIPTION
Fixes #6208 

The heading for the report tables currently uses a non-semantic `<p>` tag in the markup, which can cause issues with screen-readers and accessibility tools. This change simply alters that to an `<h2>`. 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/106325786-36aa1300-6230-11eb-9662-116582939e68.png)

### Detailed test instructions:
- Checkout branch
-   Navigate to Analytics -> Products
-   Use the inspector to verify that the pictured heading is using an `<h2>` tag, instead of a `<p>` tag.