### PR TITLE
update single column home screen width to 680px

### DIFF
--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -49,7 +49,7 @@
 }
 
 .woocommerce-homescreen-column {
-	width: 662px;
+	width: 682px;
 	top: 100px;
 	margin: 0 auto;
 	align-self: flex-start;


### PR DESCRIPTION
Fixes #6239

This PR updates the single column home screen layout so that the width of the cards are 680px. (Their current width is 660px)

<img width="1438" alt="Screen Shot 2021-02-09 at 8 05 25 AM" src="https://user-images.githubusercontent.com/4500952/107391767-e04d9780-6aad-11eb-82ee-f329fe9998fa.png">
