### PR TITLE
Fix Database Table Creation Test

### DIFF
--- a/tests/install.php
+++ b/tests/install.php
@@ -33,7 +33,7 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 		);
 
 		// Remove any existing tables in the environment.
-		$query = 'DROP TABLES IF EXISTS' . implode( ',', $tables );
+		$query = 'DROP TABLE IF EXISTS ' . implode( ',', $tables );
 		$wpdb->query( $query );
 
 		// Try to create the tables.

--- a/tests/install.php
+++ b/tests/install.php
@@ -20,6 +20,10 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	function test_create_tables() {
 		global $wpdb;
 
+		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
 		// List of tables created by Install::create_tables.
 		$tables = array(
 			"{$wpdb->prefix}wc_order_stats",

--- a/tests/install.php
+++ b/tests/install.php
@@ -20,7 +20,7 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	function test_create_tables() {
 		global $wpdb;
 
-		// List of tables created by Install::test_create_tables.
+		// List of tables created by Install::create_tables.
 		$tables = array(
 			"{$wpdb->prefix}wc_order_stats",
 			"{$wpdb->prefix}wc_order_product_lookup",


### PR DESCRIPTION
Follow up to PR https://github.com/woocommerce/woocommerce-admin/pull/6658

I noticed some issues with the `DROP TABLE` query in this test, sorry!

1. The syntax was wrong due to some typos 😅 
2. Things were getting muddled because the test suite uses temporary tables in tests. [More context](https://wordpress.stackexchange.com/a/220308).

The test was only passing because the tables already existed.

### Detailed test instructions:

-   `npm run test:php -- --filter=WC_Admin_Tests_Install`

No changelog required.