### PR TITLE
Add a console command to manage testing instructions as segment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wp-cli.local.yml
 *.zip
 .idea
 .vscode/
+phpcs.xml
 
 # Composer
 /vendor/

--- a/bin/testing-instructions.php
+++ b/bin/testing-instructions.php
@@ -1,6 +1,5 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', '1');
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/testing-instructions/Application.php';
 require_once __DIR__ . '/testing-instructions/AddCommand.php';
@@ -9,6 +8,6 @@ require_once __DIR__ . '/testing-instructions/WriteCommand.php';
 $config = require_once __DIR__ . '/testing-instructions/config.php';
 
 $app = new Application();
-$app->add(new AddCommand($config));
-$app->add(new WriteCommand($config));
-exit($app->run());
+$app->add( new AddCommand( $config ) );
+$app->add( new WriteCommand( $config ) );
+exit( $app->run() );

--- a/bin/testing-instructions/AddCommand.php
+++ b/bin/testing-instructions/AddCommand.php
@@ -133,8 +133,10 @@ class AddCommand extends Command {
 		$body   .= "\n###";
 		$pattern = '/### (Detailed test instructions:)\R+(.+?)(?=\R+###)/s';
 		preg_match( $pattern, $body, $matches );
+
 		if ( 3 === count( $matches ) ) {
-			return $matches[2];
+			//Remove <!-- --> or <!--- ---> comments.
+			return preg_replace('/(?=<!--)([\s\S]*?)-->/', '', $matches[2]);
 		}
 
 		return '';

--- a/bin/testing-instructions/AddCommand.php
+++ b/bin/testing-instructions/AddCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class AddCommand extends Command {
+
+	/**
+	 * The default command name
+	 *
+	 * @var string|null
+	 */
+	protected static $defaultName = 'add';
+
+	private $config;
+
+	public function __construct(array $config) {
+		parent::__construct();
+	    $this->config = $config;
+	}
+
+	/**
+	 * Configures the command.
+	 */
+	protected function configure() {
+		$this->setDescription( 'Adds a change file' );
+	}
+
+
+	/**
+	 * Executes the command.
+	 *
+	 * @param InputInterface $input InputInterface.
+	 * @param OutputInterface $output OutputInterface.
+	 *
+	 * @return int
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$question_helper = $this->getHelper( 'question' );
+
+		$name_question = new Question( 'Name your testing instruction: ' );
+		$name = $question_helper->ask( $input, $output, $name_question );
+		if ( null === $name ) {
+			$output->writeln( 'Got EOF when attempting to query user, aborting.');
+			return 1;
+		}
+
+		$pr_question = new Question( 'What is the PR #? ' );
+		$pr_number = $question_helper->ask( $input, $output, $pr_question );
+
+		if ( ! is_dir( $this->config['segment_file_dir'] ) ) {
+			$output->writeln( "Semgent file directory `{$this->config['segment_file_dir']} does not exist, aborting" );
+			return 1;
+		}
+
+		$segment_filename = "{$pr_number}.md";
+		$content = "### {$name} #{$pr_number}\n\n";
+
+		file_put_contents( $this->config['segment_file_dir'] . '/' . $segment_filename, $content );
+
+		$output->writeln( "\n". $segment_filename . ' has been created. Please fill out your testing instructions.' );
+	}
+}

--- a/bin/testing-instructions/AddCommand.php
+++ b/bin/testing-instructions/AddCommand.php
@@ -6,7 +6,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-
+/**
+ * Class AddCommand
+ */
 class AddCommand extends Command {
 
 	/**
@@ -16,11 +18,21 @@ class AddCommand extends Command {
 	 */
 	protected static $defaultName = 'add';
 
+	/**
+	 * Configuration.
+	 *
+	 * @var array
+	 */
 	private $config;
 
-	public function __construct(array $config) {
+	/**
+	 * AddCommand constructor.
+	 *
+	 * @param array $config
+	 */
+	public function __construct( array $config ) {
 		parent::__construct();
-	    $this->config = $config;
+		$this->config = $config;
 	}
 
 	/**
@@ -28,26 +40,32 @@ class AddCommand extends Command {
 	 */
 	protected function configure() {
 		$this->setDescription( 'Adds a change file' );
-		$this->addOption('pr', null, InputOption::VALUE_REQUIRED, 'Your PR #');
+		$this->addOption( 'pr', null, InputOption::VALUE_REQUIRED, 'Your PR #' );
 	}
 
 	/**
 	 * Executes the command.
 	 *
-	 * @param InputInterface $input InputInterface.
+	 * @param InputInterface  $input InputInterface.
 	 * @param OutputInterface $output OutputInterface.
 	 *
 	 * @return int
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-		$pr = $input->getOption('pr');
+		$pr      = $input->getOption( 'pr' );
 		$content = '';
 
+		// PR # specified, retrieve name and the testing instructions from the PR.
 		if ( $pr ) {
-			$pr_info = $this->parse_pr($pr);
-			$name = $pr_info->title;
+			$pr_info = $this->parse_pr( $pr );
+			if ( false === $pr_info ) {
+				$output->writeln( ( "Unable to retrieve PR #{$pr}." ) );
+				return 404;
+			}
+			$name      = $pr_info->title;
 			$pr_number = $pr;
-			$content = $pr_info->test_instructions;
+			$content   = $pr_info->test_instructions;
+			// Otherwise, ask the user.
 		} else {
 			$question_helper = $this->getHelper( 'question' );
 
@@ -55,7 +73,7 @@ class AddCommand extends Command {
 			$name          = $question_helper->ask( $input, $output, $name_question );
 			if ( null === $name ) {
 				$output->writeln( 'Got EOF when attempting to query user, aborting.' );
-				return 1;
+				return 400;
 			}
 
 			$pr_question = new Question( 'What is the PR #? ' );
@@ -64,36 +82,55 @@ class AddCommand extends Command {
 
 		if ( ! is_dir( $this->config['segment_file_dir'] ) ) {
 			$output->writeln( "Semgent file directory `{$this->config['segment_file_dir']} does not exist, aborting" );
-			return 1;
+			return 400;
 		}
 
 		$segment_filename = "{$pr_number}.md";
-		$heading = "### {$name} #{$pr_number}\n\n";
+		$heading          = "### {$name} #{$pr_number}\n\n";
 
 		file_put_contents( $this->config['segment_file_dir'] . '/' . $segment_filename, $heading . $content );
 
-		$output->writeln($segment_filename . ' has been created.' );
+		$output->writeln( $segment_filename . ' has been created.' );
 	}
 
+	/**
+	 * Retrieve PR information.
+	 *
+	 * @param string $pr PR # to retrieve.
+	 *
+	 * @return object Object containing PR information.
+	 */
 	private function parse_pr( $pr ) {
-		$url = 'https://api.github.com/repos/woocommerce/woocommerce-admin/pulls/' . $pr;
+		$url  = 'https://api.github.com/repos/woocommerce/woocommerce-admin/pulls/' . $pr;
 		$curl = curl_init( $url );
 		curl_setopt( $curl, CURLOPT_URL, $url );
 		curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
 		$headers = array(
-			"Accept: application/vnd.github.v3+json",
-			"User-Agent: curl"
+			'Accept: application/vnd.github.v3+json',
+			'User-Agent: curl',
 		);
 		curl_setopt( $curl, CURLOPT_HTTPHEADER, $headers );
 		$response = json_decode( curl_exec( $curl ) );
 		curl_close( $curl );
+
+		if ( isset( $response->message ) && $response->message === 'Not Found' ) {
+			return false;
+		}
+
 		$response->test_instructions = $this->get_test_instructions( $response->body );
 		return $response;
 	}
 
+	/**
+	 * Extract testing instructions from the PR description.
+	 *
+	 * @param string $body PR description body.
+	 *
+	 * @return string Testing instructions.
+	 */
 	private function get_test_instructions( $body ) {
 		// add additinal ### to make the regex working.
-		$body .= "\n###";
+		$body   .= "\n###";
 		$pattern = '/### (Detailed test instructions:)\R+(.+?)(?=\R+###)/s';
 		preg_match( $pattern, $body, $matches );
 		if ( 3 === count( $matches ) ) {

--- a/bin/testing-instructions/AddCommand.php
+++ b/bin/testing-instructions/AddCommand.php
@@ -2,8 +2,10 @@
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+
 
 class AddCommand extends Command {
 
@@ -26,8 +28,8 @@ class AddCommand extends Command {
 	 */
 	protected function configure() {
 		$this->setDescription( 'Adds a change file' );
+		$this->addOption('pr', null, InputOption::VALUE_REQUIRED, 'Your PR #');
 	}
-
 
 	/**
 	 * Executes the command.
@@ -38,17 +40,27 @@ class AddCommand extends Command {
 	 * @return int
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-		$question_helper = $this->getHelper( 'question' );
+		$pr = $input->getOption('pr');
+		$content = '';
 
-		$name_question = new Question( 'Name your testing instruction: ' );
-		$name = $question_helper->ask( $input, $output, $name_question );
-		if ( null === $name ) {
-			$output->writeln( 'Got EOF when attempting to query user, aborting.');
-			return 1;
+		if ( $pr ) {
+			$pr_info = $this->parse_pr($pr);
+			$name = $pr_info->title;
+			$pr_number = $pr;
+			$content = $pr_info->test_instructions;
+		} else {
+			$question_helper = $this->getHelper( 'question' );
+
+			$name_question = new Question( 'Name your testing instruction: ' );
+			$name          = $question_helper->ask( $input, $output, $name_question );
+			if ( null === $name ) {
+				$output->writeln( 'Got EOF when attempting to query user, aborting.' );
+				return 1;
+			}
+
+			$pr_question = new Question( 'What is the PR #? ' );
+			$pr_number   = $question_helper->ask( $input, $output, $pr_question );
 		}
-
-		$pr_question = new Question( 'What is the PR #? ' );
-		$pr_number = $question_helper->ask( $input, $output, $pr_question );
 
 		if ( ! is_dir( $this->config['segment_file_dir'] ) ) {
 			$output->writeln( "Semgent file directory `{$this->config['segment_file_dir']} does not exist, aborting" );
@@ -56,10 +68,38 @@ class AddCommand extends Command {
 		}
 
 		$segment_filename = "{$pr_number}.md";
-		$content = "### {$name} #{$pr_number}\n\n";
+		$heading = "### {$name} #{$pr_number}\n\n";
 
-		file_put_contents( $this->config['segment_file_dir'] . '/' . $segment_filename, $content );
+		file_put_contents( $this->config['segment_file_dir'] . '/' . $segment_filename, $heading . $content );
 
-		$output->writeln( "\n". $segment_filename . ' has been created. Please fill out your testing instructions.' );
+		$output->writeln($segment_filename . ' has been created.' );
+	}
+
+	private function parse_pr( $pr ) {
+		$url = 'https://api.github.com/repos/woocommerce/woocommerce-admin/pulls/' . $pr;
+		$curl = curl_init( $url );
+		curl_setopt( $curl, CURLOPT_URL, $url );
+		curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
+		$headers = array(
+			"Accept: application/vnd.github.v3+json",
+			"User-Agent: curl"
+		);
+		curl_setopt( $curl, CURLOPT_HTTPHEADER, $headers );
+		$response = json_decode( curl_exec( $curl ) );
+		curl_close( $curl );
+		$response->test_instructions = $this->get_test_instructions( $response->body );
+		return $response;
+	}
+
+	private function get_test_instructions( $body ) {
+		// add additinal ### to make the regex working.
+		$body .= "\n###";
+		$pattern = '/### (Detailed test instructions:)\R+(.+?)(?=\R+###)/s';
+		preg_match( $pattern, $body, $matches );
+		if ( 3 === count( $matches ) ) {
+			return $matches[2];
+		}
+
+		return '';
 	}
 }

--- a/bin/testing-instructions/Application.php
+++ b/bin/testing-instructions/Application.php
@@ -1,0 +1,36 @@
+<?php
+
+use Symfony\Component\Console\Application as SymfonyApplication;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * User interface for the changelogger tool.
+ */
+class Application extends SymfonyApplication {
+
+	const VERSION = '0.0.1';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'Testing Instructions', self::VERSION );
+	}
+
+	/**
+	 * Called when the application is run.
+	 *
+	 * @param InputInterface $input InputInterface.
+	 * @param OutputInterface $output OutputInterface.
+	 *
+	 * @return int
+	 * @throws Throwable
+	 */
+	public function doRun( InputInterface $input, OutputInterface $output ) {
+		$output->getFormatter()->setStyle( 'warning', new OutputFormatterStyle( 'black', 'yellow' ) );
+		return parent::doRun( $input, $output );
+	}
+
+}

--- a/bin/testing-instructions/Application.php
+++ b/bin/testing-instructions/Application.php
@@ -32,5 +32,4 @@ class Application extends SymfonyApplication {
 		$output->getFormatter()->setStyle( 'warning', new OutputFormatterStyle( 'black', 'yellow' ) );
 		return parent::doRun( $input, $output );
 	}
-
 }

--- a/bin/testing-instructions/WriteCommand.php
+++ b/bin/testing-instructions/WriteCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class WriteCommand extends Command {
+
+	/**
+	 * The default command name
+	 *
+	 * @var string|null
+	 */
+	protected static $defaultName = 'write';
+
+	private $config;
+
+	public function __construct(array $config) {
+		parent::__construct();
+	    $this->config = $config;
+	}
+
+	/**
+	 * Configures the command.
+	 */
+	protected function configure() {
+		$this->setDescription( 'Updates the TESTING-INSTRUCTIONS.md from segment files' );
+		$this->addArgument( 'version', InputArgument::REQUIRED );
+	}
+
+
+	/**
+	 * Executes the command.
+	 *
+	 * @param InputInterface $input InputInterface.
+	 * @param OutputInterface $output OutputInterface.
+	 *
+	 * @return int
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+
+		$file = $this->config['index_file'];
+		$version = $input->getArgument( 'version' );
+
+		$contents = $this->mergeSegmentFiles();
+
+		$pattern = '/^## Unreleased((?:(?!^##).)+)/ms';
+		$replacement = "## Unreleased\n## {$version}\n\n" . $contents . "\n\n";
+
+		$readme = file_get_contents( $file );
+		$new_contents = preg_replace( $pattern, $replacement, $readme );
+		if ( strlen( $new_contents ) === strlen( $readme ) || null === $new_contents ) {
+			$output->writeln( "Failed to write the changelog: please check readme.txt format." );
+			return self::FATAL_EXIT;
+		}
+
+		file_put_contents( $file, $new_contents );
+
+		$this->deleteSegments();
+
+		$output->writeln( "Index file has been updated with version {$version}." );
+	}
+
+	/**
+	 * Merge segment files into a single string.
+	 *
+	 * @return string
+	 */
+	protected function mergeSegmentFiles() {
+		$segment_dir = $this->config['segment_file_dir'];
+		$files = glob( $segment_dir . '/*.md' );
+		$contents = '';
+		foreach ( $files as $file ) {
+			$content = file_get_contents($file);
+			$contents .= "\n{$content}";
+		}
+
+		return $contents;
+	}
+
+	/**
+	 * Delete segment files.
+	 */
+	protected function deleteSegments() {
+		$segment_dir = $this->config['segment_file_dir'];
+		$files = glob( $segment_dir . '/*.md' );
+		foreach ( $files as $file ) {
+			unlink($file);
+		}
+	}
+}

--- a/bin/testing-instructions/WriteCommand.php
+++ b/bin/testing-instructions/WriteCommand.php
@@ -5,6 +5,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Class WriteCommand
+ */
 class WriteCommand extends Command {
 
 	/**
@@ -14,11 +17,21 @@ class WriteCommand extends Command {
 	 */
 	protected static $defaultName = 'write';
 
+	/**
+	 * Configuration.
+	 *
+	 * @var array
+	 */
 	private $config;
 
-	public function __construct(array $config) {
+	/**
+	 * WriteCommand constructor.
+	 *
+	 * @param array $config configuration object.
+	 */
+	public function __construct( array $config ) {
 		parent::__construct();
-	    $this->config = $config;
+		$this->config = $config;
 	}
 
 	/**
@@ -33,32 +46,29 @@ class WriteCommand extends Command {
 	/**
 	 * Executes the command.
 	 *
-	 * @param InputInterface $input InputInterface.
+	 * @param InputInterface  $input InputInterface.
 	 * @param OutputInterface $output OutputInterface.
 	 *
 	 * @return int
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-
-		$file = $this->config['index_file'];
+		$file    = $this->config['index_file'];
 		$version = $input->getArgument( 'version' );
 
 		$contents = $this->mergeSegmentFiles();
 
-		$pattern = '/^## Unreleased((?:(?!^##).)+)/ms';
+		$pattern     = '/^## Unreleased((?:(?!^##).)+)/ms';
 		$replacement = "## Unreleased\n## {$version}\n\n" . $contents . "\n\n";
 
-		$readme = file_get_contents( $file );
+		$readme       = file_get_contents( $file );
 		$new_contents = preg_replace( $pattern, $replacement, $readme );
 		if ( strlen( $new_contents ) === strlen( $readme ) || null === $new_contents ) {
-			$output->writeln( "Failed to write the changelog: please check readme.txt format." );
-			return self::FATAL_EXIT;
+			$output->writeln( 'Failed to write the changelog: please check readme.txt format.' );
+			return 500;
 		}
 
 		file_put_contents( $file, $new_contents );
-
 		$this->deleteSegments();
-
 		$output->writeln( "Index file has been updated with version {$version}." );
 	}
 
@@ -69,10 +79,10 @@ class WriteCommand extends Command {
 	 */
 	protected function mergeSegmentFiles() {
 		$segment_dir = $this->config['segment_file_dir'];
-		$files = glob( $segment_dir . '/*.md' );
-		$contents = '';
+		$files       = glob( $segment_dir . '/*.md' );
+		$contents    = '';
 		foreach ( $files as $file ) {
-			$content = file_get_contents($file);
+			$content   = file_get_contents( $file );
 			$contents .= "\n{$content}";
 		}
 
@@ -84,9 +94,9 @@ class WriteCommand extends Command {
 	 */
 	protected function deleteSegments() {
 		$segment_dir = $this->config['segment_file_dir'];
-		$files = glob( $segment_dir . '/*.md' );
+		$files       = glob( $segment_dir . '/*.md' );
 		foreach ( $files as $file ) {
-			unlink($file);
+			unlink( $file );
 		}
 	}
 }

--- a/bin/testing-instructions/WriteCommand.php
+++ b/bin/testing-instructions/WriteCommand.php
@@ -57,8 +57,8 @@ class WriteCommand extends Command {
 
 		$contents = $this->mergeSegmentFiles();
 
-		$pattern     = '/^## Unreleased((?:(?!^##).)+)/ms';
-		$replacement = "## Unreleased\n## {$version}\n\n" . $contents . "\n\n";
+		$pattern     = '/^# Testing instructions((?:(?!^##).)+)/ms';
+		$replacement = "# Testing instructions\n\n## {$version}\n" . $contents . "\n\n";
 
 		$readme       = file_get_contents( $file );
 		$new_contents = preg_replace( $pattern, $replacement, $readme );
@@ -83,7 +83,7 @@ class WriteCommand extends Command {
 		$contents    = '';
 		foreach ( $files as $file ) {
 			$content   = file_get_contents( $file );
-			$contents .= "\n{$content}";
+			$contents .= "\n\n{$content}";
 		}
 
 		return $contents;

--- a/bin/testing-instructions/config.php
+++ b/bin/testing-instructions/config.php
@@ -1,6 +1,6 @@
 <?php
 
 return array(
-	'index_file' => __DIR__ . '/../../TESTING-INSTRUCTIONS.md',
+	'index_file'	   => __DIR__ . '/../../TESTING-INSTRUCTIONS.md',
 	'segment_file_dir' => __DIR__ . '/../../testing-instructions'
 );

--- a/bin/testing-instructions/config.php
+++ b/bin/testing-instructions/config.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'index_file' => __DIR__ . '/../../TESTING-INSTRUCTIONS.md',
+	'segment_file_dir' => __DIR__ . '/../../testing-instructions'
+);

--- a/bin/tsi.php
+++ b/bin/tsi.php
@@ -1,5 +1,6 @@
 <?php
-
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/testing-instructions/Application.php';
 require_once __DIR__ . '/testing-instructions/AddCommand.php';

--- a/bin/tsi.php
+++ b/bin/tsi.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/testing-instructions/Application.php';
+require_once __DIR__ . '/testing-instructions/AddCommand.php';
+require_once __DIR__ . '/testing-instructions/WriteCommand.php';
+
+$config = require_once __DIR__ . '/testing-instructions/config.php';
+
+$app = new Application();
+$app->add(new AddCommand($config));
+$app->add(new WriteCommand($config));
+exit($app->run());

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	"require-dev": {
 		"woocommerce/woocommerce-sniffs": "0.1.0",
 		"suin/phpcs-psr4-sniff": "^2.2",
-		"bamarni/composer-bin-plugin": "^1.4"
+		"bamarni/composer-bin-plugin": "^1.4",
+		"symfony/console": "^3.4 | ^5.2"
 	},
 	"config": {
 		"platform": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"bump-version": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"wp-env-mysql-port": "node ./docker/wc-admin-wp-env/mysql-port.js",
 		"create-hook-reference": "node ./bin/hook-reference/index.js",
-		"tsi": "php ./bin/tsi.php"
+		"testing-instructions": "php ./bin/testing-instructions.php"
 	},
 	"husky": {
 		"hooks": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
 		"changelog": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'",
 		"bump-version": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"wp-env-mysql-port": "node ./docker/wc-admin-wp-env/mysql-port.js",
-		"create-hook-reference": "node ./bin/hook-reference/index.js"
+		"create-hook-reference": "node ./bin/hook-reference/index.js",
+		"tsi": "php ./bin/tsi.php"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Fixes #7059 

This PR adds a new console command to manage testing instructions as segment files in order to improve testing instruction merge conflicts we've been experiencing. 

It introduces a new workflow for adding testing instructions.

1. Open a PR for the issue to create a PR # as usual.
2. Go back to the local repository and run `npm run tsi -- add`. The command asks for the name and PR # to create a MD file in `/testing-instructions` directory. You can optionally use `--pr` option to pull the testing instructions automatically. `npm run tsi -- add --pr=:number`
3. Open the created MD file and fill out the testing instructions.
4. Commit the file.

Once we're ready to release a new version,

1. Run `npm run tsi -- write :release-version` to merge individual MD files in `/testing-instructions` into `TESTING-INSTRUCTIONS.md`


### Screenshots
![Screen Shot 2021-05-25 at 7 07 54 AM](https://user-images.githubusercontent.com/4723145/119513128-ccf6cd00-bd28-11eb-83f5-bc58ecf5c25b.jpg)
![Screen Shot 2021-05-25 at 7 08 38 AM](https://user-images.githubusercontent.com/4723145/119513142-ce27fa00-bd28-11eb-878b-1e0af98fa396.jpg)

