### PR TITLE
Fix empty nav menu

### DIFF
--- a/client/navigation/components/container/index.js
+++ b/client/navigation/components/container/index.js
@@ -160,7 +160,7 @@ const Container = ( { menuItems } ) => {
 						];
 
 						return [
-							( !! primaryAndFavoriteItems ||
+							( !! primaryAndFavoriteItems.length ||
 								!! pluginItems ) && (
 								<NavigationMenu
 									key={ category.id }
@@ -188,7 +188,7 @@ const Container = ( { menuItems } ) => {
 													)
 									}
 								>
-									{ !! primaryAndFavoriteItems && (
+									{ !! primaryAndFavoriteItems.length && (
 										<NavigationGroup>
 											{ primaryAndFavoriteItems.map(
 												( item ) => (


### PR DESCRIPTION
Fixes empty nav menus being shown due to boolean check on empty array of combined favorite/primary items.

### Screenshots

#### Before
<img width="261" alt="Screen Shot 2021-02-17 at 7 24 22 PM" src="https://user-images.githubusercontent.com/10561050/108285783-dbe04900-7155-11eb-83a1-2607d39deaad.png">

#### After

<img width="268" alt="Screen Shot 2021-02-17 at 7 23 05 PM" src="https://user-images.githubusercontent.com/10561050/108285785-dbe04900-7155-11eb-8c13-3a829bfbf21e.png">


### Detailed test instructions:

1. Activate an extension that adds a category to the new nav.
2. Enable the new navigation.
3. Navigate to various menu categories.
4. Make sure empty menus are not shown.