### PR TITLE
Add filter to profile wizard steps

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -65,9 +65,9 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 3. Make sure the menu title can still be seen.
 ### Add filter to profile wizard steps #6564
 
-1. Remove a step via the filter.
+1. Add the following JS to your admin head.  You can use a plugin like "Add Admin Javascript" to do this:
 ```
-addFilter( STEPS_FILTER, 'woocommerce-admin', ( steps ) => {
+wp.hooks.addFilter( 'woocommerce_admin_profile_wizard_steps', 'woocommerce-admin', ( steps ) => {
 	return steps.filter( ( step ) => step.key !== 'product-types' );
 } );
 ```

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -63,6 +63,16 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 1. Enable the new navigation.
 2. Shorten your viewport height so that the secondary menu overlaps the main.
 3. Make sure the menu title can still be seen.
+### Add filter to profile wizard steps #6564
+
+1. Remove a step via the filter.
+```
+addFilter( STEPS_FILTER, 'woocommerce-admin', ( steps ) => {
+	return steps.filter( ( step ) => step.key !== 'product-types' );
+} );
+```
+2. Navigate to the profile wizard. `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`.
+3. Make sure the filtered step (product types) is not shown.
 
 ### Use wc filter to get status tabs for tools category #6525
 

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { Component, createElement } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { identity, pick } from 'lodash';
@@ -35,6 +36,8 @@ import StoreDetails from './steps/store-details';
 import Theme from './steps/theme';
 import './style.scss';
 import { isSelectiveBundleInstallSegmentation } from './steps/business-details/data/segmentation';
+
+const STEPS_FILTER = 'woocommerce_admin_profile_wizard_steps';
 
 class ProfileWizard extends Component {
 	constructor( props ) {
@@ -155,7 +158,8 @@ class ProfileWizard extends Component {
 				container: Benefits,
 			} );
 		}
-		return steps;
+
+		return applyFilters( STEPS_FILTER, steps );
 	}
 
 	getCurrentStep() {

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Allow the manager role to query certain options #6577
 - Fix: Fix hidden menu title on smaller screens #6562
 - Fix: Add gross sales column to CSV export #6567
+- Dev: Add filter to profile wizard steps #6564
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539


### PR DESCRIPTION
Fixes #6352 

Adds a filter to allow steps to be added and/or removed.

### Screenshots
<img width="1343" alt="Screen Shot 2021-03-10 at 2 52 28 PM" src="https://user-images.githubusercontent.com/10561050/110689105-4eba6e00-81b0-11eb-9a7c-39069d29ca1f.png">


### Detailed test instructions:

1. Remove a step via the filter.
```
addFilter( STEPS_FILTER, 'woocommerce-admin', ( steps ) => {
	return steps.filter( ( step ) => step.key !== 'product-types' );
} );
```
2. Navigate to the profile wizard. `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`.
3. Make sure the filtered step (product types) is not shown.