### PR TITLE
Add tests for Payment Gateway Connect component

### DIFF
--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
@@ -14,6 +14,26 @@ import { useSlot } from '@woocommerce/experimental';
  */
 import sanitizeHTML from '~/lib/sanitize-html';
 
+export const validateFields = ( values, fields ) => {
+	const errors = {};
+	const getField = ( fieldId ) =>
+		fields.find( ( field ) => field.id === fieldId );
+
+	for ( const [ fieldKey, value ] of Object.entries( values ) ) {
+		const field = getField( fieldKey );
+		// Matches any word that is capitalized aside from abrevitions like ID.
+		const label = field.label.replace( /([A-Z][a-z]+)/g, ( val ) =>
+			val.toLowerCase()
+		);
+
+		if ( ! ( value || field.type === 'checkbox' ) ) {
+			errors[ fieldKey ] = `Please enter your ${ label }`;
+		}
+	}
+
+	return errors;
+};
+
 export const Connect = ( {
 	markConfigured,
 	paymentGateway,
@@ -71,26 +91,6 @@ export const Connect = ( {
 			} );
 	};
 
-	const validate = ( values ) => {
-		const errors = {};
-		const getField = ( fieldId ) =>
-			fields.find( ( field ) => field.id === fieldId );
-
-		for ( const [ fieldKey, value ] of Object.entries( values ) ) {
-			const field = getField( fieldKey );
-			// Matches any word that is capitalized aside from abrevitions like ID.
-			const label = field.label.replace( /([A-Z][a-z]+)/g, ( val ) =>
-				val.toLowerCase()
-			);
-
-			if ( ! ( value || field.type === 'checkbox' ) ) {
-				errors[ fieldKey ] = `Please enter your ${ label }`;
-			}
-		}
-
-		return errors;
-	};
-
 	const helpText = setupHelpText && (
 		<p dangerouslySetInnerHTML={ sanitizeHTML( setupHelpText ) } />
 	);
@@ -100,7 +100,7 @@ export const Connect = ( {
 			isBusy={ isUpdating }
 			onSubmit={ handleSubmit }
 			submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
-			validate={ validate }
+			validate={ ( values ) => validateFields( values, fields ) }
 			{ ...props }
 		/>
 	);

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/connect.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Connect, validateFields } from '../Connect';
+
+const mockGateway = {
+	id: 'mock-gateway',
+	title: 'Mock Gateway',
+	connectionUrl: 'http://mockgateway.com/connect',
+	setupHelpText: 'Help text',
+	settingsUrl:
+		'https://example.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=mock-gateway',
+	requiredSettings: [
+		{
+			id: 'api_key',
+			label: 'API key',
+			type: 'text',
+			default: '',
+		},
+		{
+			id: 'api_secret',
+			label: 'API secret',
+			type: 'text',
+			default: '',
+		},
+	],
+};
+
+const defaultProps = {
+	markConfigured: () => {},
+	recordConnectStartEvent: () => {},
+	paymentGateway: mockGateway,
+};
+
+describe( 'Connect', () => {
+	it( 'should show help text', () => {
+		const { queryByText } = render( <Connect { ...defaultProps } /> );
+
+		expect( queryByText( 'Help text' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render a button with the connection URL', () => {
+		const { container } = render( <Connect { ...defaultProps } /> );
+
+		const button = container.querySelector( 'a' );
+		expect( button.textContent ).toBe( 'Connect' );
+		expect( button.href ).toBe( mockGateway.connectionUrl );
+	} );
+
+	it( 'should render fields when no connection URL exists', () => {
+		const props = {
+			...defaultProps,
+			paymentGateway: {
+				...mockGateway,
+				connectionUrl: null,
+			},
+		};
+		const { container } = render( <Connect { ...props } /> );
+
+		const inputs = container.querySelectorAll( 'input' );
+		expect( inputs.length ).toBe( 2 );
+		expect( inputs[ 0 ].placeholder ).toBe( 'API key' );
+		expect( inputs[ 1 ].placeholder ).toBe( 'API secret' );
+	} );
+
+	it( 'should render the manage button when no connection URL or fields exist', () => {
+		const props = {
+			...defaultProps,
+			paymentGateway: {
+				...mockGateway,
+				connectionUrl: null,
+				requiredSettings: [],
+			},
+		};
+		const { container } = render( <Connect { ...props } /> );
+
+		const button = container.querySelector( 'a' );
+		expect( button.textContent ).toBe( 'Manage' );
+		expect( button.href ).toBe( mockGateway.settingsUrl );
+	} );
+} );
+
+describe( 'validateFields', () => {
+	it( 'should return an empty object when no errors exist', () => {
+		const values = {
+			api_key: '123',
+			api_secret: '123',
+		};
+		const errors = validateFields( values, mockGateway.requiredSettings );
+
+		expect( errors ).toMatchObject( {} );
+	} );
+
+	it( 'should return the errors using field labels when errors exist', () => {
+		const values = {
+			api_key: '123',
+			api_secret: null,
+		};
+		const errors = validateFields( values, mockGateway.requiredSettings );
+
+		expect( errors ).toMatchObject( {
+			api_secret: 'Please enter your API secret',
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes (part of) #7121 

Adds tests for the `Connect `component.

### Detailed test instructions:

1. Check that tests are passing and comprehensive.