### PR TITLE
Exclude woocommerce shipping for stores that are only offering downlo…

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Exclude WC Shipping for store that are only offering downloadable products #6917
+
+1. Start OBW and enter an address that is in the US.
+2. Choose "food and drink" from the Industry 
+3. Choose "Downloads" from the Product Types step.
+4. When you get to the Business Details step, expand "Add recommended business features to my site" by clicking the down arrow.
+5. Note that "WooCommerce Shipping" is not listed.
+
 ### Redirect users to WooCommerce Home after setting up a payment method #6891
 
 1. Navigate to WooCommerce -> Home and choose "Choose payment methods".

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -85,12 +85,19 @@ const installableExtensions = [
 					'shipping'
 				),
 				isVisible: ( countryCode, industry, productTypes ) => {
-					return (
-						countryCode === 'US' ||
+					// Exclude the WooCommerce Shipping mention if the user is not in the US.
+					// Exclude the WooCommerce Shipping mention if the user is in the US but
+					// only selected digital products in the Product Types step.
+					if (
+						countryCode !== 'US' ||
 						( countryCode === 'US' &&
 							productTypes.length === 1 &&
 							productTypes[ 0 ] === 'downloads' )
-					);
+					) {
+						return false;
+					}
+
+					return true;
 				},
 			},
 			{

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Autocompleter for custom Search in FilterPicker #6880
 - Fix: Get currency from CurrencyContext #6723
 - Fix: Correct the left position of transient notices when the new nav is used. #6914
+- Fix: Exclude WC Shipping for store that are only offering downloadable products #6917
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786


### PR DESCRIPTION
Fixes #6848 

This PR excludes WooCommece Shipping recommendations for stores that are only offering downloadable products.

### Detailed test instructions:

1. Start OBW and enter an address that is in the US.
2. Choose "food and drink" from the Industry 
3. Choose "Downloads" from the Product Types step.
4. When you get to the Business Details step, expand "Add recommended business features to my site" by clicking the down arrow.
5. Note that "WooCommerce Shipping" is not listed.