### PR TITLE
Update choose niche note cta URL

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Update: Update choose niche note cta URL #6733
 - Fix: Fix unreleated variations showing up in the Products reports #6647
 - Tweak: Add tracking data for the preview site btn #6623
 - Tweak: Add check to see if value for contains is array, show warning if not. #6645

--- a/src/Notes/ChooseNiche.php
+++ b/src/Notes/ChooseNiche.php
@@ -73,7 +73,7 @@ class ChooseNiche {
 		$note->add_action(
 			'choose-niche',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://woocommerce.com/posts/idea-to-first-ecommerce-customer-finding-an-audience/?utm_source=inbox',
+			'https://woocommerce.com/from-idea-to-first-customer/?utm_source=inbox',
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true
 		);


### PR DESCRIPTION
Fixes #6707 

Updates the link for the CTA to the landing page instead of the blog post for the choose niche note.

### Detailed test instructions:

1. Delete the note in your database if it exists `wc-admin-choose-niche`
2. Complete the onboarding profile:
 - Don't check the option to setup for client.
 - Set product count to 0
3. Run `wc_admin_daily`.
4. Check that the "Learn More" button takes you to the landing page.