### PR TITLE
Fix for the Utilities page title

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -172,7 +172,7 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 6. Check that the users are able to see the new navigation menu.
 7. Click on various tabs in the activity panel.
 8. Make sure the tabs work as expected.
-9. Make sure that users without the `manage_woocommerce` permission are not able to see the "Store Setup" tab.
+9. Make sure that users without the `manage_woocommerce` permission are not able to see the "Finish setup" tab.
 10. With a user that can `manage_woocommerce`, navigate to the homepage via URL and make sure the homescreen is shown. `/wp-admin/admin.php?page=wc-admin`
 11. With a user that cannot `view_woocommerce_reports` make sure navigating to an analytics report does not work. `/wp-admin/admin.php?page=wc-admin&path=/analytics/overview`
 

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -131,7 +131,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 
 		const setup = {
 			name: 'setup',
-			title: __( 'Store Setup', 'woocommerce-admin' ),
+			title: __( 'Finish setup', 'woocommerce-admin' ),
 			icon: <SetupProgress />,
 			onClick: () => {
 				const currentLocation = window.location.href;

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -43,7 +43,6 @@
 		background: $studio-white;
 		font-weight: 600;
 		font-size: 14px;
-		text-transform: capitalize;
 	}
 }
 

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -241,7 +241,7 @@ class CoreMenu {
 					'title'      => __( 'Utilities', 'woocommerce-admin' ),
 					'capability' => 'manage_woocommerce',
 					'id'         => 'tools-utilities',
-					'url'        => 'admin.php?page=wc-status&tab=tools',
+					'url'        => 'admin.php?page=wc-status&tab=utilities',
 					'order'      => 30,
 				),
 				array(
@@ -254,7 +254,7 @@ class CoreMenu {
 				),
 				array(
 					'parent'     => 'woocommerce-tools',
-					'title'      => __( 'Scheduled Actions', 'woocommerce-admin' ),
+					'title'      => __( 'Scheduled actions', 'woocommerce-admin' ),
 					'capability' => 'manage_woocommerce',
 					'id'         => 'tools-scheduled_actions',
 					'url'        => 'admin.php?page=wc-status&tab=action-scheduler',


### PR DESCRIPTION
Minor changes and things I still need assistance with.
- Tried to get `Utilities` to show up correctly in the header but for some reason it's still not showing up there. This is in Tools > Utilities with the new navigation.


<img width="160" alt="Screen Shot 2021-03-05 at 10 06 35 AM" src="https://user-images.githubusercontent.com/5121465/110141159-7ff30280-7d9a-11eb-8910-5f8486293765.png">

- Updated the "Store Setup" link in the app bar with "Finish setup". This is to make the link more of a call to action. Also updated the test instructions but there's another file with Store Setup queries that I didn't touch.



- Minor change to the header title by removing the `TextTransform: Capitalize`. I checked that this doesn't impact extensions. Actually, this doesn't impact anything...