### PR TITLE
Skip intermittent failing test

### DIFF
--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -57,6 +57,7 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	 * Test that sample product data is imported.
 	 */
 	public function test_import_sample_products() {
+		$this->markTestSkipped( 'Skipped as test randomly fails on line 77.' );
 		wp_set_current_user( $this->user );
 
 		$this->remove_color_or_logo_attribute_taxonomy();


### PR DESCRIPTION
Skips the `test_import_sample_products` which intermittently fails on line 77, where the imported products is less then 2.

Created a follow up cooldown issue for this: https://github.com/woocommerce/woocommerce-admin/issues/6272