### PR TITLE
Add Daily PHP Tests to CI

### DIFF
--- a/.github/workflows/daily-php.yml
+++ b/.github/workflows/daily-php.yml
@@ -30,7 +30,7 @@ jobs:
               shell: bash
             - name: Run the PHP unit tests
               env:
-                  WP_VERSION: ${{ matrix.woocommerce }}
+                  WP_VERSION: ${{ matrix.wordpress }}
                   WC_VERSION: ${{ matrix.woocommerce }}
               run: npm run test:php
               shell: bash

--- a/.github/workflows/daily-php.yml
+++ b/.github/workflows/daily-php.yml
@@ -1,0 +1,36 @@
+name: 'Daily PHP Tests'
+
+on:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+    daily-test-php:
+        name: "Test PHP"
+        runs-on: ubuntu-18.04
+        strategy:
+            fail-fast: false
+            matrix:
+                wordpress: ['latest', 'nightly']
+                woocommerce: ['latest', 'nightly']
+                exclude:
+                    - {'wordpress': 'nightly', 'woocommerce': 'nightly'}
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v2
+            - name: Setup Node.js
+              uses: actions/setup-node@v2-beta
+              with:
+                  node-version: '14'
+            - name: Build
+              run: |
+                  npm run build:feature-config	
+                  composer install  --no-dev
+              shell: bash
+            - name: Run the PHP unit tests
+              env:
+                  WP_VERSION: ${{ matrix.woocommerce }}
+                  WC_VERSION: ${{ matrix.woocommerce }}
+              run: npm run test:php
+              shell: bash

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -170,7 +170,7 @@ install_deps() {
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 
 	# Install WooCommerce (latest non-hyphenated (beta, RC) tag)
-	if [[ "$WC_VERSION" == "" ]]; then
+	if [[ "$WC_VERSION" == "" || "$WC_VERSION" == "latest" ]]; then
 		LATEST_WC_TAG="$(git ls-remote --tags https://github.com/woocommerce/woocommerce.git | awk '{print $2}' | sed 's/^refs\/tags\///' | grep -E '^[0-9]\.[0-9]\.[0-9]$' | sort -V | tail -n 1)"
 	else
 		LATEST_WC_TAG="$WC_VERSION"


### PR DESCRIPTION
Fixes (partially) #6659

Adds a daily workflow to CI, running the PHP tests against nightly builds of WordPress and WooCommerce. It uses the Docker PHP Test Suite to run the tests 🎉 

A small change was made to the `bin/install-wp-tests.sh` script to support using `latest` as a value for the `WC_VERSION` environment variable.

It was suggested in internal discussions to add Slack notifications. I'd like to see this as a follow-up effort. 

Note this reveals a failing PHP test! This should be investigated further separately.

### Detailed test instructions:

- In this PR, see the `Daily PHP Tests` checks.
- See that tests are run against latest and nightly build combinations of WordPress and WooCommerce

No changelog.