### PR TITLE
Skip extensions in navigation flyout menu

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -294,6 +294,11 @@ class CoreMenu {
 		}
 
 		foreach( $top_level_items as $item ) {
+			// Skip extensions.
+			if ( $item['menuId'] === 'plugins' ) {
+				continue;
+			}
+
 			// Skip specific categories.
 			if (
 				in_array(

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -295,7 +295,7 @@ class CoreMenu {
 
 		foreach( $top_level_items as $item ) {
 			// Skip extensions.
-			if ( $item['menuId'] === 'plugins' ) {
+			if ( ! isset( $item['menuId'] ) || $item['menuId'] === 'plugins' ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #6276

Skips extensions in the flyout menu until we have favorites in place.

### Screenshots

#### Before
<img width="333" alt="Screen Shot 2021-02-04 at 6 13 15 PM" src="https://user-images.githubusercontent.com/10561050/106967171-aaf32380-6714-11eb-9b31-ab5bac4e429b.png">

#### After
<img width="341" alt="Screen Shot 2021-02-04 at 6 12 13 PM" src="https://user-images.githubusercontent.com/10561050/106967154-a3337f00-6714-11eb-9367-13fa19e82aa9.png">


### Detailed test instructions:

1. Add a plugin that registers a plugin menu item (or register your own via `add_plugin_item()`.
2. Navigate to a non-WC page.
3. Hover the "WooCommerce" menu item.
4. Make sure no extension items are shown.