### PR TITLE
Remove CI tests for WooCommerce 4.7

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -27,11 +27,6 @@ jobs:
                       woocommerce: '4.9.1'
                       phpunit: '6.5.9'
                       composer: '2.0.6'
-                    - php: '7.3'
-                      wordpress: '5.6'
-                      woocommerce: '4.7.0'
-                      phpunit: '6.5.9'
-                      composer: '1.10.19'
         steps:
             - name: Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.7.0


### PR DESCRIPTION
Removes the WooCommerce 4.7 job from the `Run PHP unit tests` Github Action.

This job was previously failing, however I don't think it is worth fixing because this version is lower than the minimum supported WooCommerce version (4.8).

### Detailed test instructions:

-   Confirm CI checks on this PR pass.

No changelog required.