### PR TITLE
Parse transient value to integer if retrieved from transient

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Add target to the button to open it in a new tab  #7110
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
 - Fix: Set autoload to false for all remote inbox notifications options. #7060
+- Fix: Issue where summary stats were not showing in Analytics > Stock. #7161
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015
 - Update: Task list component with new Experimental Task list. #6849

--- a/src/API/Reports/Stock/Stats/DataStore.php
+++ b/src/API/Reports/Stock/Stats/DataStore.php
@@ -29,6 +29,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( false === $low_stock_count ) {
 			$low_stock_count = $this->get_low_stock_count();
 			set_transient( $low_stock_transient_name, $low_stock_count, $cache_expire );
+		} else {
+			$low_stock_count = intval( $low_stock_count );
 		}
 		$report_data['lowstock'] = $low_stock_count;
 
@@ -39,6 +41,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			if ( false === $count ) {
 				$count = $this->get_count( $status );
 				set_transient( $transient_name, $count, $cache_expire );
+			} else {
+				$count = intval( $count );
 			}
 			$report_data[ $status ] = $count;
 		}
@@ -48,6 +52,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( false === $product_count ) {
 			$product_count = $this->get_product_count();
 			set_transient( $product_count_transient_name, $product_count, $cache_expire );
+		} else {
+			$product_count = intval( $product_count );
 		}
 		$report_data['products'] = $product_count;
 		return $report_data;


### PR DESCRIPTION
Fixes #7158 

When saving an integer in a transient it is returned as a string, this change converts it back to an integer when it exists.

No changelog, as it is in the 2.4 changes (it is being cherry picked)

### Screenshots

<img width="1493" alt="Screen Shot 2021-06-10 at 1 44 26 PM" src="https://user-images.githubusercontent.com/2240960/121564577-fd5d8d00-c9f1-11eb-91f1-e79fc9ca6354.png">

### Detailed test instructions:

- Complete the onboarding setup wizard.
- Add some Products.
- Change Stock status to "Out of Stock" for few products.
- Go to Analytics > Stock screen.
- Note that Total count is displayed at the bottom
- Change it to 'Low stock' and see if the summary numbers still show correctly at the bottom

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
