### PR TITLE
Add settings menu items on non-settings pages

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -42,6 +42,8 @@ class CoreMenu {
 	 * Add registered admin settings as menu items.
 	 */
 	public static function get_setting_items() {
+		// Calling this method adds pages to the below tabs filter on non-settings pages.
+		\WC_Admin_Settings::get_settings_pages();
 		$tabs = apply_filters( 'woocommerce_settings_tabs_array', array() );
 
 		$menu_items = array();


### PR DESCRIPTION
Fixes #6180

Shows missing settings on non-settings pages due to the change in how we retrieve settings pages.

### Screenshots

<img width="255" alt="Screen Shot 2021-02-01 at 3 24 14 PM" src="https://user-images.githubusercontent.com/10561050/106513983-aecb3f80-64a1-11eb-98dc-e6cfd8f08125.png">


### Detailed test instructions:

1. Enable the new navigation.
2. Load up a non-WC settings page.
3. Make sure all "Settings" items appear.
4. Load up the any of the settings pages.
5. Make sure items still appear the same.