### PR TITLE
Bump versions to 2.1.0-dev

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,6 +1,8 @@
 Testing instructions
 ====================
 
+## Unreleased
+
 ## 2.0.0
 
 ### Add the Mollie payment provider setup task #6257

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "2.0.0-dev",
+	"version": "2.1.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.0.0-dev",
+	"version": "2.1.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -8261,16 +8261,6 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
 			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
 		},
-		"@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "4.14.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.1.tgz",
@@ -11891,6 +11881,12 @@
 						"quick-lru": "^4.0.1"
 					}
 				},
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12090,6 +12086,18 @@
 						"debug": "^4.1.1",
 						"get-stream": "^5.1.0",
 						"yauzl": "^2.10.0"
+					},
+					"dependencies": {
+						"@types/yauzl": {
+							"version": "2.9.1",
+							"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+							"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"@types/node": "*"
+							}
+						}
 					}
 				},
 				"fast-glob": {
@@ -12741,6 +12749,30 @@
 						"tar-fs": "^2.0.0",
 						"unbzip2-stream": "^1.3.3",
 						"ws": "^7.2.3"
+					},
+					"dependencies": {
+						"tar-fs": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+							"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+							"dev": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"mkdirp-classic": "^0.5.2",
+								"pump": "^3.0.0",
+								"tar-stream": "^2.1.4"
+							}
+						},
+						"unbzip2-stream": {
+							"version": "1.4.3",
+							"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+							"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.2.1",
+								"through": "^2.3.8"
+							}
+						}
 					}
 				},
 				"quick-lru": {
@@ -13872,6 +13904,12 @@
 				"postcss-value-parser": "^4.1.0"
 			},
 			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30001185",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
+					"integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+					"dev": true
+				},
 				"postcss-value-parser": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
@@ -27153,6 +27191,15 @@
 				"path-exists": "^3.0.0"
 			}
 		},
+		"locutus": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.2.5"
+			}
+		},
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -36641,26 +36688,6 @@
 				}
 			}
 		},
-		"tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				}
-			}
-		},
 		"tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -37463,16 +37490,6 @@
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 			"dev": true
-		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			}
 		},
 		"unc-path-regex": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.0.0-dev",
+	"version": "2.1.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.6.0
 Requires PHP: 7.0
-Stable tag: 2.0.0-dev
+Stable tag: 2.1.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 
@@ -71,7 +71,13 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 2. Activity Panels
 3. Analytics
 
+== Changelog ==
+
 == Unreleased ==
+
+- Dev: Allow highlight tooltip to use body tag as parent. #6309
+
+== 2.0.0 02/05/2021 ==
 
 - Tweak: Bump minimum supported version of PHP to 7.0. #6046
 - Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
@@ -91,9 +97,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Onboarding - Fixed "Business Details" error. #6271
 - Enhancement: Use the new Paypal payments plugin for onboarding. #6261
 - Fix: Show management links when only main task list is hidden. #6291
-- Dev: Allow highlight tooltip to use body tag as parent. #6309
-
-== Changelog ==
 
 == 1.9.0 1/15/2021 ==
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -24,7 +24,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.0-dev';
+	const VERSION = '2.1.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -154,7 +154,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.0.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.1.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 2.0.0-dev
+ * Version: 2.1.0-dev
  * Requires at least: 5.3
  * Requires PHP: 5.6.20
  *


### PR DESCRIPTION
This bumps the main branch versions to `2.1.0-dev`. It also gets the readme.txt and testing instructions ready for 2.1.0.