### PR TITLE
Fixing incorrect Transformer casing throwing an error in case-sensitive environments

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Changelog ==
 
 == Unreleased ==
+- Fix: Transformer casing is incorrect and creates an error on case-sensitive systems #7104
 - Dev: Reduce the specificity and complexity of the ReportError component #6846
 - Add: Create onboarding package to house refactored WCPay card and relevant components #7058
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026

--- a/src/RemoteInboxNotifications/TransformerService.php
+++ b/src/RemoteInboxNotifications/TransformerService.php
@@ -21,7 +21,7 @@ class TransformerService {
 	 * @return TransformerInterface|null
 	 */
 	public static function create_transformer( $name ) {
-		$camel_cased = lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $name ) ) ) );
+		$camel_cased = str_replace( ' ', '', ucwords( str_replace( '_', ' ', $name ) ) );
 
 		$classname = __NAMESPACE__ . '\\Transformers\\' . $camel_cased;
 		if ( ! class_exists( $classname ) ) {


### PR DESCRIPTION
I recently came across an issue in [a PR](https://github.com/woocommerce/woocommerce-admin/pull/7073#issuecomment-849956380) that wasn't reproducible on other systems. This has to do with the casing on the class names of the recently added Transformer Service.

For example, a name of `dot_notation` is being converted to `dotNotation` to make them camel-case, but the class names are actually PascalCase. This is _not_ causing an issue for most as `class_exists` is generally not case sensitive, but it falls back to the autoloader and `file_exists` when a class is not directly defined. This _does_ become case sensitive if the OS environment is itself, which is why I'm encountering the issue on my linux machine. More details on [this stack overflow](https://stackoverflow.com/questions/15488632/php-class-exists-acting-case-sensitive).


### Detailed test instructions:

-   Disable marketing suggestions
- Set country to `US`, or another that is covered by the current default gateways
-   Go to remote payment screen and ensure that defaults are displayed as expected
