### PR TITLE
Revert minimum WooCommerce version to 3.6

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -7,7 +7,7 @@
 1. Download the [WooCommerce 4.7 zip](https://downloads.wordpress.org/plugin/woocommerce.4.7.0.zip)and install it on the site.
 2. See that there are no fatal errors on site frontend or wp-admin dashboard.
 3. Update WooCommerce to the latest version from WP Admin
-4. See that there are no fatal errors on site frontend or wp-admin dashboard.
+4. Perform some smoke tests to see that WooCommerce Admin works as expected.
 
 ### Add legacy report items to new navigation #6507
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Revert minimum WooCommerce version to 3.6 #6531
+
+1. Download the [WooCommerce 4.7 zip](https://downloads.wordpress.org/plugin/woocommerce.4.7.0.zip)and install it on the site.
+2. See that there are no fatal errors on site frontend or wp-admin dashboard.
+3. Update WooCommerce to the latest version from WP Admin
+4. See that there are no fatal errors on site frontend or wp-admin dashboard.
+
 ### Add legacy report items to new navigation #6507
 
 1. Enable the new navigation experience.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Added warning when WC-Admin is active but not being used #6453
 - Add: Remove Mollie promo note on install #6510
 - Add: Remote Inbox Notifications rule to trigger when WooCommerce Admin is upgraded. #6040
+- Fix: Fatal error when WooCommerce 4.7 or lower is installed. #6531
 
 == 2.1.0 ==
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -221,7 +221,7 @@ class FeaturePlugin {
 		$errors                      = array();
 		$wordpress_version           = get_bloginfo( 'version' );
 		$minimum_wordpress_version   = '5.4';
-		$minimum_woocommerce_version = '4.8';
+		$minimum_woocommerce_version = '3.6'; // Don't bump this until this https://github.com/woocommerce/woocommerce-admin/issues/6530 is resolved.
 		$wordpress_minimum_met       = version_compare( $wordpress_version, $minimum_wordpress_version, '>=' );
 		$woocommerce_minimum_met     = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, $minimum_woocommerce_version, '>=' );
 


### PR DESCRIPTION
Fixes #6527

This is intended as a quick fix to prevent a fatal error when WooCommerce 4.7 or lower is installed.

It reverts a [recent version bump for the minimum WooCommerce version.](https://github.com/woocommerce/woocommerce-admin/pull/6342/files#diff-7abab38864f4a11fb2f48f09381a6086c791611d96892153da3e90f161b76a8bL223-R224)

It should be followed up with a fix to address the issues with the "Deactivate old WooCommerce Admin version" note described in https://github.com/woocommerce/woocommerce-admin/issues/6530.

### Detailed test instructions:

-   Download the [WooCommerce 4.7 zip](https://downloads.wordpress.org/plugin/woocommerce.4.7.0.zip) and install it on the site.
-  See that there are no fatal errors on site frontend or wp-admin dashboard.
-  Update WooCommerce to the latest version.
-  Perform some smoke tests to see that WooCommerce Admin works as expected.
