### PR TITLE
Set `is_deleted` from the database when instantiating a `Note`

### DIFF
--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -109,6 +109,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_date_created( $note_row->date_created );
 			$note->set_date_reminder( $note_row->date_reminder );
 			$note->set_is_snoozable( $note_row->is_snoozable );
+			$note->set_is_deleted( (bool) $note_row->is_deleted );
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );


### PR DESCRIPTION
Currently, after a note is dismissed in the Inbox (i.e. `is_deleted` is set to `true`), any future instance of that same note has `is_deleted` set to `false` because the property from the database row isn't recovered and set in the constructor.
If one of those instances is `save()`'d, the note re-appears in the Inbox.

In particular, this behavior is easier to reproduce with notes obtained via _remote inbox notifications_ as those notes are instantiated and saved (losing their `is_deleted` value) as part of the process fetching + running specs.

This PR fixes the above by restoring the `is_deleted` value from the database row when creating `Note` objects for existing notes.

### Screenshots
The screencast below shows a note being dismissed and then reappearing once `wc_admin_daily` runs. See the detailed instructions for how to reproduce.

https://user-images.githubusercontent.com/184724/107632078-fd13d780-6c33-11eb-8c85-1474fdb3d353.mov


### Detailed test instructions:

#### Via remote inbox notifications
- Set `DataSourcePoller::DATA_SOURCES` to `https://gist.githubusercontent.com/jorgeatorres/5b7b6d0f872dfda12ba1d6797faaa896/raw/cd892b859a870ba88fd92edff938785fd11f7fb3/notifications.json`.
- Manually run the `wc_admin_daily` cron job.
- See a new note ("This is a note you can not dismiss") appear in the Inbox.
- Dismiss said note.
- Confirm it is no longer in the Inbox after a page refresh.
- Manually run the `wc_admin_daily` cron job again.
- Click "Inbox" and see the dismissed note again.
- On this branch (`set-is-deleted`) the dismissed note stays dismissed.

#### Programmatically
The following PHP can be used to reproduce:

```php
<?php
$note = new Automattic\WooCommerce\Admin\Notes\Note();
$note->set_name( 'wc-undismissable-note' );
$note->set_title( 'Undismissable note' );
$note->set_content( 'I don\'t wanna dismiss a thing' );
$note->set_content_data( (object) array() );
$note->set_type( 'info' );
$note->set_source( 'woocommerce-admin' );
$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), 'https://woocommerce.com/', 'actioned', true );
$note->set_is_deleted( true );
$note->save();

$note = new Automattic\WooCommerce\Admin\Notes\Note( $note->get_id() );
var_dump( $note->get_is_deleted() ); // Should return `true` but doesn't. Works correctly on branch `set-is-deleted`.
exit;
```
