### PR TITLE
Bumped version and changelog of component package to 6.1.0

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
--   Add optional `children` prop to `<SummaryNumber>`.
--   Add `@woocommerce/experimental`, `md5` and `dompurify` as dependencies.
+# 6.1.0
+
+-   Make pagination buttons height and width consistent. #6725
+-   Add optional `children` prop to `<SummaryNumber>`. #6748
+-   Add `@woocommerce/experimental`, `md5` and `dompurify` as dependencies. #6804
 
 # 6.0.0
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Unreleased
-
 # 6.1.0
 
 -   Make pagination buttons height and width consistent. #6725

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bump version in component package to 6.1.0 as this also includes a feature change in `SummaryNumber`. 
I added one changelog that wasn't listed, but displayed in the commit histories.

### Detailed test instructions:

Read through the test changes, make sure they make sense.

No changelog needed.
