### PR TITLE
SlotFill: Remove Navigation's context

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -20,6 +20,7 @@ import {
 } from '@woocommerce/data';
 import { recordPageView } from '@woocommerce/tracks';
 import '@woocommerce/notices';
+import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -172,6 +173,7 @@ class _Layout extends Component {
 						</Suspense>
 					) }
 				</div>
+				<PluginArea scope="woocommerce-admin" />
 			</SlotFillProvider>
 		);
 	}

--- a/client/navigation/components/Item/index.js
+++ b/client/navigation/components/Item/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { NavigationItem } from '@woocommerce/experimental';
+import { NavigationItem, useSlot } from '@woocommerce/experimental';
 import { recordEvent } from '@woocommerce/tracks';
-import { WooNavigationItem, useNavSlot } from '@woocommerce/navigation';
+import { WooNavigationItem } from '@woocommerce/navigation';
 
 const Item = ( { item } ) => {
-	const slot = useNavSlot( 'woocommerce_navigation_' + item.id );
+	const slot = useSlot( 'woocommerce_navigation_' + item.id );
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	const trackClick = ( id ) => {

--- a/client/navigation/index.js
+++ b/client/navigation/index.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { PluginArea } from '@wordpress/plugins';
-import { NavSlotFillProvider } from '@woocommerce/navigation';
 import { withNavigationHydration } from '@woocommerce/data';
 
 /**
@@ -11,15 +9,8 @@ import { withNavigationHydration } from '@woocommerce/data';
 import './style.scss';
 import Container from './components/container';
 
-const Navigation = () => (
-	<NavSlotFillProvider>
-		<Container />
-		<PluginArea />
-	</NavSlotFillProvider>
-);
-
 const HydratedNavigation = withNavigationHydration( window.wcNavigation )(
-	Navigation
+	Container
 );
 
 export default HydratedNavigation;

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -262,22 +262,3 @@ export const WooNavigationItem = ( { children, item } ) => {
 WooNavigationItem.Slot = ( { name } ) => (
 	<Slot name={ 'woocommerce_navigation_' + name } />
 );
-
-/**
- * Export @wordpress/components SlotFillProvider so that Slots, Fills, and useSlot
- * have access to the same context.
- *
- * This is a workaround because components exported from this package do not have
- * the same `context` as those created in the /client folder. This problem is due
- * to WC Admin bundling @wordpress/components instead of enqueuing and using
- * wp.components from the window.
- */
-export { SlotFillProvider as NavSlotFillProvider } from '@wordpress/components';
-
-/**
- * Similar to NavSlotFillProvider above, this is a workaround because components
- * exported from this package do not have the same `context` as those created
- * in the /client folder. This problem is due to WC Admin bundling @wordpress/components
- * instead of enqueuing and using wp.components from the window.
- */
-export { useSlot as useNavSlot } from '@woocommerce/experimental';

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Check active plugins before getting the PayPal onboarding status #6625
 - Fix: Remove no-reply from inbox notification emails #6644
 - Fix: Set up shipping costs task, redirect to shipping settings after completion. #6791
+- Fix: Remove Navigation's uneeded SlotFill context #6832
 - Fix: Onboarding logic on WooCommerce update to keep task list present. #6803
 - Fix: Pause inbox message “GivingFeedbackNotes” #6802
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818


### PR DESCRIPTION
Due to [SlotFillProvider's use of Singleton](https://github.com/WordPress/gutenberg/issues/27191), our previous bundling of `wp.components` caused context issues and Navigation needed to provide its own context in order to export Fills to be used by extensions.

Now that wc-admin no longer bundles `wp.components`, we no longer have this issue. As such, this extra context can be removed and use the one[ introduced here](https://github.com/woocommerce/woocommerce-admin/pull/6792) instead.

## Plugin Scoping

All fills are rendered in a `<PluginArea />` component so that they can be placed in their corresponding Slots. Recently, scoping was introduced in https://github.com/WordPress/gutenberg/pull/27438 so that only relevant items are rendered. This prevents unrelated Fills from being rendered and lifecycle methods executed.

This PR adds `<PluginArea scope="woocommerce-admin" />`

### Detailed test instructions:

Test internal usage of the slotFill

1. Turn on Navigation
2. While on a wc-admin page, navigation to another wc-admin page
3. Navigation should occur without a page refresh. This means the Fill is appropriately rendered in the Slot. If a page refresh occurs, it means a Fill that has wc-admin's `<Link />` didn't work correctly.

Test external usage

1. Install and activate a plugin that uses SlotFill. Here is one https://github.com/psealock/Woo-Navigation-Examples
2. You should see the PHP generated Nav item replaced by the Fill that says "Hello"

<img width="266" alt="Screen Shot 2021-04-20 at 2 19 47 PM" src="https://user-images.githubusercontent.com/1922453/115327739-8e2e9e00-a1e3-11eb-9046-430bd52d008c.png">
