### PR TITLE
Add note date range logic

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Optional children prop to SummaryNumber component #6748
 - Add: Extend payment gateways REST endpoint #6919
 - Add: Add remote payment gateway recommendations initial docs #6962
+- Add: Note date range logic for GivingFeedback, and InsightFirstSale note. #6969
 - Dev: Add data source filter to remote inbox notification system #6794
 - Dev: Add A/A test #6669
 - Dev: Add support for nonces in note actions #6726

--- a/src/Notes/GivingFeedbackNotes.php
+++ b/src/Notes/GivingFeedbackNotes.php
@@ -31,9 +31,7 @@ class GivingFeedbackNotes {
 	 * @return Note
 	 */
 	protected static function get_note() {
-		// We need to show Admin Giving feeback notification after 8 days of install.
-		$eight_days_in_seconds = 8 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $eight_days_in_seconds ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-2-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/GivingFeedbackNotes.php
+++ b/src/Notes/GivingFeedbackNotes.php
@@ -31,7 +31,7 @@ class GivingFeedbackNotes {
 	 * @return Note
 	 */
 	protected static function get_note() {
-		if ( ! self::is_wc_admin_active_in_date_range( 'week-2-4' ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/InsightFirstSale.php
+++ b/src/Notes/InsightFirstSale.php
@@ -31,7 +31,7 @@ class InsightFirstSale {
 	 * @return Note
 	 */
 	public static function get_note() {
-		if ( ! self::is_wc_admin_active_in_date_range( 'week-2-4' ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/InsightFirstSale.php
+++ b/src/Notes/InsightFirstSale.php
@@ -31,8 +31,7 @@ class InsightFirstSale {
 	 * @return Note
 	 */
 	public static function get_note() {
-		// We want to show the note after eight days.
-		if ( ! self::wc_admin_active_for( 8 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-2-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -21,7 +21,7 @@ trait NoteTraits {
 	 * @param int $seconds Time in seconds to check.
 	 * @return bool Whether or not WooCommerce admin has been active for $seconds.
 	 */
-	public static function wc_admin_active_for( $seconds ) {
+	private static function wc_admin_active_for( $seconds ) {
 		return WCAdminHelper::is_wc_admin_active_for( $seconds );
 	}
 
@@ -31,7 +31,7 @@ trait NoteTraits {
 	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
 	 * @return bool Whether or not WooCommerce admin has been active within the range.
 	 */
-	public static function is_wc_admin_active_in_date_range( $range ) {
+	private static function is_wc_admin_active_in_date_range( $range ) {
 		return WCAdminHelper::is_wc_admin_active_in_date_range( $range );
 	}
 

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -26,6 +26,16 @@ trait NoteTraits {
 	}
 
 	/**
+	 * Test if WooCommerce Admin has been active within a pre-defined range.
+	 *
+	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
+	 * @return bool Whether or not WooCommerce admin has been active within the range.
+	 */
+	public static function is_wc_admin_active_in_date_range( $range ) {
+		return WCAdminHelper::is_wc_admin_active_in_date_range( $range );
+	}
+
+	/**
 	 * Check if the note has been previously added.
 	 *
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -23,9 +23,9 @@ class WCAdminHelper {
 			'start' => 0,
 			'end'   => WEEK_IN_SECONDS,
 		),
-		'week-2-4'  => array(
+		'week-1-4'  => array(
 			'start' => WEEK_IN_SECONDS,
-			'end'   => MONTH_IN_SECONDS,
+			'end'   => WEEK_IN_SECONDS * 4,
 		),
 		'month-1-3' => array(
 			'start' => MONTH_IN_SECONDS,
@@ -73,9 +73,19 @@ class WCAdminHelper {
 	 * Test if WooCommerce Admin has been active within a pre-defined range.
 	 *
 	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
+	 * @throws \InvalidArgumentException Throws exception when invalid $range is passed in.
 	 * @return bool Whether or not WooCommerce admin has been active within the range.
 	 */
 	public static function is_wc_admin_active_in_date_range( $range ) {
+		if ( ! array_key_exists( $range, self::WC_ADMIN_STORE_AGE_RANGES ) ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					'"%s" range is not supported, use one of: %s',
+					$range,
+					implode( ', ', array_keys( self::WC_ADMIN_STORE_AGE_RANGES ) )
+				)
+			);
+		}
 		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
 
 		$range_data = self::WC_ADMIN_STORE_AGE_RANGES[ $range ];

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -79,8 +79,8 @@ class WCAdminHelper {
 		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
 
 		$range_data = self::WC_ADMIN_STORE_AGE_RANGES[ $range ];
-		if ( $range_data && $range_data['start'] >= $wc_admin_active_for ) {
-			return $range_data['end'] ? $range_data['end'] < $wc_admin_active_for : true;
+		if ( $range_data && $wc_admin_active_for >= $range_data['start'] ) {
+			return isset( $range_data['end'] ) ? $wc_admin_active_for < $range_data['end'] : true;
 		}
 		return false;
 	}

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -18,6 +18,28 @@ class WCAdminHelper {
 	 */
 	const WC_ADMIN_TIMESTAMP_OPTION = 'woocommerce_admin_install_timestamp';
 
+	const WC_ADMIN_STORE_AGE_RANGES = array(
+		'week-1'    => array(
+			'start' => 0,
+			'end'   => WEEK_IN_SECONDS,
+		),
+		'week-2-4'  => array(
+			'start' => WEEK_IN_SECONDS,
+			'end'   => MONTH_IN_SECONDS,
+		),
+		'month-1-3' => array(
+			'start' => MONTH_IN_SECONDS,
+			'end'   => MONTH_IN_SECONDS * 3,
+		),
+		'month-3-6' => array(
+			'start' => MONTH_IN_SECONDS * 3,
+			'end'   => MONTH_IN_SECONDS * 6,
+		),
+		'month-6+'  => array(
+			'start' => MONTH_IN_SECONDS * 6,
+		),
+	);
+
 	/**
 	 * Get the number of seconds that the store has been active.
 	 *
@@ -45,5 +67,21 @@ class WCAdminHelper {
 		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
 
 		return ( $wc_admin_active_for >= $seconds );
+	}
+
+	/**
+	 * Test if WooCommerce Admin has been active within a pre-defined range.
+	 *
+	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
+	 * @return bool Whether or not WooCommerce admin has been active within the range.
+	 */
+	public static function is_wc_admin_active_in_date_range( $range ) {
+		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
+
+		$range_data = self::WC_ADMIN_STORE_AGE_RANGES[ $range ];
+		if ( $range_data && $range_data['start'] >= $wc_admin_active_for ) {
+			return $range_data['end'] ? $range_data['end'] < $wc_admin_active_for : true;
+		}
+		return false;
 	}
 }

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -68,8 +68,8 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 		return array(
 			'1 day old store within week?'             => array( DAY_IN_SECONDS, 'week-1', true ),
 			'10 day old store not within week?'        => array( 10 * DAY_IN_SECONDS, 'week-1', false ),
-			'10 day old store within 1-4 weeks?'       => array( 10 * DAY_IN_SECONDS, 'week-2-4', true ),
-			'1 day old store not within 1-4 weeks?'    => array( DAY_IN_SECONDS, 'week-2-4', false ),
+			'10 day old store within 1-4 weeks?'       => array( 10 * DAY_IN_SECONDS, 'week-1-4', true ),
+			'1 day old store not within 1-4 weeks?'    => array( DAY_IN_SECONDS, 'week-1-4', false ),
 			'2 month old store within 1-3 months?'     => array( 2 * MONTH_IN_SECONDS, 'month-1-3', true ),
 			'5 month old store not within 1-3 months?' => array( 5 * MONTH_IN_SECONDS, 'month-1-3', false ),
 			'5 month old store within 3-6 months?'     => array( 5 * MONTH_IN_SECONDS, 'month-3-6', true ),

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -40,7 +40,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	 */
 	public function test_is_wc_admin_active_in_date_range_with_invalid_range() {
 		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( '"random-range" range is not supported, use one of: week-1, week-2-4, month-1-3, month-3-6, month-6+' );
+		$this->expectExceptionMessage( '"random-range" range is not supported, use one of: week-1, week-1-4, month-1-3, month-3-6, month-6+' );
 
 		WCAdminHelper::is_wc_admin_active_in_date_range( 'random-range' );
 	}

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * WCAdminHelper tests
+ *
+ * @package WooCommerce\Admin\Tests\WCAdminHelper
+ */
+
+use \Automattic\WooCommerce\Admin\WCAdminHelper;
+
+/**
+ * WC_Admin_Tests_Plugin_Helper Class
+ *
+ * @package WooCommerce\Admin\Tests\PluginHelper
+ */
+class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
+
+	/**
+	 * Test wc_admin_active_for one hour
+	 */
+	public function test_is_wc_admin_active_for_one_hour() {
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - ( HOUR_IN_SECONDS * 10 ) );
+
+		// Active for one hour - true.
+		$active_for = WCAdminHelper::is_wc_admin_active_for( HOUR_IN_SECONDS );
+		$this->assertEquals( true, $active_for );
+	}
+
+	/**
+	 * Test wc_admin_active_for one hour
+	 */
+	public function test_is_wc_admin_active_for_7_days() {
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - ( HOUR_IN_SECONDS * 10 ) );
+		// Active for 7 days - false.
+		$active_for = WCAdminHelper::is_wc_admin_active_for( DAY_IN_SECONDS * 7 );
+		$this->assertEquals( false, $active_for );
+	}
+
+	/**
+	 * @dataProvider range_provider
+	 * Test wc_admin_active_in_date_range 1 week if 1 day old
+	 *
+	 * @param number  $store_age age in seconds of store.
+	 * @param string  $range expected store range.
+	 * @param boolean $expected expected boolean value.
+	 */
+	public function test_is_wc_admin_active_in_date_range( $store_age, $range, $expected ) {
+		// 1 day.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - $store_age );
+
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( $range );
+		$this->assertEquals( $expected, $active_for );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function range_provider() {
+		return array(
+			'1 day old store within week?'             => array( DAY_IN_SECONDS, 'week-1', true ),
+			'10 day old store not within week?'        => array( 10 * DAY_IN_SECONDS, 'week-1', false ),
+			'10 day old store within 1-4 weeks?'       => array( 10 * DAY_IN_SECONDS, 'week-2-4', true ),
+			'1 day old store not within 1-4 weeks?'    => array( DAY_IN_SECONDS, 'week-2-4', false ),
+			'2 month old store within 1-3 months?'     => array( 2 * MONTH_IN_SECONDS, 'month-1-3', true ),
+			'5 month old store not within 1-3 months?' => array( 5 * MONTH_IN_SECONDS, 'month-1-3', false ),
+			'5 month old store within 3-6 months?'     => array( 5 * MONTH_IN_SECONDS, 'month-3-6', true ),
+			'7 month old store not within 3-6 months?' => array( 7 * MONTH_IN_SECONDS, 'month-3-6', false ),
+			'9 month old store within 6+ months?'      => array( 9 * MONTH_IN_SECONDS, 'month-6+', true ),
+			'2 month old store not within 6+ months?'  => array( 2 * MONTH_IN_SECONDS, 'month-6+', false ),
+		);
+	}
+}

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -8,9 +8,9 @@
 use \Automattic\WooCommerce\Admin\WCAdminHelper;
 
 /**
- * WC_Admin_Tests_Plugin_Helper Class
+ * WC_Admin_Tests_Admin_Helper Class
  *
- * @package WooCommerce\Admin\Tests\PluginHelper
+ * @package WooCommerce\Admin\Tests\WCAdminHelper
  */
 class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 
@@ -26,7 +26,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test wc_admin_active_for one hour
+	 * Test wc_admin_active_for 7 days
 	 */
 	public function test_is_wc_admin_active_for_7_days() {
 		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - ( HOUR_IN_SECONDS * 10 ) );
@@ -37,7 +37,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider range_provider
-	 * Test wc_admin_active_in_date_range 1 week if 1 day old
+	 * Test wc_admin_active_in_date_range with data provided from range_provider.
 	 *
 	 * @param number  $store_age age in seconds of store.
 	 * @param string  $range expected store range.
@@ -52,7 +52,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @return array[]
+	 * @return array[] list of range options.
 	 */
 	public function range_provider() {
 		return array(

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -36,6 +36,16 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wc_admin_active_in_date_range with invalid range
+	 */
+	public function test_is_wc_admin_active_in_date_range_with_invalid_range() {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( '"random-range" range is not supported, use one of: week-1, week-2-4, month-1-3, month-3-6, month-6+' );
+
+		WCAdminHelper::is_wc_admin_active_in_date_range( 'random-range' );
+	}
+
+	/**
 	 * @dataProvider range_provider
 	 * Test wc_admin_active_in_date_range with data provided from range_provider.
 	 *


### PR DESCRIPTION
Partially addresses #4789 

Defines a set of ranges for the store age the can be used for displaying Notes, this includes an upper range, which should prevent newer notes from showing up in older stores. 
There will be follow up PRs to update the rest of the notes, as part of this PR I updated a couple different ones that directly overlapped with a defined range.

### Detailed test instructions:

- On a new store with the onboarding flow finished and having the WC Admin test helper plugin installed ([latest release here](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.2.0))
- Make sure the `You're invited to share your experience` note is not displayed (givingFeedback)
- Update the `woocommerce_admin_install_timestamp` option with a timestamp older then 4 weeks - (Ex: `1617888471` (April 8th)) through the test helper **Tools > WCA Test Helper > Options**
- Go to **Tools > WCA Test Helper > Tools** and run the wc_admin_daily job
- Go to **WooCommerce > Home** and notice that the `You're invited to share your experience` note is not displayed
- Update the `woocommerce_admin_install_timestamp` option again with a timestamp between 7 days and 4 weeks (28 days).
- Trigger the `wc_admin_daily` job again
- Go to **WooCommerce > Home** and notice that the `You're invited to share your experience` note is now displayed
- When updating the store to older to 4 weeks again should keep the note displayed (until dismissed).

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
