### PR TITLE
Un-skip product import test, delete all products in the setup

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Throw exception if the data store cannot be loaded when trying to use notes. #6771
 - Fix: Autocompleter for custom Search in FilterPicker #6880
 - Fix: Get currency from CurrencyContext #6723
+- Fix: Delete all products when running product import tests, unskip previously skipped test. #6905
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858
 - Dev: Fixed storybook build script #6875
 - Dev: Removed allowed keys list for adding woocommerce_meta data. #6889 🎉 @xristos3490
+- Dev: Delete all products when running product import tests, unskip previously skipped test. #6905
 - Feature: Add recommended payment methods in payment settings. #6760
 - Fix: Disable the continue btn on OBW when requested are being made #6838
 - Fix: Event tracking for merchant email notes #6616
@@ -112,7 +113,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Throw exception if the data store cannot be loaded when trying to use notes. #6771
 - Fix: Autocompleter for custom Search in FilterPicker #6880
 - Fix: Get currency from CurrencyContext #6723
-- Fix: Delete all products when running product import tests, unskip previously skipped test. #6905
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -30,6 +30,13 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+
+		// Empty the db of any products.
+		$query    = new \WC_Product_Query();
+		$products = $query->get_products();
+		foreach ( $products as $product ) {
+			$product->delete( true );
+		}
 	}
 
 	/**
@@ -57,7 +64,6 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	 * Test that sample product data is imported.
 	 */
 	public function test_import_sample_products() {
-		$this->markTestSkipped( 'Skipped as test randomly fails on line 77.' );
 		wp_set_current_user( $this->user );
 
 		$this->remove_color_or_logo_attribute_taxonomy();


### PR DESCRIPTION
Fixes #6272

This removes the skip from a product import test (which was being skipped due to an intermittent issue where products were already present when the test was run, resulting in a failing assertion). It also, in the fixture setup, deletes all products from the database, which should resolve the underlying issue.

### Detailed test instructions:

-   Run PHP tests: `npm run test:php`
- There should be three skips (already existing) and no test failures
