### PR TITLE
Update folded header style

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -62,6 +62,10 @@
 
 .folded .woocommerce-layout__header {
 	width: calc(100% - 36px);
+
+	@include breakpoint( '<782px' ) {
+		width: 100%;
+	}
 }
 
 .is-wp-toolbar-disabled .woocommerce-layout__header {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -60,6 +60,10 @@
 	}
 }
 
+.folded .woocommerce-layout__header {
+	width: calc(100% - 36px);
+}
+
 .is-wp-toolbar-disabled .woocommerce-layout__header {
 	top: 0;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Update folded header style #6724
 - Fix: Fix unreleated variations showing up in the Products reports #6647
 - Tweak: Add tracking data for the preview site btn #6623
 - Tweak: Add check to see if value for contains is array, show warning if not. #6645


### PR DESCRIPTION
Fixes #6719 

Update folded header style.

### Screenshots
Before
<img width="1440" alt="before" src="https://user-images.githubusercontent.com/56378160/113222074-448e0b80-9254-11eb-8e1a-3df26c94246c.png">

After
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/56378160/113222091-49eb5600-9254-11eb-99f4-cc3c805763db.png">


### Detailed test instructions:
1. Go to the WooCommerce -> Orders screen
2. Collapse the WP menu
3. See full-width header
4. Narrow to smaller screen and see full-width header
5. Enable new WooCommerce navigation
6. Go to Orders screen
7. See full-width header
8. Narrow to smaller screen and see full-width header

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
