### PR TITLE
Disable the continue btn when plugins are being installed/activated

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Disable the continue btn when plugins are being installed/activated #6838
+
+1. In OBW fill out store details with a USA address 
+2. Click Continue and select Fashion, apparel, and accessories, 
+3. Click Continue, and select Physical products, and continue.
+4. The business details tab should show a Business details tab, and a Free features tab (disabled at first)
+5. Select 1-10 for the first dropdown, and No for the second, and click Continue.
+6. Make sure the "Add recommended business features to my site is ticked
+7. Click Continue, before the page redirects click Continue again
+8. Confirm no error has been recorded in your browser console.
+
 ### Remove PayPal for India #6828
 
 -   Setup a new store and set your country to `India`.

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -437,6 +437,7 @@ export const SelectiveExtensionsBundle = ( {
 							onSubmit( values );
 						} }
 						isBusy={ isInstallingActivating }
+						disabled={ isInstallingActivating }
 						isPrimary
 					>
 						Continue

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add support for running php unit tests in PHP 8. #6678
 - Dev: Add event recording to start of gateway connections #6801
 - Feature: Add recommended payment methods in payment settings. #6760
+- Fix: Disable the continue btn on OBW when requested are being made #6838
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Use the store timezone to make time data requests #6632
 - Fix: Update the checked input radio button margin style #6701


### PR DESCRIPTION
Fixes #6836 

This PR disabled the continue button when the plugins are being installed/activated to prevent an accident click. 

### Detailed test instructions:

1. In OBW fill out store details with a USA address 
2. Click Continue and select Fashion, apparel, and accessories, 
3. Click Continue, and select Physical products, and continue.
4. The business details tab should show a Business details tab, and a Free features tab (disabled at first)
5. Select 1-10 for the first dropdown, and No for the second, and click Continue.
6. Make sure the "Add recommended business features to my site is ticked
7. Click Continue, before the page redirects click Continue again
8. Confirm no error has been recorded in your browser console.
