### PR TITLE
override wpbody styles when nav present

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -48,11 +48,6 @@
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
 		Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
-	margin-top: -$adminbar-height;
-	@include breakpoint( '<600px' ) {
-		margin-top: -$adminbar-height-mobile;
-	}
-
 	#wpwrap {
 		top: 0;
 	}
@@ -87,12 +82,13 @@
 		#wpbody {
 			padding-left: 0;
 		}
+	}
+}
 
-		#wpcontent {
-			> #wpbody {
-				margin-top: 32px !important;
-			}
-		}
+.wp-toolbar .woocommerce-admin-full-screen {
+	margin-top: -$adminbar-height;
+	@include breakpoint( '<600px' ) {
+		margin-top: -$adminbar-height-mobile;
 	}
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -45,8 +45,8 @@
 .woocommerce-admin-full-screen {
 	background: $studio-gray-0;
 	color: $studio-gray-60;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
-		'Helvetica Neue', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+		Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
 	margin-top: -$adminbar-height;
 	@include breakpoint( '<600px' ) {
@@ -80,6 +80,18 @@
 		> #wpbody {
 			display: block;
 			margin-top: 0 !important;
+		}
+	}
+
+	&.has-woocommerce-navigation {
+		#wpbody {
+			padding-left: 0;
+		}
+
+		#wpcontent {
+			> #wpbody {
+				margin-top: 32px !important;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6350

In the new Header styles refactor, Navigation styles weren't considered so full screen had incorrect `margin-top` and `padding-left`. This PR fixes those styles when `has-woocommerce-navigation` is present on the `body`

<img width="1026" alt="Screen Shot 2021-02-17 at 5 26 37 PM" src="https://user-images.githubusercontent.com/1922453/108156483-9e73bf80-7145-11eb-8174-ea8c13111198.png">

### Detailed test instructions:

1. Turn on Navigation
2. Visit OBW
3. See things nicely laid out
4. Turn off Navigation
5. See OBW looking good as well
