### PR TITLE
Order and styles updates to nav footer

### DIFF
--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -66,9 +66,9 @@
 
 	&.is-root {
 		.components-navigation__menu-secondary {
-			border-top: 1px solid $gray-700;
+			border-top: 1px solid $studio-gray-80;
 			margin: 0 -#{$gap-smaller};
-			padding: $gap $gap-smaller;
+			padding: $gap $gap-smaller $gap-small $gap-smaller;
 		}
 	}
 }

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -104,7 +104,7 @@ class CoreMenu {
 				'title'  => __( 'Settings', 'woocommerce-admin' ),
 				'id'     => 'woocommerce-settings',
 				'menuId' => 'secondary',
-				'order'  => 10,
+				'order'  => 20,
 				'url'    => 'admin.php?page=wc-settings',
 			),
 			array(

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -216,7 +216,7 @@ class CoreMenu {
 					'id'         => 'woocommerce-marketplace',
 					'url'        => 'wc-addons',
 					'menuId'     => 'secondary',
-					'order'      => 20,
+					'order'      => 10,
 				),
 				// Tools category.
 				array(


### PR DESCRIPTION
Minor changes to the nav footer:
- Lightened the border color
- Made padding visually consistent on top and bottom
- Reordered items so that `Marketplace` appears above `Settings`

<img width="252" alt="image" src="https://user-images.githubusercontent.com/5121465/108411000-ba32a080-71ed-11eb-9056-eb3d21c38362.png">

