### PR TITLE
Include onboarding settings on the analytic pages

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -64,6 +64,13 @@
 
 1. Install and activate Jetpack
 2. Confirm Jetpack in not show in Free features list
+### Include onboarding settings on the analytic pages #7109
+
+1. Finish the onboarding wizard as usual.
+2. Navigate to one of the analytic pages then refresh the page.
+3. Navigate to WooCommerce -> Home and start OBW again.
+4. Click the continue button.
+5. OBW should continue without an error.
 
 ### Set target to blank for the external links #6999
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Unreleased ==
 
 - Fix: WCPay not working in local payments task #7151
-
+- Fix: Include onboarding settings on the analytic pages #7109
 == 2.4.0 6/10/2021 ==
 - Dev: Reduce the specificity and complexity of the ReportError component #6846
 - Add: Create onboarding package to house refactored WCPay card and relevant components #7058

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,15 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: WCPay not working in local payments task #7151
 
 == 2.4.0 6/10/2021 ==
+- Dev: Reduce the specificity and complexity of the ReportError component #6846
+- Add: Create onboarding package to house refactored WCPay card and relevant components #7058
+- Fix: Preventing redundant notices when installing plugins via payments task list. #7026
+- Fix: Autocompleter for custom Search in CompareFilter #6911
+- Fix: Include onboarding settings on the analytic pages #7109
+- Dev: Converting <SettingsForm /> component to TypeScript. #6981
+- Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
+- Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
+- Fix: Set autoload to false for all remote inbox notifications options. #7060
 - Add: Consume remote payment methods on frontend #6867
 - Add: Extend payment gateways REST endpoint #6919
 - Add: Add remote payment gateway recommendations initial docs #6962

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -626,7 +626,7 @@ class Onboarding {
 	}
 
 	/**
-	 * Determine if the current page is home or setup wizard.
+	 * Determine if the current page is one of the WC Admin pages.
 	 *
 	 * @return bool
 	 */

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -631,28 +631,12 @@ class Onboarding {
 	 * @return bool
 	 */
 	protected function is_wc_pages() {
-		$allowed_paths = array(
-			'wc-admin',
-			'wc-admin&path=/setup-wizard',
-			'wc-admin&path=/analytics/overview',
-			'wc-admin&path=/analytics/products',
-			'wc-admin&path=/analytics/revenue',
-			'wc-admin&path=/analytics/orders',
-			'wc-admin&path=/analytics/variations',
-			'wc-admin&path=/analytics/categories',
-			'wc-admin&path=/analytics/coupons',
-			'wc-admin&path=/analytics/taxes',
-			'wc-admin&path=/analytics/downloads',
-			'wc-admin&path=/analytics/stock',
-			'wc-admin&path=/analytics/settings',
-			'wc-admin&path=/marketing',
-		);
-		$current_page  = PageController::get_instance()->get_current_page();
+		$current_page = PageController::get_instance()->get_current_page();
 		if ( ! $current_page || ! isset( $current_page['path'] ) ) {
 			return false;
 		}
 
-		return in_array( $current_page['path'], $allowed_paths, true );
+		return 0 === strpos( $current_page['path'], 'wc-admin' );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -630,8 +630,23 @@ class Onboarding {
 	 *
 	 * @return bool
 	 */
-	protected function is_home_or_setup_wizard_page() {
-		$allowed_paths = array( 'wc-admin', 'wc-admin&path=/setup-wizard' );
+	protected function is_wc_pages() {
+		$allowed_paths = array(
+			'wc-admin',
+			'wc-admin&path=/setup-wizard',
+			'wc-admin&path=/analytics/overview',
+			'wc-admin&path=/analytics/products',
+			'wc-admin&path=/analytics/revenue',
+			'wc-admin&path=/analytics/orders',
+			'wc-admin&path=/analytics/variations',
+			'wc-admin&path=/analytics/categories',
+			'wc-admin&path=/analytics/coupons',
+			'wc-admin&path=/analytics/taxes',
+			'wc-admin&path=/analytics/downloads',
+			'wc-admin&path=/analytics/stock',
+			'wc-admin&path=/analytics/settings',
+			'wc-admin&path=/marketing',
+		);
 		$current_page  = PageController::get_instance()->get_current_page();
 		if ( ! $current_page || ! isset( $current_page['path'] ) ) {
 			return false;
@@ -658,7 +673,7 @@ class Onboarding {
 		if (
 			( ! self::should_show_profiler() && ! self::should_show_tasks()
 			||
-			! $this->is_home_or_setup_wizard_page()
+			! $this->is_wc_pages()
 		)
 		) {
 			return $settings;


### PR DESCRIPTION
Fixes #7081 

The underlying cause for the issue is that we don't add onboarding settings to JS `wcSettings` on the analytic pages. This PR adds JS onboarding settings on the analytics pages.


### Detailed test instructions:

1. Finish the onboarding wizard as usual.
2. Navigate to one of the analytic pages then refresh the page.
3. Navigate to WooCommerce -> Home and start OBW again.
4. Click the continue button.
5. OBW should continue without an error.