### PR TITLE
Optimize payment gateway resolution

### DIFF
--- a/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayList.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayList.js
@@ -12,6 +12,7 @@ import './RecommendedPaymentGatewayList.scss';
 
 export const RecommendedPaymentGatewayList = ( {
 	heading,
+	installedPaymentGateways,
 	recommendedPaymentGateway,
 	recommendedPaymentGateways,
 	markConfigured,
@@ -28,6 +29,9 @@ export const RecommendedPaymentGatewayList = ( {
 							markConfigured={ markConfigured }
 							paymentGateway={ paymentGateway }
 							isRecommended={ recommendedPaymentGateway === key }
+							installedPaymentGateways={
+								installedPaymentGateways
+							}
 							recommendedPaymentGatewayKeys={ recommendedPaymentGateways.keys() }
 						/>
 					);

--- a/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayListItem.js
+++ b/client/task-list/tasks/payments/RemotePayments/components/RecommendedPaymentGatewayList/RecommendedPaymentGatewayListItem.js
@@ -4,11 +4,9 @@
 import classnames from 'classnames';
 import { Fragment } from '@wordpress/element';
 import { CardBody, CardMedia, CardDivider } from '@wordpress/components';
-import { PAYMENT_GATEWAYS_STORE_NAME } from '@woocommerce/data';
 import { RecommendedRibbon, SetupRequired } from '@woocommerce/onboarding';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text, useSlot } from '@woocommerce/experimental';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,6 +16,7 @@ import { PaymentAction } from '../../../components/PaymentAction';
 import './RecommendedPaymentGatewayList.scss';
 
 export const RecommendedPaymentGatewayListItem = ( {
+	installedPaymentGateways,
 	isRecommended,
 	paymentGateway,
 	markConfigured,
@@ -34,17 +33,13 @@ export const RecommendedPaymentGatewayListItem = ( {
 
 	const slot = useSlot( `woocommerce_remote_payment_${ key }` );
 
-	const installedPaymentGateway = useSelect( ( select ) => {
-		return (
-			select( PAYMENT_GATEWAYS_STORE_NAME ).getPaymentGateway( key ) || {}
-		);
-	} );
+	const installedPaymentGateway = installedPaymentGateways[ key ] || {};
 
 	const {
 		enabled: isEnabled = false,
 		needs_setup: needsSetup = false,
 		required_settings_keys: requiredSettingsKeys = [],
-		settings_url: manageUrl,
+		settings_url: manageUrl = null,
 	} = installedPaymentGateway;
 
 	const isConfigured = ! needsSetup;

--- a/client/task-list/tasks/payments/RemotePayments/index.js
+++ b/client/task-list/tasks/payments/RemotePayments/index.js
@@ -202,6 +202,7 @@ export const RemotePayments = ( { query } ) => {
 						'Enabled payment methods',
 						'woocommerce-admin'
 					) }
+					installedPaymentGateways={ installedPaymentGateways }
 					recommendedPaymentGateway={ recommendedPaymentGateway }
 					recommendedPaymentGateways={
 						enabledPaymentGatewayRecommendations
@@ -215,6 +216,7 @@ export const RemotePayments = ( { query } ) => {
 						'Additional payment methods',
 						'woocommerce-admin'
 					) }
+					installedPaymentGateways={ installedPaymentGateways }
 					recommendedPaymentGateways={
 						additionalPaymentGatewayRecommendations
 					}

--- a/packages/data/src/payment-gateways/resolvers.ts
+++ b/packages/data/src/payment-gateways/resolvers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import {
 	getPaymentGatewaysRequest,
 } from './actions';
 
-import { API_NAMESPACE } from './constants';
+import { API_NAMESPACE, STORE_KEY } from './constants';
 import { PaymentGateway } from './types';
 
 export function* getPaymentGateways() {
@@ -26,6 +27,14 @@ export function* getPaymentGateways() {
 			path: API_NAMESPACE + '/payment_gateways',
 		} );
 		yield getPaymentGatewaysSuccess( response );
+		for ( let i = 0; i < response.length; i++ ) {
+			yield controls.dispatch(
+				STORE_KEY,
+				'finishResolution',
+				'getPaymentGateway',
+				[ response[ i ].id ]
+			);
+		}
 	} catch ( e ) {
 		yield getPaymentGatewaysError( e );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -141,6 +141,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849
+- Update: Optimize payment gateway resolution #7124
 - Update: Experimental task list import to the experimental package. #6950
 - Update: Redirect to WC Home after setting up a payment method #6891
 - Dev: Remove react-docgen docs in favor of Storybook #7055


### PR DESCRIPTION
Fixes #7120 

* Fixes premature fetching of gateways before installation
* Resolves individual gateways if a request is made to fetch all gateways

### Detailed test instructions:

1. Make sure some payment gateways are not installed and open your Network tab.
2. Visit the payments task.
3. Make sure 404s do not occur.
4. Make sure individual payment gateway requests are not made yet.
5. Click into an installed gateway and note that no additional request is made.
6. Go to a new payment gateway that requires install.
7. Note that the gateway is fetched after install.