### PR TITLE
Navigation: Migrate methods to `admin_menu` hook

### DIFF
--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -41,7 +41,7 @@ class Homescreen {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
-		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
+		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -40,7 +40,7 @@ class Homescreen {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
-		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
+		// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
 		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -40,8 +40,14 @@ class Homescreen {
 	public function __construct() {
 		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
-		// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
-		add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
+		// In WC Core 5.1 $submenu manipulation occurs in admin_menu, not admin_head. See https://github.com/woocommerce/woocommerce/pull/29088.
+		if ( version_compare( WC_VERSION, '5.1', '>=' ) ) {
+			// priority is 20 to run after admin_menu hook for woocommerce runs, so that submenu is populated.
+			add_action( 'admin_menu', array( $this, 'update_link_structure' ), 20 );
+		} else {
+			// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
+			add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
+		}
 		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -37,7 +37,7 @@ class CoreMenu {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'register_post_types' ) );
 		// Add this after we've finished migrating menu items to avoid hiding these items.
-		add_action( 'add_menu_classes', array( $this, 'add_dashboard_menu_items' ), PHP_INT_MAX );
+		add_action( 'admin_menu', array( $this, 'add_dashboard_menu_items' ), PHP_INT_MAX );
 	}
 
 	/**
@@ -279,18 +279,14 @@ class CoreMenu {
 
 	/**
 	 * Add the dashboard items to the WP menu to create a quick-access flyout menu.
-	 *
-	 * @param array $menu Menu.
-	 * @returna array
 	 */
-	public function add_dashboard_menu_items( $menu ) {
+	public function add_dashboard_menu_items() {
+		global $submenu, $menu;
 		$top_level_items = Menu::get_category_items( 'woocommerce' );
 
 		// phpcs:disable
-		global $submenu;
-
 		if ( ! isset( $submenu['woocommerce'] ) ) {
-			return $menu;
+			return;
 		}
 
 		foreach( $top_level_items as $item ) {
@@ -336,8 +332,6 @@ class CoreMenu {
 			);
 		}
 		// phpcs:enable
-
-		return $menu;
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -523,13 +523,6 @@ class Menu {
 
 		foreach ( $submenu_items as $key => $menu_item ) {
 			if ( in_array( $menu_item[2], CoreMenu::get_excluded_items(), true ) ) {
-				// phpcs:disable
-				if ( ! isset( $menu_item[ self::CSS_CLASSES ] ) ) {
-					$submenu['woocommerce'][ $key ][] .= ' hide-if-js';
-				} else {
-					$submenu['woocommerce'][ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
-				}
-				// phpcs:enable
 				continue;
 			}
 
@@ -612,7 +605,11 @@ class Menu {
 
 		foreach ( $menu as $key => $menu_item ) {
 			if ( self::has_callback( $menu_item ) ) {
+				// Disable phpcs since we need to override submenu classes.
+				// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.
+				// phpcs:disable
 				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+				// phps:enable
 				continue;
 			}
 
@@ -620,8 +617,21 @@ class Menu {
 			$has_children = isset( $submenu[ $menu_item[ self::CALLBACK ] ] ) && isset( $submenu[ $menu_item[ self::CALLBACK ] ][0] );
 			$first_child  = $has_children ? $submenu[ $menu_item[ self::CALLBACK ] ][0] : null;
 			if ( 'woocommerce' !== $menu_item[2] && self::has_callback( $first_child ) ) {
+				// Disable phpcs since we need to override submenu classes.
+				// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.
+				// phpcs:disable
 				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+				// phps:enable
 			}
+		}
+
+		if ( isset( $submenu['woocommerce'] ) ) {
+			$submenu['woocommerce'] = array_filter(
+				$submenu['woocommerce'],
+				function ( $submenu_item ) {
+					return ! in_array( $submenu_item[2], CoreMenu::get_excluded_items(), true );
+				}
+			);
 		}
 
 		foreach ( $submenu as $parent_key => $parent ) {

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -90,16 +90,7 @@ class Menu {
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 
 		add_filter( 'admin_menu', array( $this, 'migrate_core_child_items' ) );
-		add_filter( 'admin_menu', array( $this, 'migrate_menu_items' ), 700 );
-
-		// // In WC Core 5.1 $submenu manipulation occurs in admin_menu, not admin_head. See https://github.com/woocommerce/woocommerce/pull/29088.
-		// if ( version_compare( WC_VERSION, '5.1', '>=' ) ) {
-		// add_filter( 'add_menu_classes', array( $this, 'migrate_core_child_items' ) );
-		// add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
-		// } else {
-		// add_filter( 'add_menu_classes', array( $this, 'migrate_core_child_items' ) );
-		// add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
-		// }
+		add_filter( 'admin_menu', array( $this, 'migrate_menu_items' ), PHP_INT_MAX - 1 );
 	}
 
 	/**

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -616,6 +616,7 @@ class Menu {
 			}
 		}
 
+		// Remove excluded submenu items
 		if ( isset( $submenu['woocommerce'] ) ) {
 			$submenu['woocommerce'] = array_filter(
 				$submenu['woocommerce'],


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/6310 moves Nav logic to `admin_menu` action so that Calypso can correctly gather correct Sidebar items. As such, this breaks WC Navigation unless the same changes are made in Nav logic. Those changes are this PR.

### Detailed test instructions:

1. Checkout the branch from this Core pull request https://github.com/woocommerce/woocommerce/pull/29088
2. Turn on Navigation
3. Check the flyout menu that it is correct
4. Enter WooCommerce and check that items are all correct
5. Checkout WC Core release branch [release/5.0](https://github.com/woocommerce/woocommerce/tree/release/5.0) and repeat steps 1 - 4.

### Bonus Testing

Note: I haven't done this yet because my testing env got deleted.

1. Fire up an eComm testing environment with the Nav Unification branch of wpcomsh found in https://github.com/Automattic/wpcomsh/pull/577#issuecomment-769527303
2. Use the branch from the Core pull request https://github.com/woocommerce/woocommerce/pull/29088
3. Visit the Calypso side of things and make sure the Nav Unification and new WC Nav are working as expected.

### Known Issue

The number of orders is not reflected in the flyout menu

<img width="214" alt="Screen Shot 2021-02-11 at 2 14 54 PM" src="https://user-images.githubusercontent.com/1922453/107597345-34f43c80-6c7f-11eb-80f3-dd5e849f892e.png">

