### PR TITLE
Improve WC Shipping & Tax logic

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -117,6 +117,35 @@ UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7
 ```
 - No note should have been added.
 
+### Improve WC Shipping & Tax logic #6547
+
+**Scenario 1** - Exclude the WooCommerce Shipping mention if the user is not in the US
+
+1. Start OBW and enter an address that is not in the US
+2. Choose "food and drink" from the Industry (this forces Business Details to display "Free features" tab)
+3. When you get to the "Business Details", click "Free features"
+4. Expand "Add recommended business features to my site" by clicking the down arrow.
+5. Confirm that "WooCommerce Shipping" is not listed
+
+**Scenario 2**- Exclude the WooCommerce Shipping mention if the user is in the US but only selected digital products in the Product Types step
+
+1. Start OBW and enter an address that is in the US.
+2. Choose "food and drink" from the Industry (this forces Business Details to display the "Free features" tab)
+3. Choose "Downloads" from the Product Types step.
+4. When you get to the Business Details step, expand "Add recommended business features to my site" by clicking the down arrow.
+5. Confirm that "WooCommerce Shipping" is not listed
+
+**Scenario 3** -  Include WooCommerce Tax if the user is in one of the following countries: US | FR | GB | DE | CA | PL | AU | GR | BE | PT | DK | SE
+
+1. Start OBW and enter an address that is in one of the following countries 
+
+    US | FR | GB | DE | CA | PL | AU | GR | BE | PT | DK | SE
+
+2. Continue to the Business Details step.
+3. Expand "Add recommended business features to my site" by clicking the down arrow.
+4. Confirm that "WooCommerce Tax" is listed.
+>>>>>>> bbeebaf91 (Add changelog)
+
 ### Use wc filter to get status tabs for tools category #6525
 
 1. Register a new tab via the filter.

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -69,13 +69,21 @@ class BusinessDetails extends Component {
 
 		const { getCurrencyConfig } = this.context;
 
-		const businessExtensions = Object.keys(
-			extensionInstallationOptions
-		).filter(
-			( key ) =>
-				extensionInstallationOptions[ key ] &&
-				key !== 'install_extensions'
-		);
+		const businessExtensions = Object.keys( extensionInstallationOptions )
+			.filter(
+				( key ) =>
+					extensionInstallationOptions[ key ] &&
+					key !== 'install_extensions'
+			)
+			.map( ( key ) => {
+				// Remove anything after :
+				// Please refer to selective-extensions-bundle/index.js
+				// installableExtensions variable
+				// this is to allow duplicate slugs (Tax & Shipping for example)
+				return key.split( ':' )[ 0 ];
+			} )
+			// remove duplicate
+			.filter( ( item, index, arr ) => arr.indexOf( item ) === index );
 
 		recordEvent( 'storeprofiler_store_business_features_continue', {
 			product_number: productCount,
@@ -88,7 +96,9 @@ class BusinessDetails extends Component {
 				extensionInstallationOptions
 			).every( ( val ) => val ),
 			install_woocommerce_services:
-				extensionInstallationOptions[ 'woocommerce-services' ],
+				extensionInstallationOptions[
+					'woocommerce-services:shipping'
+				] || extensionInstallationOptions[ 'woocommerce-services:tax' ],
 			install_mailchimp:
 				extensionInstallationOptions[ 'mailchimp-for-woocommerce' ],
 			install_mailpoet: extensionInstallationOptions.mailpoet,
@@ -413,6 +423,7 @@ class BusinessDetails extends Component {
 					onSubmit={ this.onContinue }
 					country={ country }
 					industry={ profileItems.industry }
+					productTypes={ profileItems.product_types }
 				/>
 			</>
 		);

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -36,6 +36,26 @@ import './style.scss';
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
 const FREE_FEATURES_TAB_NAME = 'free-features';
 
+export const filterBusinessExtensions = ( extensionInstallationOptions ) => {
+	return (
+		Object.keys( extensionInstallationOptions )
+			.filter(
+				( key ) =>
+					extensionInstallationOptions[ key ] &&
+					key !== 'install_extensions'
+			)
+			.map( ( key ) => {
+				// Remove anything after :
+				// Please refer to selective-extensions-bundle/index.js
+				// installableExtensions variable
+				// this is to allow duplicate slugs (Tax & Shipping for example)
+				return key.split( ':' )[ 0 ];
+			} )
+			// remove duplicate
+			.filter( ( item, index, arr ) => arr.indexOf( item ) === index )
+	);
+};
+
 class BusinessDetails extends Component {
 	constructor() {
 		super();
@@ -69,21 +89,9 @@ class BusinessDetails extends Component {
 
 		const { getCurrencyConfig } = this.context;
 
-		const businessExtensions = Object.keys( extensionInstallationOptions )
-			.filter(
-				( key ) =>
-					extensionInstallationOptions[ key ] &&
-					key !== 'install_extensions'
-			)
-			.map( ( key ) => {
-				// Remove anything after :
-				// Please refer to selective-extensions-bundle/index.js
-				// installableExtensions variable
-				// this is to allow duplicate slugs (Tax & Shipping for example)
-				return key.split( ':' )[ 0 ];
-			} )
-			// remove duplicate
-			.filter( ( item, index, arr ) => arr.indexOf( item ) === index );
+		const businessExtensions = filterBusinessExtensions(
+			extensionInstallationOptions
+		);
 
 		recordEvent( 'storeprofiler_store_business_features_continue', {
 			product_number: productCount,

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -77,19 +77,12 @@ const installableExtensions = [
 					'shipping'
 				),
 				isVisible: ( countryCode, industry, productTypes ) => {
-					// Exclude the WooCommerce Shipping mention if the user is not in the US.
-					// Exclude the WooCommerce Shipping mention if the user is in the US but
-					// only selected digital products in the Product Types step.
-					if (
-						countryCode !== 'US' ||
+					return (
+						countryCode === 'US' ||
 						( countryCode === 'US' &&
 							productTypes.length === 1 &&
 							productTypes[ 0 ] === 'downloads' )
-					) {
-						return false;
-					}
-
-					return true;
+					);
 				},
 			},
 			{
@@ -102,7 +95,7 @@ const installableExtensions = [
 					'tax'
 				),
 				isVisible: ( countryCode ) => {
-					const allowedCountries = [
+					return [
 						'US',
 						'FR',
 						'GB',
@@ -115,15 +108,7 @@ const installableExtensions = [
 						'PT',
 						'DK',
 						'SE',
-					];
-
-					// Exclude the WooCommerce Tax if the user is not in one of the following countries:
-					// US | FR | GB | DE | CA | PL | AU | GR | BE | PT | DK | SE
-					if ( ! allowedCountries.includes( countryCode ) ) {
-						return false;
-					}
-
-					return true;
+					].includes( countryCode );
 				},
 			},
 			{

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -307,7 +307,7 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
  * @param {Array} plugins  list of plugins
  * @param {string} country  Woo store country
  * @param {Array} industry List of selected industries
- * @param productTypes
+ * @param {Array} productTypes List of selected product types
  */
 const getVisiblePlugins = ( plugins, country, industry, productTypes ) => {
 	const countryCode = getCountryCode( country );

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { filterBusinessExtensions } from '../flows/selective-bundle';
+
+describe( 'BusinessDetails', () => {
+	test( 'filtering extensions', () => {
+		const extensions = {
+			'creative-mail-by-constant-contact': true,
+			'facebook-for-woocommerce': true,
+			install_extensions: true,
+			jetpack: true,
+			'kliken-marketing-for-google': true,
+			'mailchimp-for-woocommerce': true,
+			'woocommerce-payments': true,
+			'woocommerce-services:shipping': true,
+			'woocommerce-services:tax': true,
+		};
+
+		const expectedExtensions = [
+			'creative-mail-by-constant-contact',
+			'facebook-for-woocommerce',
+			'jetpack',
+			'kliken-marketing-for-google',
+			'mailchimp-for-woocommerce',
+			'woocommerce-payments',
+			'woocommerce-services',
+		];
+
+		const filteredExtensions = filterBusinessExtensions( extensions );
+
+		expect( filteredExtensions ).toEqual( expectedExtensions );
+	} );
+} );

--- a/packages/data/src/plugins/constants.js
+++ b/packages/data/src/plugins/constants.js
@@ -48,6 +48,14 @@ export const pluginNames = {
 		'WooCommerce Shipping & Tax',
 		'woocommerce-admin'
 	),
+	'woocommerce-services:shipping': __(
+		'WooCommerce Shipping & Tax',
+		'woocommerce-admin'
+	),
+	'woocommerce-services:tax': __(
+		'WooCommerce Shipping & Tax',
+		'woocommerce-admin'
+	),
 	'woocommerce-shipstation-integration': __(
 		'WooCommerce ShipStation Gateway',
 		'woocommerce-admin'

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Add gross sales column to CSV export #6567
 - Dev: Add filter to profile wizard steps #6564
 - Tweak: Adjust targeting store age for the Add First Product note #6554
+- Tweak: Improve WC Shipping & Tax logic #6547
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539

--- a/tests/e2e/specs/activate-and-setup/complete-business-section.js
+++ b/tests/e2e/specs/activate-and-setup/complete-business-section.js
@@ -75,7 +75,7 @@ export async function unselectAllFeaturesAndContinue(
 	await waitForElementCount(
 		page,
 		'.components-checkbox-control__input',
-		shouldWCPayBeListed ? 9 : 8
+		shouldWCPayBeListed ? 10 : 7
 	);
 	const wcPayLabel = await getElementByText( 'a', 'WooCommerce Payments' );
 	if ( shouldWCPayBeListed ) {


### PR DESCRIPTION
Fixes #6490 

This PR updates the selective extension bundle component to selectively displays WooCommerce Shipping & Tax depending on the user's country and selected product types during OBW.

Acceptance criteria are listed in the original issue #6490 

### Detailed test instructions:

**Scenario 1** - Exclude the WooCommerce Shipping mention if the user is not in the US

1. Start OBW and enter an address that is not in the US
2. Choose "food and drink" from the Industry (this forces Business Details to display "Free features" tab)
3. When you get to the "Business Details", click "Free features"
4. Expand "Add recommended business features to my site" by clicking the down arrow.
5. Confirm that "WooCommerce Shipping" is not listed

**Scenario 2**- Exclude the WooCommerce Shipping mention if the user is in the US but only selected digital products in the Product Types step

1. Start OBW and enter an address that is in the US.
2. Choose "food and drink" from the Industry (this forces Business Details to display the "Free features" tab)
3. Choose "Downloads" from the Product Types step.
4. When you get to the Business Details step, expand "Add recommended business features to my site" by clicking the down arrow.
5. Confirm that "WooCommerce Shipping" is not listed

**Scenario 3** -  Include WooCommerce Tax if the user is in one of the following countries: US | FR | GB | DE | CA | PL | AU | GR | BE | PT | DK | SE

1. Start OBW and enter an address that is in one of the following countries 

    US | FR | GB | DE | CA | PL | AU | GR | BE | PT | DK | SE

2. Continue to the Business Details step.
3. Expand "Add recommended business features to my site" by clicking the down arrow.
4. Confirm that "WooCommerce Tax" is listed.
