### PR TITLE
Add IE and NZ to the selective bundle install list

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -436,6 +436,16 @@ For each task in that list apart from "Store details":
 12. Go to **WooCommerce > Settings > Payments**, **Paystack** should be selected.
 13. Click **Manage**, the secret and public key's should match what you entered in step 9.
 
+### Add New Zealand and Ireland to the selective bundle option #6649
+- Start a new Woo store and go to **WooCommerce > Home** to start the onboarding wizard
+- Fill in an address with the country set to **New Zealand — Northland** (try a second time with **Ireland — Carlow**)
+- You can select what every industry and product type for the next two windows or select (**Fashion, apparel, and accessories**, and **Physical products**)
+- On the business details tab it should just show the dropdowns, and show a **Free features** tab at the top (disabled at first)
+- Fill out the dropdowns and click continue
+- It should show the free features tab, click the expansion button, **WooCommerce payments** should be listed as part of the free features.
+- Keeping WooCommerce payments selected, finish the onboarding
+- Check your installed plugins, WooCommerce payments should be installed.
+
 # 2.1.3
 ### Fix a bug where the JetPack connection flow would not activate #6521
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -436,16 +436,6 @@ For each task in that list apart from "Store details":
 12. Go to **WooCommerce > Settings > Payments**, **Paystack** should be selected.
 13. Click **Manage**, the secret and public key's should match what you entered in step 9.
 
-### Add New Zealand and Ireland to the selective bundle option #6649
-- Start a new Woo store and go to **WooCommerce > Home** to start the onboarding wizard
-- Fill in an address with the country set to **New Zealand — Northland** (try a second time with **Ireland — Carlow**)
-- You can select what every industry and product type for the next two windows or select (**Fashion, apparel, and accessories**, and **Physical products**)
-- On the business details tab it should just show the dropdowns, and show a **Free features** tab at the top (disabled at first)
-- Fill out the dropdowns and click continue
-- It should show the free features tab, click the expansion button, **WooCommerce payments** should be listed as part of the free features.
-- Keeping WooCommerce payments selected, finish the onboarding
-- Check your installed plugins, WooCommerce payments should be installed.
-
 # 2.1.3
 ### Fix a bug where the JetPack connection flow would not activate #6521
 

--- a/client/profile-wizard/steps/business-details/data/segmentation.js
+++ b/client/profile-wizard/steps/business-details/data/segmentation.js
@@ -24,6 +24,8 @@ const SUPPORTED_COUNTRIES = [
 	'DK',
 	'SE',
 	'JP',
+	'IE',
+	'NZ',
 ];
 export const isSelectiveBundleInstallSegmentation = ( country ) => {
 	return SUPPORTED_COUNTRIES.includes( getCountryCode( country ) );

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Paystack payment provider to several african countries. #6579
 - Dev: Payments task: include Mercado Pago #6572
 - Dev: Ensure script asset.php files are included in builds #6635
+- Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
 
 == 2.1.3 3/14/2021  ==
 


### PR DESCRIPTION
Fixes #6646 

Add New Zealand and Ireland to the selective bundle install list, these where missed in the original PR: #6508 

### Screenshots

<img width="764" alt="Screen Shot 2021-03-23 at 1 56 37 PM" src="https://user-images.githubusercontent.com/2240960/112186362-cf7d5f00-8bdf-11eb-9625-ca2399457a75.png">

### Detailed test instructions:

- Start a new Woo store and go to **WooCommerce > Home** to start the onboarding wizard
- Fill in an address with the country set to **New Zealand — Northland** (try a second time with **Ireland — Carlow**)
- You can select what every industry and product type for the next two windows or select (**Fashion, apparel, and accessories**, and **Physical products**)
- On the business details tab it should just show the dropdowns, and show a **Free features** tab at the top (disabled at first)
- Fill out the dropdowns and click continue
- It should show the free features tab, click the expansion button, **WooCommerce payments** should be listed as part of the free features.
- Keeping WooCommerce payments selected, finish the onboarding
- Check your installed plugins, WooCommerce payments should be installed.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
