### PR TITLE
Delete customer data on network user deletion

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -69,6 +69,18 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 8. Attempt to directly visit the benefits page. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=benefits`
 9. Note that you are redirected to the homescreen.
 
+### Delete customer data on network user deletion #6574
+
+1. Set up a multisite network.
+2. Create a new user.
+3. Make an order with that user.
+4. Note the customer data under WooCommerce -> Customers.
+5. Navigate to Network -> All users `/wp-admin/network/users.php`.
+6. Delete that user.
+7. Wait for the scheduled action to finish or manually run the `wc-admin_delete_user_customers` action under Tools -> Scheduled Actions.
+8. Navigate to WooCommerce -> Customers.
+9. Make sure that customer data has been deleted.
+
 ### Fix hidden menu title on smaller screens #6562
 
 1. Enable the new navigation.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Update undefined task name properties for help panel tracks #6565
 - Fix: Allow the manager role to query certain options #6577
 - Dev: Refactor profile wizard benefits step and add tests #6583
+- Fix: Delete customer data on network user deletion #6574
 - Fix: Fix hidden menu title on smaller screens #6562
 - Fix: Add gross sales column to CSV export #6567
 - Dev: Add filter to profile wizard steps #6564

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -30,6 +30,7 @@ class CustomersScheduler extends ImportScheduler {
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );
+		add_action( 'remove_user_from_blog', array( __CLASS__, 'schedule_user_delete' ) );
 
 		CustomersDataStore::init();
 		parent::init();


### PR DESCRIPTION
Fixes #5914 

Deletes customer data when a user is deleted via the network.

### Detailed test instructions:

1. Set up a multisite network.
2. Create a new user.
3. Make an order with that user.
4. Note the customer data under WooCommerce -> Customers.
5. Navigate to Network -> All users `/wp-admin/network/users.php`.
6. Delete that user.
7. Wait for the scheduled action to finish or manually run the `wc-admin_delete_user_customers` action under Tools -> Scheduled Actions.
8. Navigate to WooCommerce -> Customers.
9. Make sure that customer data has been deleted.