### PR TITLE
Use tab char instead of single quote to prevent CSV injection

### DIFF
--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+- Use tab char for the CSV injection prevention.
+
 # 1.3.1
 
 -   Update dependencies.

--- a/packages/csv-export/src/__mocks__/mock-csv-data.js
+++ b/packages/csv-export/src/__mocks__/mock-csv-data.js
@@ -1,2 +1,2 @@
 export default `Date,Orders,Description,"Total Sales",Refunds,Coupons,Taxes,Shipping,"Net Sales","Negative Number"
-2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200,\t-123`;
+2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200,"\t-123"`;

--- a/packages/csv-export/src/__mocks__/mock-csv-data.js
+++ b/packages/csv-export/src/__mocks__/mock-csv-data.js
@@ -1,2 +1,2 @@
 export default `Date,Orders,Description,"Total Sales",Refunds,Coupons,Taxes,Shipping,"Net Sales","Negative Number"
-2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200,'-123`;
+2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200,\t-123`;

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -11,7 +11,7 @@ function escapeCSVValue( value ) {
 	// See: http://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
 	// See: WC_CSV_Exporter::escape_data()
 	if ( [ '=', '+', '-', '@' ].includes( stringValue.charAt( 0 ) ) ) {
-		stringValue = "'" + stringValue;
+		stringValue = '\t' + stringValue;
 	} else if ( stringValue.match( /[,"\s]/ ) ) {
 		stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
 	}

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -11,7 +11,7 @@ function escapeCSVValue( value ) {
 	// See: http://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
 	// See: WC_CSV_Exporter::escape_data()
 	if ( [ '=', '+', '-', '@' ].includes( stringValue.charAt( 0 ) ) ) {
-		stringValue = '\t' + stringValue;
+		stringValue = '"\t' + stringValue + '"';
 	} else if ( stringValue.match( /[,"\s]/ ) ) {
 		stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
 	}

--- a/packages/csv-export/src/test/index.js
+++ b/packages/csv-export/src/test/index.js
@@ -31,6 +31,29 @@ describe( 'generateCSVDataFromTable', () => {
 			mockCSVData
 		);
 	} );
+
+	it( 'should prefix tab character when the cell value starts with one of =, +, -, and @', () => {
+		[ '=', '+', '-', '@' ].forEach( ( val ) => {
+			const expected = 'value\n\t' + val + 'test';
+			const result = generateCSVDataFromTable(
+				[
+					{
+						label: 'value',
+						key: 'value',
+					},
+				],
+				[
+					[
+						{
+							display: 'value',
+							value: val + 'test',
+						},
+					],
+				]
+			);
+			expect( result ).toBe( expected );
+		} );
+	} );
 } );
 
 describe( 'generateCSVFileName', () => {

--- a/packages/csv-export/src/test/index.js
+++ b/packages/csv-export/src/test/index.js
@@ -34,7 +34,7 @@ describe( 'generateCSVDataFromTable', () => {
 
 	it( 'should prefix tab character when the cell value starts with one of =, +, -, and @', () => {
 		[ '=', '+', '-', '@' ].forEach( ( val ) => {
-			const expected = 'value\n\t' + val + 'test';
+			const expected = 'value\n"\t' + val + 'test"';
 			const result = generateCSVDataFromTable(
 				[
 					{

--- a/readme.txt
+++ b/readme.txt
@@ -96,7 +96,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026
 - Fix: Autocompleter for custom Search in CompareFilter #6911
 - Fix: Include onboarding settings on the analytic pages #7109
-- Fix: Use a tab character in favor of single quote for CSV injection prevention #7154 
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981
 - Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884

--- a/readme.txt
+++ b/readme.txt
@@ -85,13 +85,18 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Revert Card component removal #7167
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
+- Fix:  Use tab char for the CSV injection prevention. #7154
 
 == 2.4.0 6/10/2021 ==
+- Dev: Add Jetpack Backup admin note #6738
+- Add: Adding WCPay payment configuration defaults. #7097
+- Fix: Transformer casing is incorrect and creates an error on case-sensitive systems #7104
 - Dev: Reduce the specificity and complexity of the ReportError component #6846
 - Add: Create onboarding package to house refactored WCPay card and relevant components #7058
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026
 - Fix: Autocompleter for custom Search in CompareFilter #6911
 - Fix: Include onboarding settings on the analytic pages #7109
+- Fix: Use a tab character in favor of single quote for CSV injection prevention #7154 
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981
 - Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884


### PR DESCRIPTION
Fixes #7040

This PR replaces a single quote to a tab char that is used to prevent CSV injection.

For the CSV injection details, please refer to the following articles.

https://www.contextis.com/blog/comma-separated-vulnerabilities
http://georgemauer.net/2017/10/07/csv-injection.html
https://owasp.org/www-community/attacks/CSV_Injection

Both a single quote and tab char work, but some CSV viewers display a single quote visually.  This PR uses a tab char to prevent that. 

### Detailed test instructions:

You will need both WooCommerce Admin and Payments to test this change.

1. Clone this repository and run `npm start` to build the change.
2. Install & activate WooCommerce Payments
3. Open your terminal and cd to WooCommerce Admin directory.
4. Copy `packages/csv-export` directory and replace `node_modules/@woocommerce/csv-export` in your WooCommerce Payments plugin.
5. Run `npm start` in WooCommerce Payments.
6. Go through WooCommerce Payments setup process.
7. Place a new order using WooCommerce Payments
8. Refund the order
9. Navigate to Payments -> Transactions and click the download button.
10. Observe that the - value doesn't have a single quote.



