### PR TITLE
Fix the onTransitionEnd callback

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -86,12 +86,14 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 	};
 
 	const closePanel = () => {
-		setCurrentTab( '' );
 		setIsPanelOpen( false );
 	};
 
 	const clearPanel = () => {
-		setIsPanelSwitching( 'false' );
+		if ( ! isPanelOpen ) {
+			setIsPanelSwitching( false );
+			setCurrentTab( '' );
+		}
 	};
 
 	// On smaller screen, the panel buttons are hidden behind a toggle.

--- a/client/header/activity-panel/panel.js
+++ b/client/header/activity-panel/panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Suspense } from '@wordpress/element';
+import { Suspense, useRef, useCallback } from '@wordpress/element';
 import classnames from 'classnames';
 import { Spinner } from '@woocommerce/components';
 
@@ -31,14 +31,29 @@ export const Panel = ( {
 		}
 	};
 
+	const possibleFocusPanel = () => {
+		if ( ! containerRef.current || ! isPanelOpen || ! tab ) {
+			return;
+		}
+
+		focusOnMountRef( containerRef.current );
+	};
+
 	const finishTransition = ( e ) => {
 		if ( e && e.propertyName === 'transform' ) {
 			clearPanel();
+			possibleFocusPanel();
 		}
 	};
 
-	const ref = useFocusOnMount();
+	const focusOnMountRef = useFocusOnMount();
 	const useFocusOutsideProps = useFocusOutside( handleFocusOutside );
+	const containerRef = useRef( null );
+
+	const mergedContainerRef = useCallback( ( node ) => {
+		containerRef.current = node;
+		focusOnMountRef( node );
+	}, [] );
 
 	if ( ! tab ) {
 		return <div className="woocommerce-layout__activity-panel-wrapper" />;
@@ -64,7 +79,7 @@ export const Panel = ( {
 			aria-label={ tab.title }
 			onTransitionEnd={ finishTransition }
 			{ ...useFocusOutsideProps }
-			ref={ ref }
+			ref={ mergedContainerRef }
 		>
 			<div
 				className="woocommerce-layout__activity-panel-content"

--- a/client/header/activity-panel/panel.js
+++ b/client/header/activity-panel/panel.js
@@ -14,8 +14,8 @@ import useFocusOutside from '../../hooks/useFocusOutside';
 export const Panel = ( {
 	content,
 	isPanelOpen,
-	currentTab,
 	isPanelSwitching,
+	currentTab,
 	tab,
 	closePanel,
 	clearPanel,
@@ -28,6 +28,12 @@ export const Panel = ( {
 
 		if ( isPanelOpen && ! isClickOnModalOrSnackbar ) {
 			closePanel();
+		}
+	};
+
+	const finishTransition = ( e ) => {
+		if ( e && e.propertyName === 'transform' ) {
+			clearPanel();
 		}
 	};
 
@@ -56,8 +62,7 @@ export const Panel = ( {
 			tabIndex={ 0 }
 			role="tabpanel"
 			aria-label={ tab.title }
-			onTransitionEnd={ clearPanel }
-			onAnimationEnd={ clearPanel }
+			onTransitionEnd={ finishTransition }
 			{ ...useFocusOutsideProps }
 			ref={ ref }
 		>


### PR DESCRIPTION
Fixes #6427 

Fix the `panelSwitching` logic settings the `'false'` to be an actual boolean was the root of the issue. Did a small other fix, which keeps the focusOutside logic working on a more consistent basis.
TESTS to come :)

### Screenshots

![fix-activity-panel](https://user-images.githubusercontent.com/2240960/108908505-c194e800-75f9-11eb-80dd-0ff2f91f52d6.gif)

### Detailed test instructions:

- Open the **WooCommerce > Home** page on wp-admin.
- Click on the Help button in the top right, and check if the panel opens and closes smoothly
- You can toggle by click on the 'help' button, or clicking outside of the panel should close it as well
- Navigate to **Analytics > Overview**
- Click on the Inbox in the top right, panel should still open and close smoothly