### PR TITLE
Revert copy for setup checklist

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -67,7 +67,7 @@ const getPageTitle = ( defaultTitle ) => {
 	// If it's the task list then render a title based on which task the user is on.
 	return (
 		{
-			payments: __( 'Choose payment methods', 'woocommerce-admin' ),
+			payments: __( 'Set up payments', 'woocommerce-admin' ),
 			tax: __( 'Add tax rates', 'woocommerce-admin' ),
 			appearance: __( 'Personalize your store', 'woocommerce-admin' ),
 			products: __( 'Add products', 'woocommerce-admin' ),

--- a/client/header/test/index.js
+++ b/client/header/test/index.js
@@ -86,9 +86,7 @@ describe( 'Header', () => {
 			queryByTestId( 'header-back-button' )
 		).not.toBeEmptyDOMElement();
 
-		expect(
-			queryByText( 'Set up payments' )
-		).not.toBeEmptyDOMElement();
+		expect( queryByText( 'Set up payments' ) ).not.toBeEmptyDOMElement();
 	} );
 
 	it( 'should render decoded breadcrumb name', () => {

--- a/client/header/test/index.js
+++ b/client/header/test/index.js
@@ -87,7 +87,7 @@ describe( 'Header', () => {
 		).not.toBeEmptyDOMElement();
 
 		expect(
-			queryByText( 'Choose payment methods' )
+			queryByText( 'Set up payments' )
 		).not.toBeEmptyDOMElement();
 	} );
 

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -203,10 +203,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 					isComplete={ isTaskListComplete }
 					query={ query }
 					tasks={ setupTasks }
-					title={ __(
-						'Get ready to start selling',
-						'woocommerce-admin'
-					) }
+					title={ __( 'Finish setup', 'woocommerce-admin' ) }
 					trackedCompletedTasks={ trackedCompletedTasks || [] }
 				/>
 			) }

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -95,14 +95,14 @@ export function getAllTasks( {
 	).includes( 'woocommerce-payments' );
 
 	let purchaseAndInstallText = __(
-		'Add paid extensions to your store',
+		'Add paid extensions to my store',
 		'woocommerce-admin'
 	);
 
 	if ( uniqueItemsList.length === 1 ) {
 		const { name: itemName } = uniqueItemsList[ 0 ];
 		const purchaseAndInstallFormat = __(
-			'Add %s to your store',
+			'Add %s to my store',
 			'woocommerce-admin'
 		);
 		purchaseAndInstallText = sprintf( purchaseAndInstallFormat, itemName );
@@ -138,7 +138,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'products',
-			title: __( 'Add products', 'woocommerce-admin' ),
+			title: __( 'Add my products', 'woocommerce-admin' ),
 			container: <Products />,
 			onClick: () => {
 				onTaskSelect( 'products' );
@@ -195,7 +195,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'payments',
-			title: __( 'Choose payment methods', 'woocommerce-admin' ),
+			title: __( 'Set up payments', 'woocommerce-admin' ),
 			container: <Payments />,
 			completed: hasPaymentGateway,
 			onClick: () => {
@@ -211,7 +211,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'tax',
-			title: __( 'Add tax rates', 'woocommerce-admin' ),
+			title: __( 'Set up tax', 'woocommerce-admin' ),
 			container: <Tax />,
 			onClick: () => {
 				onTaskSelect( 'tax' );
@@ -224,7 +224,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'shipping',
-			title: __( 'Set up shipping costs', 'woocommerce-admin' ),
+			title: __( 'Set up shipping', 'woocommerce-admin' ),
 			container: <Shipping />,
 			onClick: () => {
 				if ( shippingZonesCount > 0 ) {
@@ -246,7 +246,7 @@ export function getAllTasks( {
 		},
 		{
 			key: 'appearance',
-			title: __( 'Personalize your store', 'woocommerce-admin' ),
+			title: __( 'Personalize my store', 'woocommerce-admin' ),
 			container: <Appearance />,
 			onClick: () => {
 				onTaskSelect( 'appearance' );

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -144,7 +144,7 @@ describe( 'TaskDashboard and TaskList', () => {
 		type: 'extension',
 	};
 
-	it( 'renders the "Get ready to start selling" and "Things to do next" tasks lists', async () => {
+	it( 'renders the "Finish setup" and "Things to do next" tasks lists', async () => {
 		apiFetch.mockResolvedValue( {} );
 		getAllTasks.mockReturnValue( tasks );
 		const { container } = render( <TaskDashboard query={ {} } /> );

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -39,7 +39,7 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn(),
 } ) );
 
-const TASK_LIST_HEADING = 'Get ready to start selling';
+const TASK_LIST_HEADING = 'Finish setup';
 const EXTENDED_TASK_LIST_HEADING = 'Things to do next';
 
 describe( 'TaskDashboard and TaskList', () => {

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Call existing filters for leaderboards in analytics. #6626
 - Fix: Set target to blank for the external links #6999
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
+- Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Experimental task list import to the experimental package. #6950
 - Update: Redirect to WC Home after setting up a payment method #6891

--- a/tests/e2e/constants/taskTitles.ts
+++ b/tests/e2e/constants/taskTitles.ts
@@ -1,6 +1,6 @@
 export const TaskTitles = {
 	storeDetails: 'Store details',
-	addPayments: 'Choose payment methods',
+	addPayments: 'Set up payments',
 	wooPayments:
 		'Set up WooCommerce PaymentsBy setting up, you are agreeing to the Terms of Service2 minutes',
 	addProducts: 'Add products',

--- a/tests/e2e/pages/PaymentsSetup.ts
+++ b/tests/e2e/pages/PaymentsSetup.ts
@@ -19,7 +19,7 @@ export class PaymentsSetup extends BasePage {
 	url = 'wp-admin/admin.php?page=wc-admin&task=payments';
 
 	async isDisplayed() {
-		await waitForElementByText( 'h1', 'Choose payment methods' );
+		await waitForElementByText( 'h1', 'Set up payments' );
 	}
 
 	async closeHelpModal() {

--- a/tests/e2e/pages/WcHomescreen.ts
+++ b/tests/e2e/pages/WcHomescreen.ts
@@ -27,7 +27,7 @@ export class WcHomescreen extends BasePage {
 		await page.waitForSelector(
 			'.woocommerce-task-card .woocommerce-task-list__item-title'
 		);
-		await waitForElementByText( 'p', 'Get ready to start selling' );
+		await waitForElementByText( 'p', 'Finish setup' );
 		const list = await this.page.$$eval(
 			'.woocommerce-task-card .woocommerce-task-list__item-title',
 			( items ) => items.map( ( item ) => item.textContent )

--- a/tests/e2e/specs/tasks/payment.test.ts
+++ b/tests/e2e/specs/tasks/payment.test.ts
@@ -33,7 +33,7 @@ describe( 'Payment setup task', () => {
 	} );
 
 	it( 'Can visit the payment setup task from the homescreen if the setup wizard has been skipped', async () => {
-		await homeScreen.clickOnTaskList( 'Choose payment methods' );
+		await homeScreen.clickOnTaskList( 'Set up payments' );
 		await paymentsSetup.closeHelpModal();
 		await paymentsSetup.isDisplayed();
 	} );


### PR DESCRIPTION
Fixes #6943

This PR reverts back copy in Setup Checklist.

### Detailed test instructions:

- Compare the diff in this PR:
  -  `client/task-list/index.js` with [this change](https://github.com/woocommerce/woocommerce-admin/commit/ef6aa388c40abffecb512e1af49c915ebe1449a6#diff-148b443dac4ecc6e426b7dca0475271e131ff015d751fb90262bd16156695856R135)
  - `client/task-list/tasks.js` with [this change](https://github.com/woocommerce/woocommerce-admin/commit/ef6aa388c40abffecb512e1af49c915ebe1449a6#diff-5819c659c28ae2e77a147c661fe8bd0f1cc3206a636b74281ece1674cf88480dL86)