### PR TITLE
Show management links when main task list is hidden

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -48,6 +48,7 @@ export const Layout = ( {
 	isBatchUpdating,
 	query,
 	requestingTaskList,
+	isTaskListHidden,
 	bothTaskListsHidden,
 	shouldShowWelcomeModal,
 	shouldShowWelcomeFromCalypsoModal,
@@ -100,7 +101,7 @@ export const Layout = ( {
 				</Column>
 				<Column shouldStick={ shouldStickColumns }>
 					<StatsOverview />
-					{ ! isTaskListEnabled && <StoreManagementLinks /> }
+					{ isTaskListHidden && <StoreManagementLinks /> }
 				</Column>
 			</>
 		);
@@ -221,14 +222,17 @@ export default compose(
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||
 			'single_column';
+		const isTaskListHidden =
+			getOption( 'woocommerce_task_list_hidden' ) === 'yes';
 
 		return {
 			defaultHomescreenLayout,
 			isBatchUpdating: isNotesRequesting( 'batchUpdateNotes' ),
 			shouldShowWelcomeModal,
 			shouldShowWelcomeFromCalypsoModal,
+			isTaskListHidden,
 			bothTaskListsHidden:
-				getOption( 'woocommerce_task_list_hidden' ) === 'yes' &&
+				isTaskListHidden &&
 				getOption( 'woocommerce_extended_task_list_hidden' ) === 'yes',
 			requestingTaskList:
 				isResolving( 'getOption', [

--- a/client/homescreen/test/index.js
+++ b/client/homescreen/test/index.js
@@ -20,6 +20,10 @@ jest.mock( 'task-list', () => jest.fn().mockReturnValue( '[TaskList]' ) );
 // We aren't testing the <InboxPanel /> component here.
 jest.mock( 'inbox-panel', () => jest.fn().mockReturnValue( '[InboxPanel]' ) );
 
+jest.mock( '../../store-management-links', () => ( {
+	StoreManagementLinks: jest.fn().mockReturnValue( '[StoreManagementLinks]' ),
+} ) );
+
 jest.mock( '@woocommerce/data', () => ( {
 	...jest.requireActual( '@woocommerce/data' ),
 	useUserPreferences: jest.fn().mockReturnValue( {} ),
@@ -236,6 +240,51 @@ describe( 'Homescreen Layout', () => {
 
 		expect(
 			within( secondColumn ).getByText( /\[StatsOverview\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( firstColumn ).queryByText( /\[StatsOverview\]/ )
+		).toBeNull();
+	} );
+
+	it( 'should display the correct blocks in each column when task list is hidden', () => {
+		useUserPreferences.mockReturnValue( {
+			homepage_layout: 'two_columns',
+		} );
+		const { container } = render(
+			<Layout
+				requestingTaskList={ false }
+				bothTaskListsHidden={ false }
+				isTaskListHidden={ true }
+				query={ {} }
+				updateOptions={ () => {} }
+			/>
+		);
+
+		const columns = container.getElementsByClassName(
+			'woocommerce-homescreen-column'
+		);
+		expect( columns ).toHaveLength( 2 );
+		const firstColumn = columns[ 0 ];
+		const secondColumn = columns[ 1 ];
+
+		expect(
+			within( firstColumn ).getByText( /\[TaskList\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( firstColumn ).getByText( /\[InboxPanel\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( secondColumn ).queryByText( /\[TaskList\]/ )
+		).toBeNull();
+		expect(
+			within( secondColumn ).queryByText( /\[InboxPanel\]/ )
+		).toBeNull();
+
+		expect(
+			within( secondColumn ).getByText( /\[StatsOverview\]/ )
+		).toBeInTheDocument();
+		expect(
+			within( secondColumn ).getByText( /\[StoreManagementLinks\]/ )
 		).toBeInTheDocument();
 		expect(
 			within( firstColumn ).queryByText( /\[StatsOverview\]/ )

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Fixed the Add First Product email note checks. #6260
 - Fix: Onboarding - Fixed "Business Details" error. #6271
 - Enhancement: Use the new Paypal payments plugin for onboarding. #6261
+- Fix: Show management links when only main task list is hidden. #6291
 
 
 == Changelog ==


### PR DESCRIPTION
Fixes #6288 

Show the management links when the main Woo task list is hidden, instead of when both the task list and extended task list are hidden.
Put this up, but will require some feedback from Pedro and Elizabeth on the origin ticket before merging - #6288 

### Screenshots

<img width="1423" alt="Screen Shot 2021-02-08 at 4 31 20 PM" src="https://user-images.githubusercontent.com/2240960/107277709-2d3c5a00-6a2b-11eb-8fe2-80dc38e7726b.png">

### Detailed test instructions:

- Create new Woo store and finish the onboarding flow
- Go to the Woo home screen and click the 3 dots on **Finish setup** and click **Hide this**
- The management links card should show up now (not previously) under the **Stats overview** card