### PR TITLE
Fix hidden menu title on smaller screens

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fix hidden menu title on smaller screens #6562
+
+1. Enable the new navigation.
+2. Shorten your viewport height so that the secondary menu overlaps the main.
+3. Make sure the menu title can still be seen.
 ### Use wc filter to get status tabs for tools category #6525
 
 1. Register a new tab via the filter.

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -17,6 +17,10 @@
 	.components-navigation {
 		box-sizing: border-box;
 	}
+
+	.components-navigation__menu-title {
+		overflow: visible;
+	}
 }
 
 .woocommerce-navigation__wrapper {

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Fix hidden menu title on smaller screens #6562
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539


### PR DESCRIPTION
Fixes #6395 

Fixes the menu being hidden when the viewport height is too small.

I tested this with the `hasSearch` prop as well and search seemed to be styled correctly.  cc @Copons to make sure I haven't broken anything in https://github.com/WordPress/gutenberg/pull/25315 in case we opt to use this feature in the future.  Is there a reason for the `overflow: hidden;` on the title?

### Screenshots

#### Before
<img width="320" alt="Screen Shot 2021-03-10 at 1 15 11 PM" src="https://user-images.githubusercontent.com/10561050/110677063-b964ad00-81a2-11eb-94d6-02740bcfac8a.png">


#### After
<img width="304" alt="Screen Shot 2021-03-10 at 1 13 09 PM" src="https://user-images.githubusercontent.com/10561050/110676972-9afeb180-81a2-11eb-9023-c7e34e9af1d6.png">


### Detailed test instructions:
1. Enable the new navigation.
2. Shorten your viewport height so that the secondary menu overlaps the main.
3. Make sure the menu title can still be seen.