### PR TITLE
Update select control logic so value type stays consistent

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Deprecate use of `<Card>` in favor of the `<Card>` component in `@wordpress/components`.
 -   Fixing screen reader text being undefined for report `<Table>`
 -   Update `<SearchListControl />` to use checkbox and radio inputs.
+-   Fix <SelectControl /> so the onChange value type always matches the selected type. #6594
 
 ## Breaking changes
 

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -21,7 +21,7 @@ const options = [
 
 <SelectControl
 	label="Single value"
-	onChange={ selected => setState( { singleSelected: selected } ) }
+	onChange={ ( selected ) => setState( { singleSelected: selected } ) }
 	options={ options }
 	placeholder="Start typing to filter options..."
 	selected={ singleSelected }
@@ -49,3 +49,10 @@ const options = [
 | `showClearButton`        | boolean      | `false`    | Render a 'Clear' button next to the input box to remove its contents                                                                                            |
 | `hideBeforeSearch`       | boolean      | `false`    | Only show list options after typing a search query                                                                                                              |
 | `staticList`             | boolean      | `false`    | Render results list positioned statically instead of absolutely                                                                                                 |
+
+### onChange value
+
+The onChange value defaults to an array of the selected option(s), but will also reflect what has been passed in the `selected` prop.
+If the `selected` prop has the value set as a `string`, the `onChange` method will also be called with a string value - the `key` of the selected option (if multiple is `false`).
+
+Only string or array are the supported types here.

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -42,6 +42,7 @@ export class SelectControl extends Component {
 		this.search = this.search.bind( this );
 		this.selectOption = this.selectOption.bind( this );
 		this.setExpanded = this.setExpanded.bind( this );
+		this.setNewValue = this.setNewValue.bind( this );
 	}
 
 	bindNode( node ) {
@@ -92,21 +93,29 @@ export class SelectControl extends Component {
 	}
 
 	selectOption( option ) {
-		const { multiple, onChange, selected } = this.props;
-		const { query } = this.state;
+		const { multiple, selected } = this.props;
 		const newSelected = multiple ? [ ...selected, option ] : [ option ];
 
 		this.reset( newSelected );
 
+		const oldSelected = Array.isArray( selected )
+			? selected
+			: [ { key: selected } ];
+		const isSelected = findIndex( oldSelected, { key: option.key } );
+		if ( isSelected === -1 ) {
+			this.setNewValue( newSelected );
+		}
+	}
+
+	setNewValue( newValue ) {
+		const { onChange, selected, multiple } = this.props;
+		const { query } = this.state;
 		// Trigger a change if the selected value is different and pass back
 		// an array or string depending on the original value.
-		if ( Array.isArray( selected ) ) {
-			const isSelected = findIndex( selected, { key: option.key } );
-			if ( isSelected === -1 ) {
-				onChange( newSelected, query );
-			}
-		} else if ( selected !== option.key ) {
-			onChange( option.key, query );
+		if ( multiple || Array.isArray( selected ) ) {
+			onChange( newValue, query );
+		} else if ( newValue.length < 2 ) {
+			onChange( newValue.length > 0 ? newValue[ 0 ].key : '', query );
 		}
 	}
 
@@ -337,6 +346,7 @@ export class SelectControl extends Component {
 					listboxId={ listboxId }
 					onSearch={ this.search }
 					selected={ this.getSelected() }
+					onChange={ this.setNewValue }
 					setExpanded={ this.setExpanded }
 					updateSearchOptions={ this.updateSearchOptions }
 					decrementSelectedIndex={ this.decrementSelectedIndex }

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -4,7 +4,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { debounce, escapeRegExp, findIndex, identity, noop } from 'lodash';
+import { debounce, escapeRegExp, identity, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withFocusOutside, withSpokenMessages } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
@@ -101,7 +101,9 @@ export class SelectControl extends Component {
 		const oldSelected = Array.isArray( selected )
 			? selected
 			: [ { key: selected } ];
-		const isSelected = findIndex( oldSelected, { key: option.key } );
+		const isSelected = oldSelected.findIndex(
+			( val ) => val.key === option.key
+		);
 		if ( isSelected === -1 ) {
 			this.setNewValue( newSelected );
 		}

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -114,7 +114,7 @@ export class SelectControl extends Component {
 		// an array or string depending on the original value.
 		if ( multiple || Array.isArray( selected ) ) {
 			onChange( newValue, query );
-		} else if ( newValue.length < 2 ) {
+		} else {
 			onChange( newValue.length > 0 ? newValue[ 0 ].key : '', query );
 		}
 	}

--- a/packages/components/src/select-control/test/index.js
+++ b/packages/components/src/select-control/test/index.js
@@ -200,4 +200,104 @@ describe( 'SelectControl', () => {
 
 		expect( getAllByRole( 'option' ) ).toHaveLength( 1 );
 	} );
+
+	describe( 'selected value', () => {
+		it( 'should return an array if array', async () => {
+			const onChangeMock = jest.fn();
+			const { getByRole } = render(
+				<SelectControl
+					isSearchable
+					selected={ [ { ...options[ 0 ] } ] }
+					options={ options }
+					onSearch={ () => options }
+					onFilter={ () => options }
+					onChange={ onChangeMock }
+				/>
+			);
+
+			userEvent.clear( getByRole( 'combobox' ) );
+			userEvent.type( getByRole( 'combobox' ), 'test' );
+
+			// Wait for the search promise to resolve.
+			await waitFor( () =>
+				expect(
+					getByRole( 'option', { name: 'bar' } )
+				).toBeInTheDocument()
+			);
+			userEvent.click( getByRole( 'option', { name: 'bar' } ) );
+			expect( onChangeMock ).toHaveBeenCalledWith(
+				[ options[ 2 ] ],
+				'test'
+			);
+		} );
+
+		it( 'should return key value as string if selected is string', async () => {
+			const onChangeMock = jest.fn();
+			const { getByRole } = render(
+				<SelectControl
+					isSearchable
+					selected={ options[ 0 ].key }
+					options={ options }
+					onSearch={ () => options }
+					onFilter={ () => options }
+					onChange={ onChangeMock }
+				/>
+			);
+
+			userEvent.clear( getByRole( 'combobox' ) );
+			userEvent.type( getByRole( 'combobox' ), 'test' );
+
+			// Wait for the search promise to resolve.
+			await waitFor( () =>
+				expect(
+					getByRole( 'option', { name: 'bar' } )
+				).toBeInTheDocument()
+			);
+			userEvent.click( getByRole( 'option', { name: 'bar' } ) );
+			expect( onChangeMock ).toHaveBeenCalledWith(
+				options[ 2 ].key,
+				'test'
+			);
+		} );
+
+		describe( 'control onChange', () => {
+			it( 'should return array if selected is array and onChange triggered from control', () => {
+				const onChangeMock = jest.fn();
+				const { getByRole } = render(
+					<SelectControl
+						isSearchable
+						selected={ [ { ...options[ 0 ] } ] }
+						options={ options }
+						onSearch={ () => options }
+						onFilter={ () => options }
+						onChange={ onChangeMock }
+					/>
+				);
+
+				userEvent.clear( getByRole( 'combobox' ) );
+				userEvent.type( getByRole( 'combobox' ), '{backspace}' );
+
+				expect( onChangeMock ).toHaveBeenCalledWith( [], '' );
+			} );
+
+			it( 'should return string if selected is string and onChange triggered from control', () => {
+				const onChangeMock = jest.fn();
+				const { getByRole } = render(
+					<SelectControl
+						isSearchable
+						selected={ options[ 0 ].key }
+						options={ options }
+						onSearch={ () => options }
+						onFilter={ () => options }
+						onChange={ onChangeMock }
+					/>
+				);
+
+				userEvent.clear( getByRole( 'combobox' ) );
+				userEvent.type( getByRole( 'combobox' ), '{backspace}' );
+
+				expect( onChangeMock ).toHaveBeenCalledWith( '', '' );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
Fixes #6589 

Updated the `select-control` package to not return an array if the expected return type is a 'string'.

### Screenshots

![country-typeahead](https://user-images.githubusercontent.com/2240960/111221466-494a9280-85b9-11eb-9c9c-05adea2265ba.gif)

### Detailed test instructions:

- Start a new store and finish the onboarding flow with any address
- Click on the **Store Details** task in the home screen
- Click on the **Country/Region** typeahead field and hit backspace or delete on OSX
- It should correctly clear the typeahead field and allow you to search again.