### PR TITLE
Add in missing awaits that could have been causing tests to be flaky.

### DIFF
--- a/tests/e2e/pages/OnboardingWizard.ts
+++ b/tests/e2e/pages/OnboardingWizard.ts
@@ -63,7 +63,7 @@ export class OnboardingWizard extends BasePage {
 			await this.clickButtonWithText( 'No thanks' );
 		}
 
-		this.page.waitForNavigation( {
+		await this.page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 			timeout: 2000,
 		} );

--- a/tests/e2e/sections/onboarding/StoreDetailsSection.ts
+++ b/tests/e2e/sections/onboarding/StoreDetailsSection.ts
@@ -90,7 +90,7 @@ export class StoreDetailsSection extends BasePage {
 	}
 
 	async selectSetupForClient() {
-		setCheckbox( '.components-checkbox-control__input' );
+		await setCheckbox( '.components-checkbox-control__input' );
 	}
 
 	async checkClientSetupCheckbox( selected: boolean ) {


### PR DESCRIPTION
It's very easy to miss an await and at the moment it seems we're not linting our e2e tests so I'll look to see if we can add a lint rule for this in the e2e tests in future such as https://palantir.github.io/tslint/rules/no-floating-promises/

No changelog required