### PR TITLE
Use box sizing and padding to fix nav and admin menu styling

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -22,11 +22,6 @@
 	.update-nag {
 		display: none;
 	}
-
-	#wpbody {
-		padding-top: 0;
-		display: block;
-	}
 }
 
 .woocommerce-admin-is-loading {

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -61,7 +61,7 @@ body.is-wc-nav-folded {
 	}
 
 	#wpbody {
-		margin-left: 0;
+		padding-left: 0;
 	}
 }
 
@@ -94,10 +94,10 @@ body.is-wc-nav-folded {
 	}
 
 	#wpbody {
-		margin-left: $navigation-width;
+		padding-left: $navigation-width;
 
 		@media ( max-width: 960px ) {
-			margin-left: 0;
+			padding-left: 0;
 		}
 	}
 
@@ -112,14 +112,6 @@ body.is-wc-nav-folded {
 			@include breakpoint( '<960px' ) {
 				width: $header-height;
 				height: $header-height;
-			}
-		}
-
-		.woocommerce-layout__header-heading {
-			margin-left: $navigation-width;
-
-			@include breakpoint( '<960px' ) {
-				margin-left: $header-height;
 			}
 		}
 	}

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -1,9 +1,4 @@
 .woocommerce-embed-page {
-	#wpbody {
-		margin-top: $header-height;
-		padding-top: 0;
-	}
-
 	#wpbody .woocommerce-layout,
 	.woocommerce-layout__notice-list-hide + .wrap {
 		padding-top: 10px;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -2,6 +2,9 @@
 	#wpbody {
 		margin-top: $header-height;
 		padding-top: 0;
+		display: inline-block;
+		width: 100%;
+		box-sizing: border-box;
 	}
 
 	#wpbody .woocommerce-layout,

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -2,9 +2,6 @@
 	#wpbody {
 		margin-top: $header-height;
 		padding-top: 0;
-		display: inline-block;
-		width: 100%;
-		box-sizing: border-box;
 	}
 
 	#wpbody .woocommerce-layout,

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -47,6 +47,8 @@
 	display: inline-block;
 	width: 100%;
 	box-sizing: border-box;
+	padding-top: 0;
+	margin-top: $header-height;
 }
 
 #wpfooter {

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -43,6 +43,12 @@
 	box-sizing: border-box;
 }
 
+#wpbody {
+	display: inline-block;
+	width: 100%;
+	box-sizing: border-box;
+}
+
 #wpfooter {
 	display: none;
 }


### PR DESCRIPTION
Fixes an issue that caused the admin menu to be pushed down by the header height.

### Screenshots

**Before**
<img width="604" alt="Screen Shot 2021-02-12 at 1 52 41 PM" src="https://user-images.githubusercontent.com/10561050/107809784-a7295780-6d39-11eb-894d-06b60251c2da.png">
**After**
<img width="439" alt="Screen Shot 2021-02-12 at 1 47 47 PM" src="https://user-images.githubusercontent.com/10561050/107809786-a7295780-6d39-11eb-9c0f-ac0bdfc0a6e3.png">


### Detailed test instructions:

1. Disable the new nav.
2. Check that the admin menu styling is correct.
3. Navigate to various embed and non-embed pages.
4. Enable the new nav.
5. Check both embed and non-embed pages.
6. Check mobile screen sizes to make sure things appear as expected.