### PR TITLE
Add plugin installer to allow installation of plugins via URL

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Add plugin installer to allow installation of plugins via URL #6805
+
+1. Visit any admin page with the params `plugin_action` (`install`, `activate`, or `install-activate`) and `plugins` (list of comma separated plugins). `wp-admin/admin.php?page=wc-admin&plugin_action=install&plugins=jetpack`
+2. If visiting this URL from a link, make sure you are sent back to the referer.
+3. Check that the plugins provided are installed, activated, or both depending on your query.
+
 ### Retain persisted queries when navigating to Homescreen #6614
 
 1. Go to Analytics Report.

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -14,9 +14,9 @@ To enable the new onboarding experience manually, log-in to `wp-admin`, and go t
 
 To power the new onboarding flow client side, new REST API endpoints have been introduced. These are purpose built endpoints that exist under the `/wc-admin/onboarding/` namespace, and are not meant to be shipped in the core rest API package. The source is stored in `src/API/Plugins.php`, `src/API/OnboardingProfile.php`, and `src/API/OnboardingTasks.php` respectively.
 
-* POST `/wc-admin/plugins/install` - Installs a requested plugin, if present in the `woocommerce_admin_plugins_whitelist` array.
+* POST `/wc-admin/plugins/install` - Install requested plugins.
 * GET `/wc-admin/plugins/active` - Returns a list of the currently active plugins.
-* POST `/wc-admin/plugins/activate` - Activates the requested plugins,  if present in the `woocommerce_admin_plugins_whitelist` array. Multiple plugins can be passed to activate at once.
+* POST `/wc-admin/plugins/activate` - Activates the requested plugins. Multiple plugins can be passed to activate at once.
 * GET `/wc-admin/plugins/connect-jetpack` - Generates a URL for connecting to Jetpack. A `redirect_url` is accepted, which is used upon a successful connection.
 * POST `/wc-admin/plugins/request-wccom-connect` - Generates a URL for the WooCommerce.com connection process.
 * POST `/wc-admin/plugins/finish-wccom-connect` - Finishes the WooCommerce.com connection process by storing the received access token.

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Add: Add plugin installer to allow installation of plugins via URL #6805
 - Update: Adding setup required icon for non-configured payment methods #6811
 - Update: UI updates to Payment Task screen #6766
 - Dev: Add data source filter to remote inbox notification system #6794

--- a/src/API/MarketingOverview.php
+++ b/src/API/MarketingOverview.php
@@ -80,13 +80,9 @@ class MarketingOverview extends \WC_REST_Data_Controller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function activate_plugin( $request ) {
-		$allowed_plugins = InstalledExtensions::get_allowed_plugins();
-		$plugin_slug     = $request->get_param( 'plugin' );
+		$plugin_slug = $request->get_param( 'plugin' );
 
-		if (
-			! PluginsHelper::is_plugin_installed( $plugin_slug ) ||
-			! in_array( $plugin_slug, $allowed_plugins, true )
-		) {
+		if ( ! PluginsHelper::is_plugin_installed( $plugin_slug ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'Invalid plugin.', 'woocommerce-admin' ), 404 );
 		}
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -176,6 +176,7 @@ class FeaturePlugin {
 		Events::instance()->init();
 		API\Init::instance();
 		ReportExporter::init();
+		PluginsInstaller::init();
 
 		// CRUD classes.
 		Notes::init();

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -48,7 +48,6 @@ class Homescreen {
 			// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 			add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
 		}
-		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_homescreen_allowed_plugins' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 	}
@@ -115,21 +114,6 @@ class Homescreen {
 		// Move menu item to top of array.
 		unset( $submenu['woocommerce'][ $wc_admin_key ] );
 		array_unshift( $submenu['woocommerce'], $menu );
-	}
-
-	/**
-	 * Gets an array of plugins that can be installed & activated via the home screen.
-	 *
-	 * @param array $plugins Array of plugin slugs to be allowed.
-	 *
-	 * @return array
-	 */
-	public static function get_homescreen_allowed_plugins( $plugins ) {
-		$homescreen_plugins = array(
-			'jetpack' => 'jetpack/jetpack.php',
-		);
-
-		return array_merge( $plugins, $homescreen_plugins );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -204,7 +204,6 @@ class Onboarding {
 	private function add_filters() {
 		// Rest API hooks need to run before is_admin() checks.
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
-		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_onboarding_allowed_plugins' ), 10, 2 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -636,7 +635,7 @@ class Onboarding {
 			return false;
 		}
 
-		return in_array( $current_page['path'], $allowed_paths );
+		return in_array( $current_page['path'], $allowed_paths, true );
 	}
 
 	/**
@@ -735,44 +734,6 @@ class Onboarding {
 		$options[] = 'general';
 
 		return $options;
-	}
-
-	/**
-	 * Gets an array of plugins that can be installed & activated via the onboarding wizard.
-	 *
-	 * @param array $plugins Array of plugin slugs to be allowed.
-	 *
-	 * @return array
-	 * @todo Handle edgecase of where installed plugins may have versioned folder names (i.e. `jetpack-main/jetpack.php`).
-	 */
-	public static function get_onboarding_allowed_plugins( $plugins ) {
-		$onboarding_plugins = apply_filters(
-			'woocommerce_admin_onboarding_plugins_whitelist',
-			array(
-				'facebook-for-woocommerce'            => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
-				'mailchimp-for-woocommerce'           => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
-				'creative-mail-by-constant-contact'   => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-				'kliken-marketing-for-google'         => 'kliken-marketing-for-google/kliken-marketing-for-google.php',
-				'jetpack'                             => 'jetpack/jetpack.php',
-				'woocommerce-services'                => 'woocommerce-services/woocommerce-services.php',
-				'woocommerce-gateway-stripe'          => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
-				'woocommerce-paypal-payments'         => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
-				'klarna-checkout-for-woocommerce'     => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
-				'klarna-payments-for-woocommerce'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
-				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',
-				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
-				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/gateway-payfast.php',
-				'woo-paystack'                        => 'woo-paystack/woo-paystack.php',
-				'woocommerce-payments'                => 'woocommerce-payments/woocommerce-payments.php',
-				'woocommerce-gateway-eway'            => 'woocommerce-gateway-eway/woocommerce-gateway-eway.php',
-				'woo-razorpay'                        => 'woo-razorpay/woo-razorpay.php',
-				'mollie-payments-for-woocommerce'     => 'mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php',
-				'payu-india'                          => 'payu-india/index.php',
-				'mailpoet'                            => 'mailpoet/mailpoet.php',
-				'woocommerce-mercadopago'             => 'woocommerce-mercadopago/woocommerce-mercadopago.php',
-			)
-		);
-		return array_merge( $plugins, $onboarding_plugins );
 	}
 
 	/**

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -25,26 +25,10 @@ class ShippingLabelBanner {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_shipping_banner_allowed_plugins' ), 10, 2 );
-
 		if ( ! is_admin() ) {
 			return;
 		}
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 6, 2 );
-	}
-
-	/**
-	 * Gets an array of plugins that can be installed & activated via shipping label prompt.
-	 *
-	 * @param array $plugins Array of plugin slugs to be allowed.
-	 *
-	 * @return array
-	 */
-	public static function get_shipping_banner_allowed_plugins( $plugins ) {
-		$shipping_banner_plugins = array(
-			'woocommerce-services' => 'woocommerce-services/woocommerce-services.php',
-		);
-		return array_merge( $plugins, $shipping_banner_plugins );
 	}
 
 	/**

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -61,6 +61,24 @@ class PluginsHelper {
 	}
 
 	/**
+	 * Get an array of installed plugins with their file paths as a key value pair.
+	 *
+	 * @return array
+	 */
+	public static function get_installed_plugins_paths() {
+		$plugins           = get_plugins();
+		$installed_plugins = array();
+
+		foreach ( $plugins as $path => $plugin ) {
+			$path_parts                 = explode( '/', $path );
+			$slug                       = $path_parts[0];
+			$installed_plugins[ $slug ] = $path;
+		}
+
+		return $installed_plugins;
+	}
+
+	/**
 	 * Get an array of active plugin slugs.
 	 *
 	 * @return array

--- a/src/PluginsInstaller.php
+++ b/src/PluginsInstaller.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * PluginsInstaller
+ *
+ * Installer to allow plugin installation via URL query.
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\API\Plugins;
+
+/**
+ * Class PluginsInstaller
+ */
+class PluginsInstaller {
+	/**
+	 * Constructor
+	 */
+	public static function init() {
+		add_action( 'admin_init', array( __CLASS__, 'possibly_install_activate_plugins' ) );
+	}
+
+	/**
+	 * Check if an install or activation is being requested via URL query.
+	 */
+	public static function possibly_install_activate_plugins() {
+		/* phpcs:disable WordPress.Security.NonceVerification.Recommended */
+		if ( ! isset( $_GET['plugin_action'] ) || ! isset( $_GET['plugins'] ) || ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		$plugins       = sanitize_text_field( wp_unslash( $_GET['plugins'] ) );
+		$plugin_action = sanitize_text_field( wp_unslash( $_GET['plugin_action'] ) );
+		/* phpcs:enable WordPress.Security.NonceVerification.Recommended */
+
+		$plugins_api     = new Plugins();
+		$install_result  = null;
+		$activate_result = null;
+
+		switch ( $plugin_action ) {
+			case 'install':
+				$install_result = $plugins_api->install_plugins( array( 'plugins' => $plugins ) );
+				break;
+			case 'activate':
+				$activate_result = $plugins_api->activate_plugins( array( 'plugins' => $plugins ) );
+				break;
+			case 'install-activate':
+				$install_result  = $plugins_api->install_plugins( array( 'plugins' => $plugins ) );
+				$activate_result = $plugins_api->activate_plugins( array( 'plugins' => implode( ',', $install_result['data']['installed'] ) ) );
+				break;
+		}
+
+		self::display_results( $result );
+	}
+
+	/**
+	 * Display the results of installation and activation on the page.
+	 *
+	 * @param array $install_result Result of installation.
+	 * @param array $activate_result Result of activation.
+	 */
+	public static function display_results( $install_result, $activate_result ) {
+		if ( ! $install_result && ! $activate_result ) {
+			return;
+		}
+
+		// @todo Parse results to plugin names and messages to display in a notice.
+	}
+
+}

--- a/src/PluginsInstaller.php
+++ b/src/PluginsInstaller.php
@@ -53,6 +53,7 @@ class PluginsInstaller {
 		}
 
 		self::display_results( $result );
+		self::redirect_to_referer();
 	}
 
 	/**
@@ -67,6 +68,19 @@ class PluginsInstaller {
 		}
 
 		// @todo Parse results to plugin names and messages to display in a notice.
+	}
+
+	/**
+	 * Redirect back to the referring page if one exists.
+	 */
+	public static function redirect_to_referer() {
+		if ( ! isset( $_SERVER['HTTP_REFERER'] ) ) {
+			return;
+		}
+
+		$referer = $_SERVER['HTTP_REFERER']; // phpcs:ignore sanitization ok.
+		wp_safe_redirect( $referer );
+		exit();
 	}
 
 }

--- a/tests/api/plugins.php
+++ b/tests/api/plugins.php
@@ -109,44 +109,4 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'woocommerce_rest_invalid_plugins', $data['code'] );
 	}
-
-	/**
-	 * Test that installing a non-whitelisted plugin fails, but installs the whitelisted.
-	 */
-	public function test_install_non_allowed_plugins() {
-		wp_set_current_user( $this->user );
-
-		$request = new WP_REST_Request( 'POST', $this->endpoint . '/install' );
-		$request->set_query_params(
-			array(
-				'plugins' => 'facebook-for-woocommerce,hello-dolly',
-			)
-		);
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( false, $data['success'] );
-		$this->assertArrayHasKey( 'hello-dolly', $data['errors']->errors );
-		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['data']['installed'] );
-	}
-
-	/**
-	 * Test that activating a non-whitelisted plugin fails, but activates the whitelisted.
-	 */
-	public function test_activate_non_allowed_plugins() {
-		wp_set_current_user( $this->user );
-
-		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
-		$request->set_query_params(
-			array(
-				'plugins' => 'facebook-for-woocommerce,hello-dolly',
-			)
-		);
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( false, $data['success'] );
-		$this->assertArrayHasKey( 'hello-dolly', $data['errors']->errors );
-		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['data']['activated'] );
-	}
 }


### PR DESCRIPTION
Fixes (part of) #6689 

* Allows any plugins to be installed/activated from the plugins API (removes whitelisting)
* Allows plugins to be installed via URL query

**Question: Should this be moved under `Features`?**

This PR adds the ability to install plugins directly via URL.  This allows remote notifications to use a URL to install plugins.  This route was chosen over async note actions because:
1. Async note actions don't trigger a page refresh which could cause odd behavior with newly installed plugins.
2. Async note actions don't allow the additional params needed to customize installed plugins.

### Detailed test instructions:

1. Visit any admin page with the params `plugin_action` (`install`, `activate`, or `install-activate`) and `plugins` (list of comma separated plugins). `wp-admin/admin.php?page=wc-admin&plugin_action=install&plugins=jetpack`
2. If visiting this URL from a link, make sure you are sent back to the referer.
3. Check that the plugins provided are installed, activated, or both depending on your query.
4. Optionally, check that the plugin success/error message is stored in the database option `woocommerce_admin_plugin_installer_message` (follow-up will be created to address showing this via notice on the page).  Note that this option will be deleted after it's fetched, so you may need to throw in a `wp_die()` to see it.