### PR TITLE
WCPay: Enable wcpay/support-international-countries on 2.3.1

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -17,6 +17,6 @@
 		"shipping-label-banner": true,
 		"store-alerts": true,
 		"wcpay": true,
-		"wcpay/support-international-countries": false
+		"wcpay/support-international-countries": true
 	}
 }


### PR DESCRIPTION
Related to #6976

This PR turns the `wcpay/support-international-countries` feature to `true` on the core build in the `release/2.3.1` branch. This has already been toggled on in `main` so this seemed to be the easiest way to get this turned back on for 2.3.1