### PR TITLE
Change `siteUrl` to `homeUrl` on navigation site title

### DIFF
--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -19,7 +19,7 @@ import { addHistoryListener } from '../../utils';
 
 const Header = () => {
 	const siteTitle = getSetting( 'siteTitle', '' );
-	const siteUrl = getSetting( 'siteUrl', '' );
+	const homeUrl = getSetting( 'homeUrl', '' );
 	const isScrolled = useIsScrolled();
 	const navClasses = {
 		folded: 'is-wc-nav-folded',
@@ -109,7 +109,7 @@ const Header = () => {
 				{ buttonIcon }
 			</Button>
 			<Button
-				href={ siteUrl }
+				href={ homeUrl }
 				className="woocommerce-navigation-header__site-title"
 				as="span"
 			>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1100,6 +1100,7 @@ class Loader {
 		$settings['wcVersion']       = WC_VERSION;
 		$settings['siteUrl']         = site_url();
 		$settings['shopUrl']         = get_permalink( wc_get_page_id( 'shop' ) );
+		$settings['homeUrl']         = home_url();
 		$settings['dateFormat']      = get_option( 'date_format' );
 		$settings['plugins']         = array(
 			'installedPlugins' => PluginsHelper::get_installed_plugin_slugs(),


### PR DESCRIPTION
Fixes #6161 

Change `siteUrl` to `homeUrl` on navigation site title

### Screenshots
Site title
<img width="133" alt="螢幕快照 2021-02-01 下午5 05 18" src="https://user-images.githubusercontent.com/56378160/106523893-cf01fb00-64af-11eb-8363-4a38a4320f49.png">

Direct to Home page (ex. My account)
<img width="544" alt="螢幕快照 2021-02-01 下午5 05 42" src="https://user-images.githubusercontent.com/56378160/106523951-e7721580-64af-11eb-8a5c-4eb44bc8e7be.png">

### Detailed test instructions:
- Go to WP settings and set the home page to My account
- Go to WC settings and use the new navigation feature
- Click on the header site title `My Site` and see that the page direct to My account

