### PR TITLE
Update Broken Link Anchors to Online Support

### DIFF
--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -41,22 +41,22 @@ function getHomeItems() {
 		{
 			title: __( 'Inbox', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-1',
+				'https://docs.woocommerce.com/document/home-screen/#section-2',
 		},
 		{
 			title: __( 'Stats Overview', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-2',
+				'https://docs.woocommerce.com/document/home-screen/#section-4',
 		},
 		{
 			title: __( 'Store Management', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-3',
+				'https://docs.woocommerce.com/document/home-screen/#section-5',
 		},
 		{
 			title: __( 'Store Setup Checklist', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-setup-wizard/#section-9',
+				'https://docs.woocommerce.com/document/woocommerce-setup-wizard/#store-setup-checklist',
 		},
 	];
 }

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add navigation favorites data store #6275
 - Add: Add navigation intro modal. #6367
 - Fix: Reset Navigation submenu before making Flyout #6396
+- Fix: Broken link anchors to online documentation. #6455
 
 == 2.0.0 02/05/2021 ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: support use of Array.flat in client and packages. #6411
 - Fix: Correct the Klarna slug #6440
 - Tweak: Refactor autoloader to remove global variable. #6412
+- Fix: Broken link anchors to online documentation. #6455
 
 == 2.1.0 ==
 
@@ -126,7 +127,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add navigation favorites data store #6275
 - Add: Add navigation intro modal. #6367
 - Fix: Reset Navigation submenu before making Flyout #6396
-- Fix: Broken link anchors to online documentation. #6455
 
 == 2.0.0 02/05/2021 ==
 


### PR DESCRIPTION
Fixes #6426

Updates the link anchors to woocommerce.com online documentation to match the correct section in the document.

Note: I have[ added testing instructions](https://github.com/woocommerce/woocommerce-admin/wiki/Smoke-Test-Checklist#help-panel) for this to our Smoke Test Checklist, since I feel these links are subject change on woocommerce.com’s end. As such, no testing instructions need to be committed.

### Screenshots

<img width="520" alt="Screen Shot 2021-02-26 at 1 20 32 pm" src="https://user-images.githubusercontent.com/9312929/109258605-867ef880-7835-11eb-95e1-c8aa9e932058.png">

### Detailed test instructions:

-   Go to the "Help" panel on Home screen.
-   For each of the help items, ensure they link to appropriate documentation on woocommerce.com