### PR TITLE
Add settings_section event prop for CES

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Add settings_section event prop for CES #6762
 - Fix: Retain persisted queries when navigating to Homescreen #6614
 - Update: Update choose niche note cta URL #6733
 - Fix: Update folded header style #6724

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -358,9 +358,18 @@ class CustomerEffortScoreTracks {
 	public function run_on_update_options() {
 		// $current_tab is set when WC_Admin_Settings::save_settings is called.
 		global $current_tab;
+		global $current_section;
 
 		if ( $this->has_been_shown( self::SETTINGS_CHANGE_ACTION_NAME ) ) {
 			return;
+		}
+
+		$props = array(
+			'settings_area' => $current_tab,
+		);
+
+		if ( $current_section ) {
+			$props['settings_section'] = $current_section;
 		}
 
 		$this->enqueue_to_ces_tracks(
@@ -373,9 +382,7 @@ class CustomerEffortScoreTracks {
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'woocommerce_page_wc-settings',
 				'adminpage'      => 'woocommerce_page_wc-settings',
-				'props'          => (object) array(
-					'settings_area' => $current_tab,
-				),
+				'props'          => (object) $props,
 			)
 		);
 	}


### PR DESCRIPTION
Fixes #6717 

This PR adds a new event prop for CES when setting pages get updated.

### Screenshots

Screenshot 1

![Screen Shot 2021-04-07 at 4 26 30 PM](https://user-images.githubusercontent.com/4723145/113946820-25e0c500-97be-11eb-80fc-36e47d940cd3.jpg)


### Detailed test instructions:

1. Open browser console.
2. Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` and check "Verbose" under the "All levels" dropdown.
3. Navigate to WooCommerce -> Settings -> Payments
4. Click "Set up" on one of the payments.
5. Click "Save changes" button.
6. Confirm the event data contains  `settings_section` (Screenshot 1)