### PR TITLE
Update insight inbox message and add no option

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -74,6 +74,7 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 1. Enable the new navigation.
 2. Shorten your viewport height so that the secondary menu overlaps the main.
 3. Make sure the menu title can still be seen.
+
 ### Add filter to profile wizard steps #6564
 
 1. Add the following JS to your admin head.  You can use a plugin like "Add Admin Javascript" to do this:
@@ -92,6 +93,11 @@ wp.hooks.addFilter( 'woocommerce_admin_profile_wizard_steps', 'woocommerce-admin
 - Create a `jurassic.ninja` instance.
 - Upload the plugin and activate it.
 - Update the installation date (we need a store between 2 and 5 days old). You can do it with an SQL statement like this:
+
+### Update Insight inbox message #6555
+
+1. Checkout this branch.
+2. Update the installation date of your store if it hasn't been at least a day. You can use the following SQL uqery.
 
 ```
 UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 5 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
@@ -144,7 +150,10 @@ UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7
 2. Continue to the Business Details step.
 3. Expand "Add recommended business features to my site" by clicking the down arrow.
 4. Confirm that "WooCommerce Tax" is listed.
->>>>>>> bbeebaf91 (Add changelog)
+3. Install & activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) plugin
+4. Navigate to Tools -> Cron Events
+5. Run `wc_admin_daily` job
+6. Navigate to WooCommerce -> Home and confirm the Insight note.
 
 ### Use wc filter to get status tabs for tools category #6525
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add filter to profile wizard steps #6564
 - Tweak: Adjust targeting store age for the Add First Product note #6554
 - Tweak: Improve WC Shipping & Tax logic #6547
+- Tweak: Update Insight inbox note content #6555
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539

--- a/src/Notes/InsightFirstProductAndPayment.php
+++ b/src/Notes/InsightFirstProductAndPayment.php
@@ -38,7 +38,7 @@ class InsightFirstProductAndPayment {
 
 		$note = new Note();
 		$note->set_title( __( 'Insight', 'woocommerce-admin' ) );
-		$note->set_content( __( 'More than 80% of new merchants add the first product and have at least one payment method set up during the first week. We\'re here to help your business succeed! Do you find this type of insight useful?', 'woocommerce-admin' ) );
+		$note->set_content( __( 'More than 80% of new merchants add the first product and have at least one payment method set up during the first week.<br><br>Do you find this type of insight useful?', 'woocommerce-admin' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_SURVEY );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
@@ -51,6 +51,15 @@ class InsightFirstProductAndPayment {
 			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
+
+		$note->add_action(
+			'affirm-insight-first-product-and-payment',
+			__( 'No', 'woocommerce-admin' ),
+			false,
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
+			__( 'Thanks for your feedback', 'woocommerce-admin' )
+		);		
 
 		return $note;
 	}


### PR DESCRIPTION
Fixes #6264 

This PR updates the note content and adds 'No' action.


### Screenshots

Before:

![image (1)](https://user-images.githubusercontent.com/5121465/106802644-d7ca0c80-6628-11eb-952b-14723c148e99.png)

After:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/5121465/106803242-9d14a400-6629-11eb-8e1f-ef2bd6515310.png">

### Detailed test instructions:

Please delete the existing Insight note if you already have it in your database. You can use the following SQL query.

```
delete from wp_wc_admin_notes where name='wc-admin-insight-first-product-and-payment'
```

1. Checkout this branch.
2. Update the installation date of your store if it hasn't been at least a day. You can use the following SQL query.

```
UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 5 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
```

3. Install & activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) plugin
4. Navigate to Tools -> Cron Events
5. Run `wc_admin_daily` job
6. Navigate to WooCommerce -> Home and confirm the Insight note.