### PR TITLE
Separate secondary items into separate menu in navigation

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -142,105 +142,97 @@ const Container = ( { menuItems } ) => {
 							secondary: secondaryItems,
 							plugins: pluginItems,
 						} = categorizedItems[ category.id ] || {};
-						return (
-							<>
-								{ ( !! primaryItems || !! pluginItems ) && (
-									<NavigationMenu
-										key={ category.id }
-										title={ category.title }
-										menu={ category.id }
-										parentMenu={ category.parent }
-										backButtonLabel={
-											isRootBackVisible
-												? rootBackLabel
-												: category.backButtonLabel ||
-												  null
-										}
-										onBackButtonClick={
-											isRootBackVisible
-												? () => {
-														trackBackClick(
-															'woocommerce'
-														);
-														window.location = rootBackUrl;
-												  }
-												: () =>
-														trackBackClick(
-															category.id
-														)
-										}
-									>
-										{ !! primaryItems && (
-											<NavigationGroup>
-												{ primaryItems.map(
-													( item ) => (
-														<Item
-															key={ item.id }
-															item={ item }
-														/>
+						return [
+							( !! primaryItems || !! pluginItems ) && (
+								<NavigationMenu
+									key={ category.id }
+									title={ category.title }
+									menu={ category.id }
+									parentMenu={ category.parent }
+									backButtonLabel={
+										isRootBackVisible
+											? rootBackLabel
+											: category.backButtonLabel || null
+									}
+									onBackButtonClick={
+										isRootBackVisible
+											? () => {
+													trackBackClick(
+														'woocommerce'
+													);
+													window.location = rootBackUrl;
+											  }
+											: () =>
+													trackBackClick(
+														category.id
 													)
-												) }
-											</NavigationGroup>
-										) }
-										{ !! pluginItems && (
-											<NavigationGroup
-												title={
-													category.id ===
-													'woocommerce'
-														? __(
-																'Extensions',
-																'woocommerce-admin'
-														  )
-														: null
-												}
-											>
-												{ pluginItems.map( ( item ) => (
-													<Item
-														key={ item.id }
-														item={ item }
-													/>
-												) ) }
-											</NavigationGroup>
-										) }
-									</NavigationMenu>
-								) }
-								{ !! secondaryItems && (
-									<NavigationMenu
-										className="components-navigation__menu-secondary"
-										key={ `secondary/${ category.id }` }
-										title={
-											! isRoot ? category.title : null
-										}
-										menu={ category.id }
-										parentMenu={ category.parent }
-										backButtonLabel={
-											category.backButtonLabel || null
-										}
-										onBackButtonClick={
-											isRootBackVisible
-												? null
-												: () =>
-														trackBackClick(
-															category.id
-														)
-										}
-									>
-										<NavigationGroup
-											onBackButtonClick={ () =>
-												trackBackClick( category.id )
-											}
-										>
-											{ secondaryItems.map( ( item ) => (
+									}
+								>
+									{ !! primaryItems && (
+										<NavigationGroup>
+											{ primaryItems.map( ( item ) => (
 												<Item
 													key={ item.id }
 													item={ item }
 												/>
 											) ) }
 										</NavigationGroup>
-									</NavigationMenu>
-								) }
-							</>
-						);
+									) }
+									{ !! pluginItems && (
+										<NavigationGroup
+											title={
+												category.id === 'woocommerce'
+													? __(
+															'Extensions',
+															'woocommerce-admin'
+													  )
+													: null
+											}
+										>
+											{ pluginItems.map( ( item ) => (
+												<Item
+													key={ item.id }
+													item={ item }
+												/>
+											) ) }
+										</NavigationGroup>
+									) }
+								</NavigationMenu>
+							),
+							!! secondaryItems && (
+								<NavigationMenu
+									className="components-navigation__menu-secondary"
+									key={ `secondary/${ category.id }` }
+									title={ ! isRoot ? category.title : null }
+									menu={ category.id }
+									parentMenu={ category.parent }
+									backButtonLabel={
+										category.backButtonLabel || null
+									}
+									onBackButtonClick={
+										isRootBackVisible
+											? null
+											: () =>
+													trackBackClick(
+														category.id
+													)
+									}
+								>
+									<NavigationGroup
+										onBackButtonClick={ () =>
+											trackBackClick( category.id )
+										}
+									>
+										{ secondaryItems.map( ( item ) => (
+											<Item
+												key={ item.id }
+												item={ item }
+											/>
+										) ) }
+									</NavigationGroup>
+								</NavigationMenu>
+							),
+						];
 					} ) }
 				</Navigation>
 			</div>

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
+import classnames from 'classnames';
 import { compose } from '@wordpress/compose';
 import {
 	Navigation,
@@ -114,10 +115,15 @@ const Container = ( { menuItems } ) => {
 		} );
 	};
 
-	const isRootBackVisible = activeLevel === 'woocommerce' && rootBackUrl;
+	const isRoot = activeLevel === 'woocommerce';
+	const isRootBackVisible = isRoot && rootBackUrl;
+
+	const classes = classnames( 'woocommerce-navigation', {
+		'is-root': isRoot,
+	} );
 
 	return (
-		<div className="woocommerce-navigation">
+		<div className={ classes }>
 			<Header />
 			<div className="woocommerce-navigation__wrapper" ref={ navDomRef }>
 				<Navigation
@@ -146,64 +152,95 @@ const Container = ( { menuItems } ) => {
 							plugins: pluginItems,
 						} = categorizedItems[ category.id ] || {};
 						return (
-							<NavigationMenu
-								key={ category.id }
-								title={ category.title }
-								menu={ category.id }
-								parentMenu={ category.parent }
-								backButtonLabel={
-									category.backButtonLabel || null
-								}
-								onBackButtonClick={
-									isRootBackVisible
-										? null
-										: () => trackBackClick( category.id )
-								}
-							>
-								{ !! primaryItems && (
-									<NavigationGroup>
-										{ primaryItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
-								) }
-								{ !! pluginItems && (
-									<NavigationGroup
-										title={
-											category.id === 'woocommerce'
-												? __(
-														'Extensions',
-														'woocommerce-admin'
-												  )
-												: null
+							<>
+								{ ( !! primaryItems || !! pluginItems ) && (
+									<NavigationMenu
+										key={ category.id }
+										title={ category.title }
+										menu={ category.id }
+										parentMenu={ category.parent }
+										backButtonLabel={
+											category.backButtonLabel || null
+										}
+										onBackButtonClick={
+											isRootBackVisible
+												? null
+												: () =>
+														trackBackClick(
+															category.id
+														)
 										}
 									>
-										{ pluginItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
+										{ !! primaryItems && (
+											<NavigationGroup>
+												{ primaryItems.map(
+													( item ) => (
+														<Item
+															key={ item.id }
+															item={ item }
+														/>
+													)
+												) }
+											</NavigationGroup>
+										) }
+										{ !! pluginItems && (
+											<NavigationGroup
+												title={
+													category.id ===
+													'woocommerce'
+														? __(
+																'Extensions',
+																'woocommerce-admin'
+														  )
+														: null
+												}
+											>
+												{ pluginItems.map( ( item ) => (
+													<Item
+														key={ item.id }
+														item={ item }
+													/>
+												) ) }
+											</NavigationGroup>
+										) }
+									</NavigationMenu>
 								) }
 								{ !! secondaryItems && (
-									<NavigationGroup
-										onBackButtonClick={ () =>
-											trackBackClick( category.id )
+									<NavigationMenu
+										className="components-navigation__menu-secondary"
+										key={ category.id }
+										title={
+											! isRoot ? category.title : null
+										}
+										menu={ category.id }
+										parentMenu={ category.parent }
+										backButtonLabel={
+											category.backButtonLabel || null
+										}
+										onBackButtonClick={
+											isRootBackVisible
+												? null
+												: () =>
+														trackBackClick(
+															category.id
+														)
 										}
 									>
-										{ secondaryItems.map( ( item ) => (
-											<Item
-												key={ item.id }
-												item={ item }
-											/>
-										) ) }
-									</NavigationGroup>
+										<NavigationGroup
+											onBackButtonClick={ () =>
+												trackBackClick( category.id )
+											}
+										>
+											{ secondaryItems.map( ( item ) => (
+												<Item
+													key={ item.id }
+													item={ item }
+												/>
+											) ) }
+										</NavigationGroup>
+									</NavigationMenu>
 								) }
-							</NavigationMenu>
+							</>
 						);
 					} ) }
 				</Navigation>

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -207,7 +207,7 @@ const Container = ( { menuItems } ) => {
 								{ !! secondaryItems && (
 									<NavigationMenu
 										className="components-navigation__menu-secondary"
-										key={ category.id }
+										key={ `secondary/${ category.id }` }
 										title={
 											! isRoot ? category.title : null
 										}

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 import { compose } from '@wordpress/compose';
 import {
 	Navigation,
-	NavigationBackButton,
 	NavigationMenu,
 	NavigationGroup,
 } from '@woocommerce/experimental';
@@ -137,14 +136,6 @@ const Container = ( { menuItems } ) => {
 						setActiveLevel( ...args );
 					} }
 				>
-					{ isRootBackVisible && (
-						<NavigationBackButton
-							className="woocommerce-navigation__back-to-dashboard"
-							href={ rootBackUrl }
-							backButtonLabel={ rootBackLabel }
-							onClick={ () => trackBackClick( 'woocommerce' ) }
-						></NavigationBackButton>
-					) }
 					{ categories.map( ( category ) => {
 						const {
 							primary: primaryItems,
@@ -160,11 +151,19 @@ const Container = ( { menuItems } ) => {
 										menu={ category.id }
 										parentMenu={ category.parent }
 										backButtonLabel={
-											category.backButtonLabel || null
+											isRootBackVisible
+												? rootBackLabel
+												: category.backButtonLabel ||
+												  null
 										}
 										onBackButtonClick={
 											isRootBackVisible
-												? null
+												? () => {
+														trackBackClick(
+															'woocommerce'
+														);
+														window.location = rootBackUrl;
+												  }
 												: () =>
 														trackBackClick(
 															category.id

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -1,6 +1,6 @@
 .woocommerce-navigation {
 	display: grid;
-	grid-template-rows: min-content 2fr;
+	grid-template-rows: min-content 1fr;
 	height: 100%;
 
 	h2 {
@@ -8,8 +8,6 @@
 	}
 
 	.components-navigation__menu {
-		display: grid;
-		grid-template-rows: min-content 2fr;
 		overflow-y: auto;
 		margin-bottom: 0;
 		padding-bottom: $gap-large;
@@ -23,10 +21,6 @@
 		margin-bottom: 0;
 	}
 
-	.woocommerce-navigation__back-to-dashboard {
-		margin-top: 24px;
-	}
-
 	.components-navigation {
 		height: 100%;
 	}
@@ -34,7 +28,7 @@
 	.components-navigation > div {
 		height: 100%;
 		display: grid;
-		grid-template-rows: min-content 2fr;
+		grid-template-rows: 1fr min-content;
 	}
 
 	&.is-root {

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -1,12 +1,18 @@
 .woocommerce-navigation {
+	display: grid;
+	grid-template-rows: min-content 2fr;
+	height: 100%;
+
 	h2 {
 		color: inherit; // This should be handled at component level.
 	}
 
 	.components-navigation__menu {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
+		display: grid;
+		grid-template-rows: min-content 2fr;
+		overflow-y: auto;
+		margin-bottom: 0;
+		padding-bottom: $gap-large;
 	}
 
 	.components-navigation__group + .components-navigation__group {
@@ -19,5 +25,25 @@
 
 	.woocommerce-navigation__back-to-dashboard {
 		margin-top: 24px;
+	}
+
+	.components-navigation {
+		height: 100%;
+	}
+
+	.components-navigation > div {
+		height: 100%;
+		display: grid;
+		grid-template-rows: min-content 2fr;
+	}
+
+	&.is-root {
+		padding-bottom: 100px;
+
+		.components-navigation__menu-secondary {
+			border-top: 1px solid $gray-700;
+			margin: 0 -#{$gap-smaller};
+			padding: $gap $gap-smaller;
+		}
 	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -50,7 +50,6 @@
 
 	.woocommerce-navigation__wrapper {
 		overflow-y: auto;
-		height: calc(100vh - #{$header-height});
 	}
 
 	.components-navigation {


### PR DESCRIPTION
Fixes #6150

* Converts the navigation to a grid.
* Moves secondary items into a second menu.

My original attempt involved using absolutely positioning and padding to position the menu, however, this created issues with the menu overlapping at various screen sizes and broken in child menus.

This solution allows the secondary menu to grow or shrink in size and still have both menus work cohesively.

### Screenshots

<img width="329" alt="Screen Shot 2021-02-02 at 5 20 42 PM" src="https://user-images.githubusercontent.com/10561050/106670752-70a24e80-657b-11eb-8877-7b03118a8ebf.png">
<img width="565" alt="Screen Shot 2021-02-02 at 5 20 34 PM" src="https://user-images.githubusercontent.com/10561050/106670753-713ae500-657b-11eb-88b0-2f0a2cc6b453.png">


### Detailed test instructions:

1. Navigate through various navigation categories.
2. Make sure everything is visually as expected.
3. Make sure the back to dashboard button works as expected.
4. Shrink the viewport in height.
5. Make sure the secondary menu is visible, but the primary is scrollable.