### PR TITLE
Fix Various PHP Lint Errors

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -285,7 +285,7 @@ class OnboardingTasks {
 		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
 			$script_assets_filename = Loader::get_script_asset_filename( 'onboarding-homepage-notice' );
 			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-			
+
 			wp_enqueue_script(
 				'onboarding-homepage-notice',
 				Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ),

--- a/src/Notes/InsightFirstProductAndPayment.php
+++ b/src/Notes/InsightFirstProductAndPayment.php
@@ -59,7 +59,7 @@ class InsightFirstProductAndPayment {
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
-		);		
+		);
 
 		return $note;
 	}

--- a/tests/install.php
+++ b/tests/install.php
@@ -17,10 +17,10 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 *
 	 * @group database
 	 */
-	function test_create_tables() {
+	public function test_create_tables() {
 		global $wpdb;
 
-		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308
+		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308.
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 
@@ -33,12 +33,12 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 			"{$wpdb->prefix}wc_admin_notes",
 			"{$wpdb->prefix}wc_admin_note_actions",
 			"{$wpdb->prefix}wc_customer_lookup",
-			"{$wpdb->prefix}wc_category_lookup"
+			"{$wpdb->prefix}wc_category_lookup",
 		);
 
 		// Remove any existing tables in the environment.
 		$query = 'DROP TABLE IF EXISTS ' . implode( ',', $tables );
-		$wpdb->query( $query );
+		$wpdb->query( $query ); // phpcs:ignore.
 
 		// Try to create the tables.
 		Install::create_tables();


### PR DESCRIPTION
Fixes some PHP lint errors that have built up as a result of issue https://github.com/woocommerce/woocommerce-admin/issues/6704.

### Detailed test instructions:

-   Run `npm run lint:php`.
-   See that there are no errors (except for PHP 5.6 issues).

No changelog.