### PR TITLE
Update onboarding logic setting task list to hidden

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Fix: Set up shipping costs task, redirect to shipping settings after completion. #6791
 - Add: Optional children prop to SummaryNumber component #6748
+- Fix: Onboarding logic on WooCommerce update to keep task list present. #6803
 
 == 2.2.0 3/30/2021 ==
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\PageController;
-use \Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Admin\WCAdminHelper;
 
 /**
  * Contains backend logic for the onboarding profile and checklist feature.
@@ -1101,6 +1101,9 @@ class Onboarding {
 
 		$onboarding_data['completed'] = true;
 		update_option( self::PROFILE_DATA_OPTION, $onboarding_data );
-		update_option( 'woocommerce_task_list_hidden', 'yes' );
+
+		if ( ! WCAdminHelper::is_wc_admin_active_for( DAY_IN_SECONDS ) ) {
+			update_option( 'woocommerce_task_list_hidden', 'yes' );
+		}
 	}
 }

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -1094,8 +1094,11 @@ class Onboarding {
 		}
 
 		$onboarding_data = get_option( self::PROFILE_DATA_OPTION, array() );
-		// Don't make updates if the profiler is completed, but task list is potentially incomplete.
-		if ( isset( $onboarding_data['completed'] ) && $onboarding_data['completed'] ) {
+		// Don't make updates if the profiler is completed or skipped, but task list is potentially incomplete.
+		if (
+			( isset( $onboarding_data['completed'] ) && $onboarding_data['completed'] ) ||
+			( isset( $onboarding_data['skipped'] ) && $onboarding_data['skipped'] )
+		) {
 			return;
 		}
 

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Admin\Notes;
 
+use Automattic\WooCommerce\Admin\WCAdminHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -20,16 +22,7 @@ trait NoteTraits {
 	 * @return bool Whether or not WooCommerce admin has been active for $seconds.
 	 */
 	public static function wc_admin_active_for( $seconds ) {
-		// Getting install timestamp reference class-wc-admin-install.php.
-		$wc_admin_installed = get_option( 'woocommerce_admin_install_timestamp', false );
-
-		if ( false === $wc_admin_installed ) {
-			update_option( 'woocommerce_admin_install_timestamp', time() );
-
-			return false;
-		}
-
-		return ( ( time() - $wc_admin_installed ) >= $seconds );
+		return WCAdminHelper::is_wc_admin_active_for( $seconds );
 	}
 
 	/**

--- a/src/RemoteInboxNotifications/WCAdminActiveForProvider.php
+++ b/src/RemoteInboxNotifications/WCAdminActiveForProvider.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
 
+use Automattic\WooCommerce\Admin\WCAdminHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -17,8 +19,6 @@ class WCAdminActiveForProvider {
 	 * @return number Number of seconds.
 	 */
 	public function get_wcadmin_active_for_in_seconds() {
-		$install_timestamp = get_option( 'woocommerce_admin_install_timestamp' );
-
-		return time() - $install_timestamp;
+		return WCAdminHelper::get_wcadmin_active_for_in_seconds();
 	}
 }

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WCAdminHelper
+ *
+ * Helper class for generic WCAdmin functions.
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WCAdminHelper
+ */
+class WCAdminHelper {
+	/**
+	 * WC Admin timestamp option name.
+	 */
+	const WC_ADMIN_TIMESTAMP_OPTION = 'woocommerce_admin_install_timestamp';
+
+	/**
+	 * Get the number of seconds that the store has been active.
+	 *
+	 * @return number Number of seconds.
+	 */
+	public static function get_wcadmin_active_for_in_seconds() {
+		$install_timestamp = get_option( self::WC_ADMIN_TIMESTAMP_OPTION );
+
+		if ( false === $install_timestamp ) {
+			$install_timestamp = time();
+			update_option( self::WC_ADMIN_TIMESTAMP_OPTION, $install_timestamp );
+		}
+
+		return time() - $install_timestamp;
+	}
+
+
+	/**
+	 * Test how long WooCommerce Admin has been active.
+	 *
+	 * @param int $seconds Time in seconds to check.
+	 * @return bool Whether or not WooCommerce admin has been active for $seconds.
+	 */
+	public static function is_wc_admin_active_for( $seconds ) {
+		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
+
+		return ( $wc_admin_active_for >= $seconds );
+	}
+}


### PR DESCRIPTION
Fixes #6045 

The main change here is that we don't auto set the task list to hidden on update if WC Admin is older than one day. This covers the scenario where an active store with a (quite) old version of WC doesn't see the task list.

This PR also moves the timestamp logic out of the `NoteTraits` and a provider for the `RuleProcessor` into a helper class instead.

### Detailed test instructions:

- Start on a fresh site
- On the Onboarding wizard screen, click the `Skip set up store details` at the bottom.
- Don't complete any tasks on the Home Screen but note that Task List is there and Store Details is not selected.
- Using phpMyAdmin plugin alter the `woocommerce_version` option value to something lower then the current (this will trigger a update)
- Go to **WooCommerce > Home** and notice that the task list is still present and the store details is not selected.
- Using the phpMyAdmin plugin alter the `woocommerce_admin_install_timestamp` option making sure it is less then a day old ([Epochconverter](https://www.epochconverter.com/) is handy for that).
- Also delete the `woocommerce_onboarding_profile` option (mimicking a older store)
- Update the `woocommerce_version` option also to a lower version again
- Go to **WooCommerce > Home** and notice that the task list is hidden.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
