### PR TITLE
Packages: Bump versions for release

### DIFF
--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.1
+
+-   Update dependencies.
+
 # 1.3.0
 
 -   Update to @wordpress/eslint coding standards.

--- a/packages/csv-export/package.json
+++ b/packages/csv-export/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/csv-export",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "WooCommerce utility library to convert data to CSV files.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.0
+
+-   Return countryInfo as an empty object if not in locale info #6188
+-   Localize regional currency information for use during onboarding setup #5969
+-   Update dependencies
+
 # 3.0.0
 
 ## Breaking changes

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/currency",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "WooCommerce currency utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/customer-effort-score/CHANGELOG.md
+++ b/packages/customer-effort-score/CHANGELOG.md
@@ -1,7 +1,3 @@
-# Unreleased
-
--   Add TypeScript to `<CustomerFeedbackModal />` component.
-
 # 1.0.0
 
 -   Initial release.

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,6 +1,12 @@
-# Unreleased
+# 1.2.0
 
 -   Add management of persisted queries to navigation data store.
+-   Add TypeScript support.
+-   Generate MD5 hashes without bundling all of Node crypto. #5768
+-   Fix HoC-wrapped components from being named "Anonymous". #5898
+-   Reduce Unnecessary Re-renders in Revenue Report. #5986
+-   Add useUser hook. #6365
+-   Fix bug in useSettings that causes an infinite loop. #6540
 
 # 1.1.1
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,9 +1,11 @@
-# Unreleased
+# 3.0.0
 
 -   Take into account leap year in calculating `getLastPeriod`.
+
 ## Breaking changes
 
 -   Move Lodash to a peer dependency.
+
 # 2.1.0
 
 -   Update to @wordpress/eslint coding standards.

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/date",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "WooCommerce date utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Unreleased
+# 6.0.0
 
 -   Moving `addHistoryListener()` to this package, which supports adding a listener that is executed for history changes.
+-   Update dependencies.
+-   Add management of persisted queries to navigation.
+-   Add page parameter to getNewPath to override default page wc-admin #5821
 
 ## Breaking changes
 

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/navigation",
-	"version": "5.2.0",
+	"version": "6.0.0",
 	"description": "WooCommerce navigation utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -1,5 +1,4 @@
-Notices
-=======
+# Notices
 
 State management for notices.
 
@@ -7,6 +6,8 @@ NOTE: This has been copied from Gutenberg so that we can iterate on it faster
 than if we were relying on Gutenberg releasing a new version with our
 requirements. Once Gutenberg supports our requirements this package should be
 removed.
+
+**Update:** Changes required have been shipped in the Gutenberg package released with WP 5.7, so this package will be removed when WP 5.9 becomes available. Please use the Gutenberg version instead.
 
 ## Installation
 
@@ -17,7 +18,6 @@ npm install @wordpress/notices
 ```
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
-
 
 ## Usage
 

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.1
+
+-   Update dependencies.
+-   Add TypeScript support.
+
 # 2.1.0
 
 -   Update to @wordpress/eslint coding standards.

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/number",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Number formatting utilities for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/tracks/CHANGELOG.md
+++ b/packages/tracks/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+-   Update dependencies.
+-   Add TypeScript support.
+
 # 1.0.0
 
 -   Released package

--- a/packages/tracks/package.json
+++ b/packages/tracks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/tracks",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "WooCommerce user event tracking utilities for Automattic based projects.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bump versions in packages that had unreleased changes. I added some that weren't already added to the changelog by looking at [commit histories](https://github.com/woocommerce/woocommerce-admin/commits/main/packages/tracks) for each package.

## Test instructions

Read through the changes, make sure they make sense