### PR TITLE
Add task hierarchy support to task item

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -19,7 +19,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import './style.scss';
 import CartModal from '../dashboard/components/cart-modal';
-import { getAllTasks } from './tasks';
+import { getAllTasks, taskSort } from './tasks';
 import { getCountryCode } from '../dashboard/utils';
 import TaskList from './task-list';
 import { DisplayOption } from '../header/activity-panel/display-options';
@@ -179,14 +179,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 	const { task } = query;
 
 	const extensionTasks =
-		Array.isArray( extension ) &&
-		extension.sort( ( a, b ) => {
-			if ( Boolean( a.completed ) === Boolean( b.completed ) ) {
-				return 0;
-			}
-
-			return a.completed ? 1 : -1;
-		} );
+		Array.isArray( extension ) && extension.sort( taskSort );
 
 	const currentTask = getCurrentTask( [
 		...( extensionTasks || [] ),

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -19,14 +19,14 @@
 				}
 			}
 
-			.woocommerce-list__item:not(.is-complete) {
+			.woocommerce-list__item:not(.complete) {
 				.woocommerce-task__icon {
 					border: 1px solid $gray-100;
 					background: $white;
 				}
 			}
 
-			.woocommerce-list__item.is-complete {
+			.woocommerce-list__item.complete {
 				.woocommerce-list__item-title {
 					color: $gray-700;
 				}

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -14,7 +14,7 @@ $task-alert-yellow: #f0b849;
 		background: transparent;
 	}
 
-	&.is-l3 {
+	&.is-level-3 {
 		&::before {
 			background-color: $alert-red;
 		}
@@ -23,7 +23,7 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	&.is-l2 {
+	&.is-level-2 {
 		&::before {
 			background-color: $task-alert-yellow;
 		}

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -34,7 +34,6 @@ $task-alert-yellow: #f0b849;
 	}
 
 	.woocommerce-task-list__item-before {
-		// margin-right: 20px;
 		display: flex;
 		align-items: center;
 		padding: $gap 20px $gap $gap-large;

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -14,7 +14,7 @@ $task-alert-yellow: #f0b849;
 		background: transparent;
 	}
 
-	&.is-level-1 {
+	&.level-1 {
 		&::before {
 			background-color: $alert-red;
 		}
@@ -23,7 +23,7 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	&.is-level-2 {
+	&.level-2 {
 		&::before {
 			background-color: $task-alert-yellow;
 		}
@@ -70,7 +70,7 @@ $task-alert-yellow: #f0b849;
 		left: 5px;
 	}
 
-	&.is-complete {
+	&.complete {
 		.woocommerce-task__icon {
 			background-color: var(--wp-admin-theme-color);
 		}

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -14,7 +14,7 @@ $task-alert-yellow: #f0b849;
 		background: transparent;
 	}
 
-	&.is-level-3 {
+	&.is-level-1 {
 		&::before {
 			background-color: $alert-red;
 		}

--- a/client/task-list/task-item.scss
+++ b/client/task-list/task-item.scss
@@ -1,21 +1,61 @@
 $foreground-color: var(--wp-admin-theme-color);
+$task-alert-yellow: #f0b849;
 
 .woocommerce-task-list__item {
+	position: relative;
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 4px;
+		height: 100%;
+		background: transparent;
+	}
+
+	&.is-l3 {
+		&::before {
+			background-color: $alert-red;
+		}
+		.gridicons-notice-outline {
+			fill: $alert-red;
+		}
+	}
+
+	&.is-l2 {
+		&::before {
+			background-color: $task-alert-yellow;
+		}
+	}
+
 	.woocommerce-task-list__item-title {
 		color: $foreground-color;
 	}
 
 	.woocommerce-task-list__item-before {
-		margin-right: 20px;
+		// margin-right: 20px;
 		display: flex;
 		align-items: center;
+		padding: $gap 20px $gap $gap-large;
+	}
+
+	.woocommerce-task-list__item-text {
+		padding: $gap 0;
+
+		.woocommerce-pill {
+			padding: 1px $gap-smaller;
+			margin-left: $gap-smaller;
+		}
 	}
 
 	.woocommerce-task-list__item-after {
 		margin-left: $gap;
+		margin-right: $gap-large;
 		display: flex;
 		align-items: center;
 		margin-left: auto;
+		padding: $gap 0;
 	}
 
 	.woocommerce-task-list__item-before .woocommerce-task__icon {
@@ -31,13 +71,6 @@ $foreground-color: var(--wp-admin-theme-color);
 		left: 5px;
 	}
 
-	.woocommerce-task-list__item-text {
-		.woocommerce-pill {
-			padding: 1px $gap-smaller;
-			margin-left: $gap-smaller;
-		}
-	}
-
 	&.is-complete {
 		.woocommerce-task__icon {
 			background-color: var(--wp-admin-theme-color);
@@ -50,5 +83,10 @@ $foreground-color: var(--wp-admin-theme-color);
 		.woocommerce-task-list__item-content {
 			display: none;
 		}
+	}
+
+	.components-tooltip .components-popover__content {
+		width: 160px;
+		white-space: normal;
 	}
 }

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -3,9 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { Text } from '@woocommerce/experimental';
 import { __experimentalListItem as ListItem } from '@woocommerce/components';
+import NoticeOutline from 'gridicons/dist/notice-outline';
 import classnames from 'classnames';
 
 /**
@@ -24,6 +25,7 @@ type TaskItemProps = {
 	time?: string;
 	content?: string;
 	expanded?: boolean;
+	level?: 'l1' | 'l2' | 'l3';
 };
 
 export const TaskItem: React.FC< TaskItemProps > = ( {
@@ -36,22 +38,43 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	time,
 	content,
 	expanded = false,
+	level = 'l1',
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		'is-complete': completed,
+		'is-l2': level === 'l2' && ! completed,
+		'is-l3': level === 'l3' && ! completed,
 	} );
+	let tooltip = '';
+	if ( level === 'l2' ) {
+		tooltip = __(
+			'This task is required to set up your extension',
+			'woocommerce-admin'
+		);
+	} else if ( level === 'l3' ) {
+		tooltip = __(
+			'This task is required to keep your store running',
+			'woocommerce-admin'
+		);
+	}
 	return (
 		<ListItem
-			disableGutters={ false }
+			disableGutters={ true }
 			className={ className }
 			onClick={ onClick }
 			animation="slide-right"
 		>
-			<div className="woocommerce-task-list__item-before">
-				<div className="woocommerce-task__icon">
-					{ completed && <Icon icon={ check } /> }
+			<Tooltip text={ tooltip }>
+				<div className="woocommerce-task-list__item-before">
+					{ level === 'l3' && ! completed ? (
+						<NoticeOutline size={ 36 } />
+					) : (
+						<div className="woocommerce-task__icon">
+							{ completed && <Icon icon={ check } /> }
+						</div>
+					) }
 				</div>
-			</div>
+			</Tooltip>
 			<div className="woocommerce-task-list__item-text">
 				<span className="woocommerce-task-list__item-title">
 					<Text

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -35,14 +35,14 @@ const OptionalTaskTooltip: React.FC< {
 	children: JSX.Element;
 } > = ( { level, children } ) => {
 	let tooltip = '';
-	if ( level === 2 ) {
-		tooltip = __(
-			'This task is required to set up your extension',
-			'woocommerce-admin'
-		);
-	} else if ( level === 3 ) {
+	if ( level === 1 ) {
 		tooltip = __(
 			'This task is required to keep your store running',
+			'woocommerce-admin'
+		);
+	} else if ( level === 2 ) {
+		tooltip = __(
+			'This task is required to set up your extension',
 			'woocommerce-admin'
 		);
 	}
@@ -62,12 +62,12 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	time,
 	content,
 	expanded = false,
-	level = 1,
+	level = 3,
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		'is-complete': completed,
 		'is-level-2': level === 2 && ! completed,
-		'is-level-3': level === 3 && ! completed,
+		'is-level-1': level === 1 && ! completed,
 	} );
 
 	return (
@@ -79,7 +79,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 		>
 			<OptionalTaskTooltip level={ level }>
 				<div className="woocommerce-task-list__item-before">
-					{ level === 3 && ! completed ? (
+					{ level === 1 && ! completed ? (
 						<NoticeOutline size={ 36 } />
 					) : (
 						<div className="woocommerce-task__icon">

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -32,15 +32,16 @@ type TaskItemProps = {
 
 const OptionalTaskTooltip: React.FC< {
 	level: TaskLevel;
+	completed: boolean;
 	children: JSX.Element;
-} > = ( { level, children } ) => {
+} > = ( { level, completed, children } ) => {
 	let tooltip = '';
-	if ( level === 1 ) {
+	if ( level === 1 && ! completed ) {
 		tooltip = __(
 			'This task is required to keep your store running',
 			'woocommerce-admin'
 		);
-	} else if ( level === 2 ) {
+	} else if ( level === 2 && ! completed ) {
 		tooltip = __(
 			'This task is required to set up your extension',
 			'woocommerce-admin'
@@ -65,9 +66,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	level = 3,
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
-		'is-complete': completed,
-		'is-level-2': level === 2 && ! completed,
-		'is-level-1': level === 1 && ! completed,
+		complete: completed,
+		'level-2': level === 2 && ! completed,
+		'level-1': level === 1 && ! completed,
 	} );
 
 	return (
@@ -77,7 +78,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 			onClick={ onClick }
 			animation="slide-right"
 		>
-			<OptionalTaskTooltip level={ level }>
+			<OptionalTaskTooltip level={ level } completed={ completed }>
 				<div className="woocommerce-task-list__item-before">
 					{ level === 1 && ! completed ? (
 						<NoticeOutline size={ 36 } />

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -15,6 +15,8 @@ import classnames from 'classnames';
 import './task-item.scss';
 import sanitizeHTML from '../lib/sanitize-html';
 
+type TaskLevel = 1 | 2 | 3;
+
 type TaskItemProps = {
 	title: string;
 	completed: boolean;
@@ -25,20 +27,20 @@ type TaskItemProps = {
 	time?: string;
 	content?: string;
 	expanded?: boolean;
-	level?: 'l1' | 'l2' | 'l3';
+	level?: TaskLevel;
 };
 
 const OptionalTaskTooltip: React.FC< {
-	level: 'l1' | 'l2' | 'l3';
+	level: TaskLevel;
 	children: JSX.Element;
 } > = ( { level, children } ) => {
 	let tooltip = '';
-	if ( level === 'l2' ) {
+	if ( level === 2 ) {
 		tooltip = __(
 			'This task is required to set up your extension',
 			'woocommerce-admin'
 		);
-	} else if ( level === 'l3' ) {
+	} else if ( level === 3 ) {
 		tooltip = __(
 			'This task is required to keep your store running',
 			'woocommerce-admin'
@@ -60,24 +62,24 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	time,
 	content,
 	expanded = false,
-	level = 'l1',
+	level = 1,
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		'is-complete': completed,
-		'is-l2': level === 'l2' && ! completed,
-		'is-l3': level === 'l3' && ! completed,
+		'is-level-2': level === 2 && ! completed,
+		'is-level-3': level === 3 && ! completed,
 	} );
 
 	return (
 		<ListItem
-			disableGutters={ true }
+			disableGutters
 			className={ className }
 			onClick={ onClick }
 			animation="slide-right"
 		>
 			<OptionalTaskTooltip level={ level }>
 				<div className="woocommerce-task-list__item-before">
-					{ level === 'l3' && ! completed ? (
+					{ level === 3 && ! completed ? (
 						<NoticeOutline size={ 36 } />
 					) : (
 						<div className="woocommerce-task__icon">

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -28,6 +28,28 @@ type TaskItemProps = {
 	level?: 'l1' | 'l2' | 'l3';
 };
 
+const OptionalTaskTooltip: React.FC< {
+	level: 'l1' | 'l2' | 'l3';
+	children: JSX.Element;
+} > = ( { level, children } ) => {
+	let tooltip = '';
+	if ( level === 'l2' ) {
+		tooltip = __(
+			'This task is required to set up your extension',
+			'woocommerce-admin'
+		);
+	} else if ( level === 'l3' ) {
+		tooltip = __(
+			'This task is required to keep your store running',
+			'woocommerce-admin'
+		);
+	}
+	if ( level === 'l1' ) {
+		return children;
+	}
+	return <Tooltip text={ tooltip }>{ children }</Tooltip>;
+};
+
 export const TaskItem: React.FC< TaskItemProps > = ( {
 	completed,
 	title,
@@ -45,18 +67,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 		'is-l2': level === 'l2' && ! completed,
 		'is-l3': level === 'l3' && ! completed,
 	} );
-	let tooltip = '';
-	if ( level === 'l2' ) {
-		tooltip = __(
-			'This task is required to set up your extension',
-			'woocommerce-admin'
-		);
-	} else if ( level === 'l3' ) {
-		tooltip = __(
-			'This task is required to keep your store running',
-			'woocommerce-admin'
-		);
-	}
+
 	return (
 		<ListItem
 			disableGutters={ true }
@@ -64,7 +75,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 			onClick={ onClick }
 			animation="slide-right"
 		>
-			<Tooltip text={ tooltip }>
+			<OptionalTaskTooltip level={ level }>
 				<div className="woocommerce-task-list__item-before">
 					{ level === 'l3' && ! completed ? (
 						<NoticeOutline size={ 36 } />
@@ -74,7 +85,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 						</div>
 					) }
 				</div>
-			</Tooltip>
+			</OptionalTaskTooltip>
 			<div className="woocommerce-task-list__item-text">
 				<span className="woocommerce-task-list__item-title">
 					<Text

--- a/client/task-list/task-item.tsx
+++ b/client/task-list/task-item.tsx
@@ -44,7 +44,7 @@ const OptionalTaskTooltip: React.FC< {
 			'woocommerce-admin'
 		);
 	}
-	if ( level === 'l1' ) {
+	if ( tooltip === '' ) {
 		return children;
 	}
 	return <Tooltip text={ tooltip }>{ children }</Tooltip>;

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -298,6 +298,7 @@ export const TaskList = ( {
 									isDismissable={ task.isDismissable }
 									onDismiss={ () => dismissTask( task ) }
 									time={ task.time }
+									level={ task.level }
 								/>
 							) ) }
 						</ListComp>

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -264,3 +264,15 @@ export function getAllTasks( {
 		'extension'
 	);
 }
+
+export function taskSort( a, b ) {
+	if ( a.completed || b.completed ) {
+		return a.completed ? 1 : -1;
+	}
+	const aLevel = a.level || 'l1';
+	const bLevel = b.level || 'l1';
+	if ( aLevel === bLevel ) {
+		return 0;
+	}
+	return aLevel > bLevel ? -1 : 1;
+}

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -258,19 +258,23 @@ export function getAllTasks( {
 			type: 'setup',
 		},
 	];
-	return groupListOfObjectsBy(
-		applyFilters( 'woocommerce_admin_onboarding_task_list', tasks, query ),
-		'type',
-		'extension'
+	const filteredTasks = applyFilters(
+		'woocommerce_admin_onboarding_task_list',
+		tasks,
+		query
 	);
+	for ( const task of filteredTasks ) {
+		task.level = task.level ? parseInt( task.level, 10 ) : 1;
+	}
+	return groupListOfObjectsBy( filteredTasks, 'type', 'extension' );
 }
 
 export function taskSort( a, b ) {
 	if ( a.completed || b.completed ) {
 		return a.completed ? 1 : -1;
 	}
-	const aLevel = a.level || 'l1';
-	const bLevel = b.level || 'l1';
+	const aLevel = a.level || 1;
+	const bLevel = b.level || 1;
 	if ( aLevel === bLevel ) {
 		return 0;
 	}

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -264,7 +264,7 @@ export function getAllTasks( {
 		query
 	);
 	for ( const task of filteredTasks ) {
-		task.level = task.level ? parseInt( task.level, 10 ) : 1;
+		task.level = task.level ? parseInt( task.level, 10 ) : 3;
 	}
 	return groupListOfObjectsBy( filteredTasks, 'type', 'extension' );
 }
@@ -273,10 +273,11 @@ export function taskSort( a, b ) {
 	if ( a.completed || b.completed ) {
 		return a.completed ? 1 : -1;
 	}
-	const aLevel = a.level || 1;
-	const bLevel = b.level || 1;
+	// Three is the lowest level.
+	const aLevel = a.level || 3;
+	const bLevel = b.level || 3;
 	if ( aLevel === bLevel ) {
 		return 0;
 	}
-	return aLevel > bLevel ? -1 : 1;
+	return aLevel > bLevel ? 1 : -1;
 }

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -24,6 +24,7 @@ import { DisplayOption } from '../../header/activity-panel/display-options';
 
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../tasks', () => ( {
+	...jest.requireActual( '../tasks' ),
 	recordTaskViewEvent: jest.fn(),
 	getAllTasks: jest.fn(),
 } ) );

--- a/client/task-list/test/task-sort.js
+++ b/client/task-list/test/task-sort.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { taskSort } from '../tasks';
+
+describe( 'task sort', () => {
+	const list = [
+		{ key: 'comp', completed: true },
+		{ key: 'comp-l3', completed: true, level: 'l3' },
+		{ key: 'comp-l2', completed: true, level: 'l2' },
+		{ key: 'uncomp-l3', completed: false, level: 'l3' },
+		{ key: 'uncomp', completed: false },
+		{ key: 'uncomp-l2', completed: false, level: 'l2' },
+		{ key: 'uncomp-l1', completed: false, level: 'l1' },
+	];
+	it( 'should put all l3 levels at the top if not completed', () => {
+		const sorted = [ ...list ].sort( taskSort );
+		expect( sorted[ 0 ].key ).toEqual( 'uncomp-l3' );
+		expect( sorted[ 1 ].key ).toEqual( 'uncomp-l2' );
+		expect( sorted[ 2 ].key ).toEqual( 'uncomp' );
+		expect( sorted[ 3 ].key ).toEqual( 'uncomp-l1' );
+	} );
+
+	it( 'should put all completed items at the bottom', () => {
+		const sorted = [ ...list, { key: 'test', completed: true } ].sort(
+			taskSort
+		);
+		for ( let i = 1; i < 5; i++ ) {
+			expect( sorted[ sorted.length - i ].completed ).toEqual( true );
+		}
+	} );
+} );

--- a/client/task-list/test/task-sort.js
+++ b/client/task-list/test/task-sort.js
@@ -6,7 +6,7 @@ import { taskSort } from '../tasks';
 describe( 'task sort', () => {
 	const list = [
 		{ key: 'comp', completed: true },
-		{ key: 'comp-l3', completed: true, level: 3 },
+		{ key: 'comp-l1', completed: true, level: 1 },
 		{ key: 'comp-l2', completed: true, level: 2 },
 		{ key: 'uncomp-l3', completed: false, level: 3 },
 		{ key: 'uncomp', completed: false },
@@ -15,10 +15,10 @@ describe( 'task sort', () => {
 	];
 	it( 'should put all l3 levels at the top if not completed', () => {
 		const sorted = [ ...list ].sort( taskSort );
-		expect( sorted[ 0 ].key ).toEqual( 'uncomp-l3' );
+		expect( sorted[ 0 ].key ).toEqual( 'uncomp-l1' );
 		expect( sorted[ 1 ].key ).toEqual( 'uncomp-l2' );
-		expect( sorted[ 2 ].key ).toEqual( 'uncomp' );
-		expect( sorted[ 3 ].key ).toEqual( 'uncomp-l1' );
+		expect( sorted[ 2 ].key ).toEqual( 'uncomp-l3' );
+		expect( sorted[ 3 ].key ).toEqual( 'uncomp' );
 	} );
 
 	it( 'should put all completed items at the bottom', () => {

--- a/client/task-list/test/task-sort.js
+++ b/client/task-list/test/task-sort.js
@@ -6,12 +6,12 @@ import { taskSort } from '../tasks';
 describe( 'task sort', () => {
 	const list = [
 		{ key: 'comp', completed: true },
-		{ key: 'comp-l3', completed: true, level: 'l3' },
-		{ key: 'comp-l2', completed: true, level: 'l2' },
-		{ key: 'uncomp-l3', completed: false, level: 'l3' },
+		{ key: 'comp-l3', completed: true, level: 3 },
+		{ key: 'comp-l2', completed: true, level: 2 },
+		{ key: 'uncomp-l3', completed: false, level: 3 },
 		{ key: 'uncomp', completed: false },
-		{ key: 'uncomp-l2', completed: false, level: 'l2' },
-		{ key: 'uncomp-l1', completed: false, level: 'l1' },
+		{ key: 'uncomp-l2', completed: false, level: 2 },
+		{ key: 'uncomp-l1', completed: false, level: 1 },
 	];
 	it( 'should put all l3 levels at the top if not completed', () => {
 		const sorted = [ ...list ].sort( taskSort );

--- a/client/task-list/test/task-sort.js
+++ b/client/task-list/test/task-sort.js
@@ -13,7 +13,7 @@ describe( 'task sort', () => {
 		{ key: 'uncomp-l2', completed: false, level: 2 },
 		{ key: 'uncomp-l1', completed: false, level: 1 },
 	];
-	it( 'should put all l3 levels at the top if not completed', () => {
+	it( 'should put all l1 levels at the top if not completed', () => {
 		const sorted = [ ...list ].sort( taskSort );
 		expect( sorted[ 0 ].key ).toEqual( 'uncomp-l1' );
 		expect( sorted[ 1 ].key ).toEqual( 'uncomp-l2' );

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Delete all products when running product import tests, unskip previously skipped test. #6905
 - Enhancement: Add recommended payment methods in payment settings. #6760
 - Enhancement: Add expand/collapse to extendable task list. #6910
+- Enhancement: Add task hierarchy support to extended task list. #6916
 - Fix: Disable the continue btn on OBW when requested are being made #6838
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Use the store timezone to make time data requests #6632

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,3 +2,10 @@ declare module '@woocommerce/e2e-utils';
 declare module '@woocommerce/e2e-environment';
 declare module '@wordpress/data';
 declare module '@wordpress/compose';
+declare module 'gridicons/dist/*' {
+	const value: React.ElementType< {
+		size?: 12 | 18 | 24 | 36 | 48 | 54 | 72;
+		onClick?: ( event: MouseEvent | KeyboardEvent ) => void;
+	} >;
+	export default value;
+}


### PR DESCRIPTION
Fixes #6639 

This adds support for three different task levels (l1, l2, l3), where l1 is the most important.
I also disabled the gutters padding from the task list and moved to padding down to each section (before, text, after), this way we could display a tooltip any on the left side (and not just the icon).

**Note**:
I haven't added this yet:
`If L1 tasks appear in the list, the task list appears above the activity panel (orders, etc) on the home screen`
This might require a re-factor of some kind, given how getAllTasks is nested in a couple components and relies on a lot of external variables.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="954" alt="Screen Shot 2021-04-30 at 2 25 15 PM" src="https://user-images.githubusercontent.com/2240960/116735341-ba58d480-a9c4-11eb-8a76-b2cf29e82c52.png">

### Detailed test instructions:

-  Create a 3PD task list by following the JS portion of [this tutorial](https://developer.woocommerce.com/2021/02/26/use-setup-tasks-to-provide-a-first-class-on-boarding-experience-for-merchants/), you can create a new extension using `npm run example -- --ext=add-task` 
Sample of filter:
```
addFilter(
	'woocommerce_admin_onboarding_task_list',
	'woocommerce_gpf',
	( tasks ) => {
		return [
			...tasks,
			{
				key: 'woocommerce_test_item_1',
				title: 'Title',
				container: <TestComp />,
				completed: true,
				visible: true,
				additionalInfo: 'additional info',
				time: '5 minutes',
				isDismissable: true,
                                 level: '2'
			}
                 ]
    }
);
```
- Make sure the above plugin is enabled, and you have added several items to the `woocommerce_admin_onboarding_task_list` filter, create an item for each level -> 1, 2, 3 (any undefined).
- Navigate to **WooCommerce > Home**
- Notice how level '1' shows at the top of the list and has a red bar with an icon
- Notice how level '2' shows up after the level '1' and has a yellow bar, but no icon.
- All other level '3' items and undefined should show after these two.
- Hover over the left side of level '2' and '1', it should show a tooltip saying `This task is required to set up your extension` for level 2 and `This task is required to keep your store running` for level 1.
- Now update one of the l2/l3 task list items to completed
- The completed items should show up at the bottom with a generic styling.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
