### PR TITLE
Add payment gateway return URL and action

### DIFF
--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentConnect.js
@@ -21,7 +21,7 @@ export const PaymentConnect = ( {
 } ) => {
 	const {
 		id,
-		oauth_connection_url: oAuthConnectionUrl,
+		connection_url: connectionUrl,
 		setup_help_text: setupHelpText,
 		required_settings_keys: settingKeys,
 		settings,
@@ -126,11 +126,11 @@ export const PaymentConnect = ( {
 		);
 	}
 
-	if ( oAuthConnectionUrl ) {
+	if ( connectionUrl ) {
 		return (
 			<>
 				{ helpText }
-				<Button isPrimary href={ oAuthConnectionUrl }>
+				<Button isPrimary href={ connectionUrl }>
 					{ __( 'Connect', 'woocommerce-admin' ) }
 				</Button>
 			</>

--- a/docs/features/remote-payments.md
+++ b/docs/features/remote-payments.md
@@ -48,7 +48,7 @@ Name | Return | Default | Description
 --- | --- | --- | ---
 `needs_setup()` | boolean | `false` | Used to determine if the gateway still requires setup in order to be used.
 `get_required_settings_keys()` | array | `[]` | An array of keys for fields required to properly configure the gateway.  The keys must match those of already registered form fields in the payment gateway.
-`get_oauth_connection_url()` | string | `null` | The oAuth connection URL to be used to quickly connect a payment gateway provider.  If provided, this will be used in place of required setting fields.
+`get_connection_url()` | string | `null` | The connection URL to be used to quickly connect a payment gateway provider. If provided, this will be used in place of required setting fields. 
 `get_post_install_script_handles()` | array | `[]` | An array of script handles previously registered with `wp_register_script` to enqueue after the payment gateway has been installed.  This is primarily used to `SlotFill` the payment connection step, but can allow any script to be added to assist in payment gateway setup.
 `get_setup_help_text()` | string | `null` | Help text to be shown above the connection step's submit button.
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add COD method to default payment gateway recommendations #7057
 - Add: Add BACS as default fallback payment gateway #7073
 - Add: A/B test of progressive checklist features. #7089
+- Add: Add payment gateway return URL and action #7095
 - Dev: Update package-lock to fix versioning of local packages. #6843
 - Dev: Use rule processing for remote payment methods #6830
 - Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -35,9 +35,9 @@ class PaymentGatewaysController {
 		$data['post_install_scripts'] = self::get_post_install_scripts( $gateway );
 		$data['settings_url']         = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
-		if ( method_exists( $gateway, 'get_oauth_connection_url' ) ) {
-			$return_url                   = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
-			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url( $return_url );
+		if ( method_exists( $gateway, 'get_connection_url' ) ) {
+			$return_url             = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
+			$data['connection_url'] = $gateway->get_connection_url( $return_url );
 		}
 
 		if ( method_exists( $gateway, 'get_setup_help_text' ) ) {

--- a/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
+++ b/src/Features/RemotePaymentMethods/PaymentGatewaysController.php
@@ -17,6 +17,7 @@ class PaymentGatewaysController {
 	 */
 	public static function init() {
 		add_filter( 'woocommerce_rest_prepare_payment_gateway', array( __CLASS__, 'extend_response' ), 10, 3 );
+		add_filter( 'admin_init', array( __CLASS__, 'possibly_do_connection_return_action' ) );
 	}
 
 	/**
@@ -35,7 +36,8 @@ class PaymentGatewaysController {
 		$data['settings_url']         = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
 		if ( method_exists( $gateway, 'get_oauth_connection_url' ) ) {
-			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url();
+			$return_url                   = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
+			$data['oauth_connection_url'] = $gateway->get_oauth_connection_url( $return_url );
 		}
 
 		if ( method_exists( $gateway, 'get_setup_help_text' ) ) {
@@ -72,5 +74,27 @@ class PaymentGatewaysController {
 		}
 
 		return $scripts;
+	}
+
+	/**
+	 * Call an action after a gating has been successfully returned.
+	 */
+	public static function possibly_do_connection_return_action() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if (
+			! isset( $_GET['page'] ) ||
+			'wc-admin' !== $_GET['page'] ||
+			! isset( $_GET['task'] ) ||
+			'payments' !== $_GET['task'] ||
+			! isset( $_GET['connection-return'] )
+		) {
+			return;
+		}
+
+		$gateway_id = sanitize_text_field( wp_unslash( $_GET['connection-return'] ) );
+
+		// phpcs:enable WordPress.Security.NonceVerification
+
+		do_action( 'woocommerce_admin_payment_gateway_connection_return', $gateway_id );
 	}
 }


### PR DESCRIPTION
Fixes #7045 

* Provides a return URL for gateways.
* Adds an action for gateways to hook into on connection return.
* Renames the oauth connection URL to just connection URL since we use non-oauth connection.

### Detailed test instructions:

1. In any installed gateway, add the `get_connection_url()` static method with a `$return_url` argument in the gateway class.
```php
public static get_connection_url( $return_url ) {
  error_log( $return_url );
}
```
2. Note that the URL (first argument) is provided.
3. Add a hook for the connection return action.
```php
add_action( 'woocommerce_admin_payment_gateway_connection_return', function( $gateway ) {
    if ( $gateway === 'my-gateway' ) {
        wp_die('Gateway connected');
    }
} );
```
4. Visit the payments task with the matching `connection-return` param - `/wp-admin/admin.php?page=wc-admin&task=payments&connection-return=my-gateway` and note the hook works as expected.