### PR TITLE
Move admin menu manipulation from admin_head to admin_menu

### DIFF
--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -41,7 +41,7 @@ class Homescreen {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
-		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
+		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -40,7 +40,7 @@ class Homescreen {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
-		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
+		// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
 		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -40,8 +40,14 @@ class Homescreen {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
-		// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
-		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
+		// In WC Core 5.1 $submenu manipulation occurs in admin_menu, not admin_head. See https://github.com/woocommerce/woocommerce/pull/29088.
+		if ( version_compare( WC_VERSION, '5.1', '>=' ) ) {
+			// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
+			add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
+		} else {
+			// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
+			add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
+		}
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );


### PR DESCRIPTION
**_Note: This PR should be tested in conjunction with https://github.com/woocommerce/woocommerce/pull/29088_**

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR move WooCommerce Admin's admin menu manipulation from `admin_head` hooks to `admin_menu` hooks. This, along with a corresponding fix in `woocommerce/woocommerce`, addresses the issues seen when the WooCommerce admin menu is displayed in Calypso when WordPress.com's Nav Unification is enabled (currently only for Automatticians). See pbIJXs-Ee-p2 for more details.

Specifically, the following issues are fixed when using Calypso with WordPress.com's Nav Unification enabled:

- The WooCommerce submenu item gets replaced by the Home submenu item, and clicking on it correctly shows the WooCommerce Admin home screen
- The Orders count appears

When accessing wp-admin, there should be no change to the WooCommerce admin menus.

#### Before

![Before admin_menu](https://user-images.githubusercontent.com/2098816/107539529-0dc04100-6b93-11eb-9517-1fc97aca8bca.png)

#### After

![After admin_menu](https://user-images.githubusercontent.com/2098816/107539561-144eb880-6b93-11eb-8a43-0a0cdc7a8440.png)

Note: The following issues will be addressed in separate PRs:

- Products menu item position: May be fixed by either https://github.com/woocommerce/woocommerce/pull/28763 or https://github.com/Automattic/jetpack/pull/18758
- WooCommerce and Products menu icons: Issue https://github.com/Automattic/wp-calypso/issues/49145; may be fixed by switching to SVG icons (issue with that: https://github.com/Automattic/wp-calypso/issues/49145)

### How to test the changes in this Pull Request:

#### General wp-admin testing without Nav Unification

1. Checkout the corresponding `woocommerce/woocommerce` branch (see https://github.com/woocommerce/woocommerce/pull/29088).
2. Checkout this branch.
3. Access wp-admin.
4. Verify that all WooCommerce admin menus appear and function the same as before.

#### Testing Nav Unification

Make your test site act like an "Atomic" site:

5. Connect Jetpack on your test site to WordPress.com.
6. Clone `wpcomsh` repo (see https://github.com/Automattic/wpcomsh for details)
7. Checkout the `add/admin-menu-request-impersonation` branch (577-gh-Automattic/wpcomsh)
8. Add a plugin to `mu-plugins` with the following line, to enable Nav Unification:

```
add_filter( 'jetpack_load_admin_menu_class', '__return_true' );
```

9. Access your connected site from WordPress.com (Calypso) and verify that the menu items appear correctly (excluding issues described above)

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Dev: Admin menu modification has been moved from `admin_head` hooks to `admin_menu` hooks.