### PR TITLE
Only fetch remote payment gateway recommendations when opted in

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Update WC Payments copy on the task list #6734
 - Tweak: Add check to see if value for contains is array, show warning if not. #6645
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Update: Update choose niche note cta URL #6733
 - Update: UI updates to Payment Task screen #6766
 - Update: Adding setup required icon for non-configured payment methods #6811

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -57,11 +57,17 @@ class Init {
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
 			if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
 				return self::get_default_specs();
-			} else {
-				$specs = DataSourcePoller::read_specs_from_data_sources();
-				$specs = self::localize( $specs );
-				set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
 			}
+
+			$specs = DataSourcePoller::read_specs_from_data_sources();
+
+			// Fall back to default specs if polling failed.
+			if ( ! $specs ) {
+				return self::get_default_specs();
+			}
+
+			$specs = self::localize( $specs );
+			set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
 		}
 
 		return $specs;

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -86,7 +86,7 @@ class Init {
 				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
 				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
 				'plugins'    => array( 'woocommerce-payfast-gateway' ),
-				'is_visible' => array(
+				'is_visible' => (object) array(
 					'type'      => 'base_location_country',
 					'value'     => 'ZA',
 					'operation' => '=',

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -55,13 +55,38 @@ class Init {
 
 		// Fetch specs if they don't yet exist.
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
-			// We are running too early, need to poll data sources first.
-			$specs = DataSourcePoller::read_specs_from_data_sources();
-			$specs = self::localize( $specs );
-			set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
+			if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
+				return self::get_default_specs();
+			} else {
+				$specs = DataSourcePoller::read_specs_from_data_sources();
+				$specs = self::localize( $specs );
+				set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
+			}
 		}
 
 		return $specs;
+	}
+
+	/**
+	 * Get default specs.
+	 *
+	 * @return array Default specs.
+	 */
+	public static function get_default_specs() {
+		return array(
+			(object) array(
+				'key'        => 'payfast',
+				'title'      => __( 'PayFast', 'woocommerce-admin' ),
+				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
+				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
+				'plugins'    => array( 'woocommerce-payfast-gateway' ),
+				'is_visible' => array(
+					'type'      => 'base_location_country',
+					'value'     => 'ZA',
+					'operation' => '=',
+				),
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6854 

Only fetches remote payment gateways when opted into marketplace suggestions.

Note that this does not cover all gateways which will be handled in https://github.com/woocommerce/woocommerce-admin/issues/6855.

I also suspect that the default specs will need to be moved into their own file to keep the size down, but this will largely be dictated by how many default gateways are included.

### Detailed test instructions:

1. Install and activate the remote tester - https://github.com/joshuatf/woocommerce-admin-remote-tester
2. Set your store country to SA.
3. Opt into marketplace suggestions (WooCommerce->Settings->Advanced).
4. Make sure the API response from `/wp-json/wc-admin/onboarding/payments` contains the PayFast information.
5. Delete the transient `woocommerce_admin_remote_payment_methods_specs`
6. Opt out of marketplace suggestions.
7. Make sure the API response from `/wp-json/wc-admin/onboarding/payments` still contains the PayFast information. (Specs should be nearly identical, but you'll notice that the default specs don't include the `locale` property.)