### PR TITLE
Updated event tracking for merchant email notes

### DIFF
--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -479,7 +479,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		// We need to set the current user for tracking reasons. And unset user after tracking.
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $request->get_param( 'user_id' ) );
-		wc_admin_record_tracks_event( 'wcadmin_email_note_opened', array( 'note_name' => $note->get_name() ) );
+		wc_admin_record_tracks_event( 'email_note_opened', array( 'note_name' => $note->get_name() ) );
 		wp_set_current_user( $current_user_id );
 	}
 

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -477,9 +477,10 @@ class Notes extends \WC_REST_CRUD_Controller {
 		}
 
 		// We need to set the current user for tracking reasons. And unset user after tracking.
+		$current_user_id = get_current_user_id();
 		wp_set_current_user( $request->get_param( 'user_id' ) );
 		wc_admin_record_tracks_event( 'wcadmin_email_note_opened', array( 'note_name' => $note->get_name() ) );
-		wp_set_current_user( 0 );
+		wp_set_current_user( $current_user_id );
 	}
 
 	/**

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -476,11 +476,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			return;
 		}
 
-		// We need to set the current user for tracking reasons. And unset user after tracking.
-		$current_user_id = get_current_user_id();
-		wp_set_current_user( $request->get_param( 'user_id' ) );
-		wc_admin_record_tracks_event( 'email_note_opened', array( 'note_name' => $note->get_name() ) );
-		wp_set_current_user( $current_user_id );
+		NotesRepository::record_tracks_event_with_user( $request->get_param( 'user_id' ), 'email_note_opened', array( 'note_name' => $note->get_name() ) );
 	}
 
 	/**

--- a/src/Notes/MerchantEmailNotifications/MerchantEmailNotifications.php
+++ b/src/Notes/MerchantEmailNotifications/MerchantEmailNotifications.php
@@ -53,12 +53,7 @@ class MerchantEmailNotifications {
 			return;
 		}
 
-		// We need to set the current user for tracking reasons. And unset user after tracking.
-		$current_user_id = get_current_user_id();
-		wp_set_current_user( $user_id );
 		Notes::trigger_note_action( $note, $triggered_action );
-		wp_set_current_user( $current_user_id );
-
 		$url = $triggered_action->query;
 
 		// We will use "wp_safe_redirect" when it's an internal redirect.

--- a/src/Notes/MerchantEmailNotifications/MerchantEmailNotifications.php
+++ b/src/Notes/MerchantEmailNotifications/MerchantEmailNotifications.php
@@ -54,9 +54,10 @@ class MerchantEmailNotifications {
 		}
 
 		// We need to set the current user for tracking reasons. And unset user after tracking.
+		$current_user_id = get_current_user_id();
 		wp_set_current_user( $user_id );
 		Notes::trigger_note_action( $note, $triggered_action );
-		wp_set_current_user( 0 );
+		wp_set_current_user( $current_user_id );
 
 		$url = $triggered_action->query;
 

--- a/src/Notes/MerchantEmailNotifications/NotificationEmail.php
+++ b/src/Notes/MerchantEmailNotifications/NotificationEmail.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Admin\Notes\MerchantEmailNotifications;
 
-use Automattic\WooCommerce\Admin\Notes;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -206,10 +206,6 @@ class NotificationEmail extends \WC_Email {
 			$this->get_headers(),
 			$this->get_attachments()
 		);
-		// We need to set the current user for tracking reasons.
-		$current_user_id = get_current_user_id();
-		wp_set_current_user( $user_id );
-		wc_admin_record_tracks_event( 'email_note_sent', array( 'note_name' => $this->note->get_name() ) );
-		wp_set_current_user( $current_user_id );
+		Notes::record_tracks_event_with_user( $user_id, 'email_note_sent', array( 'note_name' => $this->note->get_name() ) );
 	}
 }

--- a/src/Notes/MerchantEmailNotifications/NotificationEmail.php
+++ b/src/Notes/MerchantEmailNotifications/NotificationEmail.php
@@ -209,7 +209,7 @@ class NotificationEmail extends \WC_Email {
 		// We need to set the current user for tracking reasons.
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $user_id );
-		wc_admin_record_tracks_event( 'wcadmin_email_note_sent', array( 'note_name' => $this->note->get_name() ) );
+		wc_admin_record_tracks_event( 'email_note_sent', array( 'note_name' => $this->note->get_name() ) );
 		wp_set_current_user( $current_user_id );
 	}
 }

--- a/src/Notes/MerchantEmailNotifications/NotificationEmail.php
+++ b/src/Notes/MerchantEmailNotifications/NotificationEmail.php
@@ -206,8 +206,10 @@ class NotificationEmail extends \WC_Email {
 			$this->get_headers(),
 			$this->get_attachments()
 		);
+		// We need to set the current user for tracking reasons.
+		$current_user_id = get_current_user_id();
 		wp_set_current_user( $user_id );
 		wc_admin_record_tracks_event( 'wcadmin_email_note_sent', array( 'note_name' => $this->note->get_name() ) );
-		wp_set_current_user( 0 );
+		wp_set_current_user( $current_user_id );
 	}
 }

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -379,10 +379,6 @@ class Notes {
 	 * @param array  $params The params to send to the event recording.
 	 */
 	public static function record_tracks_event_with_user( $user_id, $event_name, $params ) {
-		if ( ! $user_id ) {
-			return;
-		}
-
 		// We save the current user id to set it back after the event recording.
 		$current_user_id = get_current_user_id();
 

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -365,7 +365,7 @@ class Notes {
 		if ( in_array( $note->get_type(), array( 'error', 'update' ), true ) ) {
 			wc_admin_record_tracks_event( 'store_alert_action', $event_params );
 		} else {
-			self::record_tracks_event_without_cookie( 'inbox_action_click', $event_params );
+			self::record_tracks_event_without_cookies( 'inbox_action_click', $event_params );
 		}
 
 		return $note;

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -352,25 +352,62 @@ class Notes {
 
 		$note->save();
 
+		$event_params = array(
+			'note_name'    => $note->get_name(),
+			'note_type'    => $note->get_type(),
+			'note_title'   => $note->get_title(),
+			'note_content' => $note->get_content(),
+			'action_name'  => $triggered_action->name,
+			'action_label' => $triggered_action->label,
+			'screen'       => self::get_screen_name(),
+		);
+
 		if ( in_array( $note->get_type(), array( 'error', 'update' ), true ) ) {
-			$tracks_event = 'wcadmin_store_alert_action';
+			wc_admin_record_tracks_event( 'wcadmin_store_alert_action', $event_params );
 		} else {
-			$tracks_event = 'wcadmin_inbox_action_click';
+			self::record_tracks_event_without_cookie( 'inbox_action_click', $event_params );
 		}
 
-		wc_admin_record_tracks_event(
-			$tracks_event,
-			array(
-				'note_name'    => $note->get_name(),
-				'note_type'    => $note->get_type(),
-				'note_title'   => $note->get_title(),
-				'note_content' => $note->get_content(),
-				'action_name'  => $triggered_action->name,
-				'action_label' => $triggered_action->label,
-				'screen'       => self::get_screen_name(),
-			)
-		);
 		return $note;
+	}
+
+	/**
+	 * Record tracks event for a specific user.
+	 *
+	 * @param int    $user_id The user id we want to record for the event.
+	 * @param string $event_name Name of the event to record.
+	 * @param array  $params The params to send to the event recording.
+	 */
+	public static function record_tracks_event_with_user( $user_id, $event_name, $params ) {
+		if ( ! $user_id ) {
+			return;
+		}
+
+		// We save the current user id to set it back after the event recording.
+		$current_user_id = get_current_user_id();
+
+		wp_set_current_user( $user_id );
+		self::record_tracks_event_without_cookies( $event_name, $params );
+		wp_set_current_user( $current_user_id );
+
+	}
+
+	/**
+	 * Record tracks event without using cookies.
+	 *
+	 * @param string $event_name Name of the event to record.
+	 * @param array  $params The params to send to the event recording.
+	 */
+	public static function record_tracks_event_without_cookies( $event_name, $params ) {
+		// We save the cookie to set it back after the event recording.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$anon_id = isset( $_COOKIE['tk_ai'] ) ? $_COOKIE['tk_ai'] : null;
+
+		unset( $_COOKIE['tk_ai'] );
+		wc_admin_record_tracks_event( $event_name, $params );
+		if ( isset( $anon_id ) ) {
+			setcookie( 'tk_ai', $anon_id );
+		}
 	}
 
 	/**

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -363,7 +363,7 @@ class Notes {
 		);
 
 		if ( in_array( $note->get_type(), array( 'error', 'update' ), true ) ) {
-			wc_admin_record_tracks_event( 'wcadmin_store_alert_action', $event_params );
+			wc_admin_record_tracks_event( 'store_alert_action', $event_params );
 		} else {
 			self::record_tracks_event_without_cookie( 'inbox_action_click', $event_params );
 		}

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -394,7 +394,7 @@ class Notes {
 	 * @param string $event_name Name of the event to record.
 	 * @param array  $params The params to send to the event recording.
 	 */
-	public static function record_tracks_event_without_cookies( $event_name, $params ) {
+	private static function record_tracks_event_without_cookies( $event_name, $params ) {
 		// We save the cookie to set it back after the event recording.
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$anon_id = isset( $_COOKIE['tk_ai'] ) ? $_COOKIE['tk_ai'] : null;


### PR DESCRIPTION
This is a follow-up of [PR 6616](https://github.com/woocommerce/woocommerce-admin/pull/6616) 

Now we re-set the current `user_id` to the latest `user_id`, after event recording.

### UPDATE

The event recording had an issue in websites without `Jetpack`, so this PR also adds a fix for that.
The issue was related to the setting of the cookie `tk_ai` [in core](https://github.com/woocommerce/woocommerce/blob/master/includes/tracks/class-wc-tracks-client.php#L162). It uses the cookie to get the user but if it's not set the value `_woocommerce_tracks_anon_id` stored in `wp_usermeta` will be used instead. So the problem was that sometimes it used the value stored in the cookie and sometimes it used the value stored in the DB. Now we unset the cookie before recording the event to always get the same behavior.

### Detailed test instructions:

- The testing instructions are the same as [PR 6616](https://github.com/woocommerce/woocommerce-admin/pull/6616), but it's necessary to test in a site without Jetpack and also in a site with the plugin installed.
- In both cases verify that the `userid` we use to set the current user (after recording the event) is the same as before.

(no changelog)

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
