### PR TITLE
Add text for manage button when no help text exists

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -240,8 +240,8 @@
 		font-size: 14px;
 		color: $studio-gray-50;
 		font-weight: 400;
-		margin-top: 16px;
-		margin-bottom: $gap-smaller;
+		margin-top: $gap;
+		margin-bottom: $gap;
 	}
 }
 

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
@@ -151,7 +151,7 @@ export const Connect = ( {
 				</p>
 			) }
 			<Button isPrimary href={ settingsUrl }>
-				{ __( 'Manage', 'woocommerce-admin' ) }
+				{ __( 'Set up', 'woocommerce-admin' ) }
 			</Button>
 		</>
 	);

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
@@ -142,7 +142,14 @@ export const Connect = ( {
 
 	return (
 		<>
-			{ helpText }
+			{ helpText || (
+				<p>
+					{ __(
+						"You can manage this payment gateway's settings by clicking the button below.",
+						'woocommerce-admin'
+					) }
+				</p>
+			) }
 			<Button isPrimary href={ settingsUrl }>
 				{ __( 'Manage', 'woocommerce-admin' ) }
 			</Button>

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/Connect.js
@@ -145,7 +145,7 @@ export const Connect = ( {
 			{ helpText || (
 				<p>
 					{ __(
-						"You can manage this payment gateway's settings by clicking the button below.",
+						"You can manage this payment gateway's settings by clicking the button below",
 						'woocommerce-admin'
 					) }
 				</p>

--- a/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/connect.js
+++ b/client/task-list/tasks/payments/PaymentGatewaySuggestions/components/Setup/test/connect.js
@@ -68,7 +68,7 @@ describe( 'Connect', () => {
 		expect( inputs[ 1 ].placeholder ).toBe( 'API secret' );
 	} );
 
-	it( 'should render the manage button when no connection URL or fields exist', () => {
+	it( 'should render the set up button when no connection URL or fields exist', () => {
 		const props = {
 			...defaultProps,
 			paymentGateway: {
@@ -80,7 +80,7 @@ describe( 'Connect', () => {
 		const { container } = render( <Connect { ...props } /> );
 
 		const button = container.querySelector( 'a' );
-		expect( button.textContent ).toBe( 'Manage' );
+		expect( button.textContent ).toBe( 'Set up' );
 		expect( button.href ).toBe( mockGateway.settingsUrl );
 	} );
 } );


### PR DESCRIPTION
Fixes #7189 

Adds in some basic text for managing a payment gateway's setting if no connection settings or URL exist.

cc @elizaan36 @pmcpinto if you have any input on this or copy changes here.

### Screenshots

#### Before

<img width="693" alt="Screen Shot 2021-06-15 at 6 17 56 PM" src="https://user-images.githubusercontent.com/10561050/122130693-05f4ff80-ce06-11eb-8c01-d8e208efd3a0.png">

#### After

<img width="702" alt="Screen Shot 2021-06-15 at 6 06 15 PM" src="https://user-images.githubusercontent.com/10561050/122130654-fa093d80-ce05-11eb-8835-5278a96c4b23.png">


### Detailed test instructions:

1. Set up a gateway that is not enhanced but also requires plugin install (i.e., don't install one of the gateways with the PRs we've been working on).
2. Go to the payment task.
3. Go through the install step.
4. Note the "Manage" button and default help text.