### PR TITLE
Fix error handling when remote free extension API returns empty array

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -411,6 +411,11 @@ export const SelectiveExtensionsBundle = ( {
 				path: '/wc-admin/onboarding/free-extensions',
 			} )
 				.then( ( results ) => {
+					if ( ! results?.length ) {
+						// Assuming empty array or null results is err.
+						setLocalInstallableExtensions();
+						return;
+					}
 					const transformedExtensions = transformRemoteExtensions(
 						results
 					);

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Bug with Orders Report coupon exclusion filter. #7021
 - Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
 - Fix: Notices not dissapearing. #7077
+- Fix: Fix error handling when remote free extension API returns empty array. #7147
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/7138

RemoteFreeExtension API `/wp-json/wc-admin/onboarding/free-extensions?_locale=user` will return empty array if the datasource failed to fetch. This PR will assume an empty response as error in fetching datasource, and in return will render the fallback extension list instead.

### Detailed test instructions:

1. In your local, edit the line [here](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/RemoteFreeExtensions/DataSourcePoller.php#L16) to a valid URL with a domain that doesn't exist.
2. Delete the transient `woocommerce_admin_remote_free_extensions_specs` if it exists.
3. Optionally, open up the network tab in your browser console and wait for a request to the mentioned API.
3. Try to load the list of free extensions in the Business Details step.
4. Observe that the list still loads despite having returned empty array.
