### PR TITLE
Do a git clean before the core release as well

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -111,7 +111,7 @@ status "Starting a Github release... 👷‍♀️"
 ./bin/github-deploy.sh ${PLUGIN_TAG} ${ZIP_FILE}
 
 if [ $IS_CUSTOM_BUILD = false ]; then
-    # Remove ignored files to reset repository to pristine condition. Previous
+	# Remove ignored files to reset repository to pristine condition. Previous
 	# test ensures that changed files abort the plugin build.
 	status "Cleaning working directory... 🛀"
 	git clean -xdf

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -111,6 +111,11 @@ status "Starting a Github release... 👷‍♀️"
 ./bin/github-deploy.sh ${PLUGIN_TAG} ${ZIP_FILE}
 
 if [ $IS_CUSTOM_BUILD = false ]; then
+    # Remove ignored files to reset repository to pristine condition. Previous
+	# test ensures that changed files abort the plugin build.
+	status "Cleaning working directory... 🛀"
+	git clean -xdf
+
 	# Install PHP dependencies
 	status "Gathering PHP dependencies... 🐿️"
 	composer install --no-dev

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Fixed storybook build script #6875
 - Dev: Removed allowed keys list for adding woocommerce_meta data. #6889 🎉 @xristos3490
 - Dev: Delete all products when running product import tests, unskip previously skipped test. #6905
+- Dev: Do a git clean before the core release. #6945
 - Enhancement: Add recommended payment methods in payment settings. #6760
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916


### PR DESCRIPTION
Fixes an issue where both the minified and non minified assets get included into the core zip file. This PR also adds the `git clean` method before doing the core release, this way we start on a fresh slate.

### Detailed test instructions:

-   Add a `exit()` command [here](https://github.com/woocommerce/woocommerce-admin/blob/main/bin/github-deploy.sh#L121) (before the official Github release), and commit this change (only locally).
- Run `npm run build:release`
- Once the release is done, unzip the generated `woocommerce-admin.zip` file (in a different directory).
- Open the `dist` folder and any nested folder there in (`app` or `customer-effort-score`)
- Notice how there are no `minified` files, the `index.asset.php` should exist.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
