### PR TITLE
Add unit tests for payment gateway suggestions data source poller

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php
+++ b/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php
@@ -12,6 +12,14 @@ defined( 'ABSPATH' ) || exit;
  * This handles polling specs from JSON endpoints.
  */
 class DataSourcePoller {
+	/**
+	 * Name of data sources filter.
+	 */
+	const FILTER_NAME = 'woocommerce_admin_payment_gateway_suggestions_data_sources';
+
+	/**
+	 * Default data sources array.
+	 */
 	const DATA_SOURCES = array(
 		'https://woocommerce.com/wp-json/wccom/payment-methods/1.0/methods.json',
 	);
@@ -43,7 +51,7 @@ class DataSourcePoller {
 	 */
 	public static function read_specs_from_data_sources() {
 		$specs        = array();
-		$data_sources = apply_filters( 'woocommerce_admin_payment_gateway_suggestions_data_sources', self::DATA_SOURCES );
+		$data_sources = apply_filters( self::FILTER_NAME, self::DATA_SOURCES );
 
 		// Note that this merges the specs from the data sources based on the
 		// id - last one wins.

--- a/tests/features/payment-gateway-suggestions/data-source-poller.php
+++ b/tests/features/payment-gateway-suggestions/data-source-poller.php
@@ -55,7 +55,7 @@ class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_Test_C
 								array(
 									'id' => 'mock-gateway3',
 								),
-							),
+							)
 						),
 					);
 				}

--- a/tests/features/payment-gateway-suggestions/data-source-poller.php
+++ b/tests/features/payment-gateway-suggestions/data-source-poller.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Test the data source poller for payment gateway suggestions.
+ *
+ * @package WooCommerce\Admin\Tests\PaymentGatewaySuggestions
+ */
+
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as PaymentGatewaySuggestions;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DataSourcePoller;
+
+/**
+ * class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller
+ */
+class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_Test_Case {
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		add_filter(
+			DataSourcePoller::FILTER_NAME,
+			function() {
+				return array(
+					'payment-gateway-suggestions-data-source.json',
+				);
+			}
+		);
+
+		add_filter(
+			'pre_http_request',
+			function( $pre, $parsed_args, $url ) {
+				if ( 'payment-gateway-suggestions-data-source.json' === $url ) {
+					return array(
+						'body' => wp_json_encode(
+							array(
+								array(
+									'id' => 'mock-gateway1',
+								),
+								array(
+									'id' => 'mock-gateway2',
+								),
+								array(
+									'key' => 'mock-gateway-invalid',
+								),
+							),
+						),
+					);
+				}
+
+				if ( 'payment-gateway-suggestions-data-source2.json' === $url ) {
+					return array(
+						'body' => wp_json_encode(
+							array(
+								array(
+									'id' => 'mock-gateway3',
+								),
+							),
+						),
+					);
+				}
+
+				return $pre;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_all_filters( DataSourcePoller::FILTER_NAME );
+	}
+
+	/**
+	 * Test that a data source can be read.
+	 */
+	public function test_read_data_source() {
+		$data = DataSourcePoller::read_specs_from_data_sources();
+		$this->assertArrayHasKey( 'mock-gateway1', $data );
+		$this->assertArrayHasKey( 'mock-gateway2', $data );
+		$this->assertArrayNotHasKey( 'mock-gateway3', $data );
+	}
+
+	/**
+	 * Test that an empty array is returned when the data source does not work.
+	 */
+	public function test_read_invalid_data_source() {
+		add_filter(
+			DataSourcePoller::FILTER_NAME,
+			function() {
+				return array(
+					'bad-data-source.json',
+				);
+			},
+			20
+		);
+
+		$data = DataSourcePoller::read_specs_from_data_sources();
+		$this->assertEmpty( $data );
+	}
+
+	/**
+	 * Test that specs can be merged.
+	 */
+	public function test_merge_specs() {
+		add_filter(
+			DataSourcePoller::FILTER_NAME,
+			function() {
+				return array(
+					'payment-gateway-suggestions-data-source.json',
+					'payment-gateway-suggestions-data-source2.json',
+				);
+			},
+			20
+		);
+
+		$data = DataSourcePoller::read_specs_from_data_sources();
+		$this->assertArrayHasKey( 'mock-gateway1', $data );
+		$this->assertArrayHasKey( 'mock-gateway2', $data );
+		$this->assertArrayHasKey( 'mock-gateway3', $data );
+	}
+
+	/**
+	 * Test that invalid specs aren't merged.
+	 */
+	public function test_merge_invalid_specs() {
+		$data = DataSourcePoller::read_specs_from_data_sources();
+		$this->assertCount( 2, $data );
+		$this->assertArrayNotHasKey( 'mock-gateway-invalid', $data );
+	}
+
+}

--- a/tests/features/payment-gateway-suggestions/data-source-poller.php
+++ b/tests/features/payment-gateway-suggestions/data-source-poller.php
@@ -43,7 +43,7 @@ class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_Test_C
 								array(
 									'key' => 'mock-gateway-invalid',
 								),
-							),
+							)
 						),
 					);
 				}

--- a/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -66,14 +66,14 @@ class WC_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	public function test_get_default_specs() {
 		remove_all_filters( 'transient_' . PaymentGatewaySuggestions::SPECS_TRANSIENT_NAME );
 		add_filter(
-			'woocommerce_admin_payment_gateway_suggestions_data_sources',
+			DataSourcePoller::FILTER_NAME,
 			function() {
 				return array();
-			},
-			PHP_INT_MAX
+			}
 		);
 		$specs    = PaymentGatewaySuggestions::get_specs();
 		$defaults = DefaultPaymentGateways::get_all();
+		remove_all_filters( DataSourcePoller::FILTER_NAME );
 		$this->assertEquals( $defaults, $specs );
 	}
 

--- a/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as PaymentGatewaySuggestions;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DefaultPaymentGateways;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DataSourcePoller;
 
 /**
  * class WC_Tests_PaymentGatewaySuggestions_Init


### PR DESCRIPTION
Fixes #7122 

Adds unit tests for the `DataSourcePoller` class.

### Detailed test instructions:

1. Make sure tests pass and are comprehensive.