### PR TITLE
Updated transition time, and added external icon for link

### DIFF
--- a/client/payments/payment-recommendations.scss
+++ b/client/payments/payment-recommendations.scss
@@ -1,7 +1,7 @@
 .woocommerce-recommended-payments-card {
 	margin: 0 15px 10px 0;
 	animation: isLoaded;
-	animation-duration: 2000ms;
+	animation-duration: 250ms;
 
 	.woocommerce-list__item {
 		> .woocommerce-list__item-inner {
@@ -44,6 +44,10 @@
 
 	.components-card__footer {
 		padding: $gap $gap-large;
+
+		.gridicon {
+			margin-left: $gap-smallest;
+		}
 	}
 
 	.woocommerce-list__item-enter {

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -23,6 +23,7 @@ import {
 	OPTIONS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import ExternalIcon from 'gridicons/dist/external';
 
 /**
  * Internal dependencies
@@ -218,6 +219,7 @@ const PaymentRecommendations: React.FC = () => {
 			<CardFooter>
 				<Button href={ SEE_MORE_LINK } isTertiary>
 					{ __( 'See more options', 'woocommerce-admin' ) }
+					<ExternalIcon size={ 18 } />
 				</Button>
 			</CardFooter>
 		</Card>

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Experimental task list import to the experimental package. #6950
 - Update: Redirect to WC Home after setting up a payment method #6891
+- Update: Payment recommendation screen transition and add external link icon. #7022
 
 == 2.3.0 5/13/2021 ==
 - Add: Add plugin installer to allow installation of plugins via URL #6805


### PR DESCRIPTION
This change was discussed with Elizabeth in Slack, to speed up fade transition for the payment recommendations, and add a `external` icon to the **See more options** button.

### Accessibility

-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)

### Screenshots

https://d.pr/i/c70lUr

### Detailed test instructions:

- Make sure you have **Display suggestions within WooCommerce** enabled in **WooCommerce > Settings > Advanced > WooCommerce.com**
- Create a store with a american based address
- Go to the payments settings screen **WooCommerce > Settings > Payments**
- You might have to wait a second or two, but notice the quick fade of the **Recommended ways to get paid**.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
