### PR TITLE
Add loading placeholders for payment gateways task

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -111,12 +111,16 @@ export const Layout = ( {
 	};
 
 	const renderTaskList = () => {
-		if ( requestingTaskList ) {
+		const isSingleTask = Boolean( query.task );
+
+		if ( requestingTaskList && ! isSingleTask ) {
 			return <TaskListPlaceholder />;
 		}
 
 		return (
-			<Suspense fallback={ <TaskListPlaceholder /> }>
+			<Suspense
+				fallback={ isSingleTask ? null : <TaskListPlaceholder /> }
+			>
 				<TaskList query={ query } userPreferences={ userPrefs } />
 			</Suspense>
 		);

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -229,6 +229,7 @@
 	}
 }
 
+// @todo This can be migrated into the PaymentMethod component once the remote payment feature is enabled.
 .woocommerce-task-payment-method {
 	> h3 {
 		margin: 0;

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethod.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethod.js
@@ -21,7 +21,8 @@ import { useSlot } from '@woocommerce/experimental';
  * Internal dependencies
  */
 import { createNoticesFromResponse } from '~/lib/notices';
-import { PaymentConnect } from './PaymentConnect';
+import { PaymentConnect } from '../PaymentConnect';
+import './PaymentMethod.scss';
 
 export const PaymentMethod = ( {
 	markConfigured,

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethod.scss
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethod.scss
@@ -1,0 +1,19 @@
+.woocommerce-task-payment-method.is-loading {
+	.woocommerce-stepper__step-label {
+		@include placeholder();
+		display: inline-block;
+		width: 60%;
+	}
+
+	.woocommerce-stepper__step-icon {
+		@include placeholder();
+	}
+
+	.woocommerce-stepper__step:nth-child(1) .woocommerce-stepper__step-label {
+		width: 30%;
+	}
+
+	.woocommerce-stepper__step-number {
+		display: none;
+	}
+}

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethodPlaceholder.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/PaymentMethodPlaceholder.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Card, CardBody } from '@wordpress/components';
+import { Stepper } from '@woocommerce/components';
+
+export const PaymentMethodPlaceholder = () => {
+	const classes = classnames(
+		'is-loading',
+		'woocommerce-task-payment-method',
+		'woocommerce-task-card'
+	);
+
+	return (
+		<Card aria-hidden="true" className={ classes }>
+			<CardBody>
+				<Stepper
+					isVertical
+					currentStep={ 'none' }
+					steps={ [
+						{
+							key: 'first',
+							label: '',
+						},
+						{
+							key: 'second',
+							label: '',
+						},
+					] }
+				/>
+			</CardBody>
+		</Card>
+	);
+};

--- a/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/index.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/PaymentMethod/index.js
@@ -1,0 +1,2 @@
+export { PaymentMethod } from './PaymentMethod';
+export { PaymentMethodPlaceholder } from './PaymentMethodPlaceholder';

--- a/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayList.scss
+++ b/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayList.scss
@@ -10,10 +10,22 @@
 		flex-shrink: 0;
 
 		img,
-		svg {
+		svg,
+		.is-placeholder {
 			margin: auto;
 			max-width: 100px;
 			display: block;
+		}
+
+		.is-placeholder {
+			height: 36px;
+		}
+	}
+
+	.woocommerce-task-payment__footer {
+		.is-placeholder {
+			width: 70px;
+			height: 36px;
 		}
 	}
 
@@ -77,5 +89,14 @@
 			order: 2;
 			text-align: right;
 		}
+	}
+}
+
+.woocommerce-recommended-payment-gateway-list-placeholder {
+	.is-placeholder {
+		@include placeholder();
+		display: inline-block;
+		max-width: 240px;
+		width: 80%;
 	}
 }

--- a/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayListPlaceholder.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayListPlaceholder.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Fragment } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	CardMedia,
+	CardDivider,
+} from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
+
+const PlaceholderItem = () => {
+	const classes = classnames(
+		'woocommerce-task-payment',
+		'woocommerce-task-card'
+	);
+
+	return (
+		<Fragment>
+			<CardBody
+				style={ { paddingLeft: 0, marginBottom: 0 } }
+				className={ classes }
+			>
+				<CardMedia isBorderless>
+					<span className="is-placeholder" />
+				</CardMedia>
+				<div className="woocommerce-task-payment__description">
+					<Text as="h3" className="woocommerce-task-payment__title">
+						<span className="is-placeholder" />
+					</Text>
+					<div className="woocommerce-task-payment__content">
+						<span className="is-placeholder" />
+					</div>
+				</div>
+				<div className="woocommerce-task-payment__footer">
+					<span className="is-placeholder" />
+				</div>
+			</CardBody>
+			<CardDivider />
+		</Fragment>
+	);
+};
+
+export const RecommendedPaymentGatewayListPlaceholder = () => {
+	const classes =
+		'is-loading woocommerce-recommended-payment-gateway-list-placeholder';
+
+	return (
+		<Card aria-hidden="true" className={ classes }>
+			<CardHeader as="h2">
+				<span className="is-placeholder" />
+			</CardHeader>
+			<PlaceholderItem />
+			<PlaceholderItem />
+			<PlaceholderItem />
+		</Card>
+	);
+};

--- a/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/index.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/index.js
@@ -1,1 +1,2 @@
 export { RecommendedPaymentGatewayList } from './RecommendedPaymentGatewayList';
+export { RecommendedPaymentGatewayListPlaceholder } from './RecommendedPaymentGatewayListPlaceholder';

--- a/client/task-list/tasks/payments/RemotePayments/index.js
+++ b/client/task-list/tasks/payments/RemotePayments/index.js
@@ -15,7 +15,10 @@ import { useMemo, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { RecommendedPaymentGatewayList } from './components/RecommendedPaymentGatewayList';
+import {
+	RecommendedPaymentGatewayList,
+	RecommendedPaymentGatewayListPlaceholder,
+} from './components/RecommendedPaymentGatewayList';
 import { PaymentMethod } from './components/PaymentMethod';
 import { WCPayMethodCard } from '../components/WCPayMethodCard';
 import './components/BacsPaymentGatewaySetup';
@@ -165,6 +168,10 @@ export const RemotePayments = ( { query } ) => {
 
 	return (
 		<div className="woocommerce-task-payments">
+			{ ! paymentGatewayRecommendations.size && (
+				<RecommendedPaymentGatewayListPlaceholder />
+			) }
+
 			{ !! wcPayGateway && (
 				<WCPayMethodCard
 					isEnabled={

--- a/client/task-list/tasks/payments/RemotePayments/index.js
+++ b/client/task-list/tasks/payments/RemotePayments/index.js
@@ -19,7 +19,10 @@ import {
 	RecommendedPaymentGatewayList,
 	RecommendedPaymentGatewayListPlaceholder,
 } from './components/RecommendedPaymentGatewayList';
-import { PaymentMethod } from './components/PaymentMethod';
+import {
+	PaymentMethod,
+	PaymentMethodPlaceholder,
+} from './components/PaymentMethod';
 import { WCPayMethodCard } from '../components/WCPayMethodCard';
 import './components/BacsPaymentGatewaySetup';
 
@@ -145,6 +148,10 @@ export const RemotePayments = ( { query } ) => {
 
 		return gateway;
 	}, [ isResolving, query, paymentGatewayRecommendations ] );
+
+	if ( query.method && ! currentPaymentGateway ) {
+		return <PaymentMethodPlaceholder />;
+	}
 
 	if ( currentPaymentGateway ) {
 		return (

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Consume remote payment methods on frontend #6867
 - Add: Extend payment gateways REST endpoint #6919
 - Add: Add remote payment gateway recommendations initial docs #6962
+- Add: Add loading placeholders for payment gateways task #7123
 - Add: Note date range logic for GivingFeedback, and InsightFirstSale note. #6969
 - Add: Add transient notices feature #6809
 - Add: Add transformers in remote inbox notifications #6948


### PR DESCRIPTION
Fixes #7119

Adds in loading placeholders for the gateway suggestions list and gateway task.

### Screenshots

<img width="699" alt="Screen Shot 2021-06-03 at 1 07 26 PM" src="https://user-images.githubusercontent.com/10561050/120686464-fb824f80-c46e-11eb-9193-015199c64478.png">
<img width="695" alt="Screen Shot 2021-06-03 at 11 48 49 AM" src="https://user-images.githubusercontent.com/10561050/120686465-fc1ae600-c46e-11eb-8e50-b3b2c396e4a9.png">


### Detailed test instructions:

1. Start on the task list.
2. Visit the payments task.
3. Note the placeholder on load.
4. Refresh the page and make sure loading works as expected.
5. Navigate to an individual payment gateway task and refresh.
6. Note the placeholder on load.