### PR TITLE
Extend payment gateways REST endpoint

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Consume remote payment methods on frontend #6867
 - Add: Add plugin installer to allow installation of plugins via URL #6805
 - Add: Optional children prop to SummaryNumber component #6748
+- Add: Extend payment gateways REST endpoint #6919
 - Dev: Add data source filter to remote inbox notification system #6794
 - Dev: Add A/A test #6669
 - Dev: Add support for nonces in note actions #6726

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
+use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\PaymentGateways;
 
 /**
  * Remote Payment Methods engine.
@@ -21,6 +22,7 @@ class Init {
 	 */
 	public function __construct() {
 		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
+		PaymentGatewaysController::init();
 	}
 
 	/**

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
-use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\PaymentGateways;
+use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\PaymentGatewaysController;
 
 /**
  * Remote Payment Methods engine.

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -38,6 +38,8 @@ class PaymentGatewaysController {
 
 		$data['setup_fields'] = self::get_setup_fields( $gateway );
 
+		$data['settings_url'] = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
+
 		$response->set_data( $data );
 
 		return $response;

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -36,7 +36,7 @@ class PaymentGatewaysController {
 			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url();
 		}
 
-		$data['setup_fields'] = self::get_setup_fields( $gateway );
+		$data['setup_fields'] = self::get_setup_form_fields( $gateway );
 
 		$data['settings_url'] = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
@@ -51,11 +51,23 @@ class PaymentGatewaysController {
 	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
 	 * @return array
 	 */
-	public static function get_setup_fields( $gateway ) {
-		if ( ! method_exists( $gateway, 'get_setup_field_keys' ) ) {
-			return array();
+	public static function get_setup_form_fields( $gateway ) {
+		if ( ! method_exists( $gateway, 'get_setup_form_field_keys' ) ) {
+			return apply_filters( 'woocommerce_settings_api_setup_form_fields_' . $gateway->id, array(), $gateway );
 		}
 
-		return array();
+		$setup_form_field_keys = $gateway->get_setup_form_field_keys();
+		$form_fields           = $gateway->get_form_fields();
+		$setup_fields          = array();
+
+		foreach ( $setup_form_field_keys as $key ) {
+			if ( ! isset( $form_fields[ $key ] ) ) {
+				continue;
+			}
+
+			$setup_fields[ $key ] = $form_fields[ $key ];
+		}
+
+		return apply_filters( 'woocommerce_settings_api_setup_form_fields_' . $gateway->id, $setup_fields, $gateway );
 	}
 }

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -36,38 +36,14 @@ class PaymentGatewaysController {
 			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url();
 		}
 
-		$data['setup_fields'] = self::get_setup_form_fields( $gateway );
+		if ( method_exists( $gateway, 'get_required_settings_keys' ) ) {
+			$data['required_settings_keys'] = $gateway->get_required_settings_keys();
+		}
 
 		$data['settings_url'] = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
 		$response->set_data( $data );
 
 		return $response;
-	}
-
-	/**
-	 * Get setup fields from keys.
-	 *
-	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
-	 * @return array
-	 */
-	public static function get_setup_form_fields( $gateway ) {
-		if ( ! method_exists( $gateway, 'get_setup_form_field_keys' ) ) {
-			return apply_filters( 'woocommerce_settings_api_setup_form_fields_' . $gateway->id, array(), $gateway );
-		}
-
-		$setup_form_field_keys = $gateway->get_setup_form_field_keys();
-		$form_fields           = $gateway->get_form_fields();
-		$setup_fields          = array();
-
-		foreach ( $setup_form_field_keys as $key ) {
-			if ( ! isset( $form_fields[ $key ] ) ) {
-				continue;
-			}
-
-			$setup_fields[ $key ] = $form_fields[ $key ];
-		}
-
-		return apply_filters( 'woocommerce_settings_api_setup_form_fields_' . $gateway->id, $setup_fields, $gateway );
 	}
 }

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Logic for extending WC_REST_Payment_Gateways_Controller.
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PaymentGateway class
+ */
+class PaymentGatewaysController {
+
+	/**
+	 * Initialize payment gateway changes.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_rest_prepare_payment_gateway', array( __CLASS__, 'extend_response' ), 10, 3 );
+	}
+
+	/**
+	 * Add necessary fields to REST API response.
+	 *
+	 * @param  WP_REST_Response   $response   Response data.
+	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
+	 * @param  WP_REST_Request    $request    Request object.
+	 * @return WP_REST_Response
+	 */
+	public static function extend_response( $response, $gateway, $request ) {
+		$data = $response->get_data();
+
+		$data['needs_setup'] = $gateway->needs_setup();
+
+		if ( method_exists( $gateway, 'get_oauth_connection_url' ) ) {
+			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url();
+		}
+
+		$data['setup_fields'] = self::get_setup_fields( $gateway );
+
+		$response->set_data( $data );
+
+		return $response;
+	}
+
+	/**
+	 * Get setup fields from keys.
+	 *
+	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
+	 * @return array
+	 */
+	public static function get_setup_fields( $gateway ) {
+		if ( ! method_exists( $gateway, 'get_setup_field_keys' ) ) {
+			return array();
+		}
+
+		return array();
+	}
+}


### PR DESCRIPTION
Fixes #6876 

Adds the following data to the payments gateway endpoint:

* `needs_setup` - Already exists in core.  Used to determine if the gateway is setup yet or not.
* `setup_fields` - Fields specific to setup.  Up for debate on naming- I opted for "setup" since "needs_setup" was already in place.  Some previous iterations: `required_fields|essential_fields|configuration_fields`
* `settings_url` - URL to access settings page.
* `oauth_connection_url` - oAuth connection URL if one exists.

Note that I returned the full settings field data as opposed to just returning the keys.  The reason is to allow further flexibility if a gateway wanted to use the filter `woocommerce_settings_api_setup_form_fields_` to add/modify fields.

### Screenshots
<img width="867" alt="Screen Shot 2021-05-03 at 8 05 18 PM" src="https://user-images.githubusercontent.com/10561050/116948443-5c8aed80-ac4d-11eb-9452-8b20fb846336.png">

### Detailed test instructions:

1. Enable the remote payment methods feature.
2. Install and activate the payfast gateway from this branch - https://github.com/woocommerce/woocommerce-gateway-payfast/pull/43
3. Optionally add a connection URL to the `class-wc-gateway-payfast.php` file.
``` php
	/**
	 * Get the oAuth URL to connect the payment method.
	 *
	 * @return string
	 */
	public function get_oauth_connection_url() {
		return 'http://wordpress.com';
	}
```
4. Make a `GET` request to `/wp-json/wc/v3/payment_gateways/payfast`
5. Check that the 4 fields mentioned above are returned with the correct data.  Also note that `needs_setup` does not appear to be widely adopted and will need to be updated to return the correct value.