### PR TITLE
Add tilde (~) option for client root directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
 	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
+	settings: {
+		'import/resolver': 'webpack',
+	},
 	rules: {
 		// temporary conversion to warnings until the below are all handled.
 		'@wordpress/i18n-translator-comments': 'warn',

--- a/client/profile-wizard/steps/business-details/data/revenue-options.js
+++ b/client/profile-wizard/steps/business-details/data/revenue-options.js
@@ -8,7 +8,7 @@ import CurrencyFactory from '@woocommerce/currency';
 /**
  * Internal dependencies
  */
-import { getCurrencyRegion } from '../../../../dashboard/utils';
+import { getCurrencyRegion } from '~/dashboard/utils';
 import { getNumberRangeString } from './product-options';
 
 const { formatAmount } = CurrencyFactory( CURRENCY );

--- a/client/profile-wizard/steps/business-details/data/segmentation.js
+++ b/client/profile-wizard/steps/business-details/data/segmentation.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getCountryCode } from '../../../../dashboard/utils';
+import { getCountryCode } from '~/dashboard/utils';
 
 // Determine if a store should see the selective bundle install a/b experiment based on country and chosen industries
 // from the profile wizard.

--- a/client/profile-wizard/steps/business-details/flows/bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/bundle/index.js
@@ -28,8 +28,8 @@ import { Text } from '@woocommerce/experimental';
 /**
  * Internal dependencies
  */
-import { CurrencyContext } from '../../../../../lib/currency-context';
-import { createNoticesFromResponse } from '../../../../../lib/notices';
+import { CurrencyContext } from '~/lib/currency-context';
+import { createNoticesFromResponse } from '~/lib/notices';
 import { extensionBenefits } from '../../data/extension-benefits';
 import { sellingVenueOptions } from '../../data/selling-venue-options';
 import { platformOptions } from '../../data/platform-options';

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -24,8 +24,8 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { CurrencyContext } from '../../../../../lib/currency-context';
-import { createNoticesFromResponse } from '../../../../../lib/notices';
+import { CurrencyContext } from '~/lib/currency-context';
+import { createNoticesFromResponse } from '~/lib/notices';
 import { platformOptions } from '../../data/platform-options';
 import { sellingVenueOptions } from '../../data/selling-venue-options';
 import { getRevenueOptions } from '../../data/revenue-options';

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -20,9 +20,9 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { AppIllustration } from '../app-illustration';
 import './style.scss';
-import { setAllPropsToValue } from '../../../../../../lib/collections';
-import { getCountryCode } from '../../../../../../dashboard/utils';
-import { isWCPaySupported } from '../../../../../../task-list/tasks/payments/wcpay';
+import { setAllPropsToValue } from '~/lib/collections';
+import { getCountryCode } from '~/dashboard/utils';
+import { isWCPaySupported } from '~/task-list/tasks/payments/wcpay';
 
 const generatePluginDescriptionWithLink = ( description, productName ) => {
 	return interpolateComponents( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14179,6 +14179,12 @@
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
 			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
 		},
+		"array-find": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+			"dev": true
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -20265,6 +20271,64 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				}
+			}
+		},
+		"eslint-import-resolver-webpack": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.0.tgz",
+			"integrity": "sha512-hZWGcmjaJZK/WSCYGI/y4+FMGQZT+cwW/1E/P4rDwFj2PbanlQHISViw4ccDJ+2wxAqjgwBfxwy3seABbVKDEw==",
+			"dev": true,
+			"requires": {
+				"array-find": "^1.0.0",
+				"debug": "^2.6.9",
+				"enhanced-resolve": "^0.9.1",
+				"find-root": "^1.1.0",
+				"has": "^1.0.3",
+				"interpret": "^1.2.0",
+				"lodash": "^4.17.15",
+				"node-libs-browser": "^1.0.0 || ^2.0.0",
+				"resolve": "^1.13.1",
+				"semver": "^5.7.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"enhanced-resolve": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+					"integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.2.0",
+						"tapable": "^0.1.8"
+					}
+				},
+				"interpret": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+					"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+					"dev": true
+				},
+				"memory-fs": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+					"integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+					"dev": true
+				},
+				"tapable": {
+					"version": "0.1.10",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+					"integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
 		"cross-env": "7.0.3",
 		"css-loader": "3.6.0",
 		"docsify-cli": "4.4.2",
+		"eslint-import-resolver-webpack": "^0.13.0",
 		"eslint-plugin-import": "^2.22.1",
 		"fork-ts-checker-webpack-plugin": "^6.1.0",
 		"fs-extra": "8.1.0",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Updated `dependency-group` rule to have imports starting with `~/` labeled as local. #6517
+
 # 1.1.0
 
 -   Updated `@wordpress/eslint-plugin` dependency to latest version.

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -33,7 +33,7 @@ module.exports = {
 		 * @return {WCPackageLocality} Package locality.
 		 */
 		function getPackageLocality( source ) {
-			if ( source.startsWith( '.' ) ) {
+			if ( source.startsWith( '.' ) || source.startsWith( '~/' ) ) {
 				return 'Internal';
 			}
 			return 'External';

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Remote Inbox Notifications rule to trigger when WooCommerce Admin is upgraded. #6040
 - Feature: Increase target audience for business feature step. #6508
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
+- Dev: Add tilde (~) to represent client root directory for imports. #6517
 
 == 2.1.0 3/10/2021  ==
 

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -9,6 +9,7 @@
 		"tinymce": "<rootDir>/tests/js/mocks/tinymce",
 		"@woocommerce/(settings|wc-admin-settings)": "<rootDir>/client/wc-admin-settings/index.js",
 		"@woocommerce/(.*)": "<rootDir>/packages/$1/src",
+		"~/(.*)": "<rootDir>/client/$1",
 		"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/js/mocks/static",
 		"\\.(scss|css)$": "<rootDir>/tests/js/mocks/style-mock.js"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,10 @@
 		"skipLibCheck": false,
 		"module": "esnext",
 		"typeRoots": [ "**/node_modules/@types" ],
-		"baseUrl": "./client",
+		"baseUrl": "./",
 		"paths": {
-			"@woocommerce/*": [ "../packages/*/src" ],
-			"~/*": [ "../client/*" ]
+			"@woocommerce/*": [ "packages/*/src" ],
+			"~/*": [ "client/*" ]
 		}
 	},
 	"exclude": [ "node_modules", "build", "build-module", "dist", "vendor" ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
 		"typeRoots": [ "**/node_modules/@types" ],
 		"baseUrl": "./client",
 		"paths": {
-			"@woocommerce/*": [ "../packages/*/src" ]
+			"@woocommerce/*": [ "../packages/*/src" ],
+			"~/*": [ "../client/*" ]
 		}
 	},
 	"exclude": [ "node_modules", "build", "build-module", "dist", "vendor" ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,6 +146,7 @@ const webpackConfig = {
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		alias: {
+			'~': path.resolve( __dirname + '/client' ),
 			'gutenberg-components': path.resolve(
 				__dirname,
 				'node_modules/@wordpress/components/src'


### PR DESCRIPTION
Allow files to import items from the root client directory by using `~`.
Example:
`import * from '~/dashboard/components'`

If you prefer a relative import auto complete in your vscode you could set this setting:
`"javascript.preferences.importModuleSpecifier": "relative"`
Or if you want vscode to decide for you use:
`"javascript.preferences.importModuleSpecifier": "shortest"`

### Screenshots

<img width="685" alt="Screen Shot 2021-03-04 at 12 38 11 PM" src="https://user-images.githubusercontent.com/2240960/109997358-8162f300-7ce6-11eb-82b4-8890b3f0395c.png">

### Detailed test instructions:

- Load this branch and build the app `npm run dev`, there should be no errors and the app should work fine.
- Update one of the components that are using a local import and switch to using the `~/`
- It should update fine, and the app should still work as intended.
- In VSCode when importing with `~/` it should correctly show autocomplete (you might have to restart the TS server for this) 
  In Vscode you can do that by CMD+Shift+p and typing Restart TS server (it should show the option to restart).
- Run `npm run lint`, there should be no errors.
