### PR TITLE
Update error messages for plugin activation and installation

### DIFF
--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -41,7 +41,6 @@ function Snackbar(
 		onRemove = noop,
 		icon = null,
 		explicitDismiss = false,
-		status,
 		// onDismiss is a callback executed when the snackbar is dismissed.
 		// It is distinct from onRemove, which _looks_ like a callback but is
 		// actually the function to call to remove the snackbar from the UI.
@@ -100,7 +99,6 @@ function Snackbar(
 		'components-snackbar__content',
 		{
 			'components-snackbar__content-with-icon': !! icon,
-			'is-error': status === 'error',
 		}
 	);
 

--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -41,6 +41,7 @@ function Snackbar(
 		onRemove = noop,
 		icon = null,
 		explicitDismiss = false,
+		status,
 		// onDismiss is a callback executed when the snackbar is dismissed.
 		// It is distinct from onRemove, which _looks_ like a callback but is
 		// actually the function to call to remove the snackbar from the UI.
@@ -99,6 +100,7 @@ function Snackbar(
 		'components-snackbar__content',
 		{
 			'components-snackbar__content-with-icon': !! icon,
+			'is-error': status === 'error',
 		}
 	);
 

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 1.3.2
+# Unreleased
 
+-   Fix error parsing of plugin data package. #7164
 -   Update dependencies
 
 # 1.3.1

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -60,7 +60,7 @@ export function formatErrors(
 				);
 			}
 		);
-	} else if ( typeof response === 'string') {
+	} else if ( typeof response === 'string' ) {
 		return response;
 	} else {
 		return response.message;
@@ -193,9 +193,9 @@ export function* installPlugins( plugins: string[] ) {
 
 		return results;
 	} catch ( error ) {
-		if (plugins.length === 1 && !error[plugins[0]]) {
+		if ( plugins.length === 1 && ! error[ plugins[ 0 ] ] ) {
 			// Incase of a network error
-			error = { [plugins[0]]: error.message };
+			error = { [ plugins[ 0 ] ]: error.message };
 		}
 		yield setError( 'installPlugins', error );
 		throw new Error( formatErrorMessage( error ) );
@@ -224,9 +224,9 @@ export function* activatePlugins( plugins: string[] ) {
 
 		return results;
 	} catch ( error ) {
-		if (plugins.length === 1 && !error[plugins[0]]) {
+		if ( plugins.length === 1 && ! error[ plugins[ 0 ] ] ) {
 			// Incase of a network error
-			error = { [plugins[0]]: error.message };
+			error = { [ plugins[ 0 ] ]: error.message };
 		}
 		yield setError( 'activatePlugins', error );
 		throw new Error( formatErrorMessage( error, 'activate' ) );
@@ -248,7 +248,12 @@ export function* installAndActivatePlugins( plugins: string[] ) {
 }
 
 export const createErrorNotice = ( errorMessage: string ) => {
-	return controls.dispatch( 'core/notices', 'createNotice', 'error', errorMessage );
+	return controls.dispatch(
+		'core/notices',
+		'createNotice',
+		'error',
+		errorMessage
+	);
 };
 
 export function* connectToJetpack(

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -36,13 +36,13 @@ type ActivatePluginsResponse = PluginsResponse< {
 } >;
 
 function isWPError(
-	error: WPError< PluginNames > | string
+	error: WPError< PluginNames > | Error | string
 ): error is WPError< PluginNames > {
 	return ( error as WPError ).errors !== undefined;
 }
 
 export function formatErrors(
-	response: WPError< PluginNames > | string
+	response: WPError< PluginNames > | Error | string
 ): string {
 	if ( isWPError( response ) ) {
 		// Replace the slug with a plugin name if a constant exists.
@@ -60,8 +60,12 @@ export function formatErrors(
 				);
 			}
 		);
+	} else if ( typeof response === 'string') {
+		return response;
+	} else {
+		return response.message;
 	}
-	return response as string;
+	return '';
 }
 
 const formatErrorMessage = (
@@ -73,7 +77,7 @@ const formatErrorMessage = (
 		_n(
 			'Could not %(actionType)s %(pluginName)s plugin, %(error)s',
 			'Could not %(actionType)s the following plugins: %(pluginName)s with these Errors: %(error)s',
-			Object.keys( pluginErrors ).length,
+			Object.keys( pluginErrors ).length || 1,
 			'woocommerce-admin'
 		),
 		{
@@ -189,6 +193,10 @@ export function* installPlugins( plugins: string[] ) {
 
 		return results;
 	} catch ( error ) {
+		if (plugins.length === 1 && !error[plugins[0]]) {
+			// Incase of a network error
+			error = { [plugins[0]]: error.message };
+		}
 		yield setError( 'installPlugins', error );
 		throw new Error( formatErrorMessage( error ) );
 	}
@@ -216,8 +224,12 @@ export function* activatePlugins( plugins: string[] ) {
 
 		return results;
 	} catch ( error ) {
+		if (plugins.length === 1 && !error[plugins[0]]) {
+			// Incase of a network error
+			error = { [plugins[0]]: error.message };
+		}
 		yield setError( 'activatePlugins', error );
-		throw new Error( formatErrors( error ) );
+		throw new Error( formatErrorMessage( error, 'activate' ) );
 	}
 }
 
@@ -236,7 +248,7 @@ export function* installAndActivatePlugins( plugins: string[] ) {
 }
 
 export const createErrorNotice = ( errorMessage: string ) => {
-	return controls.dispatch( 'core/notices', 'createNotice', errorMessage );
+	return controls.dispatch( 'core/notices', 'createNotice', 'error', errorMessage );
 };
 
 export function* connectToJetpack(


### PR DESCRIPTION
Fixes #7159 

This fixes an issue where we could get a `undefined` notice showing up if a plugin failed to activate or install due to a network request failure.
I also did some general updates of the error parsing flow.

No changelog as it is in the data package.

### Screenshots

<img width="1136" alt="Screen Shot 2021-06-10 at 4 17 19 PM" src="https://user-images.githubusercontent.com/2240960/121583989-571c8200-ca07-11eb-89ee-cb83c14993a0.png">

### Detailed test instructions:

- Finish the onboarding flow without installing Jetpack (remove from free features list)
- Open Chrome dev tools and add this to the Network request blocking -> `*/index.php?rest_route=%2Fwc-admin%2Fplugins%2Finstall&_locale=user`, you can also add `*/index.php?rest_route=%2Fwc-admin%2Fplugins%2Factivate&_locale=user` for the activation.
- Go to WooCommerce->Home  and click on "Get Jetpack" button in `Stats overview`.
- It should show a descriptive notice instead of `undefined`
- Now remove the `k` in `jetpack` [here](https://github.com/woocommerce/woocommerce-admin/blob/main/packages/data/src/plugins/actions.ts#L270-L271) to trigger an error from the API
- Click "Get Jetpack" again, the error notices should show up nicely

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
