### PR TITLE
Fix deprecated warnings from `select` control in `@wordpress/data-controls`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9194,7 +9194,7 @@
 			"requires": {
 				"@wordpress/components": "^11.1.1",
 				"@wordpress/compose": "^3.22.0",
-				"@wordpress/data": "^4.25.0",
+				"@wordpress/data": "^4.27.3",
 				"@wordpress/element": "2.19.0",
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/notices": "^2.11.0",
@@ -10315,7 +10315,7 @@
 			"requires": {
 				"@babel/runtime": "7.14.0",
 				"@wordpress/a11y": "2.15.2",
-				"@wordpress/data": "4.26.1"
+				"@wordpress/data": "4.27.3"
 			},
 			"dependencies": {
 				"@wordpress/a11y": {
@@ -10822,17 +10822,17 @@
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.26.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.26.1.tgz",
-			"integrity": "sha512-+GIi9uI18Do1CkKU7AkTeQ/vJ0vzP4lJyBZv5GmTYhdkjxPMxcAzcdfJA/ZNnZGhiQAFsv+HuI3aJ8KC3Y3yMA==",
+			"version": "4.27.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.27.3.tgz",
+			"integrity": "sha512-5763NgNV9IIa1CC3Q80dAvrH6108tJtj3IrHfUCZmUk1atSNsOMBCkLdQ7tGTTi2JFejeGEMg1LJI22JD5zM6Q==",
 			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"@wordpress/compose": "^3.23.1",
-				"@wordpress/deprecated": "^2.11.0",
-				"@wordpress/element": "^2.19.0",
-				"@wordpress/is-shallow-equal": "^3.0.0",
-				"@wordpress/priority-queue": "^1.10.0",
-				"@wordpress/redux-routine": "^3.13.0",
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^3.25.3",
+				"@wordpress/deprecated": "^2.12.3",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/is-shallow-equal": "^3.1.3",
+				"@wordpress/priority-queue": "^1.11.2",
+				"@wordpress/redux-routine": "^3.14.2",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^4.0.0",
 				"lodash": "^4.17.19",
@@ -10842,6 +10842,20 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"dependencies": {
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
 				"@wordpress/is-shallow-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@wordpress/base-styles": "3.3.0",
 		"@wordpress/components": "11.1.3",
 		"@wordpress/core-data": "2.25.0",
-		"@wordpress/data": "4.26.1",
+		"@wordpress/data": "4.27.3",
 		"@wordpress/data-controls": "1.20.1",
 		"@wordpress/date": "3.13.0",
 		"@wordpress/dom": "2.16.0",

--- a/packages/customer-effort-score/package.json
+++ b/packages/customer-effort-score/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@wordpress/components": "^11.1.1",
 		"@wordpress/compose": "^3.22.0",
-		"@wordpress/data": "^4.25.0",
+		"@wordpress/data": "^4.27.3",
 		"@wordpress/element": "2.19.0",
 		"@wordpress/i18n": "3.17.0",
 		"@wordpress/notices": "^2.11.0",

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch, select } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { _n, sprintf } from '@wordpress/i18n';
 
 /**
@@ -222,8 +223,8 @@ export function* activatePlugins( plugins: string[] ) {
 
 export function* installAndActivatePlugins( plugins: string[] ) {
 	try {
-		yield dispatch( STORE_NAME, 'installPlugins', plugins );
-		const activations: InstallPluginsResponse = yield dispatch(
+		yield controls.dispatch( STORE_NAME, 'installPlugins', plugins );
+		const activations: InstallPluginsResponse = yield controls.dispatch(
 			STORE_NAME,
 			'activatePlugins',
 			plugins
@@ -235,16 +236,20 @@ export function* installAndActivatePlugins( plugins: string[] ) {
 }
 
 export const createErrorNotice = ( errorMessage: string ) => {
-	return dispatch( 'core/notices', 'createNotice', errorMessage );
+	return controls.dispatch( 'core/notices', 'createNotice', errorMessage );
 };
 
 export function* connectToJetpack(
 	getAdminLink: ( endpoint: string ) => string
 ) {
-	const url: string = yield select( STORE_NAME, 'getJetpackConnectUrl', {
-		redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
-	} );
-	const error: string = yield select(
+	const url: string = yield controls.resolveSelect(
+		STORE_NAME,
+		'getJetpackConnectUrl',
+		{
+			redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
+		}
+	);
+	const error: string = yield controls.resolveSelect(
 		STORE_NAME,
 		'getPluginsError',
 		'getJetpackConnectUrl'
@@ -262,10 +267,10 @@ export function* installJetpackAndConnect(
 	getAdminLink: ( endpoint: string ) => string
 ) {
 	try {
-		yield dispatch( STORE_NAME, 'installPlugins', [ 'jetpack' ] );
-		yield dispatch( STORE_NAME, 'activatePlugins', [ 'jetpack' ] );
+		yield controls.dispatch( STORE_NAME, 'installPlugins', [ 'jetpack' ] );
+		yield controls.dispatch( STORE_NAME, 'activatePlugins', [ 'jetpack' ] );
 
-		const url: string = yield dispatch(
+		const url: string = yield controls.dispatch(
 			STORE_NAME,
 			'connectToJetpack',
 			getAdminLink
@@ -282,7 +287,7 @@ export function* connectToJetpackWithFailureRedirect(
 	getAdminLink: ( endpoint: string ) => string
 ) {
 	try {
-		const url: string = yield dispatch(
+		const url: string = yield controls.dispatch(
 			STORE_NAME,
 			'connectToJetpack',
 			getAdminLink

--- a/packages/data/src/plugins/resolvers.ts
+++ b/packages/data/src/plugins/resolvers.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, select } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -115,7 +116,7 @@ function* setOnboardingStatusWithOptions() {
 		merchant_id_production: string;
 		client_id_production: string;
 		client_secret_production: string;
-	} = yield select(
+	} = yield controls.resolveSelect(
 		OPTIONS_STORE_NAME,
 		'getOption',
 		'woocommerce-ppcp-settings'
@@ -136,7 +137,9 @@ function* setOnboardingStatusWithOptions() {
 export function* getPaypalOnboardingStatus() {
 	yield setIsRequesting( 'getPaypalOnboardingStatus', true );
 
-	const errorData: { data?: { status: number } } = yield select(
+	const errorData: {
+		data?: { status: number };
+	} = yield controls.resolveSelect(
 		STORE_NAME,
 		'getPluginsError',
 		'getPaypalOnboardingStatus'

--- a/packages/data/src/plugins/test/actions.ts
+++ b/packages/data/src/plugins/test/actions.ts
@@ -8,15 +8,20 @@
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 jest.mock( '@wordpress/data-controls', () => ( {
-	dispatch: jest.fn(),
-	select: jest.fn(),
 	apiFetch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	controls: {
+		dispatch: jest.fn(),
+		select: jest.fn(),
+	},
 } ) );
 
 /**
  * External dependencies
  */
-import { dispatch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -48,14 +53,16 @@ describe( 'installJetPackAndConnect', () => {
 		// Run the install
 		installer.next();
 
-		expect( dispatch ).toHaveBeenCalledWith( STORE_NAME, 'installPlugins', [
-			'jetpack',
-		] );
+		expect( controls.dispatch ).toHaveBeenCalledWith(
+			STORE_NAME,
+			'installPlugins',
+			[ 'jetpack' ]
+		);
 
 		// Run the activate
 		installer.next();
 
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( controls.dispatch ).toHaveBeenCalledWith(
 			STORE_NAME,
 			'activatePlugins',
 			[ 'jetpack' ]

--- a/packages/data/src/settings/actions.js
+++ b/packages/data/src/settings/actions.js
@@ -3,7 +3,8 @@
  */
 
 import { __ } from '@wordpress/i18n';
-import { apiFetch, select } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { concat } from 'lodash';
 
 /**
@@ -58,7 +59,11 @@ export function* persistSettingsForGroup( group ) {
 	// first dispatch the is persisting action
 	yield setIsRequesting( group, true );
 	// get all dirty keys with select control
-	const dirtyKeys = yield select( STORE_NAME, 'getDirtyKeys', group );
+	const dirtyKeys = yield controls.resolveSelect(
+		STORE_NAME,
+		'getDirtyKeys',
+		group
+	);
 	// if there is nothing dirty, bail
 	if ( dirtyKeys.length === 0 ) {
 		yield setIsRequesting( group, false );
@@ -66,7 +71,7 @@ export function* persistSettingsForGroup( group ) {
 	}
 
 	// get data slice for keys
-	const dirtyData = yield select(
+	const dirtyData = yield controls.resolveSelect(
 		STORE_NAME,
 		'getSettingsForGroup',
 		group,

--- a/packages/data/src/settings/resolvers.js
+++ b/packages/data/src/settings/resolvers.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ function settingsToSettingsResource( settings ) {
 }
 
 export function* getSettings( group ) {
-	yield dispatch( STORE_NAME, 'setIsRequesting', group, true );
+	yield controls.dispatch( STORE_NAME, 'setIsRequesting', group, true );
 
 	try {
 		const url = NAMESPACE + '/settings/' + group;

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@babel/runtime": "7.14.0",
 		"@wordpress/a11y": "2.15.2",
-		"@wordpress/data": "4.26.1"
+		"@wordpress/data": "4.27.3"
 	},
 	"peerDependencies": {
 		"lodash": "^4.17.0"

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Call existing filters for leaderboards in analytics. #6626
 - Fix: Set target to blank for the external links #6999
 - Fix style regression with the Chart header. #7002
+- Fix: Deprecated warnings from select control @wordpress/data-controls . #7007
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849

--- a/readme.txt
+++ b/readme.txt
@@ -115,7 +115,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Call existing filters for leaderboards in analytics. #6626
 - Fix: Set target to blank for the external links #6999
 - Fix style regression with the Chart header. #7002
-- Fix: Deprecated warnings from select control @wordpress/data-controls . #7007
+- Fix: Deprecated warnings from select control @wordpress/data-controls. #7007
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849


### PR DESCRIPTION
Fixes #6831 

This makes use of the `controls` of the `@wordpress/data` package instead of the controls within `@wordpress/data-controls`, as [they are deprecated](https://github.com/WordPress/gutenberg/blob/trunk/packages/data-controls/src/index.js#L55-L77).
I also updated `@wordpress/data` as resolveSelect was added then, not a 100% sure if this was needed as we do use `wp.data.controls`, but it doesn't hurt.

### Screenshots

<img width="1087" alt="Screen Shot 2021-05-18 at 4 07 45 PM" src="https://user-images.githubusercontent.com/2240960/118709350-3a6ba080-b7f3-11eb-914a-4e694e356153.png">

### Detailed test instructions:

- Create plugin zip `npm run test:zip` and install it on a jurassic website (mostly to test the jetpack connect part)
- Step through the onboarding flow, make sure to keep some of the recommended (free) plugins selected
- After the onboarding flow it should trigger the jetpack connection correctly
- Check the installed plugins and make sure the items you selected for the free extensions where installed.
- Check the e2e github action, and make sure it doesn't show any depreciated warnings as such:
<img width="1136" alt="Screen Shot 2021-05-18 at 4 03 46 PM" src="https://user-images.githubusercontent.com/2240960/118708877-a7326b00-b7f2-11eb-8630-e8a641f929f0.png">


<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
