### PR TITLE
Add legacy report items to new navigation

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Add legacy report items to new navigation #6507
+
+1. Enable the new navigation experience.
+2. Navigate to Analytics->Reports.
+3. Note that all the reports exist and navigating to those reports works as expected.
+4. Check that report menu items are marked active when navigating to that page.
+
 ### Fix double prefixing of navigation URLs #6460
 
 1. Register a navigation menu item with a full URL or admin link.

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -75,6 +75,7 @@ body.is-wc-nav-folded {
 		display: none !important;
 	}
 
+	&.woocommerce_page_wc-reports,
 	&.woocommerce_page_wc-settings,
 	&.woocommerce_page_wc-status {
 		.woo-nav-tab-wrapper {

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Add: Add legacy report items to new navigation #6507
 - Dev: Add initial tests for navigation Menu class #6492
 - Fix: Add check for navigating being enabled. #6462
 - Dev: Add nav favorite button tests #6446

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -96,6 +96,12 @@ class CoreMenu {
 				'order' => 30,
 			),
 			array(
+				'title'  => __( 'Reports', 'woocommerce-admin' ),
+				'id'     => 'woocommerce-reports',
+				'parent' => 'woocommerce-analytics',
+				'order'  => 200,
+			),
+			array(
 				'title' => __( 'Marketing', 'woocommerce-admin' ),
 				'id'    => 'woocommerce-marketing',
 				'order' => 40,
@@ -264,8 +270,35 @@ class CoreMenu {
 			// WooCommerce Admin items.
 			$wca_items,
 			// Settings category.
-			$setting_items
+			$setting_items,
+			// Legacy report items.
+			self::get_legacy_report_items()
 		);
+	}
+
+	/**
+	 * Get legacy report items.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_report_items() {
+		$reports    = \WC_Admin_Reports::get_reports();
+		$menu_items = array();
+
+		$order = 0;
+		foreach ( $reports as $key => $report ) {
+			$menu_items[] = array(
+				'parent'     => 'woocommerce-reports',
+				'title'      => $report['title'],
+				'capability' => 'view_woocommerce_reports',
+				'id'         => $key,
+				'url'        => 'wc-reports&tab=' . $key,
+				'order'      => $order,
+			);
+			$order++;
+		}
+
+		return $menu_items;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6476

Adds in the legacy reports to the new navigation experience.

### Screenshots

<img width="590" alt="Screen Shot 2021-03-03 at 4 51 48 PM" src="https://user-images.githubusercontent.com/10561050/109877241-c3395e00-7c40-11eb-80a5-e6302c0e0108.png">


### Detailed test instructions:

1. Enable the new navigation experience.
2. Navigate to Analytics->Reports.
3. Note that all the reports exist and navigating to those reports works as expected.
4. Check that report menu items are marked active when navigating to that page.