### PR TITLE
Update docker test suite readme

### DIFF
--- a/docker/wc-admin-php-test-suite/readme.md
+++ b/docker/wc-admin-php-test-suite/readme.md
@@ -1,4 +1,3 @@
-
 # Docker PHP Test Suite
 
 A docker app to run the PHP Test Suite.
@@ -11,7 +10,7 @@ For convenience, the PHP Test Suite can be run from an npm script.
 npm run test:php
 ```
 
-This runs the the `phpunit` container with `docker-compose -f run --rm phpunit`.  On first use, the container will install the PHP Test Suite and perform the tests. Subsequent use will only perform the tests.
+This runs the the `phpunit` container with `docker-compose -f run --rm phpunit`. On first use, the container will install the PHP Test Suite and perform the tests. Subsequent use will only perform the tests.
 
 ## Re-install Test Suite
 
@@ -39,6 +38,18 @@ By default, the minimum supported versions of WordPress and WooCommerce are used
 WP_VERSION=5.6 WC_VERSION=4.9.0 npm run test:php
 ```
 
+## Selecting PHP versions
+
+The PHP test suite supports running tests in PHP 7 and 8. We do use a custom PHPUnit fork of version ~7.5 when running tests in PHP 8, for the reasoning why see [this WooCommerce Readme](https://github.com/woocommerce/woocommerce/blob/trunk/tests/README.md#running-tests-in-php-8).
+
+As mentioned in the readme, when running tests in PHP 8 it will modify the composer files in `/bin/composer/phpunit`, please remember to not include these changes in any of your commits.
+
+To run tests using PHP 8:
+
+```shell
+PHP_VERSION=8 npm run test:php
+```
+
 ## Development
 
-When comitting changes to the `Dockerfile` or `entrypoint.sh` files, bump the `wc-admin-php-test-suite-phpunit` image tag version in `docker-composer.xml`. This will result in an image  rebuild automatically upon next use, enabling the changes to be applied for all users.
+When comitting changes to the `Dockerfile` or `entrypoint.sh` files, bump the `wc-admin-php-test-suite-phpunit` image tag version in `docker-composer.xml`. This will result in an image rebuild automatically upon next use, enabling the changes to be applied for all users.


### PR DESCRIPTION
This is a small follow up of #6678, updating the README of the docker php-test-suite.

No changelog necessary.