### PR TITLE
Bump PHP Test Version to 7.0 in PHPCS config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.0-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />


### PR DESCRIPTION
This bumps the PHP `testVersion` value in the PHPCS config to `7.0-`, representing the minimum supported version of PHP in WooCommerce.

This removes errors previously reported about incompatibility with PHP 5.6. For example:

```
FILE: src/Features/Navigation/Favorites.php
--------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
--------------------------------------------------------------------------------------
  52 | ERROR | null coalescing operator (??) is not present in PHP version 5.6 or
     |       | earlier
  85 | ERROR | null coalescing operator (??) is not present in PHP version 5.6 or
     |       | earlier
 117 | ERROR | null coalescing operator (??) is not present in PHP version 5.6 or
     |       | earlier
--------------------------------------------------------------------------------------
```

### Detailed test instructions:

-   Run `npm run lint:php`
-   See that there are no errors about PHP version incompatibilities.

No changelog.