### PR TITLE
Remove Composer v1 Downgrade in PHP Tests

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -180,10 +180,8 @@ install_deps() {
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
 	# Bring in WooCommerce Core dependencies
- 	composer self-update --1
 	cd "woocommerce"
  	composer install --no-dev
-	composer self-update --2
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce


### PR DESCRIPTION
Fixes #5784

Removes the Composer 1 downgrade when installing WooCommerce for PHP tests. This was added in PR #5650 due to incompatibilities with older WooCommerce versions.

The downgrade is no longer required since the minimum supported WooCommerce version (4.8) and higher supports Composer 2.

### Detailed test instructions:

-   Confirm CI checks for PHP pass in this PR. 

Note: The PHP check using WooCommerce 4.7 can be ignored since that version is unsupported. I have created a separate [PR](https://github.com/woocommerce/woocommerce-admin/pull/6640) to remove it.

No changelog required.
