### PR TITLE
Ensure get_active_plugins returns an array to populate preloaded plugin settings

### DIFF
--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -314,7 +314,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public static function active_plugins() {
 		return( array(
-			'plugins' => PluginsHelper::get_active_plugin_slugs(),
+			'plugins' => array_values( PluginsHelper::get_active_plugin_slugs() ),
 		) );
 	}
 	/**


### PR DESCRIPTION
Fixes a fatal error on app initialisation. The plugin data store is expecting an array for active plugins but now getting an object. This is due to changes in https://github.com/woocommerce/woocommerce-admin/pull/6805.

This PR changes the array back to an array as defined by JS. @joshuatf can you double check there aren't any side effects from this change?

### Detailed test instructions:

Load the Homescreen and make sure it appears without error

