### PR TITLE
Sort unreleased readme for ease of consumption.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,37 +75,37 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
-- Fix: Use the store timezone to make time data requests #6632
 - Add: Add plugin installer to allow installation of plugins via URL #6805
-- Update: Adding setup required icon for non-configured payment methods #6811
-- Update: UI updates to Payment Task screen #6766
+- Add: Optional children prop to SummaryNumber component #6748
 - Dev: Add data source filter to remote inbox notification system #6794
-- Fix: Make pagination buttons height and width consistent #6725
-- Tweak: Add settings_section event prop for CES #6762
-- Fix: Retain persisted queries when navigating to Homescreen #6614
-- Update: Update choose niche note cta URL #6733
-- Fix: Update folded header style #6724
-- Tweak: Refactor payments to allow management of methods #6786
-- Fix: Fix unreleated variations showing up in the Products reports #6647
-- Tweak: Add tracking data for the preview site btn #6623
-- Tweak: Update WC Payments copy on the task list #6734
-- Tweak: Add check to see if value for contains is array, show warning if not. #6645
 - Dev: Add A/A test #6669
-- Fix: Event tracking for merchant email notes #6616
-- Fix: Check active plugins before getting the PayPal onboarding status #6625
 - Dev: Add support for nonces in note actions #6726
 - Dev: Add support for running php unit tests in PHP 8. #6678
+- Dev: Add event recording to start of gateway connections #6801
+- Fix: Event tracking for merchant email notes #6616
+- Fix: Use the store timezone to make time data requests #6632
+- Fix: Make pagination buttons height and width consistent #6725
+- Fix: Retain persisted queries when navigating to Homescreen #6614
+- Fix: Update folded header style #6724
+- Fix: Unreleated variations showing up in the Products reports #6647
+- Fix: Check active plugins before getting the PayPal onboarding status #6625
 - Fix: Remove no-reply from inbox notification emails #6644
-- Performance: Avoid updating customer info synchronously from the front end. #6765
 - Fix: Set up shipping costs task, redirect to shipping settings after completion. #6791
-- Add: Optional children prop to SummaryNumber component #6748
 - Fix: Onboarding logic on WooCommerce update to keep task list present. #6803
 - Fix: Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin #6710
-- Fix: Pause inbox message "GivingFeedbackNotes" #6802
-- Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Fix: Pause inbox message “GivingFeedbackNotes” #6802
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 - Fix: Parsing bad JSON string data from user WooCommerce meta. #6819
-- Dev: Add event recording to start of gateway connections #6801
+- Performance: Avoid updating customer info synchronously from the front end. #6765
+- Tweak: Add settings_section event prop for CES #6762
+- Tweak: Refactor payments to allow management of methods #6786
+- Tweak: Add tracking data for the preview site button #6623
+- Tweak: Update WC Payments copy on the task list #6734
+- Tweak: Add check to see if value for contains is array, show warning if not. #6645
+- Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Update: Update choose niche note cta URL #6733
+- Update: UI updates to Payment Task screen #6766
+- Update: Adding setup required icon for non-configured payment methods #6811
 
 == 2.2.0 3/30/2021 ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Pause inbox message “GivingFeedbackNotes” #6802
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 - Fix: Parsing bad JSON string data from user WooCommerce meta. #6819
+- Fix: Remove PayPal for India #6828
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786


### PR DESCRIPTION
Alphabetizing the readme for 2.3.0 to get things tidied up and ready for release.

No changelog