### PR TITLE
Convert date to timestamp before passing to set_date_prop to persist …

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Use the store timezone to make time data requests #6632
 - Fix: Update the checked input radio button margin style #6701
+- Fix: Convert date to timestamp before passing to set_date_prop to persist timezone #6795
 - Fix: Make pagination buttons height and width consistent #6725
 - Fix: Retain persisted queries when navigating to Homescreen #6614
 - Fix: Update folded header style #6724
@@ -94,7 +95,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Remove no-reply from inbox notification emails #6644
 - Fix: Set up shipping costs task, redirect to shipping settings after completion. #6791
 - Fix: Onboarding logic on WooCommerce update to keep task list present. #6803
-- Fix: Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin #6710
 - Fix: Pause inbox message “GivingFeedbackNotes” #6802
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 - Fix: Parsing bad JSON string data from user WooCommerce meta. #6819

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -503,7 +503,10 @@ class Note extends \WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note date prop cannot be empty.', 'woocommerce-admin' ) );
 		}
 
-		$this->set_date_prop( 'date_created', wc_string_to_timestamp( $date ) );
+		if ( is_string( $date ) ) {
+			$date = wc_string_to_timestamp( $date );
+		}
+		$this->set_date_prop( 'date_created', $date );
 	}
 
 	/**
@@ -512,7 +515,10 @@ class Note extends \WC_Data {
 	 * @param string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
 	 */
 	public function set_date_reminder( $date ) {
-		$this->set_date_prop( 'date_reminder', wc_string_to_timestamp( $date ) );
+		if ( is_string( $date ) ) {
+			$date = wc_string_to_timestamp( $date );
+		}
+		$this->set_date_prop( 'date_reminder', $date );
 	}
 
 	/**

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -503,7 +503,7 @@ class Note extends \WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note date prop cannot be empty.', 'woocommerce-admin' ) );
 		}
 
-		$this->set_date_prop( 'date_created', $date );
+		$this->set_date_prop( 'date_created', wc_string_to_timestamp( $date ) );
 	}
 
 	/**
@@ -512,7 +512,7 @@ class Note extends \WC_Data {
 	 * @param string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
 	 */
 	public function set_date_reminder( $date ) {
-		$this->set_date_prop( 'date_reminder', $date );
+		$this->set_date_prop( 'date_reminder', wc_string_to_timestamp( $date ) );
 	}
 
 	/**

--- a/tests/notes/class-wc-tests-notes-note.php
+++ b/tests/notes/class-wc-tests-notes-note.php
@@ -35,13 +35,15 @@ class WC_Tests_Notes_Note extends WC_Unit_Test_Case {
 	 * when it gets saved multiple times.
 	 */
 	public function test_note_correctly_sets_created_date_when_saved() {
+		update_option( 'timezone_string', 'America/Los_Angeles' );
 		// Create a new note.
 		$note = new Note();
 		$note->set_title( 'title2' );
 		$note->save();
 
 		// Load it via the data store.
-		$note                         = new Note( $note->get_id() );
+		$note = new Note( $note->get_id() );
+		$note->set_content( 'test' );
 		$date_created_from_first_save = $note->get_date_created()->format( 'Y-m-d H:i:s' );
 		// Save it again.
 		$note->save();

--- a/tests/notes/class-wc-tests-notes-note.php
+++ b/tests/notes/class-wc-tests-notes-note.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Admin note test
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Admin\Notes\Note;
+
+/**
+ * Class WC_Tests_Notes_Note
+ */
+class WC_Tests_Notes_Note extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests a note can be created with timestamp.
+	 */
+	public function test_note_correctly_sets_created_date_with_timestamp() {
+		$timestamp     = time();
+		$datetime      = new WC_DateTime( "@{$timestamp}", new DateTimeZone( 'UTC' ) );
+		$expected_date = $datetime->format( 'Y-m-d H:i:s' );
+
+		$note = new Note();
+		$note->set_title( 'test1' );
+		$note->set_date_created( $timestamp );
+		$note->save();
+
+		$note         = new Note( $note->get_id() );
+		$date_created = $note->get_date_created()->format( 'Y-m-d H:i:s' );
+		$this->assertEquals( $expected_date, $date_created );
+	}
+
+	/**
+	 * Tests note correctly saves/loads date_created value
+	 * when it gets saved multiple times.
+	 */
+	public function test_note_correctly_sets_created_date_when_saved() {
+		// Create a new note.
+		$note = new Note();
+		$note->set_title( 'title2' );
+		$note->save();
+
+		// Load it via the data store.
+		$note                         = new Note( $note->get_id() );
+		$date_created_from_first_save = $note->get_date_created()->format( 'Y-m-d H:i:s' );
+		// Save it again.
+		$note->save();
+		// Then load it again.
+		$date_created_from_second_save = $note->get_date_created()->format( 'Y-m-d H:i:s' );
+
+		$this->assertEquals( $date_created_from_first_save, $date_created_from_second_save );
+	}
+
+}


### PR DESCRIPTION
Fixes #6742 

This PR converts the datetime string into timestamp before passing it to `WC_Data::set_date_prop` to prevent the value gets changes.

### Detailed test instructions:

This is a bit confusing to understand at first. Let's reproduce it first to understand what the problem is.

1. Navigate to Settings -> General and change Timezone to UTC-7 for testing purposes.
2. Navigate to WooCommerce -> Home
3. Choose a note and find the note in the D.B
4. Make a note of `date_created` value of the note from the D.B.
5. Dismiss the note by clicking the "Dismiss" button.
6. Go back to the D.B and check   the `date_created` value again. The value has been changed when it should not.

Testing the fix

Checkout this branch and repeat the steps. The `date_created` value should not be changed for this time.

