### PR TITLE
Offload remote inbox notifications engine run using action-scheduler

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -97,7 +97,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add filter variation to tracks data in products analytics. #6913
 - Dev: Offload remote inbox notifications engine run using action-scheduler. #6995
 - Dev: Add source param support for notes query. #6979
-- Enhancement: Add recommended payment methods in payment settings. #6760
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916
 - Fix: Remove Navigation's uneeded SlotFill context #6832

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add payment method selector to onboarding store #6921
 - Dev: Add disabled prop to SelectControl #6902
 - Dev: Add filter variation to tracks data in products analytics. #6913
+- Dev: Offload remote inbox notifications engine run using action-scheduler. #6995
 - Enhancement: Add recommended payment methods in payment settings. #6760
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916

--- a/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
+++ b/src/RemoteInboxNotifications/ProductCountRuleProcessor.php
@@ -40,14 +40,10 @@ class ProductCountRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$products          = $this->product_query->get_products();
-		$new_product_count = property_exists( $stored_state, 'new_product_count' )
-			? $stored_state->new_product_count
-			: 0;
-		$count             = $products->total + $new_product_count;
+		$products = $this->product_query->get_products();
 
 		return ComparisonOperation::compare(
-			$count,
+			$products->total,
 			$rule->value,
 			$rule->operation
 		);

--- a/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -25,6 +25,9 @@ class RemoteInboxNotificationsEngine {
 	 * Initialize the engine.
 	 */
 	public static function init() {
+		// Init things that need to happen before admin_init.
+		add_action( 'init', array( __CLASS__, 'on_init' ), 0, 0 );
+
 		// Continue init via admin_init.
 		add_action( 'admin_init', array( __CLASS__, 'on_admin_init' ) );
 
@@ -73,10 +76,19 @@ class RemoteInboxNotificationsEngine {
 
 		add_action( 'activated_plugin', array( __CLASS__, 'run' ) );
 		add_action( 'deactivated_plugin', array( __CLASS__, 'run_on_deactivated_plugin' ), 10, 1 );
-		StoredStateSetupForProducts::init();
+		StoredStateSetupForProducts::admin_init();
 
 		// Pre-fetch stored state so it has the correct initial values.
 		self::get_stored_state();
+	}
+
+	/**
+	 * An init hook is used here so that StoredStateSetupForProducts can set
+	 * up a hook that gets triggered by action-scheduler - this is needed
+	 * because the admin_init hook doesn't get triggered by WP Cron.
+	 */
+	public static function on_init() {
+		StoredStateSetupForProducts::init();
 	}
 
 	/**

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -39,11 +39,6 @@ class StoredStateSetupForProducts {
 	 */
 	public static function run_remote_notifications() {
 		RemoteInboxNotificationsEngine::run();
-
-		// Clean up from setting the product count increment.
-		$stored_state                    = RemoteInboxNotificationsEngine::get_stored_state();
-		$stored_state->new_product_count = 0;
-		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
 	}
 
 	/**
@@ -119,12 +114,6 @@ class StoredStateSetupForProducts {
 
 		$stored_state                         = RemoteInboxNotificationsEngine::get_stored_state();
 		$stored_state->there_are_now_products = true;
-
-		// This is used to increment the product count yielded by the query,
-		// which is one less than the actual product count at this point in the
-		// product publish lifecycle. This is currently being used by
-		// ProductCountRuleProcessor.
-		$stored_state->new_product_count = 1;
 
 		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
 

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -18,11 +18,17 @@ class StoredStateSetupForProducts {
 		'woocommerce_admin/stored_state_setup_for_products/async/run_remote_notifications';
 
 	/**
-	 * Initialize the class
+	 * Initialize the class via the admin_init hook.
 	 */
-	public static function init() {
+	public static function admin_init() {
 		add_action( 'product_page_product_importer', array( __CLASS__, 'run_on_product_importer' ) );
 		add_action( 'transition_post_status', array( __CLASS__, 'run_on_transition_post_status' ), 10, 3 );
+	}
+
+	/**
+	 * Initialize the class via the init hook.
+	 */
+	public static function init() {
 		add_action( self::ASYNC_RUN_REMOTE_NOTIFICATIONS_ACTION_NAME, array( __CLASS__, 'run_remote_notifications' ) );
 	}
 


### PR DESCRIPTION
Partially fixes #6189

This uses action-scheduler to offload running the remote inbox notifications engine run when adding or importing products.

### Detailed test instructions:

1. delete all products
5. delete all admin notes (using the test helper plugin)
2. add test feed url to `DataSourcePoller`: `https://gist.githubusercontent.com/becdetat/2d9895ad8e159ece76e8b3d029b09e8b/raw/30ad24cef0945220fbe351fa5af5d5cca8f4cf55/three-products.json`
6. add three new products
7. wait a minute for action-scheduler to do it's magic
8. visit WC Admin's home page
9. The new test note should be present

![image](https://user-images.githubusercontent.com/224531/118444713-d4b6e000-b730-11eb-9aaa-0a1f688f588e.png)
