### PR TITLE
Update highlight tooltip to make use of anchor logic

### DIFF
--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -46,32 +46,28 @@ function HighlightTooltip( {
 
 	useEffect( () => {
 		const element = document.getElementById( id );
-		let container;
+		let container, parent;
 		if ( element && ! node ) {
 			// Add tooltip container
 			if ( ! useAnchor ) {
-				const parent = element.parentElement;
-				container = document.createElement( 'div' );
-				container.classList.add( 'highlight-tooltip__container' );
-				parent.appendChild( container );
-				setNode( container );
+				parent = element.parentElement;
 			} else {
-				const parentElement = document.createElement( 'div' );
-				document.body.appendChild( parentElement );
-				container = document.createElement( 'div' );
-				parentElement.appendChild( container );
-				setNode( container );
-				setAnchorRect( element.getBoundingClientRect() );
+				parent = document.createElement( 'div' );
+				document.body.appendChild( parent );
 			}
+			container = document.createElement( 'div' );
+			container.classList.add( 'highlight-tooltip__container' );
+			parent.appendChild( container );
+			setNode( container );
 		}
-		const timeoutId = showTooltip( container );
+		const timeoutId = triggerShowTooltip( container );
 
 		return () => {
 			if ( container ) {
-				const parent = container.parentElement;
-				parent.removeChild( container );
+				const parentElement = container.parentElement;
+				parentElement.removeChild( container );
 				if ( useAnchor ) {
-					parent.remove();
+					parentElement.remove();
 				}
 			}
 			if ( timeoutId ) {
@@ -92,7 +88,7 @@ function HighlightTooltip( {
 			if ( ! show ) {
 				node.classList.remove( SHOW_CLASS );
 			} else if ( node ) {
-				showTooltip( node );
+				triggerShowTooltip( node );
 			}
 		}
 	}, [ show ] );
@@ -109,25 +105,29 @@ function HighlightTooltip( {
 		}
 	}
 
-	const showTooltip = ( container ) => {
+	const triggerShowTooltip = ( container ) => {
 		let timeoutId = null;
 		if ( delay > 0 ) {
 			timeoutId = setTimeout( () => {
 				timeoutId = null;
-				if ( container ) {
-					container.classList.add( SHOW_CLASS );
-				}
-				setShowHighlight( show );
-				onShow();
+				showTooltip( container );
 			}, delay );
 		} else if ( ! showHighlight ) {
-			if ( container ) {
-				container.classList.add( SHOW_CLASS );
-			}
-			setShowHighlight( true );
-			onShow();
+			showTooltip( container );
 		}
 		return timeoutId;
+	};
+
+	const showTooltip = ( container ) => {
+		const element = document.getElementById( id );
+		if ( element && useAnchor ) {
+			setAnchorRect( element.getBoundingClientRect() );
+		}
+		if ( container ) {
+			container.classList.add( SHOW_CLASS );
+		}
+		setShowHighlight( true );
+		onShow();
 	};
 
 	const triggerClose = () => {

--- a/client/header/activity-panel/highlight-tooltip/index.js
+++ b/client/header/activity-panel/highlight-tooltip/index.js
@@ -70,6 +70,9 @@ function HighlightTooltip( {
 			if ( container ) {
 				const parent = container.parentElement;
 				parent.removeChild( container );
+				if ( useAnchor ) {
+					parent.remove();
+				}
 			}
 			if ( timeoutId ) {
 				clearTimeout( timeoutId );

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -382,6 +382,7 @@ export class ActivityPanel extends Component {
 				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
 						delay={ 1000 }
+						useAnchor={ true }
 						title={ __(
 							"We're here for help",
 							'woocommerce-admin'

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Onboarding - Fixed "Business Details" error. #6271
 - Enhancement: Use the new Paypal payments plugin for onboarding. #6261
 - Fix: Show management links when only main task list is hidden. #6291
+- Dev: Allow highlight tooltip to use body tag as parent. #6309
 
 == Changelog ==
 


### PR DESCRIPTION
Make use of the tooltip `anchorRect` property, allowing us to add the tooltip to the `body` instead of adding it as a child element.

### Screenshots

<img width="1813" alt="Screen Shot 2021-02-10 at 10 24 21 AM" src="https://user-images.githubusercontent.com/2240960/107522686-532c4080-6b8a-11eb-9acf-e71ed26825de.png">

### Detailed test instructions:

- Load a new Woocommerce store and finish the onboarding wizard
- Visit a task from the home screen task list, but don't finish it
- Go back to the homescreen, and visit that same task again
- A popup should show up pointing to the help menu in the top right (this should look and work correctly)