### PR TITLE
Add unit tests around extended payment gateway controller

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,10 +75,11 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Add: SlotFill to Abbreviated Notification panel #7091
+- Add: Add unit tests around extended payment gateway controller #7133
 - Fix: WCPay not working in local payments task #7151
 - Fix: Include onboarding settings on the analytic pages #7109
 - Tweak: Revert Card component removal #7167
-- Add: SlotFill to Abbreviated Notification panel #7091
 
 == 2.4.0 6/10/2021 ==
 - Dev: Reduce the specificity and complexity of the ReportError component #6846

--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -35,18 +35,18 @@ class PaymentGatewaysController {
 		$data['post_install_scripts'] = self::get_post_install_scripts( $gateway );
 		$data['settings_url']         = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
-		if ( method_exists( $gateway, 'get_connection_url' ) ) {
-			$return_url             = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
-			$data['connection_url'] = $gateway->get_connection_url( $return_url );
-		}
+		$return_url             = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
+		$data['connection_url'] = method_exists( $gateway, 'get_connection_url' )
+			? $gateway->get_connection_url( $return_url )
+			: null;
 
-		if ( method_exists( $gateway, 'get_setup_help_text' ) ) {
-			$data['setup_help_text'] = $gateway->get_setup_help_text();
-		}
+		$data['setup_help_text'] = method_exists( $gateway, 'get_setup_help_text' )
+			? $gateway->get_setup_help_text()
+			: null;
 
-		if ( method_exists( $gateway, 'get_required_settings_keys' ) ) {
-			$data['required_settings_keys'] = $gateway->get_required_settings_keys();
-		}
+		$data['required_settings_keys'] = method_exists( $gateway, 'get_required_settings_keys' )
+			? $gateway->get_required_settings_keys()
+			: array();
 
 		$response->set_data( $data );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -126,7 +126,7 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-session-handler.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-wc-data.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-wc-object-query.php';
-		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-payment-gateway.php';
+		require_once $this->tests_dir . '/framework/class-wc-mock-payment-gateway.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-payment-token-stub.php';
 		require_once $wc_tests_framework_base_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -126,7 +126,8 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-session-handler.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-wc-data.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-wc-object-query.php';
-		require_once $this->tests_dir . '/framework/class-wc-mock-payment-gateway.php';
+		require_once $wc_tests_framework_base_dir . '/framework/class-wc-mock-payment-gateway.php';
+		require_once $this->tests_dir . '/framework/class-wc-mock-enhanced-payment-gateway.php';
 		require_once $wc_tests_framework_base_dir . '/framework/class-wc-payment-token-stub.php';
 		require_once $wc_tests_framework_base_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 

--- a/tests/features/payment-gateway-suggestions/payment-gateway-controller.php
+++ b/tests/features/payment-gateway-suggestions/payment-gateway-controller.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Test the class that extends the payment gateway REST response.
+ *
+ * @package WooCommerce\Admin\Tests\PaymentGatewaySuggestions
+ */
+
+use Automattic\WooCommerce\Admin\Features\RemotePaymentMethods\PaymentGatewaysController;
+
+/**
+ * class WC_Tests_PaymentGatewaySuggestions_PaymentGatewaysController
+ */
+class WC_Tests_PaymentGatewaySuggestions_PaymentGatewaysController extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/payment_gateways';
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
+
+		add_filter(
+			'woocommerce_payment_gateways',
+			function( $gateways ) {
+				$gateways[] = 'WC_Mock_Payment_Gateway';
+
+				return $gateways;
+			}
+		);
+		WC()->payment_gateways()->init();
+
+		$this->gateway = new WC_Mock_Payment_Gateway();
+	}
+
+	/**
+	 * Get mock gateway.
+	 */
+	public function get_mock_gateway_response() {
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/mock' );
+		$response = $this->server->dispatch( $request );
+		return $response->get_data();
+	}
+
+	/**
+	 * Tests that needs_setup is initially false.
+	 */
+	public function test_payment_gateway_needs_setup() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertFalse( $response['needs_setup'] );
+	}
+
+	/**
+	 * Tests that the gateway no longer needs setup.
+	 */
+	public function test_payment_gateway_setup() {
+		$this->gateway->update_option( 'api_key', '123' );
+		$response = $this->get_mock_gateway_response();
+		$this->assertTrue( $response['needs_setup'] );
+	}
+
+	/**
+	 * Tests the gateways post install script handles and returned script dependencies.
+	 */
+	public function test_post_install_scripts() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertCount( 1, $response['post_install_scripts'] );
+		$this->assertEquals( 'post-install-script', $response['post_install_scripts'][0]->handle );
+	}
+
+	/**
+	 * Tests the gateway's settings URL.
+	 */
+	public function test_settings_url() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertEquals(
+			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=mock' ),
+			$response['settings_url']
+		);
+	}
+
+	/**
+	 * Tests the gateway connection URL.
+	 */
+	public function test_connection_url() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertEquals(
+			'http://testconnection.com?return=' . wc_admin_url( '&task=payments&connection-return=mock' ),
+			$response['connection_url']
+		);
+	}
+
+	/**
+	 * Tests the setup help text.
+	 */
+	public function test_setup_help_text() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertEquals(
+			'Test help text.',
+			$response['setup_help_text']
+		);
+	}
+
+	/**
+	 * Tests the gateways post install script handles and returned script dependencies.
+	 */
+	public function test_required_settings_keys() {
+		$response = $this->get_mock_gateway_response();
+		$this->assertCount( 1, $response['required_settings_keys'] );
+		$this->assertEquals( 'api_key', $response['required_settings_keys'][0] );
+	}
+
+}
+

--- a/tests/features/payment-gateway-suggestions/payment-gateway-controller.php
+++ b/tests/features/payment-gateway-suggestions/payment-gateway-controller.php
@@ -35,22 +35,42 @@ class WC_Tests_PaymentGatewaySuggestions_PaymentGatewaysController extends WC_RE
 			'woocommerce_payment_gateways',
 			function( $gateways ) {
 				$gateways[] = 'WC_Mock_Payment_Gateway';
+				$gateways[] = 'WC_Mock_Enhanced_Payment_Gateway';
 
 				return $gateways;
 			}
 		);
 		WC()->payment_gateways()->init();
 
-		$this->gateway = new WC_Mock_Payment_Gateway();
+		$this->gateway = new WC_Mock_Enhanced_Payment_Gateway();
 	}
 
 	/**
 	 * Get mock gateway.
 	 */
 	public function get_mock_gateway_response() {
-		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/mock' );
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/mock-enhanced' );
 		$response = $this->server->dispatch( $request );
 		return $response->get_data();
+	}
+
+	/**
+	 * Tests a gateway that has not been enhanced with the new methods.
+	 */
+	public function test_non_enhanced_gateway() {
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/mock' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'needs_setup', $data );
+		$this->assertEquals( array(), $data['post_install_scripts'] );
+		$this->assertEquals(
+			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=mock' ),
+			$data['settings_url']
+		);
+		$this->assertEquals( null, $data['connection_url'] );
+		$this->assertEquals( null, $data['setup_help_text'] );
+		$this->assertEquals( array(), $data['required_settings_keys'] );
 	}
 
 	/**
@@ -85,7 +105,7 @@ class WC_Tests_PaymentGatewaySuggestions_PaymentGatewaysController extends WC_RE
 	public function test_settings_url() {
 		$response = $this->get_mock_gateway_response();
 		$this->assertEquals(
-			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=mock' ),
+			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=mock-enhanced' ),
 			$response['settings_url']
 		);
 	}
@@ -96,7 +116,7 @@ class WC_Tests_PaymentGatewaySuggestions_PaymentGatewaysController extends WC_RE
 	public function test_connection_url() {
 		$response = $this->get_mock_gateway_response();
 		$this->assertEquals(
-			'http://testconnection.com?return=' . wc_admin_url( '&task=payments&connection-return=mock' ),
+			'http://testconnection.com?return=' . wc_admin_url( '&task=payments&connection-return=mock-enhanced' ),
 			$response['connection_url']
 		);
 	}

--- a/tests/framework/class-wc-mock-enhanced-payment-gateway.php
+++ b/tests/framework/class-wc-mock-enhanced-payment-gateway.php
@@ -1,29 +1,23 @@
 <?php
 /**
- * Class WC_Mock_Payment_Gateway
+ * Class WC_Mock_Enhanced_Payment_Gateway
  *
  * @package WooCommerce\Admin\Tests\Framework
  */
 
 /**
- * Class WC_Mock_Payment_Gateway
+ * Class WC_Mock_Enhanced_Payment_Gateway
  */
-class WC_Mock_Payment_Gateway extends WC_Payment_Gateway {
+class WC_Mock_Enhanced_Payment_Gateway extends WC_Payment_Gateway {
 	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {
 		$this->enabled            = 'yes';
-		$this->id                 = 'mock';
+		$this->id                 = 'mock-enhanced';
 		$this->has_fields         = false;
-		$this->order_button_text  = __( 'Proceed to PayPal', 'woocommerce-admin' );
-		$this->method_title       = 'Mock Gateway';
-		$this->method_description = 'Mock Gateway for unit tests';
-		$this->pay_button_id      = 'mock-pay-button';
-		$this->supports           = array(
-			'products',
-			'pay_button',
-		);
+		$this->method_title       = 'Mock Enhanced Gateway';
+		$this->method_description = 'Mock Enhanced Gateway for unit tests';
 
 		// Load the settings.
 		$this->init_form_fields();
@@ -53,7 +47,7 @@ class WC_Mock_Payment_Gateway extends WC_Payment_Gateway {
 	 * Determine if the gateway requires further setup.
 	 */
 	public function needs_setup() {
-		$settings = get_option( 'woocommerce_mock_settings', array() );
+		$settings = get_option( 'woocommerce_mock-enhanced_settings', array() );
 		return ! empty( $settings['api_key'] );
 	}
 

--- a/tests/framework/class-wc-mock-payment-gateway.php
+++ b/tests/framework/class-wc-mock-payment-gateway.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Class WC_Mock_Payment_Gateway
+ *
+ * @package WooCommerce\Admin\Tests\Framework
+ */
+
+/**
+ * Class WC_Mock_Payment_Gateway
+ */
+class WC_Mock_Payment_Gateway extends WC_Payment_Gateway {
+	/**
+	 * Constructor for the gateway.
+	 */
+	public function __construct() {
+		$this->enabled            = 'yes';
+		$this->id                 = 'mock';
+		$this->has_fields         = false;
+		$this->order_button_text  = __( 'Proceed to PayPal', 'woocommerce-admin' );
+		$this->method_title       = 'Mock Gateway';
+		$this->method_description = 'Mock Gateway for unit tests';
+		$this->pay_button_id      = 'mock-pay-button';
+		$this->supports           = array(
+			'products',
+			'pay_button',
+		);
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => '',
+				'type'    => 'checkbox',
+				'label'   => '',
+				'default' => 'yes',
+			),
+			'api_key' => array(
+				'title'   => __( 'API Key', 'woocommerce-admin' ),
+				'type'    => 'text',
+				'default' => '',
+			),
+		);
+	}
+
+	/**
+	 * Determine if the gateway requires further setup.
+	 */
+	public function needs_setup() {
+		$settings = get_option( 'woocommerce_mock_settings', array() );
+		return ! empty( $settings['api_key'] );
+	}
+
+	/**
+	 * Get post install script handles.
+	 *
+	 * @return array
+	 */
+	public function get_post_install_script_handles() {
+		wp_register_script(
+			'post-install-script',
+			'post-install-script.js',
+			array(),
+			'1.0.0',
+			true
+		);
+
+		return array(
+			'post-install-script',
+			'unregistered-handle',
+		);
+	}
+
+	/**
+	 * Get connection URL.
+	 *
+	 * @param string $return_url Return URL.
+	 * @return string
+	 */
+	public function get_connection_url( $return_url ) {
+		return 'http://testconnection.com?return=' . $return_url;
+	}
+
+	/**
+	 * Get setup help text.
+	 *
+	 * @return string
+	 */
+	public function get_setup_help_text() {
+		return 'Test help text.';
+	}
+
+	/**
+	 * Get required settings keys.
+	 *
+	 * @return array
+	 */
+	public function get_required_settings_keys() {
+		return array( 'api_key' );
+	}
+}
+


### PR DESCRIPTION
Fixes #7122 

Adds tests around the extended properties in the payment gateway.

### Detailed test instructions:

1. Make sure tests pass and are comprehensive.