### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@2.9.0
               with:
-                  php-version: '7.4'
+                  php-version: '7.3'
             - name: Install PHP dependencies
               run: |
                   composer self-update 2.0.6
@@ -34,5 +34,6 @@ jobs:
                   composer require wp-cli/i18n-command
                   npm run build
                   npm install jest --global
+                  WP_VERSION=5.6.2
                   npm run docker:up
                   npm run test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
     e2e-tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         steps:
             - name: Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.7.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
     e2e-tests:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - name: Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.7.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@2.9.0
               with:
-                  php-version: '7.3'
+                  php-version: '7.4'
             - name: Install PHP dependencies
               run: |
                   composer self-update 2.0.6

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -7,7 +7,7 @@ jobs:
             WP_CORE_DIR: '/tmp/wordpress'
             COMPOSER_DEV: 1
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
PHP unit tests were failing due to a change in the Github actions environment.
E2E tests were failing because of that issue (they rely on port 8084 which is used in ubuntu 20 environment) *and* because of an issue with @woocommerce/e2e-environment

This seeks to fix both issues.

No changelog required.