### PR TITLE
Add CES track settings tab on updating settings

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,4 +1,5 @@
-# Testing instructions
+Testing instructions
+====================
 
 ## Unreleased
 
@@ -120,18 +121,19 @@ localStorage.setItem( 'debug', 'wc-admin:tracks' );
 -   Click on `Save changes`.
 -   Observe in developer console, `wcadmin_ces_snackbar_view` is logged when CES prompt is displayed.
 -   In the event props, it should have a new `settings_area` key followed by the value of the settings tab you have selected.
+
 ## 2.0.0
 
 ### Add the Mollie payment provider setup task #6257
 
--   You'll need a site that has the setup task list visible. Complete the OBW and make sure you're in a Mollie supported country (Such as United Kingdom).
--   Go to the setup payments task
--   Mollie should be listed as an option
--   Click "Set up" button on the Mollie task
--   It should install and activate the mollie payments plugin
--   The connect step should provide links to create an account or go straight to Mollie settings. (test both links work)
--   Click "continue"
--   You should arrive back at the payment provider list
+- You'll need a site that has the setup task list visible. Complete the OBW and make sure you're in a Mollie supported country (Such as United Kingdom).
+- Go to the setup payments task
+- Mollie should be listed as an option
+- Click "Set up" button on the Mollie task
+- It should install and activate the mollie payments plugin
+- The connect step should provide links to create an account or go straight to Mollie settings. (test both links work)
+- Click "continue"
+- You should arrive back at the payment provider list
 
 ### Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
 
@@ -143,74 +145,73 @@ localStorage.setItem( 'debug', 'wc-admin:tracks' );
 
 ### Add: new inbox message - Getting started in Ecommerce - watch this webinar. #6086
 
--   First you'll need to make sure you meet the criteria for the note:
+- First you'll need to make sure you meet the criteria for the note:
     1. obw is done
     2. revenue is between 0-2500
     3. do not check "setting up for client" in obw
     4. store should have no products
--   Next you need to install WP Crontrol, go to its list of cron events and click "run now" on "wc_admin_daily"
--   Confirm the new note is displayed and that the content matches that specified below:
-    -   Title: Getting Started in eCommerce - webinar
-    -   Copy: We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.
-    -   CTA leads to: https://youtu.be/V_2XtCOyZ7o
-    -   CTA label: Watch the webinar
+- Next you need to install WP Crontrol, go to its list of cron events and click "run now" on "wc_admin_daily"
+- Confirm the new note is displayed and that the content matches that specified below:
+    - Title: Getting Started in eCommerce - webinar
+    - Copy: We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.
+    - CTA leads to: https://youtu.be/V_2XtCOyZ7o
+    - CTA label: Watch the webinar
 
 ### Update: store deprecation welcome modal support doc link #6094
 
--   Starting with a fresh store (or by deleting the woocommerce_task_list_welcome_modal_dismissed option), visit /wp-admin/admin.php?page=wc-admin. You should see the standard welcome modal.
--   Add &from-calypso to the URL. You should see the Calypso welcome modal.
--   Notice "Learn more" links to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
+- Starting with a fresh store (or by deleting the woocommerce_task_list_welcome_modal_dismissed option), visit /wp-admin/admin.php?page=wc-admin. You should see the standard welcome modal.
+- Add &from-calypso to the URL. You should see the Calypso welcome modal.
+- Notice "Learn more" links to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
 
 ### Enhancement: Allowing users to create products by selecting a template. #5892
 
--   Load new store and finish the Wizard
--   Go to the `Add my products` task
--   Click the `Start with a template` option, and select either a physical, digital, variable product
--   Once you click `Go`, it should redirect you to an edit page of the new post, with the data from the sample-data.csv (mentioned in the original ticket). Only the title is missing, as it is saved as auto-draft.
--   You should be able to save the new product as draft or publish it.
--   You should be able to exit without making any changes, and not having the product show up as draft in your product list.
-    -   Create new product from template
-    -   Wait until redirected
-    -   Without saving go to the **Products > all products** page, the new product should not be displayed.
+- Load new store and finish the Wizard
+- Go to the `Add my products` task
+- Click the `Start with a template` option, and select either a physical, digital, variable product
+- Once you click `Go`, it should redirect you to an edit page of the new post, with the data from the sample-data.csv (mentioned in the original ticket). Only the title is missing, as it is saved as auto-draft.
+- You should be able to save the new product as draft or publish it.
+- You should be able to exit without making any changes, and not having the product show up as draft in your product list. 
+  - Create new product from template
+  - Wait until redirected
+  - Without saving go to the **Products > all products** page, the new product should not be displayed.
 
 ### Update: Homescreen layout, moving Inbox panel for better interaction. #6122
 
--   Create a new woo store, and finish the onboarding wizard.
--   Go to the home screen, and make sure the panels follow this order:
--   Two column:
-    -   Left column: store setup and/or management tasks + inbox panel
-    -   Right column: stats overview + store management shortcuts (only shows when setup tasks is hidden)
--   Single column:
-    -   store setup tasks, inbox panel, stats overview, store management links (only visible when setup tasks is hidden).
--   Hide the setup tasks list, and see if the store management links show up in the right place.
+- Create a new woo store, and finish the onboarding wizard.
+- Go to the home screen, and make sure the panels follow this order:
+- Two column:
+  - Left column: store setup and/or management tasks + inbox panel
+  - Right column: stats overview + store management shortcuts (only shows when setup tasks is hidden)
+- Single column:
+  - store setup tasks, inbox panel, stats overview, store management links (only visible when setup tasks is hidden).
+- Hide the setup tasks list, and see if the store management links show up in the right place.
 
 ### Enhancement: Use the new Paypal payments plugin for onboarding. #6261
 
--   Create new woo store, and finish the onboarding wizard
--   Go to the home screen, and click the **Set up payments** task. **Paypal Payments** option should be listed as an option, with a **Set up** button.
--   Click **Set up** on the Paypal plugin.
--   It should automatically start the **Install** step, and install and enable the [Paypal Payments](https://woocommerce.com/products/woocommerce-paypal-payments/) plugin.
--   For Paypal Payments version greater then `1.1.0`.
-    -   For the second step it should show a `Connect` button
-    -   Click on **Connect** and a window should popup for Paypal, follow this until finished. The last button is - Go back to Woocommerce Developers
-    -   Once done, the page should reload, and briefly show the setup screen again, it should then finish and go back to the payment list.
-    -   Once on the payment list, the `Set up` button should be gone, and instead show a toggle, that is set to enabled.
-        -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
--   For Paypal Payments version `1.1.0` and below
-    -   For the second step it will show the manual fields (merchant email, merchant id, client id, client secret).
-    -   Check if the help links work below, they should help with finding the above credentials.
-        -   If you have a business account set up, you can find the credentials in these two places
-        -   [Get live app credentials](https://developer.paypal.com/developer/applications/)
-        -   [Merchant id](https://www.paypal.com/businessmanage/account/aboutBusiness)
-    -   Fill in the credentials and click **Proceed**, this should succeed and redirect you to the Payment options list
-    -   The **Set up** button should be replaced by a toggle, that is set to enabled.
-        -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
+- Create new woo store, and finish the onboarding wizard
+- Go to the home screen, and click the **Set up payments** task. **Paypal Payments** option should be listed as an option, with a **Set up** button.
+- Click **Set up** on the Paypal plugin.
+- It should automatically start the **Install** step, and install and enable the [Paypal Payments](https://woocommerce.com/products/woocommerce-paypal-payments/) plugin.
+- For Paypal Payments version greater then `1.1.0`.
+  - For the second step it should show a `Connect` button
+  - Click on **Connect** and a window should popup for Paypal, follow this until finished. The last button is - Go back to Woocommerce Developers
+  - Once done, the page should reload, and briefly show the setup screen again, it should then finish and go back to the payment list.
+  - Once on the payment list, the `Set up` button should be gone, and instead show a toggle, that is set to enabled.
+    - The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
+- For Paypal Payments version `1.1.0` and below
+  - For the second step it will show the manual fields (merchant email, merchant id, client id, client secret). 
+  - Check if the help links work below, they should help with finding the above credentials.
+    - If you have a business account set up, you can find the credentials in these two places
+    - [Get live app credentials](https://developer.paypal.com/developer/applications/)
+    - [Merchant id](https://www.paypal.com/businessmanage/account/aboutBusiness)
+  - Fill in the credentials and click **Proceed**, this should succeed and redirect you to the Payment options list
+  - The **Set up** button should be replaced by a toggle, that is set to enabled.
+    - The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
 
 Once everything is configured and enabled do a client test
-
--   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
--   Navigate to one of the products and add it to the cart
--   Click **go to checkout**
--   Paypal should be one of the options to pay
--   Filling in your billing/shipping info then click pay with **Paypal**
--   The paypal pay window should pop up correctly without errors.
+- Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
+- Navigate to one of the products and add it to the cart
+- Click **go to checkout**
+- Paypal should be one of the options to pay
+- Filling in your billing/shipping info then click pay with **Paypal**
+- The paypal pay window should pop up correctly without errors.

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,5 +1,4 @@
-Testing instructions
-====================
+# Testing instructions
 
 ## Unreleased
 
@@ -102,18 +101,37 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 10. With a user that can `manage_woocommerce`, navigate to the homepage via URL and make sure the homescreen is shown. `/wp-admin/admin.php?page=wc-admin`
 11. With a user that cannot `view_woocommerce_reports` make sure navigating to an analytics report does not work. `/wp-admin/admin.php?page=wc-admin&path=/analytics/overview`
 
+### Add CES track settings tab on updating settings #6368
+
+-   Make sure tracking is enabled in settings:
+
+```
+/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
+```
+
+-   Delete the option `woocommerce_ces_shown_for_actions` to make sure CES prompt triggers when updating settings.
+-   Enable the logging of Tracks events to your browser dev console:
+
+```
+localStorage.setItem( 'debug', 'wc-admin:tracks' );
+```
+
+-   Go to WooCommerce > Settings, and select a top-level tab such as Products, Shipping, etc.
+-   Click on `Save changes`.
+-   Observe in developer console, `wcadmin_ces_snackbar_view` is logged when CES prompt is displayed.
+-   In the event props, it should have a new `settings_area` key followed by the value of the settings tab you have selected.
 ## 2.0.0
 
 ### Add the Mollie payment provider setup task #6257
 
-- You'll need a site that has the setup task list visible. Complete the OBW and make sure you're in a Mollie supported country (Such as United Kingdom).
-- Go to the setup payments task
-- Mollie should be listed as an option
-- Click "Set up" button on the Mollie task
-- It should install and activate the mollie payments plugin
-- The connect step should provide links to create an account or go straight to Mollie settings. (test both links work)
-- Click "continue"
-- You should arrive back at the payment provider list
+-   You'll need a site that has the setup task list visible. Complete the OBW and make sure you're in a Mollie supported country (Such as United Kingdom).
+-   Go to the setup payments task
+-   Mollie should be listed as an option
+-   Click "Set up" button on the Mollie task
+-   It should install and activate the mollie payments plugin
+-   The connect step should provide links to create an account or go straight to Mollie settings. (test both links work)
+-   Click "continue"
+-   You should arrive back at the payment provider list
 
 ### Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
 
@@ -125,73 +143,74 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 
 ### Add: new inbox message - Getting started in Ecommerce - watch this webinar. #6086
 
-- First you'll need to make sure you meet the criteria for the note:
+-   First you'll need to make sure you meet the criteria for the note:
     1. obw is done
     2. revenue is between 0-2500
     3. do not check "setting up for client" in obw
     4. store should have no products
-- Next you need to install WP Crontrol, go to its list of cron events and click "run now" on "wc_admin_daily"
-- Confirm the new note is displayed and that the content matches that specified below:
-    - Title: Getting Started in eCommerce - webinar
-    - Copy: We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.
-    - CTA leads to: https://youtu.be/V_2XtCOyZ7o
-    - CTA label: Watch the webinar
+-   Next you need to install WP Crontrol, go to its list of cron events and click "run now" on "wc_admin_daily"
+-   Confirm the new note is displayed and that the content matches that specified below:
+    -   Title: Getting Started in eCommerce - webinar
+    -   Copy: We want to make eCommerce and this process of getting started as easy as possible for you. Watch this webinar to get tips on how to have our store up and running in a breeze.
+    -   CTA leads to: https://youtu.be/V_2XtCOyZ7o
+    -   CTA label: Watch the webinar
 
 ### Update: store deprecation welcome modal support doc link #6094
 
-- Starting with a fresh store (or by deleting the woocommerce_task_list_welcome_modal_dismissed option), visit /wp-admin/admin.php?page=wc-admin. You should see the standard welcome modal.
-- Add &from-calypso to the URL. You should see the Calypso welcome modal.
-- Notice "Learn more" links to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
+-   Starting with a fresh store (or by deleting the woocommerce_task_list_welcome_modal_dismissed option), visit /wp-admin/admin.php?page=wc-admin. You should see the standard welcome modal.
+-   Add &from-calypso to the URL. You should see the Calypso welcome modal.
+-   Notice "Learn more" links to https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/
 
 ### Enhancement: Allowing users to create products by selecting a template. #5892
 
-- Load new store and finish the Wizard
-- Go to the `Add my products` task
-- Click the `Start with a template` option, and select either a physical, digital, variable product
-- Once you click `Go`, it should redirect you to an edit page of the new post, with the data from the sample-data.csv (mentioned in the original ticket). Only the title is missing, as it is saved as auto-draft.
-- You should be able to save the new product as draft or publish it.
-- You should be able to exit without making any changes, and not having the product show up as draft in your product list. 
-  - Create new product from template
-  - Wait until redirected
-  - Without saving go to the **Products > all products** page, the new product should not be displayed.
+-   Load new store and finish the Wizard
+-   Go to the `Add my products` task
+-   Click the `Start with a template` option, and select either a physical, digital, variable product
+-   Once you click `Go`, it should redirect you to an edit page of the new post, with the data from the sample-data.csv (mentioned in the original ticket). Only the title is missing, as it is saved as auto-draft.
+-   You should be able to save the new product as draft or publish it.
+-   You should be able to exit without making any changes, and not having the product show up as draft in your product list.
+    -   Create new product from template
+    -   Wait until redirected
+    -   Without saving go to the **Products > all products** page, the new product should not be displayed.
 
 ### Update: Homescreen layout, moving Inbox panel for better interaction. #6122
 
-- Create a new woo store, and finish the onboarding wizard.
-- Go to the home screen, and make sure the panels follow this order:
-- Two column:
-  - Left column: store setup and/or management tasks + inbox panel
-  - Right column: stats overview + store management shortcuts (only shows when setup tasks is hidden)
-- Single column:
-  - store setup tasks, inbox panel, stats overview, store management links (only visible when setup tasks is hidden).
-- Hide the setup tasks list, and see if the store management links show up in the right place.
+-   Create a new woo store, and finish the onboarding wizard.
+-   Go to the home screen, and make sure the panels follow this order:
+-   Two column:
+    -   Left column: store setup and/or management tasks + inbox panel
+    -   Right column: stats overview + store management shortcuts (only shows when setup tasks is hidden)
+-   Single column:
+    -   store setup tasks, inbox panel, stats overview, store management links (only visible when setup tasks is hidden).
+-   Hide the setup tasks list, and see if the store management links show up in the right place.
 
 ### Enhancement: Use the new Paypal payments plugin for onboarding. #6261
 
-- Create new woo store, and finish the onboarding wizard
-- Go to the home screen, and click the **Set up payments** task. **Paypal Payments** option should be listed as an option, with a **Set up** button.
-- Click **Set up** on the Paypal plugin.
-- It should automatically start the **Install** step, and install and enable the [Paypal Payments](https://woocommerce.com/products/woocommerce-paypal-payments/) plugin.
-- For Paypal Payments version greater then `1.1.0`.
-  - For the second step it should show a `Connect` button
-  - Click on **Connect** and a window should popup for Paypal, follow this until finished. The last button is - Go back to Woocommerce Developers
-  - Once done, the page should reload, and briefly show the setup screen again, it should then finish and go back to the payment list.
-  - Once on the payment list, the `Set up` button should be gone, and instead show a toggle, that is set to enabled.
-    - The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
-- For Paypal Payments version `1.1.0` and below
-  - For the second step it will show the manual fields (merchant email, merchant id, client id, client secret). 
-  - Check if the help links work below, they should help with finding the above credentials.
-    - If you have a business account set up, you can find the credentials in these two places
-    - [Get live app credentials](https://developer.paypal.com/developer/applications/)
-    - [Merchant id](https://www.paypal.com/businessmanage/account/aboutBusiness)
-  - Fill in the credentials and click **Proceed**, this should succeed and redirect you to the Payment options list
-  - The **Set up** button should be replaced by a toggle, that is set to enabled.
-    - The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
+-   Create new woo store, and finish the onboarding wizard
+-   Go to the home screen, and click the **Set up payments** task. **Paypal Payments** option should be listed as an option, with a **Set up** button.
+-   Click **Set up** on the Paypal plugin.
+-   It should automatically start the **Install** step, and install and enable the [Paypal Payments](https://woocommerce.com/products/woocommerce-paypal-payments/) plugin.
+-   For Paypal Payments version greater then `1.1.0`.
+    -   For the second step it should show a `Connect` button
+    -   Click on **Connect** and a window should popup for Paypal, follow this until finished. The last button is - Go back to Woocommerce Developers
+    -   Once done, the page should reload, and briefly show the setup screen again, it should then finish and go back to the payment list.
+    -   Once on the payment list, the `Set up` button should be gone, and instead show a toggle, that is set to enabled.
+        -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
+-   For Paypal Payments version `1.1.0` and below
+    -   For the second step it will show the manual fields (merchant email, merchant id, client id, client secret).
+    -   Check if the help links work below, they should help with finding the above credentials.
+        -   If you have a business account set up, you can find the credentials in these two places
+        -   [Get live app credentials](https://developer.paypal.com/developer/applications/)
+        -   [Merchant id](https://www.paypal.com/businessmanage/account/aboutBusiness)
+    -   Fill in the credentials and click **Proceed**, this should succeed and redirect you to the Payment options list
+    -   The **Set up** button should be replaced by a toggle, that is set to enabled.
+        -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
 
 Once everything is configured and enabled do a client test
-- Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
-- Navigate to one of the products and add it to the cart
-- Click **go to checkout**
-- Paypal should be one of the options to pay
-- Filling in your billing/shipping info then click pay with **Paypal**
-- The paypal pay window should pop up correctly without errors.
+
+-   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
+-   Navigate to one of the products and add it to the cart
+-   Click **go to checkout**
+-   Paypal should be one of the options to pay
+-   Filling in your billing/shipping info then click pay with **Paypal**
+-   The paypal pay window should pop up correctly without errors.

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Enqueue scripts called incorrectly in php unit tests #6358
 - Fix: Removed @woocommerce/components/card from OBW #6374
 - Fix: Email notes now are turned off by default #6324
+- Add: CES track settings tab on updating settings #6368
 
 == 2.0.0 02/05/2021 ==
 

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -211,7 +211,7 @@ class CustomerEffortScoreTracks {
 	 * Enqueue the CES survey trigger for setting changes.
 	 */
 	public function run_on_update_options() {
-		// $current_tab is set when WC_Admin_Settings::save is called.
+		// $current_tab is set when WC_Admin_Settings::save_settings is called.
 		global $current_tab;
 
 		if ( $this->has_been_shown( self::SETTINGS_CHANGE_ACTION_NAME ) ) {

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -211,6 +211,9 @@ class CustomerEffortScoreTracks {
 	 * Enqueue the CES survey trigger for setting changes.
 	 */
 	public function run_on_update_options() {
+		// $current_tab is set when WC_Admin_Settings::save is called.
+		global $current_tab;
+
 		if ( $this->has_been_shown( self::SETTINGS_CHANGE_ACTION_NAME ) ) {
 			return;
 		}
@@ -225,7 +228,9 @@ class CustomerEffortScoreTracks {
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'woocommerce_page_wc-settings',
 				'adminpage'      => 'woocommerce_page_wc-settings',
-				'props'          => (object) array(),
+				'props'          => (object) array(
+					'settings_area' => $current_tab,
+				),
 			)
 		);
 	}

--- a/tests/features/class-wc-tests-ces-tracks.php
+++ b/tests/features/class-wc-tests-ces-tracks.php
@@ -50,7 +50,7 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Verify that the queue does not add duplicate item by cehcking
+	 * Verify that the queue does not add duplicate item by checking
 	 * action and label values.
 	 */
 	public function test_the_queue_does_not_allow_duplicate() {
@@ -86,5 +86,33 @@ class WC_Tests_CES_Tracks extends WC_Unit_Test_Case {
 		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
 
 		$this->assertEmpty( $queue_items );
+	}
+
+	/**
+	 * Verify that it adds `settings_area` prop.
+	 */
+	public function test_settings_area_included_in_event_props() {
+		// Global assignment to mimic what's done in WC_Admin_Settings::save_settings.
+		global $current_tab;
+		$current_tab = 'test_tab';
+		$ces         = new CustomerEffortScoreTracks();
+
+		do_action( 'woocommerce_update_options' );
+
+		$queue_items = get_option( $ces::CES_TRACKS_QUEUE_OPTION_NAME, array() );
+		$this->assertNotEmpty( $queue_items );
+
+		$expected_queue_item = array_filter(
+			$queue_items,
+			function ( $item ) use ( $ces ) {
+				return $ces::SETTINGS_CHANGE_ACTION_NAME === $item['action'];
+			}
+		);
+
+		// Remove global assignment.
+		unset( $GLOBALS['current_tab'] );
+
+		$this->assertCount( 1, $expected_queue_item );
+		$this->assertEquals( 'test_tab', $expected_queue_item[0]['props']->settings_area );
 	}
 }


### PR DESCRIPTION
This PR adds `settings_area` prop to CES prompt on settings change. This allows to track which top-level segment in settings the user is giving feedback upon.

Fixes https://github.com/woocommerce/woocommerce-admin/issues/6306.
### Detailed test instructions:

- Make sure tracking is enabled in settings: 
```
/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
```
- Delete the option `woocommerce_ces_shown_for_actions` to make sure CES prompt triggers when updating settings.
- Enable the logging of Tracks events to your browser dev console:
```
localStorage.setItem( 'debug', 'wc-admin:tracks' );
```
- Go to WooCommerce  > Settings, and select a top-level tab such as Products, Shipping, etc.
- Click on `Save changes`.
- Observe in developer console, `wcadmin_ces_snackbar_view` is logged when CES prompt is displayed.
- In the event props, it should have a new `settings_area` key followed by the value of the settings tab you have selected.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
