### PR TITLE
Check if value for contains comparison is an array

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Add check to see if value for contains is array, show warning if not. #6645
 - Tweak: Add default value for contains op #6622
 - Dev: Close activity panel tabs by default and track #6566
 - Dev: Update undefined task name properties for help panel tracks #6565

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -281,7 +281,7 @@ class OnboardingTasks {
 	 */
 	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
-		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.		
+		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
 			$script_assets = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/onboarding-homepage-notice.min.asset.php';
 
 			wp_enqueue_script(
@@ -439,6 +439,7 @@ class OnboardingTasks {
 	 */
 	public static function track_task_completion( $old_value, $new_value ) {
 		$old_value       = is_array( $old_value ) ? $old_value : array();
+		$new_value       = is_array( $new_value ) ? $new_value : array();
 		$untracked_tasks = array_diff( $new_value, $old_value );
 
 		foreach ( $untracked_tasks as $task ) {

--- a/src/RemoteInboxNotifications/ComparisonOperation.php
+++ b/src/RemoteInboxNotifications/ComparisonOperation.php
@@ -19,18 +19,6 @@ class ComparisonOperation {
 	 * @param string $operation     The operation used to compare the operands.
 	 */
 	public static function compare( $left_operand, $right_operand, $operation ) {
-		if ( $operation && strpos( $operation, 'contains' ) !== false && ! is_array( $left_operand ) ) {
-			$logger = wc_get_logger();
-			$logger->warning(
-				'Operation comparison "contains" option value is not an array, defaulting to empty array.',
-				array(
-					'operation'     => $operation,
-					'left_operand'  => $left_operand,
-					'right_operand' => $right_operand,
-				)
-			);
-			$left_operand = array();
-		}
 		switch ( $operation ) {
 			case '=':
 				return $left_operand === $right_operand;

--- a/src/RemoteInboxNotifications/ComparisonOperation.php
+++ b/src/RemoteInboxNotifications/ComparisonOperation.php
@@ -19,6 +19,18 @@ class ComparisonOperation {
 	 * @param string $operation     The operation used to compare the operands.
 	 */
 	public static function compare( $left_operand, $right_operand, $operation ) {
+		if ( $operation && strpos( $operation, 'contains' ) !== false && ! is_array( $left_operand ) ) {
+			$logger = wc_get_logger();
+			$logger->warning(
+				'Operation comparison "contains" option value is not an array, defaulting to empty array.',
+				array(
+					'operation'     => $operation,
+					'left_operand'  => $left_operand,
+					'right_operand' => $right_operand,
+				)
+			);
+			$left_operand = array();
+		}
 		switch ( $operation ) {
 			case '=':
 				return $left_operand === $right_operand;

--- a/tests/remote-inbox-notifications/option-rule-processor.php
+++ b/tests/remote-inbox-notifications/option-rule-processor.php
@@ -57,4 +57,71 @@ class WC_Tests_RemoteInboxNotifications_OptionRuleProcessor extends WC_Unit_Test
 
 		$this->assertEquals( true, $result );
 	}
+
+	/**
+	 * Test contains of array
+	 *
+	 * @group fast
+	 */
+	public function test_rule_passes_for_contains() {
+		add_option( 'contain_item', array( 'test' ) );
+		$processor = new OptionRuleProcessor();
+		$rule      = json_decode(
+			'
+			{
+				"type": "option",
+				"option_name": "contain_item",
+				"value": "test",
+				"default": [],
+				"operation": "contains"
+			}
+			'
+		);
+
+		$result = $processor->process( $rule, null );
+		$this->assertEquals( true, $result );
+
+		$rule->value = 'not_included';
+		$result      = $processor->process( $rule, null );
+		$this->assertEquals( false, $result );
+		delete_option( 'contain_item' );
+	}
+
+	/**
+	 * Test not contains of value that is not an array
+	 *
+	 * @group fast
+	 */
+	public function test_rule_contains_with_no_array_value() {
+		add_option( 'contain_item', false );
+		$processor = new OptionRuleProcessor();
+		$rule      = json_decode(
+			'
+			{
+				"type": "option",
+				"option_name": "contain_item",
+				"value": "test",
+				"default": [],
+				"operation": "contains"
+			}
+			'
+		);
+
+		$result = $processor->process( $rule, null );
+		$this->assertEquals( false, $result );
+
+		$rule->operation = '!contains';
+		$result          = $processor->process( $rule, null );
+		$this->assertEquals( true, $result );
+
+		update_option( 'contain_item', 'random_string' );
+		$rule->operation = 'contains';
+		$result          = $processor->process( $rule, null );
+		$this->assertEquals( false, $result );
+
+		$rule->operation = '!contains';
+		$result          = $processor->process( $rule, null );
+		$this->assertEquals( true, $result );
+		delete_option( 'contain_item' );
+	}
 }


### PR DESCRIPTION
This is in addition to @moon0326 fix here: #6622 

This PR addresses an issue where the value used for the `contains` comparison in the Remote Inbox notifications could not be an array type, and this throws errors in php 8 when passed into `in_array` (warnings in php 7).
It gracefully defaults to an empty array now, but does show a warning in the WC logs, so it could be fixed.

Not adding this to testing instructions, as it is mostly an extra safety measure.

### Detailed test instructions:

- Start a new store you can skip the onboarding wizard
- Install and activate the [WP Log viewer](https://wordpress.org/plugins/wp-log-viewer/) plugin
- Make sure your store is older then 3 days, you can do that by updating the `woocommerce_admin_install_timestamp` option to a timestamp older then 3 days, could use [epochconverter for this](https://www.epochconverter.com/).
- Create a product and publish it
- Check the log viewer and the WC logs (**WooCommerce > Status > Logs > log-(todays date)-(random hash)**)
- It should not include warnings or error in relation to the ComparisonOperator
- Now set the `woocommerce_task_list_tracked_completed_tasks` option to something that is not an array (string or boolean), like so with the cli: `wp option set woocommerce_task_list_tracked_completed_tasks false`
- Go back to your product, edit it, and click update (it should update successfully)
- No new debug logs should of appeared, but if you go to the WC logs it should show a warning like this:
`WARNING Operation comparison "contains" option value is not an array, defaulting to empty array.`.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
