### PR TITLE
Add Paystack as fallback gateway

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Free extension list powered by remote config #6952
 - Add: Add PayPal to fallback payment gateways #7001
 - Add: Add a data store for WC Payments REST APIs #6918
+- Add: Add Paystack as fallback gateway #7025
 - Dev: Update package-lock to fix versioning of local packages. #6843
 - Dev: Use rule processing for remote payment methods #6830
 - Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -65,12 +65,7 @@ class DefaultPaymentGateways {
 				'plugins'    => array( 'woo-paystack' ),
 				'is_visible' => array(
 					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
-					(object) array(
-						'type'        => 'option',
-						'option_name' => 'woocommerce_onboarding_profile',
-						'value'       => 'cbd-other-hemp-derived-products',
-						'operation'   => '!contains',
-					),
+					self::get_rules_for_cbd( false ),
 				),
 			),
 		);
@@ -82,7 +77,7 @@ class DefaultPaymentGateways {
 	 * @param array $countries Array of countries to match.
 	 * @return object Rules to match.
 	 */
-	public function get_rules_for_countries( $countries ) {
+	public static function get_rules_for_countries( $countries ) {
 		$rules = array();
 
 		foreach ( $countries as $country ) {
@@ -96,6 +91,36 @@ class DefaultPaymentGateways {
 		return (object) array(
 			'type'     => 'or',
 			'operands' => $rules,
+		);
+	}
+
+	/**
+	 * Get default rules for CBD based on given argument.
+	 *
+	 * @param bool $should_have Whether or not the store should have CBD as an industry (true) or not (false).
+	 * @return array Rules to match.
+	 */
+	public static function get_rules_for_cbd( $should_have ) {
+		return (object) array(
+			'type'         => 'option',
+			'transformers' => array(
+				(object) array(
+					'use'       => 'dot_notation',
+					'arguments' => (object) array(
+						'path' => 'industry',
+					),
+				),
+				(object) array(
+					'use'       => 'array_column',
+					'arguments' => (object) array(
+						'key' => 'slug',
+					),
+				),
+			),
+			'option_name'  => 'woocommerce_onboarding_profile',
+			'operation'    => $should_have ? 'contains' : '!contains',
+			'value'        => 'cbd-other-hemp-derived-products',
+			'default'      => array(),
 		);
 	}
 

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -20,16 +20,6 @@ class DefaultPaymentGateways {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
-		$stripe_countries       = OnboardingTasks::get_stripe_supported_countries();
-		$stripe_countries_rules = array();
-		foreach ( $stripe_countries as $country ) {
-			$stripe_countries_rules[] = (object) array(
-				'type'      => 'base_location_country',
-				'value'     => $country,
-				'operation' => '=',
-			);
-		}
-
 		return array(
 			array(
 				'key'        => 'payfast',
@@ -58,10 +48,7 @@ class DefaultPaymentGateways {
 				'image'      => WC()->plugin_url() . '/assets/images/stripe.png',
 				'plugins'    => array( 'woocommerce-gateway-stripe' ),
 				'is_visible' => array(
-					(object) array(
-						'type'     => 'or',
-						'operands' => $stripe_countries_rules,
-					),
+					self::get_rules_for_countries( OnboardingTasks::get_stripe_supported_countries() ),
 					(object) array(
 						'type'        => 'option',
 						'option_name' => 'woocommerce_onboarding_profile',
@@ -70,6 +57,45 @@ class DefaultPaymentGateways {
 					),
 				),
 			),
+			array(
+				'key'        => 'paystack',
+				'title'      => __( 'Paystack', 'woocommerce-admin' ),
+				'content'    => __( 'Paystack helps African merchants accept one-time and recurring payments online with a modern, safe, and secure payment gateway.', 'woocommerce-admin' ),
+				'image'      => plugins_url( 'images/onboarding/paystack.png', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'    => array( 'woo-paystack' ),
+				'is_visible' => array(
+					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
+					(object) array(
+						'type'        => 'option',
+						'option_name' => 'woocommerce_onboarding_profile',
+						'value'       => 'cbd-other-hemp-derived-products',
+						'operation'   => '!contains',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Get rules that match the store base location to one of the provided countries.
+	 *
+	 * @param array $countries Array of countries to match.
+	 * @return object Rules to match.
+	 */
+	public function get_rules_for_countries( $countries ) {
+		$rules = array();
+
+		foreach ( $countries as $country ) {
+			$rules[] = (object) array(
+				'type'      => 'base_location_country',
+				'value'     => $country,
+				'operation' => '=',
+			);
+		}
+
+		return (object) array(
+			'type'     => 'or',
+			'operands' => $rules,
 		);
 	}
 


### PR DESCRIPTION
Fixes (part of) #6855 

Adds Paystack as a fallback gateway when remote recommended gateways aren't fetched.


### Screenshots
<img width="701" alt="Screen Shot 2021-05-19 at 4 51 40 PM" src="https://user-images.githubusercontent.com/10561050/118882740-7de11000-b8c2-11eb-9338-071ae3a8d93a.png">

### Detailed test instructions:

1. Check out this branch of the Paystack plugin and install/activate. https://github.com/tubiz/woo-paystack/pull/63
2. Visit the task list and the Paystack payment task.
3. Check that the required fields are shown.
4. If the new data store is merged (https://github.com/woocommerce/woocommerce-admin/pull/6918) and hooked up (pending), check that the currency is updated to `ZAR` and `testmode` is turned off after updated.