### PR TITLE
Fix a bug where the test zip command used the wrong file suffix for JS

### DIFF
--- a/bin/build-test-zip.sh
+++ b/bin/build-test-zip.sh
@@ -2,7 +2,7 @@
 #
 # Build a test zip from current branch for uploading to test site
 #
-npm run build
+WC_ADMIN_PHASE=plugin npm run build
 composer install --no-dev
 rm woocommerce-admin.zip
 ./bin/make-zip.sh woocommerce-admin.zip

--- a/bin/build-test-zip.sh
+++ b/bin/build-test-zip.sh
@@ -2,7 +2,9 @@
 #
 # Build a test zip from current branch for uploading to test site
 #
-WC_ADMIN_PHASE=plugin npm run build
+phase=${WC_ADMIN_PHASE:-plugin} 
+
+WC_ADMIN_PHASE=$phase npm run build
 composer install --no-dev
 rm woocommerce-admin.zip
 ./bin/make-zip.sh woocommerce-admin.zip


### PR DESCRIPTION
No changelog required.

Fixes #7027

@ilyasfoo thanks for spotting this issue, could you test this and see if it fixes the problem?

The issue was that in the test zip command we didn't set WC_ADMIN_PHASE which was added a while back to determine what kind of file suffixes to generate in webpack.