### PR TITLE
Fix storybook example for the experimental list components.

### DIFF
--- a/packages/components/src/list/stories/index.js
+++ b/packages/components/src/list/stories/index.js
@@ -3,15 +3,16 @@
  */
 import Gridicon from 'gridicons';
 import { withConsole } from '@storybook/addon-console';
+import {
+	List as ExperimentalList,
+	ListItem as ExperimentalListItem,
+	CollapsibleList as ExperimentalCollapsibleList,
+} from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
-import List, {
-	ExperimentalList,
-	ExperimentalListItem,
-	ExperimentalCollapsibleList,
-} from '../';
+import List from '../';
 import './style.scss';
 
 function logItemClick( event ) {

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -3,6 +3,7 @@
  */
 @import '../client/stylesheets/index';
 @import '../packages/components/src/style';
+@import '../packages/experimental/src/style';
 
 // Use system font, consistent with WordPress core (wp-admin)
 body {


### PR DESCRIPTION
The storybook examples using the experimental components broke.

No changelog.