### PR TITLE
Add filter to allow the wp toolbar in navigation

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -47,8 +47,11 @@
 	}
 }
 
-.has-woocommerce-navigation .woocommerce-layout__header {
+.is-wp-toolbar-disabled .woocommerce-layout__header {
 	top: 0;
+}
+
+.has-woocommerce-navigation .woocommerce-layout__header {
 	left: 0;
 	width: 100%;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -85,7 +85,13 @@
 	}
 }
 
-.wp-toolbar .woocommerce-admin-full-screen {
+.is-wp-toolbar-disabled {
+	#wpadminbar {
+		display: none !important;
+	}
+}
+
+.wp-toolbar .is-wp-toolbar-disabled {
 	margin-top: -$adminbar-height;
 	@include breakpoint( '<600px' ) {
 		margin-top: -$adminbar-height-mobile;

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -24,8 +24,12 @@
 	position: absolute;
 	top: $header-height;
 	width: 100%;
-	height: calc(100vh - #{$header-height});
+	height: calc(100vh - #{$header-height + $adminbar-height});
 	overflow-y: auto;
+}
+
+.is-wp-toolbar-disabled .woocommerce-navigation__wrapper {
+	height: calc(100vh - #{$header-height});
 }
 
 body.is-wc-nav-expanded {
@@ -66,7 +70,6 @@ body.is-wc-nav-folded {
 }
 
 .has-woocommerce-navigation {
-	#wpadminbar,
 	#adminmenuwrap,
 	#adminmenuback {
 		display: none !important;
@@ -118,5 +121,11 @@ body.is-wc-nav-folded {
 
 	#woocommerce-embedded-root.is-embed-loading {
 		margin-bottom: -$adminbar-height;
+	}
+
+	&:not(.is-wp-toolbar-disabled) {
+		#wpbody-content {
+			margin-top: $adminbar-height;
+		}
 	}
 }

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -80,6 +80,7 @@ class ProfileWizard extends Component {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );
 		document.body.classList.add( 'woocommerce-admin-full-screen' );
+		document.body.classList.add( 'is-wp-toolbar-disabled' );
 
 		recordEvent( 'storeprofiler_step_view', {
 			step: this.getCurrentStep().key,
@@ -104,6 +105,7 @@ class ProfileWizard extends Component {
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
 		document.body.classList.remove( 'woocommerce-admin-full-screen' );
+		document.body.classList.remove( 'is-wp-toolbar-disabled' );
 	}
 
 	getSteps() {

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -14,6 +14,10 @@ The fastest way to get started is by creating an example plugin from WooCommerce
 
 This will create a new plugin that covers various features of the navigation and helps to register some intial items and categories within the new navigation menu.  After running the command above, you can make edits directly to the files at `docs/examples/extensions/add-navigation-items` and they will be built and copied to your `wp-content/add-navigation-items` folder on save.
 
+If you need to enable the WP Toolbar for debugging purposes in the new navigation, you can add the following filter to do so:
+
+`add_filter( 'woocommerce_navigation_wp_toolbar_disabled', '__return_false' );`
+
 ### Adding a menu category
 
 Categories in the new navigation are menu items that house child menu items.

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 - Dev: Remove Google fonts and material icons. #6343
 - Add: Remove CES actions for adding and editing a product and editing an order #6355
+- Dev: Add filter to allow enabling the WP toolbar within the new navigation. #6371
 
 == 2.0.0 02/05/2021 ==
 

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -151,6 +151,10 @@ class Screen {
 	public function add_body_class( $classes ) {
 		if ( self::is_woocommerce_page() ) {
 			$classes .= ' has-woocommerce-navigation';
+
+			if ( apply_filters( 'woocommerce_navigation_wp_toolbar_disabled', true ) ) {
+				$classes .= ' is-wp-toolbar-disabled';
+			}
 		}
 
 		return $classes;

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -152,6 +152,11 @@ class Screen {
 		if ( self::is_woocommerce_page() ) {
 			$classes .= ' has-woocommerce-navigation';
 
+			/**
+			 * Adds the ability to skip disabling of the WP toolbar.
+			 *
+			 * @param boolean $bool WP Toolbar disabled.
+			 */
 			if ( apply_filters( 'woocommerce_navigation_wp_toolbar_disabled', true ) ) {
 				$classes .= ' is-wp-toolbar-disabled';
 			}


### PR DESCRIPTION
Fixes #6162 

Adds a filter that allows the toolbar to be shown.  Also refactors hidden toolbar styling to be styled via a single class so we can use it anywhere the toolbar gets hidden.

Note to @joelclimbsthings - since this relies on a negative margin on the body class, we'll probably need to using `padding-top` to adjust the `body` position in https://github.com/woocommerce/woocommerce-admin/pull/6337.

### Screenshots
<img width="602" alt="Screen Shot 2021-02-18 at 10 28 00 AM" src="https://user-images.githubusercontent.com/10561050/108379908-5c458f00-71d4-11eb-9b4b-e92ac9e4e499.png">


### Detailed test instructions:

1. Check that existing styles work with a combo of the following:
* Navigation turned on/off.
* Embed pages/non-embed pages.
* Onboarding wizard.
2. Disable the wp toolbar via the filter `add_filter( 'woocommerce_navigation_wp_toolbar_disabled', '__return_false' );`
3. Check that the toolbar is shown and the above combo styling is as expected.