### PR TITLE
Add navigation intro modal

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -121,6 +121,19 @@ localStorage.setItem( 'debug', 'wc-admin:tracks' );
 -   Click on `Save changes`.
 -   Observe in developer console, `wcadmin_ces_snackbar_view` is logged when CES prompt is displayed.
 -   In the event props, it should have a new `settings_area` key followed by the value of the settings tab you have selected.
+### Add navigation intro modal #6367
+
+1. Visit the homescreen and dismiss the original welcome modal if you haven't already.
+2. Enable the new navigation under WooCommerce -> Settings -> Advanced -> Features. (This will also require opting into tracking).
+3. Visit the WooCommerce Admin homescreen.
+4. Note the new modal.
+5. Check that pagination works as expected and modal styling is as expected.
+6. Dismiss the modal.
+7. Refresh the page to verify the modal does not reappear.
+8. On a new site, enable the navigation before visiting the homescreen.
+9. Navigate to the homescreen.
+10. Note the welcome modal is shown and the navigation intro modal is not shown.
+11. Refresh the page and note the nav intro modal was dismissed and never shown.
 
 ## 2.0.0
 

--- a/client/homescreen/constants.js
+++ b/client/homescreen/constants.js
@@ -1,0 +1,11 @@
+/**
+ * Welcome modal dismissed option name.
+ */
+export const WELCOME_MODAL_DISMISSED_OPTION_NAME =
+	'woocommerce_task_list_welcome_modal_dismissed';
+
+/**
+ * Welcome from calypso modal dismissed option name.
+ */
+export const WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME =
+	'woocommerce_welcome_from_calypso_modal_dismissed';

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -23,26 +23,26 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import StatsOverview from './stats-overview';
-import TaskListPlaceholder from '../task-list/placeholder';
-import InboxPanel from '../inbox-panel';
-import { IntroModal as NavigationIntroModal } from '../navigation/components/intro-modal';
-import { WelcomeModal } from './welcome-modal';
-import { WelcomeFromCalypsoModal } from './welcome-from-calypso-modal';
 import ActivityHeader from '../header/activity-panel/activity-header';
 import { ActivityPanel } from './activity-panel';
-
+import { Column } from './column';
+import InboxPanel from '../inbox-panel';
+import { IntroModal as NavigationIntroModal } from '../navigation/components/intro-modal';
+import StatsOverview from './stats-overview';
+import { StoreManagementLinks } from '../store-management-links';
+import TaskListPlaceholder from '../task-list/placeholder';
+import {
+	WELCOME_MODAL_DISMISSED_OPTION_NAME,
+	WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME,
+} from './constants';
+import { WelcomeFromCalypsoModal } from './welcome-from-calypso-modal';
+import { WelcomeModal } from './welcome-modal';
 import './style.scss';
 import '../dashboard/style.scss';
-import { StoreManagementLinks } from '../store-management-links';
-import { Column } from './column';
 
 const TaskList = lazy( () =>
 	import( /* webpackChunkName: "task-list" */ '../task-list' )
 );
-
-const WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME =
-	'woocommerce_welcome_from_calypso_modal_dismissed';
 
 export const Layout = ( {
 	defaultHomescreenLayout,
@@ -131,8 +131,7 @@ export const Layout = ( {
 				<WelcomeModal
 					onClose={ () => {
 						updateOptions( {
-							woocommerce_task_list_welcome_modal_dismissed:
-								'yes',
+							[ WELCOME_MODAL_DISMISSED_OPTION_NAME ]: 'yes',
 						} );
 					} }
 				/>
@@ -207,12 +206,11 @@ export default compose(
 			fromCalypsoUrlArgIsPresent;
 
 		const welcomeModalDismissed =
-			getOption( 'woocommerce_task_list_welcome_modal_dismissed' ) ===
-			'yes';
+			getOption( WELCOME_MODAL_DISMISSED_OPTION_NAME ) === 'yes';
 
 		const welcomeModalDismissedHasResolved = hasFinishedResolution(
 			'getOption',
-			[ 'woocommerce_task_list_welcome_modal_dismissed' ]
+			[ WELCOME_MODAL_DISMISSED_OPTION_NAME ]
 		);
 
 		const shouldShowWelcomeModal =

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -26,6 +26,7 @@ import { __ } from '@wordpress/i18n';
 import StatsOverview from './stats-overview';
 import TaskListPlaceholder from '../task-list/placeholder';
 import InboxPanel from '../inbox-panel';
+import { IntroModal as NavigationIntroModal } from '../navigation/components/intro-modal';
 import { WelcomeModal } from './welcome-modal';
 import { WelcomeFromCalypsoModal } from './welcome-from-calypso-modal';
 import ActivityHeader from '../header/activity-panel/activity-header';
@@ -146,6 +147,7 @@ export const Layout = ( {
 					} }
 				/>
 			) }
+			{ window.wcAdminFeatures.navigation && <NavigationIntroModal /> }
 		</div>
 	);
 };

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Guide } from '@wordpress/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { Text } from '@woocommerce/experimental';
 import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -12,7 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import './style.scss';
 
-const introModalOption = 'navigation_intro_modal_dismissed';
+const introModalOption = 'woocommerce_navigation_intro_modal_dismissed';
 
 export const IntroModal = () => {
 	const [ isOpen, setOpen ] = useState( true );
@@ -45,24 +47,62 @@ export const IntroModal = () => {
 		return null;
 	}
 
+	const getPage = ( title, description, videoId ) => {
+		return {
+			content: (
+				<div className="woocommerce-navigation-intro-modal__page-wrapper">
+					<div className="woocommerce-navigation-intro-modal__page-text">
+						<Text variant="title.large" as="h2">
+							{ title }
+						</Text>
+						<Text variant="body.large">{ description }</Text>
+					</div>
+					<iframe
+						title={ title }
+						width="420"
+						height="315"
+						src={ `https://www.youtube.com/embed/${ videoId }` }
+					></iframe>
+				</div>
+			),
+		};
+	};
+
 	return (
 		<Guide
 			className="woocommerce-navigation-intro-modal"
 			onFinish={ dismissModal }
 			pages={ [
-				{
-					content: (
-						<iframe
-							title="Rick Roll"
-							width="420"
-							height="315"
-							src="https://www.youtube.com/embed/dQw4w9WgXcQ"
-						></iframe>
+				getPage(
+					__(
+						'A new navigation for WooCommerce',
+						'woocommerce-admin'
 					),
-				},
-				{
-					content: 'Number 2',
-				},
+					__(
+						'All of your store management features in one place',
+						'woocommerce-admin'
+					),
+					'dQw4w9WgXcQ'
+				),
+				getPage(
+					__( 'Focus on managing your store', 'woocommerce-admin' ),
+					__(
+						'Give your attention to key areas of WooCommerce with little distraction',
+						'woocommerce-admin'
+					),
+					'dQw4w9WgXcQ'
+				),
+				getPage(
+					__(
+						'Easily find and favorite your extensions',
+						'woocommerce-admin'
+					),
+					__(
+						"They'll appear in the top level of the navigation for quick access",
+						'woocommerce-admin'
+					),
+					'dQw4w9WgXcQ'
+				),
 			] }
 		/>
 	);

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { Guide } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export const IntroModal = () => {
+	const [ isOpen, setOpen ] = useState( true );
+
+	const dismissModal = () => {
+		setOpen( false );
+	};
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Guide
+			className="woocommerce-navigation-intro-modal"
+			onFinish={ dismissModal }
+			pages={ [
+				{
+					content: (
+						<iframe
+							title="Rick Roll"
+							width="420"
+							height="315"
+							src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+						></iframe>
+					),
+				},
+				{
+					content: 'Number 2',
+				},
+			] }
+		/>
+	);
+};

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -15,25 +15,30 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import './style.scss';
 
 const introModalOption = 'woocommerce_navigation_intro_modal_dismissed';
+const trackingOption = 'woocommerce_allow_tracking';
 
 export const IntroModal = () => {
 	const [ isOpen, setOpen ] = useState( true );
 
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
-	const { isDismissed, isResolving } = useSelect( ( select ) => {
-		const dismissedOption = select( OPTIONS_STORE_NAME ).getOption(
-			introModalOption
-		);
-		return {
-			isDismissed: dismissedOption === 'yes',
-			isResolving:
-				typeof dismissedOption === 'undefined' ||
-				select( OPTIONS_STORE_NAME ).isResolving( 'getOption', [
-					introModalOption,
-				] ),
-		};
-	} );
+	const { allowTracking, isDismissed, isResolving } = useSelect(
+		( select ) => {
+			const { getOption, isResolving: isOptionResolving } = select(
+				OPTIONS_STORE_NAME
+			);
+			const dismissedOption = getOption( introModalOption );
+
+			return {
+				allowTracking: getOption( trackingOption ) === 'yes',
+				isDismissed: dismissedOption === 'yes',
+				isResolving:
+					typeof dismissedOption === 'undefined' ||
+					isOptionResolving( 'getOption', [ introModalOption ] ) ||
+					isOptionResolving( 'getOption', [ trackingOption ] ),
+			};
+		}
+	);
 
 	const dismissModal = () => {
 		updateOptions( {
@@ -43,7 +48,7 @@ export const IntroModal = () => {
 		setOpen( false );
 	};
 
-	if ( ! isOpen || isDismissed || isResolving ) {
+	if ( ! isOpen || isDismissed || isResolving || ! allowTracking ) {
 		return null;
 	}
 

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -13,10 +13,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import './style.scss';
+import { WELCOME_MODAL_DISMISSED_OPTION_NAME } from '../../../homescreen/constants';
 
-const introModalOption = 'woocommerce_navigation_intro_modal_dismissed';
-const welcomeModalOption = 'woocommerce_task_list_welcome_modal_dismissed';
-const trackingOption = 'woocommerce_allow_tracking';
+const INTRO_MODAL_DISMISSED_OPTION_NAME =
+	'woocommerce_navigation_intro_modal_dismissed';
+const TRACKING_OPTION_NAME = 'woocommerce_allow_tracking';
 
 export const IntroModal = () => {
 	const [ isOpen, setOpen ] = useState( true );
@@ -32,23 +33,28 @@ export const IntroModal = () => {
 		const { getOption, isResolving: isOptionResolving } = select(
 			OPTIONS_STORE_NAME
 		);
-		const dismissedOption = getOption( introModalOption );
+		const dismissedOption = getOption( INTRO_MODAL_DISMISSED_OPTION_NAME );
 
 		return {
-			allowTracking: getOption( trackingOption ) === 'yes',
+			allowTracking: getOption( TRACKING_OPTION_NAME ) === 'yes',
 			isDismissed: dismissedOption === 'yes',
-			isWelcomeModalShown: getOption( welcomeModalOption ) !== 'yes',
+			isWelcomeModalShown:
+				getOption( WELCOME_MODAL_DISMISSED_OPTION_NAME ) !== 'yes',
 			isResolving:
 				typeof dismissedOption === 'undefined' ||
-				isOptionResolving( 'getOption', [ introModalOption ] ) ||
-				isOptionResolving( 'getOption', [ welcomeModalOption ] ) ||
-				isOptionResolving( 'getOption', [ trackingOption ] ),
+				isOptionResolving( 'getOption', [
+					INTRO_MODAL_DISMISSED_OPTION_NAME,
+				] ) ||
+				isOptionResolving( 'getOption', [
+					WELCOME_MODAL_DISMISSED_OPTION_NAME,
+				] ) ||
+				isOptionResolving( 'getOption', [ TRACKING_OPTION_NAME ] ),
 		};
 	} );
 
 	const dismissModal = () => {
 		updateOptions( {
-			[ introModalOption ]: 'yes',
+			[ INTRO_MODAL_DISMISSED_OPTION_NAME ]: 'yes',
 		} );
 		recordEvent( 'navigation_intro_modal_close', {} );
 		setOpen( false );

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -47,7 +47,7 @@ export const IntroModal = () => {
 		return null;
 	}
 
-	const getPage = ( title, description, videoId ) => {
+	const getPage = ( title, description, imageUrl ) => {
 		return {
 			content: (
 				<div className="woocommerce-navigation-intro-modal__page-wrapper">
@@ -57,12 +57,7 @@ export const IntroModal = () => {
 						</Text>
 						<Text variant="body.large">{ description }</Text>
 					</div>
-					<iframe
-						title={ title }
-						width="420"
-						height="315"
-						src={ `https://www.youtube.com/embed/${ videoId }` }
-					></iframe>
+					<img alt={ title } src={ imageUrl } />
 				</div>
 			),
 		};
@@ -82,7 +77,7 @@ export const IntroModal = () => {
 						'All of your store management features in one place',
 						'woocommerce-admin'
 					),
-					'dQw4w9WgXcQ'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-1.gif'
 				),
 				getPage(
 					__( 'Focus on managing your store', 'woocommerce-admin' ),
@@ -90,7 +85,7 @@ export const IntroModal = () => {
 						'Give your attention to key areas of WooCommerce with little distraction',
 						'woocommerce-admin'
 					),
-					'dQw4w9WgXcQ'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-2.gif'
 				),
 				getPage(
 					__(
@@ -101,7 +96,7 @@ export const IntroModal = () => {
 						"They'll appear in the top level of the navigation for quick access",
 						'woocommerce-admin'
 					),
-					'dQw4w9WgXcQ'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-3.gif'
 				),
 			] }
 		/>

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -2,21 +2,46 @@
  * External dependencies
  */
 import { Guide } from '@wordpress/components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 import { useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+const introModalOption = 'navigation_intro_modal_dismissed';
+
 export const IntroModal = () => {
 	const [ isOpen, setOpen ] = useState( true );
 
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+
+	const { isDismissed, isResolving } = useSelect( ( select ) => {
+		const dismissedOption = select( OPTIONS_STORE_NAME ).getOption(
+			introModalOption
+		);
+		return {
+			isDismissed: dismissedOption === 'yes',
+			isResolving:
+				typeof dismissedOption === 'undefined' ||
+				select( OPTIONS_STORE_NAME ).isResolving( 'getOption', [
+					introModalOption,
+				] ),
+		};
+	} );
+
 	const dismissModal = () => {
+		updateOptions( {
+			[ introModalOption ]: 'yes',
+		} );
+		recordEvent( 'navigation_intro_modal_close', {} );
 		setOpen( false );
 	};
 
-	if ( ! isOpen ) {
+	if ( ! isOpen || isDismissed || isResolving ) {
 		return null;
 	}
 

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -62,7 +62,9 @@ export const IntroModal = () => {
 						</Text>
 						<Text variant="body.large">{ description }</Text>
 					</div>
-					<img alt={ title } src={ imageUrl } />
+					<div className="woocommerce-navigation-intro-modal__image-wrapper">
+						<img alt={ title } src={ imageUrl } />
+					</div>
 				</div>
 			),
 		};
@@ -82,7 +84,7 @@ export const IntroModal = () => {
 						'All of your store management features in one place',
 						'woocommerce-admin'
 					),
-					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-1.gif'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-1-32.gif'
 				),
 				getPage(
 					__( 'Focus on managing your store', 'woocommerce-admin' ),
@@ -90,7 +92,7 @@ export const IntroModal = () => {
 						'Give your attention to key areas of WooCommerce with little distraction',
 						'woocommerce-admin'
 					),
-					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-2.gif'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-2-32.gif'
 				),
 				getPage(
 					__(
@@ -101,7 +103,7 @@ export const IntroModal = () => {
 						"They'll appear in the top level of the navigation for quick access",
 						'woocommerce-admin'
 					),
-					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-3.gif'
+					'https://woocommerce.com/wp-content/uploads/2021/02/nav-intro-video-3-32.gif'
 				),
 			] }
 		/>

--- a/client/navigation/components/intro-modal/style.scss
+++ b/client/navigation/components/intro-modal/style.scss
@@ -29,6 +29,10 @@
 			bottom: 100%;
 			margin-bottom: $gap;
 		}
+
+		.components-guide__back-button {
+			display: none;
+		}
 	}
 
 	&.components-modal__frame.components-guide {
@@ -41,7 +45,10 @@
 	}
 
 	.woocommerce-navigation-intro-modal__page-text {
-		padding: #{$gap * 4} $gap-large #{$gap * 4} $gap-largest;
+		padding: $gap-largest;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 
 		h2 {
 			font-weight: bold;

--- a/client/navigation/components/intro-modal/style.scss
+++ b/client/navigation/components/intro-modal/style.scss
@@ -1,7 +1,9 @@
 .woocommerce-navigation-intro-modal {
+	width: 670px;
+
 	.components-guide__page-control {
 		order: 3;
-		margin: $gap-small 0;
+		margin: $gap 0;
 
 		li {
 			margin: 0;
@@ -10,6 +12,14 @@
 
 	iframe {
 		width: 100%;
+	}
+
+	.components-modal__header {
+		display: none;
+	}
+
+	.components-guide__container {
+		margin-top: 0;
 	}
 
 	.components-guide__footer {
@@ -21,11 +31,26 @@
 		.components-button {
 			position: absolute;
 			bottom: 100%;
-			margin-bottom: $gap-small;
+			margin-bottom: $gap;
 		}
 	}
 
 	&.components-modal__frame.components-guide {
 		height: auto;
+	}
+
+	.woocommerce-navigation-intro-modal__page-wrapper {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.woocommerce-navigation-intro-modal__page-text {
+		padding: #{$gap * 4} $gap-large #{$gap * 4} $gap-largest;
+
+		h2 {
+			font-weight: bold;
+			margin-bottom: $gap-smaller;
+			max-width: 85%;
+		}
 	}
 }

--- a/client/navigation/components/intro-modal/style.scss
+++ b/client/navigation/components/intro-modal/style.scss
@@ -1,0 +1,31 @@
+.woocommerce-navigation-intro-modal {
+	.components-guide__page-control {
+		order: 3;
+		margin: $gap-small 0;
+
+		li {
+			margin: 0;
+		}
+	}
+
+	iframe {
+		width: 100%;
+	}
+
+	.components-guide__footer {
+		box-sizing: border-box;
+		margin: 0;
+		height: 0;
+		overflow: visible;
+
+		.components-button {
+			position: absolute;
+			bottom: 100%;
+			margin-bottom: $gap-small;
+		}
+	}
+
+	&.components-modal__frame.components-guide {
+		height: auto;
+	}
+}

--- a/client/navigation/components/intro-modal/style.scss
+++ b/client/navigation/components/intro-modal/style.scss
@@ -10,10 +10,6 @@
 		}
 	}
 
-	iframe {
-		width: 100%;
-	}
-
 	.components-modal__header {
 		display: none;
 	}

--- a/client/navigation/components/intro-modal/style.scss
+++ b/client/navigation/components/intro-modal/style.scss
@@ -1,6 +1,10 @@
 .woocommerce-navigation-intro-modal {
 	width: 670px;
 
+	@include breakpoint( '<782px' ) {
+		width: 350px;
+	}
+
 	.components-guide__page-control {
 		order: 3;
 		margin: $gap 0;
@@ -42,10 +46,24 @@
 	.woocommerce-navigation-intro-modal__page-wrapper {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
+
+		img {
+			max-width: 100%;
+		}
+
+		@include breakpoint( '<782px' ) {
+			grid-template-columns: 1fr;
+
+			.woocommerce-navigation-intro-modal__image-wrapper {
+				grid-row: 1;
+				max-height: 328px;
+				overflow: hidden;
+			}
+		}
 	}
 
 	.woocommerce-navigation-intro-modal__page-text {
-		padding: $gap-largest;
+		padding: $gap-large;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -53,7 +71,6 @@
 		h2 {
 			font-weight: bold;
 			margin-bottom: $gap-smaller;
-			max-width: 85%;
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Removed @woocommerce/components/card from OBW #6374
 - Fix: Email notes now are turned off by default #6324
 - Add: CES track settings tab on updating settings #6368
+- Add: Add navigation intro modal. #6367
 
 == 2.0.0 02/05/2021 ==
 


### PR DESCRIPTION
Fixes #6214 

Adds the video intro modal.

### Screenshots

<img width="697" alt="Screen Shot 2021-02-18 at 10 29 50 PM" src="https://user-images.githubusercontent.com/10561050/108455357-17554300-723c-11eb-9da3-563ca997029e.png">



### Detailed test instructions:

1. Enable the new navigation under WooCommerce -> Settings -> Advanced -> Features. (This will also require opting into tracking).
2. Visit the WooCommerce Admin homescreen.
3. Note the new modal.
4. Check that pagination works as expected and modal styling is as expected.
5. Dismiss the modal.
6. Refresh the page to verify the modal does not reappear.

1. On a new site, enable the navigation before visiting the homescreen.
2. Navigate to the homescreen.
3. Note the welcome modal is shown and the navigation intro modal is not shown.
4. Refresh the page and note the nav intro modal was dismissed and never shown.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
