### PR TITLE
RemoteFreeExtension hide bundle when all of its plugins are not visible

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -328,6 +328,34 @@ const getVisiblePlugins = ( plugins, country, industry, productTypes ) => {
 	);
 };
 
+/**
+ * Returns bundles that have at least 1 visible plugin.
+ *
+ * @param {Array} bundles  list of bundles
+ * @param {string} country  Woo store country
+ * @param {Array} industry List of selected industries
+ * @param {Array} productTypes List of selected product types
+ *
+ * @return {Array} Array of visible bundles
+ */
+const getVisibleBundles = ( bundles, country, industry, productTypes ) => {
+	return bundles
+		.map( ( bundle ) => {
+			return {
+				...bundle,
+				plugins: getVisiblePlugins(
+					bundle.plugins,
+					country,
+					industry,
+					productTypes
+				),
+			};
+		} )
+		.filter( ( bundle ) => {
+			return bundle.plugins.length;
+		} );
+};
+
 const transformRemoteExtensions = ( extensionData ) => {
 	return extensionData.map( ( section ) => {
 		const plugins = section.plugins.map( ( plugin ) => {
@@ -400,7 +428,14 @@ export const SelectiveExtensionsBundle = ( {
 				industry,
 				productTypes
 			);
-			setInstallableExtensions( installableExtensionsData );
+			setInstallableExtensions(
+				getVisibleBundles(
+					installableExtensionsData,
+					country,
+					industry,
+					productTypes
+				)
+			);
 			setValues( initialValues );
 			setIsFetching( false );
 		};
@@ -428,7 +463,14 @@ export const SelectiveExtensionsBundle = ( {
 						industry,
 						productTypes
 					);
-					setInstallableExtensions( transformedExtensions );
+					setInstallableExtensions(
+						getVisibleBundles(
+							transformedExtensions,
+							country,
+							industry,
+							productTypes
+						)
+					);
 					setValues( initialValues );
 					setIsFetching( false );
 				} )
@@ -520,21 +562,18 @@ export const SelectiveExtensionsBundle = ( {
 									{ isFetching ? (
 										<Spinner />
 									) : (
-										getVisiblePlugins(
-											plugins,
-											country,
-											industry,
-											productTypes
-										).map( ( { description, key } ) => (
-											<BundleExtensionCheckbox
-												key={ key }
-												description={ description }
-												isChecked={ values[ key ] }
-												onChange={ getCheckboxChangeHandler(
-													key
-												) }
-											/>
-										) )
+										plugins.map(
+											( { description, key } ) => (
+												<BundleExtensionCheckbox
+													key={ key }
+													description={ description }
+													isChecked={ values[ key ] }
+													onChange={ getCheckboxChangeHandler(
+														key
+													) }
+												/>
+											)
+										)
 									) }
 								</div>
 							)

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 - Fix: WCPay not working in local payments task #7151
 - Fix: Include onboarding settings on the analytic pages #7109
+- Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
 - Tweak: Revert Card component removal #7167
 - Add: SlotFill to Abbreviated Notification panel #7091
 


### PR DESCRIPTION
Fixes #7170

Small refactor to filter out bundles where all of its plugins are not visible. 

### Screenshots

<img width="400" src="https://user-images.githubusercontent.com/3747241/121891094-a5a28700-cd4d-11eb-890c-cd4d9df1ad04.png">

### Detailed test instructions:

1. On OBW, enter South Africa as the store address.
1. Go to "Free Features" tab on "Business Details" screen.
1. Click on "Add recommended business features to my site" dropdown.
1. Observe only "GROW YOUR STORE" bundle is shown.