### PR TITLE
Adjust targeting store age: 2 - 5 days for the Add First Product note

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -85,6 +85,38 @@ wp.hooks.addFilter( 'woocommerce_admin_profile_wizard_steps', 'woocommerce-admin
 2. Navigate to the profile wizard. `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`.
 3. Make sure the filtered step (product types) is not shown.
 
+### Adjust targeting store age: 2 - 5 days for the Add First Product note #6554
+
+- Checkout this branch.
+- Create a zip for testing with `npm run zip:test`.
+- Create a `jurassic.ninja` instance.
+- Upload the plugin and activate it.
+- Update the installation date (we need a store between 2 and 5 days old). You can do it with an SQL statement like this:
+
+```
+UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 5 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
+```
+
+- Run the cron (this tool can help [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)).
+- You should have received an email like the image above.
+- Verify the note's status is `sent`. You can use an SQL statement like this:
+```
+SELECT `status` FROM `wp_wc_admin_notes` WHERE `name` = 'wc-admin-add-first-product-note'
+```
+- Now delete the note with an SQL statement like:
+```
+DELETE FROM `wp_wc_admin_notes` WHERE `name` = 'wc-admin-add-first-product-note';
+```
+- Add a new order and run the cron.
+- No note should have been added.
+- Remove the order, add a product and run the cron.
+- No note should have been added.
+- Delete the product and modify the store creation date to 7 days with an SQL statement like:
+```
+UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
+```
+- No note should have been added.
+
 ### Use wc filter to get status tabs for tools category #6525
 
 1. Register a new tab via the filter.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Fix hidden menu title on smaller screens #6562
 - Fix: Add gross sales column to CSV export #6567
 - Dev: Add filter to profile wizard steps #6564
+- Tweak: Adjust targeting store age for the Add First Product note #6554
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539

--- a/src/Notes/AddFirstProduct.php
+++ b/src/Notes/AddFirstProduct.php
@@ -29,7 +29,6 @@ class AddFirstProduct {
 	 * @return Note
 	 */
 	public static function get_note() {
-		// We want to show the note after 3 days and before 30.
 		if ( ! self::wc_admin_active_for( 2 * DAY_IN_SECONDS ) || self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
 			return;
 		}

--- a/src/Notes/AddFirstProduct.php
+++ b/src/Notes/AddFirstProduct.php
@@ -30,7 +30,7 @@ class AddFirstProduct {
 	 */
 	public static function get_note() {
 		// We want to show the note after 3 days and before 30.
-		if ( ! self::wc_admin_active_for( 3 * DAY_IN_SECONDS ) || self::wc_admin_active_for( 30 * DAY_IN_SECONDS ) ) {
+		if ( ! self::wc_admin_active_for( 2 * DAY_IN_SECONDS ) || self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #6360 

This PR adjusts the target store age from 3 - 30 days to 2 - 5 days.

The code is exactly the same, except the # of days changes.

Original PR can be found [here](https://github.com/woocommerce/woocommerce-admin/pull/6260)



### Detailed test instructions:

These test instructions are copied from the original PR, but with an updated timestamp


- Checkout this branch.
- Create a zip for testing with `npm run zip:test`.
- Create a `jurassic.ninja` instance.
- Upload the plugin and activate it.
- Update the installation date (we need a store between 2 and 5 days old). You can do it with an SQL statement like this:

```
UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 5 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
```

- Run the cron (this tool can help [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)).
- You should have received an email like the image above.
- Verify the note's status is `sent`. You can use an SQL statement like this:
```
SELECT `status` FROM `wp_wc_admin_notes` WHERE `name` = 'wc-admin-add-first-product-note'
```
- Now delete the note with an SQL statement like:
```
DELETE FROM `wp_wc_admin_notes` WHERE `name` = 'wc-admin-add-first-product-note';
```
- Add a new order and run the cron.
- No note should have been added.
- Remove the order, add a product and run the cron.
- No note should have been added.
- Delete the product and modify the store creation date to 7 days with an SQL statement like:
```
UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
```
- No note should have been added.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
