### PR TITLE
Javascript error regarding <StoreAlerts> component breaking Homescreen

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -37,7 +37,7 @@ export class StoreAlerts extends Component {
 		const alerts = this.getAlerts();
 
 		this.state = {
-			currentIndex: alerts.length > 0 ? 0 : null,
+			currentIndex: alerts instanceof Array ? 0 : null,
 		};
 
 		this.previousAlert = this.previousAlert.bind( this );


### PR DESCRIPTION
Fixes #6316 

An error was preventing Homescreen from rendering when any admin alerts were present: 
`Uncaught (in promise) TypeError: alert is undefined`

The variable `currentIndex` was being initialized to null when `alerts` was a valid array, but empty. This PR resolves that by initializing `currentIndex` to 0 whenever `alerts` is a valid array.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/107586319-8a174c00-6bb4-11eb-82a7-58d4d467b1f1.png)

### Detailed test instructions:

- Checkout latest main 
- This is only reproducible when you have an unactioned admin note. 
-  Open the `wp_wc_admin_notes` within your store DB, and change any note with a type of `update` to be "_unactioned_" under status. In my case I did this with the `wc-update-db-reminder` note.
- Navigate to the Homescreen
- You should see the error shown in screenshots.
- Now checkout this branch, the error should disappear.