### PR TITLE
Fix navigation priority settings conflict

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -51,7 +51,7 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		debounceTimer = setTimeout( function () {
 			const wpBody = document.querySelector( '#wpbody' );
 
-			if ( ! wpBody ) {
+			if ( ! wpBody || ! headerElement.current ) {
 				return;
 			}
 

--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -26,6 +26,7 @@ const Container = ( { menuItems } ) => {
 	useEffect( () => {
 		// Collapse the original WP Menu.
 		document.documentElement.classList.remove( 'wp-toolbar' );
+		document.body.classList.add( 'has-woocommerce-navigation' );
 		const adminMenu = document.getElementById( 'adminmenumain' );
 
 		if ( ! adminMenu ) {

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -2,6 +2,69 @@
 @import './components/container/style';
 @import './components/header/style';
 
+.woocommerce-navigation {
+	position: relative;
+	width: $navigation-width;
+	box-sizing: border-box;
+	background-color: $gray-900;
+	z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
+
+	@media ( max-width: 960px ) {
+		width: $header-height;
+		height: $header-height;
+	}
+
+	.components-navigation {
+		box-sizing: border-box;
+	}
+}
+
+.woocommerce-navigation__wrapper {
+	background-color: $gray-900;
+	position: absolute;
+	top: $header-height;
+	width: 100%;
+	height: calc(100vh - #{$header-height});
+	overflow-y: auto;
+}
+
+body.is-wc-nav-expanded {
+	.woocommerce-navigation {
+		width: $navigation-width;
+		height: 100%;
+	}
+}
+
+body.is-wc-nav-folded {
+	.woocommerce-navigation {
+		width: $header-height;
+		height: $header-height;
+		overflow: hidden;
+
+		.woocommerce-navigation-header {
+			> * {
+				display: none;
+			}
+		}
+
+		.woocommerce-navigation-header__site-icon {
+			display: block;
+		}
+
+		.components-navigation {
+			display: none;
+		}
+	}
+
+	.woocommerce-transient-notices {
+		left: $gap;
+	}
+
+	#wpbody {
+		margin-left: 0;
+	}
+}
+
 .has-woocommerce-navigation {
 	#wpadminbar,
 	#adminmenuwrap,
@@ -34,69 +97,6 @@
 		margin-left: $navigation-width;
 
 		@media ( max-width: 960px ) {
-			margin-left: 0;
-		}
-	}
-
-	.woocommerce-navigation {
-		position: relative;
-		width: $navigation-width;
-		box-sizing: border-box;
-		background-color: $gray-900;
-		z-index: 1100; //Must be greater than z-index on .woocommerce-layout__header
-
-		@media ( max-width: 960px ) {
-			width: $header-height;
-			height: $header-height;
-		}
-	}
-
-	.woocommerce-navigation__wrapper {
-		background-color: $gray-900;
-		position: absolute;
-		top: $header-height;
-		width: 100%;
-		height: calc(100vh - #{$header-height});
-		overflow-y: auto;
-	}
-
-	.components-navigation {
-		box-sizing: border-box;
-	}
-
-	&.is-wc-nav-expanded {
-		.woocommerce-navigation {
-			width: $navigation-width;
-			height: 100%;
-		}
-	}
-
-	&.is-wc-nav-folded {
-		.woocommerce-navigation {
-			width: $header-height;
-			height: $header-height;
-			overflow: hidden;
-
-			.woocommerce-navigation-header {
-				> * {
-					display: none;
-				}
-			}
-
-			.woocommerce-navigation-header__site-icon {
-				display: block;
-			}
-
-			.components-navigation {
-				display: none;
-			}
-		}
-
-		.woocommerce-transient-notices {
-			left: $gap;
-		}
-
-		#wpbody {
 			margin-left: 0;
 		}
 	}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -86,7 +86,7 @@ class Menu {
 	 * Init.
 	 */
 	public function init() {
-		add_action( 'admin_menu', array( $this, 'add_core_items' ), PHP_INT_MAX );
+		add_action( 'admin_menu', array( $this, 'add_core_items' ), 100 );
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 
 		add_filter( 'admin_menu', array( $this, 'migrate_core_child_items' ), PHP_INT_MAX - 1 );


### PR DESCRIPTION
Fixes a conflict between the settings pages PR and nav changes which update the hooks from `admin_menu_classes` to `admin_menu`.

This PR also adds in some fallback measure to prevent the bizarre styling seen when the nav component is loaded, but the server did not correctly detect `is_woocommerce_page()`.

Note this PR may partially break the new settings pages, but since this is behind a flag on not yet actively being worked on, I think we can follow up with a fix here.

### Screenshots

Before
<img width="949" alt="Screen Shot 2021-02-12 at 2 51 44 PM" src="https://user-images.githubusercontent.com/10561050/107815800-de9c0200-6d41-11eb-853e-78a6ac0e9525.png">

After
<img width="775" alt="Screen Shot 2021-02-12 at 2 51 27 PM" src="https://user-images.githubusercontent.com/10561050/107815793-dc39a800-6d41-11eb-98ee-ff54ad7c7262.png">


### Detailed test instructions:

1. Enable the new nav.
2. Make sure styles aren't broken.
3. Optionally, comment out this line in Screen.php and note that styles get "unbroken" after the nav is loaded.
`$classes .= ' has-woocommerce-navigation';`