### PR TITLE
Set target to blank for the external links

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Set target to blank for the external links #6999
+
+1. Clone this repository.
+2. Complete the OBW
+3. Navigate to WooCommerce -> Home
+4. Hide the Setup task list on the Home screen.
+5. Note that the Store Management section appears on the Home screen.
+6. Click on the Visit My Store link.
+7. Observe that the link opens in a new tab.
+
 ### Exclude WC Shipping for store that are only offering downloadable products #6917
 
 1. Start OBW and enter an address that is in the US.

--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -20,6 +20,7 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 				onClick={ onClick }
 				href={ href }
 				type={ linkType }
+				target={ isExternal ? '_blank' : null }
 				className="woocommerce-quick-links__item-link"
 			>
 				<Icon

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: SelectControl focus and de-focus bug #6906
 - Fix: Multiple preload tag output bug. #6998
 - Fix: Call existing filters for leaderboards in analytics. #6626
+- Fix: Set target to blank for the external links #6999
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Experimental task list import to the experimental package. #6950


### PR DESCRIPTION
Fixes #6907 

This PR sets `target=_blank` for the external links to open them in a new tab.

### Detailed test instructions:

1. Clone this repository.
2. Complete the OBW
3. Navigate to WooCommerce -> Home
4. Hide the Setup task list on the Home screen.
5. Note that the Store Management section appears on the Home screen.
6. Click on the Visit My Store link.
7. Observe that the link opens in a new tab.
