### PR TITLE
Update the options API to allow nested properties

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add support for nonces in note actions #6726
 - Dev: Add support for running php unit tests in PHP 8. #6678
 - Dev: Add event recording to start of gateway connections #6801
+- Dev: Update the options API to allow nested properties #6866
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Use the store timezone to make time data requests #6632
 - Fix: Make pagination buttons height and width consistent #6725

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -208,17 +208,39 @@ class Options extends \WC_REST_Data_Controller {
 	public static function get_option_value( $key, $value ) {
 		$option_indices = explode( '.', $key );
 
-		// Currently this only supports single level nested properties.
-		if ( count( $option_indices ) !== 2 ) {
+		// Return the value directly if not modifying a nested property.
+		if ( count( $option_indices ) === 1 ) {
 			return $value;
 		}
 
-		$current_value = get_option( $option_indices[0], array() );
-		$merged_value  = is_array( $current_value ) ? $current_value : array();
+		$option_value = get_option( $option_indices[0], array() );
+		self::merge_values( $option_value, $option_indices, $value );
 
-		$merged_value[ $option_indices[1] ] = $value;
+		return $option_value;
+	}
 
-		return $merged_value;
+	/**
+	 * Merge option values into a nested property given an option and indices.
+	 *
+	 * @param string $option_value Current option value.
+	 * @param array  $indices Indices of properties to access.
+	 * @param array  $index_value Value to assign to final nested index.
+	 */
+	public static function merge_values( &$option_value, $indices, $index_value ) {
+		if ( ! is_array( $option_value ) ) {
+			$option_value = array();
+		}
+
+		foreach ( $indices as $index ) {
+			// Create an empty array if the index is not an array.
+			if ( ! isset( $option_value[ $index ] ) || ! is_array( $option_value[ $index ] ) ) {
+				$option_value[ $index ] = array();
+			}
+
+			$option_value = &$option_value[ $index ];
+		}
+
+		$option_value = $index_value;
 	}
 
 	/**

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -190,23 +190,23 @@ class Options extends \WC_REST_Data_Controller {
 	/**
 	 * Get the option name.
 	 *
-	 * @param string $key Option name and any nested properties separated by `.`.
+	 * @param string $key Option name and any nested properties separated by `/`.
 	 * @return string Option name.
 	 */
 	public static function get_option_name( $key ) {
-		$option_indices = explode( '.', $key );
+		$option_indices = explode( '/', $key );
 		return $option_indices[0];
 	}
 
 	/**
 	 * Get the option value and merged nested properties.
 	 *
-	 * @param string $key Option name and any nested properties separated by `.`.
+	 * @param string $key Option name and any nested properties separated by `/`.
 	 * @param string $value Option value.
 	 * @return string Updated value.
 	 */
 	public static function get_option_value( $key, $value ) {
-		$option_indices = explode( '.', $key );
+		$option_indices = explode( '/', $key );
 
 		// Return the value directly if not modifying a nested property.
 		if ( count( $option_indices ) === 1 ) {

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -213,7 +213,8 @@ class Options extends \WC_REST_Data_Controller {
 			return $value;
 		}
 
-		$option_value = get_option( $option_indices[0], array() );
+		$option_name  = array_shift( $option_indices );
+		$option_value = get_option( $option_name, array() );
 		self::merge_values( $option_value, $option_indices, $value );
 
 		return $option_value;

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -179,10 +179,46 @@ class Options extends \WC_REST_Data_Controller {
 		}
 
 		foreach ( $params as $key => $value ) {
-			$updated[ $key ] = update_option( $key, $value );
+			$option_name     = self::get_option_name( $key );
+			$new_value       = self::get_option_value( $key, $value );
+			$updated[ $key ] = update_option( $option_name, $new_value );
 		}
 
 		return $updated;
+	}
+
+	/**
+	 * Get the option name.
+	 *
+	 * @param string $key Option name and any nested properties separated by `.`.
+	 * @return string Option name.
+	 */
+	public static function get_option_name( $key ) {
+		$option_indices = explode( '.', $key );
+		return $option_indices[0];
+	}
+
+	/**
+	 * Get the option value and merged nested properties.
+	 *
+	 * @param string $key Option name and any nested properties separated by `.`.
+	 * @param string $value Option value.
+	 * @return string Updated value.
+	 */
+	public static function get_option_value( $key, $value ) {
+		$option_indices = explode( '.', $key );
+
+		// Currently this only supports single level nested properties.
+		if ( count( $option_indices ) !== 2 ) {
+			return $value;
+		}
+
+		$current_value = get_option( $option_indices[0], array() );
+		$merged_value  = is_array( $current_value ) ? $current_value : array();
+
+		$merged_value[ $option_indices[1] ] = $value;
+
+		return $merged_value;
 	}
 
 	/**

--- a/tests/api/options.php
+++ b/tests/api/options.php
@@ -89,4 +89,52 @@ class WC_Tests_API_Options extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'Store notice updated.', get_option( 'woocommerce_demo_store_notice' ) );
 	}
+
+	/**
+	 * Test that options with nested properties can be updated.
+	 */
+	public function test_update_nested_options() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'woocommerce_admin_test_nested/level1a' => '1a' ) ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'level1a' => '1a' ), get_option( 'woocommerce_admin_test_nested' ) );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'woocommerce_admin_test_nested/level1b' => '1b' ) ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			array(
+				'level1a' => '1a',
+				'level1b' => '1b',
+			),
+			get_option( 'woocommerce_admin_test_nested' )
+		);
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'woocommerce_admin_test_nested/level1b/level2b' => '2b' ) ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			array(
+				'level1a' => '1a',
+				'level1b' => array(
+					'level2b' => '2b',
+				),
+			),
+			get_option( 'woocommerce_admin_test_nested' )
+		);
+	}
 }


### PR DESCRIPTION
In some upcoming changes with the remote payments config, we need to allow more easily edit nested options properties.  For example, many plugins don't use an option `my_plugin_enabled`, but instead use the format:

```
'my_plugin' => array (
    'other_plugin_info' => ...,
    'enabled' => 1
)
```

This PR simply allows modifying only the specified nested property while retaining other values in the option.  In the above example, you can send a request to update `my_plugin/enabled` to only update the `enabled` property.

While initially I used a `.` to delineate the nested property, I switched to `/` since I found options that use a dot in the option name while I did not find any in my DB that use a slash.

### Detailed test instructions:

1. Make a REST API request to the options endpoint `/wp-json/wc-admin/options?_locale=user`.
2. Use a slash to specify a nested property to modify:
```json
{
"my_option/nested_property": "a"
}
```
3. Make sure `my_option` contains the correct data `array( 'nested_property' => 'a' )`
4. Make another request to the same option with a different property.
```json
{
"my_option/other_property": "b"
}
```
5. Make sure `my_option` contains both values without overwriting the first  `array( 'nested_property' => 'a', 'other_property' => 'b' )`
6. Test with multiple depth levels, e.g., `my_option/level1/level2`. Properties that don't have arrays at a given index should be overwritten with an empty array.
7. Make sure no other regressions have occurred with non-nested options.