### PR TITLE
Add try catch around JSON parse of users meta values

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Fix parsing bad JSON string data in useUserPreferences hook. #6819
+
 # 1.2.0
 
 -   Add management of persisted queries to navigation data store.

--- a/packages/data/src/user/use-user-preferences.js
+++ b/packages/data/src/user/use-user-preferences.js
@@ -18,11 +18,21 @@ import { STORE_NAME } from './constants';
 const getWooCommerceMeta = ( user ) => {
 	const wooMeta = user.woocommerce_meta || {};
 
-	const userData = mapValues( wooMeta, ( data ) => {
+	const userData = mapValues( wooMeta, ( data, key ) => {
 		if ( ! data || data.length === 0 ) {
 			return '';
 		}
-		return JSON.parse( data );
+		try {
+			return JSON.parse( data );
+		} catch ( e ) {
+			/* eslint-disable no-console */
+			console.error(
+				`Error parsing value '${ data }' for ${ key }`,
+				e.message
+			);
+			/* eslint-enable no-console */
+			return '';
+		}
 	} );
 
 	return userData;

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Pause inbox message "GivingFeedbackNotes" #6802
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
+- Fix: Parsing bad JSON string data from user WooCommerce meta. #6819
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #6816 

Add a try catch around the JSON parse of the user WooCommerce meta values, as this would prevent a white screen when a value does not parse correctly.

### Detailed test instructions:

- On a new store with the onboarding flow finished
- Update one of the users WooCommerce meta fields (like woocommerce_admin_task_list_tracked_started_tasks within wp_usermeta) to something that would fail parsing {}{} like this.
- After updating, load the WooCommerce > Home
- Home screen should load correctly, it will show (several) console errors in the console (appears that `getWooCommerceMeta` gets called a lot).

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
