### PR TITLE
Fix Formatting in Coupons E2E Test

### DIFF
--- a/tests/e2e/specs/marketing/coupons.test.ts
+++ b/tests/e2e/specs/marketing/coupons.test.ts
@@ -1,23 +1,23 @@
 /**
  * Internal dependencies
  */
- import { Coupons } from '../../pages/Coupons';
- import { Login } from '../../pages/Login';
- 
- describe( 'Coupons page', () => {
-     const couponsPage = new Coupons( page );
-     const login = new Login( page );
- 
-     beforeAll( async () => {
-         await login.login();
-     } );
-     afterAll( async () => {
-         await login.logout();
-     } );
- 
-     it( 'A user can view the coupons overview without it crashing', async () => {
-         await couponsPage.navigate();
-         await couponsPage.isDisplayed();
-     } );
- } );
- 
+import { Coupons } from '../../pages/Coupons';
+import { Login } from '../../pages/Login';
+
+describe( 'Coupons page', () => {
+	const couponsPage = new Coupons( page );
+	const login = new Login( page );
+
+	beforeAll( async () => {
+		await login.login();
+	} );
+
+	afterAll( async () => {
+		await login.logout();
+	} );
+
+	it( 'A user can view the coupons overview without it crashing', async () => {
+		await couponsPage.navigate();
+		await couponsPage.isDisplayed();
+	} );
+} );


### PR DESCRIPTION
While poking around the E2E tests I noticed the coupons test has the wrong indentation. This fixes the indentation and other formatting issues according to the linter.

No changelog.