### PR TITLE
Apply responsive header style to all pages

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -48,3 +48,9 @@
 		margin-top: -1px;
 	}
 }
+
+.wp-responsive-open {
+	.woocommerce-layout__header {
+		margin-left: 2px;
+	}
+}

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -48,12 +48,6 @@
 }
 
 .woocommerce_page_wc-admin {
-	.wp-responsive-open {
-		.woocommerce-layout__header {
-			margin-left: 2px;
-		}
-	}
-
 	.woocommerce-filters-date__content:not(.is-mobile) {
 		z-index: 2; /* below of woocommerce-layout__header */
 	}


### PR DESCRIPTION
Fixes #6251 

Apply responsive header style to all pages

### Screenshots
Before
<img width="267" alt="螢幕快照 2021-02-08 下午4 13 18" src="https://user-images.githubusercontent.com/56378160/107282404-e9485580-6a28-11eb-8519-f3aca7f02550.png">
After
<img width="224" alt="螢幕快照 2021-02-08 下午4 14 54" src="https://user-images.githubusercontent.com/56378160/107282422-ef3e3680-6a28-11eb-936a-92e11b0f0755.png">


### Detailed test instructions:
- Go to WooCommerce Home / Orders / Customers
- Check that header renders as expected
