### PR TITLE
Redirect to shipping settings page when task is completed

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -42,6 +42,18 @@ In case the report shows "no data", please reimport historical data by following
 -   Choose payment methods
 -   See no error message
 
+### Set up shipping costs task, redirect to shipping settings after completion. #6791
+
+-   Create a new store, and finish the Onboarding flow
+-   Go to **WooCommerce > Home** and select the **Set up shipping costs** task, it should show the standard stepper
+-   Type some number in the 'Shipping cost' input
+-   Click the 'Rest of the world' toggle to toggle it on.
+-   Type some number in the 'Shipping cost' input box under the 'Rest of the world' label
+-   Finish the set up, but don't need to install the shipping label plugin
+-   Once on home screen the **Set up shipping costs** task should show as finished
+-   Click on the task again
+-   It should now redirect to the shipping settings page.
+
 ## 2.2.0
 
 ### Fixed event tracking for merchant email notes #6616

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -26,6 +26,7 @@ import {
 	isWCPaySupported,
 } from './tasks/payments/wcpay';
 import { groupListOfObjectsBy } from '../lib/collections';
+import { getLinkTypeAndHref } from '~/store-management-links';
 
 export function recordTaskViewEvent(
 	taskName,
@@ -226,8 +227,15 @@ export function getAllTasks( {
 			title: __( 'Set up shipping costs', 'woocommerce-admin' ),
 			container: <Shipping />,
 			onClick: () => {
-				onTaskSelect( 'shipping' );
-				updateQueryString( { task: 'shipping' } );
+				if ( shippingZonesCount > 0 ) {
+					window.location = getLinkTypeAndHref( {
+						type: 'wc-settings',
+						tab: 'shipping',
+					} ).href;
+				} else {
+					onTaskSelect( 'shipping' );
+					updateQueryString( { task: 'shipping' } );
+				}
 			},
 			completed: shippingZonesCount > 0,
 			visible:

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add support for running php unit tests in PHP 8. #6678
 - Fix: Remove no-reply from inbox notification emails #6644
 - Performance: Avoid updating customer info synchronously from the front end. #6765
+- Fix: Set up shipping costs task, redirect to shipping settings after completion. #6791
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #6387 

When the shipping task list is finished we redirect users to the shipping settings page instead, as suggested by @timmyc in https://github.com/woocommerce/woocommerce-admin/issues/6387#issuecomment-811476672.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)

### Screenshots

![shipping-task](https://user-images.githubusercontent.com/2240960/114551421-bfcec480-9c39-11eb-9cd3-b399e2eb6d8e.gif)

### Detailed test instructions:

- Create a new store, and finish the Onboarding flow
- Go to **WooCommerce > Home** and select the **Set up shipping costs** task, it should show the standard stepper
- Type some number in the 'Shipping cost' input
- Click the 'Rest of the world' toggle to toggle it on.
- Type some number in the 'Shipping cost' input box under the 'Rest of the world' label 
- Finish the set up, but don't need to install the shipping label plugin
- Once on home screen the **Set up shipping costs** task should show as finished
- Click on the task again
- It should now redirect to the shipping settings page.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->