### PR TITLE
Add favoriting extensions client UI

### DIFF
--- a/client/navigation/components/category-title/index.js
+++ b/client/navigation/components/category-title/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -45,7 +46,17 @@ export const CategoryTitle = ( { category } ) => {
 					isTertiary
 					onClick={ toggleFavorite }
 					icon={ isFavorited ? 'star-filled' : 'star-empty' }
-					aria-label={ 'Add this extension to your favorites.' }
+					aria-label={
+						isFavorited
+							? __(
+									'Add this item to your favorites.',
+									'woocommerce-admin'
+							  )
+							: __(
+									'Remove this item from your favorites.',
+									'woocommerce-admin'
+							  )
+					}
 				/>
 			</span>
 		);

--- a/client/navigation/components/category-title/index.js
+++ b/client/navigation/components/category-title/index.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import './style.scss';
 
 export const CategoryTitle = ( { category } ) => {
 	const { id, title } = category;

--- a/client/navigation/components/category-title/index.js
+++ b/client/navigation/components/category-title/index.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -23,8 +24,17 @@ export const CategoryTitle = ( { category } ) => {
 		NAVIGATION_STORE_NAME
 	);
 
-	const isFavorite = favorites.includes( id );
+	const isFavorited = favorites.includes( id );
 	const className = 'woocommerce-navigation-category-title';
+
+	const toggleFavorite = () => {
+		const toggle = isFavorited ? removeFavorite : addFavorite;
+		toggle( id );
+		recordEvent( 'navigation_favorite', {
+			id,
+			action: isFavorited ? 'unfavorite' : 'favorite',
+		} );
+	};
 
 	if ( category.menuId === 'plugins' ) {
 		return (
@@ -33,10 +43,8 @@ export const CategoryTitle = ( { category } ) => {
 				<Button
 					className={ `${ className }__favorite-button` }
 					isTertiary
-					onClick={ () =>
-						isFavorite ? removeFavorite( id ) : addFavorite( id )
-					}
-					icon={ isFavorite ? 'star-filled' : 'star-empty' }
+					onClick={ toggleFavorite }
+					icon={ isFavorited ? 'star-filled' : 'star-empty' }
 					aria-label={ 'Add this extension to your favorites.' }
 				/>
 			</span>

--- a/client/navigation/components/category-title/index.js
+++ b/client/navigation/components/category-title/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { NAVIGATION_STORE_NAME } from '@woocommerce/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+export const CategoryTitle = ( { category } ) => {
+	const { id, title } = category;
+
+	const { favorites } = useSelect( ( select ) => {
+		return {
+			favorites: select( NAVIGATION_STORE_NAME ).getFavorites(),
+		};
+	} );
+
+	const { addFavorite, removeFavorite } = useDispatch(
+		NAVIGATION_STORE_NAME
+	);
+
+	const isFavorite = favorites.includes( id );
+	const className = 'woocommerce-navigation-category-title';
+
+	if ( category.menuId === 'plugins' ) {
+		return (
+			<span className={ className }>
+				<span className={ `${ className }__text` }>{ title }</span>
+				<Button
+					className={ `${ className }__favorite-button` }
+					isTertiary
+					onClick={ () =>
+						isFavorite ? removeFavorite( id ) : addFavorite( id )
+					}
+					icon={ isFavorite ? 'star-filled' : 'star-empty' }
+					aria-label={ 'Add this extension to your favorites.' }
+				/>
+			</span>
+		);
+	}
+
+	return <span className={ className }>{ title }</span>;
+};
+
+export default CategoryTitle;

--- a/client/navigation/components/category-title/style.scss
+++ b/client/navigation/components/category-title/style.scss
@@ -1,0 +1,20 @@
+.woocommerce-navigation-category-title {
+    display: flex;
+    align-items: center;
+
+    .woocommerce-navigation-category-title__favorite-button {
+        margin-left: auto;
+
+        .dashicon {
+            margin: 0;
+        }
+
+        .dashicons-star-empty {
+            color: gray;
+        }
+
+        .dashicons-star-filled {
+            color: yellow;
+        }
+    }
+}

--- a/client/navigation/components/category-title/style.scss
+++ b/client/navigation/components/category-title/style.scss
@@ -1,20 +1,20 @@
 .woocommerce-navigation-category-title {
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 
-    .woocommerce-navigation-category-title__favorite-button {
-        margin-left: auto;
+	.woocommerce-navigation-category-title__favorite-button {
+		margin-left: auto;
 
-        .dashicon {
-            margin: 0;
-        }
+		.dashicon {
+			margin: 0;
+		}
 
-        .dashicons-star-empty {
-            color: gray;
-        }
+		.dashicons-star-empty {
+			color: $gray-600;
+		}
 
-        .dashicons-star-filled {
-            color: yellow;
-        }
-    }
+		.dashicons-star-filled {
+			color: $alert-yellow;
+		}
+	}
 }

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -206,7 +206,13 @@ const Container = ( { menuItems } ) => {
 								<NavigationMenu
 									className="components-navigation__menu-secondary"
 									key={ `secondary/${ category.id }` }
-									title={ ! isRoot ? category.title : null }
+									title={
+										! isRoot && (
+											<CategoryTitle
+												category={ category }
+											/>
+										)
+									}
 									menu={ category.id }
 									parentMenu={ category.parent }
 									backButtonLabel={

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -18,6 +18,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { addHistoryListener, getMatchingItem } from '../../utils';
+import CategoryTitle from '../category-title';
 import Header from '../header';
 import Item from '../../components/Item';
 
@@ -146,7 +147,9 @@ const Container = ( { menuItems } ) => {
 							( !! primaryItems || !! pluginItems ) && (
 								<NavigationMenu
 									key={ category.id }
-									title={ category.title }
+									title={
+										<CategoryTitle category={ category } />
+									}
 									menu={ category.id }
 									parentMenu={ category.parent }
 									backButtonLabel={

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -3,8 +3,8 @@
 	grid-template-rows: min-content 1fr;
 	height: 100%;
 
-	h2 {
-		color: inherit; // This should be handled at component level.
+	h2 > span {
+		width: 100%;
 	}
 
 	.components-navigation__menu {


### PR DESCRIPTION
Fixes (part of) #6213 

Adds the UI to favorite extensions from the navigation menu.  Note that the colors still need to be updated here (missing Figma design links).

We may also want to consider optimistically updating our data store (up for discussion).

### Screenshots
<img width="308" alt="Screen Shot 2021-02-08 at 11 53 00 AM" src="https://user-images.githubusercontent.com/10561050/107254155-0834f080-6a05-11eb-9eb6-f17af3014833.png">


### Detailed test instructions:

1. Install an extension that registers a category.
2. Navigate to that extension's menu.
3. Toggle the favorite on/off and make sure it works as expected.
4. (Assuming #6136 is hooked up) - make sure selections persist on refresh.