### PR TITLE
Remove PayPal for India

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Remove PayPal for India #6828
+
+-  Setup a new store and set your country to `India`.
+-  Go to 'Choose Payment method' Checklist on the home page.
+-  Verify that PayPal is not presented as a payment method.
+
 ### Add event recording to start of gateway connections #6801
 
 -   Enable debug messages inside browser devtools, you can do it by running `localStorage.setItem( 'debug', 'wc-admin:*' );` in your browser console. And don't forget to enable all log levels.

--- a/client/task-list/tasks/payments/methods/index.js
+++ b/client/task-list/tasks/payments/methods/index.js
@@ -264,7 +264,7 @@ export function getPaymentMethods( {
 				</>
 			),
 			before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
-			visible: ! hasCbdIndustry,
+			visible: countryCode !== 'IN' && ! hasCbdIndustry,
 			plugins: [ PAYPAL_PLUGIN ],
 			container: <PayPal />,
 			isConfigured:

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 - Fix: Parsing bad JSON string data from user WooCommerce meta. #6819
 - Dev: Add event recording to start of gateway connections #6801
+- Fix: Remove PayPal for India #6828
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #6825

This PR removes PayPal payment option for India.

### Screenshots
![screenshot-one wordpress test-2021 04 19-13_52_57](https://user-images.githubusercontent.com/1314156/115274037-a08ed600-a116-11eb-881f-759da96fc994.png)


### Detailed test instructions:

-  Setup a new store and set your country to `India`.
-  Go to 'Choose Payment method' Checklist on the home page.
-  Verify that PayPal is not presented as a payment method.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
