### PR TITLE
Update the mercado option name, so it enables correctly

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -416,7 +416,7 @@ export default compose(
 			'woocommerce_mollie_payments_settings',
 			'woocommerce_payubiz_settings',
 			'woocommerce_paystack_settings',
-			'woocommerce_mercadopago_settings',
+			'woocommerce_woo-mercado-pago-basic_settings',
 		];
 
 		const options = optionNames.reduce( ( result, name ) => {

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -236,8 +236,11 @@ export function getPaymentMethods( {
 			plugins: [ MERCADOPAGO_PLUGIN ],
 			container: <MercadoPago />,
 			isConfigured: activePlugins.includes( MERCADOPAGO_PLUGIN ),
-			isEnabled: enabledPaymentGateways.includes( 'mercadopago' ),
-			optionName: 'woocommerce_mercadopago_settings',
+			isEnabled:
+				options[ 'woocommerce_woo-mercado-pago-basic_settings' ] &&
+				options[ 'woocommerce_woo-mercado-pago-basic_settings' ]
+					.enabled === 'yes',
+			optionName: 'woocommerce_woo-mercado-pago-basic_settings',
 		},
 		{
 			key: 'paypal',

--- a/client/task-list/test/payments.js
+++ b/client/task-list/test/payments.js
@@ -167,8 +167,11 @@ describe( 'TaskList > Payments', () => {
 			it( 'Detects whether the plugin is enabled based on the received options', () => {
 				const mercadoPagoParams = {
 					...params,
-					onboardingStatus: {
-						enabledPaymentGateways: [ 'mercadopago' ],
+					options: {
+						...params.options,
+						'woocommerce_woo-mercado-pago-basic_settings': {
+							enabled: 'yes',
+						},
 					},
 				};
 

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Payments task: include Mercado Pago #6572
 - Dev: Ensure script asset.php files are included in builds #6635
 - Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
+- Fix: Update the Mercado option used for enabling/disabling. #6677
 
 == 2.1.3 3/14/2021  ==
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -703,7 +703,7 @@ class Onboarding {
 		$options[] = 'woocommerce_task_list_tracked_completed_tasks';
 		$options[] = 'woocommerce_task_list_dismissed_tasks';
 		$options[] = 'woocommerce_allow_tracking';
-		$options[] = 'woocommerce_mercadopago_settings';
+		$options[] = 'woocommerce_woo-mercado-pago-basic_settings';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce-ppcp-settings';
 		$options[] = 'woocommerce_ppcp-gateway_settings';


### PR DESCRIPTION
Partially fixes #6648 

Update the Mercado Pago payment provider logic to make use of the `woocommerce_woo-mercado-pago-basic_settings` option, which the plugin also uses.
This is a partial fix, as the plugin does rely on the user credentials being entered and will set enabled back to `no` if those credentials aren't present (when the plugin initialization is triggered (like going to the payments setting screen)). See [this comment](https://github.com/woocommerce/woocommerce-admin/issues/6648#issuecomment-807346801) for more context.

### Screenshots

<img width="1642" alt="Screen Shot 2021-03-25 at 5 02 09 PM" src="https://user-images.githubusercontent.com/2240960/112536164-e19c0080-8d8b-11eb-94c8-69c2a6f76611.png">

### Detailed test instructions:

- Start a new Woo store
- Complete the onboarding setup wizard and enter the store address among the following options: Mexico
Brazil, Argentina, Chile, Colombia, Peru and Uruguay
- Go to "Choose payments section" on "WooCommerce-Home" page
- Click on "Setup" button for Mercado Pago payments for WooCommerce plugin.
- Open a new tab with **WooCommerce > Settings > Payments** 
- Click on "Continue' button 
- The Mercado plugin shows as enabled, now refresh the other tab (Payments settings), note that the Mercado payment method is enabled.
- Refresh this page again, note the payment method is now disabled (it will only stay enabled once the credentials are entered)
- Refresh your original tab again (with the list of payment providers on the home screen), note that the Mercado payment is set to disabled now, reflecting the correct setting.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
