### PR TITLE
Fix renovate bot check in changelog lint

### DIFF
--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -13,7 +13,7 @@ jobs:
                   access_token: ${{ github.token }}
             - name: Check out repository code
               uses: actions/checkout@v2
-              if: github.event.pull_request.user.login != 'renovate'
+              if: github.event.pull_request.user.login != 'renovate[bot]'
             - name: skip-workflow
               id: skip-workflow
               uses: saulmaldonado/skip-workflow@v1.1.0
@@ -23,15 +23,16 @@ jobs:
                   pr-message: 'body'
                   search: '["pull_request"]'
             - name: Check for changelog entry
-              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip
+              if: github.event.pull_request.user.login != 'renovate[bot]' && !steps.skip-workflow.outputs.skip
               env:
                   PR_NUMBER: ${{github.event.number}}
               run: bin/ci/lint-changelog.sh
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
-              if: github.event.pull_request.user.login != 'renovate' && !steps.skip-workflow.outputs.skip && always()
+              if: github.event.pull_request.user.login != 'renovate[bot]' && !steps.skip-workflow.outputs.skip && always()
               with:
                   access_token: ${{ github.token }}
                   label: ${{ env.label }}
                   action: ${{ env.label_action }}
+


### PR DESCRIPTION
This PR fixes our lint changelog GitHub action that checks for renovate bot's PRs. The actual login name is found to be `renovate[bot]` instead of `renovate`.

![image](https://user-images.githubusercontent.com/3747241/110459452-f465d280-8107-11eb-93d9-914b57258c2f.png)

#### Testing instructions

Note: It is kind of an intrusive test to existing PRs.

1. Find a PR made by renovate bot that's failing the changelog lint
2. Check out the PR using GitHub cli: `gh pr checkout ....`
3. Cherry pick the commit `ba4edfb`
4. Push the changes
5. Observe the test result

I have made this test on https://github.com/woocommerce/woocommerce-admin/pull/6496, where you can observe the debug log:

![image](https://user-images.githubusercontent.com/3747241/110460556-4d823600-8109-11eb-8a12-e2b933e0d0c9.png)

No changelog required