### PR TITLE
Refactor profile wizard benefits step and add tests

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -57,6 +57,17 @@ Testing `woocommerce_navigation_intro_modal_dismissed`
 3. Open browser inspector and select the Network tab.
 4. Navigate to WooCommerce -> Home
 5. Confirm that the request to `/wp-json/wc-admin/options?options=woocommerce_navigation_intro_modal_dismissed&_locale=user` returns 200 status.
+### Refactor profile wizard benefits step and add tests #6583
+
+1. Deactivate Jetpack and/or WooCommerce Services.
+2. Visit the profiler benefits page. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=benefits`
+3. Click "Yes please!" to continue.
+4. Without connecting to Jetpack, navigate backwards using your browser's back button.
+5. Make sure the page continues to display (benefits may have changed) and that action buttons are functional.
+6. Make sure skipping the install works as expected.
+7. Connect Jetpack.
+8. Attempt to directly visit the benefits page. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=benefits`
+9. Note that you are redirected to the homescreen.
 
 ### Fix hidden menu title on smaller screens #6562
 

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -27,7 +27,7 @@ import { getAdminLink } from '@woocommerce/wc-admin-settings';
 /**
  * Internal dependencies
  */
-import Benefits from './steps/benefits';
+import { BenefitsLayout } from './steps/benefits';
 import { BusinessDetailsStep } from './steps/business-details';
 import Industry from './steps/industry';
 import ProductTypes from './steps/product-types';
@@ -155,7 +155,7 @@ class ProfileWizard extends Component {
 		) {
 			steps.push( {
 				key: 'benefits',
-				container: Benefits,
+				container: BenefitsLayout,
 			} );
 		}
 

--- a/client/profile-wizard/steps/benefits/benefit.js
+++ b/client/profile-wizard/steps/benefits/benefit.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { H } from '@woocommerce/components';
+
+export const Benefit = ( { description, icon, title } ) => {
+	return (
+		<div className="woocommerce-profile-wizard__benefit-card" key={ title }>
+			{ icon }
+			<div className="woocommerce-profile-wizard__benefit-card-content">
+				<H className="woocommerce-profile-wizard__benefit-card-title">
+					{ title }
+				</H>
+				<p>{ description }</p>
+			</div>
+		</div>
+	);
+};

--- a/client/profile-wizard/steps/benefits/benefits.js
+++ b/client/profile-wizard/steps/benefits/benefits.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Benefit } from './benefit';
+import ManagementIcon from './images/management';
+import SalesTaxIcon from './images/sales_tax';
+import ShippingLabels from './images/shipping_labels';
+import SpeedIcon from './images/speed';
+
+export const Benefits = ( { jetpack = false, wcs = false } ) => {
+	return (
+		<div className="woocommerce-profile-wizard__benefits">
+			{ ! jetpack && (
+				<Benefit
+					title={ __(
+						'Store management on the go',
+						'woocommerce-admin'
+					) }
+					icon={ <ManagementIcon /> }
+					description={ __(
+						'Your store in your pocket. Manage orders, receive sales notifications, and more. Only with a Jetpack connection.',
+						'woocommerce-admin'
+					) }
+				/>
+			) }
+			{ ( ! wcs || ! jetpack ) && (
+				<Benefit
+					title={ __( 'Automated sales taxes', 'woocommerce-admin' ) }
+					icon={ <SalesTaxIcon /> }
+					description={ __(
+						'Ensure that the correct rate of tax is charged on all of your orders automatically, and print shipping labels at home.',
+						'woocommerce-admin'
+					) }
+				/>
+			) }
+			{ ! jetpack && (
+				<Benefit
+					title={ __(
+						'Improved speed & security',
+						'woocommerce-admin'
+					) }
+					icon={ <SpeedIcon /> }
+					description={ __(
+						'Automatically block brute force attacks and speed up your store using our powerful, global server network to cache images.',
+						'woocommerce-admin'
+					) }
+				/>
+			) }
+			{ jetpack && ! wcs && (
+				<Benefit
+					title={ __(
+						'Print shipping labels at home',
+						'woocommerce-admin'
+					) }
+					icon={ <ShippingLabels /> }
+					description={ __(
+						'Save time at the post office by printing shipping labels for your orders at home.',
+						'woocommerce-admin'
+					) }
+				/>
+			) }
+		</div>
+	);
+};

--- a/client/profile-wizard/steps/benefits/benefits.js
+++ b/client/profile-wizard/steps/benefits/benefits.js
@@ -12,10 +12,10 @@ import SalesTaxIcon from './images/sales_tax';
 import ShippingLabels from './images/shipping_labels';
 import SpeedIcon from './images/speed';
 
-export const Benefits = ( { jetpack = false, wcs = false } ) => {
+export const Benefits = ( { isJetpackSetup = false, isWcsSetup = false } ) => {
 	return (
 		<div className="woocommerce-profile-wizard__benefits">
-			{ ! jetpack && (
+			{ ! isJetpackSetup && (
 				<Benefit
 					title={ __(
 						'Store management on the go',
@@ -28,7 +28,7 @@ export const Benefits = ( { jetpack = false, wcs = false } ) => {
 					) }
 				/>
 			) }
-			{ ( ! wcs || ! jetpack ) && (
+			{ ( ! isWcsSetup || ! isJetpackSetup ) && (
 				<Benefit
 					title={ __( 'Automated sales taxes', 'woocommerce-admin' ) }
 					icon={ <SalesTaxIcon /> }
@@ -38,7 +38,7 @@ export const Benefits = ( { jetpack = false, wcs = false } ) => {
 					) }
 				/>
 			) }
-			{ ! jetpack && (
+			{ ! isJetpackSetup && (
 				<Benefit
 					title={ __(
 						'Improved speed & security',
@@ -51,7 +51,7 @@ export const Benefits = ( { jetpack = false, wcs = false } ) => {
 					) }
 				/>
 			) }
-			{ jetpack && ! wcs && (
+			{ isJetpackSetup && ! isWcsSetup && (
 				<Benefit
 					title={ __(
 						'Print shipping labels at home',

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -64,7 +64,7 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 
 	const isJetpackActive = ! pluginsToInstall.includes( 'jetpack' );
 	const isWcsActive = ! pluginsToInstall.includes( 'woocommerce-services' );
-	const isComplete = isWcsActive && isJetpackActive && isJetpackConnected();
+	const isComplete = isWcsActive && isJetpackActive && isJetpackConnected;
 
 	useEffect( () => {
 		// Skip this step if already complete.

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -150,6 +150,7 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 				<div className="woocommerce-profile-wizard__step-header">
 					<Text variant="title.small" as="h2">
 						{ sprintf(
+							/* translators: %s = names of plugins to install, e.g. Jetpack and Woocommerce Services */
 							__(
 								'Enhance your store with %s',
 								'woocommerce-admin'
@@ -189,8 +190,9 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 						{ isAcceptingTos
 							? interpolateComponents( {
 									mixedString: sprintf(
+										/* translators: %1$s: names of plugins to install, e.g. Jetpack and Woocommerce Services, %2$s: singular or plural form of 'plugins'   */
 										__(
-											'%s %s will be installed & activated for free, and you agree to our {{link}}Terms of Service{{/link}}.',
+											'%1$s %2$s will be installed & activated for free, and you agree to our {{link}}Terms of Service{{/link}}.',
 											'woocommerce-admin'
 										),
 										pluginNamesString,
@@ -207,8 +209,9 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 									},
 							  } )
 							: sprintf(
+									/* translators: %1$s: names of plugins to install, e.g. Jetpack and Woocommerce Services, %2$s: singular or plural form of 'plugins'   */
 									__(
-										'%s %s will be installed & activated for free.',
+										'%1$s %2$s will be installed & activated for free.',
 										'woocommerce-admin'
 									),
 									pluginNamesString,

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -37,7 +37,9 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 
 		return {
 			activePlugins: getActivePlugins(),
-			isJetpackConnected: select( PLUGINS_STORE_NAME ),
+			isJetpackConnected: select(
+				PLUGINS_STORE_NAME
+			).isJetpackConnected(),
 			isProfileItemsError: Boolean(
 				getOnboardingError( 'updateProfileItems' )
 			),
@@ -62,12 +64,23 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 
 	const isJetpackActive = ! pluginsToInstall.includes( 'jetpack' );
 	const isWcsActive = ! pluginsToInstall.includes( 'woocommerce-services' );
+	const isComplete = isWcsActive && isJetpackActive && isJetpackConnected();
 
 	useEffect( () => {
+		// Skip this step if already complete.
+		if ( isComplete ) {
+			goToNextStep();
+			return;
+		}
+
 		recordEvent( 'storeprofiler_plugins_to_install', {
 			plugins: pluginsToInstall,
 		} );
 	}, [] );
+
+	if ( isComplete ) {
+		return null;
+	}
 
 	const skipPluginInstall = async () => {
 		const plugins = isJetpackActive ? 'skipped-wcs' : 'skipped';
@@ -160,8 +173,8 @@ export const BenefitsLayout = ( { goToNextStep } ) => {
 					</Text>
 				</div>
 				<Benefits
-					jetpack={ ! isJetpackActive || ! isJetpackConnected }
-					wcs={ ! isWcsActive }
+					isJetpackSetup={ isJetpackActive && isJetpackConnected }
+					isWcsSetup={ isWcsActive }
 				/>
 			</CardBody>
 			<CardFooter isBorderless justify="center">

--- a/client/profile-wizard/steps/benefits/test/index.js
+++ b/client/profile-wizard/steps/benefits/test/index.js
@@ -1,0 +1,205 @@
+/**
+ * External dependencies
+ */
+import { act, fireEvent, render } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { BenefitsLayout } from '../';
+
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useDispatch: jest.fn().mockReturnValue( {} ),
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
+describe( 'BenefitsLayout', () => {
+	it( 'should show WooCommerce Service when it is to be installed', () => {
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [ 'jetpack' ],
+			isJetpackConnected: true,
+		} ) );
+
+		const { container, queryByText } = render( <BenefitsLayout /> );
+
+		expect(
+			container.querySelectorAll(
+				'.woocommerce-profile-wizard__benefit-card'
+			).length
+		).toBe( 2 );
+		expect( queryByText( 'Print shipping labels at home' ) ).not.toBeNull();
+		expect( queryByText( 'Automated sales taxes' ) ).not.toBeNull();
+	} );
+
+	it( 'should show Jetpack benefits when Jetpack is to be installed', () => {
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [ 'woocommerce-services' ],
+			isJetpackConnected: false,
+		} ) );
+
+		const { container, queryByText } = render( <BenefitsLayout /> );
+
+		expect(
+			container.querySelectorAll(
+				'.woocommerce-profile-wizard__benefit-card'
+			).length
+		).toBe( 3 );
+		expect( queryByText( 'Store management on the go' ) ).not.toBeNull();
+		expect( queryByText( 'Automated sales taxes' ) ).not.toBeNull();
+		expect( queryByText( 'Improved speed & security' ) ).not.toBeNull();
+
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [ 'jetpack', 'woocommerce-services' ],
+			isJetpackConnected: false,
+		} ) );
+
+		expect(
+			container.querySelectorAll(
+				'.woocommerce-profile-wizard__benefit-card'
+			).length
+		).toBe( 3 );
+		expect( queryByText( 'Store management on the go' ) ).not.toBeNull();
+		expect( queryByText( 'Automated sales taxes' ) ).not.toBeNull();
+		expect( queryByText( 'Improved speed & security' ) ).not.toBeNull();
+	} );
+
+	it( 'should show Jetpack benefits when Jetpack is not connected', () => {
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [ 'jetpack', 'woocommerce-services' ],
+			isJetpackConnected: false,
+		} ) );
+
+		const { container, queryByText } = render( <BenefitsLayout /> );
+
+		expect(
+			container.querySelectorAll(
+				'.woocommerce-profile-wizard__benefit-card'
+			).length
+		).toBe( 3 );
+		expect( queryByText( 'Store management on the go' ) ).not.toBeNull();
+		expect( queryByText( 'Automated sales taxes' ) ).not.toBeNull();
+		expect( queryByText( 'Improved speed & security' ) ).not.toBeNull();
+	} );
+
+	it( 'should skip the benefits step when setup is already complete', () => {
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [ 'jetpack', 'woocommerce-services' ],
+			isJetpackConnected: true,
+		} ) );
+		const goToNextStep = jest.fn();
+
+		const { container } = render(
+			<BenefitsLayout goToNextStep={ goToNextStep } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( goToNextStep ).toHaveBeenCalled();
+	} );
+
+	it( 'should skip the plugin installation when clicking skip', () => {
+		const goToNextStep = jest.fn();
+		const updateProfileItems = jest.fn();
+
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [],
+			isJetpackConnected: false,
+		} ) );
+		useDispatch.mockReturnValue( {
+			updateProfileItems,
+		} );
+
+		const { queryByText } = render(
+			<BenefitsLayout goToNextStep={ goToNextStep } />
+		);
+
+		fireEvent.click( queryByText( 'No thanks' ) );
+		expect( updateProfileItems ).toHaveBeenCalledWith( {
+			plugins: 'skipped',
+		} );
+	} );
+
+	it( 'should install the plugins when opting in', async () => {
+		const goToNextStep = jest.fn();
+		const updateProfileItems = jest.fn();
+		const installAndActivatePlugins = jest.fn();
+
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [],
+			isJetpackConnected: false,
+		} ) );
+		useDispatch.mockReturnValue( {
+			installAndActivatePlugins,
+			updateOptions: jest.fn(),
+			updateProfileItems,
+		} );
+
+		await act( async () => {
+			const { queryByText } = render(
+				<BenefitsLayout goToNextStep={ goToNextStep } />
+			);
+
+			fireEvent.click( queryByText( 'Yes please!' ) );
+			expect( updateProfileItems ).toHaveBeenCalledWith( {
+				plugins: 'installed',
+			} );
+			expect( installAndActivatePlugins ).toHaveBeenCalledWith( [
+				'jetpack',
+				'woocommerce-services',
+			] );
+		} );
+	} );
+
+	it( 'should show a busy state for the install action', () => {
+		// Prevent the promise from resolving right away.
+		useDispatch.mockReturnValue( {
+			installAndActivatePlugins: () => new Promise( () => {} ),
+			updateOptions: jest.fn(),
+			updateProfileItems: jest.fn(),
+		} );
+
+		const { queryByText } = render( <BenefitsLayout /> );
+
+		const installButton = queryByText( 'Yes please!' );
+		const skipButton = queryByText( 'No thanks' );
+
+		act( () => {
+			fireEvent.click( installButton );
+		} );
+
+		expect( installButton.classList ).toContain( 'is-busy' );
+		expect( installButton.disabled ).toBeTruthy();
+		expect( skipButton.disabled ).toBeTruthy();
+	} );
+
+	it( 'should show a busy state for the skip action', async () => {
+		const { queryByText, rerender } = render( <BenefitsLayout /> );
+
+		// Prevent the promise from resolving right away.
+		useDispatch.mockReturnValue( {
+			updateProfileItems: new Promise( () => {} ),
+		} );
+		useSelect.mockImplementation( () => ( {
+			activePlugins: [],
+			isJetpackConnected: false,
+			isUpdatingProfileItems: true,
+		} ) );
+
+		const installButton = queryByText( 'Yes please!' );
+		const skipButton = queryByText( 'No thanks' );
+		fireEvent.click( skipButton );
+
+		rerender( <BenefitsLayout /> );
+
+		expect( installButton.disabled ).toBeTruthy();
+		expect( skipButton.disabled ).toBeTruthy();
+		expect( skipButton.classList ).toContain( 'is-busy' );
+	} );
+} );

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Close activity panel tabs by default and track #6566
 - Dev: Update undefined task name properties for help panel tracks #6565
 - Fix: Allow the manager role to query certain options #6577
+- Dev: Refactor profile wizard benefits step and add tests #6583
 - Fix: Fix hidden menu title on smaller screens #6562
 - Fix: Add gross sales column to CSV export #6567
 - Dev: Add filter to profile wizard steps #6564


### PR DESCRIPTION
Fixes #6020 

* Refactors the benefits step with a more declarative `isInstalling` state.
* Allows visiting the benefits page when plugins have been installed but not connected.
* Redirects to the homescreen if Jetpack is installed and all plugins are connected.
* Adds tests.

Note that the "Yes please!" does not really work to connect to Jetpack on the 2nd go round if both plugins are already activated.  Should we update this to allow this if they directly visit this page?  (I'm think yes, but need a sanity check). cc @pmcpinto @elizaan36 

### Screenshots

#### Before
<img width="393" alt="Screen Shot 2021-03-12 at 10 38 25 AM" src="https://user-images.githubusercontent.com/10561050/111009905-dcd65600-8362-11eb-8794-68c28ddcec19.png">


#### After
<img width="835" alt="Screen Shot 2021-03-12 at 6 43 30 PM" src="https://user-images.githubusercontent.com/10561050/111009906-dfd14680-8362-11eb-99a5-de4e1ecc8524.png">


### Detailed test instructions:

1. Deactivate Jetpack and/or WooCommerce Services.
2. Visit the profiler benefits page. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=benefits`
3. Click "Yes please!" to continue.
4. Without connecting to Jetpack, navigate backwards using your browser's back button.
5. Make sure the page continues to display (benefits may have changed) and that action buttons are functional.
6. Make sure skipping the install works as expected.
7. Connect Jetpack.
8. Attempt to directly visit the benefits page. `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=benefits`
9. Note that you are redirected to the homescreen.