### PR TITLE
Add customer name column to CSV export

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -17,6 +17,13 @@
 11. Click "Continue with my active theme"
 12. After finishing the wizard, this should redirect you to the "Jetpack" setup connection flow. (You should not be redirected straight to the homescreen).
 
+### Add customer name column to CSV export #6556
+
+- Create more than 25 orders
+- Go to Analytics -> Orders -> Click "Download"
+- Click download link in the email
+- See customer column with customer full name
+
 ### Allow the manager role to query certain options #6577
 
 Testing `woocommerce_ces_tracks_queue`

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: CES survey for importing products #6419
 - Add: CES survey for adding product categories, tags, and attributes #6418
 - Fix: Correct a bug where the JP connection flow would not happen when installing JP in the OBW. #6521
+- Fix: Add customer name column to CSV export #6556
 
 == 2.1.0 3/10/2021  ==
 

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -476,6 +476,16 @@ class Controller extends ReportsController implements ExportableInterface {
 	}
 
 	/**
+	 * Get customer name column export value.
+	 *
+	 * @param array $customer Customer from report row.
+	 * @return string
+	 */
+	protected function _get_customer_name( $customer ) {
+		return $customer['first_name'] . ' ' . $customer['last_name'];
+	}
+
+	/**
 	 * Get products column export value.
 	 *
 	 * @param array $products Products from report row.
@@ -516,7 +526,8 @@ class Controller extends ReportsController implements ExportableInterface {
 			'date_created'   => __( 'Date', 'woocommerce-admin' ),
 			'order_number'   => __( 'Order #', 'woocommerce-admin' ),
 			'status'         => __( 'Status', 'woocommerce-admin' ),
-			'customer_type'  => __( 'Customer', 'woocommerce-admin' ),
+			'customer_name'  => __( 'Customer', 'woocommerce-admin' ),
+			'customer_type'  => __( 'Customer Type', 'woocommerce-admin' ),
 			'products'       => __( 'Product(s)', 'woocommerce-admin' ),
 			'num_items_sold' => __( 'Items Sold', 'woocommerce-admin' ),
 			'coupons'        => __( 'Coupon(s)', 'woocommerce-admin' ),
@@ -546,6 +557,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'date_created'   => $item['date_created'],
 			'order_number'   => $item['order_number'],
 			'status'         => $item['status'],
+			'customer_name'  => isset( $item['extended_info']['customer'] ) ? $this->_get_customer_name( $item['extended_info']['customer'] ) : null,
 			'customer_type'  => $item['customer_type'],
 			'products'       => isset( $item['extended_info']['products'] ) ? $this->_get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold' => $item['num_items_sold'],

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -481,7 +481,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @param array $customer Customer from report row.
 	 * @return string
 	 */
-	protected function _get_customer_name( $customer ) {
+	protected function get_customer_name( $customer ) {
 		return $customer['first_name'] . ' ' . $customer['last_name'];
 	}
 
@@ -557,7 +557,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'date_created'   => $item['date_created'],
 			'order_number'   => $item['order_number'],
 			'status'         => $item['status'],
-			'customer_name'  => isset( $item['extended_info']['customer'] ) ? $this->_get_customer_name( $item['extended_info']['customer'] ) : null,
+			'customer_name'  => isset( $item['extended_info']['customer'] ) ? $this->get_customer_name( $item['extended_info']['customer'] ) : null,
 			'customer_type'  => $item['customer_type'],
 			'products'       => isset( $item['extended_info']['products'] ) ? $this->_get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold' => $item['num_items_sold'],


### PR DESCRIPTION
Fixes #6534 

Add customer name column to CSV export


### Screenshots
Before
<img width="439" alt="螢幕快照 2021-03-09 下午8 34 22" src="https://user-images.githubusercontent.com/56378160/110562108-e8354180-8116-11eb-843f-1598e12809d4.png">

After
<img width="560" alt="螢幕快照 2021-03-09 下午8 34 01" src="https://user-images.githubusercontent.com/56378160/110562128-f2574000-8116-11eb-940e-dc28f64c8943.png">


### Detailed test instructions:

-   Create more than 25 orders
-   Go to Analytics -> Orders -> Click "Download"
-   Click download link in the email
-   See customer column with customer full name