### PR TITLE
Onboarding - Fixed "Business Details" error

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -410,6 +410,8 @@ class BusinessDetails extends Component {
 	}
 
 	render() {
+		const { initialValues } = this.props;
+
 		// There is a hack here to help us manage the selected tab programatically.
 		// We set the tab name "current-tab". when its the one we want selected. This tricks
 		// the logic in the TabPanel and allows us to switch which tab has the name "current-tab"
@@ -420,7 +422,10 @@ class BusinessDetails extends Component {
 				initialTabName="current-tab"
 				onSelect={ ( tabName ) => {
 					if ( this.state.currentTab !== tabName ) {
-						this.setState( { currentTab: tabName } );
+						this.setState( {
+							currentTab: tabName,
+							savedValues: initialValues,
+						} );
 					}
 				} }
 				tabs={ [

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
 - Tweak: Refactored extended task list. #6081
 - Fix: Fixed the Add First Product email note checks. #6260
+- Fix: Onboarding - Fixed "Business Details" error. #6271
 
 
 == Changelog ==


### PR DESCRIPTION
Fixes #6262

This PR adds an initial value to `savedValues` in the "Business Details" step in the OBW. With this addition, the "Continue" button on "Free features" works again.

### Screenshots
![Captura de Pantalla 2021-02-04 a la(s) 15 11 40](https://user-images.githubusercontent.com/1314156/106936435-52fbf300-66fb-11eb-9370-39f4b2454225.png)


### Detailed test instructions:

- Check out this branch.
- Go to the "Industry" step in the OBW and select `Food and drink`.
- Go to the "Business Details" step and press `Free features`.
- Press `Continue`.
- It should work.
- Try also selecting and unselecting some checkboxes before pressing `Continue`.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
