### PR TITLE
Fix some minor inbox panel issues, left over from re-factor

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -240,6 +240,8 @@ const InboxPanel = () => {
 				);
 				setDismiss( undefined );
 			}
+		} else {
+			setDismiss( undefined );
 		}
 	};
 

--- a/packages/experimental/src/inbox-note/action.tsx
+++ b/packages/experimental/src/inbox-note/action.tsx
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 
 type InboxNoteActionProps = {
 	onClick: () => void;
@@ -29,7 +28,15 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 		const targetHref = event.currentTarget.href || '';
 		let isActionable = true;
 
-		if ( targetHref.length && ! targetHref.startsWith( adminUrl ) ) {
+		let adminUrl = '';
+		if ( window.wcSettings ) {
+			adminUrl = window.wcSettings.adminUrl;
+		}
+
+		if (
+			targetHref.length &&
+			( ! adminUrl || ! targetHref.startsWith( adminUrl ) )
+		) {
 			event.preventDefault();
 			isActionable = false; // link buttons shouldn't be "busy".
 			window.open( targetHref, '_blank' );

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -107,8 +107,8 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		let isClickOutsideDropdown = false;
 		if ( relatedTarget && 'className' in relatedTarget ) {
 			const classNames = relatedTarget.className;
-			isClickOutsideDropdown = dropdownClasses.some( ( className ) =>
-				classNames.includes( className )
+			isClickOutsideDropdown = dropdownClasses.some( ( cName ) =>
+				classNames.includes( cName )
 			);
 		}
 		if ( isClickOutsideDropdown ) {
@@ -246,9 +246,14 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead;
 	const date = dateCreated;
 	const hasImage = layout !== 'plain' && layout !== '';
-	const cardClassName = classnames( 'woocommerce-inbox-message', className, layout, {
-		'message-is-unread': unread && status === 'unactioned',
-	} );
+	const cardClassName = classnames(
+		'woocommerce-inbox-message',
+		className,
+		layout,
+		{
+			'message-is-unread': unread && status === 'unactioned',
+		}
+	);
 
 	return (
 		<VisibilitySensor onChange={ onVisible }>

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -55,6 +55,7 @@ type InboxNoteProps = {
 	onNoteActionClick?: ( note: InboxNote, action: InboxNoteAction ) => void;
 	onBodyLinkClick?: ( note: InboxNote, link: string ) => void;
 	onNoteVisible?: ( note: InboxNote ) => void;
+	className?: string;
 };
 
 const DropdownWithPopoverProps = Dropdown as React.ComponentType<
@@ -68,6 +69,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 	onNoteActionClick,
 	onBodyLinkClick,
 	onNoteVisible,
+	className,
 } ) => {
 	const [ clickedActionText, setClickedActionText ] = useState( false );
 	const hasBeenSeen = useRef( false );
@@ -244,7 +246,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead;
 	const date = dateCreated;
 	const hasImage = layout !== 'plain' && layout !== '';
-	const cardClassName = classnames( 'woocommerce-inbox-message', layout, {
+	const cardClassName = classnames( 'woocommerce-inbox-message', className, layout, {
 		'message-is-unread': unread && status === 'unactioned',
 	} );
 

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -2,6 +2,7 @@ declare global {
 	interface Window {
 		wcSettings: {
 			preloadOptions: Record< string, unknown >;
+			adminUrl: string;
 		};
 	}
 }


### PR DESCRIPTION
Fix some minor inbox panel issues, left over from re-factor (#7006)

### Detailed test instructions:

- Navigate to **WooCommerce > Home**
- Scroll down and click **Dismiss** on one of the notes and **Dismiss this message**
- Click cancel when the modal pops up (the modal should dissapear)
- Now click on one of the actions that re-directs to another page within `wp-admin`. Like the new navigation nudge (Enable in settings button), it should redirect correctly and not load a new tab.

No changelog as it is just some small clean up from a previous PR