### PR TITLE
Bump minimum WP version to 5.4

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
  * Version: 2.1.0-dev
- * Requires at least: 5.3
+ * Requires at least: 5.4
  * Requires PHP: 5.6.20
  *
  * WC requires at least: 4.5.0


### PR DESCRIPTION
We have an L2 support, which is current + last two releases. Now that WP 5.6 is out, we can bump the minimum version to 5.4.