### PR TITLE
Set autoload to false for all remote inbox notifications options

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981
 - Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
+- Fix: Set autoload to false for all remote inbox notifications options. #7060
 - Add: Consume remote payment methods on frontend #6867
 - Add: Extend payment gateways REST endpoint #6919
 - Add: Add remote payment gateway recommendations initial docs #6962

--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -54,7 +54,11 @@ class DataSourcePoller {
 		}
 
 		// Persist the specs as an option.
-		update_option( RemoteInboxNotificationsEngine::SPECS_OPTION_NAME, $specs );
+		update_option(
+			RemoteInboxNotificationsEngine::SPECS_OPTION_NAME,
+			$specs,
+			false
+		);
 
 		return 0 !== count( $specs );
 	}

--- a/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/src/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -107,11 +107,11 @@ class RemoteInboxNotificationsEngine {
 	 * WooCommerceAdminUpdatedRuleProcessor trigger on WCA update.
 	 */
 	public static function run_on_woocommerce_admin_updated() {
-		update_option( self::WCA_UPDATED_OPTION_NAME, true );
+		update_option( self::WCA_UPDATED_OPTION_NAME, true, false );
 
 		self::run();
 
-		update_option( self::WCA_UPDATED_OPTION_NAME, false );
+		update_option( self::WCA_UPDATED_OPTION_NAME, false, false );
 	}
 
 	/**
@@ -130,7 +130,12 @@ class RemoteInboxNotificationsEngine {
 				$stored_state
 			);
 
-			add_option( self::STORED_STATE_OPTION_NAME, $stored_state );
+			add_option(
+				self::STORED_STATE_OPTION_NAME,
+				$stored_state,
+				'',
+				false
+			);
 		}
 
 		return $stored_state;
@@ -155,6 +160,6 @@ class RemoteInboxNotificationsEngine {
 	 * @param object $stored_state The stored state.
 	 */
 	public static function update_stored_state( $stored_state ) {
-		update_option( self::STORED_STATE_OPTION_NAME, $stored_state );
+		update_option( self::STORED_STATE_OPTION_NAME, $stored_state, false );
 	}
 }


### PR DESCRIPTION
Fixes #6763 

This sets autoload to false for all remote inbox notification system options. Previously they used the default which is true, which meant that the specs were being loaded on every request.

### Detailed test instructions:

- check the `autoload` value for the `wc_remote_inbox_notifications_specs` option. It should be true or yes.
- run the `wc_admin_daily` cron task
- check the `autoload` value for the `wc_remote_inbox_notifications_specs` option again. It should now be false.
