### PR TITLE
Try: Refactor head and body heights

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -182,7 +182,7 @@
 	}
 }
 
-.woocommerce-layout__activity-panel-mobile-toggle {
+.woocommerce-layout__activity-panel-mobile-toggle.components-button {
 	margin-right: 10px;
 	max-width: 48px;
 

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -2,19 +2,18 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	position: fixed;
-	right: 0;
-	top: 32px;
 	height: $header-height;
 
 	@include breakpoint( '<782px' ) {
-		position: relative;
+		position: absolute;
+		top: 100%;
 		background: $studio-white;
 		margin: 0;
 		padding: 0;
 		width: 100vw;
 		display: none;
 		flex: 1 100%;
+		right: 0;
 	}
 
 	@include breakpoint( '782px-960px' ) {
@@ -186,12 +185,10 @@
 .woocommerce-layout__activity-panel-mobile-toggle {
 	margin-right: 10px;
 	max-width: 48px;
-	height: $header-height;
-	position: absolute;
-	right: 0;
-	bottom: 0;
+
 	@include breakpoint( '>782px' ) {
 		display: none;
+		height: 100%;
 	}
 }
 
@@ -294,8 +291,4 @@
 
 .woocommerce-layout__notice-list-hide {
 	display: none;
-}
-
-.has-woocommerce-navigation .woocommerce-layout__activity-panel {
-	top: 0;
 }

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -43,7 +43,11 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 	useLayoutEffect( () => {
 		updateBodyMargin();
 		window.addEventListener( 'resize', updateBodyMargin );
-		return () => window.removeEventListener( 'resize', updateBodyMargin );
+		return () => {
+			window.removeEventListener( 'resize', updateBodyMargin );
+			const wpBody = document.querySelector( '#wpbody' );
+			wpBody.style.marginTop = null;
+		};
 	}, [ isModalDismissed ] );
 
 	useEffect( () => {

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -24,21 +24,12 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const pageTitle = sections.slice( -1 )[ 0 ];
 	const isScrolled = useIsScrolled();
 	const { updateUserPreferences, ...userData } = useUserPreferences();
-
 	const isModalDismissed = userData.android_app_banner_dismissed === 'yes';
+	let debounceTimer = null;
 
 	const className = classnames( 'woocommerce-layout__header', {
 		'is-scrolled': isScrolled,
 	} );
-
-	const updateBodyMargin = () => {
-		const wpBody = document.querySelector( '#wpbody' );
-		if ( ! wpBody ) {
-			return;
-		}
-
-		wpBody.style.marginTop = `${ headerElement.current.offsetHeight }px`;
-	};
 
 	useLayoutEffect( () => {
 		updateBodyMargin();
@@ -46,9 +37,27 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		return () => {
 			window.removeEventListener( 'resize', updateBodyMargin );
 			const wpBody = document.querySelector( '#wpbody' );
+
+			if ( ! wpBody ) {
+				return;
+			}
+
 			wpBody.style.marginTop = null;
 		};
 	}, [ isModalDismissed ] );
+
+	const updateBodyMargin = () => {
+		clearTimeout( debounceTimer );
+		debounceTimer = setTimeout( function () {
+			const wpBody = document.querySelector( '#wpbody' );
+
+			if ( ! wpBody ) {
+				return;
+			}
+
+			wpBody.style.marginTop = `${ headerElement.current.offsetHeight }px`;
+		}, 200 );
+	};
 
 	useEffect( () => {
 		if ( ! isEmbedded ) {

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -16,6 +16,7 @@ import './style.scss';
 import ActivityPanel from './activity-panel';
 import { MobileAppBanner } from '../mobile-banner';
 import useIsScrolled from '../hooks/useIsScrolled';
+import Navigation from '../navigation';
 
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );
@@ -72,23 +73,28 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 				/>
 			) }
 
-			<Text
-				className="woocommerce-layout__header-heading"
-				as="h1"
-				variant="subtitle.small"
-			>
-				{ decodeEntities( pageTitle ) }
-			</Text>
-			{ window.wcAdminFeatures[ 'activity-panels' ] && (
-				<ActivityPanel
-					isEmbedded={ isEmbedded }
-					query={ query }
-					userPreferencesData={ {
-						...userData,
-						updateUserPreferences,
-					} }
-				/>
-			) }
+			<div className="woocommerce-layout__header-wrapper">
+				{ window.wcAdminFeatures.navigation && <Navigation /> }
+
+				<Text
+					className="woocommerce-layout__header-heading"
+					as="h1"
+					variant="subtitle.small"
+				>
+					{ decodeEntities( pageTitle ) }
+				</Text>
+
+				{ window.wcAdminFeatures[ 'activity-panels' ] && (
+					<ActivityPanel
+						isEmbedded={ isEmbedded }
+						query={ query }
+						userPreferencesData={ {
+							...userData,
+							updateUserPreferences,
+						} }
+					/>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useLayoutEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useUserPreferences } from '@woocommerce/data';
@@ -30,6 +30,21 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const className = classnames( 'woocommerce-layout__header', {
 		'is-scrolled': isScrolled,
 	} );
+
+	const updateBodyMargin = () => {
+		const wpBody = document.querySelector( '#wpbody' );
+		if ( ! wpBody ) {
+			return;
+		}
+
+		wpBody.style.marginTop = `${ headerElement.current.offsetHeight }px`;
+	};
+
+	useLayoutEffect( () => {
+		updateBodyMargin();
+		window.addEventListener( 'resize', updateBodyMargin );
+		return () => window.removeEventListener( 'resize', updateBodyMargin );
+	}, [ isModalDismissed ] );
 
 	useEffect( () => {
 		if ( ! isEmbedded ) {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -2,9 +2,8 @@
 	background: $studio-white;
 	box-sizing: border-box;
 	padding: 0;
-	min-height: $header-height;
 	position: fixed;
-	width: 100%;
+	width: calc(100% - 160px);
 	top: $adminbar-height;
 	z-index: 1001; /* on top of #wp-content-editor-tools */
 
@@ -14,11 +13,18 @@
 
 	.woocommerce-layout__header-wrapper {
 		display: flex;
+		align-items: center;
+		min-height: $header-height;
 	}
 
 	@include breakpoint( '<782px' ) {
 		flex-flow: row wrap;
 		top: $adminbar-height-mobile;
+		width: 100%;
+	}
+
+	@include breakpoint( '782px-960px' ) {
+		width: calc(100% - 36px);
 	}
 
 	.woocommerce-layout__header-breadcrumbs-wrapper {
@@ -34,7 +40,6 @@
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
 		height: $header-height;
-		line-height: $header-height;
 		background: $studio-white;
 		font-weight: 600;
 		font-size: 14px;
@@ -45,6 +50,7 @@
 .has-woocommerce-navigation .woocommerce-layout__header {
 	top: 0;
 	left: 0;
+	width: 100%;
 }
 
 .woocommerce-page {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -12,6 +12,10 @@
 		box-shadow: $header-scroll-shadow;
 	}
 
+	.woocommerce-layout__header-wrapper {
+		display: flex;
+	}
+
 	@include breakpoint( '<782px' ) {
 		flex-flow: row wrap;
 		top: $adminbar-height-mobile;
@@ -40,6 +44,7 @@
 
 .has-woocommerce-navigation .woocommerce-layout__header {
 	top: 0;
+	left: 0;
 }
 
 .woocommerce-page {

--- a/client/header/test/index.js
+++ b/client/header/test/index.js
@@ -19,6 +19,17 @@ jest.mock( '@woocommerce/data', () => ( {
 	} ),
 } ) );
 
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
 /**
  * External dependencies
  */
@@ -28,6 +39,8 @@ import { render, fireEvent } from '@testing-library/react';
  * Internal dependencies
  */
 import { Header } from '../index.js';
+
+global.window.wcNavigation = {};
 
 const encodedBreadcrumb = [
 	[ 'admin.php?page=wc-settings', 'Settings' ],

--- a/client/index.js
+++ b/client/index.js
@@ -14,7 +14,6 @@ import {
 import './stylesheets/_index.scss';
 import { PageLayout, EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import { CustomerEffortScoreTracksContainer } from './customer-effort-score-tracks';
-import Navigation from './navigation';
 
 // Modify webpack pubilcPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -73,14 +72,6 @@ if ( appRoot ) {
 		</div>,
 		wpBody.insertBefore( noticeContainer, wrap )
 	);
-}
-
-const navigationRoot = document.getElementById(
-	'woocommerce-embedded-navigation'
-);
-
-if ( navigationRoot ) {
-	render( <Navigation />, navigationRoot );
 }
 
 // Render the CustomerEffortScoreTracksContainer only if

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -25,6 +25,8 @@
 
 	#wpbody {
 		padding-top: 0;
+		display: inline-block;
+		width: 100%;
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -4,15 +4,11 @@
 }
 
 .woocommerce-layout__primary {
-	margin: 80px 0 0 $fallback-gutter-large;
-	margin: 80px 0 0 $gutter-large;
-
-	@include breakpoint( '>960px' ) {
-		margin-top: 100px;
-	}
+	margin: $gutter-large 0 0 $fallback-gutter-large;
+	margin: $gutter-large 0 0 $gutter-large;
 
 	@include breakpoint( '<782px' ) {
-		margin-top: 60px;
+		margin-top: 20px;
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -18,8 +18,14 @@
 	max-width: 100%;
 }
 
-.woocommerce-page .update-nag {
-	display: none;
+.woocommerce-page {
+	.update-nag {
+		display: none;
+	}
+
+	#wpbody {
+		padding-top: 0;
+	}
 }
 
 .woocommerce-admin-is-loading {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -25,8 +25,7 @@
 
 	#wpbody {
 		padding-top: 0;
-		display: inline-block;
-		width: 100%;
+		display: block;
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -53,7 +53,11 @@
 	color: $studio-gray-60;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
-	margin-top: -32px;
+
+	margin-top: -$adminbar-height;
+	@include breakpoint( '<600px' ) {
+		margin-top: -$adminbar-height-mobile;
+	}
 
 	#wpwrap {
 		top: 0;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -81,6 +81,7 @@
 
 		> #wpbody {
 			display: block;
+			margin-top: 0 !important;
 		}
 	}
 }

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -24,6 +24,7 @@ import Item from '../../components/Item';
 const Container = ( { menuItems } ) => {
 	useEffect( () => {
 		// Collapse the original WP Menu.
+		document.documentElement.classList.remove( 'wp-toolbar' );
 		const adminMenu = document.getElementById( 'adminmenumain' );
 		adminMenu.classList.add( 'folded' );
 	}, [] );

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -26,6 +26,11 @@ const Container = ( { menuItems } ) => {
 		// Collapse the original WP Menu.
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		const adminMenu = document.getElementById( 'adminmenumain' );
+
+		if ( ! adminMenu ) {
+			return;
+		}
+
 		adminMenu.classList.add( 'folded' );
 	}, [] );
 

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -65,8 +65,6 @@
 	}
 
 	&.is-root {
-		padding-bottom: 100px;
-
 		.components-navigation__menu-secondary {
 			border-top: 1px solid $gray-700;
 			margin: 0 -#{$gap-smaller};

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -3,10 +3,6 @@
 @import './components/header/style';
 
 .has-woocommerce-navigation {
-	.screen-reader-shortcut:focus {
-		top: 7px;
-	}
-
 	#wpadminbar,
 	#adminmenuwrap,
 	#adminmenuback {

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -126,4 +126,8 @@
 			}
 		}
 	}
+
+	#woocommerce-embedded-root.is-embed-loading {
+		margin-bottom: -$adminbar-height;
+	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -45,7 +45,6 @@
 	.woocommerce-navigation {
 		position: relative;
 		width: $navigation-width;
-		height: 100%;
 		box-sizing: border-box;
 		background-color: $gray-900;
 		z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
@@ -99,13 +98,32 @@
 		.woocommerce-transient-notices {
 			left: $gap;
 		}
+
+		#wpbody {
+			margin-left: 0;
+		}
 	}
 
-	.woocommerce-transient-notices {
-		left: $navigation-width + $gap;
+	.woocommerce-layout__header.is-embed-loading {
+		&::before {
+			content: '';
+			position: fixed;
+			width: $navigation-width;
+			height: 100%;
+			background: $gray-900;
 
-		@include breakpoint( '<782px' ) {
-			left: $gap;
+			@include breakpoint( '<960px' ) {
+				width: $header-height;
+				height: $header-height;
+			}
+		}
+
+		.woocommerce-layout__header-heading {
+			margin-left: $navigation-width;
+
+			@include breakpoint( '<960px' ) {
+				margin-left: $header-height;
+			}
 		}
 	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -3,8 +3,6 @@
 @import './components/header/style';
 
 .has-woocommerce-navigation {
-	margin-top: -$admin-bar-height;
-
 	.screen-reader-shortcut:focus {
 		top: 7px;
 	}

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -29,6 +29,14 @@
 
 	#wpcontent,
 	#wpfooter {
+		margin-left: 0;
+
+		@media ( max-width: 960px ) {
+			margin-left: 0;
+		}
+	}
+
+	#wpbody {
 		margin-left: $navigation-width;
 
 		@media ( max-width: 960px ) {
@@ -36,10 +44,8 @@
 		}
 	}
 
-	#woocommerce-embedded-navigation {
-		position: fixed;
-		top: 0;
-		left: 0;
+	.woocommerce-navigation {
+		position: relative;
 		width: $navigation-width;
 		height: 100%;
 		box-sizing: border-box;
@@ -53,6 +59,10 @@
 	}
 
 	.woocommerce-navigation__wrapper {
+		background-color: $gray-900;
+		position: absolute;
+		width: 100%;
+		height: calc(100vh - #{$header-height});
 		overflow-y: auto;
 	}
 
@@ -61,31 +71,19 @@
 	}
 
 	&.is-wc-nav-expanded {
-		#woocommerce-embedded-navigation {
+		.woocommerce-navigation {
 			width: $navigation-width;
 			height: 100%;
 		}
 	}
 
 	&.is-wc-nav-folded {
-		#wpcontent,
-		#wpfooter {
-			margin-left: 0;
-		}
-
-		.woocommerce-layout__header {
-			margin-left: $header-height;
-		}
-
-		#woocommerce-embedded-navigation {
+		.woocommerce-navigation {
 			width: $header-height;
 			height: $header-height;
+			overflow: hidden;
 
 			.woocommerce-navigation-header {
-				&.is-scrolled {
-					box-shadow: $header-scroll-shadow;
-				}
-
 				> * {
 					display: none;
 				}

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -58,6 +58,7 @@
 	.woocommerce-navigation__wrapper {
 		background-color: $gray-900;
 		position: absolute;
+		top: $header-height;
 		width: 100%;
 		height: calc(100vh - #{$header-height});
 		overflow-y: auto;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -39,14 +39,6 @@
 		}
 	}
 
-	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {
-		padding-top: $header-height + 40;
-
-		@include breakpoint( '<782px' ) {
-			padding-top: 30px;
-		}
-	}
-
 	#screen-meta {
 		border-right: 0;
 		margin: 0;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -104,12 +104,6 @@
 		}
 	}
 
-	.woocommerce-layout__activity-panel-mobile-toggle {
-		@include breakpoint( '>782px' ) {
-			display: none;
-		}
-	}
-
 	.woocommerce-activity-card__actions {
 		a.components-button:not(.is-primary) {
 			color: $gray-text;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -5,6 +5,7 @@
 
 	#wpbody {
 		margin-top: $header-height;
+		padding-top: 0;
 	}
 
 	#wpbody .woocommerce-layout,

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -1,8 +1,4 @@
 .woocommerce-embed-page {
-	#wpwrap {
-		display: inline-block;
-	}
-
 	#wpbody {
 		margin-top: $header-height;
 		padding-top: 0;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -1,7 +1,15 @@
 .woocommerce-embed-page {
+	#wpwrap {
+		display: inline-block;
+	}
+
+	#wpbody {
+		margin-top: $header-height;
+	}
+
 	#wpbody .woocommerce-layout,
 	.woocommerce-layout__notice-list-hide + .wrap {
-		padding-top: $header-height + 10;
+		padding-top: 10px;
 	}
 
 	#wpcontent,
@@ -36,11 +44,6 @@
 		@include breakpoint( '<782px' ) {
 			padding-top: 30px;
 		}
-	}
-
-	#screen-meta,
-	#screen-meta-links {
-		top: $header-height;
 	}
 
 	#screen-meta {

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -63,6 +63,10 @@
 	#wpadminbar {
 		position: fixed;
 	}
+
+	html.wp-toolbar {
+		padding-top: $adminbar-height-mobile;
+	}
 }
 
 // Temporary fix for compability with the Jetpack masterbar

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -33,8 +33,6 @@ class Init {
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_opt_out_scripts' ) );
 
 		if ( Loader::is_feature_enabled( 'navigation' ) ) {
-			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
-
 			Menu::instance()->init();
 			CoreMenu::instance()->init();
 			Screen::instance()->init();
@@ -129,20 +127,6 @@ class Init {
 		$options[] = self::TOGGLE_OPTION_NAME;
 
 		return $options;
-	}
-
-	/**
-	 * Set up a div for the navigation.
-	 * The initial contents here are meant as a place loader for when the PHP page initialy loads.
-	 */
-	public static function embed_navigation() {
-		if ( ! Screen::is_woocommerce_page() ) {
-			return;
-		}
-
-		?>
-		<div id="woocommerce-embedded-navigation"></div>
-		<?php
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6235 

Refactors header heights to be more dynamic.

Originally, I liked the idea of using some kind of global data store that contained information about the height/header.  However, this reduces benefits to non-React elements that may need context about the header.  In the end, I went with a more "natural" approach that assumes we only have one header and the body is pushed down according to its height.  In a nutshell:

* Any sticky (header) elements belong in the header.
* The WP body `#wpbody` is always pushed down by the dynamic height of this header.
* Body elements should not "guess" at how much padding is needed above them to compensate for header discrepancies.

Note that we could modify the margin to be added to the actual `body` instead of `#wpbody` if there are benefits to doing so (not seeing any yet).

This approach also favors removing the `wp-toolbar` class, however this can only be done via JS since it's always added when `is_admin()` is `true` so there is some extra CSS to modify this when that isn't possible.

### Screenshots

<img width="598" alt="Screen Shot 2021-02-02 at 12 49 19 PM" src="https://user-images.githubusercontent.com/10561050/106641352-1a221980-6555-11eb-97c0-813deabf3b91.png">
<img width="671" alt="Screen Shot 2021-02-02 at 12 49 12 PM" src="https://user-images.githubusercontent.com/10561050/106641354-1abab000-6555-11eb-9514-04d90f5cf2d7.png">
<img width="513" alt="Screen Shot 2021-02-02 at 12 48 11 PM" src="https://user-images.githubusercontent.com/10561050/106641356-1abab000-6555-11eb-8671-0a4083a6e8d6.png">
<img width="986" alt="Screen Shot 2021-02-02 at 12 47 46 PM" src="https://user-images.githubusercontent.com/10561050/106641359-1abab000-6555-11eb-94b5-ce69bd46164a.png">


### Detailed test instructions:

1. Test various embed and non-embed WC pages.
2. Test various screen sizes.
3. Test with the new navigation turned both on and off.
4. Test full screen pages (i.e., setup wizard).
5. Test with the mobile banner enabled.
6. Test with various combinations of the above.