### PR TITLE
Prepare Documentation for 2.1.3 release

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -10,21 +10,6 @@
 5. Click the download link in the email
 6. See gross sales column
 
-### Fix a bug where the JetPack connection flow would not activate
-
-1. With a fresh install of wc-admin and woocommerce, go to the home screen
-2. Going to the homescreen redirects to the profile setup wizard
-3. The first step is "Store details" choose United States (any state) for country and fill in the other details with test data.
-4. Click "continue", you should be taken to the "Industry" step.
-5. In the "Industry" step check the "Food and Drink" option only. Click "continue"
-6. In the "Product Type" step choose any value and click "continue"
-7. You should arrive at the "Business details" step which provides 2 tabs: "Business details" and "Free features". In the "Business Details" tab fill out the dropdowns with any values. Click "continue".
-8. In the "Free features" step expand the list of extensions to install by clicking the arrow to the right of "Add recommended business features to my site".
-9. Uncheck all the extensions except for "Enhance speed and security with Jetpack"
-10. Click "continue", the plugin will be installed and you should arrive at the theme step.
-11. Click "Continue with my active theme"
-12. After finishing the wizard, this should redirect you to the "Jetpack" setup connection flow. (You should not be redirected straight to the homescreen).
-
 ### Allow the manager role to query certain options #6577
 
 Testing `woocommerce_ces_tracks_queue`
@@ -195,37 +180,6 @@ For each task in that list apart from "Store details":
 3. A title in the top left should reflect the original task name from the task list. e.g. "Add tax rates"
 4. Clicking the chevron to the left of the title should take you back to the home screen
 
-### Update target audience of business feature step #6508
-
-Scenario #1
-
-1. With a fresh install of wc-admin and woocommerce, go to the home screen, which starts the onboarding wizard
-2. Fill out the store details with a canadian address (addr: 4428 Blanshard, country/region: Canada -- British Columbia, city: Victoria, postcode: V8W 2H9)
-3. Click continue and select **Fashion, apparel, and accessories**, continue, and select **Physical products**, and continue.
-4. The business details tab should show a **Business details** tab, and a **Free features** tab (disabled at first)
-     - There should only be dropdowns visible on the **Business details** step (no checkboxes)
-5. Select **1-10** for the first dropdown, and **No** for the second, and click Continue.
-6. Click on the expansion icon for the **Add recommended business features to my site**
-7. It should list 7 features, including **WooCommerce Payments** (top one)
-     - Note down the selected features, for step 10
-8. Click continue, and select your theme, after it should redirect to the home screen (showing the welcome modal, you can step through this).
-9. The home screen task list should include a **Set up WooCommerce Payments** task, and there should also be a **Set up additional payment providers** inbox card displayed (below the task list).
-10. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 7 are installed and activated.
-
-Scenario #2
-
-1. With a fresh install of wc-admin and woocommerce, go to the home screen, which starts the onboarding wizard
-2. Fill out the store details with a spanish address (addr: C/ Benito Guinea 52, country/region: Spain -- Barcelona, city: Canet de Mar, postcode: 08360)
-3. Click continue and select **Fashion, apparel, and accessories**, continue, and select **Physical products**, and continue.
-4. On the business details tab select **1-10** for the first dropdown, and **No** for the second.
-     - After filling the dropdowns it should show several checkboxes with plugins (Facebook, mailchimp, creative mail, google ads)
-     - Note which ones you kept selected (you can unselect one or two)
-5. Click continue, and select your theme, it should show the **WooCommerce Shipping & Tax** step after, you can click **No thanks**.
-6. You will be redirected to the home screen, showing the welcome modal, you can step through this.
-7. The task list should show the **Choose payment methods** task, and the **Set up additional payment providers** inbox card should not be present.
-8. Click on the **Choose payment methods** task, it should not be displaying the **Woocommerce Payments** option.
-9. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 4 are installed and activated.
-
 ### Add Ireland to Square payment method #6559
 
 1. Go to the store setup wizard `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
@@ -285,6 +239,53 @@ Scenario #2
 - Go to Products > Attributes.
 - Add a new attribute.
 - Observe CES prompt "How easy was it to add a product attribute?" is displayed.
+
+# 2.1.3
+### Fix a bug where the JetPack connection flow would not activate #6521
+
+1. With a fresh install of wc-admin and woocommerce, go to the home screen
+2. Going to the homescreen redirects to the profile setup wizard
+3. The first step is "Store details" choose United States (any state) for country and fill in the other details with test data.
+4. Click "continue", you should be taken to the "Industry" step.
+5. In the "Industry" step check the "Food and Drink" option only. Click "continue"
+6. In the "Product Type" step choose any value and click "continue"
+7. You should arrive at the "Business details" step which provides 2 tabs: "Business details" and "Free features". In the "Business Details" tab fill out the dropdowns with any values. Click "continue".
+8. In the "Free features" step expand the list of extensions to install by clicking the arrow to the right of "Add recommended business features to my site".
+9. Uncheck all the extensions except for "Enhance speed and security with Jetpack"
+10. Click "continue", the plugin will be installed and you should arrive at the theme step.
+11. Click "Continue with my active theme"
+12. After finishing the wizard, this should redirect you to the "Jetpack" setup connection flow. (You should not be redirected straight to the homescreen).
+
+### Update target audience of business feature step #6508
+
+Scenario #1
+
+1. With a fresh install of wc-admin and woocommerce, go to the home screen, which starts the onboarding wizard
+2. Fill out the store details with a canadian address (addr: 4428 Blanshard, country/region: Canada -- British Columbia, city: Victoria, postcode: V8W 2H9)
+3. Click continue and select **Fashion, apparel, and accessories**, continue, and select **Physical products**, and continue.
+4. The business details tab should show a **Business details** tab, and a **Free features** tab (disabled at first)
+     - There should only be dropdowns visible on the **Business details** step (no checkboxes)
+5. Select **1-10** for the first dropdown, and **No** for the second, and click Continue.
+6. Click on the expansion icon for the **Add recommended business features to my site**
+7. It should list 7 features, including **WooCommerce Payments** (top one)
+     - Note down the selected features, for step 10
+8. Click continue, and select your theme, after it should redirect to the home screen (showing the welcome modal, you can step through this).
+9. The home screen task list should include a **Set up WooCommerce Payments** task, and there should also be a **Set up additional payment providers** inbox card displayed (below the task list).
+10. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 7 are installed and activated.
+
+Scenario #2
+
+1. With a fresh install of wc-admin and woocommerce, go to the home screen, which starts the onboarding wizard
+2. Fill out the store details with a spanish address (addr: C/ Benito Guinea 52, country/region: Spain -- Barcelona, city: Canet de Mar, postcode: 08360)
+3. Click continue and select **Fashion, apparel, and accessories**, continue, and select **Physical products**, and continue.
+4. On the business details tab select **1-10** for the first dropdown, and **No** for the second.
+     - After filling the dropdowns it should show several checkboxes with plugins (Facebook, mailchimp, creative mail, google ads)
+     - Note which ones you kept selected (you can unselect one or two)
+5. Click continue, and select your theme, it should show the **WooCommerce Shipping & Tax** step after, you can click **No thanks**.
+6. You will be redirected to the home screen, showing the welcome modal, you can step through this.
+7. The task list should show the **Choose payment methods** task, and the **Set up additional payment providers** inbox card should not be present.
+8. Click on the **Choose payment methods** task, it should not be displaying the **Woocommerce Payments** option.
+9. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 4 are installed and activated.
 
 ## 2.1.2
 

--- a/readme.txt
+++ b/readme.txt
@@ -109,7 +109,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Associated Order Number for refunds was hidden #6428
 - Add: Remove Mollie promo note on install #6510
 - Add: Remote Inbox Notifications rule to trigger when WooCommerce Admin is upgraded. #6040
-- Feature: Increase target audience for business feature step. #6508
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
 - Dev: Store profiler - Added MailPoet to new Business Details step  #6515
 - Dev: Add tilde (~) to represent client root directory for imports. #6517
@@ -117,14 +116,18 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: CES survey for search product, order, customer #6420
 - Add: CES survey for importing products #6419
 - Add: CES survey for adding product categories, tags, and attributes #6418
+
+== 2.1.3 3/14/2021  ==
+
+- Feature: Increase target audience for business feature step. #6508
 - Fix: Correct a bug where the JP connection flow would not happen when installing JP in the OBW. #6521
 
-== 2.1.0 3/10/2021  ==
+== 2.1.2 3/10/2021  ==
 
 - Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.1.0 3/4/2021  ==
+== 2.1.1 3/4/2021  ==
 
 - Fix: Restore missing Correct the Klarna slug #6440
 


### PR DESCRIPTION
Updates the changelog and testing instructions for the 2.1.3 release.

This also fixes some incorrect version numbers for 2.1.x.

No changelog required.