### PR TITLE
When publishing the docs on gh workflow the WP css was not imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ languages/*
 !languages/README.md
 woocommerce-admin.zip
 includes/feature-config.php
-storybook/wordpress
+/storybook/wordpress
 tests/e2e/screenshots/*
 docs/components/storybook/*
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",
 		"predev": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development npm run build:feature-config && cross-env WC_ADMIN_PHASE=development npm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",
-		"docs": "STORYBOOK=true npx build-storybook -c storybook/.storybook -o ./docs/components/storybook",
+		"docs": "./bin/import-wp-css-storybook.sh && STORYBOOK=true npx build-storybook -c storybook/.storybook -o ./docs/components/storybook",
 		"i18n": "npm run -s i18n:js && npm run -s i18n:check && npm run -s i18n:pot && npm run -s i18n:build",
 		"i18n:build": "php bin/combine-pot-files.php languages/woocommerce-admin.po languages/woocommerce-admin.pot",
 		"i18n:check": "grunt checktextdomain",


### PR DESCRIPTION
I found one bug with the docs being published to gh pages which is that the wordpress CSS was not imported. I didn't spot this in manual testing, because I didn't notice that the directory was retained between checkouts of different branches. Whoops! 

No changelog required