### PR TITLE
Fix inconsistent quoting in the storybook script

### DIFF
--- a/bin/import-wp-css-storybook.sh
+++ b/bin/import-wp-css-storybook.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-STORYBOOK_WORDPRESS_DIR="$DIR/../storybook/wordpress";
-STORY_BOOK_CSS_PATH="$DIR/../storybook/wordpress/css";
-TMP_DIR="$DIR/../storybook/wordpress/tmp";
+STORYBOOK_WORDPRESS_DIR=$DIR/../storybook/wordpress;
+STORY_BOOK_CSS_PATH=$DIR/../storybook/wordpress/css;
+TMP_DIR=$DIR/../storybook/wordpress/tmp;
 ARCHIVE_CSS_PATH="wordpress/wp-admin/css";
 ARCHIVE_IMG_PATH="wordpress/wp-admin/images";
 
-mkdir -p $STORY_BOOK_CSS_PATH;
-mkdir -p $TMP_DIR;
+mkdir -p "$STORY_BOOK_CSS_PATH";
+mkdir -p "$TMP_DIR";
 
 function download_and_extract_css {
-    curl -o $1/wordpress-latest.zip https://wordpress.org/nightly-builds/wordpress-latest.zip;
-    unzip -qq "$1/wordpress-latest.zip" "$ARCHIVE_CSS_PATH/*" "$ARCHIVE_IMG_PATH/*" -d $TMP_DIR;
-    rsync -a "$TMP_DIR/$ARCHIVE_CSS_PATH" $STORYBOOK_WORDPRESS_DIR;
-    rsync -a "$TMP_DIR/$ARCHIVE_IMG_PATH" $STORYBOOK_WORDPRESS_DIR;
-    rm -fr $TMP_DIR;
+    curl -o "$STORYBOOK_WORDPRESS_DIR/wordpress-latest.zip" https://wordpress.org/nightly-builds/wordpress-latest.zip;
+    unzip -qq "$STORYBOOK_WORDPRESS_DIR/wordpress-latest.zip" "$ARCHIVE_CSS_PATH/*" "$ARCHIVE_IMG_PATH/*" -d "$TMP_DIR";
+    rsync -a "$TMP_DIR/$ARCHIVE_CSS_PATH" "$STORYBOOK_WORDPRESS_DIR";
+    rsync -a "$TMP_DIR/$ARCHIVE_IMG_PATH" "$STORYBOOK_WORDPRESS_DIR";
+    rm -r "$TMP_DIR";
 }
 
-if [ -z "$(find $STORY_BOOK_CSS_PATH -iname '*.css')" ] || [ "$1" == "-f" ]
+if [ -z "$(find "$STORY_BOOK_CSS_PATH" -iname '*.css')" ] || [ "$1" == "-f" ]
 then
     # The directory is not empty, import css
-    download_and_extract_css $STORYBOOK_WORDPRESS_DIR;
+    download_and_extract_css;
 else
     echo "Wordpress CSS already imported, pass -f to force an update";
 fi

--- a/bin/import-wp-css-storybook.sh
+++ b/bin/import-wp-css-storybook.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-STORYBOOK_WORDPRESS_DIR=$DIR/../storybook/wordpress;
-STORY_BOOK_CSS_PATH=$DIR/../storybook/wordpress/css;
-TMP_DIR=$DIR/../storybook/wordpress/tmp;
+STORYBOOK_WORDPRESS_DIR="$DIR/../storybook/wordpress";
+STORY_BOOK_CSS_PATH="$DIR/../storybook/wordpress/css";
+TMP_DIR="$DIR/../storybook/wordpress/tmp";
 ARCHIVE_CSS_PATH="wordpress/wp-admin/css";
 ARCHIVE_IMG_PATH="wordpress/wp-admin/images";
 


### PR DESCRIPTION
Fixes #6735

This ensures that directories containing spaces will not fail to run this script.

I also added a build of the packages to the script which ensures you can run the script standalone with minimal confusion.

No changelog required