### PR TITLE
Add source support for notes query

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add payment method selector to onboarding store #6921
 - Dev: Add disabled prop to SelectControl #6902
 - Dev: Add filter variation to tracks data in products analytics. #6913
+- Dev: Add source param support for notes query. #6979
 - Enhancement: Add recommended payment methods in payment settings. #6760
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -192,6 +192,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		$args['page']       = $request['page'];
 		$args['type']       = isset( $request['type'] ) ? $request['type'] : array();
 		$args['status']     = isset( $request['status'] ) ? $request['status'] : array();
+		$args['source']     = isset( $request['source'] ) ? $request['source'] : array();
 		$args['is_deleted'] = 0;
 
 		if ( 'date' === $args['orderby'] ) {
@@ -568,6 +569,15 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
 				'enum' => Note::get_allowed_statuses(),
+				'type' => 'string',
+			),
+		);
+		$params['source']   = array(
+			'description'       => __( 'Source of note.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_list',
+			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
 				'type' => 'string',
 			),
 		);

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -381,6 +381,28 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	}
 
 	/**
+	 * Parses the query arguments passed in as arrays and escapes the values.
+	 *
+	 * @param array      $args the query arguments.
+	 * @param string     $key the key of the specific argument.
+	 * @param array|null $allowed_types optional allowed_types if only a specific set is allowed.
+	 * @return array the escaped array of argument values.
+	 */
+	private function get_escaped_arguments_array_by_key( $args = array(), $key = '', $allowed_types = null ) {
+		$arg_array = array();
+		if ( isset( $args[ $key ] ) ) {
+			foreach ( $args[ $key ] as $args_type ) {
+				$args_type = trim( $args_type );
+				$allowed   = is_null( $allowed_types ) ? true : in_array( $args_type, $allowed_types, true );
+				if ( $allowed ) {
+					$arg_array[] = sprintf( "'%s'", esc_sql( $args_type ) );
+				}
+			}
+		}
+		return $arg_array;
+	}
+
+	/**
 	 * Return where clauses for getting notes by status and type. For use in both the count and listing queries.
 	 *
 	 *  @param array $args Array of args to pass.
@@ -388,43 +410,23 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 */
 	public function get_notes_where_clauses( $args = array() ) {
 		$allowed_types    = Note::get_allowed_types();
-		$where_type_array = array();
-		if ( isset( $args['type'] ) ) {
-			foreach ( $args['type'] as $args_type ) {
-				$args_type = trim( $args_type );
-				if ( in_array( $args_type, $allowed_types, true ) ) {
-					$where_type_array[] = "'" . esc_sql( $args_type ) . "'";
-				}
-			}
-		}
+		$where_type_array = $this->get_escaped_arguments_array_by_key( $args, 'type', $allowed_types );
 
 		$allowed_statuses   = Note::get_allowed_statuses();
-		$where_status_array = array();
-		if ( isset( $args['status'] ) ) {
-			foreach ( $args['status'] as $args_status ) {
-				$args_status = trim( $args_status );
-				if ( in_array( $args_status, $allowed_statuses, true ) ) {
-					$where_status_array[] = "'" . esc_sql( $args_status ) . "'";
-				}
-			}
-		}
+		$where_status_array = $this->get_escaped_arguments_array_by_key( $args, 'status', $allowed_statuses );
 
 		$escaped_is_deleted = '';
 		if ( isset( $args['is_deleted'] ) ) {
 			$escaped_is_deleted = esc_sql( $args['is_deleted'] );
 		}
 
-		$where_name_array = [];
-		if ( isset( $args['name'] ) ) {
-			foreach ( $args['name'] as $args_name ) {
-				$args_name          = trim( $args_name );
-				$where_name_array[] = sprintf( "'%s'", esc_sql( $args_name ) );
-			}
-		}
+		$where_name_array   = $this->get_escaped_arguments_array_by_key( $args, 'name' );
+		$where_source_array = $this->get_escaped_arguments_array_by_key( $args, 'source' );
 
 		$escaped_where_types  = implode( ',', $where_type_array );
 		$escaped_where_status = implode( ',', $where_status_array );
 		$escaped_where_names  = implode( ',', $where_name_array );
+		$escaped_where_source = implode( ',', $where_source_array );
 		$where_clauses        = '';
 
 		if ( ! empty( $escaped_where_types ) ) {
@@ -437,6 +439,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		if ( ! empty( $escaped_where_names ) ) {
 			$where_clauses .= " AND name IN ($escaped_where_names)";
+		}
+
+		if ( ! empty( $escaped_where_source ) ) {
+			$where_clauses .= " AND source IN ($escaped_where_source)";
 		}
 
 		$where_clauses .= $escaped_is_deleted ? ' AND is_deleted = 1' : ' AND is_deleted = 0';

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -393,7 +393,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		if ( isset( $args[ $key ] ) ) {
 			foreach ( $args[ $key ] as $args_type ) {
 				$args_type = trim( $args_type );
-				$allowed   = is_null( $allowed_types ) ? true : in_array( $args_type, $allowed_types, true );
+				$allowed   = is_null( $allowed_types ) || in_array( $args_type, $allowed_types, true );
 				if ( $allowed ) {
 					$arg_array[] = sprintf( "'%s'", esc_sql( $args_type ) );
 				}

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -286,6 +286,59 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test note with source.
+	 */
+	public function test_get_notes_with_one_source() {
+		wp_set_current_user( $this->user );
+
+		$note = new Note();
+		$note->set_name( 'note name' );
+		$note->set_title( 'note from a-source' );
+		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
+		$note->set_source( 'a-source' );
+		$note->save();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'source' => 'a-source' ) );
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $notes ) );
+		$this->assertEquals( $notes[0]['title'], 'note from a-source' );
+	}
+
+	/**
+	 * Test note with source.
+	 */
+	public function test_get_notes_with_multiple_sources() {
+		wp_set_current_user( $this->user );
+
+		$note = new Note();
+		$note->set_name( 'note name' );
+		$note->set_title( 'note from source-1' );
+		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
+		$note->set_source( 'source-1' );
+		$note->save();
+		$note = new Note();
+		$note->set_name( 'note name' );
+		$note->set_title( 'note from source-2' );
+		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
+		$note->set_source( 'source-2' );
+		$note->save();
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'source' => 'source-1,source-2' ) );
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( $notes[0]['title'], 'note from source-1' );
+		$this->assertEquals( $notes[1]['title'], 'note from source-2' );
+	}
+
+	/**
 	 * Test ordering of notes.
 	 */
 	public function test_order_notes() {

--- a/tests/notes/class-wc-tests-notes-data-store.php
+++ b/tests/notes/class-wc-tests-notes-data-store.php
@@ -241,4 +241,35 @@ class WC_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		$this->assertFalse( $note );
 		$this->assertEquals( 1, did_action( 'woocommerce_caught_exception' ) );
 	}
+
+	/**
+	 * Test that sources are correctly added to where clause.
+	 */
+	public function test_get_notes_where_clauses_with_sources() {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		$where_clause = $data_store->get_notes_where_clauses(
+			array(
+				'source' => array( 'source', 'another-source' ),
+			)
+		);
+		$this->assertEquals( " AND source IN ('source','another-source') AND is_deleted = 0", $where_clause );
+	}
+
+	/**
+	 * Test that invalid types are filtered out.
+	 */
+	public function test_get_notes_where_clauses_with_invalid_types() {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		$where_clause = $data_store->get_notes_where_clauses(
+			array(
+				'type' => array( 'random', Note::E_WC_ADMIN_NOTE_MARKETING ),
+			)
+		);
+		$this->assertEquals(
+			sprintf( " AND type IN ('%s') AND is_deleted = 0", Note::E_WC_ADMIN_NOTE_MARKETING ),
+			$where_clause
+		);
+	}
 }


### PR DESCRIPTION
This adds support to the notes query for a `source` param, allowing us to filter by sources. I needed this for the WC pay homescreen - https://github.com/Automattic/woocommerce-payments/issues/1662 although this could also be accomplished by adding two separate filters, it seemed more appropriate to support this by default.

### Detailed test instructions:

- Load this branch and go to **WooCommerce > Home** all notes should be displayed correctly.
- Add `source: [  'woocommerce.com' ],` to the inbox query [here](https://github.com/woocommerce/woocommerce-admin/blob/main/client/inbox-panel/index.js#L142)
- Load the home page, and notice how only the `woocommerce.com` notes are being displayed (you can double check with the `wp_wc_admin_notes` table.
- Now change `woocommerce.com` to something random and refresh the home page
- It should not show any notes


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
