### PR TITLE
Fix "Themes" step visibility bug in IE 11

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -87,6 +87,15 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 8. Navigate to WooCommerce -> Customers.
 9. Make sure that customer data has been deleted.
 
+### Fix "Themes" step visibility in IE 11 #6578
+
+1. Get an IE 11 test environment. I downloaded a trial version of Parallels Desktop on [here](https://www.parallels.com/) and IE 11 virtual machine from [developer.microsoft.com](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
+2. Make a zip version of this branch by running `npm run test:zip`
+3. Make a JN site -> install and activate the zip file.
+4. Open IE 11 and start OBW
+5. Confirm that the themes are displayed correctly.
+
+
 ### Fix hidden menu title on smaller screens #6562
 
 1. Enable the new navigation.

--- a/client/ie.scss
+++ b/client/ie.scss
@@ -3,3 +3,26 @@
  *
  * @format
  */
+
+ .woocommerce-profile-wizard__body .woocommerce-profile-wizard__container {
+	> .woocommerce-profile-wizard__themes-tab-panel {
+		@include breakpoint( '>782px' ) {
+			.woocommerce-profile-wizard__themes {
+                @for $i from 1 through 40 {
+                    .components-card:nth-child(#{$i}) {
+                        margin-bottom: $gap-large;
+                        @if $i % 2 == 0 {
+                            grid-column: 2;
+                            grid-row: $i /2;
+                            margin-left: $gap-large / 2;
+                        } @else {
+                            grid-column: 1;
+                            grid-row: ($i / 2)+0.5;
+                            margin-right: $gap-large / 2;
+                        }
+                    }
+                }
+			}
+		}
+	}
+}

--- a/client/ie.scss
+++ b/client/ie.scss
@@ -4,24 +4,25 @@
  * @format
  */
 
- .woocommerce-profile-wizard__body .woocommerce-profile-wizard__container {
+.woocommerce-profile-wizard__body .woocommerce-profile-wizard__container {
 	> .woocommerce-profile-wizard__themes-tab-panel {
 		@include breakpoint( '>782px' ) {
 			.woocommerce-profile-wizard__themes {
-                @for $i from 1 through 40 {
-                    .components-card:nth-child(#{$i}) {
-                        margin-bottom: $gap-large;
-                        @if $i % 2 == 0 {
-                            grid-column: 2;
-                            grid-row: $i /2;
-                            margin-left: $gap-large / 2;
-                        } @else {
-                            grid-column: 1;
-                            grid-row: ($i / 2)+0.5;
-                            margin-right: $gap-large / 2;
-                        }
-                    }
-                }
+				@for $i from 1 through 40 {
+					.components-card:nth-child(#{$i}) {
+						margin-bottom: $gap-large;
+						@if $i % 2 == 0 {
+							grid-column: 2;
+							grid-row: $i /2;
+							margin-left: $gap-large / 2;
+						}
+						@else {
+							grid-column: 1;
+							grid-row: ($i / 2) +0.5;
+							margin-right: $gap-large / 2;
+						}
+					}
+				}
 			}
 		}
 	}

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -103,12 +103,13 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	}
 
 	.components-form-file-upload {
-		flex: 1;
+		flex: 1 1 auto;
 		width: 100%;
+        display: flex;
 	}
 
 	.components-form-file-upload > .components-button {
-		flex: 1;
+		flex: 1 1 auto;
 		flex-direction: column;
 		justify-content: center;
 		margin: 0;

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -105,7 +105,7 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	.components-form-file-upload {
 		flex: 1 1 auto;
 		width: 100%;
-        display: flex;
+		display: flex;
 	}
 
 	.components-form-file-upload > .components-button {

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Allow the manager role to query certain options #6577
 - Dev: Refactor profile wizard benefits step and add tests #6583
 - Fix: Delete customer data on network user deletion #6574
+- Fix: Fix Themes step visibility in IE 11 #6578
 - Fix: Fix hidden menu title on smaller screens #6562
 - Fix: Add gross sales column to CSV export #6567
 - Dev: Add filter to profile wizard steps #6564


### PR DESCRIPTION
Fixes #6219 

This PR fixes the "Themes" step visibility bug in IE11.

The IE 11 does not fully support CSS grid and its properties. One way to fix the grid in IE 11 is to define `grid-row` and `grid-column` styles for each item in the grid. You can read more about it [here](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/).

Since most users who go through the OBW start with the default set of themes, this PR defines `grid-row` and `grid-column` styles for the first 40 children (up to 40 themes) in the grid. 40 themes should be safe enough to cover most users.

### Screenshots

![Screen Shot 2021-03-11 at 7 05 43 PM](https://user-images.githubusercontent.com/4723145/110888127-683ae300-82a0-11eb-83cb-5f4a8453fb17.jpg)


### Detailed test instructions:

1. Get an IE 11 test environment. I downloaded a trial version of Parallels Desktop on [here](https://www.parallels.com/) and IE 11 virtual machine from [developer.microsoft.com](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
2. Make a zip version of this branch by running `npm run test:zip`
3. Make a JN site -> install and activate the zip file.
4. Open IE 11 and start OBW
5. Confirm that the themes are displayed correctly.
