### PR TITLE
Adding setup required indicator for non-configured payment methods

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -213,6 +213,18 @@
 		margin-top: $gap-large;
 	}
 
+	.woocommerce-task-payment__setup_required {
+		display: flex;
+		align-items: center;
+		font-size: 14px;
+		margin-left: $gap-small;
+		font-weight: 400;
+		gap: 3px;
+		> svg {
+			fill: #efb854;
+		}
+	}
+
 	.components-card__header {
 		font-size: 20px;
 		font-weight: 400;

--- a/client/task-list/tasks/payments/components/Action.js
+++ b/client/task-list/tasks/payments/components/Action.js
@@ -49,7 +49,38 @@ export const Action = ( {
 		} );
 	};
 
-	if ( hasSetup && ! isConfigured ) {
+	const ManageButton = () => (
+		<Button
+			className={ classes }
+			isSecondary
+			href={ manageUrl }
+			onClick={
+				methodKey === 'wcpay'
+					? () => recordEvent( 'tasklist_payment_manage' )
+					: () => {}
+			}
+		>
+			{ __( 'Manage', 'woocommerce-admin' ) }
+		</Button>
+	);
+
+	if ( ! hasSetup ) {
+		if ( ! isEnabled ) {
+			return (
+				<Button
+					className={ classes }
+					isSecondary
+					onClick={ () => markConfigured( methodKey ) }
+				>
+					{ __( 'Enable', 'woocommerce-admin' ) }
+				</Button>
+			);
+		}
+
+		return <ManageButton />;
+	}
+
+	if ( ! isEnabled ) {
 		return (
 			<div>
 				<Button
@@ -66,36 +97,22 @@ export const Action = ( {
 		);
 	}
 
-	if ( ( hasSetup && isConfigured ) || ( ! hasSetup && isEnabled ) ) {
-		if ( ! manageUrl ) {
-			return null;
-		}
-
+	if ( ! isConfigured ) {
 		return (
 			<div>
 				<Button
 					className={ classes }
-					isSecondary
-					href={ manageUrl }
-					onClick={
-						methodKey === 'wcpay'
-							? () => recordEvent( 'tasklist_payment_manage' )
-							: () => {}
-					}
+					isPrimary={ isRecommended }
+					isSecondary={ ! isRecommended }
+					isBusy={ isBusy }
+					disabled={ isBusy }
+					onClick={ () => handleClick() }
 				>
-					{ __( 'Manage', 'woocommerce-admin' ) }
+					{ __( 'Finish setup', 'woocommerce-admin' ) }
 				</Button>
 			</div>
 		);
 	}
 
-	return (
-		<Button
-			className={ classes }
-			isSecondary
-			onClick={ () => markConfigured( methodKey ) }
-		>
-			{ __( 'Enable', 'woocommerce-admin' ) }
-		</Button>
-	);
+	return <ManageButton />;
 };

--- a/client/task-list/tasks/payments/components/PaymentAction.js
+++ b/client/task-list/tasks/payments/components/PaymentAction.js
@@ -7,7 +7,7 @@ import { updateQueryString } from '@woocommerce/navigation';
 import { useState } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 
-export const Action = ( {
+export const PaymentAction = ( {
 	hasSetup = false,
 	isConfigured = false,
 	isEnabled = false,

--- a/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
@@ -9,8 +9,8 @@ import {
 	CardMedia,
 	CardHeader,
 	CardDivider,
+	__experimentalText as Text,
 } from '@wordpress/components';
-import { H } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -67,12 +67,15 @@ export const PaymentMethodList = ( {
 						<CardMedia isBorderless>{ before }</CardMedia>
 						<div className="woocommerce-task-payment__description">
 							{ showRecommendedRibbon && <RecommendedRibbon /> }
-							<H className="woocommerce-task-payment__title">
+							<Text
+								as="h3"
+								className="woocommerce-task-payment__title"
+							>
 								{ title }{ ' ' }
 								{ isEnabled && ! isConfigured && (
 									<SetupRequired />
 								) }
-							</H>
+							</Text>
 							<div className="woocommerce-task-payment__content">
 								{ content }
 							</div>

--- a/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
@@ -16,7 +16,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { Action } from '../Action';
+import { PaymentAction } from '../PaymentAction';
 import { RecommendedRibbon } from '../RecommendedRibbon';
 import { SetupRequired } from '../SetupRequired';
 
@@ -81,7 +81,7 @@ export const PaymentMethodList = ( {
 							</div>
 						</div>
 						<div className="woocommerce-task-payment__footer">
-							<Action
+							<PaymentAction
 								manageUrl={ manageUrl }
 								methodKey={ key }
 								hasSetup={ !! method.container }

--- a/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
@@ -18,6 +18,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { Action } from '../Action';
 import { RecommendedRibbon } from '../RecommendedRibbon';
+import { SetupRequired } from '../SetupRequired';
 
 import './PaymentMethodList.scss';
 
@@ -33,6 +34,7 @@ export const PaymentMethodList = ( {
 			const {
 				before,
 				content,
+				isEnabled,
 				isConfigured,
 				key,
 				title,
@@ -66,7 +68,10 @@ export const PaymentMethodList = ( {
 						<div className="woocommerce-task-payment__description">
 							{ showRecommendedRibbon && <RecommendedRibbon /> }
 							<H className="woocommerce-task-payment__title">
-								{ title }
+								{ title }{ ' ' }
+								{ isEnabled && ! isConfigured && (
+									<SetupRequired />
+								) }
 							</H>
 							<div className="woocommerce-task-payment__content">
 								{ content }

--- a/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.js
@@ -9,8 +9,8 @@ import {
 	CardMedia,
 	CardHeader,
 	CardDivider,
-	__experimentalText as Text,
 } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -71,7 +71,7 @@ export const PaymentMethodList = ( {
 								as="h3"
 								className="woocommerce-task-payment__title"
 							>
-								{ title }{ ' ' }
+								{ title }
 								{ isEnabled && ! isConfigured && (
 									<SetupRequired />
 								) }

--- a/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.scss
+++ b/client/task-list/tasks/payments/components/PaymentMethodList/PaymentMethodList.scss
@@ -43,6 +43,8 @@
 	}
 
 	.woocommerce-task-payment__title {
+		display: flex;
+		align-items: center;
 		font-size: 16px;
 		font-weight: 500;
 		color: $studio-gray-80;

--- a/client/task-list/tasks/payments/components/PaymentSetup.js
+++ b/client/task-list/tasks/payments/components/PaymentSetup.js
@@ -14,7 +14,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { createNoticesFromResponse } from '~/lib/notices';
 
-export const Setup = ( { method, markConfigured, query } ) => {
+export const PaymentSetup = ( { method, markConfigured, query } ) => {
 	const { activePlugins } = useSelect( ( select ) => {
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 

--- a/client/task-list/tasks/payments/components/SetupRequired.js
+++ b/client/task-list/tasks/payments/components/SetupRequired.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
+import { __ } from '@wordpress/i18n';
+import { __experimentalText as Text } from '@wordpress/components';
+
+export const SetupRequired = () => {
+	return (
+		<span className="woocommerce-task-payment__setup_required">
+			<NoticeOutlineIcon />
+			<Text variant="small">
+				{ __( 'Setup required', 'woocommerce-admin' ) }
+			</Text>
+		</span>
+	);
+};

--- a/client/task-list/tasks/payments/components/SetupRequired.js
+++ b/client/task-list/tasks/payments/components/SetupRequired.js
@@ -3,7 +3,7 @@
  */
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import { __ } from '@wordpress/i18n';
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 
 export const SetupRequired = () => {
 	return (

--- a/client/task-list/tasks/payments/components/WCPayAcceptedMethods.js
+++ b/client/task-list/tasks/payments/components/WCPayAcceptedMethods.js
@@ -18,7 +18,7 @@ import Discover from '../images/cards/discover.js';
 import JCB from '../images/cards/jcb.js';
 import UnionPay from '../images/cards/unionpay.js';
 
-export default () => (
+export const WCPayAcceptedMethods = () => (
 	<>
 		<Text as="h3" variant="label">
 			{ __( 'Accepted payment methods', 'woocommerce-admin' ) }

--- a/client/task-list/tasks/payments/components/WCPayAcceptedMethods.js
+++ b/client/task-list/tasks/payments/components/WCPayAcceptedMethods.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __experimentalText as Text } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
+++ b/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
@@ -101,11 +101,7 @@ export const WCPayCard = ( props ) => {
 					isLoading={ loading }
 					onSetup={ () => {} }
 					onSetupCallback={ onClick }
-					setupButtonText={
-						isEnabled
-							? __( 'Finish setup', 'woocommerce-admin' )
-							: __( 'Get started', 'woocommerce-admin' )
-					}
+					setupButtonText={ __( 'Get started', 'woocommerce-admin' ) }
 				/>
 			</CardFooter>
 		</Card>

--- a/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
+++ b/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
@@ -11,15 +11,15 @@ import {
 import interpolateComponents from 'interpolate-components';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
-import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
-import WCPayAcceptedMethods from '../WCPayAcceptedMethods';
-import WCPayLogo from '../../images/wcpay-logo';
+import { WCPayAcceptedMethods } from '../WCPayAcceptedMethods';
+import { SetupRequired } from '../SetupRequired';
 import { Action } from '../Action';
+import WCPayLogo from '../../images/wcpay-logo';
 import './WCPayCard.scss';
 
 const TosPrompt = () =>
@@ -58,14 +58,7 @@ export const WCPayCard = ( props ) => {
 						{ __( 'Recommended', 'woocommerce-admin' ) }
 					</span>
 				) }
-				{ isEnabled && (
-					<span className="woocommerce-task-payment__setup_required">
-						<NoticeOutlineIcon />
-						<Text variant="small">
-							{ __( 'Setup required', 'woocommerce-admin' ) }
-						</Text>
-					</span>
-				) }
+				{ isEnabled && <SetupRequired /> }
 			</CardHeader>
 			<CardBody>
 				<Text className="woocommerce-task-payment-wcpay__description">

--- a/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
+++ b/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
@@ -1,13 +1,9 @@
 /**
  * External dependencies
  */
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	CardFooter,
-	__experimentalText as Text,
-} from '@wordpress/components';
+import { Card, CardBody, CardHeader, CardFooter } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
+
 import interpolateComponents from 'interpolate-components';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';

--- a/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
+++ b/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.js
@@ -18,7 +18,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { WCPayAcceptedMethods } from '../WCPayAcceptedMethods';
 import { SetupRequired } from '../SetupRequired';
-import { Action } from '../Action';
+import { PaymentAction } from '../PaymentAction';
 import WCPayLogo from '../../images/wcpay-logo';
 import './WCPayCard.scss';
 
@@ -85,7 +85,7 @@ export const WCPayCard = ( props ) => {
 				<Text>
 					<TosPrompt />
 				</Text>
-				<Action
+				<PaymentAction
 					methodKey={ methodKey }
 					hasSetup={ !! container }
 					isConfigured={ isConfigured }

--- a/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.scss
+++ b/client/task-list/tasks/payments/components/WCPayCard/WCPayCard.scss
@@ -28,15 +28,4 @@
 		display: flex;
 		justify-content: flex-start;
 	}
-
-	.woocommerce-task-payment__setup_required {
-		display: flex;
-		align-items: center;
-		font-size: 14px;
-		margin-left: $gap-small;
-		gap: 3px;
-		> svg {
-			fill: #efb854;
-		}
-	}
 }

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -199,7 +199,6 @@ export const Payments = ( { query } ) => {
 		);
 	}
 
-	// Group by enabled and configured and the rest
 	const [ enabledCardMethods, additionalCardMethods ] = sift(
 		methods,
 		( method ) => method.isEnabled && method.isConfigured

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -20,7 +20,7 @@ import { WCPayCard } from './components/WCPayCard';
 import { PaymentMethodList } from './components/PaymentMethodList';
 import { getCountryCode } from '../../../dashboard/utils';
 import { getPaymentMethods } from './methods';
-import { Setup } from './components/Setup';
+import { PaymentSetup } from './components/PaymentSetup';
 import { sift } from '../../../utils';
 
 export const setMethodEnabledOption = async (
@@ -195,7 +195,10 @@ export const Payments = ( { query } ) => {
 
 	if ( currentMethod ) {
 		return (
-			<Setup method={ currentMethod } markConfigured={ markConfigured } />
+			<PaymentSetup
+				method={ currentMethod }
+				markConfigured={ markConfigured }
+			/>
 		);
 	}
 

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -199,13 +199,10 @@ export const Payments = ( { query } ) => {
 		);
 	}
 
-	// Group by enabled vs the rest, with exception for WCPay which must be configured as well
+	// Group by enabled and configured and the rest
 	const [ enabledCardMethods, additionalCardMethods ] = sift(
 		methods,
-		( method ) =>
-			method.isEnabled &&
-			( method.key !== 'wcpay' ||
-				( method.key === 'wcpay' && method.isConfigured ) )
+		( method ) => method.isEnabled && method.isConfigured
 	);
 
 	const wcPayIndex = additionalCardMethods.findIndex(

--- a/client/task-list/tasks/payments/methods/index.js
+++ b/client/task-list/tasks/payments/methods/index.js
@@ -43,6 +43,8 @@ const getPaymentsSettingsUrl = ( methodKey ) => {
 	);
 };
 
+const methodDefaults = { isConfigured: true };
+
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
@@ -562,5 +564,7 @@ export function getPaymentMethods( {
 		} );
 	}
 
-	return methods.filter( ( method ) => method.visible );
+	return methods
+		.filter( ( method ) => method.visible )
+		.map( ( method ) => ( { ...methodDefaults, ...method } ) );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Update: Adding setup required icon for non-configured payment methods #6811
 - Update: UI updates to Payment Task screen #6766
 - Dev: Add data source filter to remote inbox notification system #6794
 - Fix: Make pagination buttons height and width consistent #6725


### PR DESCRIPTION
Fixes #6699 

Ended up refactoring some of the logic in `<Action />` to try to make it a little simpler, and added a default state for the methods. I used this to provide a default state of `true` for `isConfigured` for methods without a setup. This helped simplify the rest of the logic throughout the components.

Primary visual change here is the addition of the "Setup required" indicator for all payment methods when enabled but not configured. These changes augment those already started in https://github.com/woocommerce/woocommerce-admin/pull/6786 by @joshuatf .


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader

### Screenshots
**Needs setup for WCPay & Stripe**
![image](https://user-images.githubusercontent.com/444632/114936631-8640b980-9df1-11eb-9715-add7251c1209.png)


### Detailed test instructions:

-   Checkout fresh site (or just ensure you can get to the payment method task)
-   Navigate to payment method task from the task list on the Homescreen
- Ensure that all buttons appear as they should, with "Setup," or "Enable" for regular methods, and "Get started" for WCPay.
- Force WCPay & another method that requires setup to appear as enabled (likely in `methods/index.js`)
- Ensure that their buttons now appear as "Finish setup."
- Flag those methods now as already configured via the same file (`methods/index.js`)
- Ensure that the "Manage" button now appears and functions as expected.
- Quick smoke test to ensure that button functionality works as expected, with setup/etc.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->