### PR TITLE
Add unminified assets if no minified assets exist in `make-zip.sh`

### DIFF
--- a/bin/make-zip.sh
+++ b/bin/make-zip.sh
@@ -22,10 +22,11 @@ output 2 "Creating archive... 🎁"
 ZIP_FILE=$1
 
 build_files=$(find dist \( -name '*.js' -o -name '*.css' \))
-asset_files=$(find dist \( -name '*.min.asset.php' \))
-if [[ -z $asset_files ]]; then
-	output 3 "No min.asset.php files found, adding un minified assets"
-	asset_files=$(find dist \( -name '*.asset.php' \))
+asset_files=$(find dist \( -name '*.asset.php' \))
+if [[ $(find dist/app \( -name '*.asset.php' \) | wc -l) -gt 1 ]]; then
+	output 3 "$asset_files"
+	output 1 "Multiple asset.php files exists per directory, have you removed the old build?"
+	exit;
 fi
 
 zip -r "${ZIP_FILE}" \

--- a/bin/make-zip.sh
+++ b/bin/make-zip.sh
@@ -23,6 +23,10 @@ ZIP_FILE=$1
 
 build_files=$(find dist \( -name '*.js' -o -name '*.css' \))
 asset_files=$(find dist \( -name '*.min.asset.php' \))
+if [[ -z $asset_files ]]; then
+	output 3 "No min.asset.php files found, adding un minified assets"
+	asset_files=$(find dist \( -name '*.asset.php' \))
+fi
 
 zip -r "${ZIP_FILE}" \
 	woocommerce-admin.php \


### PR DESCRIPTION
Check if there has been minified asset.php files found, if not, then it will add the non minified asset files, showing a warning in case there of.

### Detailed test instructions:

- Run `rm -rf dist`
- Run build for core -> `WC_ADMIN_PHASE=core npm run build`
- Run `./bin/make-zip.sh woocommerce-admin.zip` and make sure the `*.asset.php` files were included in the `dist/app` folder.
- Run `rm -rf dist`
- Run build for development -> `npm run build`
- Run `./bin/make-zip.sh woocommerce-admin.zip` and make sure the `*min.asset.php` files were included in the `dist/app` folder.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
