### PR TITLE
Try: Use the store timezone to make time data requests

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -4,10 +4,12 @@
 
 ### Use the store timezone to make time data requests #6632
 
-1. Create a store with a timezone significantly ahead of or behind the timezone you currently reside in.
-2. Create a test order and mark complete.
-3. Navigate to various analytics reports and note the time filter is based on the current store time.  E.g., If your store timezone is 12 hours ahead of your current time, you may see `1st - 23rd` instead of `1st - 22nd` for "Month to date" depending on your time of day.
-4. Note that the recently added order shows up in analytics reports.
+1. Go to Settings -> General.
+2. Set your store timezone significantly ahead of or behind the timezone you currently reside in.
+3. Create a test order and mark complete.
+4. Navigate to various analytics reports and note the time filter is based on the current store time.  E.g., If your store timezone is 12 hours ahead of your current time, you may see `1st - 23rd` instead of `1st - 22nd` for "Month to date" depending on your time of day.
+5. Note that the recently added order shows up in analytics reports.
+6. Change your timezone and repeat, testing with both locations (e.g., `Amsterdam`) and also UTC offsets (e.g., `UTC-6`).
 
 ### Add plugin installer to allow installation of plugins via URL #6805
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Use the store timezone to make time data requests #6632
+
+1. Create a store with a timezone significantly ahead of or behind the timezone you currently reside in.
+2. Create a test order and mark complete.
+3. Navigate to various analytics reports and note the time filter is based on the current store time.  E.g., If your store timezone is 12 hours ahead of your current time, you may see `1st - 23rd` instead of `1st - 22nd` for "Month to date" depending on your time of day.
+4. Note that the recently added order shows up in analytics reports.
+
 ### Add plugin installer to allow installation of plugins via URL #6805
 
 1. Visit any admin page with the params `plugin_action` (`install`, `activate`, or `install-activate`) and `plugins` (list of comma separated plugins). `wp-admin/admin.php?page=wc-admin&plugin_action=install&plugins=jetpack`

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -13,3 +13,5 @@ npm install @woocommerce/date --save
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
 
 ## Usage
+
+The `date` package makes use of the global `window.wcSettings.timeZone`.  If a timezone is set, the current and last periods will be converted from your browser's timezone to the store timezone.  If none is set, these periods will be based on your browser's timezone.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -8,6 +8,8 @@ import { parse } from 'qs';
 
 export const isoDateFormat = 'YYYY-MM-DD';
 
+export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss';
+
 /**
  * DateValue Object
  *
@@ -62,15 +64,15 @@ export const periods = [
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
 	if ( timeOfDay === 'start' ) {
-		return date.startOf( 'day' ).format( 'YYYY-MM-DDTHH:mm:ss' );
+		return date.startOf( 'day' ).format( defaultDateTimeFormat );
 	}
 	if ( timeOfDay === 'now' ) {
 		// Set seconds to 00 to avoid consecutives calls happening before the previous
 		// one finished.
-		return date.format( 'YYYY-MM-DDTHH:mm:ss' );
+		return date.format( defaultDateTimeFormat );
 	}
 	if ( timeOfDay === 'end' ) {
-		return date.endOf( 'day' ).format( 'YYYY-MM-DDTHH:mm:ss' );
+		return date.endOf( 'day' ).format( defaultDateTimeFormat );
 	}
 	throw new Error(
 		'appendTimestamp requires second parameter to be either `start`, `now` or `end`'
@@ -134,18 +136,18 @@ export function getRangeLabel( after, before ) {
  */
 export function getStoreCurrentTime() {
 	if ( ! window.wcSettings || ! window.wcSettings.timeZone || ! moment.tz ) {
-		return moment().format( 'YYYY-MM-DD HH:mm:ss' );
+		return moment().format( defaultDateTimeFormat );
 	}
 
 	if ( [ '+', '-' ].includes( window.wcSettings.timeZone.charAt( 0 ) ) ) {
 		return moment()
 			.utcOffset( window.wcSettings.timeZone )
-			.format( 'YYYY-MM-DD HH:mm:ss' );
+			.format( defaultDateTimeFormat );
 	}
 
 	return moment()
 		.tz( window.wcSettings.timeZone )
-		.format( 'YYYY-MM-DD HH:mm:ss' );
+		.format( defaultDateTimeFormat );
 }
 
 /**

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -61,17 +61,16 @@ export const periods = [
  * @return {string} - String date with timestamp attached.
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
-	date = date.format( isoDateFormat );
 	if ( timeOfDay === 'start' ) {
-		return date + 'T00:00:00';
+		return date.startOf( 'day' ).format();
 	}
 	if ( timeOfDay === 'now' ) {
 		// Set seconds to 00 to avoid consecutives calls happening before the previous
 		// one finished.
-		return date + 'T' + moment().format( 'HH:mm:00' );
+		return date.format();
 	}
 	if ( timeOfDay === 'end' ) {
-		return date + 'T23:59:59';
+		return date.endOf( 'day' ).format();
 	}
 	throw new Error(
 		'appendTimestamp requires second parameter to be either `start`, `now` or `end`'

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -135,7 +135,7 @@ export function getRangeLabel( after, before ) {
  * @return {string} - Datetime string.
  */
 export function getStoreTimeZoneMoment() {
-	if ( ! window.wcSettings || ! window.wcSettings.timeZone || ! moment.tz ) {
+	if ( ! window.wcSettings || ! window.wcSettings.timeZone ) {
 		return moment();
 	}
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -136,7 +136,13 @@ export function getRangeLabel( after, before ) {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getLastPeriod( period, compare ) {
-	const primaryStart = moment().startOf( period ).subtract( 1, period );
+	const primaryStart = moment(
+		moment()
+			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
+			.format( 'YYYY-MM-DD HH:mm:ss' )
+	)
+		.startOf( period )
+		.subtract( 1, period );
 	const primaryEnd = primaryStart.clone().endOf( period );
 	let secondaryStart;
 	let secondaryEnd;
@@ -180,8 +186,17 @@ export function getLastPeriod( period, compare ) {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getCurrentPeriod( period, compare ) {
-	const primaryStart = moment().startOf( period );
-	const primaryEnd = moment();
+	const primaryStart = moment(
+		moment()
+			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
+			.format( 'YYYY-MM-DD HH:mm:ss' )
+	).startOf( period );
+	const primaryEnd = moment(
+		moment()
+			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
+			.format( 'YYYY-MM-DD HH:mm:ss' )
+	);
+
 	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;
 	let secondaryEnd;

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -134,20 +134,16 @@ export function getRangeLabel( after, before ) {
  *
  * @return {string} - Datetime string.
  */
-export function getStoreCurrentTime() {
+export function getStoreTimeZoneMoment() {
 	if ( ! window.wcSettings || ! window.wcSettings.timeZone || ! moment.tz ) {
-		return moment().format( defaultDateTimeFormat );
+		return moment();
 	}
 
 	if ( [ '+', '-' ].includes( window.wcSettings.timeZone.charAt( 0 ) ) ) {
-		return moment()
-			.utcOffset( window.wcSettings.timeZone )
-			.format( defaultDateTimeFormat );
+		return moment().utcOffset( window.wcSettings.timeZone );
 	}
 
-	return moment()
-		.tz( window.wcSettings.timeZone )
-		.format( defaultDateTimeFormat );
+	return moment().tz( window.wcSettings.timeZone );
 }
 
 /**
@@ -158,7 +154,7 @@ export function getStoreCurrentTime() {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getLastPeriod( period, compare ) {
-	const primaryStart = moment( getStoreCurrentTime() )
+	const primaryStart = getStoreTimeZoneMoment()
 		.startOf( period )
 		.subtract( 1, period );
 	const primaryEnd = primaryStart.clone().endOf( period );
@@ -204,8 +200,8 @@ export function getLastPeriod( period, compare ) {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getCurrentPeriod( period, compare ) {
-	const primaryStart = moment( getStoreCurrentTime() ).startOf( period );
-	const primaryEnd = moment( getStoreCurrentTime() );
+	const primaryStart = getStoreTimeZoneMoment().startOf( period );
+	const primaryEnd = getStoreTimeZoneMoment();
 
 	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -62,15 +62,15 @@ export const periods = [
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
 	if ( timeOfDay === 'start' ) {
-		return date.startOf( 'day' ).format();
+		return date.startOf( 'day' ).format( 'YYYY-MM-DDTHH:mm:ss' );
 	}
 	if ( timeOfDay === 'now' ) {
 		// Set seconds to 00 to avoid consecutives calls happening before the previous
 		// one finished.
-		return date.format();
+		return date.format( 'YYYY-MM-DDTHH:mm:ss' );
 	}
 	if ( timeOfDay === 'end' ) {
-		return date.endOf( 'day' ).format();
+		return date.endOf( 'day' ).format( 'YYYY-MM-DDTHH:mm:ss' );
 	}
 	throw new Error(
 		'appendTimestamp requires second parameter to be either `start`, `now` or `end`'
@@ -128,6 +128,27 @@ export function getRangeLabel( after, before ) {
 }
 
 /**
+ * Gets the current time in the store time zone if set.
+ *
+ * @return {string} - Datetime string.
+ */
+export function getStoreCurrentTime() {
+	if ( ! window.wcSettings || ! window.wcSettings.timeZone || ! moment.tz ) {
+		return moment().format( 'YYYY-MM-DD HH:mm:ss' );
+	}
+
+	if ( [ '+', '-' ].includes( window.wcSettings.timeZone.charAt( 0 ) ) ) {
+		return moment()
+			.utcOffset( window.wcSettings.timeZone )
+			.format( 'YYYY-MM-DD HH:mm:ss' );
+	}
+
+	return moment()
+		.tz( window.wcSettings.timeZone )
+		.format( 'YYYY-MM-DD HH:mm:ss' );
+}
+
+/**
  * Get a DateValue object for a period prior to the current period.
  *
  * @param {string} period - the chosen period
@@ -135,11 +156,7 @@ export function getRangeLabel( after, before ) {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getLastPeriod( period, compare ) {
-	const primaryStart = moment(
-		moment()
-			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
-			.format( 'YYYY-MM-DD HH:mm:ss' )
-	)
+	const primaryStart = moment( getStoreCurrentTime() )
 		.startOf( period )
 		.subtract( 1, period );
 	const primaryEnd = primaryStart.clone().endOf( period );
@@ -185,16 +202,8 @@ export function getLastPeriod( period, compare ) {
  * @return {DateValue} -  DateValue data about the selected period
  */
 export function getCurrentPeriod( period, compare ) {
-	const primaryStart = moment(
-		moment()
-			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
-			.format( 'YYYY-MM-DD HH:mm:ss' )
-	).startOf( period );
-	const primaryEnd = moment(
-		moment()
-			.tz( window.wcSettings ? window.wcSettings.timeZone : null )
-			.format( 'YYYY-MM-DD HH:mm:ss' )
-	);
+	const primaryStart = moment( getStoreCurrentTime() ).startOf( period );
+	const primaryEnd = moment( getStoreCurrentTime() );
 
 	const daysSoFar = primaryEnd.diff( primaryStart, 'days' );
 	let secondaryStart;

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -22,7 +22,15 @@ import {
 	getPreviousDate,
 	getChartTypeForQuery,
 	getAllowedIntervalsForQuery,
+	getStoreTimeZoneMoment,
 } from '../src';
+
+jest.mock( 'moment', () => {
+	const m = jest.requireActual( 'moment' );
+	m.prototype.tz = jest.fn().mockImplementation( () => m() );
+
+	return m;
+} );
 
 describe( 'appendTimestamp', () => {
 	it( 'should append `start` timestamp', () => {
@@ -935,5 +943,54 @@ describe( 'getChartTypeForQuery', () => {
 			chartType: 'burrito',
 		};
 		expect( getChartTypeForQuery( query ) ).toBe( 'line' );
+	} );
+} );
+
+describe( 'getStoreTimeZoneMoment', () => {
+	it( 'should return the default moment when no timezone exists', () => {
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		expect( getStoreTimeZoneMoment() ).toHaveProperty( '_isAMomentObject' );
+
+		expect( mockTz ).not.toHaveBeenCalled();
+		expect( utcOffset ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should use the timezone string when one is set', () => {
+		global.window.wcSettings = {
+			timeZone: 'Asia/Taipei',
+		};
+
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).toHaveBeenCalledWith( 'Asia/Taipei' );
+		expect( utcOffset ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should use the utc offest when it is set', () => {
+		global.window.wcSettings = {
+			timeZone: '+06:00',
+		};
+
+		const mockTz = ( moment.prototype.tz = jest.fn() );
+		const utcOffset = ( moment.prototype.utcOffset = jest.fn() );
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).not.toHaveBeenCalled();
+		expect( utcOffset ).toHaveBeenCalledWith( '+06:00' );
+
+		global.window.wcSettings = {
+			timeZone: '-04:00',
+		};
+
+		getStoreTimeZoneMoment();
+
+		expect( mockTz ).not.toHaveBeenCalled();
+		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
 	} );
 } );

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -33,9 +33,9 @@ describe( 'appendTimestamp', () => {
 
 	it( 'should append `now` timestamp', () => {
 		const nowTimestamp = moment().format( 'HH:mm:00' );
-		expect( appendTimestamp( moment( '2018-01-01' ), 'now' ) ).toEqual(
-			'2018-01-01T' + nowTimestamp
-		);
+		expect(
+			appendTimestamp( moment( '2018-01-01 ' + nowTimestamp ), 'now' )
+		).toEqual( '2018-01-01T' + nowTimestamp );
 	} );
 
 	it( 'should append `end` timestamp', () => {

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Use the store timezone to make time data requests #6632
 - Add: Add plugin installer to allow installation of plugins via URL #6805
 - Update: Adding setup required icon for non-configured payment methods #6811
 - Update: UI updates to Payment Task screen #6766

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1040,6 +1040,7 @@ class Loader {
 		$settings['shopUrl']         = get_permalink( wc_get_page_id( 'shop' ) );
 		$settings['homeUrl']         = home_url();
 		$settings['dateFormat']      = get_option( 'date_format' );
+		$settings['timeZone']        = wc_timezone_string();
 		$settings['plugins']         = array(
 			'installedPlugins' => PluginsHelper::get_installed_plugin_slugs(),
 			'activePlugins'    => Plugins::get_active_plugins(),


### PR DESCRIPTION
This is an initial fix for the timezone issues outlined in p90Yrv-2cl-p2.

This PR is a superficial fix for a larger issue and most closely follows Option C from the post mentioned above.  This will make time requests and get periods based on the user store data.

There are still a number of follow-ups needed, even if we choose to only use store timezones, such as using potentially using UTC for API requests or allowing API requests with an appending timezone offset.

Note that tests are failing due to `MomentTimezoneDataPlugin` not being loaded in tests.  If anyone has insight into how to fix this, it would be greatly appreciated 🙇 

### Detailed test instructions:

1. Create a store with a timezone significantly ahead of or behind the timezone you currently reside in.
2. Create a test order and mark complete.
3. Navigate to various analytics reports and note the time filter is based on the current store time.  E.g., If your store timezone is 12 hours ahead of your current time, you may see `1st - 23rd` instead of `1st - 22nd` for "Month to date" depending on your time of day.
4. Note that the recently added order shows up in analytics reports.