### PR TITLE
Redirect to WC Home after setting up a payment method

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Redirect users to WooCommerce Home after setting up a payment method #6891
+
+1. Navigate to WooCommerce -> Home and choose "Choose payment methods".
+2. Click one of the payment methods and go through the setup process.
+3. You should be redirected to WooCommerce Home with a notice when you are done. 
+
 ### Disable the continue btn when plugins are being installed/activated #6838
 
 1. In OBW fill out store details with a USA address 

--- a/client/task-list/tasks/payments/LocalPayments.js
+++ b/client/task-list/tasks/payments/LocalPayments.js
@@ -167,9 +167,7 @@ export const LocalPayments = ( { query } ) => {
 			payment_method: methodKey,
 		} );
 
-		getHistory().push(
-			getNewPath( { ...queryParams, task: 'payments' }, '/', {} )
-		);
+		getHistory().push( getNewPath( { ...queryParams }, '/', {} ) );
 	};
 
 	const recordConnectStartEvent = ( methodName ) => {

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: UI updates to Payment Task screen #6766
 - Update: Adding setup required icon for non-configured payment methods #6811
 - Update: Task list component with new Experimental Task list. #6849
+- Update: Redirect to WC Home after setting up a payment method #6891
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #6873 

This PR redirects users to WC Home after setting up a payment setup. We previously redirected users to the payment task.

### Detailed test instructions:

1. Navigate to WooCommerce -> Home and choose "Choose payment methods".
2. Click one of the payment methods and go through the setup process.
3. You should be redirected to WooCommerce Home with a notice when you are done. 

