### PR TITLE
Fix a bug where the incorrect index was set for alerts.

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -34,10 +34,9 @@ import './style.scss';
 export class StoreAlerts extends Component {
 	constructor( props ) {
 		super( props );
-		const alerts = this.getAlerts();
 
 		this.state = {
-			currentIndex: alerts.length > 0 ? 0 : null,
+			currentIndex: 0,
 		};
 
 		this.previousAlert = this.previousAlert.bind( this );


### PR DESCRIPTION
This was causing a fatal error for store alerts after a change made in #6286 

Its not really the fault of that change directly, but we should never have had a fall back to `null` for the index. At first I wasn't sure but after some testing and reading the code I'm confident. The real issue here is that we check how many alerts there are *in the constructor*. That happens before the component mounts and also always before the alerts have actually been resolved.

Once we have alerts loaded setting the index to null makes no sense at all.

Secondly to support my approach there are many other conditional checks that ensure the component is not displayed if there are no alerts later.

One of those checks is `preloadAlertCount` which is populated by PHP before the page load, so if there are no alerts to display this will be 0. If the preloadAlertCount is populated but there are no alerts a second check of the length of `alerts` will stop the component rendering.

### Testing

To test this you'll need to trigger an alert. A really simple way to do this would be updating Woocommerce plugin to latest, if you weren't on latest already this would trigger an alert to update the database.

Otherwise I'm guessing you'll need to trigger an alert via some other way, I haven't done the due diligence to figure this out, but if you can't use the first method let me know.