### PR TITLE
Add PayPal to fallback payment gateways

### DIFF
--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -124,21 +124,32 @@ export const PaymentConnect = ( {
 		return errors;
 	};
 
-	const helpText = interpolateComponents( {
-		mixedString: __(
-			'Your API details can be obtained from your {{link/}}',
-			'woocommerce-admin'
-		),
-		components: {
-			link: (
-				<Link href={ apiDetailsUrl } target="_blank" type="external">
-					{ sprintf( __( '%(title)s account', 'woocommerce-admin' ), {
-						title,
-					} ) }
-				</Link>
-			),
-		},
-	} );
+	const helpText = apiDetailsUrl && (
+		<p>
+			{ interpolateComponents( {
+				mixedString: __(
+					'Your API details can be obtained from your {{link/}}',
+					'woocommerce-admin'
+				),
+				components: {
+					link: (
+						<Link
+							href={ apiDetailsUrl }
+							target="_blank"
+							type="external"
+						>
+							{ sprintf(
+								__( '%(title)s account', 'woocommerce-admin' ),
+								{
+									title,
+								}
+							) }
+						</Link>
+					),
+				},
+			} ) }
+		</p>
+	);
 
 	const DefaultForm = ( props ) => (
 		<DynamicForm
@@ -154,10 +165,10 @@ export const PaymentConnect = ( {
 	if ( state === 'error' ) {
 		return (
 			<Text>
-				{
-					( __( 'There was an error loading the payment fields' ),
-					'woocommerce-admin' )
-				}
+				{ __(
+					'There was an error loading the payment fields',
+					'woocommerce-admin'
+				) }
 			</Text>
 		);
 	}
@@ -181,7 +192,7 @@ export const PaymentConnect = ( {
 			) : (
 				<>
 					<DefaultForm />
-					<p>{ helpText }</p>
+					{ helpText }
 				</>
 			) }
 		</>

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DynamicForm, WooRemotePaymentForm } from '@woocommerce/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
@@ -19,6 +20,7 @@ export const PaymentConnect = ( {
 } ) => {
 	const {
 		key,
+		oauth_connection_url: oAuthConnectionUrl,
 		setup_help_text: helpText,
 		required_settings_keys: settingKeys,
 		settings,
@@ -117,7 +119,13 @@ export const PaymentConnect = ( {
 				/>
 			) : (
 				<>
-					<DefaultForm />
+					{ oAuthConnectionUrl ? (
+						<Button isPrimary href={ oAuthConnectionUrl }>
+							{ __( 'Connect', 'woocommerce-admin' ) }
+						</Button>
+					) : (
+						<DefaultForm />
+					) }
 					{ helpText && (
 						<p
 							dangerouslySetInnerHTML={ sanitizeHTML( helpText ) }

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -4,12 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	DynamicForm,
-	Link,
-	WooRemotePaymentForm,
-} from '@woocommerce/components';
-import interpolateComponents from 'interpolate-components';
+import { DynamicForm, WooRemotePaymentForm } from '@woocommerce/components';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSlot } from '@woocommerce/experimental';
 
@@ -128,28 +123,14 @@ export const PaymentConnect = ( {
 	}
 
 	if ( oAuthConnectionUrl ) {
-		const tosText = interpolateComponents( {
-			mixedString: __(
-				'By clicking "Connect," you agree to the {{tosLink}}Terms of Service{{/tosLink}}.',
-				'woocommerce-admin'
-			),
-			components: {
-				tosLink: (
-					<Link
-						href="https://wordpress.com/tos"
-						target="_blank"
-						type="external"
-					/>
-				),
-			},
-		} );
-
 		return (
 			<>
 				<Button isPrimary href={ oAuthConnectionUrl }>
 					{ __( 'Connect', 'woocommerce-admin' ) }
 				</Button>
-				<p>{ tosText }</p>
+				{ helpText && (
+					<p dangerouslySetInnerHTML={ sanitizeHTML( helpText ) } />
+				) }
 			</>
 		);
 	}

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod.js
@@ -133,8 +133,8 @@ export const PaymentMethod = ( {
 		),
 		content: paymentGateway ? (
 			<PaymentConnect
-				method={ method }
 				markConfigured={ markConfigured }
+				paymentGateway={ paymentGateway }
 				recordConnectStartEvent={ recordConnectStartEvent }
 			/>
 		) : null,

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethodList/PaymentMethodList.js
@@ -88,9 +88,9 @@ export const PaymentMethodList = ( {
 							<PaymentAction
 								manageUrl={ manageUrl }
 								methodKey={ key }
-								hasSetup={
-									!! plugins.length || !! fields.length
-								}
+								hasSetup={ Boolean(
+									plugins.length || fields.length
+								) }
 								isConfigured={ isConfigured }
 								isEnabled={ method.isEnabled }
 								isRecommended={ isRecommended }

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethodList/PaymentMethodList.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethodList/PaymentMethodList.js
@@ -38,6 +38,7 @@ export const PaymentMethodList = ( {
 				is_enabled: isEnabled,
 				is_configured: isConfigured,
 				key,
+				plugins,
 				title,
 				is_visible: isVisible,
 				loading,
@@ -87,7 +88,9 @@ export const PaymentMethodList = ( {
 							<PaymentAction
 								manageUrl={ manageUrl }
 								methodKey={ key }
-								hasSetup={ !! fields.length }
+								hasSetup={
+									!! plugins.length || !! fields.length
+								}
 								isConfigured={ isConfigured }
 								isEnabled={ method.isEnabled }
 								isRecommended={ isRecommended }

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add transformers in remote inbox notifications #6948
 - Add: Get post install scripts from gateway and enqueue in client #6967
 - Add: Free extension list powered by remote config #6952
+- Add: Add PayPal to fallback payment gateways #7001
 - Dev: Update package-lock to fix versioning of local packages. #6843
 - Dev: Use rule processing for remote payment methods #6830
 - Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -365,7 +365,7 @@ class OnboardingTasks {
 	 *
 	 * @return array
 	 */
-	private static function get_stripe_supported_countries() {
+	public static function get_stripe_supported_countries() {
 		// https://stripe.com/global.
 		return array(
 			'AU',

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -35,12 +35,20 @@ class DefaultPaymentGateways {
 				'key'        => 'payfast',
 				'title'      => __( 'PayFast', 'woocommerce-admin' ),
 				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
-				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/payfast.png',
 				'plugins'    => array( 'woocommerce-payfast-gateway' ),
-				'is_visible' => (object) array(
-					'type'      => 'base_location_country',
-					'value'     => 'ZA',
-					'operation' => '=',
+				'is_visible' => array(
+					(object) array(
+						'type'      => 'base_location_country',
+						'value'     => 'ZA',
+						'operation' => '=',
+					),
+					(object) array(
+						'type'        => 'option',
+						'option_name' => 'woocommerce_onboarding_profile',
+						'value'       => 'cbd-other-hemp-derived-products',
+						'operation'   => '!contains',
+					),
 				),
 			),
 			array(

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -7,6 +7,8 @@ namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
 /**
  * Default Payment Gateways
  */
@@ -18,6 +20,16 @@ class DefaultPaymentGateways {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
+		$stripe_countries       = OnboardingTasks::get_stripe_supported_countries();
+		$stripe_countries_rules = array();
+		foreach ( $stripe_countries as $country ) {
+			$stripe_countries_rules[] = (object) array(
+				'type'      => 'base_location_country',
+				'value'     => $country,
+				'operation' => '=',
+			);
+		}
+
 		return array(
 			array(
 				'key'        => 'payfast',
@@ -25,10 +37,29 @@ class DefaultPaymentGateways {
 				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
 				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
 				'plugins'    => array( 'woocommerce-payfast-gateway' ),
-				'is_visible' => array(
+				'is_visible' => (object) array(
 					'type'      => 'base_location_country',
 					'value'     => 'ZA',
 					'operation' => '=',
+				),
+			),
+			array(
+				'key'        => 'stripe',
+				'title'      => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
+				'content'    => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/stripe.png',
+				'plugins'    => array( 'woocommerce-gateway-stripe' ),
+				'is_visible' => array(
+					(object) array(
+						'type'     => 'or',
+						'operands' => $stripe_countries_rules,
+					),
+					(object) array(
+						'type'        => 'option',
+						'option_name' => 'woocommerce_onboarding_profile',
+						'value'       => 'cbd-other-hemp-derived-products',
+						'operation'   => '!contains',
+					),
 				),
 			),
 		);

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Gets a list of fallback methods if remote fetching is disabled.
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Default Payment Gateways
+ */
+class DefaultPaymentGateways {
+
+	/**
+	 * Get default specs.
+	 *
+	 * @return array Default specs.
+	 */
+	public static function get_all() {
+		return array(
+			array(
+				'key'        => 'payfast',
+				'title'      => __( 'PayFast', 'woocommerce-admin' ),
+				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
+				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
+				'plugins'    => array( 'woocommerce-payfast-gateway' ),
+				'is_visible' => array(
+					'type'      => 'base_location_country',
+					'value'     => 'ZA',
+					'operation' => '=',
+				),
+			),
+		);
+	}
+
+}

--- a/src/Features/RemotePaymentMethods/EvaluateMethod.php
+++ b/src/Features/RemotePaymentMethods/EvaluateMethod.php
@@ -21,21 +21,11 @@ class EvaluateMethod {
 	 */
 	public static function evaluate( $spec ) {
 		$rule_evaluator = new RuleEvaluator();
-		$method         = $spec;
+		$method         = (object) $spec;
 
-		if ( isset( $spec->is_visible ) ) {
-			$is_visible         = $rule_evaluator->evaluate( $spec->is_visible );
+		if ( isset( $method->is_visible ) ) {
+			$is_visible         = $rule_evaluator->evaluate( (object) $method->is_visible );
 			$method->is_visible = $is_visible;
-			// Return early if visibility does not pass.
-			if ( ! $is_visible ) {
-				$method->is_configured = false;
-				return $method;
-			}
-		}
-
-		if ( isset( $spec->is_configured ) ) {
-			$is_configured         = $rule_evaluator->evaluate( $method->is_configured );
-			$method->is_configured = $is_configured;
 		}
 
 		return $method;

--- a/src/Features/RemotePaymentMethods/EvaluateMethod.php
+++ b/src/Features/RemotePaymentMethods/EvaluateMethod.php
@@ -24,7 +24,7 @@ class EvaluateMethod {
 		$method         = (object) $spec;
 
 		if ( isset( $method->is_visible ) ) {
-			$is_visible         = $rule_evaluator->evaluate( (object) $method->is_visible );
+			$is_visible         = $rule_evaluator->evaluate( $method->is_visible );
 			$method->is_visible = $is_visible;
 		}
 

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\RemotePaymentMethods;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
+use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\DefaultPaymentGateways;
 use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\PaymentGatewaysController;
 
 /**
@@ -56,14 +57,14 @@ class Init {
 		// Fetch specs if they don't yet exist.
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
 			if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
-				return self::get_default_specs();
+				return DefaultPaymentGateways::get_all();
 			}
 
 			$specs = DataSourcePoller::read_specs_from_data_sources();
 
 			// Fall back to default specs if polling failed.
 			if ( ! $specs ) {
-				return self::get_default_specs();
+				return DefaultPaymentGateways::get_all();
 			}
 
 			$specs = self::localize( $specs );
@@ -71,28 +72,6 @@ class Init {
 		}
 
 		return $specs;
-	}
-
-	/**
-	 * Get default specs.
-	 *
-	 * @return array Default specs.
-	 */
-	public static function get_default_specs() {
-		return array(
-			array(
-				'key'        => 'payfast',
-				'title'      => __( 'PayFast', 'woocommerce-admin' ),
-				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
-				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
-				'plugins'    => array( 'woocommerce-payfast-gateway' ),
-				'is_visible' => array(
-					'type'      => 'base_location_country',
-					'value'     => 'ZA',
-					'operation' => '=',
-				),
-			),
-		);
 	}
 
 	/**

--- a/src/Features/RemotePaymentMethods/Init.php
+++ b/src/Features/RemotePaymentMethods/Init.php
@@ -80,13 +80,13 @@ class Init {
 	 */
 	public static function get_default_specs() {
 		return array(
-			(object) array(
+			array(
 				'key'        => 'payfast',
 				'title'      => __( 'PayFast', 'woocommerce-admin' ),
 				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.  Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
 				'image'      => __( 'https =>//www.payfast.co.za/assets/images/payfast_logo_colour.svg', 'woocommerce-admin' ),
 				'plugins'    => array( 'woocommerce-payfast-gateway' ),
-				'is_visible' => (object) array(
+				'is_visible' => array(
 					'type'      => 'base_location_country',
 					'value'     => 'ZA',
 					'operation' => '=',

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -38,6 +38,10 @@ class PaymentGatewaysController {
 			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url();
 		}
 
+		if ( method_exists( $gateway, 'get_setup_help_text' ) ) {
+			$data['setup_help_text'] = $gateway->get_setup_help_text();
+		}
+
 		if ( method_exists( $gateway, 'get_required_settings_keys' ) ) {
 			$data['required_settings_keys'] = $gateway->get_required_settings_keys();
 		}


### PR DESCRIPTION
Fixes (part of) #6855 

Adds PayPal as a fallback if the remote specs can't be pulled.

### Screenshots

<img width="703" alt="Screen Shot 2021-05-17 at 3 22 17 PM" src="https://user-images.githubusercontent.com/10561050/118551774-13966700-b72c-11eb-975d-7091c14eb200.png">
<img width="704" alt="Screen Shot 2021-05-19 at 2 45 38 PM" src="https://user-images.githubusercontent.com/10561050/118867310-ef17c780-b8b0-11eb-9ca1-59bfd29393fb.png">
<img width="698" alt="Screen Shot 2021-05-19 at 2 58 59 PM" src="https://user-images.githubusercontent.com/10561050/118869019-de685100-b8b2-11eb-83ab-8503905003ef.png">



### Detailed test instructions:

1. Disable the remote payment tester plugin if active and delete the transient `woocommerce_admin_remote_payment_methods_specs`.
2. Install and activate this branch of the PayPal plugin - https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1569
2. Navigate to the payments task in the task list.
3. Stripe should be shown if the store is set to a stripe enabled store (e.g., `U.S.`) and has not selected cbd as an industry during onboarding.
4. Stripe fields should be shown after going into the setup if non-https.
5. If an SSL is being used on the site, you should see the stripe "Connect" button.

Note that some follow-ups are needed around connection when redirecting back to the site.