### PR TITLE
Components: Release prep

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -89,3 +89,12 @@ Changes:
 If you accept, Lerna will create git tags, publish those to github, then push your packages to npm.
 
 🎉 You have a published package!
+
+### Publishing a single package
+
+Sometimes, its helpful to release a singular package. This can be done directly through npm. Be sure versions and builds are correct.
+
+-   Bump the version in the package's package.json as well as its CHANGELOG file.
+-   `npm install && npm run build` to build packages.
+-   `cd packages/<package-name>`
+-   `npm publish`

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 6.0.0
 
 -   Change styling of `<ProductImage />`.
 -   Remove the `showCount` prop from `<SearchListItem>`. Count will always be displayed if any of those props is not undefined/null: `countLabel` and `item.count`.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "5.1.2",
+	"version": "6.0.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
This PR bumps the version of `@woocommerce/components` to `6.0.0`. This release will include a breaking change in regards to moving Lodash to a peer dependency.

Include are also instructions for releasing a singular package instead of all of them as you would via Lerna.

### Detailed test instructions:

Just read over the changes and check that they make sense