### PR TITLE
Add Mercado Pago as default fallback payment gateway

### DIFF
--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -21,7 +21,7 @@ export const PaymentConnect = ( {
 	const {
 		key,
 		oauth_connection_url: oAuthConnectionUrl,
-		setup_help_text: helpText,
+		setup_help_text: setupHelpText,
 		required_settings_keys: settingKeys,
 		settings,
 		settings_url: settingsUrl,
@@ -99,6 +99,9 @@ export const PaymentConnect = ( {
 		return errors;
 	};
 
+	const helpText = setupHelpText && (
+		<p dangerouslySetInnerHTML={ sanitizeHTML( setupHelpText ) } />
+	);
 	const DefaultForm = ( props ) => (
 		<DynamicForm
 			fields={ fields }
@@ -127,12 +130,10 @@ export const PaymentConnect = ( {
 	if ( oAuthConnectionUrl ) {
 		return (
 			<>
+				{ helpText }
 				<Button isPrimary href={ oAuthConnectionUrl }>
 					{ __( 'Connect', 'woocommerce-admin' ) }
 				</Button>
-				{ helpText && (
-					<p dangerouslySetInnerHTML={ sanitizeHTML( helpText ) } />
-				) }
 			</>
 		);
 	}
@@ -140,17 +141,18 @@ export const PaymentConnect = ( {
 	if ( fields.length ) {
 		return (
 			<>
+				{ helpText }
 				<DefaultForm />
-				{ helpText && (
-					<p dangerouslySetInnerHTML={ sanitizeHTML( helpText ) } />
-				) }
 			</>
 		);
 	}
 
 	return (
-		<Button isPrimary href={ settingsUrl }>
-			{ __( 'Manage', 'woocommerce-admin' ) }
-		</Button>
+		<>
+			{ helpText }
+			<Button isPrimary href={ settingsUrl }>
+				{ __( 'Manage', 'woocommerce-admin' ) }
+			</Button>
+		</>
 	);
 };

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Note date range logic for GivingFeedback, and InsightFirstSale note. #6969
 - Add: Add transient notices feature #6809
 - Add: Add transformers in remote inbox notifications #6948
+- Add: Add Mercado Pago as default fallback payment gateway #7043
 - Add: Get post install scripts from gateway and enqueue in client #6967
 - Add: Free extension list powered by remote config #6952
 - Add: Add PayPal to fallback payment gateways #7001

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -65,6 +65,22 @@ class DefaultPaymentGateways {
 				'plugins'    => array( 'woo-paystack' ),
 				'is_visible' => array(
 					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
+					(object) array(
+						'type'        => 'option',
+						'option_name' => 'woocommerce_onboarding_profile',
+						'value'       => 'cbd-other-hemp-derived-products',
+						'operation'   => '!contains',
+					),
+				),
+			),
+			array(
+				'key'        => 'paystack',
+				'title'      => __( 'Paystack', 'woocommerce-admin' ),
+				'content'    => __( 'Paystack helps African merchants accept one-time and recurring payments online with a modern, safe, and secure payment gateway.', 'woocommerce-admin' ),
+				'image'      => plugins_url( 'images/onboarding/paystack.png', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'    => array( 'woo-paystack' ),
+				'is_visible' => array(
+					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
 					self::get_rules_for_cbd( false ),
 				),
 			),

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -69,7 +69,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'mercadopago',
+				'key'        => 'woo-mercado-pago-custom',
 				'title'      => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
 				'content'    => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
 				'image'      => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -65,23 +65,17 @@ class DefaultPaymentGateways {
 				'plugins'    => array( 'woo-paystack' ),
 				'is_visible' => array(
 					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
-					(object) array(
-						'type'        => 'option',
-						'option_name' => 'woocommerce_onboarding_profile',
-						'value'       => 'cbd-other-hemp-derived-products',
-						'operation'   => '!contains',
-					),
+					self::get_rules_for_cbd( false ),
 				),
 			),
 			array(
-				'key'        => 'paystack',
-				'title'      => __( 'Paystack', 'woocommerce-admin' ),
-				'content'    => __( 'Paystack helps African merchants accept one-time and recurring payments online with a modern, safe, and secure payment gateway.', 'woocommerce-admin' ),
-				'image'      => plugins_url( 'images/onboarding/paystack.png', WC_ADMIN_PLUGIN_FILE ),
-				'plugins'    => array( 'woo-paystack' ),
+				'key'        => 'mercadopago',
+				'title'      => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
+				'content'    => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
+				'image'      => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'    => array( 'woocommerce-mercadopago' ),
 				'is_visible' => array(
-					self::get_rules_for_countries( array( 'ZA', 'GH', 'NG' ) ),
-					self::get_rules_for_cbd( false ),
+					self::get_rules_for_countries( array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ) ),
 				),
 			),
 			array(


### PR DESCRIPTION
Fixes (part of) #6855 

* Adds Mercado Pago to fallback gateways.
* Moves help text above submit buttons.

### Screenshots

<img width="693" alt="Screen Shot 2021-05-21 at 12 43 45 PM" src="https://user-images.githubusercontent.com/10561050/119171316-6759c680-ba32-11eb-9b73-0bd2e6582db4.png">


### Detailed test instructions:

1. Install this branch of Mercado Pago. https://github.com/woocommerce/woocommerce-gateway-mercadopago/pull/5
2. Delete any remote payment transients.
3. Check that the Mercado Pago payment gateway recommendation is shown.
4. Check that the help text is correctly loaded.