### PR TITLE
Add gross sales column to CSV export

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -4,10 +4,11 @@
 
 ### Add gross sales column to CSV export #6567
 
-1. Create more than 25 revenues
-2. Go to Analytics -> Revenue -> Click "Download"
-3. Click the download link in the email
-4. See gross sales column
+1. Navigate to Analytics -> Revenue
+2. Adjust the date filter so that more than 25 rows are visible
+4. Click "Download"
+5. Click the download link in the email
+6. See gross sales column
 
 ### Fix a bug where the JetPack connection flow would not activate
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Add gross sales column to CSV export #6567
+
+1. Create more than 25 revenues
+2. Go to Analytics -> Revenue -> Click "Download"
+3. Click the download link in the email
+4. See gross sales column
+
 ### Fix a bug where the JetPack connection flow would not activate
 
 1. With a fresh install of wc-admin and woocommerce, go to the home screen
@@ -51,6 +58,7 @@ add_filter( 'woocommerce_admin_status_tabs', function ( array $tabs ) {
 ```
 2. Enable the new navigation.
 3. Make sure the menu item for the registered tab is shown under `Tools`.
+
 ### Remove mobile activity panel toggle #6539
 
 1. Narrow your viewport to < 782px.

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 - Fix: Allow the manager role to query certain options #6577
 - Fix: Fix hidden menu title on smaller screens #6562
+- Fix: Add gross sales column to CSV export #6567
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525
 - Tweak: Remove mobile activity panel toggle #6539

--- a/src/API/Reports/Revenue/Stats/Controller.php
+++ b/src/API/Reports/Revenue/Stats/Controller.php
@@ -447,6 +447,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		return array(
 			'date'         => __( 'Date', 'woocommerce-admin' ),
 			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+			'gross_sales'  => __( 'Gross Sales', 'woocommerce-admin' ),
 			'total_sales'  => __( 'Total Sales', 'woocommerce-admin' ),
 			'refunds'      => __( 'Returns', 'woocommerce-admin' ),
 			'coupons'      => __( 'Coupons', 'woocommerce-admin' ),
@@ -468,6 +469,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		return array(
 			'date'         => $item['date_start'],
 			'orders_count' => $subtotals['orders_count'],
+			'gross_sales'  => self::csv_number_format( $subtotals['gross_sales'] ),
 			'total_sales'  => self::csv_number_format( $subtotals['total_sales'] ),
 			'refunds'      => self::csv_number_format( $subtotals['refunds'] ),
 			'coupons'      => self::csv_number_format( $subtotals['coupons'] ),


### PR DESCRIPTION
Fixes #6558 

Add gross sales column to CSV export


### Screenshots
Before
<img width="599" alt="before" src="https://user-images.githubusercontent.com/56378160/110704418-ede86100-81c2-11eb-850a-a10807eff914.png">

After
<img width="681" alt="螢幕快照 2021-03-10 下午4 59 14" src="https://user-images.githubusercontent.com/56378160/110704462-fb055000-81c2-11eb-9770-de437b097f9c.png">


### Detailed test instructions:

- Create more than 25 revenues
- Go to Analytics -> Revenue -> Click "Download"
- Click the download link in the email
- See gross sales column
