### PR TITLE
Update Paths to Exclude from Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@
 /config* export-ignore
 /client* export-ignore
 /docker* export-ignore
+/storybook* export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@
 /docs* export-ignore
 /config* export-ignore
 /client* export-ignore
+/docker* export-ignore


### PR DESCRIPTION
Fixes #6588

This excludes additional paths from the Composer package by adding `export-ignore` git attributes.

- docker
- storybook

These contain development files only so are not needed by consuming packages.

### Detailed test instructions:

Note I don't think this is possible to test this with Composer until it is in a release. Instead, I'm using `git archive` to provide similar usage.

- Create a git archive 

```
git archive --output=./test.zip --format=zip HEAD
```

-   See that the `docker` and `storybook` paths do not exist in the zip.

No changelog required