### PR TITLE
Allow manager role to query options

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -17,6 +17,24 @@
 11. Click "Continue with my active theme"
 12. After finishing the wizard, this should redirect you to the "Jetpack" setup connection flow. (You should not be redirected straight to the homescreen).
 
+### Allow the manager role to query certain options #6577
+
+Testing `woocommerce_ces_tracks_queue`
+
+1. Checkout this branch.
+2. Open browser inspector and select the Network tab.
+2. Navigate to WooCommerce -> Settings.
+3. Confirm that the request to `/wp-json/wc-admin/options?options=woocommerce_ces_tracks_queue&_locale=user` returns 200 status.
+
+
+Testing `woocommerce_navigation_intro_modal_dismissed`
+
+1. Checkout this branch.
+2. Navigate to WooCommerce -> Settings -> Advanced -> features (/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features) and enable Navigation
+3. Open browser inspector and select the Network tab.
+4. Navigate to WooCommerce -> Home
+5. Confirm that the request to `/wp-json/wc-admin/options?options=woocommerce_navigation_intro_modal_dismissed&_locale=user` returns 200 status.
+
 ### Fix hidden menu title on smaller screens #6562
 
 1. Enable the new navigation.

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Allow the manager role to query certain options #6577
 - Fix: Fix hidden menu title on smaller screens #6562
 - Dev: Add nav intro modal tests #6518
 - Dev: Use wc filter to get status tabs for tools category #6525

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -129,13 +129,15 @@ class Options extends \WC_REST_Data_Controller {
 	 */
 	public function get_option_permissions( $request ) {
 		$permissions = array(
-			'theme_mods_' . get_stylesheet()     => current_user_can( 'edit_theme_options' ),
-			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
-			'woocommerce-ppcp-settings'          => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_ppcp-gateway_setting'   => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
+			'theme_mods_' . get_stylesheet()               => current_user_can( 'edit_theme_options' ),
+			'woocommerce_setup_jetpack_opted_in'           => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_stripe_settings'                  => current_user_can( 'manage_woocommerce' ),
+			'woocommerce-ppcp-settings'                    => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_ppcp-gateway_setting'             => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_demo_store'                       => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_demo_store_notice'                => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_ces_tracks_queue'                 => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_navigation_intro_modal_dismissed' => current_user_can( 'manage_woocommerce' ),
 		);
 
 		return apply_filters( 'woocommerce_rest_api_option_permissions', $permissions, $request );


### PR DESCRIPTION
Fixes #6415 

This PR allows the manager role to query `woocommerce_ces_tracks_queue` and `woocommerce_navigation_intro_modal_dismissed` options


### Detailed test instructions:

Testing `woocommerce_ces_tracks_queue`

1. Checkout this branch.
2. Open browser inspector and select the Network tab.
2. Navigate to WooCommerce -> Settings.
3. Confirm that the request to `/wp-json/wc-admin/options?options=woocommerce_ces_tracks_queue&_locale=user` returns 200 status.


Testing `woocommerce_navigation_intro_modal_dismissed`

1. Checkout this branch.
2. Navigate to WooCommerce -> Settings -> Advanced -> features (/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features) and enable Navigation
3. Open browser inspector and select the Network tab.
4. Navigate to WooCommerce -> Home
5. Confirm that the request to `/wp-json/wc-admin/options?options=woocommerce_navigation_intro_modal_dismissed&_locale=user` returns 200 status.
