### PR TITLE
Add tracking for mail poet installs

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -91,6 +91,7 @@ class BusinessDetails extends Component {
 				extensionInstallationOptions[ 'woocommerce-services' ],
 			install_mailchimp:
 				extensionInstallationOptions[ 'mailchimp-for-woocommerce' ],
+			install_mailpoet: extensionInstallationOptions.mailpoet,
 			install_jetpack: extensionInstallationOptions.jetpack,
 			install_google_ads:
 				extensionInstallationOptions[ 'kliken-marketing-for-google' ],

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: CES survey for search product, order, customer #6420
 - Add: CES survey for importing products #6419
 - Add: CES survey for adding product categories, tags, and attributes #6418
+- Add: Include tracking for mail poet installs in the selective bundle install #6603
 
 == 2.1.3 3/14/2021  ==
 


### PR DESCRIPTION
Fixes #6596 


### Accessibility

n/a

### Screenshots

n/a

### Detailed test instructions:

Note that I won't be adding testing instructions for an added track here. But here's how to test in dev

1. Make sure you have tracks logging enabled in console 
2. Go to the onboarding wizard (doesn't have to be fresh site)
3. Choose US as country, go through steps till you get to "free features" tab
4. Expand the options, disable all the other extensions to install except for mail poet.
5. Click continue, you should see a track logged in console: `wcadmin_storeprofiler_store_business_features_continue` one of the props of the track should be `mailpoet: true`
