### PR TITLE
Check if features are currently being enabled

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == 2.2.0 3/26/2021 ==
 
+- Fix: Check if features are currently being enabled #6688
 - Add: Next new novel navigation nudge note #6610
 - Fix: Fix the activity panel toggle not closing on click #6679
 - Tweak: Add default value for contains op #6622

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -130,7 +130,14 @@ class Features {
 		$features = self::get_beta_feature_options();
 
 		if ( isset( $features[ $feature ] ) ) {
-			return 'yes' === get_option( $features[ $feature ], 'no' );
+			$feature_option = $features[ $feature ];
+			// Check if the feature is currently being enabled.
+			/* phpcs:disable WordPress.Security.NonceVerification */
+			if ( isset( $_POST[ $feature_option ] ) && '1' === $_POST[ $feature_option ] ) {
+				return true;
+			}
+
+			return 'yes' === get_option( $feature_option, 'no' );
 		}
 
 		return true;


### PR DESCRIPTION
Fixes #6686 

Adds back in @joelclimbsthings's fix in https://github.com/woocommerce/woocommerce-admin/pull/6462 and moves to the `Features` class to check if a feature is currently being enabled to avoid race conditions.

### Detailed test instructions:

1. Delete the option `woocommerce_navigation_enabled`.
2. Enable the navigation.
3. Make sure no errors occur.