### PR TITLE
Navigation: Add temp override to fix Gutenberg item CSS

### DIFF
--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -36,13 +36,13 @@
 		&:not(:hover) {
 			a.components-button {
 				// ${ G2.lightGray.ui };
-				color: rgb(148, 148, 148);
+				color: #949494;
 			}
 		}
 		&.is-active {
 			a.components-button {
 				// ${ UI.textDark };
-				color: rgb(240, 240, 240);
+				color: #fff;
 			}
 		}
 		/*

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -15,6 +15,39 @@
 
 	.components-navigation__item {
 		margin-bottom: 0;
+
+		/*
+		* <-------- Start Temporary Code -------->
+		*
+		* A change to Gutenberg base Navigation component in version 9.8.3
+		* requires these overrides. As of this comment, the problematic code
+		* was published to .org but not shipped as part of WP 5.7.
+		*
+		* A fix in Gutenberg is https://github.com/WordPress/gutenberg/pull/28619
+		*
+		* Criteria for removal
+		* 1. https://github.com/WordPress/gutenberg/pull/28619 is merged and deployed to .org
+		* 2. https://github.com/WordPress/gutenberg/pull/28619 is included in the Gutenberg version associated with WP 5.7
+		* 3. If not part of WP 5.7, this code will be required until WP 6.0 is released and WC Admin no longer supports 5.7
+		*/
+		a.components-button {
+			padding: 6px 16px;
+		}
+		&:not(:hover) {
+			a.components-button {
+				// ${ G2.lightGray.ui };
+				color: rgb(148, 148, 148);
+			}
+		}
+		&.is-active {
+			a.components-button {
+				// ${ UI.textDark };
+				color: rgb(240, 240, 240);
+			}
+		}
+		/*
+		* <-------- End Temporary Code -------->
+		*/
 	}
 
 	.woocommerce-navigation__back-to-dashboard {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6052

https://github.com/WordPress/gutenberg/pull/28619 Fixes an issue where Nav item base styles weren't included so WC Admin use of Gutenberg links as part of the Nav don't get the styles needed. 

Since we can't guarantee users won't have Gutenberg plugin activated or ensure the problematic code won't be shipped in 5.7, we need to include overrides in this repo as well.

### Detailed test instructions:

1. Reproduce the issue by activating Gutenberg plugin and use `main` of wc-admin
2. Run `npm run dev` in Gutenberg using the latest from master
3. Visit any Analytics page and see the links disappear

<img width="239" alt="Screen Shot 2021-01-13 at 9 08 40 AM" src="https://user-images.githubusercontent.com/1922453/104367080-2ed74700-557f-11eb-88a0-9d9f3f0ee443.png">

4. Now apply this branch and see the links come back to life. Note that padding was affected too, so ensure no regression in that regard as well.
5. Visit a Core WC page such as products and make sure the links look ok in this context too.
5. Make sure the criteria for removal make sense.
