### PR TITLE
Remove rest API props from onboarding confirmed as no longer used.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Missing i18n in Welcome modal. #6456
 - Fix: Restore visual styles back to Analytics tabs. #5913
 - Add: Add a "rather not say" option to revenue in the profile wizard. #6475
+- Dev: Remove `items_purchased` and `account_type` props from onboarding profile API. #6520
 
 == 2.1.0 ==
 

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -240,18 +240,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'installed',
 				),
 			),
-			'account_type'        => array(
-				'type'              => 'string',
-				'description'       => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-				'enum'              => array(
-					'new',
-					'existing',
-					'google',
-				),
-			),
 			'industry'            => array(
 				'type'              => 'array',
 				'description'       => __( 'Industry.', 'woocommerce-admin' ),
@@ -369,13 +357,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'sanitize_callback' => 'sanitize_title_with_dashes',
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'items_purchased'     => array(
-				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'setup_client'        => array(

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -104,7 +104,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 16, $properties );
+		$this->assertCount( 14, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -107,7 +107,6 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertCount( 16, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
-		$this->assertArrayHasKey( 'account_type', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
 		$this->assertArrayHasKey( 'product_types', $properties );
 		$this->assertArrayHasKey( 'product_count', $properties );
@@ -118,7 +117,6 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'business_extensions', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );
 		$this->assertArrayHasKey( 'wccom_connected', $properties );
-		$this->assertArrayHasKey( 'items_purchased', $properties );
 		$this->assertArrayHasKey( 'plugins', $properties );
 		$this->assertArrayHasKey( 'setup_client', $properties );
 	}


### PR DESCRIPTION
I've chatted with a few people to confirm this, we're not using these REST API props any more so now they can be removed.

The only risk I was really concerned with was if these props existed already in a user's onboarding profile and we tried to wholesale update a users profile. As far as I can tell this is not an issue, we always update only a select few props at a time and none of our existing code touches these properties.