### PR TITLE
Improve changelog linting automation

### DIFF
--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -21,7 +21,7 @@ jobs:
                   phrase: 'no-changelog'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   pr-message: 'title & body'
-                  search: '["commit_messages", "pull_request"]'
+                  search: '["pull_request"]'
             - name: Check for changelog entry
               if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip
               env:

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -1,5 +1,7 @@
 name: Lint the changelog
-on: [pull_request]
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
 
 jobs:
     lint-changelog:
@@ -13,7 +15,7 @@ jobs:
               uses: actions/checkout@v2
               if: github.event.pull_request.user.login != 'renovate'
             - name: skip-workflow
-              id: skip-workflow # id used for referencing step
+              id: skip-workflow
               uses: saulmaldonado/skip-workflow@v1.1.0
               with:
                   phrase: 'no-changelog'

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -20,6 +20,8 @@ jobs:
               with:
                   phrase: 'no-changelog'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  pr-message: 'title & body'
+                  search: '["commit_messages", "pull_request"]'
             - name: Check for changelog entry
               if: github.event.pull_request.user.login != 'renovate'
               env:

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -30,7 +30,7 @@ jobs:
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
-              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip || always()
+              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip && always()
               with:
                   access_token: ${{ github.token }}
                   label: ${{ env.label }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -18,7 +18,7 @@ jobs:
               id: skip-workflow
               uses: saulmaldonado/skip-workflow@v1.1.0
               with:
-                  phrase: /^no changelog/i
+                  phrase: /no changelog/i
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   pr-message: 'body'
                   search: '["pull_request"]'

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -18,7 +18,7 @@ jobs:
               id: skip-workflow
               uses: saulmaldonado/skip-workflow@v1.1.0
               with:
-                  phrase: 'no-changelog'
+                  phrase: /^no changelog/i
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   pr-message: 'body'
                   search: '["pull_request"]'

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -11,14 +11,22 @@ jobs:
                   access_token: ${{ github.token }}
             - name: Check out repository code
               uses: actions/checkout@v2
+              if: github.event.pull_request.user.login != 'renovate'
+            - name: skip-workflow
+              id: skip-workflow # id used for referencing step
+              uses: saulmaldonado/skip-workflow@v1
+              with:
+                  phrase: 'no-changelog'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Check for changelog entry
+              if: github.event.pull_request.user.login != 'renovate'
               env:
                   PR_NUMBER: ${{github.event.number}}
               run: bin/ci/lint-changelog.sh
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
-              if: ${{ always() }}
+              if: ${{ github.event.pull_request.user.login != 'renovate' || always() }}
               with:
                   access_token: ${{ github.token }}
                   label: ${{ env.label }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -14,7 +14,7 @@ jobs:
               if: github.event.pull_request.user.login != 'renovate'
             - name: skip-workflow
               id: skip-workflow # id used for referencing step
-              uses: saulmaldonado/skip-workflow@v1
+              uses: saulmaldonado/skip-workflow@v1.1.0
               with:
                   phrase: 'no-changelog'
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -23,14 +23,14 @@ jobs:
                   pr-message: 'title & body'
                   search: '["commit_messages", "pull_request"]'
             - name: Check for changelog entry
-              if: github.event.pull_request.user.login != 'renovate'
+              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip
               env:
                   PR_NUMBER: ${{github.event.number}}
               run: bin/ci/lint-changelog.sh
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
-              if: ${{ github.event.pull_request.user.login != 'renovate' || always() }}
+              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip || always()
               with:
                   access_token: ${{ github.token }}
                   label: ${{ env.label }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   phrase: 'no-changelog'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  pr-message: 'title & body'
+                  pr-message: 'body'
                   search: '["pull_request"]'
             - name: Check for changelog entry
               if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip


### PR DESCRIPTION
This adds some extra logic and steps to the changelog linting workflow that hopefully makes it more useful.

The workflow now is that the lint will check your PR description for the phrase `no changelog` (case insensitive). If it detects this it will skip the linting and the check will automatically pass, also a label will not be added to remind you to add a changelog.

Furthermore the lint now happens every time you edit the PR description, so if you would like to add the `no changelog` tag later on you can do this.

The only thing this won't do is in the case that the label was added during an initial check, then you added the skip phrase later it won't remove the label for you afterwards. I evaluated the complexity of this and for now it didn't feel worth trying to achieve this. It's my thought that it is 1 click to remove the label yourself if you hit this case.

I won't be switching this check to required just yet, but in theory I think it's more robust to do that after these changes are merged.

The skip phrase is contained in this pr description so it won't lint changelog and will pass:

<img width="834" alt="Screenshot 2021-02-25 at 11 37 00 AM" src="https://user-images.githubusercontent.com/1281828/109075973-be673c80-775e-11eb-9b7c-d39e6dd39a80.png">

And then editing the PR description and removing the skip:

<img width="832" alt="Screenshot 2021-02-25 at 11 45 26 AM" src="https://user-images.githubusercontent.com/1281828/109076154-038b6e80-775f-11eb-98ad-47799d9d1a1f.png">