### PR TITLE
Wraps the dropdown icon in a button to allow keyboard usability

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -485,9 +485,8 @@ export const SelectiveExtensionsBundle = ( {
 								'Add recommended business features to my site'
 							) }
 						</p>
-						<Icon
+						<Button
 							className="woocommerce-admin__business-details__selective-extensions-bundle__expand"
-							icon={ showExtensions ? chevronUp : chevronDown }
 							onClick={ () => {
 								setShowExtensions( ! showExtensions );
 
@@ -498,7 +497,13 @@ export const SelectiveExtensionsBundle = ( {
 									);
 								}
 							} }
-						/>
+						>
+							<Icon
+								icon={
+									showExtensions ? chevronUp : chevronDown
+								}
+							/>
+						</Button>
 					</div>
 					{ showExtensions &&
 						installableExtensions.map(

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
@@ -15,6 +15,7 @@
 			display: flex;
 			padding: $gap-large 0 $gap-large 30px;
 			border-bottom: 1px solid $gray-200;
+			align-items: center;
 		}
 
 		.woocommerce-admin__business-details__selective-extensions-bundle__description {
@@ -55,9 +56,7 @@
 	}
 
 	.woocommerce-admin__business-details__selective-extensions-bundle__expand {
-		margin-left: 21px;
-		margin-top: -2px;
-		cursor: pointer;
+		margin-left: 9px;
 	}
 
 	.woocommerce-profile-wizard__business-details__free-features__illustration {

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Bug with Orders Report coupon exclusion filter. #7021
 - Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
 - Fix: Notices not dissapearing. #7077
+- Fix: Keyboard accessibility on the free features tab. #7149
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849


### PR DESCRIPTION
Fixes #7131 

Wraps the dropdown icon in a button to allow keyboard usability

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader

### Screenshots

### Detailed test instructions:

- On a new store start the onboarding flow
- Walk through the steps (use a Canadian or American address) to the Business details step
- Once on the Free features tab in Business details, click the **tab** key and see if you can expand the free features list
- Check if you can un-select any of the free free features and continue with your keyboard (use space bar to deselect a checkbox).


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
