### PR TITLE
Fix notices, to make sure it uses the correct store

### DIFF
--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -18,10 +18,11 @@ const QUEUE_OPTION = 'woocommerce_admin_transient_notices_queue';
 const QUEUED_NOTICE_FILTER = 'woocommerce_admin_queued_notice_filter';
 
 function TransientNotices( props ) {
-	const { createNotice, removeNotice: onRemove } = useDispatch(
-		'core/notices'
-	);
-	const { removeNotice: onRemove2 } = useDispatch( 'core/notices2' );
+	const { removeNotice: onRemove } = useDispatch( 'core/notices' );
+	const {
+		createNotice: createNotice2,
+		removeNotice: onRemove2,
+	} = useDispatch( 'core/notices2' );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const {
 		currentUser = {},
@@ -59,7 +60,7 @@ function TransientNotices( props ) {
 		getCurrentUserNotices().forEach( ( queuedNotice ) => {
 			const notice = applyFilters( QUEUED_NOTICE_FILTER, queuedNotice );
 
-			createNotice( notice.status, notice.content, {
+			createNotice2( notice.status, notice.content, {
 				onDismiss: () => {
 					dequeueNotice( notice.id );
 				},

--- a/client/layout/transient-notices/index.js
+++ b/client/layout/transient-notices/index.js
@@ -19,7 +19,7 @@ const QUEUED_NOTICE_FILTER = 'woocommerce_admin_queued_notice_filter';
 
 function TransientNotices( props ) {
 	const { createNotice, removeNotice: onRemove } = useDispatch(
-		'core/notices2'
+		'core/notices'
 	);
 	const { removeNotice: onRemove2 } = useDispatch( 'core/notices2' );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix style regression with the Chart header. #7002
 - Fix styling of the advanced filter operator selection. #7005
 - Fix: Deprecated warnings from select control @wordpress/data-controls. #7007
+- Fix: Notices not dissapearing. #7077
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849


### PR DESCRIPTION
This fixes an issue where the notices where not being removed, it turned out we were using the wrong store.

### Screenshots

![dismiss-popups](https://user-images.githubusercontent.com/2240960/119686361-a2863c00-be1c-11eb-89b9-905f354629a5.gif)

### Detailed test instructions:

- Go to **WooCommerce > Home** having finished the onboarding flow
- Dismiss one of the inbox notes by clicking **Dismiss > Dismiss this message**
- Notice the notice in the bottom left, click on the notice/popup (either Undo or just the popup)
- This should make the popup disapear (previously didn't)



<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
