### PR TITLE
Enqueue beta features scripts on enqueue_scripts action instead of filter 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Remove Google fonts and material icons. #6343
 - Add: Remove CES actions for adding and editing a product and editing an order #6355
 - Dev: Add unit tests to Navigation's Container component. #6344
+- Fix: Enqueue scripts called incorrectly in php unit tests #6358
 
 == 2.0.0 02/05/2021 ==
 

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -236,7 +236,9 @@ class Features {
 	 */
 	public static function maybe_load_beta_features_modal( $hook ) {
 		if (
-			'woocommerce_page_wc-settings' !== $hook
+			'woocommerce_page_wc-settings' !== $hook ||
+			! isset( $_GET['tab'] ) || 'advanced' !== $_GET['tab'] || // phpcs:ignore CSRF ok.
+			! isset( $_GET['section'] ) || 'features' !== $_GET['section'] // phpcs:ignore CSRF ok.
 		) {
 			return;
 		}

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -36,7 +36,7 @@ class Features {
 		add_action( 'init', array( __CLASS__, 'load_features' ), 4 );
 		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
 		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 10, 2 );
-		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'maybe_load_beta_features_modal' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_load_beta_features_modal' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'update_option_woocommerce_allow_tracking', array( __CLASS__, 'maybe_disable_features' ), 10, 2 );
@@ -60,10 +60,10 @@ class Features {
 		$features = [];
 
 		$navigation_class = self::get_feature_class( 'navigation' );
-		$settings_class = self::get_feature_class( 'settings' );
+		$settings_class   = self::get_feature_class( 'settings' );
 		if ( $navigation_class ) {
 			$features['navigation'] = $navigation_class::TOGGLE_OPTION_NAME;
-			$features['settings'] = $settings_class::TOGGLE_OPTION_NAME;
+			$features['settings']   = $settings_class::TOGGLE_OPTION_NAME;
 		}
 
 		return $features;
@@ -232,14 +232,18 @@ class Features {
 	/**
 	 * Conditionally loads the beta features tracking modal.
 	 *
-	 * @param array $settings Settings.
-	 * @return array
+	 * @param string $hook Page hook.
 	 */
-	public static function maybe_load_beta_features_modal( $settings ) {
+	public static function maybe_load_beta_features_modal( $hook ) {
+		if (
+			'woocommerce_page_wc-settings' !== $hook
+		) {
+			return;
+		}
 		$tracking_enabled = get_option( 'woocommerce_allow_tracking', 'no' );
 
 		if ( 'yes' === $tracking_enabled ) {
-			return $settings;
+			return;
 		}
 
 		$rtl = is_rtl() ? '.rtl' : '';
@@ -258,8 +262,6 @@ class Features {
 			Loader::get_file_version( 'js' ),
 			true
 		);
-
-		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6258 

Updated the `maybe_load_beta_features_modal` to be triggered on the `admin_enqueue_scripts` action as the function add's different scripts to the page. Previously it was triggered on the `woocommerce_get_settings_advanced` filter, which didn't only happen on the settings page.

### Screenshots

No warnings as mentioned in the original ticket:
<img width="776" alt="Screen Shot 2021-02-17 at 10 49 34 AM" src="https://user-images.githubusercontent.com/2240960/108221211-e8d94a00-710d-11eb-8d77-2c432e320d5d.png">

Modal still correctly appears when trying to enable the new nav when tracking is disabled:
<img width="1782" alt="Screen Shot 2021-02-17 at 10 49 54 AM" src="https://user-images.githubusercontent.com/2240960/108221299-04dceb80-710e-11eb-83c0-f31b4b19d231.png">


### Detailed test instructions:

- Checkout this branch and run `npm run test:php` in your console, the `Notice: wp_enqueue_style was called...` log should not appear (pretty noticable if they do, try running the tests on `main`).
- Make sure the option `woocommerce_allow_tracking` is set to `no` or removed.
- Navigate to **WooCommerce > Settings > Advanced > Features**
- Try to enable one of the **Features** like the new navigation
- The **Build a Better WooCommerce** modal should popup (`beta-features-tracking-modal`)
- Set the `woocommerce_allow_tracking` to `yes` and reload the **Advanced > Features** settings page
- Try to enable one of the **Features**
- The **Build a Better WooCommerce** modal should not pop up

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
