### PR TITLE
Fix removal of core settings pages

### DIFF
--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -618,12 +618,15 @@ class Menu {
 
 		// Remove excluded submenu items
 		if ( isset( $submenu['woocommerce'] ) ) {
-			$submenu['woocommerce'] = array_filter(
-				$submenu['woocommerce'],
-				function ( $submenu_item ) {
-					return ! in_array( $submenu_item[2], CoreMenu::get_excluded_items(), true );
+			foreach ( $submenu['woocommerce'] as $key => $submenu_item ) {
+				if ( in_array( $submenu_item[ self::CALLBACK ], CoreMenu::get_excluded_items(), true ) ) {
+					if ( isset( $submenu['woocommerce'][ $key ][ self::CSS_CLASSES ] ) ) {
+						$submenu['woocommerce'][ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+					} else {
+						$submenu['woocommerce'][ $key ][] = 'hide-if-js';
+					}
 				}
-			);
+			}
 		}
 
 		foreach ( $submenu as $parent_key => $parent ) {

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -89,8 +89,8 @@ class Menu {
 		add_action( 'admin_menu', array( $this, 'add_core_items' ) );
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 
-		add_filter( 'admin_menu', array( $this, 'migrate_core_child_items' ) );
-		add_filter( 'admin_menu', array( $this, 'migrate_menu_items' ), PHP_INT_MAX - 1 );
+		add_filter( 'admin_menu', array( $this, 'migrate_core_child_items' ), PHP_INT_MAX - 1 );
+		add_filter( 'admin_menu', array( $this, 'migrate_menu_items' ), PHP_INT_MAX - 2 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6327 

Fixes settings page removal that resulted in inability to access core settings pages.

### Screenshots
<img width="1089" alt="Screen Shot 2021-02-11 at 4 39 53 PM" src="https://user-images.githubusercontent.com/10561050/107702370-24948f80-6c88-11eb-90c8-2976fe31e3be.png">


### Detailed test instructions:

1. Enable the new navigation.
2. Make sure you can access core settings pages.
3. Check that the flyout menu has the correct items.
4. Make sure all other nav items work as expected.