### PR TITLE
Correct the left position of transient notices when the new nav is used

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -130,6 +130,12 @@ In case the report shows "no data", please reimport historical data by following
 -   Click on the 3 dots of the card, click `Hide this`, it should make the card disappear, it should also not show on refresh.
     This can't be shown again unless the `woocommerce_show_marketplace_suggestions` option is deleted (through PHPMyAdmin or using `wp option delete woocommerce_show_marketplace_suggestions`).
 
+### Correct the left position of transient notices when the new nav is used #6914
+
+1. Enable new navigation, via Settings -> Advanced -> Features
+2. Go to Analytics -> Products, select "Single product", and select a product
+3. The CES notice should appear in the expected position.
+
 ## 2.2.0
 
 ### Fixed event tracking for merchant email notes #6616

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -130,12 +130,6 @@ In case the report shows "no data", please reimport historical data by following
 -   Click on the 3 dots of the card, click `Hide this`, it should make the card disappear, it should also not show on refresh.
     This can't be shown again unless the `woocommerce_show_marketplace_suggestions` option is deleted (through PHPMyAdmin or using `wp option delete woocommerce_show_marketplace_suggestions`).
 
-### Correct the left position of transient notices when the new nav is used #6914
-
-1. Enable new navigation, via Settings -> Advanced -> Features
-2. Go to Analytics -> Products, select "Single product", and select a product
-3. The CES notice should appear in the expected position.
-
 ## 2.2.0
 
 ### Fixed event tracking for merchant email notes #6616

--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -22,6 +22,10 @@
 			margin-right: auto;
 		}
 	}
+
+	.has-woocommerce-navigation & {
+		left: $navigation-width + $gap;
+	}
 }
 
 .components-snackbar {

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Throw exception if the data store cannot be loaded when trying to use notes. #6771
 - Fix: Autocompleter for custom Search in FilterPicker #6880
 - Fix: Get currency from CurrencyContext #6723
+- Fix: Correct the left position of transient notices when the new nav is used. #6914
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786


### PR DESCRIPTION
Fixes #6442

When the new navigation is enabled, transient notices (for example the Customer Effort Score prompt) are still aligned to be the same   as when the new navigation is not enabled - it is aligned too far to the left.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/224531/116652617-eb3b0880-a9c8-11eb-81b7-8b6407aa555d.png)

After:
![image](https://user-images.githubusercontent.com/224531/116652558-c21a7800-a9c8-11eb-9587-6148bc616c94.png)


### Detailed test instructions:

1. Enable new navigation, via Settings -> Advanced -> Features
2. Go to Analytics -> Products, select "Single product", and select a product
3. The CES notice should appear in the expected position.

