### PR TITLE
Add WordPress Version Selection to Docker PHP Test Suite

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -17,14 +17,6 @@ TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
-# Error if WP < 5
-if [[ $WP_VERSION =~ ^([0-9]+)[0-9\.]+\-? ]]; then
-	if [ "5.3" -gt "${BASH_REMATCH[1]}" ]; then
-		echo "You must use WordPress 5.3 or greater."
-		exit 1
-	fi
-fi
-
 download() {
     if [ `which curl` ]; then
         curl -s "$1" > "$2";

--- a/docker/wc-admin-php-test-suite/docker-compose.yml
+++ b/docker/wc-admin-php-test-suite/docker-compose.yml
@@ -3,13 +3,14 @@ version: "3"
 services:
   phpunit:
     build: "."
-    image: wc-admin-php-test-suite-phpunit:1.1.0
+    image: wc-admin-php-test-suite-phpunit:1.2.0
     volumes:
       - "test-suite:/tmp"
       - "../../:/app"
     environment:
       - WC_CORE_DIR=/tmp/wordpress/wp-content/plugins/woocommerce
       - WC_VERSION=${WC_VERSION:-4.5.0}
+      - WP_VERSION=${WP_VERSION:-5.3}
       - DB_USER=root
       - DB_PASS=password
       - DB_NAME=wordpress_test

--- a/docker/wc-admin-php-test-suite/docker-compose.yml
+++ b/docker/wc-admin-php-test-suite/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   phpunit:
     build: "."
-    image: wc-admin-php-test-suite-phpunit:1.2.0
+    image: wc-admin-php-test-suite-phpunit:1.2.1
     volumes:
       - "test-suite:/tmp"
       - "../../:/app"

--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -12,12 +12,14 @@ done
 function install {
 	# Delete previous state.
 	rm -f /tmp/.INSTALLED_WC_VERSION
+	rm -f /tmp/.INSTALLED_WP_VERSION
 
 	# Run the install script.
-	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST latest true
+	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION true
 
-	# Remember the installed WooCommerce version.
+	# Update state.
 	echo "$WC_VERSION" > /tmp/.INSTALLED_WC_VERSION
+	echo "$WP_VERSION" > /tmp/.INSTALLED_WP_VERSION
 }
 
 # Run the install script if the installed WooCommerce version is unknown.
@@ -27,6 +29,17 @@ else
 	# Run the install script if the WooCommerce version has changed.
 	INSTALLED_WC_VERSION=`cat /tmp/.INSTALLED_WC_VERSION`
 	if [ "$WC_VERSION" != "$INSTALLED_WC_VERSION" ]; then
+		install
+	fi
+fi
+
+# Run the install script if the installed WordPress version is unknown.
+if [ ! -f /tmp/.INSTALLED_WP_VERSION ]; then
+	install
+else
+	# Run the install script if the WordPress version has changed.
+	INSTALLED_WC_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
+	if [ "$WP_VERSION" != "$INSTALLED_WP_VERSION" ]; then
 		install
 	fi
 fi

--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -41,7 +41,7 @@ if [ ! -f /tmp/.INSTALLED_WP_VERSION ]; then
 	install
 else
 	# Run the install script if the WordPress version has changed.
-	INSTALLED_WP_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
+	INSTALLED_WC_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
 	if [ "$WP_VERSION" != "$INSTALLED_WP_VERSION" ]; then
 		install
 	fi

--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -38,7 +38,7 @@ if [ ! -f /tmp/.INSTALLED_WP_VERSION ]; then
 	install
 else
 	# Run the install script if the WordPress version has changed.
-	INSTALLED_WC_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
+	INSTALLED_WP_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
 	if [ "$WP_VERSION" != "$INSTALLED_WP_VERSION" ]; then
 		install
 	fi

--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -41,7 +41,7 @@ if [ ! -f /tmp/.INSTALLED_WP_VERSION ]; then
 	install
 else
 	# Run the install script if the WordPress version has changed.
-	INSTALLED_WC_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
+	INSTALLED_WP_VERSION=`cat /tmp/.INSTALLED_WP_VERSION`
 	if [ "$WP_VERSION" != "$INSTALLED_WP_VERSION" ]; then
 		install
 	fi

--- a/docker/wc-admin-php-test-suite/entrypoint.sh
+++ b/docker/wc-admin-php-test-suite/entrypoint.sh
@@ -14,6 +14,9 @@ function install {
 	rm -f /tmp/.INSTALLED_WC_VERSION
 	rm -f /tmp/.INSTALLED_WP_VERSION
 
+	# Delete any previous installations.
+	rm -rf /tmp/*
+
 	# Run the install script.
 	bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION true
 

--- a/docker/wc-admin-php-test-suite/readme.md
+++ b/docker/wc-admin-php-test-suite/readme.md
@@ -31,12 +31,12 @@ PHPUnit flags can be passed to the npm script. To limit testing to a single test
 npm run test:php -- --filter=<name of test>
 ```
 
-## Selecting the WooCommerce Version
+## Selecting the WordPress and WooCommerce Versions
 
-By default, the minimum supported version of WooCommerce is used to build the test suite. This can be overridden with an environment variable.
+By default, the minimum supported versions of WordPress and WooCommerce are used to build the test suite. This can be overridden with environment variables.
 
 ```shell
-WC_VERSION=4.9.0 npm run test:php
+WP_VERSION=5.6 WC_VERSION=4.9.0 npm run test:php
 ```
 
 ## Development


### PR DESCRIPTION
This PR follows-up https://github.com/woocommerce/woocommerce-admin/pull/6119, adding the ability to select which WordPress version to use in the Docker PHP Test Suite.

```
WP_VERSION=5.6 npm run test:php 
```

WordPress 5.3 is used as the default version if none is selected. This is the [minimum supported version](https://github.com/woocommerce/woocommerce-admin/blob/8d04830d77f5bfdb6eb26089ff3b735d796dd2a6/readme.txt#L39).

The image version number tag was bumped to trigger an image rebuild automatically. This ensures the  ENTRYPOINT changes activate on next use.

The README documentation was also updated.

### Detailed test instructions:

-   Run the test suite normally: `npm run test:php`
-   In the output, confirm the image is rebuilt.

```
Building phpunit
Step 1/12 : FROM alpine
 ```

-   In the output, confirm the installation script is triggered and WordPress 5.3 is used by default:

```
+ curl -s https://wordpress.org/wordpress-5.3.6.tar.gz
```
```
+ svn co --quiet https://develop.svn.wordpress.org/branches/5.3/tests/phpunit/includes/ /tmp/wordpress-tests-lib/includes
+ svn co --quiet https://develop.svn.wordpress.org/branches/5.3/tests/phpunit/data/ /tmp/wordpress-tests-lib/data
```

-   Run the test suite against the latest WordPress version: `WP_VERSION=5.6 npm run test:php`

-   In the output, confirm the installation script is triggered and WordPress 5.6 is used:

```
+ curl -s https://wordpress.org/wordpress-5.6.1.tar.gz
```
```
+ svn co --quiet https://develop.svn.wordpress.org/branches/5.5/tests/phpunit/includes/ /tmp/wordpress-tests-lib/includes
+ svn co --quiet https://develop.svn.wordpress.org/branches/5.5/tests/phpunit/data/ /tmp/wordpress-tests-lib/data
```

-   Run the test suite against the latest WordPress again: `WP_VERSION=5.6 npm run test:php`

-   Confirm the installation script is **NOT** triggered. PHPUnit should begin immediately.