### PR TITLE
Change "Store Setup" link in top bar to "Finish setup"

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -131,7 +131,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 
 		const setup = {
 			name: 'setup',
-			title: __( 'Store Setup', 'woocommerce-admin' ),
+			title: __( 'Finish setup', 'woocommerce-admin' ),
 			icon: <SetupProgress />,
 			onClick: () => {
 				const currentLocation = window.location.href;

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -144,7 +144,7 @@ describe( 'Activity Panel', () => {
 		expect( screen.getByText( '[DisplayOptions]' ) ).toBeDefined();
 	} );
 
-	it( 'should only render the store setup link when TaskList is not complete', () => {
+	it( 'should only render the finish setup link when TaskList is not complete', () => {
 		const { queryByText, rerender } = render(
 			<ActivityPanel
 				query={ {
@@ -153,7 +153,7 @@ describe( 'Activity Panel', () => {
 			/>
 		);
 
-		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+		expect( queryByText( 'Finish setup' ) ).toBeDefined();
 
 		useSelect.mockImplementation( () => ( {
 			requestingTaskListOptions: false,
@@ -169,10 +169,10 @@ describe( 'Activity Panel', () => {
 			/>
 		);
 
-		expect( queryByText( 'Store Setup' ) ).toBeNull();
+		expect( queryByText( 'Finish setup' ) ).toBeNull();
 	} );
 
-	it( 'should not render the store setup link when on the home screen and TaskList is not complete', () => {
+	it( 'should not render the finish setup link when on the home screen and TaskList is not complete', () => {
 		const { queryByText } = render(
 			<ActivityPanel
 				query={ {
@@ -182,18 +182,18 @@ describe( 'Activity Panel', () => {
 			/>
 		);
 
-		expect( queryByText( 'Store Setup' ) ).toBeNull();
+		expect( queryByText( 'Finish setup' ) ).toBeNull();
 	} );
 
-	it( 'should render the store setup link when on embedded pages and TaskList is not complete', () => {
+	it( 'should render the finish setup link when on embedded pages and TaskList is not complete', () => {
 		const { getByText } = render(
 			<ActivityPanel isEmbedded query={ {} } />
 		);
 
-		expect( getByText( 'Store Setup' ) ).toBeInTheDocument();
+		expect( getByText( 'Finish setup' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should not render the store setup link when a user does not have capabilties', () => {
+	it( 'should not render the finish setup link when a user does not have capabilties', () => {
 		useUser.mockImplementation( () => ( {
 			currentUserCan: () => false,
 		} ) );
@@ -206,7 +206,7 @@ describe( 'Activity Panel', () => {
 			/>
 		);
 
-		expect( queryByText( 'Store Setup' ) ).toBeDefined();
+		expect( queryByText( 'Finish setup' ) ).toBeDefined();
 	} );
 
 	describe( 'help panel tooltip', () => {


### PR DESCRIPTION
This is a small tweak to the "Store setup" link in the top bar that only appears when the store setup task list isn't complete.

<img width="160" alt="Screen Shot 2021-03-05 at 10 06 35 AM" src="https://user-images.githubusercontent.com/5121465/110144879-75d30300-7d9e-11eb-85e6-c5b8c89a9e00.png">

Using a verb in "Finish setup" makes the link more actionable. Also, this update uses sentence case rather than title case.

Just a note that I also changed the tests but would be great if someone had a look to make sure everything there is still ok.

cc @pmcpinto 

No changelog required