### PR TITLE
Change the emailed report filename 

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -9,6 +9,24 @@
 3. Select the tab "Business details" to go back
 4. Confirm that the previously selected values are shown. 
 
+### Change the emailed report file name #7178
+
+**Confirm the default behaviour remains the same**
+1. Create a new store and install the [WP Mail Logging by MailPoet plugin](https://wordpress.org/plugins/wp-mail-logging/)
+2. Go to Analytics -> Revenue and change the date range to last month
+3. Click the download button and make sure you see the "Your revenue report will be emailed to you" notification
+4. Go to Tools -> Scheduled Action and run the newly created `woocommerce_admin_report_export` action. After that is complete, run the `woocommerce_admin_email_report_download_link` action.
+5. Go to Tools -> WP Mail Log and check the latest email. The URL linked to the "Download your Revenue report" should work as usual. The URL will be something like `filename=wc-revenue-report-export-16236128226138`
+
+**Confirm the new filter is working**
+1. Add this code to the `woocommerce-admin.php` file
+```php
+add_filter( 'woocommerce_admin_export_id', function ($export_id) {
+	return 'different_export_id';
+} );
+```
+2. Repeat the same steps from above. The filename in the link now should be `different_export_id`.
+
 ## 2.4.0
 
 ### Add target to the button to open it in a new tab #7110

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Report export filtering bug. #7165
 - Fix: Use tab char for the CSV injection prevention. #7154
 - Fix: Use saved form values if available when switching tabs #7226
+- Dev: Add `woocommerce_admin_export_id` filter for customizing the export file name #7178
 
 == 2.4.0 6/10/2021 ==
 - Dev: Add Jetpack Backup admin note #6738

--- a/src/API/Reports/Export/Controller.php
+++ b/src/API/Reports/Export/Controller.php
@@ -159,8 +159,11 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$report_type = $request['type'];
 		$report_args = empty( $request['report_args'] ) ? array() : $request['report_args'];
 		$send_email  = isset( $request['email'] ) ? $request['email'] : false;
-		$export_id   = str_replace( '.', '', microtime( true ) );
-		$total_rows  = ReportExporter::queue_report_export( $export_id, $report_type, $report_args, $send_email );
+
+		$default_export_id = str_replace( '.', '', microtime( true ) );
+		$export_id         = apply_filters( 'woocommerce_admin_export_id', $default_export_id );
+
+		$total_rows = ReportExporter::queue_report_export( $export_id, $report_type, $report_args, $send_email );
 
 		if ( 0 === $total_rows ) {
 			return rest_ensure_response(

--- a/src/API/Reports/Export/Controller.php
+++ b/src/API/Reports/Export/Controller.php
@@ -162,6 +162,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		$default_export_id = str_replace( '.', '', microtime( true ) );
 		$export_id         = apply_filters( 'woocommerce_admin_export_id', $default_export_id );
+		$export_id 		   = (string) sanitize_file_name( $export_id );
 
 		$total_rows = ReportExporter::queue_report_export( $export_id, $report_type, $report_args, $send_email );
 


### PR DESCRIPTION
We are showing the reporting pages to all the vendors in our store, so each vendor can only see the reporting for their products.

The filename of the emailed reports [is based on the PHP's `microtime` function](https://github.com/woocommerce/woocommerce-admin/blob/38fbb4aedd0f21cf21ddaa6af93e48564fd35324/src/API/Reports/Export/Controller.php#L162), and the download page doesn't have any authorization. As a result, we're a little worried about some of our users might guess the filename URLs for previous exports made by vendors. 

The solution we have arrived at was to add this filter in. Let me know what do you think!

Slack discussion: https://a8c.slack.com/archives/C01JHKF3XPC/p1620983573337100

### Screenshots
![image](https://user-images.githubusercontent.com/10389957/121818855-7aa72d00-cc92-11eb-9596-2e8daf3d4144.png)

### Detailed test instructions:

See the [latest entry](https://github.com/woocommerce/woocommerce-admin/pull/7178/commits/0ed1d6d1f4b6fc2e6a7189c1b875c011aa8fc881) on the `TESTING-INSTRUCTIONS.md` file.
