### PR TITLE
Reconsider the removal version for deprecated components

### DIFF
--- a/packages/components/src/count/index.js
+++ b/packages/components/src/count/index.js
@@ -15,7 +15,7 @@ import deprecated from '@wordpress/deprecated';
  */
 const Count = ( { count, label } ) => {
 	deprecated( 'Count', {
-		version: '7.2.0',
+		version: '8.0.0',
 		alternative: '@woocommerce/components Badge',
 		plugin: 'WooCommerce',
 		hint: 'Use `import { Badge } from "@woocommerce/components"`',

--- a/packages/components/src/gravatar/index.js
+++ b/packages/components/src/gravatar/index.js
@@ -22,7 +22,7 @@ import deprecated from '@wordpress/deprecated';
  */
 const Gravatar = ( { alt, title, size, user, className } ) => {
 	deprecated( 'Gravatar', {
-		version: '7.2.0',
+		version: '8.0.0',
 		plugin: 'WooCommerce',
 		hint:
 			'The Gravatar component will be removed in the next version of @woocommerce/components, please consider using another library to perform this function.',

--- a/packages/components/src/segmented-selection/index.js
+++ b/packages/components/src/segmented-selection/index.js
@@ -22,7 +22,7 @@ class SegmentedSelection extends Component {
 		} = this.props;
 
 		deprecated( 'SegmentedSelection', {
-			version: '7.2.0',
+			version: '8.0.0',
 			plugin: 'WooCommerce',
 			hint:
 				'The SegmentedSelection component will be removed in the next version of @woocommerce/components, please consider using another library to perform this function.',


### PR DESCRIPTION
@louwie17 Could you take a look at this? After our discussion about the new components release I still felt uncomfortable about how soon we're removing these components, especially because `@woocommerce/components` definitely does deserve a major release this time around.

This gives us one more major release to remove the components, and I suggest we try stick strictly to semver for upcoming components releases so that it gives people time to move away if these components are still used.

No changelog required