### PR TITLE
Bump package versions for release

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.1.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.5.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.6.0"
 	}
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 7.0.0
 
 -   Fix style regression with the Chart header. #7002
 -   Fix styling of the advanced filter operator selection. #7005

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Deprecate the Count component, with plan to remove in next major version. #7115
 -   Remove the long deprecated Card component (use Card from `@wordpress/components` instead). #7114
 -   Add `<AbbreviatedCard />` component. #7017
+-   Remove support for IE11. #7112
 
 # 6.2.0
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "6.2.0",
+	"version": "7.0.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 1.3.1
 
--	Fix, state md5 as npm dependency. #7087
+-   Fix, state md5 as npm dependency. #7087
 
 # 1.3.0
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.6.0
 
 -   Add new `bundledPackages` option to bundle in specific packages.
 

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,9 +1,10 @@
-# Unreleased
+# 1.3.0
 
 -   Remove the use of Dashicons and replace with @wordpress/icons or gridicons #7020
 -   Add expanded item text and CTA button. #6956
 -   Add inbox note components (InboxNoteCard, InboxNotePlaceholder, and InboxDismissConfirmationModal). #7006
 -   Add transition animation to expanding TaskItems.
+-   Add tree shaking support to this package.
 
 # 1.2.0
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
@@ -20,6 +20,10 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": [
+		"build-style/**",
+		"src/**/*.scss"
+	],
 	"dependencies": {
 		"@babel/runtime": "7.14.0",
 		"@woocommerce/components": "file:../components",

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
 
-## Unreleased
+## 3.0.0 (2021-06-03)
 
 ## Breaking changes
 
@@ -10,13 +10,13 @@
 
 ### Breaking Change
 
-- A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
+-   A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
 
 ## 1.5.0 (2019-06-12)
 
 ### New Features
 
-- Support a new `snackbar` notice type in the `createNotice` action.
+-   Support a new `snackbar` notice type in the `createNotice` action.
 
 ## 1.1.2 (2019-01-03)
 
@@ -26,11 +26,11 @@
 
 ### New Feature
 
-- New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
+-   New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
 
 ### Bug Fixes
 
-- While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
+-   While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
 
 ## 1.0.5 (2018-11-15)
 
@@ -44,4 +44,4 @@
 
 ## 1.0.0 (2018-10-29)
 
-- Initial release.
+-   Initial release.

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/notices",
-	"version": "2.11.0",
+	"version": "3.0.0",
 	"description": "State management for notices.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+-   Initial package


### PR DESCRIPTION
Bump versions in packages that had unreleased changes.
I also added `sideEffects` to the experimental library to allow for tree shaking (by default).

No changelog necessary.

## Test instructions

Read through the changes, make sure they make sense