### PR TITLE
Add a new note with a link to the downloadable product doc

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -12,6 +12,7 @@ use \Automattic\WooCommerce\Admin\Notes\AddingAndManangingProducts;
 use \Automattic\WooCommerce\Admin\Notes\ChooseNiche;
 use \Automattic\WooCommerce\Admin\Notes\ChoosingTheme;
 use \Automattic\WooCommerce\Admin\Notes\CustomizingProductCatalog;
+use Automattic\WooCommerce\Admin\Notes\FirstDownlaodableProduct;
 use \Automattic\WooCommerce\Admin\Notes\GivingFeedbackNotes;
 use \Automattic\WooCommerce\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Admin\Notes\MobileApp;
@@ -144,6 +145,7 @@ class Events {
 		AddingAndManangingProducts::possibly_add_note();
 		CustomizingProductCatalog::possibly_add_note();
 		GettingStartedInEcommerceWebinar::possibly_add_note();
+		FirstDownlaodableProduct::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/FirstDownlaodableProduct.php
+++ b/src/Notes/FirstDownlaodableProduct.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * WooCommerce Admin Digital/Downloadable Producdt Handling note provider
+ *
+ * Adds a note with a link to the downlaodable product handling
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * FirstDownlaodableProduct.
+ */
+class FirstDownlaodableProduct {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-first-downloadable-product';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$query    = new \WC_Product_Query(
+			array(
+				'limit'        => 1,
+				'paginate'     => true,
+				'return'       => 'ids',
+				'downloadable' => 1,
+				'status'       => array( 'publish' ),
+			)
+		);
+		$products = $query->get_products();
+
+		// There must be at least 1 downloadable product.
+		if ( 0 === $products->total ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Learn more about digital/downloadable products', 'woocommerce-admin' ) );
+		$note->set_content(
+			__(
+				'Congrats on adding your first digital product! You can learn more about how to handle digital or downloadable products in our documentation.',
+				'woocommerce-admin'
+			)
+		);
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'first-downloadable-product-handling',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://docs.woocommerce.com/document/digital-downloadable-product-handling/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #5936 

This PR adds a new note for the new users when they add the first digital or downloadable product.


### Screenshots
![Screen Shot 2021-02-04 at 3 05 00 PMth_](https://user-images.githubusercontent.com/4723145/106966619-8b4f0180-66fa-11eb-9e8a-e71f75d78ed1.jpg)

### Detailed test instructions:

1. Make sure your store does not have any download products.
2. Install WP Crontrol plugin.
3. Add a new download product.
4. Navigate to Tools -> Cron Events and run `wc_admin_daily`
5. Navigate to WooCommerce -> Home and confirm that the note has been added.