### PR TITLE
Add Ireland to Square payment method

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -179,6 +179,16 @@ Scenario #2
 8. Click on the **Choose payment methods** task, it should not be displaying the **Woocommerce Payments** option.
 9. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 4 are installed and activated.
 
+### Add Ireland to Square payment method #6559
+
+1. Go to the store setup wizard `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
+1. Set up your store with Ireland as its country, and proceed until the `Business Details` step
+1. In "Currently selling anywhere?" dropdown, select either:
+    - Yes, in person at physical stores and/or events
+    - Yes, on another platform and in person at physical stores and/or events
+1. Finish the setup wizard, and go to payments task `/wp-admin/admin.php?page=wc-admin&task=payments`
+1. Observe Square as a payment method option
+
 ## 2.1.2
 
 ### Add Guards to "Deactivate Plugin" Note Handlers #6532

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -242,7 +242,9 @@ export function getPaymentMethods( {
 				( [ 'brick-mortar', 'brick-mortar-other' ].includes(
 					profileItems.selling_venues
 				) &&
-					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ) ),
+					[ 'US', 'CA', 'JP', 'GB', 'AU', 'IE' ].includes(
+						countryCode
+					) ),
 			plugins: [ 'woocommerce-square' ],
 			container: <Square />,
 			isConfigured:

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
 - Dev: Store profiler - Added MailPoet to new Business Details step  #6515
 - Dev: Add tilde (~) to represent client root directory for imports. #6517
+- Add: Add Ireland to Square payment method #6559
 
 == 2.1.0 3/10/2021  ==
 


### PR DESCRIPTION
Fixes #6481

This PR adds Ireland to Square payment method in the payments task.

### Detailed test instructions:

1. Go to the store setup wizard `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
1. Set up your store with Ireland as its country, and proceed until the `Business Details` step
1. In "Currently selling anywhere?" dropdown, select either:
    - Yes, in person at physical stores and/or events
    - Yes, on another platform and in person at physical stores and/or events
1. Finish the setup wizard, and go to payments task `/wp-admin/admin.php?page=wc-admin&task=payments`
1. Observe Square as a payment method option