### PR TITLE
WCPay: Update supported countries

### DIFF
--- a/client/task-list/tasks/payments/methods/wcpay/is-supported.js
+++ b/client/task-list/tasks/payments/methods/wcpay/is-supported.js
@@ -4,7 +4,17 @@ export function isWCPaySupported( countryCode ) {
 		window.wcAdminFeatures &&
 		window.wcAdminFeatures[ 'wcpay/support-international-countries' ]
 	) {
-		supportedCountries.push( 'AU', 'CA', 'GB', 'IE', 'NZ' );
+		supportedCountries.push(
+			'AU',
+			'CA',
+			'DE',
+			'ES',
+			'FR',
+			'GB',
+			'IE',
+			'IT',
+			'NZ'
+		);
 	}
 	return supportedCountries.includes( countryCode );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Tweak: Store profiler - Changed MailPoet's title and description #6990
+- Tweak: Adjust WC Pay supported countries #7048
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Experimental task list import to the experimental package. #6950
 - Update: Redirect to WC Home after setting up a payment method #6891


### PR DESCRIPTION
For #6976

This branch updates the list of countries in the international roll out of WC Pay to be current with what is supplied in the issue above.

### Detailed test instructions:

I believe this functionality has been tested quite extensively, but if you please, you could go through the OBW and setup checklist on a site using countries listed in this PR to verify WC Pay is shown as an option.

