### PR TITLE
Business features step: include Mailpoet

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -29,7 +29,6 @@
 
 - Create a brand new site and go to the OBW.
 - In the first OBW step (`Store Details`) set `US` in the `Country / Region` selector.
-- Set `Food and drink` in the second step (`Industry`)
 - Continue with the profiler.
 - In the 4th step (`Business Details`) choose any of the options in both selectors.
 - Under `Free features` tab, verify that the displayed extensions are:

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -25,6 +25,24 @@
 4. Navigate to other tasks such as "Store Details" or "Add products" .
 5. The "Preview Site" should not be shown on the other tasks.
 
+### Store profiler - Added MailPoet to new Business Details step  #6515
+
+- Create a brand new site and go to the OBW.
+- In the first OBW step (`Store Details`) set `US` in the `Country / Region` selector.
+- Set `Food and drink` in the second step (`Industry`)
+- Continue with the profiler.
+- In the 4th step (`Business Details`) choose any of the options in both selectors.
+- Under `Free features` tab, verify that the displayed extensions are:
+```
+Mailpoet
+Facebook
+Google Ads
+Mailchimp
+Creative Mail
+```
+(In that order)
+- Verify that the Creative Mail option copy is `Emails made easy with Creative Mail`.
+
 ### Store profiler - Added MailPoet to Business Details step  #6503
 
 - Create a brand new site and go to the OBW.

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -24,7 +24,12 @@ import { setAllPropsToValue } from '../../../../../../lib/collections';
 import { getCountryCode } from '../../../../../../dashboard/utils';
 import { isWCPaySupported } from '../../../../../../task-list/tasks/payments/wcpay';
 
-const generatePluginDescriptionWithLink = ( description, productName ) => {
+const generatePluginDescriptionWithLink = (
+	description,
+	productName,
+	linkURL
+) => {
+	const url = linkURL ?? `https://woocommerce.com/products/${ productName }`;
 	return interpolateComponents( {
 		mixedString: description,
 		components: {
@@ -33,7 +38,7 @@ const generatePluginDescriptionWithLink = ( description, productName ) => {
 					type="external"
 					target="_blank"
 					className="woocommerce-admin__business-details__selective-extensions-bundle__link"
-					href={ `https://woocommerce.com/products/${ productName }` }
+					href={ url }
 				/>
 			),
 		},
@@ -87,6 +92,17 @@ const installableExtensions = [
 	{
 		title: 'Grow your store',
 		plugins: [
+			{
+				slug: 'mailpoet',
+				description: generatePluginDescriptionWithLink(
+					__(
+						'Level up your email marketing with {{link}}Mailpoet{{/link}}',
+						'woocommerce-admin'
+					),
+					'mailpoet',
+					'https://wordpress.org/plugins/mailpoet/'
+				),
+			},
 			{
 				slug: 'facebook-for-woocommerce',
 				description: generatePluginDescriptionWithLink(

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -137,7 +137,7 @@ const installableExtensions = [
 				slug: 'creative-mail-by-constant-contact',
 				description: generatePluginDescriptionWithLink(
 					__(
-						'Reach new customers with {{link}}Creative Mail{{/link}}',
+						'Emails made easy with {{link}}Creative Mail{{/link}}',
 						'woocommerce-admin'
 					),
 					'creative-mail-for-woocommerce'

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Feature: Increase target audience for business feature step. #6508
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
+- Dev: Store profiler - Added MailPoet to new Business Details step  #6515
 
 == 2.1.0 ==
 

--- a/tests/e2e/specs/activate-and-setup/complete-business-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-business-section.js
@@ -75,7 +75,7 @@ export async function unselectAllFeaturesAndContinue(
 	await waitForElementCount(
 		page,
 		'.components-checkbox-control__input',
-		shouldWCPayBeListed ? 8 : 7
+		shouldWCPayBeListed ? 9 : 8
 	);
 	const wcPayLabel = await getElementByText( 'a', 'WooCommerce Payments' );
 	if ( shouldWCPayBeListed ) {


### PR DESCRIPTION
Fixes #6489

This is a follow-up to [PR 6503](https://github.com/woocommerce/woocommerce-admin/pull/6503).
Here the "MailPoet" option is added to the new Business Details step in the OBW.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2021 03 03-17_08_23](https://user-images.githubusercontent.com/1314156/109865761-36dc6a80-7c43-11eb-85af-03fd425f5222.png)


### Detailed test instructions:

- Create a brand new site and go to the OBW.
- In the first OBW step (`Store Details`) set `US` in the `Country / Region` selector.
- Set `Food and drink` in the second step (`Industry`)
- Continue with the profiler.
- In the 4th step (`Business Details`) choose any of the options in both selectors.
- Under `Free features` tab, verify that the displayed extensions are:
```
Mailpoet
Facebook
Google Ads
Mailchimp
Creative Mail
```
(In that order)
- Verify that the Creative Mail option copy is `Emails made easy with Creative Mail`.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
