### PR TITLE
Make sure that industry is defined in payment methods

### DIFF
--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -79,9 +79,11 @@ export function getPaymentMethods( {
 		wcPayIsConnected = false,
 	} = onboardingStatus;
 
-	const hasCbdIndustry = profileItems.industry.some( ( { slug } ) => {
-		return slug === 'cbd-other-hemp-derived-products';
-	} );
+	const hasCbdIndustry = ( profileItems.industry || [] ).some(
+		( { slug } ) => {
+			return slug === 'cbd-other-hemp-derived-products';
+		}
+	);
 
 	// Whether publishable and secret keys are filled for given mode.
 	const isStripeConfigured =


### PR DESCRIPTION
I ran into an instance where `profileItems.industry` was undefined (I skipped the OBW), this caused an error as it tried to run the function `some` on undefined.
This was caused by some recent refactoring, replacing the `some` lodash method with `profileItems.industry.some`.

### Detailed test instructions:

- Start a new store, and skip the initial onboarding flow, there is a button `Skip store details` at the bottom
- Load the `Set up payments` task, the payment options should load correctly.