### PR TITLE
Add Square as default fallback gateway

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add a data store for WC Payments REST APIs #6918
 - Add: Progressive setup checklist copy and call to action buttons. #6956
 - Add: Add Paystack as fallback gateway #7025
+- Add: Add Square as default fallback gateway #7107
 - Add: Add COD method to default payment gateway recommendations #7057
 - Add: Add BACS as default fallback payment gateway #7073
 - Add: A/B test of progressive checklist features. #7089

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -167,6 +167,28 @@ class DefaultPaymentGateways {
 					self::get_rules_for_cbd( false ),
 				),
 			),
+			array(
+				'key'        => 'woocommerce_square_credit_card',
+				'title'      => __( 'Square', 'woocommerce-admin' ),
+				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/square-black.png',
+				'plugins'    => array( 'woocommerce-square' ),
+				'is_visible' => array(
+					(object) array(
+						'type'     => 'or',
+						'operands' => (object) array(
+							array(
+								self::get_rules_for_countries( array( 'US' ) ),
+								self::get_rules_for_cbd( true ),
+							),
+							array(
+								self::get_rules_for_countries( array( 'US', 'CA', 'JP', 'GB', 'AU', 'IE' ) ),
+								self::get_rules_for_selling_venues( array( 'brick-mortar', 'brick-mortar-other' ) ),
+							),
+						),
+					),
+				),
+			),
 		);
 	}
 
@@ -196,6 +218,38 @@ class DefaultPaymentGateways {
 				'type'      => 'base_location_country',
 				'value'     => $country,
 				'operation' => '=',
+			);
+		}
+
+		return (object) array(
+			'type'     => 'or',
+			'operands' => $rules,
+		);
+	}
+
+	/**
+	 * Get rules that match the store's selling venues.
+	 *
+	 * @param array $selling_venues Array of venues to match.
+	 * @return object Rules to match.
+	 */
+	public static function get_rules_for_selling_venues( $selling_venues ) {
+		$rules = array();
+
+		foreach ( $selling_venues as $venue ) {
+			$rules[] = (object) array(
+				'type'         => 'option',
+				'transformers' => array(
+					(object) array(
+						'use'       => 'dot_notation',
+						'arguments' => (object) array(
+							'path' => 'selling_venues',
+						),
+					),
+				),
+				'option_name'  => 'woocommerce_onboarding_profile',
+				'operation'    => '=',
+				'value'        => $venue,
 			);
 		}
 

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -168,7 +168,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'woocommerce_square_credit_card',
+				'key'        => 'square_credit_card',
 				'title'      => __( 'Square', 'woocommerce-admin' ),
 				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/square-black.png',


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32258 

Adds Square as a default gateway.

### Screenshots

<img width="700" alt="Screen Shot 2021-06-02 at 4 49 01 PM" src="https://user-images.githubusercontent.com/10561050/120551035-9887ae80-c3c3-11eb-9818-ef297debc629.png">


### Detailed test instructions:

1. Check out this Square PR and make sure to clone to `woocommerce-square` in your plugins directory - https://github.com/woocommerce/woocommerce-square/pull/627
1. Set store to either a) `US` with CBD selected as an industry or b) one of `'US', 'CA', 'JP', 'GB', 'AU', 'IE'` with physical store selected as selling venue during the business details step of the profile wizard.
2. Go to the Square setup in the payments task screen.
3. Check to see if the Connect URL and button works as expected.