### PR TITLE
Update task list component to make use of new experimental list

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -129,7 +129,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		}
 	};
 
-	toggleExtensionTaskList = () => {
+	const toggleExtensionTaskList = () => {
 		const newValue = ! isExtendedTaskListHidden;
 
 		recordEvent(

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -3,10 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
 import { check } from '@wordpress/icons';
+import { useState, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	ONBOARDING_STORE_NAME,
 	OPTIONS_STORE_NAME,
@@ -23,26 +22,77 @@ import CartModal from '../dashboard/components/cart-modal';
 import { getAllTasks } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
 import TaskList from './list';
-import { DisplayOption } from '../header/activity-panel/display-options';
+import { TaskStep } from './task-step';
 
-export class TaskDashboard extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isCartModalOpen: false,
-		};
+const taskDashboardSelect = ( select ) => {
+	const { getProfileItems, getTasksStatus } = select( ONBOARDING_STORE_NAME );
+	const { getSettings } = select( SETTINGS_STORE_NAME );
+	const { getOption } = select( OPTIONS_STORE_NAME );
+	const {
+		getActivePlugins,
+		getInstalledPlugins,
+		isJetpackConnected,
+	} = select( PLUGINS_STORE_NAME );
+	const profileItems = getProfileItems();
 
-		this.toggleExtensionTaskList = this.toggleExtensionTaskList.bind(
-			this
-		);
-	}
-	componentDidMount() {
+	const trackedCompletedTasks =
+		getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
+
+	const { general: generalSettings = {} } = getSettings( 'general' );
+	const countryCode = getCountryCode(
+		generalSettings.woocommerce_default_country
+	);
+
+	const activePlugins = getActivePlugins();
+	const installedPlugins = getInstalledPlugins();
+	const onboardingStatus = getTasksStatus();
+
+	return {
+		activePlugins,
+		countryCode,
+		dismissedTasks: getOption( 'woocommerce_task_list_dismissed_tasks' ),
+		isExtendedTaskListComplete:
+			getOption( 'woocommerce_extended_task_list_complete' ) === 'yes',
+		isExtendedTaskListHidden:
+			getOption( 'woocommerce_extended_task_list_hidden' ) === 'yes',
+		isJetpackConnected: isJetpackConnected(),
+		isSetupTaskListHidden:
+			getOption( 'woocommerce_task_list_hidden' ) === 'yes',
+		isTaskListComplete:
+			getOption( 'woocommerce_task_list_complete' ) === 'yes',
+		installedPlugins,
+		onboardingStatus,
+		profileItems,
+		trackedCompletedTasks,
+	};
+};
+
+const TaskDashboard = ( { userPreferences, query } ) => {
+	const { createNotice } = useDispatch( 'core/notices' );
+	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const {
+		trackedCompletedTasks,
+		activePlugins,
+		countryCode,
+		installedPlugins,
+		isJetpackConnected,
+		onboardingStatus,
+		profileItems,
+		isSetupTaskListHidden,
+		dismissedTasks,
+		isTaskListComplete,
+		isExtendedTaskListHidden,
+		isExtendedTaskListComplete,
+	} = useSelect( taskDashboardSelect );
+
+	const [ isCartModalOpen, setIsCartModalOpen ] = useState( false );
+
+	useEffect( () => {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
-	}
+	}, [] );
 
-	getTaskStartedCount = ( taskName ) => {
-		const { userPreferences } = this.props;
+	const getTaskStartedCount = ( taskName ) => {
 		const trackedStartedTasks =
 			userPreferences.task_list_tracked_started_tasks;
 		if ( ! trackedStartedTasks || ! trackedStartedTasks[ taskName ] ) {
@@ -51,8 +101,7 @@ export class TaskDashboard extends Component {
 		return trackedStartedTasks[ taskName ];
 	};
 
-	updateTrackStartedCount = ( taskName, newCount ) => {
-		const { userPreferences } = this.props;
+	const updateTrackStartedCount = ( taskName, newCount ) => {
 		const trackedStartedTasks =
 			userPreferences.task_list_tracked_started_tasks || {};
 		userPreferences.updateUserPreferences( {
@@ -63,26 +112,24 @@ export class TaskDashboard extends Component {
 		} );
 	};
 
-	isTaskCompleted = ( taskName ) => {
-		const { trackedCompletedTasks } = this.props;
+	const isTaskCompleted = ( taskName ) => {
 		if ( ! trackedCompletedTasks ) {
 			return false;
 		}
 		return trackedCompletedTasks.includes( taskName );
 	};
 
-	onTaskSelect = ( taskName ) => {
-		const trackStartedCount = this.getTaskStartedCount( taskName );
+	const onTaskSelect = ( taskName ) => {
+		const trackStartedCount = getTaskStartedCount( taskName );
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,
 		} );
-		if ( ! this.isTaskCompleted( taskName ) ) {
-			this.updateTrackStartedCount( taskName, trackStartedCount + 1 );
+		if ( ! isTaskCompleted( taskName ) ) {
+			updateTrackStartedCount( taskName, trackStartedCount + 1 );
 		}
 	};
 
 	toggleExtensionTaskList = () => {
-		const { isExtendedTaskListHidden, updateOptions } = this.props;
 		const newValue = ! isExtendedTaskListHidden;
 
 		recordEvent(
@@ -93,184 +140,121 @@ export class TaskDashboard extends Component {
 		} );
 	};
 
-	getAllTasks() {
-		const {
-			activePlugins,
-			countryCode,
-			createNotice,
-			installAndActivatePlugins,
-			installedPlugins,
-			isJetpackConnected,
-			onboardingStatus,
-			profileItems,
-			query,
-		} = this.props;
-
-		return getAllTasks( {
-			activePlugins,
-			countryCode,
-			createNotice,
-			installAndActivatePlugins,
-			installedPlugins,
-			isJetpackConnected,
-			onboardingStatus,
-			profileItems,
-			query,
-			toggleCartModal: this.toggleCartModal.bind( this ),
-			onTaskSelect: this.onTaskSelect,
-		} );
-	}
-
-	toggleCartModal() {
-		const { isCartModalOpen } = this.state;
-
+	const toggleCartModal = () => {
 		if ( ! isCartModalOpen ) {
 			recordEvent( 'tasklist_purchase_extensions' );
 		}
 
-		this.setState( { isCartModalOpen: ! isCartModalOpen } );
-	}
+		setIsCartModalOpen( ! isCartModalOpen );
+	};
 
-	render() {
-		const {
-			dismissedTasks,
-			isExtendedTaskListComplete,
-			isExtendedTaskListHidden,
-			isSetupTaskListHidden,
-			isTaskListComplete,
-			query,
-			trackedCompletedTasks,
-		} = this.props;
-		const { isCartModalOpen } = this.state;
-		const allTasks = this.getAllTasks();
-		const { extension, setup: setupTasks } = allTasks;
+	const getCurrentTask = ( tasks ) => {
 		const { task } = query;
+		const currentTask = tasks.find( ( s ) => s.key === task );
 
-		const extensionTasks =
-			Array.isArray( extension ) &&
-			extension.sort( ( a, b ) => {
-				if ( Boolean( a.completed ) === Boolean( b.completed ) ) {
-					return 0;
-				}
+		if ( ! currentTask ) {
+			return null;
+		}
 
-				return a.completed ? 1 : -1;
-			} );
+		return currentTask;
+	};
 
+	const allTasks = getAllTasks( {
+		activePlugins,
+		countryCode,
+		createNotice,
+		installAndActivatePlugins,
+		installedPlugins,
+		isJetpackConnected,
+		onboardingStatus,
+		profileItems,
+		query,
+		toggleCartModal,
+		onTaskSelect,
+	} );
+
+	const { extension, setup: setupTasks } = allTasks;
+	const { task } = query;
+
+	const extensionTasks =
+		Array.isArray( extension ) &&
+		extension.sort( ( a, b ) => {
+			if ( Boolean( a.completed ) === Boolean( b.completed ) ) {
+				return 0;
+			}
+
+			return a.completed ? 1 : -1;
+		} );
+
+	const currentTask = getCurrentTask( [
+		...( extensionTasks || [] ),
+		...( setupTasks || [] ),
+	] );
+
+	if ( task && ! currentTask ) {
+		return null;
+	}
+	if ( currentTask ) {
 		return (
-			<>
-				{ setupTasks && ( ! isSetupTaskListHidden || task ) && (
-					<TaskList
-						dismissedTasks={ dismissedTasks || [] }
-						isComplete={ isTaskListComplete }
-						query={ query }
-						tasks={ setupTasks }
-						title={ __(
-							'Get ready to start selling',
-							'woocommerce-admin'
-						) }
-						trackedCompletedTasks={ trackedCompletedTasks || [] }
-					/>
-				) }
-				{ extensionTasks && (
-					<DisplayOption>
-						<MenuGroup
-							className="woocommerce-layout__homescreen-display-options"
-							label={ __( 'Display', 'woocommerce-admin' ) }
-						>
-							<MenuItem
-								className="woocommerce-layout__homescreen-extension-tasklist-toggle"
-								icon={ ! isExtendedTaskListHidden && check }
-								isSelected={ ! isExtendedTaskListHidden }
-								role="menuitemcheckbox"
-								onClick={ this.toggleExtensionTaskList }
-							>
-								{ __(
-									'Show things to do next',
-									'woocommerce-admin'
-								) }
-							</MenuItem>
-						</MenuGroup>
-					</DisplayOption>
-				) }
-				{ extensionTasks && ! isExtendedTaskListHidden && (
-					<TaskList
-						dismissedTasks={ dismissedTasks || [] }
-						isComplete={ isExtendedTaskListComplete }
-						name={ 'extended_task_list' }
-						query={ query }
-						tasks={ extensionTasks }
-						title={ __( 'Things to do next', 'woocommerce-admin' ) }
-						trackedCompletedTasks={ trackedCompletedTasks || [] }
-					/>
-				) }
-				{ isCartModalOpen && (
-					<CartModal
-						onClose={ () => this.toggleCartModal() }
-						onClickPurchaseLater={ () => this.toggleCartModal() }
-					/>
-				) }
-			</>
+			<TaskStep taskContainer={ currentTask.container } query={ query } />
 		);
 	}
-}
 
-export default compose(
-	withSelect( ( select ) => {
-		const { getProfileItems, getTasksStatus } = select(
-			ONBOARDING_STORE_NAME
-		);
-		const { getSettings } = select( SETTINGS_STORE_NAME );
-		const { getOption } = select( OPTIONS_STORE_NAME );
-		const {
-			getActivePlugins,
-			getInstalledPlugins,
-			isJetpackConnected,
-		} = select( PLUGINS_STORE_NAME );
-		const profileItems = getProfileItems();
+	return (
+		<>
+			{ setupTasks && ( ! isSetupTaskListHidden || task ) && (
+				<TaskList
+					dismissedTasks={ dismissedTasks || [] }
+					isComplete={ isTaskListComplete }
+					query={ query }
+					tasks={ setupTasks }
+					title={ __(
+						'Get ready to start selling',
+						'woocommerce-admin'
+					) }
+					trackedCompletedTasks={ trackedCompletedTasks || [] }
+				/>
+			) }
+			{ extensionTasks && (
+				<DisplayOption>
+					<MenuGroup
+						className="woocommerce-layout__homescreen-display-options"
+						label={ __( 'Display', 'woocommerce-admin' ) }
+					>
+						<MenuItem
+							className="woocommerce-layout__homescreen-extension-tasklist-toggle"
+							icon={ ! isExtendedTaskListHidden && check }
+							isSelected={ ! isExtendedTaskListHidden }
+							role="menuitemcheckbox"
+							onClick={ toggleExtensionTaskList }
+						>
+							{ __(
+								'Show things to do next',
+								'woocommerce-admin'
+							) }
+						</MenuItem>
+					</MenuGroup>
+				</DisplayOption>
+			) }
+			{ extensionTasks && ! isExtendedTaskListHidden && (
+				<TaskList
+					dismissedTasks={ dismissedTasks || [] }
+					isComplete={ isExtendedTaskListComplete }
+					name={ 'extended_task_list' }
+					query={ query }
+					tasks={ extensionTasks }
+					title={ __( 'Things to do next', 'woocommerce-admin' ) }
+					trackedCompletedTasks={ trackedCompletedTasks || [] }
+				/>
+			) }
+			{ isCartModalOpen && (
+				<CartModal
+					onClose={ () => toggleCartModal() }
+					onClickPurchaseLater={ () => toggleCartModal() }
+				/>
+			) }
+		</>
+	);
+};
 
-		const trackedCompletedTasks =
-			getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
-
-		const { general: generalSettings = {} } = getSettings( 'general' );
-		const countryCode = getCountryCode(
-			generalSettings.woocommerce_default_country
-		);
-
-		const activePlugins = getActivePlugins();
-		const installedPlugins = getInstalledPlugins();
-		const onboardingStatus = getTasksStatus();
-
-		return {
-			activePlugins,
-			countryCode,
-			dismissedTasks: getOption(
-				'woocommerce_task_list_dismissed_tasks'
-			),
-			isExtendedTaskListComplete:
-				getOption( 'woocommerce_extended_task_list_complete' ) ===
-				'yes',
-			isExtendedTaskListHidden:
-				getOption( 'woocommerce_extended_task_list_hidden' ) === 'yes',
-			isJetpackConnected: isJetpackConnected(),
-			isSetupTaskListHidden:
-				getOption( 'woocommerce_task_list_hidden' ) === 'yes',
-			isTaskListComplete:
-				getOption( 'woocommerce_task_list_complete' ) === 'yes',
-			installedPlugins,
-			onboardingStatus,
-			profileItems,
-			trackedCompletedTasks,
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
-		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
-
-		return {
-			createNotice,
-			installAndActivatePlugins,
-			updateOptions,
-		};
-	} )
-)( TaskDashboard );
+export default TaskDashboard;

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -22,6 +22,7 @@ import CartModal from '../dashboard/components/cart-modal';
 import { getAllTasks } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
 import TaskList from './list';
+import { DisplayOption } from '../header/activity-panel/display-options';
 import { TaskStep } from './task-step';
 
 const taskDashboardSelect = ( select ) => {
@@ -69,6 +70,7 @@ const taskDashboardSelect = ( select ) => {
 
 const TaskDashboard = ( { userPreferences, query } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 	const {
 		trackedCompletedTasks,

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -257,7 +257,7 @@ export const TaskList = ( {
 						{ renderMenu() }
 					</CardHeader>
 					<CardBody>
-						<ExperimentalList>
+						<ExperimentalList animation="slide-right">
 							{ listTasks.map( ( task ) => (
 								<TaskItem
 									key={ task.key }

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -2,56 +2,58 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, cloneElement } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import classNames from 'classnames';
+import { useEffect, useRef } from '@wordpress/element';
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { Icon, check } from '@wordpress/icons';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { List, EllipsisMenu, Badge } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
-import {
-	PLUGINS_STORE_NAME,
-	OPTIONS_STORE_NAME,
-	ONBOARDING_STORE_NAME,
-	SETTINGS_STORE_NAME,
-} from '@woocommerce/data';
+import { OPTIONS_STORE_NAME, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
-import { recordTaskViewEvent } from './tasks';
-import { getCountryCode } from '../dashboard/utils';
 import { TaskItem } from './task-item';
-import sanitizeHTML from '../lib/sanitize-html';
 
-export class TaskList extends Component {
-	componentDidMount() {
-		this.recordTaskView();
-		this.recordTaskListView();
-		this.possiblyCompleteTaskList();
-		this.possiblyTrackCompletedTasks();
-	}
+export const TaskList = ( {
+	query,
+	name = 'task_list',
+	isComplete,
+	dismissedTasks,
+	tasks,
+	trackedCompletedTasks: totalTrackedCompletedTasks,
+	title: listTitle,
+} ) => {
+	const { createNotice } = useDispatch( 'core/notices' );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { profileItems } = useSelect( ( select ) => {
+		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 
-	componentDidUpdate( prevProps ) {
-		const { query } = this.props;
-		const { query: prevQuery } = prevProps;
-		const { task: prevTask } = prevQuery;
+		return {
+			profileItems: getProfileItems(),
+		};
+	} );
+
+	const prevQueryRef = useRef( query );
+	useEffect( () => {
+		recordTaskListView();
+	}, [] );
+
+	useEffect( () => {
+		const { task: prevTask } = prevQueryRef.current;
 		const { task } = query;
 
 		if ( prevTask !== task ) {
 			window.document.documentElement.scrollTop = 0;
-			this.recordTaskView();
+			prevQueryRef.current = query;
 		}
 
-		this.possiblyCompleteTaskList();
-		this.possiblyTrackCompletedTasks();
-	}
+		possiblyCompleteTaskList();
+		possiblyTrackCompletedTasks();
+	}, [ query ] );
 
-	possiblyCompleteTaskList() {
-		const { isComplete, name = 'task_list', updateOptions } = this.props;
+	const possiblyCompleteTaskList = () => {
 		const taskListVariableName = `woocommerce_${ name }_complete`;
 		const taskListToComplete = isComplete
 			? { [ taskListVariableName ]: 'no' }
@@ -62,119 +64,78 @@ export class TaskList extends Component {
 		}
 
 		if (
-			( ! this.getIncompleteTasks().length && ! isComplete ) ||
-			( this.getIncompleteTasks().length && isComplete )
+			( ! getIncompleteTasks().length && ! isComplete ) ||
+			( getIncompleteTasks().length && isComplete )
 		) {
 			updateOptions( {
 				...taskListToComplete,
 			} );
 		}
-	}
+	};
 
-	getCompletedTaskKeys() {
-		return this.getVisibleTasks()
+	const getCompletedTaskKeys = () => {
+		return getVisibleTasks()
 			.filter( ( task ) => task.completed )
 			.map( ( task ) => task.key );
-	}
+	};
 
-	getIncompleteTasks() {
-		const { dismissedTasks, tasks } = this.props;
+	const getIncompleteTasks = () => {
 		return tasks.filter(
 			( task ) =>
 				task.visible &&
 				! task.completed &&
 				! dismissedTasks.includes( task.key )
 		);
-	}
+	};
 
-	shouldUpdateCompletedTasks( tasks, untrackedTasks, completedTasks ) {
-		if ( untrackedTasks.length > 0 ) {
-			return true;
-		}
-		if ( completedTasks.length === 0 ) {
-			return false;
-		}
-		return ! completedTasks.every(
-			( taskName ) => tasks.indexOf( taskName ) >= 0
-		);
-	}
-
-	getTrackedCompletedTasks( completedTasks, trackedTasks ) {
-		if ( ! trackedTasks ) {
-			return [];
-		}
-		return completedTasks.filter( ( taskName ) =>
-			trackedTasks.includes( taskName )
-		);
-	}
-
-	getTrackedIncompletedTasks( partialCompletedTasks, allTrackedTask ) {
-		return this.getVisibleTasks()
+	const getTrackedIncompletedTasks = (
+		partialCompletedTasks,
+		allTrackedTask
+	) => {
+		return getVisibleTasks()
 			.filter(
 				( task ) =>
 					allTrackedTask.includes( task.key ) &&
 					! partialCompletedTasks.includes( task.key )
 			)
 			.map( ( task ) => task.key );
-	}
+	};
 
-	getTasksForUpdate(
-		completedTaskKeys,
-		totalTrackedCompletedTasks,
-		trackedIncompleteTasks
-	) {
-		const mergedLists = [
-			...new Set( [
-				...completedTaskKeys,
-				...totalTrackedCompletedTasks,
-			] ),
-		];
-		return mergedLists.filter(
-			( taskName ) => ! trackedIncompleteTasks.includes( taskName )
-		);
-	}
-
-	possiblyTrackCompletedTasks() {
-		const {
-			trackedCompletedTasks: totalTrackedCompletedTasks,
-			updateOptions,
-		} = this.props;
-		const completedTaskKeys = this.getCompletedTaskKeys();
-		const trackedCompletedTasks = this.getTrackedCompletedTasks(
+	const possiblyTrackCompletedTasks = () => {
+		const completedTaskKeys = getCompletedTaskKeys();
+		const trackedCompletedTasks = getTrackedCompletedTasks(
 			completedTaskKeys,
 			totalTrackedCompletedTasks
 		);
 
-		const trackedIncompleteTasks = this.getTrackedIncompletedTasks(
+		const trackedIncompleteTasks = getTrackedIncompletedTasks(
 			trackedCompletedTasks,
 			totalTrackedCompletedTasks
 		);
 
 		if (
-			this.shouldUpdateCompletedTasks(
+			shouldUpdateCompletedTasks(
 				trackedCompletedTasks,
 				trackedIncompleteTasks,
 				completedTaskKeys
 			)
 		) {
 			updateOptions( {
-				woocommerce_task_list_tracked_completed_tasks: this.getTasksForUpdate(
+				woocommerce_task_list_tracked_completed_tasks: getTasksForUpdate(
 					completedTaskKeys,
 					totalTrackedCompletedTasks,
 					trackedIncompleteTasks
 				),
 			} );
 		}
-	}
+	};
 
-	dismissTask( { key, onDismiss } ) {
-		const { createNotice, dismissedTasks, updateOptions } = this.props;
-
+	const dismissTask = ( { key, onDismiss } ) => {
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
 					label: __( 'Undo', 'woocommerce-admin' ),
-					onClick: () => this.undoDismissTask( key ),
+					onClick: () => undoDismissTask( key ),
 				},
 			],
 		} );
@@ -187,11 +148,9 @@ export class TaskList extends Component {
 		if ( onDismiss ) {
 			onDismiss();
 		}
-	}
+	};
 
-	undoDismissTask( key ) {
-		const { dismissedTasks, updateOptions } = this.props;
-
+	const undoDismissTask = ( key ) => {
 		const updatedDismissedTasks = dismissedTasks.filter(
 			( task ) => task !== key
 		);
@@ -199,55 +158,31 @@ export class TaskList extends Component {
 		updateOptions( {
 			woocommerce_task_list_dismissed_tasks: updatedDismissedTasks,
 		} );
-	}
+	};
 
-	getVisibleTasks() {
-		const { dismissedTasks, tasks } = this.props;
+	const getVisibleTasks = () => {
 		return tasks.filter(
 			( task ) => task.visible && ! dismissedTasks.includes( task.key )
 		);
-	}
+	};
 
-	recordTaskView() {
-		const {
-			isJetpackConnected,
-			activePlugins,
-			installedPlugins,
-			query,
-		} = this.props;
-		const { task: taskName } = query;
-
-		if ( ! taskName ) {
+	const recordTaskListView = () => {
+		if ( query.task ) {
 			return;
 		}
 
-		recordTaskViewEvent(
-			taskName,
-			isJetpackConnected,
-			activePlugins,
-			installedPlugins
-		);
-	}
-
-	recordTaskListView() {
-		if ( this.getCurrentTask() ) {
-			return;
-		}
-
-		const { name = 'task_list', profileItems } = this.props;
 		const isCoreTaskList = name === 'task_list';
 		const taskListName = isCoreTaskList ? 'tasklist' : 'extended_tasklist';
 
-		const tasks = this.getVisibleTasks();
+		const visibleTasks = getVisibleTasks();
 
 		recordEvent( `${ taskListName }_view`, {
-			number_tasks: tasks.length,
+			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
 		} );
-	}
+	};
 
-	hideTaskCard( action ) {
-		const { name = 'task_list', updateOptions } = this.props;
+	const hideTaskCard = ( action ) => {
 		const isCoreTaskList = name === 'task_list';
 		const taskListName = isCoreTaskList ? 'tasklist' : 'extended_tasklist';
 		const updateOptionsParams = {
@@ -261,27 +196,15 @@ export class TaskList extends Component {
 
 		recordEvent( `${ taskListName }_completed`, {
 			action,
-			completed_task_count: this.getCompletedTaskKeys().length,
-			incomplete_task_count: this.getIncompleteTasks().length,
+			completed_task_count: getCompletedTaskKeys().length,
+			incomplete_task_count: getIncompleteTasks().length,
 		} );
 		updateOptions( {
 			...updateOptionsParams,
 		} );
-	}
+	};
 
-	getCurrentTask() {
-		const { query, tasks } = this.props;
-		const { task } = query;
-		const currentTask = tasks.find( ( s ) => s.key === task );
-
-		if ( ! currentTask ) {
-			return null;
-		}
-
-		return currentTask;
-	}
-
-	renderMenu() {
+	const renderMenu = () => {
 		return (
 			<div className="woocommerce-card__menu woocommerce-card__header-item">
 				<EllipsisMenu
@@ -289,9 +212,7 @@ export class TaskList extends Component {
 					renderContent={ () => (
 						<div className="woocommerce-task-card__section-controls">
 							<Button
-								onClick={ () =>
-									this.hideTaskCard( 'remove_card' )
-								}
+								onClick={ () => hideTaskCard( 'remove_card' ) }
 							>
 								{ __( 'Hide this', 'woocommerce-admin' ) }
 							</Button>
@@ -300,149 +221,95 @@ export class TaskList extends Component {
 				/>
 			</div>
 		);
-	}
+	};
 
-	render() {
-		const { query, title: listTitle } = this.props;
-		const { task: theTask } = query;
-		const currentTask = this.getCurrentTask();
+	const listTasks = getVisibleTasks().map( ( task ) => {
+		if ( ! task.onClick ) {
+			task.onClick = ( e ) => {
+				if ( e.target.nodeName === 'A' ) {
+					// This is a nested link, so don't activate this task.
+					return false;
+				}
 
-		if ( theTask && ! currentTask ) {
-			return null;
+				updateQueryString( { task: task.key } );
+			};
 		}
 
-		const listTasks = this.getVisibleTasks().map( ( task ) => {
-			task.className = classNames(
-				task.completed ? 'is-complete' : null,
-				task.className
-			);
-			task.before = (
-				<div className="woocommerce-task__icon">
-					{ task.completed && <Icon icon={ check } /> }
-				</div>
-			);
+		return task;
+	} );
 
-			if ( ! task.completed && task.isDismissable ) {
-				task.after = (
-					<Button
-						data-testid={ `${ task.key }-dismiss-button` }
-						isTertiary
-						onClick={ ( event ) => {
-							event.stopPropagation();
-							this.dismissTask( task );
-						} }
-					>
-						{ __( 'Dismiss', 'woocommerce-admin' ) }
-					</Button>
-				);
-			}
-
-			if ( ! task.onClick ) {
-				task.onClick = ( e ) => {
-					if ( e.target.nodeName === 'A' ) {
-						// This is a nested link, so don't activate this task.
-						return false;
-					}
-
-					updateQueryString( { task: task.key } );
-				};
-			}
-
-			return task;
-		} );
-
-		if ( ! listTasks.length ) {
-			return (
-				<div className="woocommerce-task-dashboard__container"></div>
-			);
-		}
-
-		return (
-			<>
-				<div className="woocommerce-task-dashboard__container">
-					{ currentTask ? (
-						cloneElement( currentTask.container, {
-							query,
-						} )
-					) : (
-						<>
-							<Card
-								size="large"
-								className="woocommerce-task-card woocommerce-homescreen-card"
-							>
-								<CardHeader size="medium">
-									<div className="wooocommerce-task-card__header">
-										<Text variant="title.small">
-											{ listTitle }
-										</Text>
-										<Badge
-											count={
-												this.getIncompleteTasks().length
-											}
-										/>
-									</div>
-									{ this.renderMenu() }
-								</CardHeader>
-								<CardBody>
-									<List>
-										{ listTasks.map( ( task ) => (
-											<TaskItem
-												key={ task.key }
-												title={ task.title }
-												completed={ task.completed }
-												onClick={ task.onClick }
-											/>
-										) ) }
-									</List>
-								</CardBody>
-							</Card>
-						</>
-					) }
-				</div>
-			</>
-		);
+	if ( ! listTasks.length ) {
+		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
+
+	return (
+		<>
+			<div className="woocommerce-task-dashboard__container">
+				<Card
+					size="large"
+					className="woocommerce-task-card woocommerce-homescreen-card"
+				>
+					<CardHeader size="medium">
+						<div className="wooocommerce-task-card__header">
+							<Text variant="title.small">{ listTitle }</Text>
+							<Badge count={ getIncompleteTasks().length } />
+						</div>
+						{ renderMenu() }
+					</CardHeader>
+					<CardBody>
+						<List>
+							{ listTasks.map( ( task ) => (
+								<TaskItem
+									key={ task.key }
+									title={ task.title }
+									completed={ task.completed }
+									content={ task.content }
+									onClick={ task.onClick }
+									isDismissable={ task.isDismissable }
+									onDismiss={ () => dismissTask( task ) }
+									time={ task.time }
+								/>
+							) ) }
+						</List>
+					</CardBody>
+				</Card>
+			</div>
+		</>
+	);
+};
+
+function shouldUpdateCompletedTasks( tasks, untrackedTasks, completedTasks ) {
+	if ( untrackedTasks.length > 0 ) {
+		return true;
+	}
+	if ( completedTasks.length === 0 ) {
+		return false;
+	}
+	return ! completedTasks.every(
+		( taskName ) => tasks.indexOf( taskName ) >= 0
+	);
 }
 
-export default compose(
-	withSelect( ( select ) => {
-		const { getProfileItems, getTasksStatus } = select(
-			ONBOARDING_STORE_NAME
-		);
-		const { getSettings } = select( SETTINGS_STORE_NAME );
-		const {
-			getActivePlugins,
-			getInstalledPlugins,
-			isJetpackConnected,
-		} = select( PLUGINS_STORE_NAME );
-		const profileItems = getProfileItems();
-		const { general: generalSettings = {} } = getSettings( 'general' );
-		const countryCode = getCountryCode(
-			generalSettings.woocommerce_default_country
-		);
+function getTrackedCompletedTasks( completedTasks, trackedTasks ) {
+	if ( ! trackedTasks ) {
+		return [];
+	}
+	return completedTasks.filter( ( taskName ) =>
+		trackedTasks.includes( taskName )
+	);
+}
 
-		const activePlugins = getActivePlugins();
-		const installedPlugins = getInstalledPlugins();
-		const onboardingStatus = getTasksStatus();
+function getTasksForUpdate(
+	completedTaskKeys,
+	totalTrackedCompletedTasks,
+	trackedIncompleteTasks
+) {
+	const mergedLists = [
+		...new Set( [ ...completedTaskKeys, ...totalTrackedCompletedTasks ] ),
+	];
+	return mergedLists.filter(
+		( taskName ) => ! trackedIncompleteTasks.includes( taskName )
+	);
+}
 
-		return {
-			activePlugins,
-			countryCode,
-			isJetpackConnected: isJetpackConnected(),
-			installedPlugins,
-			onboardingStatus,
-			profileItems,
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
-		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
-
-		return {
-			createNotice,
-			installAndActivatePlugins,
-			updateOptions,
-		};
-	} )
-)( TaskList );
+export default TaskList;

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -24,6 +24,7 @@ import { Text } from '@woocommerce/experimental';
  */
 import { recordTaskViewEvent } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
+import { TaskItem } from './task-item';
 import sanitizeHTML from '../lib/sanitize-html';
 
 export class TaskList extends Component {
@@ -321,28 +322,6 @@ export class TaskList extends Component {
 				</div>
 			);
 
-			task.title = (
-				<Text
-					as="div"
-					variant={ task.completed ? 'body.small' : 'button' }
-				>
-					{ task.title }
-					{ task.additionalInfo && (
-						<div
-							className="woocommerce-task__additional-info"
-							dangerouslySetInnerHTML={ sanitizeHTML(
-								task.additionalInfo
-							) }
-						></div>
-					) }
-					{ task.time && ! task.completed && (
-						<div className="woocommerce-task__estimated-time">
-							{ task.time }
-						</div>
-					) }
-				</Text>
-			);
-
 			if ( ! task.completed && task.isDismissable ) {
 				task.after = (
 					<Button
@@ -405,7 +384,16 @@ export class TaskList extends Component {
 									{ this.renderMenu() }
 								</CardHeader>
 								<CardBody>
-									<List items={ listTasks } />
+									<List>
+										{ listTasks.map( ( task ) => (
+											<TaskItem
+												key={ task.key }
+												title={ task.title }
+												completed={ task.completed }
+												onClick={ task.onClick }
+											/>
+										) ) }
+									</List>
 								</CardBody>
 							</Card>
 						</>

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { List, EllipsisMenu, Badge } from '@woocommerce/components';
+import { ExperimentalList, EllipsisMenu, Badge } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import { OPTIONS_STORE_NAME, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -257,7 +257,7 @@ export const TaskList = ( {
 						{ renderMenu() }
 					</CardHeader>
 					<CardBody>
-						<List>
+						<ExperimentalList>
 							{ listTasks.map( ( task ) => (
 								<TaskItem
 									key={ task.key }
@@ -270,7 +270,7 @@ export const TaskList = ( {
 									time={ task.time }
 								/>
 							) ) }
-						</List>
+						</ExperimentalList>
 					</CardBody>
 				</Card>
 			</div>

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -5,7 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ExperimentalList, EllipsisMenu, Badge } from '@woocommerce/components';
+import {
+	EllipsisMenu,
+	Badge,
+	__experimentalList as List,
+} from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import { OPTIONS_STORE_NAME, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -257,7 +261,7 @@ export const TaskList = ( {
 						{ renderMenu() }
 					</CardHeader>
 					<CardBody>
-						<ExperimentalList animation="slide-right">
+						<List animation="slide-right">
 							{ listTasks.map( ( task ) => (
 								<TaskItem
 									key={ task.key }
@@ -270,7 +274,7 @@ export const TaskList = ( {
 									time={ task.time }
 								/>
 							) ) }
-						</ExperimentalList>
+						</List>
 					</CardBody>
 				</Card>
 			</div>

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -1,0 +1,21 @@
+.woocommerce-task-list__item {
+	.woocommerce-task-list__item-before .woocommerce-task__icon {
+		border-radius: 50%;
+		width: 32px;
+		height: 32px;
+	}
+
+	.woocommerce-task-list__item-before .woocommerce-task__icon svg {
+		fill: $white;
+		position: relative;
+		top: 4px;
+		left: 5px;
+	}
+
+	.woocommerce-task-list__item-text {
+		.woocommerce-pill {
+			padding: 1px $gap-smaller;
+			margin-left: $gap-smaller;
+		}
+	}
+}

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -1,4 +1,16 @@
+$foreground-color: var(--wp-admin-theme-color);
+
 .woocommerce-task-list__item {
+	.woocommerce-task-list__item-title {
+		color: $foreground-color;
+	}
+
+	.woocommerce-task-list__item-before {
+		margin-right: 20px;
+		display: flex;
+		align-items: center;
+	}
+
 	.woocommerce-task-list__item-before .woocommerce-task__icon {
 		border-radius: 50%;
 		width: 32px;
@@ -16,6 +28,20 @@
 		.woocommerce-pill {
 			padding: 1px $gap-smaller;
 			margin-left: $gap-smaller;
+		}
+	}
+
+	&.is-complete {
+		.woocommerce-task__icon {
+			background-color: var(--wp-admin-theme-color);
+		}
+
+		.woocommerce-task-list__item-title {
+			color: $gray-700;
+		}
+
+		.woocommerce-task-list__item-content {
+			display: none;
 		}
 	}
 }

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -11,6 +11,13 @@ $foreground-color: var(--wp-admin-theme-color);
 		align-items: center;
 	}
 
+	.woocommerce-task-list__item-after {
+		margin-left: $gap;
+		display: flex;
+		align-items: center;
+		margin-left: auto;
+	}
+
 	.woocommerce-task-list__item-before .woocommerce-task__icon {
 		border-radius: 50%;
 		width: 32px;

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { ListItem } from '@woocommerce/components';
+import { Text } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import './task-item.scss';
+import sanitizeHTML from '../lib/sanitize-html';
+
+type ListItemProps = {
+	title: string;
+	completed: boolean;
+	onClick: () => void;
+	isDismissable?: boolean;
+	onDismiss?: () => void;
+	additionalInfo?: string;
+	time: string;
+};
+
+export const TaskItem: React.FC< ListItemProps > = ( {
+	completed,
+	title,
+	isDismissable,
+	onDismiss,
+	onClick,
+	additionalInfo,
+	time,
+} ) => {
+	return (
+		<ListItem
+			disableGutters={ false }
+			className="woocommerce-task-list__item"
+			onClick={ onClick }
+		>
+			<div className="woocommerce-task-list__item-before">
+				<div className="woocommerce-task__icon">
+					{ completed && <Icon icon={ check } /> }
+				</div>
+			</div>
+			<div className="woocommerce-task-list__item-text">
+				<span className="woocommerce-task-list__item-title">
+					<Text
+						as="div"
+						variant={ completed ? 'body.small' : 'button' }
+					>
+						{ title }
+						{ additionalInfo && (
+							<div
+								className="woocommerce-task__additional-info"
+								dangerouslySetInnerHTML={ sanitizeHTML(
+									additionalInfo
+								) }
+							></div>
+						) }
+						{ time && ! completed && (
+							<div className="woocommerce-task__estimated-time">
+								{ time }
+							</div>
+						) }
+					</Text>
+					{ title }
+				</span>
+				<span className="woocommerce-task-list__item-content"></span>
+			</div>
+			{ onDismiss && isDismissable && ! completed && (
+				<div className="woocommerce-task-list__item-after">
+					<Button
+						data-testid={ `dismiss-button` }
+						isTertiary
+						onClick={ ( event: React.MouseEvent ) => {
+							event.stopPropagation();
+							onDismiss();
+						} }
+					>
+						{ __( 'Dismiss', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			) }
+		</ListItem>
+	);
+};

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -6,6 +6,8 @@ import { Icon, check } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { ListItem } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
+import { CSSTransition } from 'react-transition-group';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,6 +23,8 @@ type ListItemProps = {
 	onDismiss?: () => void;
 	additionalInfo?: string;
 	time: string;
+	content?: string;
+	expanded?: boolean;
 };
 
 export const TaskItem: React.FC< ListItemProps > = ( {
@@ -31,11 +35,16 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 	onClick,
 	additionalInfo,
 	time,
+	content,
+	expanded = false,
 } ) => {
+	const className = classnames( 'woocommerce-task-list__item', {
+		'is-complete': completed,
+	} );
 	return (
 		<ListItem
 			disableGutters={ false }
-			className="woocommerce-task-list__item"
+			className={ className }
 			onClick={ onClick }
 		>
 			<div className="woocommerce-task-list__item-before">
@@ -58,13 +67,22 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 								) }
 							></div>
 						) }
+						<CSSTransition
+							timeout={ 500 }
+							in={ expanded && content ? true : false }
+							unmountOnExit
+							classNames="woocommerce-task-list__item-content"
+						>
+							<div className="woocommerce-task-list__item-content">
+								{ content }
+							</div>
+						</CSSTransition>
 						{ time && ! completed && (
 							<div className="woocommerce-task__estimated-time">
 								{ time }
 							</div>
 						) }
 					</Text>
-					{ title }
 				</span>
 				<span className="woocommerce-task-list__item-content"></span>
 			</div>

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { ListItem } from '@woocommerce/components';
+import { ExperimentalListItem } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
 import { CSSTransition } from 'react-transition-group';
 import classnames from 'classnames';
@@ -42,10 +42,11 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 		'is-complete': completed,
 	} );
 	return (
-		<ListItem
+		<ExperimentalListItem
 			disableGutters={ false }
 			className={ className }
 			onClick={ onClick }
+			animation="slide-right"
 		>
 			<div className="woocommerce-task-list__item-before">
 				<div className="woocommerce-task__icon">
@@ -100,6 +101,6 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 					</Button>
 				</div>
 			) }
-		</ListItem>
+		</ExperimentalListItem>
 	);
 };

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -6,7 +6,6 @@ import { Icon, check } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { ExperimentalListItem } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
-import { CSSTransition } from 'react-transition-group';
 import classnames from 'classnames';
 
 /**
@@ -68,16 +67,11 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 								) }
 							></div>
 						) }
-						<CSSTransition
-							timeout={ 500 }
-							in={ expanded && content ? true : false }
-							unmountOnExit
-							classNames="woocommerce-task-list__item-content"
-						>
+						{ expanded && content && (
 							<div className="woocommerce-task-list__item-content">
 								{ content }
 							</div>
-						</CSSTransition>
+						) }
 						{ time && ! completed && (
 							<div className="woocommerce-task__estimated-time">
 								{ time }

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { ExperimentalListItem } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
+import { __experimentalListItem as ListItem } from '@woocommerce/components';
 import classnames from 'classnames';
 
 /**
@@ -14,19 +14,19 @@ import classnames from 'classnames';
 import './task-item.scss';
 import sanitizeHTML from '../lib/sanitize-html';
 
-type ListItemProps = {
+type TaskItemProps = {
 	title: string;
 	completed: boolean;
 	onClick: () => void;
 	isDismissable?: boolean;
 	onDismiss?: () => void;
 	additionalInfo?: string;
-	time: string;
+	time?: string;
 	content?: string;
 	expanded?: boolean;
 };
 
-export const TaskItem: React.FC< ListItemProps > = ( {
+export const TaskItem: React.FC< TaskItemProps > = ( {
 	completed,
 	title,
 	isDismissable,
@@ -41,7 +41,7 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 		'is-complete': completed,
 	} );
 	return (
-		<ExperimentalListItem
+		<ListItem
 			disableGutters={ false }
 			className={ className }
 			onClick={ onClick }
@@ -79,14 +79,15 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 						) }
 					</Text>
 				</span>
-				<span className="woocommerce-task-list__item-content"></span>
 			</div>
 			{ onDismiss && isDismissable && ! completed && (
 				<div className="woocommerce-task-list__item-after">
 					<Button
 						data-testid={ `dismiss-button` }
 						isTertiary
-						onClick={ ( event: React.MouseEvent ) => {
+						onClick={ (
+							event: React.MouseEvent | React.KeyboardEvent
+						) => {
 							event.stopPropagation();
 							onDismiss();
 						} }
@@ -95,6 +96,6 @@ export const TaskItem: React.FC< ListItemProps > = ( {
 					</Button>
 				</div>
 			) }
-		</ExperimentalListItem>
+		</ListItem>
 	);
 };

--- a/client/task-list/task-step.tsx
+++ b/client/task-list/task-step.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { cloneElement, useRef, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { PLUGINS_STORE_NAME, WCDataSelector } from '@woocommerce/data';
@@ -37,15 +36,6 @@ export const TaskStep: React.FC< TaskStepProps > = ( {
 		}
 	);
 
-	useEffect( () => {
-		const { task } = query;
-		if ( prevTaskRef.current !== task ) {
-			window.document.documentElement.scrollTop = 0;
-		}
-		prevTaskRef.current = task;
-		recordTaskView();
-	}, [ query ] );
-
 	const recordTaskView = () => {
 		const { task: taskName } = query;
 
@@ -60,6 +50,15 @@ export const TaskStep: React.FC< TaskStepProps > = ( {
 			installedPlugins
 		);
 	};
+
+	useEffect( () => {
+		const { task } = query;
+		if ( prevTaskRef.current !== task ) {
+			window.document.documentElement.scrollTop = 0;
+		}
+		prevTaskRef.current = task;
+		recordTaskView();
+	}, [ query ] );
 
 	if ( ! taskContainer || ! query.task ) {
 		return null;

--- a/client/task-list/task-step.tsx
+++ b/client/task-list/task-step.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { cloneElement, useRef, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { PLUGINS_STORE_NAME, WCDataSelector } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { recordTaskViewEvent } from './tasks';
+
+type TaskStepProps = {
+	taskContainer?: React.ReactElement;
+	query: { task?: string };
+};
+
+export const TaskStep: React.FC< TaskStepProps > = ( {
+	taskContainer,
+	query,
+} ) => {
+	const prevTaskRef = useRef< string >();
+	const { isJetpackConnected, activePlugins, installedPlugins } = useSelect(
+		( select: WCDataSelector ) => {
+			const {
+				getActivePlugins,
+				getInstalledPlugins,
+				isJetpackConnected: getIsJetpackConnected,
+			} = select( PLUGINS_STORE_NAME );
+
+			return {
+				activePlugins: getActivePlugins(),
+				isJetpackConnected: getIsJetpackConnected(),
+				installedPlugins: getInstalledPlugins(),
+			};
+		}
+	);
+
+	useEffect( () => {
+		const { task } = query;
+		if ( prevTaskRef.current !== task ) {
+			window.document.documentElement.scrollTop = 0;
+		}
+		prevTaskRef.current = task;
+		recordTaskView();
+	}, [ query ] );
+
+	const recordTaskView = () => {
+		const { task: taskName } = query;
+
+		if ( ! taskName ) {
+			return;
+		}
+
+		recordTaskViewEvent(
+			taskName,
+			isJetpackConnected,
+			activePlugins,
+			installedPlugins
+		);
+	};
+
+	if ( ! taskContainer || ! query.task ) {
+		return null;
+	}
+	return (
+		<div className="woocommerce-task-dashboard__container">
+			{ cloneElement( taskContainer, {
+				query,
+			} ) }
+		</div>
+	);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8538,6 +8538,16 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
 			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
 		},
+		"@types/yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.22.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
@@ -9246,7 +9256,7 @@
 				"@wordpress/element": "2.19.0",
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/notices": "^2.11.0",
-				"classnames": "2.2.6",
+				"classnames": "2.3.1",
 				"prop-types": "15.7.2",
 				"react-transition-group": "4.4.1"
 			},
@@ -11992,12 +12002,6 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12221,18 +12225,6 @@
 						"debug": "^4.1.1",
 						"get-stream": "^5.1.0",
 						"yauzl": "^2.10.0"
-					},
-					"dependencies": {
-						"@types/yauzl": {
-							"version": "2.9.1",
-							"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-							"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"@types/node": "*"
-							}
-						}
 					}
 				},
 				"fast-glob": {
@@ -12878,30 +12870,6 @@
 						"tar-fs": "^2.0.0",
 						"unbzip2-stream": "^1.3.3",
 						"ws": "^7.2.3"
-					},
-					"dependencies": {
-						"tar-fs": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-							"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-							"dev": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"mkdirp-classic": "^0.5.2",
-								"pump": "^3.0.0",
-								"tar-stream": "^2.1.4"
-							}
-						},
-						"unbzip2-stream": {
-							"version": "1.4.3",
-							"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-							"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-							"dev": true,
-							"requires": {
-								"buffer": "^5.2.1",
-								"through": "^2.3.8"
-							}
-						}
 					}
 				},
 				"read-pkg": {
@@ -37475,6 +37443,26 @@
 				}
 			}
 		},
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				}
+			}
+		},
 		"tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -38286,6 +38274,16 @@
 				"has-bigints": "^1.0.1",
 				"has-symbols": "^1.0.2",
 				"which-boxed-primitive": "^1.0.2"
+			}
+		},
+		"unbzip2-stream": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
 			}
 		},
 		"unc-path-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9274,9 +9274,9 @@
 					}
 				},
 				"classnames": {
-					"version": "2.2.6",
-					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-					"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
 					"dev": true
 				}
 			}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -27,8 +27,8 @@ export { default as ImageUpload } from './image-upload';
 export { default as Link } from './link';
 export {
 	default as List,
-	ExperimentalList,
-	ExperimentalListItem,
+	ExperimentalList as __experimentalList,
+	ExperimentalListItem as __experimentalListItem,
 } from './list';
 export { default as MenuItem } from './ellipsis-menu/menu-item';
 export { default as MenuTitle } from './ellipsis-menu/menu-title';

--- a/packages/components/src/list/experimental-list.tsx
+++ b/packages/components/src/list/experimental-list.tsx
@@ -49,6 +49,7 @@ export const ExperimentalList: React.FC< ListProps > = ( {
 								in={ inTransition }
 								enter={ enter }
 								exit={ exit }
+								classNames="woocommerce-list__item"
 							>
 								{ cloneElement( child, {
 									animation: animationProp,

--- a/packages/customer-effort-score/package.json
+++ b/packages/customer-effort-score/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/element": "2.19.0",
 		"@wordpress/i18n": "3.17.0",
 		"@wordpress/notices": "^2.11.0",
-		"classnames": "2.2.6",
+		"classnames": "2.3.1",
 		"prop-types": "15.7.2",
 		"react-transition-group": "4.4.1"
 	},

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -95,12 +95,6 @@ export type WCDataStoreName =
 	| typeof REPORTS_STORE_NAME
 	| typeof ITEMS_STORE_NAME;
 
-type PluginSelectors = WPDataSelectors & {
-	getActivePlugins: () => string[];
-	getInstalledPlugins: () => string[];
-	isJetpackConnected: () => boolean;
-};
-
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
 export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -95,6 +95,12 @@ export type WCDataStoreName =
 	| typeof REPORTS_STORE_NAME
 	| typeof ITEMS_STORE_NAME;
 
+type PluginSelectors = WPDataSelectors & {
+	getActivePlugins: () => string[];
+	getInstalledPlugins: () => string[];
+	isJetpackConnected: () => boolean;
+};
+
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
 export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME

--- a/packages/data/src/plugins/selectors.ts
+++ b/packages/data/src/plugins/selectors.ts
@@ -68,4 +68,5 @@ export type PluginSelectors = {
 	getActivePlugins: WPDataSelector< typeof getActivePlugins >;
 	getInstalledPlugins: WPDataSelector< typeof getInstalledPlugins >;
 	getRecommendedPlugins: WPDataSelector< typeof getRecommendedPlugins >;
+	isJetpackConnected: WPDataSelector< typeof isJetpackConnected >;
 } & WPDataSelectors;

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Export component ExperimentalList and ExperimentalListItem as List and ListItem.
+
 # 1.0.0
 
 -   Initial package

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Update choose niche note cta URL #6733
 - Update: UI updates to Payment Task screen #6766
 - Update: Adding setup required icon for non-configured payment methods #6811
+- Update: Task list component with new Experimental Task list. #6849
 
 == 2.2.0 3/30/2021 ==
 

--- a/tests/e2e/pages/WcHomescreen.ts
+++ b/tests/e2e/pages/WcHomescreen.ts
@@ -25,11 +25,11 @@ export class WcHomescreen extends BasePage {
 
 	async getTaskList() {
 		await page.waitForSelector(
-			'.woocommerce-task-card .woocommerce-list__item-title'
+			'.woocommerce-task-card .woocommerce-task-list__item-title'
 		);
 		await waitForElementByText( 'p', 'Get ready to start selling' );
 		const list = await this.page.$$eval(
-			'.woocommerce-task-card .woocommerce-list__item-title',
+			'.woocommerce-task-card .woocommerce-task-list__item-title',
 			( items ) => items.map( ( item ) => item.textContent )
 		);
 		return list.map( ( item: string | null ) => {


### PR DESCRIPTION
Fixes #6773 

Updated the task-list code to make use of the ExperimentalList that got merged in https://github.com/woocommerce/woocommerce-admin/pull/6787. I also converted the components to functional components.

### Screenshots

<img width="1083" alt="Screen Shot 2021-04-26 at 1 37 58 PM" src="https://user-images.githubusercontent.com/2240960/116119303-a8a9c100-a694-11eb-9de0-fc37de354d51.png">

### Detailed test instructions:

- Start a new WooCommerce store and finish the onboarding flow
- Smoke test the task list, the task list should be have the same way it currently does
     - Hovering over tasks, clicking on tasks, and opening tasks
     - It should trigger the correct tracks (tasklist_view, task_view, tasklist_click)
- Also smoke test the 3PD task list, by following the JS portion of [this tutorial](https://developer.woocommerce.com/2021/02/26/use-setup-tasks-to-provide-a-first-class-on-boarding-experience-for-merchants/), you can create a new extension using `npm run example -- --ext=add-task` 
- Set `isDismissable` to true for one of you tasks and click this, the animation should be correct as well.


