### PR TITLE
Tweak: change MailPoet's title and description in Store Profiler

### DIFF
--- a/client/profile-wizard/steps/business-details/data/extension-benefits.js
+++ b/client/profile-wizard/steps/business-details/data/extension-benefits.js
@@ -6,10 +6,10 @@ import { __ } from '@wordpress/i18n';
 export const extensionBenefits = [
 	{
 		slug: 'mailpoet',
-		title: __( 'Email Marketing by WooCommerce', 'woocommerce-admin' ),
+		title: __( 'MailPoet', 'woocommerce-admin' ),
 		icon: 'onboarding/mailpoet.png',
 		description: __(
-			'The default all-in-one solution for WooCommerce email. Powered by MailPoet.',
+			'The default all-in-one solution for WooCommerce email.',
 			'woocommerce-admin'
 		),
 	},

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Update WC Payments copy on the task list #6734
 - Tweak: Add check to see if value for contains is array, show warning if not. #6645
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Tweak: Store profiler - Changed MailPoet's title and description #6886
 - Update: Update choose niche note cta URL #6733
 - Update: UI updates to Payment Task screen #6766
 - Update: Adding setup required icon for non-configured payment methods #6811


### PR DESCRIPTION
Fixes #6882

Change title and description of MailPoet extension in Store Profiler.

### Screenshots

<img width="1667" alt="Screenshot 2021-04-27 at 10 42 29" src="https://user-images.githubusercontent.com/470616/116212645-52488b00-a745-11eb-9df9-a2ec3a5f4f6c.png">

### Detailed test instructions:

- Create a brand new site and go to the OBW.
- In the first OBW step (Store Details), set a Country / Region other than the US (e.g., Uruguay).
- Continue with the profiler.
- In the 4th step (Business Details), choose any of the options in both selectors.
- Verify that the MailPoet extension has a new title and description
