### PR TITLE
Fix/6954 script asset filename

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Correct the left position of transient notices when the new nav is used. #6914
 - Fix: Exclude WC Shipping for store that are only offering downloadable products #6917
 - Fix: SelectControl focus and de-focus bug #6906
-- Fix: Calling of get_script_asset_filename with with extra parameter #6955
+- Fix: Calling of get_script_asset_filename with extra parameter #6955
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Correct the left position of transient notices when the new nav is used. #6914
 - Fix: Exclude WC Shipping for store that are only offering downloadable products #6917
 - Fix: SelectControl focus and de-focus bug #6906
+- Fix: Calling of get_script_asset_filename with with extra parameter #6955
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786

--- a/src/Features/Coupons.php
+++ b/src/Features/Coupons.php
@@ -129,7 +129,7 @@ class Coupons {
 			Loader::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = Loader::get_script_asset_filename( 'marketing-coupons' );
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'marketing-coupons' );
 		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 		wp_enqueue_script(

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -150,7 +150,7 @@ class Init {
 			Loader::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = Loader::get_script_asset_filename( 'navigation-opt-out' );
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'navigation-opt-out' );
 		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 		wp_enqueue_script(

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -263,7 +263,7 @@ class OnboardingTasks {
 			return;
 		}
 
-		$script_assets_filename = Loader::get_script_asset_filename( 'onboarding-product-notice' );
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-notice' );
 		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 		wp_enqueue_script(
@@ -283,7 +283,7 @@ class OnboardingTasks {
 	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
 		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
-			$script_assets_filename = Loader::get_script_asset_filename( 'onboarding-homepage-notice' );
+			$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-homepage-notice' );
 			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 			wp_enqueue_script(
@@ -309,7 +309,7 @@ class OnboardingTasks {
 			'tax' === self::get_active_task() &&
 			! self::is_active_task_complete()
 		) {
-			$script_assets_filename = Loader::get_script_asset_filename( 'onboarding-tax-notice' );
+			$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-tax-notice' );
 			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 			wp_enqueue_script(
@@ -332,7 +332,7 @@ class OnboardingTasks {
 		if ( 'product_page_product_importer' === $hook && 'done' === $step && 'product-import' === self::get_active_task() ) {
 			delete_transient( self::ACTIVE_TASK_TRANSIENT );
 
-			$script_assets_filename = Loader::get_script_asset_filename( 'onboarding-product-import-notice' );
+			$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-import-notice' );
 			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 			wp_enqueue_script(

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -135,7 +135,7 @@ class ShippingLabelBanner {
 			Loader::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = Loader::get_script_asset_filename( 'print-shipping-label-banner' );
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'print-shipping-label-banner' );
 		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
 
 		wp_enqueue_script(

--- a/tests/e2e/pages/Coupons.ts
+++ b/tests/e2e/pages/Coupons.ts
@@ -1,0 +1,10 @@
+import { BasePage } from './BasePage';
+
+export class Coupons extends BasePage {
+	url = 'wp-admin/edit.php?post_type=shop_coupon&legacy_coupon_menu=1';
+
+	async isDisplayed() {
+		// This is a smoke test that ensures the single page was rendered without crashing
+		await this.page.waitForSelector( '#woocommerce-layout__primary' );
+	}
+}

--- a/tests/e2e/specs/marketing/coupons.test.ts
+++ b/tests/e2e/specs/marketing/coupons.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+ import { Coupons } from '../../pages/Coupons';
+ import { Login } from '../../pages/Login';
+ 
+ describe( 'Coupons page', () => {
+     const couponsPage = new Coupons( page );
+     const login = new Login( page );
+ 
+     beforeAll( async () => {
+         await login.login();
+     } );
+     afterAll( async () => {
+         await login.logout();
+     } );
+ 
+     it( 'A user can view the coupons overview without it crashing', async () => {
+         await couponsPage.navigate();
+         await couponsPage.isDisplayed();
+     } );
+ } );
+ 


### PR DESCRIPTION
Fixes #6954 

This updates the calling of `Loader::get_script_asset_filename` that had been modified in https://github.com/woocommerce/woocommerce-admin/pull/6951. It crashed the coupons page as we expected two parameters now instead of one previously.

I also wrote a E2E test to cover this case.

### Screenshots

<img width="1437" alt="Screen Shot 2021-05-07 at 12 40 03 PM" src="https://user-images.githubusercontent.com/2240960/117474520-5e94cb00-af31-11eb-8bbd-dc19bae57dcb.png">

### Detailed test instructions:

- Load this branch
- Navigate to **Marketing > Coupons**
- The page should load fine.
- Do a quick smoke test of any other places we use custom react scripts (create product from the onboarding, set up taxes manually from the onboarding, disabling/enabling the new navigation)
- Do a quick search through the `woocommerce-admin` repo to make sure all the calls to `get_script_asset_filename` have two parameters.


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
