### PR TITLE
Navigation: Return $menu when no child items exist

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -503,7 +503,7 @@ class Menu {
 		global $submenu;
 
 		if ( ! isset( $submenu['woocommerce'] ) && ! isset( $submenu['edit.php?post_type=product'] ) ) {
-			return;
+			return $menu;
 		}
 
 		$submenu_items = array_merge(


### PR DESCRIPTION
Roles without capabilities to edit WooCommerce had no child items to migrate. This caused wp-admin sidebar to fatal:

<img width="993" alt="Screen Shot 2021-02-09 at 2 46 58 PM" src="https://user-images.githubusercontent.com/1922453/107305638-3808f480-6ae8-11eb-82d8-a1bcad074ea6.png">

### Detailed test instructions:

Reproduce the error on main:
1. Create a new user with "Author" role
2. Login as that user and visit any wp-admin page
3. See the error

See the fix
4. Switch to this branch and see the sidebar load correctly
