### PR TITLE
Prepare Remote Free Extensions for release

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -9,6 +9,60 @@
 3. Click on the See more options button.
 4. A new tab/window should open.
 
+### Remote Fee Extensions List #7144
+
+1. Make sure you have Marketplace suggestions turned off `wp option set woocommerce_show_marketplace_suggestions no`
+2. Set your store to a US address
+3. Be sure to deactivate the following extensions if they are active
+
+-   WooCommerce Payments
+-   WooCommerce Services
+-   Jetpack
+-   Mailpoet
+-   Facebook for WooCommerce
+-   Google Listings and Ads
+-   Mailchimp for WooCommerce
+-   Creative Mail
+
+5. Set product types to "Physical" at `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`
+6. Set the industry to anything other than CBD at `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`
+
+#### Scenario 1: Default functionality remains
+
+1. Go to Business Details step of the OBW `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features`
+2. Click on "Free features" tab
+3. Click the dropdown "Add recommended business features to my site" to see the list of free extensions.
+4. See 9 total suggestions
+
+<img width="520" alt="Screen Shot 2021-05-28 at 12 18 57 PM" src="https://user-images.githubusercontent.com/1922453/119912118-ea3ccd00-bfae-11eb-979c-82d2cb85ed4c.png">
+
+#### Scenario 2: Default functionality remains
+
+1. Turn Marketplace Suggestions on `wp option set woocommerce_show_marketplace_suggestions yes`
+2. Repeat steps in Scenario 1 and see the same result
+
+#### Scenario 3: CBD industry
+
+1. Select CBD industry only at `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry`
+2. Visit the free features of Business Details and see that WooCommerce Payments is no longer being shown
+3. Add another industry in addition to CBD and confirm WooCommerce Payments is still not being shown
+
+#### Scenario 4: Downloads Product Type
+
+1. Set the product type to "downloads" only at `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types`
+2. Visit the free features of Business Details and see that WooCommerce Shipping is not shown
+3. Add another product type, such as "physical" and confirm WooCommerce Shipping is now being shown
+
+#### Scenario 5: Location
+
+1. Set your store location to South Africa
+2. Confirm WooCommerce Payments, WooCommerce Services Shipping, and WooCommerce Services Tax are not shown.
+
+#### Scenario 6: Extension already activated
+
+1. Install and activate Jetpack
+2. Confirm Jetpack in not show in Free features list
+
 ### Set target to blank for the external links #6999
 
 1. Clone this repository.
@@ -46,9 +100,9 @@
 
 ### Fix an issue with OBW when wc-pay and Jetpack are both being installed. #6957
 
-- Complete the OBW until you get to the business details step.
-- Deselect "Add recommended business features to my site", and select only Jetpack and WooCommerce Payments for installation.
-- The plugins should be installed and activated correctly, and you should be able to continue in the flow.
+-   Complete the OBW until you get to the business details step.
+-   Deselect "Add recommended business features to my site", and select only Jetpack and WooCommerce Payments for installation.
+-   The plugins should be installed and activated correctly, and you should be able to continue in the flow.
 
 ## 2.3.0
 
@@ -76,30 +130,30 @@
 
 ### New Google Listings & Ads extension in onboarding #6939
 
-- On a new WooCommerce site/install
-- Go through all the onboarding steps till we reach `Included business features`
-- Ensure the plugin shows up correctly with the right naming and select it as the only extension to add
-![image](https://user-images.githubusercontent.com/11388669/117138107-7be75f00-ada2-11eb-9077-c839cee2155e.png)
-- Continue and confirm the `plugins were successfully activated` notice shows up
-- Finish onboarding and confirm that the extension was actually activated
+-   On a new WooCommerce site/install
+-   Go through all the onboarding steps till we reach `Included business features`
+-   Ensure the plugin shows up correctly with the right naming and select it as the only extension to add
+    ![image](https://user-images.githubusercontent.com/11388669/117138107-7be75f00-ada2-11eb-9077-c839cee2155e.png)
+-   Continue and confirm the `plugins were successfully activated` notice shows up
+-   Finish onboarding and confirm that the extension was actually activated
 
 **New Google Listings & Ads extension support in Installed Marketing Extensions section**
 
-- View the installed marketing extensions section on the page Marketing > Overview
-- The extension should appear in the following states:
+-   View the installed marketing extensions section on the page Marketing > Overview
+-   The extension should appear in the following states:
 
 1. Extension not installed (should not be included in the list, if the list is empty this section won't show at all)
-![image](https://user-images.githubusercontent.com/11388669/117135419-d2529e80-ad9e-11eb-9752-081f00beb11c.png)
+   ![image](https://user-images.githubusercontent.com/11388669/117135419-d2529e80-ad9e-11eb-9752-081f00beb11c.png)
 
 2. Extension installed but not activated (click activate to confirm it works)
-![image](https://user-images.githubusercontent.com/11388669/117135541-fb732f00-ad9e-11eb-95f9-d3739fc715da.png)
+   ![image](https://user-images.githubusercontent.com/11388669/117135541-fb732f00-ad9e-11eb-95f9-d3739fc715da.png)
 
 3. Extension installed and activated but not setup yet (click "Finish setup" to confirm we get redirected to the get started page)
-![image](https://user-images.githubusercontent.com/11388669/117135812-602e8980-ad9f-11eb-83f8-29889cdb7202.png)
+   ![image](https://user-images.githubusercontent.com/11388669/117135812-602e8980-ad9f-11eb-83f8-29889cdb7202.png)
 
 4. Extension installed, activated and setup (click settings to confirm we get redirected to the settings page)
-![image](https://user-images.githubusercontent.com/11388669/117135999-ab489c80-ad9f-11eb-874b-5f6f5ec4ce5d.png)
-Note: The documentation link is not active yet (still in draft)
+   ![image](https://user-images.githubusercontent.com/11388669/117135999-ab489c80-ad9f-11eb-874b-5f6f5ec4ce5d.png)
+   Note: The documentation link is not active yet (still in draft)
 
 ### Add plugin installer to allow installation of plugins via URL #6805
 

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -217,9 +217,12 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 	}
 
 	const extensionsList = extensions
-		.map( ( extension ) => {
-			return pluginNames[ extension ];
-		} )
+		.reduce( ( uniqueExtensionList, extension ) => {
+			const extensionName = pluginNames[ extension ];
+			return uniqueExtensionList.includes( extensionName )
+				? uniqueExtensionList
+				: [ ...uniqueExtensionList, extensionName ];
+		}, [] )
 		.join( ', ' );
 
 	if ( isInstallingActivating ) {

--- a/config/core.json
+++ b/config/core.json
@@ -13,7 +13,7 @@
 		"navigation": false,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
-		"remote-extensions-list": false,
+		"remote-extensions-list": true,
 		"payment-gateway-suggestions": false,
 		"settings": false,
 		"shipping-label-banner": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -13,7 +13,7 @@
 		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
-		"remote-extensions-list": false,
+		"remote-extensions-list": true,
 		"payment-gateway-suggestions": false,
 		"settings": false,
 		"shipping-label-banner": true,

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916
 - Enhancement: Add remind me later option to task list. #6923
+- Enhancement: Enable Remote Free Extensions List #7144
 - Fix: Rule Processing Transformer to handle dotNotation default value #7009
 - Fix: Remove Navigation's uneeded SlotFill context #6832
 - Fix: Report filters expecting specific ordering. #6847

--- a/src/Features/RemoteFreeExtensions/DataSourcePoller.php
+++ b/src/Features/RemoteFreeExtensions/DataSourcePoller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DataSourcePoller {
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/free-extensions/1.0/extensions.json',
+		'https://woocommerce.com/wp-json/wccom/obw-free-extensions/1.0/extensions.json',
 	);
 
 	/**


### PR DESCRIPTION
Fixes (partially) https://github.com/woocommerce/woocommerce-admin/issues/7039

Prepare Remote Free Extensions for release with the following changes:

* Enable feature flags for Core and Plugin releases
* Updates the woocommerce.com config url
* Include testing instructions for the entire feature for Global Step
* Fix an existing bug where WooCommerce Services was mentioned in the included plugins list twice.

### Detailed test instructions:

1. Turn off Marketplace Suggestions `wp option set woocommerce_show_marketplace_suggestions no`
2. Deactivate WooCommerce Services if you have it installed and activated.
2. Go to Business Details step of the OBW `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features`
3. Click on "Free features" tab
4. See the "WooCommerce Shipping & Tax" string only once in the help text. Screenshot below is from `main` branch which contains the string twice.

<img width="498" alt="Screen Shot 2021-06-09 at 12 53 40 PM" src="https://user-images.githubusercontent.com/1922453/121279844-56adb980-c929-11eb-8271-284fa6431e72.png">

5. Turn on Marketplace Suggestions `wp option set woocommerce_show_marketplace_suggestions yes`
6. If you've reviewed this type of thing previously, you'll need to clear the transient `wp transient delete woocommerce_admin_remote_free_extensions_specs`
6. Refresh the Business Features step page and click "Free features" tab
7. See the `free-extensions` endpoint being queried in the Network tab without error
8. Confirm a list of free extensions are being suggested. The list items will depend on how your install is configured based on country, activated plugins, industry, and product type. If you are curious, see https://github.com/Automattic/woocommerce.com/pull/10380 for a full list of scenarios and outcomes.
9. Note the help text has an empty string for "WooCommerce Shipping & Tax". This is due to a typo in the config and will be fixed by https://github.com/Automattic/woocommerce.com/pull/10474



