### PR TITLE
Add dry run option for the release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Now you can build the files using one of these commands:
 -   `npm run dev` : Build a development version
 -   `npm start` : Build a development version, watch files for changes
 -   `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
+-   `DRY_RUN=1 npm run build:release` : Builds a Wordpress plugin ZIP **without** pushing it to Github and creating a release.
 
 For more helper scripts [see here](./CONTRIBUTING.md#helper-scripts)
 

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -40,6 +40,9 @@ warning () {
 }
 
 status "💃 Time to release WooCommerce Admin 🕺"
+if [ $DRY_RUN ]; then
+  warning "This is a dry run, nothing will be pushed up to Github"
+fi
 
 warning "Please enter the version number to tag, for example, 1.0.0: "
 read -r VERSION

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -111,13 +111,18 @@ status "Generating the plugin build... 👷‍♀️"
 
 # Make a Github release.
 status "Starting a Github release... 👷‍♀️"
-./bin/github-deploy.sh ${PLUGIN_TAG} ${ZIP_FILE}
+if [ $DRY_RUN ]; then
+  PLUGIN_ZIP_FILE="woocommerce-admin-plugin.zip"
+else
+  PLUGIN_ZIP_FILE=$ZIP_FILE
+fi
+./bin/github-deploy.sh ${PLUGIN_TAG} ${PLUGIN_ZIP_FILE}
 
 if [ $IS_CUSTOM_BUILD = false ]; then
 	# Remove ignored files to reset repository to pristine condition. Previous
 	# test ensures that changed files abort the plugin build.
 	status "Cleaning working directory... 🛀"
-	git clean -xdf
+	git clean -xdf -e woocommerce-admin-plugin.zip
 
 	# Install PHP dependencies
 	status "Gathering PHP dependencies... 🐿️"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -41,7 +41,7 @@ warning () {
 
 status "💃 Time to release WooCommerce Admin 🕺"
 if [ $DRY_RUN ]; then
-  warning "This is a dry run, nothing will be pushed up to Github, it will only generate the two zips"
+  warning "This is a dry run, nothing will be pushed up to Github, it will only generate zip files."
 fi
 
 warning "Please enter the version number to tag, for example, 1.0.0: "

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -41,7 +41,7 @@ warning () {
 
 status "💃 Time to release WooCommerce Admin 🕺"
 if [ $DRY_RUN ]; then
-  warning "This is a dry run, nothing will be pushed up to Github"
+  warning "This is a dry run, nothing will be pushed up to Github, it will only generate the two zips"
 fi
 
 warning "Please enter the version number to tag, for example, 1.0.0: "
@@ -137,4 +137,11 @@ if [ $IS_CUSTOM_BUILD = false ]; then
 	./bin/github-deploy.sh ${CORE_TAG} ${ZIP_FILE}
 fi
 
+if [ $DRY_RUN ]; then
+  output 2 "Dry run successfully finished."
+  echo
+  echo "Generated $PLUGIN_ZIP_FILE for the woocommerce-admin plugin build"
+  echo "Generated $ZIP_FILE for the woocommerce-admin core build"
+  exit;
+fi
 success "Done. You've built WooCommerce Admin! 🎉 "

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -106,23 +106,23 @@ fi
 git checkout -b $BRANCH
 
 # Force add feature-config.php
-git add includes/feature-config.php --force
-git add .
+git add includes/feature-config.php --force $DRY_RUN_ARG
+git add . $DRY_RUN_ARG
 git commit -m "Adding feature-config.php directory to release" --no-verify $DRY_RUN_ARG
   
 # Force add language files
-git add languages/woocommerce-admin.pot --force
-git add .
+git add languages/woocommerce-admin.pot --force $DRY_RUN_ARG
+git add . $DRY_RUN_ARG
 git commit -m "Adding translations to release" --no-verify $DRY_RUN_ARG
   
 # Force add build directory and commit.
-git add dist/. --force
-git add .
+git add dist/. --force $DRY_RUN_ARG
+git add . $DRY_RUN_ARG
 git commit -m "Adding /dist directory to release" --no-verify $DRY_RUN_ARG
   
 # Force add vendor directory and commit.
-git add vendor/. --force
-git add .
+git add vendor/. --force $DRY_RUN_ARG
+git add . $DRY_RUN_ARG
 git commit -m "Adding /vendor directory to release" --no-verify $DRY_RUN_ARG
 
 # Push branch upstream

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -51,10 +51,6 @@ if [[ $1 == '' || $2 == '' ]]
     exit 1
 fi
 
-if [ $DRY_RUN ]; then
-  output 2 "Dry run of release finished, please delete the current $BRANCH when it is finished."
-  return;
-fi
 
 printf "This script will build files and create a tag on GitHub based on your local branch."
 echo
@@ -64,6 +60,9 @@ echo
 echo
 printf "The /dist/ directory will also be pushed to the tagged release."
 echo
+if [ $DRY_RUN ]; then
+  output 2 "This is a dry run, only the zip will be generated."
+fi
 echo
 echo "Before proceeding:"
 echo " • Ensure you have checked out the branch you wish to release"
@@ -100,8 +99,6 @@ if [ ! $DRY_RUN ]; then
   # Create a release branch.
   git checkout -b $BRANCH
 
-  warning "HIt official release"
-  exit 1
   # Force add feature-config.php
   git add includes/feature-config.php --force
   git add .
@@ -129,7 +126,6 @@ fi
 ./bin/make-zip.sh $ZIP_FILE
 
 if [ $DRY_RUN ]; then
-  output 2 "Dry run of release finished, please delete $BRANCH branch."
   exit;
 fi
 # Create the new release.

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -51,6 +51,11 @@ if [[ $1 == '' || $2 == '' ]]
     exit 1
 fi
 
+if [ $DRY_RUN ]; then
+  output 2 "Dry run of release finished, please delete $BRANCH branch."
+  return;
+fi
+
 printf "This script will build files and create a tag on GitHub based on your local branch."
 echo
 echo
@@ -114,11 +119,16 @@ git add .
 git commit -m "Adding /vendor directory to release" --no-verify
 
 # Push branch upstream
-git push origin $BRANCH
-
+if [ ! $DRY_RUN ]; then
+  git push origin $BRANCH
+fi
 # Create the zip archive
 ./bin/make-zip.sh $ZIP_FILE
 
+if [ $DRY_RUN ]; then
+  output 2 "Dry run of release finished, please delete $BRANCH branch."
+  return;
+fi
 # Create the new release.
 if [ $IS_PRE_RELEASE = true ]; then
 	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH --prerelease "v${VERSION}" --attach "${ZIP_FILE}"

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -95,48 +95,51 @@ echo
 
 BRANCH="build/${VERSION}"
 
-if [ ! $DRY_RUN ]; then
-  # Create a release branch.
-  git checkout -b $BRANCH
+NOOP_ARG=""
+DRY_RUN_ARG=""
+if [ $DRY_RUN ]; then
+  NOOP_ARG="--noop"
+  DRY_RUN_ARG="--dry-run"
+fi
 
-  # Force add feature-config.php
-  git add includes/feature-config.php --force
-  git add .
-  git commit -m "Adding feature-config.php directory to release" --no-verify
+# Create a release branch.
+git checkout -b $BRANCH
+
+# Force add feature-config.php
+git add includes/feature-config.php --force
+git add .
+git commit -m "Adding feature-config.php directory to release" --no-verify $DRY_RUN_ARG
   
-  # Force add language files
-  git add languages/woocommerce-admin.pot --force
-  git add .
-  git commit -m "Adding translations to release" --no-verify
+# Force add language files
+git add languages/woocommerce-admin.pot --force
+git add .
+git commit -m "Adding translations to release" --no-verify $DRY_RUN_ARG
   
-  # Force add build directory and commit.
-  git add dist/. --force
-  git add .
-  git commit -m "Adding /dist directory to release" --no-verify
+# Force add build directory and commit.
+git add dist/. --force
+git add .
+git commit -m "Adding /dist directory to release" --no-verify $DRY_RUN_ARG
   
-  # Force add vendor directory and commit.
-  git add vendor/. --force
-  git add .
-  git commit -m "Adding /vendor directory to release" --no-verify
+# Force add vendor directory and commit.
+git add vendor/. --force
+git add .
+git commit -m "Adding /vendor directory to release" --no-verify $DRY_RUN_ARG
 
 # Push branch upstream
-  git push origin $BRANCH
-fi
+git push origin $BRANCH $DRY_RUN_ARG
+
 # Create the zip archive
 ./bin/make-zip.sh $ZIP_FILE
 
-if [ $DRY_RUN ]; then
-  exit;
-fi
 # Create the new release.
 if [ $IS_PRE_RELEASE = true ]; then
-	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH --prerelease "v${VERSION}" --attach "${ZIP_FILE}"
+	hub $NOOP_ARG release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH --prerelease "v${VERSION}" --attach "${ZIP_FILE}"
 else
-	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}" --attach "${ZIP_FILE}"
+	hub $NOOP_ARG release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}" --attach "${ZIP_FILE}"
 fi
 
 git checkout $CURRENTBRANCH
 git branch -D $BRANCH
-git push origin --delete $BRANCH
+git push origin --delete $BRANCH $DRY_RUN_ARG
 
 output 2 "GitHub release complete."

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -94,12 +94,12 @@ fi
 output 2 "Starting release to GitHub..."
 echo
 
-# Create a release branch.
 BRANCH="build/${VERSION}"
-git checkout -b $BRANCH
-
 
 if [ ! $DRY_RUN ]; then
+  # Create a release branch.
+  git checkout -b $BRANCH
+
   warning "HIt official release"
   exit 1
   # Force add feature-config.php
@@ -130,7 +130,7 @@ fi
 
 if [ $DRY_RUN ]; then
   output 2 "Dry run of release finished, please delete $BRANCH branch."
-  return;
+  exit;
 fi
 # Create the new release.
 if [ $IS_PRE_RELEASE = true ]; then

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -52,7 +52,7 @@ if [[ $1 == '' || $2 == '' ]]
 fi
 
 if [ $DRY_RUN ]; then
-  output 2 "Dry run of release finished, please delete $BRANCH branch."
+  output 2 "Dry run of release finished, please delete the current $BRANCH when it is finished."
   return;
 fi
 
@@ -98,28 +98,31 @@ echo
 BRANCH="build/${VERSION}"
 git checkout -b $BRANCH
 
-# Force add feature-config.php
-git add includes/feature-config.php --force
-git add .
-git commit -m "Adding feature-config.php directory to release" --no-verify
 
-# Force add language files
-git add languages/woocommerce-admin.pot --force
-git add .
-git commit -m "Adding translations to release" --no-verify
-
-# Force add build directory and commit.
-git add dist/. --force
-git add .
-git commit -m "Adding /dist directory to release" --no-verify
-
-# Force add vendor directory and commit.
-git add vendor/. --force
-git add .
-git commit -m "Adding /vendor directory to release" --no-verify
+if [ ! $DRY_RUN ]; then
+  warning "HIt official release"
+  exit 1
+  # Force add feature-config.php
+  git add includes/feature-config.php --force
+  git add .
+  git commit -m "Adding feature-config.php directory to release" --no-verify
+  
+  # Force add language files
+  git add languages/woocommerce-admin.pot --force
+  git add .
+  git commit -m "Adding translations to release" --no-verify
+  
+  # Force add build directory and commit.
+  git add dist/. --force
+  git add .
+  git commit -m "Adding /dist directory to release" --no-verify
+  
+  # Force add vendor directory and commit.
+  git add vendor/. --force
+  git add .
+  git commit -m "Adding /vendor directory to release" --no-verify
 
 # Push branch upstream
-if [ ! $DRY_RUN ]; then
   git push origin $BRANCH
 fi
 # Create the zip archive

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"build:feature-config": "php bin/generate-feature-config.php",
 		"build:packages": "node ./bin/packages/build.js",
 		"build:release": "./bin/build-plugin-zip.sh",
-		"build:release-dryrun": "DRY_RUN=1 ./bin/build-plugin-zip.sh",
 		"clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",
 		"predev": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development npm run build:feature-config && cross-env WC_ADMIN_PHASE=development npm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"build:feature-config": "php bin/generate-feature-config.php",
 		"build:packages": "node ./bin/packages/build.js",
 		"build:release": "./bin/build-plugin-zip.sh",
+		"build:release-dryrun": "DRY_RUN=1 ./bin/build-plugin-zip.sh",
 		"clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",
 		"predev": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development npm run build:feature-config && cross-env WC_ADMIN_PHASE=development npm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",


### PR DESCRIPTION
This change is up for debate, but after debugging some of the release script I kept being paranoid that it will auto release at the end.
This is why I added a dry run option, that only generates the zip's of the plugin and core version.

Another thought (as I created this PR):
- We could just seperate the release part out at the end and ask if we should trigger the release (like we do for some of the other data).

### Detailed test instructions:

- Load this branch
- Run `DRY_RUN=1 npm run build:release` step through all the release questions
- When finished, notice how there are two zip files:
    - `woocommerce-admin-plugin.zip` (our plugin version)
    - `woocommerce-admin.zip` (the core version) 

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

No changelog required

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
