### PR TITLE
Add PayPal as default fallback gateway

### DIFF
--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -33,7 +33,9 @@ export const PaymentConnect = ( {
 	const slot = useSlot( `woocommerce_remote_payment_form_${ key }` );
 	const hasFills = Boolean( slot?.fills?.length );
 	const fields = settingKeys
-		? settingKeys.map( ( settingKey ) => settings[ settingKey ] )
+		? settingKeys
+				.map( ( settingKey ) => settings[ settingKey ] )
+				.filter( Boolean )
 		: [];
 
 	const isOptionsRequesting = useSelect( ( select ) => {

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -68,6 +68,21 @@ class DefaultPaymentGateways {
 					self::get_rules_for_cbd( false ),
 				),
 			),
+			array(
+				'key'        => 'ppcp-gateway',
+				'title'      => __( 'PayPal Payments', 'woocommerce-admin' ),
+				'content'    => __( "Safe and secure payments using credit cards or your customer's PayPal account.", 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/paypal.png',
+				'plugins'    => array( 'woocommerce-paypal-payments' ),
+				'is_visible' => array(
+					(object) array(
+						'type'      => 'base_location_country',
+						'value'     => 'IN',
+						'operation' => '!=',
+					),
+					self::get_rules_for_cbd( false ),
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes (part of) #6855

* Adds PayPal as a default payment gateway
* Filters out required fields that aren't found

**Note**:  The PayPal gateway will require some refactoring for the connection URL and setup keys now showing in the REST response.  This PR is simply about getting the gateway to show up in the recommendations list.

### Screenshots

<img width="713" alt="Screen Shot 2021-05-21 at 1 54 49 PM" src="https://user-images.githubusercontent.com/10561050/119178794-2cf52700-ba3c-11eb-9228-4331931066d3.png">

### Detailed test instructions:

1. Delete any remote recommendation transients.
2. Load the payments task.
3. Note that PayPal shows up in the list.