### PR TITLE
Add `slotFill` to Abbreviated Notification panel

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -57,6 +57,8 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 	const [ isPanelClosing, setIsPanelClosing ] = useState( false );
 	const [ isPanelOpen, setIsPanelOpen ] = useState( false );
 	const [ isPanelSwitching, setIsPanelSwitching ] = useState( false );
+	const { fills } = useSlot( ABBREVIATED_NOTIFICATION_SLOT_NAME );
+	const hasExtendedNotifications = Boolean( fills && fills.length );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};
@@ -111,11 +113,10 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			thingsToDoNextCount > 0 ||
 			isOrdersCardVisible ||
 			isReviewsCardVisible ||
-			isLowStockCardVisible
+			isLowStockCardVisible ||
+			hasExtendedNotifications
 		);
 	}
-	const slot = useSlot( ABBREVIATED_NOTIFICATION_SLOT_NAME );
-	const hasExtraFills = Boolean( slot.fills && slot.fills.length );
 
 	const {
 		hasUnreadNotes,
@@ -222,8 +223,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			name: 'inbox',
 			title: __( 'Inbox', 'woocommerce-admin' ),
 			icon: <Icon icon={ inboxIcon } />,
-			unread:
-				hasUnreadNotes || hasAbbreviatedNotifications || hasExtraFills,
+			unread: hasUnreadNotes || hasAbbreviatedNotifications,
 			visible:
 				( isEmbedded || ! isHomescreen() ) && ! isPerformingSetupTask(),
 		};
@@ -306,7 +306,6 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 						hasAbbreviatedNotifications={
 							hasAbbreviatedNotifications
 						}
-						hasExtraFills={ hasExtraFills }
 						thingsToDoNextCount={ thingsToDoNextCount }
 					/>
 				);

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -58,7 +58,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 	const [ isPanelOpen, setIsPanelOpen ] = useState( false );
 	const [ isPanelSwitching, setIsPanelSwitching ] = useState( false );
 	const { fills } = useSlot( ABBREVIATED_NOTIFICATION_SLOT_NAME );
-	const hasExtendedNotifications = Boolean( fills && fills.length );
+	const hasExtendedNotifications = Boolean( fills?.length );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -21,6 +21,7 @@ import {
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { applyFilters } from '@wordpress/hooks';
+import { useSlot } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
@@ -39,6 +40,7 @@ import {
 	getUnreadOrders,
 } from '../../homescreen/activity-panel/orders/utils';
 import { getUnapprovedReviews } from '../../homescreen/activity-panel/reviews/utils';
+import { ABBREVIATED_NOTIFICATION_SLOT_NAME } from './panels/inbox/abbreviated-notifications-panel';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -112,6 +114,8 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			isLowStockCardVisible
 		);
 	}
+	const slot = useSlot( ABBREVIATED_NOTIFICATION_SLOT_NAME );
+	const hasExtraFills = Boolean( slot.fills && slot.fills.length );
 
 	const {
 		hasUnreadNotes,
@@ -218,7 +222,8 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			name: 'inbox',
 			title: __( 'Inbox', 'woocommerce-admin' ),
 			icon: <Icon icon={ inboxIcon } />,
-			unread: hasUnreadNotes || hasAbbreviatedNotifications,
+			unread:
+				hasUnreadNotes || hasAbbreviatedNotifications || hasExtraFills,
 			visible:
 				( isEmbedded || ! isHomescreen() ) && ! isPerformingSetupTask(),
 		};
@@ -301,6 +306,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 						hasAbbreviatedNotifications={
 							hasAbbreviatedNotifications
 						}
+						hasExtraFills={ hasExtraFills }
 						thingsToDoNextCount={ thingsToDoNextCount }
 					/>
 				);

--- a/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
+++ b/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
@@ -29,10 +29,7 @@ const STOCK_PANEL_ID = 'stock-panel';
 
 export const ABBREVIATED_NOTIFICATION_SLOT_NAME = 'AbbreviatedNotification';
 
-export const AbbreviatedNotificationsPanel = ( {
-	hasExtraFills,
-	thingsToDoNextCount,
-} ) => {
+export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 	const {
 		ordersToProcessCount,
 		reviewsToModerateCount,
@@ -166,7 +163,7 @@ export const AbbreviatedNotificationsPanel = ( {
 					</Text>
 				</AbbreviatedCard>
 			) }
-			{ hasExtraFills && isExtendedTaskListHidden && <Slot /> }
+			{ ! isExtendedTaskListHidden && <Slot /> }
 		</div>
 	);
 };

--- a/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
+++ b/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
@@ -8,6 +8,7 @@ import { AbbreviatedCard } from '@woocommerce/components';
 import { useSelect } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { box, comment, page } from '@wordpress/icons';
+import { createSlotFill } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,7 +27,13 @@ const ORDER_PANEL_ID = 'orders-panel';
 const REVIEWS_PANEL_ID = 'reviews-panel';
 const STOCK_PANEL_ID = 'stock-panel';
 
-export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
+export const ABBREVIATED_NOTIFICATION_SLOT_NAME =
+	'__experimentalAbbreviatedNotification';
+
+export const AbbreviatedNotificationsPanel = ( {
+	hasExtraFills,
+	thingsToDoNextCount,
+} ) => {
 	const {
 		ordersToProcessCount,
 		reviewsToModerateCount,
@@ -53,6 +60,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 		} );
 	};
 
+	const { Slot } = createSlotFill( ABBREVIATED_NOTIFICATION_SLOT_NAME );
 	const isWCAdminPage = isWCAdmin( window.location.href );
 
 	return (
@@ -159,6 +167,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					</Text>
 				</AbbreviatedCard>
 			) }
+			{ hasExtraFills && isExtendedTaskListHidden && <Slot /> }
 		</div>
 	);
 };

--- a/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
+++ b/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
@@ -27,8 +27,7 @@ const ORDER_PANEL_ID = 'orders-panel';
 const REVIEWS_PANEL_ID = 'reviews-panel';
 const STOCK_PANEL_ID = 'stock-panel';
 
-export const ABBREVIATED_NOTIFICATION_SLOT_NAME =
-	'__experimentalAbbreviatedNotification';
+export const ABBREVIATED_NOTIFICATION_SLOT_NAME = 'AbbreviatedNotification';
 
 export const AbbreviatedNotificationsPanel = ( {
 	hasExtraFills,

--- a/client/header/activity-panel/panels/inbox/inbox-panel.js
+++ b/client/header/activity-panel/panels/inbox/inbox-panel.js
@@ -7,12 +7,14 @@ import { AbbreviatedNotificationsPanel } from './abbreviated-notifications-panel
 
 export const InboxPanel = ( {
 	hasAbbreviatedNotifications,
+	hasExtraFills,
 	thingsToDoNextCount,
 } ) => {
 	return (
 		<div className="woocommerce-notification-panels">
-			{ hasAbbreviatedNotifications && (
+			{ ( hasAbbreviatedNotifications || hasExtraFills ) && (
 				<AbbreviatedNotificationsPanel
+					hasExtraFills={ hasExtraFills }
 					thingsToDoNextCount={ thingsToDoNextCount }
 				/>
 			) }

--- a/client/header/activity-panel/panels/inbox/inbox-panel.js
+++ b/client/header/activity-panel/panels/inbox/inbox-panel.js
@@ -7,14 +7,12 @@ import { AbbreviatedNotificationsPanel } from './abbreviated-notifications-panel
 
 export const InboxPanel = ( {
 	hasAbbreviatedNotifications,
-	hasExtraFills,
 	thingsToDoNextCount,
 } ) => {
 	return (
 		<div className="woocommerce-notification-panels">
-			{ ( hasAbbreviatedNotifications || hasExtraFills ) && (
+			{ hasAbbreviatedNotifications && (
 				<AbbreviatedNotificationsPanel
-					hasExtraFills={ hasExtraFills }
 					thingsToDoNextCount={ thingsToDoNextCount }
 				/>
 			) }

--- a/docs/examples/extensions/add-abbreviated-notification/js/index.js
+++ b/docs/examples/extensions/add-abbreviated-notification/js/index.js
@@ -3,14 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import { Fill as ExpermientalNotificationFill } from '@wordpress/components';
+import { Fill as NotificationFill } from '@wordpress/components';
 import { AbbreviatedCard } from '@woocommerce/components';
 import { page } from '@wordpress/icons';
 import { Text } from '@woocommerce/experimental';
 
 const MyAbbreviatedNotification = () => {
 	return (
-		<ExpermientalNotificationFill name="__experimentalAbbreviatedNotification">
+		<NotificationFill name="AbbreviatedNotification">
 			<AbbreviatedCard
 				className="woocommerce-abbreviated-notification"
 				icon={ page }
@@ -26,7 +26,7 @@ const MyAbbreviatedNotification = () => {
 					{ __( 'This is an unread notifications', 'plugin-domain' ) }
 				</Text>
 			</AbbreviatedCard>
-		</ExpermientalNotificationFill>
+		</NotificationFill>
 	);
 };
 

--- a/docs/examples/extensions/add-abbreviated-notification/js/index.js
+++ b/docs/examples/extensions/add-abbreviated-notification/js/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { Fill as ExpermientalNotificationFill } from '@wordpress/components';
+import { AbbreviatedCard } from '@woocommerce/components';
+import { page } from '@wordpress/icons';
+import { Text } from '@woocommerce/experimental';
+
+const MyAbbreviatedNotification = () => {
+	return (
+		<ExpermientalNotificationFill name="__experimentalAbbreviatedNotification">
+			<AbbreviatedCard
+				className="woocommerce-abbreviated-notification"
+				icon={ page }
+				href={ '#' }
+			>
+				<Text as="h3">
+					{ __(
+						'Abbreviated Notification Example',
+						'plugin-domain'
+					) }
+				</Text>
+				<Text>
+					{ __( 'This is an unread notifications', 'plugin-domain' ) }
+				</Text>
+			</AbbreviatedCard>
+		</ExpermientalNotificationFill>
+	);
+};
+
+registerPlugin( 'my-abbreviated-notification', {
+	render: MyAbbreviatedNotification,
+} );

--- a/docs/examples/extensions/add-abbreviated-notification/woocommerce-admin-add-abbreviated-notification-example.php
+++ b/docs/examples/extensions/add-abbreviated-notification/woocommerce-admin-add-abbreviated-notification-example.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Admin Add Abbreviated Notification Example
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * Register the JS.
+ */
+function add_abbreviated_notification_register_script() {
+	if (
+		! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) ||
+		! \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page()
+	) {
+		return;
+	}
+
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
+	wp_register_script(
+		'add-abbreviated-notification',
+		plugins_url( '/dist/index.js', __FILE__ ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+
+	wp_enqueue_script( 'add-abbreviated-notification' );
+}
+add_action( 'admin_enqueue_scripts', 'add_abbreviated_notification_register_script' );

--- a/readme.txt
+++ b/readme.txt
@@ -159,6 +159,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Remove original business step flow #7103
 - Dev: Drop styling support for IE11. #7137
 - Add: Show task and activity notifications in the Inbox panel #7017
+- Add: SlotFill to Abbreviated Notification panel #7091
 
 == 2.3.1 5/24/2021 ==
 - Tweak: Store profiler - Changed MailPoet's title and description #6990

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: WCPay not working in local payments task #7151
 - Fix: Include onboarding settings on the analytic pages #7109
 - Tweak: Revert Card component removal #7167
+- Add: SlotFill to Abbreviated Notification panel #7091
 
 == 2.4.0 6/10/2021 ==
 - Dev: Reduce the specificity and complexity of the ReportError component #6846
@@ -176,7 +177,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Update remote payment docs gateway methods #7079
 - Update: Remove original business step flow #7103
 - Update: WooCommerce Shipping copy on onboarding steps #7148
-- Add: SlotFill to Abbreviated Notification panel #7091
 
 == 2.3.1 5/24/2021 ==
 - Tweak: Store profiler - Changed MailPoet's title and description #6990


### PR DESCRIPTION
This is a follow-up PR to [7017](https://github.com/woocommerce/woocommerce-admin/pull/7017)

In order to avoid filtering an array of data that turns into components, this PR aims to use `slotFill` instead.

3PD will be able to extend the abbreviated notification panel by adding their fill to the `AbbreviatedNotification` slot.

### Screenshots
![screenshot-one wordpress test-2021 05 30-11_45_25](https://user-images.githubusercontent.com/1314156/120108676-aa0b5500-c13c-11eb-9ab3-1110625a9914.png)

### Detailed test instructions:

-   Go to your terminal and run: `npm run example -- --ext=add-abbreviated-notification`
-   A new plugin should have been added (`WooCommerce Admin Add Abbreviated Notification Example`). Activate it.
-   A new abbreviated notification should be visible in the panel.


<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
