### PR TITLE
Remove CES actions for adding and editing a product and editing an order

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -3,6 +3,12 @@ Testing instructions
 
 ## Unreleased
 
+### Remove CES actions for adding and editing a product and editing an order #6355
+
+1. Add a product. The customer effort score survey should not appear.
+2. Edit a product. The customer effort score survey should not appear.
+3. Edit an order. The customer effort score survey should not appear.
+
 ## 2.0.0
 
 ### Add the Mollie payment provider setup task #6257

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Unreleased ==
 
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
+- Add: Remove CES actions for adding and editing a product and editing an order #6355
 
 == 2.0.0 02/05/2021 ==
 

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -35,11 +35,6 @@ class CustomerEffortScoreTracks {
 	const PRODUCT_ADD_PUBLISH_ACTION_NAME = 'product_add_publish';
 
 	/**
-	 * Action name for product update.
-	 */
-	const PRODUCT_UPDATE_ACTION_NAME = 'product_update';
-
-	/**
 	 * Action name for shop order update.
 	 */
 	const SHOP_ORDER_UPDATE_ACTION_NAME = 'shop_order_update';
@@ -156,8 +151,6 @@ class CustomerEffortScoreTracks {
 
 		if ( 'publish' !== $old_status ) {
 			$this->enqueue_ces_survey_for_new_product();
-		} else {
-			$this->enqueue_ces_survey_for_edited_product();
 		}
 	}
 
@@ -256,31 +249,6 @@ class CustomerEffortScoreTracks {
 				'action'         => self::PRODUCT_ADD_PUBLISH_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to add a product?',
-					'woocommerce-admin'
-				),
-				'onsubmit_label' => $this->onsubmit_label,
-				'pagenow'        => 'product',
-				'adminpage'      => 'post-php',
-				'props'          => array(
-					'product_count' => $this->get_product_count(),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Enqueue the CES survey trigger for an existing product.
-	 */
-	private function enqueue_ces_survey_for_edited_product() {
-		if ( $this->has_been_shown( self::PRODUCT_UPDATE_ACTION_NAME ) ) {
-			return;
-		}
-
-		$this->enqueue_to_ces_tracks(
-			array(
-				'action'         => self::PRODUCT_UPDATE_ACTION_NAME,
-				'label'          => __(
-					'How easy was it to edit your product?',
 					'woocommerce-admin'
 				),
 				'onsubmit_label' => $this->onsubmit_label,

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -30,11 +30,6 @@ class CustomerEffortScoreTracks {
 	const SHOWN_FOR_ACTIONS_OPTION_NAME = 'woocommerce_ces_shown_for_actions';
 
 	/**
-	 * Action name for shop order update.
-	 */
-	const SHOP_ORDER_UPDATE_ACTION_NAME = 'shop_order_update';
-
-	/**
 	 * Action name for settings change.
 	 */
 	const SETTINGS_CHANGE_ACTION_NAME = 'settings_change';
@@ -82,21 +77,6 @@ class CustomerEffortScoreTracks {
 			)
 		);
 
-		// Only hook up the transition_post_status action handler
-		// if on the edit page.
-		global $pagenow;
-		if ( 'post.php' === $pagenow ) {
-			add_action(
-				'transition_post_status',
-				array(
-					$this,
-					'run_on_transition_post_status',
-				),
-				10,
-				3
-			);
-		}
-
 		add_action(
 			'woocommerce_update_options',
 			array(
@@ -108,24 +88,6 @@ class CustomerEffortScoreTracks {
 		);
 
 		$this->onsubmit_label = __( 'Thank you for your feedback!', 'woocommerce-admin' );
-	}
-
-	/**
-	 * Hook into the post status lifecycle, to detect relevant user actions
-	 * that we want to survey about.
-	 *
-	 * @param string $new_status The new status.
-	 * @param string $old_status The old status.
-	 * @param Post   $post The post.
-	 */
-	public function run_on_transition_post_status(
-		$new_status,
-		$old_status,
-		$post
-	) {
-		if ( 'shop_order' === $post->post_type ) {
-			$this->enqueue_ces_survey_for_edited_shop_order();
-		}
 	}
 
 	/**
@@ -209,32 +171,6 @@ class CustomerEffortScoreTracks {
 			$queue
 		);
 	}
-
-	/**
-	 * Enqueue the CES survey trigger for an existing shop order.
-	 */
-	private function enqueue_ces_survey_for_edited_shop_order() {
-		if ( $this->has_been_shown( self::SHOP_ORDER_UPDATE_ACTION_NAME ) ) {
-			return;
-		}
-
-		$this->enqueue_to_ces_tracks(
-			array(
-				'action'         => self::SHOP_ORDER_UPDATE_ACTION_NAME,
-				'label'          => __(
-					'How easy was it to update an order?',
-					'woocommerce-admin'
-				),
-				'onsubmit_label' => $this->onsubmit_label,
-				'pagenow'        => 'shop_order',
-				'adminpage'      => 'post-php',
-				'props'          => array(
-					'order_count' => $this->get_shop_order_count(),
-				),
-			)
-		);
-	}
-
 
 	/**
 	 * Maybe clear the CES tracks queue, executed on every page load. If the

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -30,11 +30,6 @@ class CustomerEffortScoreTracks {
 	const SHOWN_FOR_ACTIONS_OPTION_NAME = 'woocommerce_ces_shown_for_actions';
 
 	/**
-	 * Action name for product add/publish.
-	 */
-	const PRODUCT_ADD_PUBLISH_ACTION_NAME = 'product_add_publish';
-
-	/**
 	 * Action name for shop order update.
 	 */
 	const SHOP_ORDER_UPDATE_ACTION_NAME = 'shop_order_update';
@@ -128,29 +123,8 @@ class CustomerEffortScoreTracks {
 		$old_status,
 		$post
 	) {
-		if ( 'product' === $post->post_type ) {
-			$this->maybe_enqueue_ces_survey_for_product( $new_status, $old_status );
-		} elseif ( 'shop_order' === $post->post_type ) {
+		if ( 'shop_order' === $post->post_type ) {
 			$this->enqueue_ces_survey_for_edited_shop_order();
-		}
-	}
-
-	/**
-	 * Maybe enqueue the CES survey, if product is being added or edited.
-	 *
-	 * @param string $new_status The new status.
-	 * @param string $old_status The old status.
-	 */
-	private function maybe_enqueue_ces_survey_for_product(
-		$new_status,
-		$old_status
-	) {
-		if ( 'publish' !== $new_status ) {
-			return;
-		}
-
-		if ( 'publish' !== $old_status ) {
-			$this->enqueue_ces_survey_for_new_product();
 		}
 	}
 
@@ -233,31 +207,6 @@ class CustomerEffortScoreTracks {
 		update_option(
 			self::CES_TRACKS_QUEUE_OPTION_NAME,
 			$queue
-		);
-	}
-
-	/**
-	 * Enqueue the CES survey trigger for a new product.
-	 */
-	private function enqueue_ces_survey_for_new_product() {
-		if ( $this->has_been_shown( self::PRODUCT_ADD_PUBLISH_ACTION_NAME ) ) {
-			return;
-		}
-
-		$this->enqueue_to_ces_tracks(
-			array(
-				'action'         => self::PRODUCT_ADD_PUBLISH_ACTION_NAME,
-				'label'          => __(
-					'How easy was it to add a product?',
-					'woocommerce-admin'
-				),
-				'onsubmit_label' => $this->onsubmit_label,
-				'pagenow'        => 'product',
-				'adminpage'      => 'post-php',
-				'props'          => array(
-					'product_count' => $this->get_product_count(),
-				),
-			)
 		);
 	}
 


### PR DESCRIPTION
Fixes #6308

This removes the code that triggers a customer effort score survey in response to adding and editing a product and editing an order.

### Testing instructions

1. Add a product. The customer effort score survey should not appear.
2. Edit a product. The customer effort score survey should not appear.
3. Edit an order. The customer effort score survey should not appear.

