### PR TITLE
Business features uncheck creative mail by default

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -44,6 +44,13 @@
 7. Click Continue, before the page redirects click Continue again
 8. Confirm no error has been recorded in your browser console.
 
+### Business features uncheck creative mail by default #7139
+
+2. Complete the OBW until you get to the business details step.
+2. Continue setup until the Business Detail step.
+3. Open `Free Features` tab and toggle dropdown for `Add recommended business features to my site`.
+4. Observe that the list have `Creative Mail` unchecked by default.
+
 ### Fix an issue with OBW when wc-pay and Jetpack are both being installed. #6957
 
 - Complete the OBW until you get to the business details step.

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -194,6 +194,7 @@ const installableExtensionsData = [
 					),
 					'creative-mail-for-woocommerce'
 				),
+				selected: false,
 			},
 		],
 	},
@@ -311,6 +312,8 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
  * @param {string} country  Woo store country
  * @param {Array} industry List of selected industries
  * @param {Array} productTypes List of selected product types
+ *
+ * @return {Array} Array of visible plugins
  */
 const getVisiblePlugins = ( plugins, country, industry, productTypes ) => {
 	const countryCode = getCountryCode( country );
@@ -349,8 +352,8 @@ const createInitialValues = ( extensions, country, industry, productTypes ) => {
 			country,
 			industry,
 			productTypes
-		).reduce( ( pluginAcc, { key } ) => {
-			return { ...pluginAcc, [ key ]: true };
+		).reduce( ( pluginAcc, { key, selected } ) => {
+			return { ...pluginAcc, [ key ]: selected ?? true };
 		}, {} );
 
 		return {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -345,7 +345,12 @@ const transformRemoteExtensions = ( extensionData ) => {
 };
 
 const baseValues = { install_extensions: true };
-const createInitialValues = ( extensions, country, industry, productTypes ) => {
+export const createInitialValues = (
+	extensions,
+	country,
+	industry,
+	productTypes
+) => {
 	return extensions.reduce( ( acc, curr ) => {
 		const plugins = getVisiblePlugins(
 			curr.plugins,

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { filterBusinessExtensions } from '../flows/selective-bundle';
+import { createInitialValues } from '../flows/selective-bundle/selective-extensions-bundle';
 
 describe( 'BusinessDetails', () => {
 	test( 'filtering extensions', () => {
@@ -30,5 +31,42 @@ describe( 'BusinessDetails', () => {
 		const filteredExtensions = filterBusinessExtensions( extensions );
 
 		expect( filteredExtensions ).toEqual( expectedExtensions );
+	} );
+
+	describe( 'createInitialValues', () => {
+		test( 'selected by default', () => {
+			const extensions = [
+				{
+					plugins: [
+						{
+							key: 'visible-and-not-selected',
+							selected: false,
+							isVisible: () => true,
+						},
+						{
+							key: 'visible-and-selected',
+							selected: true,
+							isVisible: () => true,
+						},
+						{
+							key: 'this-should-not-show-at-all',
+							selected: true,
+							isVisible: () => false,
+						},
+					],
+				},
+			];
+
+			const values = createInitialValues( extensions, 'US', '', [] );
+
+			expect( values ).toEqual(
+				expect.objectContaining( {
+					'visible-and-not-selected': false,
+					'visible-and-selected': true,
+				} )
+			);
+
+			expect( values ).not.toContain( 'this-should-not-show-at-all' );
+		} );
 	} );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add source param support for notes query. #6979
 - Dev: Remove the use of Dashicons and replace with @wordpress/icons or gridicons. #7020
 - Dev: Refactor inbox panel components and moved to experimental package. #7006
+- Dev: Business features uncheck creative mail by default #7139
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916
 - Enhancement: Add remind me later option to task list. #6923


### PR DESCRIPTION
Fixes #7041

This PR adds the capability for free business extensions to have a default selected value and sets CreativeMail to be unselected by default.

Note that a follow-up change is required in [woocommerce.com](https://github.com/Automattic/woocommerce.com/blob/96e7a7e58249f861542baf178fb2be2836d203a5/plugins/wccom-plugins/obw-free-extensions/includes/extensions.json.php) to apply the `selected` key for RemoteFreeExtensions.

### Screenshots
![image](https://user-images.githubusercontent.com/3747241/121150717-57d1de80-c876-11eb-9546-c846f8b62732.png)

### Detailed test instructions:

1. Disable `remote-extensions-list` feature in `config/development.json`, or run `npm start --features '{"remote-extensions-list":false}'`.
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=store-details`.
2. Continue setup until the Business Detail step.
3. Open `Free Features` tab and toggle dropdown for `Add recommended business features to my site`.
4. Observe that the list have `Creative Mail` unchecked by default.
