### PR TITLE
Update overflow visible on card media

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -246,7 +246,6 @@
 
 	.components-card__media {
 		margin: $gap-large $gap-larger;
-		overflow: visible;
 
 		img {
 			max-width: 100px;

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -246,6 +246,7 @@
 
 	.components-card__media {
 		margin: $gap-large $gap-larger;
+		overflow: visible;
 
 		img {
 			max-width: 100px;

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -295,19 +295,17 @@ class Payments extends Component {
 
 					return (
 						<Card key={ key } className={ classes }>
-							<CardMedia isBorderless>
-								{ showRecommendedRibbon && (
-									<div className="woocommerce-task-payment__recommended-ribbon">
-										<span>
-											{ __(
-												'Recommended',
-												'woocommerce-admin'
-											) }
-										</span>
-									</div>
-								) }
-								{ before }
-							</CardMedia>
+							{ showRecommendedRibbon && (
+								<div className="woocommerce-task-payment__recommended-ribbon">
+									<span>
+										{ __(
+											'Recommended',
+											'woocommerce-admin'
+										) }
+									</span>
+								</div>
+							) }
+							<CardMedia isBorderless>{ before }</CardMedia>
 							<CardBody>
 								<H className="woocommerce-task-payment__title">
 									{ title }


### PR DESCRIPTION
Fixes #6351 

Update overflow visible on card media


### Screenshots
Before
<img width="689" alt="螢幕快照 2021-02-18 下午4 46 08" src="https://user-images.githubusercontent.com/56378160/108425758-e871a980-7208-11eb-90c3-b70dad9f202e.png">

After
<img width="699" alt="螢幕快照 2021-02-18 下午4 44 20" src="https://user-images.githubusercontent.com/56378160/108425766-ec9dc700-7208-11eb-9e1b-eb9e314d24cd.png">


### Detailed test instructions:

-   Go to WooCommerce home -> Store details 
-   Use the UK so Stripe is supported and not WC pay and don't select CBD industry during the setup wizard
-   See that the 'Recommended' banner renders as expected

