### PR TITLE
Fixing site errors being concealed by new navigation

### DIFF
--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -38,7 +38,9 @@ body.is-wc-nav-expanded {
 		height: 100%;
 	}
 
-	font > .xe-notice {
+	font > .xe-notice,
+	font > .xdebug-error,
+	font > .xe-warning {
 		margin-left: calc(#{$navigation-width} + #{$gap});
 	}
 }
@@ -132,9 +134,11 @@ body.is-wc-nav-folded {
 		#wpbody-content {
 			margin-top: $adminbar-height;
 		}
+	}
 
-		font > .xe-notice {
-			margin-top: $header-height;
-		}
+	font > .xe-notice,
+	font > .xdebug-error,
+	font > .xe-warning {
+		margin-top: $header-height;
 	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -38,9 +38,7 @@ body.is-wc-nav-expanded {
 		height: 100%;
 	}
 
-	font > .xe-notice,
-	font > .xdebug-error,
-	font > .xe-warning {
+	font > .xdebug-error {
 		margin-left: calc(#{$navigation-width} + #{$gap});
 	}
 }
@@ -136,9 +134,7 @@ body.is-wc-nav-folded {
 		}
 	}
 
-	font > .xe-notice,
-	font > .xdebug-error,
-	font > .xe-warning {
+	font > .xdebug-error {
 		margin-top: $header-height;
 	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -37,6 +37,10 @@ body.is-wc-nav-expanded {
 		width: $navigation-width;
 		height: 100%;
 	}
+
+	font > .xe-notice {
+		margin-left: calc(#{$navigation-width} + #{$gap});
+	}
 }
 
 body.is-wc-nav-folded {
@@ -127,6 +131,10 @@ body.is-wc-nav-folded {
 	&:not(.is-wp-toolbar-disabled) {
 		#wpbody-content {
 			margin-top: $adminbar-height;
+		}
+
+		font > .xe-notice {
+			margin-top: $header-height;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5859

Certain site errors are displayed in a way that they are covered up by the new site navigation. This PR amends this to apply appropriate margins to the errors only when the new navigation is enabled and expanded.

### To-do
- Potentially fix by altering changes in https://github.com/woocommerce/woocommerce-admin/pull/6247 to target `body` instead of `#wpbody`
- Respond to negative margin in https://github.com/woocommerce/woocommerce-admin/pull/6371

### Screenshots

![image](https://user-images.githubusercontent.com/444632/107830247-510be280-6d40-11eb-9bba-3b01b13d7af5.png)

### Detailed test instructions:

-   Checkout branch
- Ensure the new navigation is enabled
- Navigate to a WC-Admin page (such as Homescreen)
-   Make a quick code change to cause an error. I did so by changing a variable name in `Screen.php` -> `add_screen()`. 
- Confirm that the resulting error(s) display as they do in the screenshot, and are not covered up by the side navigation.