### PR TITLE
Add Payment Gateway Suggestion Setup related component tests

### DIFF
--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -121,10 +121,9 @@ export const Setup = ( {
 							pluginSlugs={ plugins }
 						/>
 					),
-					isComplete: ! needsPluginInstall,
 			  }
 			: null;
-	}, [ needsPluginInstall ] );
+	}, [] );
 
 	const connectStep = useMemo(
 		() => ( {
@@ -147,7 +146,7 @@ export const Setup = ( {
 	);
 
 	const stepperPending =
-		! installStep?.isComplete ||
+		needsPluginInstall ||
 		isOptionUpdating ||
 		isPaymentGatewayResolving ||
 		! isPluginLoaded;
@@ -157,8 +156,8 @@ export const Setup = ( {
 			<Stepper
 				isVertical
 				isPending={ stepperPending }
-				currentStep={ installStep?.isComplete ? 'connect' : 'install' }
-				steps={ [ installStep, connectStep ] }
+				currentStep={ needsPluginInstall ? 'install' : 'connect' }
+				steps={ [ installStep, connectStep ].filter( Boolean ) }
 				{ ...props }
 			/>
 		),

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/setup.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/setup.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { act, render } from '@testing-library/react';
+import { enqueueScript } from '@woocommerce/wc-admin-settings';
+
+/**
+ * Internal dependencies
+ */
+import { Setup } from '../';
+
+jest.mock( '@woocommerce/components', () => {
+	const originalModule = jest.requireActual( '@woocommerce/components' );
+
+	return {
+		DynamicForm: () => <div />,
+		Plugins: () => <div />,
+		Stepper: originalModule.Stepper,
+	};
+} );
+
+jest.mock( '@woocommerce/wc-admin-settings' );
+
+const mockGateway = {
+	id: 'mock-gateway',
+	title: 'Mock Gateway',
+	plugins: [],
+	postInstallScripts: [],
+	installed: false,
+};
+
+const defaultProps = {
+	markConfigured: () => {},
+	recordConnectStartEvent: () => {},
+	paymentGateway: mockGateway,
+};
+
+describe( 'Setup', () => {
+	it( 'should show a connect step', () => {
+		const { queryByText } = render( <Setup { ...defaultProps } /> );
+
+		expect(
+			queryByText( 'Connect your Mock Gateway account' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not show install step when no plugins are needed', () => {
+		const { queryByText } = render( <Setup { ...defaultProps } /> );
+
+		expect( queryByText( 'Install' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should show install step when plugins are needed', () => {
+		const props = {
+			...defaultProps,
+			paymentGateway: { ...mockGateway, plugins: [ 'mock-plugin' ] },
+		};
+
+		const { queryByText } = render( <Setup { ...props } /> );
+
+		expect( queryByText( 'Install' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should enqueue post install scripts when plugin installation completes', async () => {
+		const props = {
+			...defaultProps,
+			paymentGateway: {
+				...mockGateway,
+				postInstallScripts: [ 'mock-post-install-script' ],
+			},
+		};
+		await act( async () => {
+			render( <Setup { ...props } /> );
+		} );
+
+		expect( enqueueScript ).toHaveBeenCalledTimes( 1 );
+		expect( enqueueScript ).toHaveBeenCalledWith(
+			'mock-post-install-script'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes (part of) #7121 

* Add Setup related component tests
* Simplify completion logic
* Fix bug where a `null` task is not filtered out

### Detailed test instructions:

1. Make sure tests pass and are comprehensive.
2. Make sure the install step still works as expected.
3. Make sure the busy indicator on the Stepper still works while installing.