### PR TITLE
Fix end date for last periods

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1135,7 +1135,7 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 4. Verify that now the associated order number and the related products are visible.
 
 ### Fix end date for last periods #6584
-1. We need to be in March 2021
+1. Update your system clock to March 2021
 2. Create a completed order on 29th February 2020
 3. Go to Analytics > Revenue
 4. In the date range filter, select "Last Month" preset and compare to "Previous Year"

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -11,6 +11,18 @@
 5. Click the Download button.
 6. Open the downloaded file and confirm the status values match the table.
 
+### Fix end date for last periods #6584
+1. Update your system clock to March 2021
+2. Create a completed order on 29th February 2020
+3. Go to Analytics > Revenue
+4. In the date range filter, select "Last Month" preset and compare to "Previous Year"
+5. Observe that 29th February sales are included
+6. In the date range filter, select "Last Week" preset and compare to "Previous Year"
+7. Observe that the end date is the same as the current year's end date
+8. In the date range filter, select "Last Quarter" preset and compare to "Previous Year"
+9. Observe that the end date is the same as the selected quarter and subtract 1 year
+10. In the date range filter, select "Last Year" preset and compare to "Previous Year"
+11. Observe that the end date is the same as the selected year and subtract 1 year
 ## 2.5.0
 
 ### Fix WC Home crash when the Analytics is disabled #7339
@@ -1133,19 +1145,6 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 2. Go to `Analytics` > `Orders`
 3. Set the `Date Range` filter in order to cover the refunded order date.
 4. Verify that now the associated order number and the related products are visible.
-
-### Fix end date for last periods #6584
-1. Update your system clock to March 2021
-2. Create a completed order on 29th February 2020
-3. Go to Analytics > Revenue
-4. In the date range filter, select "Last Month" preset and compare to "Previous Year"
-5. Observe that 29th February sales are included
-6. In the date range filter, select "Last Week" preset and compare to "Previous Year"
-7. Observe that the end date is the same as the current year's end date
-8. In the date range filter, select "Last Quarter" preset and compare to "Previous Year"
-9. Observe that the end date is the same as the selected quarter and subtract 1 year
-10. In the date range filter, select "Last Year" preset and compare to "Previous Year"
-11. Observe that the end date is the same as the selected year and subtract 1 year
 
 ### Remove CES actions for adding and editing a product and editing an order #6355
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -84,7 +84,6 @@ Please make sure to test it on Safari as well.
 5. Click on "Set up Tax" option on Task list.
 6. TOS should not blink. 
 
-
 ### Use saved values if available when switching tabs #7226
 
 1. Start onboarding wizard and continue to step 4.
@@ -1134,6 +1133,19 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 2. Go to `Analytics` > `Orders`
 3. Set the `Date Range` filter in order to cover the refunded order date.
 4. Verify that now the associated order number and the related products are visible.
+
+### Fix end date for last periods #6584
+1. We need to be in March 2021
+2. Create a completed order on 29th February 2020
+3. Go to Analytics > Revenue
+4. In the date range filter, select "Last Month" preset and compare to "Previous Year"
+5. Observe that 29th February sales are included
+6. In the date range filter, select "Last Week" preset and compare to "Previous Year"
+7. Observe that the end date is the same as the current year's end date
+8. In the date range filter, select "Last Quarter" preset and compare to "Previous Year"
+9. Observe that the end date is the same as the selected quarter and subtract 1 year
+10. In the date range filter, select "Last Year" preset and compare to "Previous Year"
+11. Observe that the end date is the same as the selected year and subtract 1 year
 
 ### Remove CES actions for adding and editing a product and editing an order #6355
 

--- a/changelogs/fix-6471
+++ b/changelogs/fix-6471
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix end date for last periods

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -173,9 +173,12 @@ export function getLastPeriod( period, compare ) {
 			secondaryEnd = primaryStart.clone().subtract( 1, 'days' );
 			secondaryStart = secondaryEnd.clone().subtract( daysDiff, 'days' );
 		}
-	} else {
+	} else if ( period === 'week' ) {
 		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
 		secondaryEnd = primaryEnd.clone().subtract( 1, 'years' );
+	} else {
+		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
+		secondaryEnd = secondaryStart.clone().endOf( period );
 	}
 
 	// When the period is month, be sure to force end of month to take into account leap year

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -579,6 +579,19 @@ describe( 'getLastPeriod', () => {
 				lastMonthkLastYearEnd.isSame( dateValue.secondaryEnd, 'day' )
 			).toBe( true );
 		} );
+
+		it( 'should return correct values on a leap year', () => {
+			// Mock the current time as a year and month after a leap year month, March 2021.
+			const dateNowSpy = jest
+				.spyOn( Date, 'now' )
+				.mockImplementation( () => 1615587095000 );
+
+			const dateValue = getLastPeriod( 'month', 'previous_year' );
+
+			expect( dateValue.secondaryEnd.date() ).toBe( 29 );
+
+			dateNowSpy.mockRestore();
+		} );
 	} );
 
 	describe( 'quarter', () => {


### PR DESCRIPTION
Fixes woocommerce/woocommerce-admin#6471 

Fix end date for last periods. 

**Does anyone have suggestions on fixing chart data?**

The `chartDate` maps over `primaryDate`; whether last year is a leap year; February only renders 28 days.

- Create an empty date and push the item to the end of primary; since the chart is ordered by date and this is an invalid date (Feb 29, 2021) this doesn't work. 
- Perhaps mapping over whichever array has more items, secondary, or primary would work?


### Screenshots
Before
<img width="737" alt="Before" src="https://user-images.githubusercontent.com/56378160/110992241-a50be600-8343-11eb-88c4-7615bf5cac05.png">

After
<img width="735" alt="After" src="https://user-images.githubusercontent.com/56378160/110992248-a89f6d00-8343-11eb-9e92-7a0de0f37579.png">


### Detailed test instructions:
1. We need to be in March 2021
1. Create a completed order on 29th February 2020
1. Go to Analytics > Revenue
1. In the date range filter, select "Last Month" preset and compare to "Previous Year"
1. Observe that 29th February sales are included
1. In the date range filter, select "Last Week" preset and compare to "Previous Year"
1. Observe that the end date is the same as the current year's end date
1. In the date range filter, select "Last Quarter" preset and compare to "Previous Year"
1. Observe that the end date is the same as the selected quarter and subtract 1 year
1. In the date range filter, select "Last Year" preset and compare to "Previous Year"
1. Observe that the end date is the same as the selected year and subtract 1 year

