### PR TITLE
Add eWAY as default fallback gateway

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add Mercado Pago as default fallback payment gateway #7043
 - Add: Add in Razorpay as default fallback payment gateway #7096
 - Add: Get post install scripts from gateway and enqueue in client #6967
+- Add: Add eWAY as default fallback gateway #7108
 - Add: Free extension list powered by remote config #6952
 - Add: Add PayPal to fallback payment gateways #7001
 - Add: Add a data store for WC Payments REST APIs #6918

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -154,7 +154,17 @@ class DefaultPaymentGateways {
 						'operation' => '!=',
 					),
 					self::get_rules_for_cbd( false ),
-
+				),
+			),
+			array(
+				'key'        => 'eway',
+				'title'      => __( 'eWAY', 'woocommerce-admin' ),
+				'content'    => __( 'The eWAY extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/eway-logo.jpg',
+				'plugins'    => array( 'woocommerce-gateway-eway' ),
+				'is_visible' => array(
+					self::get_rules_for_countries( array( 'AU', 'NZ' ) ),
+					self::get_rules_for_cbd( false ),
 				),
 			),
 		);

--- a/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
+++ b/src/Features/RemotePaymentMethods/DefaultPaymentGateways.php
@@ -157,7 +157,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'eway',
+				'key'        => 'eway_payments',
 				'title'      => __( 'eWAY', 'woocommerce-admin' ),
 				'content'    => __( 'The eWAY extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/eway-logo.jpg',


### PR DESCRIPTION
Fixes (part of) woocommerce/woocommerce#32258

Adds eWay as a fallback gateway.

### Screenshots

<img width="707" alt="Screen Shot 2021-06-02 at 6 09 57 PM" src="https://user-images.githubusercontent.com/10561050/120558800-0042f700-c3ce-11eb-977c-63f4baf0aa4a.png">


### Detailed test instructions:

1. Set your store to either AU or NZ and don't select CBD as an industry during onboarding.
2. Check out this branch of eway and clone into the folder `woocommerce-gateway-eway`. https://github.com/webaware/eway-payment-gateway/pull/2
3. Visit the eway payments task.
4. Fill out credentials and make sure that the gateway is marked as configured and settings persist.