### PR TITLE
Stalebot: Update label exclusion list.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,5 +19,5 @@ jobs:
                   close-pr-message: 'This PR was automatically closed due to being stale.'
                   stale-pr-label: 'status: stale'
                   stale-issue-label: 'status: stale'
-                  exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
+                  exempt-issue-labels: 'cooldown period,priority: high,priority: critical,feature: inbox,feature: components,feature: analytics,feature: marketing,feature: onboarding,feature: navigation,feature: wcpay,feature: settings,feature: home screen,feature: customer effort score,feature: setup checklist,feature: activity panel,feature: rest api'
                   ascending: true


### PR DESCRIPTION
After chatting with @pmcpinto, we would like to add all `feature: *` issue labels to the list of labels to exclude from the stalebot's logic.

The reasoning behind this change is that the bot has been closing a number of issues that we want to keep active/open in our backlog, many of which were tagged with feature labels.

Not entirely sure how to test this out :)