### PR TITLE
Add target to the button to open it in a new tab

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Add target to the button to open it in a new tab #7110
+
+1. Navigate to WooCommerce -> Settings -> Payments
+2. Wait a few seconds until the Recommended ways to get paid section appears.
+3. Click on the See more options button.
+4. A new tab/window should open.
+
 ### Set target to blank for the external links #6999
 
 1. Clone this repository.

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -217,7 +217,7 @@ const PaymentRecommendations: React.FC = () => {
 				<List items={ pluginsList } />
 			</CardBody>
 			<CardFooter>
-				<Button href={ SEE_MORE_LINK } isTertiary>
+				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
 					{ __( 'See more options', 'woocommerce-admin' ) }
 					<ExternalIcon size={ 18 } />
 				</Button>

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Create onboarding package to house refactored WCPay card and relevant components #7058
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026
 - Fix: Autocompleter for custom Search in CompareFilter #6911
+- Fix: Add target to the button to open it in a new tab  #7110
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981
 - Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884


### PR DESCRIPTION
Fixes #7105 

This PR adds `target=_blank` to the button to open it in a new window/tab.

### Detailed test instructions:

1. Navigate to WooCommerce -> Settings -> Payments
2. Wait a few seconds until the `Recommended ways to get paid` section appears.
3. Click on the `See more options` button.
4. A new tab/window should open.
