### PR TITLE
Prepare Documentation for 2.1.2 release

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -13,45 +13,6 @@ add_filter( 'woocommerce_admin_status_tabs', function ( array $tabs ) {
 ```
 2. Enable the new navigation.
 3. Make sure the menu item for the registered tab is shown under `Tools`.
-
-### Add Guards to "Deactivate Plugin" Note Handlers #6532
-
-#### Test incompatible WooCommerce version
-
--   Install and activate Woocommerce 4.7
--   See that the Woocommerce Admin plugin is deactivated.
--   Add the Deactivate Plugin note via SQL.
-
-```
-INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
-```
-
--   See that the note is in the inbox
--   Activate the Woocommerce Admin plugin.
--   See that Woocommerce Admin immediately de-activates without a fatal error.
--   See that the note remains in inbox
-
-#### Test compatible WooCommerce version
-
--   Deactivate the Woocommerce Admin plugin.
--   Install and activate the latest Woocommerce version.
--   Add the Deactivate Plugin note via SQL.
-
-```
-INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
-```
-
--   Activate the Woocommerce Admin plugin.
--   See that note is **not** in the inbox
--   Add the Deactivate Plugin note via SQL.
-
-```
-INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
-```
-
--   De-activate the Woocommerce Admin plugin.
--   See that note is **not** in the inbox
-
 ### Remove mobile activity panel toggle #6539
 
 1. Narrow your viewport to < 782px.
@@ -200,6 +161,47 @@ Scenario #2
 7. The task list should show the **Choose payment methods** task, and the **Set up additional payment providers** inbox card should not be present.
 8. Click on the **Choose payment methods** task, it should not be displaying the **Woocommerce Payments** option.
 9. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 4 are installed and activated.
+
+## 2.1.2
+
+### Add Guards to "Deactivate Plugin" Note Handlers #6532
+
+#### Test incompatible WooCommerce version
+
+-   Install and activate Woocommerce 4.7
+-   See that the Woocommerce Admin plugin is deactivated.
+-   Add the Deactivate Plugin note via SQL.
+
+```
+INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
+```
+
+-   See that the note is in the inbox
+-   Activate the Woocommerce Admin plugin.
+-   See that Woocommerce Admin immediately de-activates without a fatal error.
+-   See that the note remains in inbox
+
+#### Test compatible WooCommerce version
+
+-   Deactivate the Woocommerce Admin plugin.
+-   Install and activate the latest Woocommerce version.
+-   Add the Deactivate Plugin note via SQL.
+
+```
+INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
+```
+
+-   Activate the Woocommerce Admin plugin.
+-   See that note is **not** in the inbox
+-   Add the Deactivate Plugin note via SQL.
+
+```
+INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `icon`) VALUES ( 'wc-admin-deactivate-plugin', 'info', 'en_US', 'Deactivate old WooCommerce Admin version', 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', '{}', 'unactioned', 'woocommerce-admin', '2021-03-08 01:26:44', NULL, 0, 'plain', '', 0, 'info');
+```
+
+-   De-activate the Woocommerce Admin plugin.
+-   See that note is **not** in the inbox
+
 
 ## 2.1.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,10 +105,17 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Associated Order Number for refunds was hidden #6428
 - Add: Remove Mollie promo note on install #6510
 - Add: Remote Inbox Notifications rule to trigger when WooCommerce Admin is upgraded. #6040
-- Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
 - Feature: Increase target audience for business feature step. #6508
-- Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
+
+== 2.1.2 ==
+
+- Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
+- Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
+
+== 2.1.1 ==
+
+- Fix: Restore missing Correct the Klarna slug #6440
 
 == 2.1.0 ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,14 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Move the shipping input and text 1px lower. #6408
 - Add: WC Admin Docker setup with WP-ENV
 
+== 2.0.3 03/10/2021 ==
+
+- Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
+
+== 2.0.2 25/05/2021 ==
+
+- Fix: Correct the Klarna slug #6440
+
 == 2.0.0 02/05/2021 ==
 
 - Tweak: Bump minimum supported version of PHP to 7.0. #6046

--- a/readme.txt
+++ b/readme.txt
@@ -108,16 +108,16 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Feature: Increase target audience for business feature step. #6508
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
 
-== 2.1.2 ==
+== 2.1.0 3/10/2021  ==
 
 - Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.1.1 ==
+== 2.1.0 3/4/2021  ==
 
 - Fix: Restore missing Correct the Klarna slug #6440
 
-== 2.1.0 ==
+== 2.1.0 3/4/2021  ==
 
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 - Dev: Remove Google fonts and material icons. #6343


### PR DESCRIPTION
Updates the changelog and testing instructions for the 2.1.2 release.

No changelog required.