### PR TITLE
Checking if navigation is in the process of being enabled while initializing

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Navigation: Correct error thrown when enabling #6462
+
+1. Create a fresh store
+2. Navigate to WooCommerce -> Settings -> Advanced Tab -> Features
+3. Check the box to add the new navigation feature, and hit save
+4. Ensure that the new navigation appears on the left as expected
+
 ### Deprecate Onboarding::has_woocommerce_support #6401
 
 - Clear existing site transients. For example, by using the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin, and pressing the "Delete all transients" button it provides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,16 +8380,6 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
 			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
 		},
-		"@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "4.15.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
@@ -8786,7 +8776,11 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs2": "7.12.5",
-				"@woocommerce/csv-export": "1.2.0",
+				"@woocommerce/csv-export": "1.3.0",
+				"@woocommerce/currency": "3.0.0",
+				"@woocommerce/data": "1.1.1",
+				"@woocommerce/date": "2.1.0",
+				"@woocommerce/navigation": "5.2.0",
 				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/compose": "3.23.1",
@@ -8821,24 +8815,24 @@
 			},
 			"dependencies": {
 				"@woocommerce/csv-export": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.2.0.tgz",
-					"integrity": "sha512-86kNC0C79YnaRv35zCo134p9mAXFz9y6JExcXCVLPgwvDqj9BOr8aWvgWuRBO7uOIdhFbOuK4rd4i/WNpPjPyw==",
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.3.0.tgz",
+					"integrity": "sha512-++JfLjhmK+B++5ogy1f0OB2lLoqDSY0lZ2oKc/b3S7BvYQWcRP5N1u5D+AYcoQMUWJLI+EH52Bkp+ivwVeUAJQ==",
 					"dev": true,
 					"requires": {
-						"@babel/runtime-corejs2": "7.7.4",
+						"@babel/runtime-corejs2": "7.10.5",
 						"browser-filesaver": "1.1.1",
-						"moment": "2.22.2"
+						"moment": "2.27.0"
 					},
 					"dependencies": {
 						"@babel/runtime-corejs2": {
-							"version": "7.7.4",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-							"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+							"version": "7.10.5",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+							"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
 							"dev": true,
 							"requires": {
 								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.2"
+								"regenerator-runtime": "^0.13.4"
 							}
 						},
 						"core-js": {
@@ -8848,9 +8842,9 @@
 							"dev": true
 						},
 						"moment": {
-							"version": "2.22.2",
-							"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-							"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+							"version": "2.27.0",
+							"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+							"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
 							"dev": true
 						}
 					}
@@ -9090,28 +9084,29 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs2": "7.12.5",
-				"@woocommerce/number": "2.0.0",
+				"@woocommerce/number": "2.1.0",
 				"@wordpress/deprecated": "^2.9.0",
 				"@wordpress/html-entities": "2.10.0"
 			},
 			"dependencies": {
 				"@woocommerce/number": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
-					"integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.1.0.tgz",
+					"integrity": "sha512-3junwiGMZ9u096EqYkeAJQlEstQl1TW79hENJLNwxYBvIGkmby5oF8AOIT81+/mwphKuszUL9fNcY22RTCbA4w==",
 					"dev": true,
 					"requires": {
-						"@babel/runtime-corejs2": "7.7.4"
+						"@babel/runtime-corejs2": "7.10.5",
+						"locutus": "2.0.11"
 					},
 					"dependencies": {
 						"@babel/runtime-corejs2": {
-							"version": "7.7.4",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-							"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+							"version": "7.10.5",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+							"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
 							"dev": true,
 							"requires": {
 								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.2"
+								"regenerator-runtime": "^0.13.4"
 							}
 						}
 					}
@@ -9207,6 +9202,8 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime-corejs2": "7.12.5",
+				"@woocommerce/date": "2.1.0",
+				"@woocommerce/navigation": "5.2.0",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -11708,6 +11705,12 @@
 						"fill-range": "^7.0.1"
 					}
 				},
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11916,6 +11919,18 @@
 						"debug": "^4.1.1",
 						"get-stream": "^5.1.0",
 						"yauzl": "^2.10.0"
+					},
+					"dependencies": {
+						"@types/yauzl": {
+							"version": "2.9.1",
+							"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+							"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"@types/node": "*"
+							}
+						}
 					}
 				},
 				"fast-glob": {
@@ -12561,6 +12576,30 @@
 						"tar-fs": "^2.0.0",
 						"unbzip2-stream": "^1.3.3",
 						"ws": "^7.2.3"
+					},
+					"dependencies": {
+						"tar-fs": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+							"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+							"dev": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"mkdirp-classic": "^0.5.2",
+								"pump": "^3.0.0",
+								"tar-stream": "^2.1.4"
+							}
+						},
+						"unbzip2-stream": {
+							"version": "1.4.3",
+							"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+							"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.2.1",
+								"through": "^2.3.8"
+							}
+						}
 					}
 				},
 				"read-pkg": {
@@ -27170,6 +27209,15 @@
 				"path-exists": "^3.0.0"
 			}
 		},
+		"locutus": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.2.5"
+			}
+		},
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -36671,26 +36719,6 @@
 				}
 			}
 		},
-		"tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				}
-			}
-		},
 		"tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -37493,16 +37521,6 @@
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 			"dev": true
-		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			}
 		},
 		"unc-path-regex": {
 			"version": "0.1.2",

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Changelog ==
 
 == Unreleased ==
-
+- Fix: Add check for navigating being enabled. #6462
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 - Dev: Remove Google fonts and material icons. #6343
 - Add: Remove CES actions for adding and editing a product and editing an order #6355

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -111,6 +111,11 @@ class Init {
 		$has_option_disabled = 'yes' !== get_option( self::TOGGLE_OPTION_NAME, 'no' );
 		$is_not_compatible   = ! self::is_nav_compatible();
 
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if ( $has_option_disabled && isset( $_POST['woocommerce_navigation_enabled'] ) && '1' === $_POST['woocommerce_navigation_enabled'] ) {
+			$has_option_disabled = false;
+		}
+
 		if ( ( $has_feature_enabled && $has_option_disabled ) || $is_not_compatible ) {
 			$features = array_diff( $features, array( 'navigation' ) );
 		}


### PR DESCRIPTION
Fixes #6423

GlobalStep encountered the described UI issue when enabling the WC Nav via the Settings -> Advanced -> Features page. It looks like this was stemming from the option not updating before the Navigation feature was checking it, so on first pass it still did not initialize properly. 

I've added a check to see if the navigation is _in the process of_ being enabled. 

_Note:_ I tried to include nonce verification, but ran into some confusion. I noticed that this was being suppressed via comment elsewhere in the repo, and it doesn't seem at all consequential to do so for this use case. 

### Detailed test instructions:

-   You need to use a fresh site to reproduce this bug
-   Add WooCommerce, and this branch for WC-Admin
- Go to Settings -> Advanced -> Features and enable the new navigation
- Observe that there is no UI issue, and the navigation appears as expected

If you like, you can take a snapshot of your database _before_ enabling the navigation, and follow the steps for the `main` branch to observe the issue.

