### PR TITLE
Add fallback for the select/dispatch data-controls for older WP versions

### DIFF
--- a/packages/data/src/payment-gateways/resolvers.ts
+++ b/packages/data/src/payment-gateways/resolvers.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import {
+	apiFetch,
+	dispatch as depreciatedDispatch,
+} from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 
 /**
@@ -19,6 +22,9 @@ import {
 import { API_NAMESPACE, STORE_KEY } from './constants';
 import { PaymentGateway } from './types';
 
+const dispatch =
+	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
+
 export function* getPaymentGateways() {
 	yield getPaymentGatewaysRequest();
 
@@ -28,7 +34,7 @@ export function* getPaymentGateways() {
 		} );
 		yield getPaymentGatewaysSuccess( response );
 		for ( let i = 0; i < response.length; i++ ) {
-			yield controls.dispatch(
+			yield dispatch(
 				STORE_KEY,
 				'finishResolution',
 				'getPaymentGateway',

--- a/packages/data/src/payment-gateways/resolvers.ts
+++ b/packages/data/src/payment-gateways/resolvers.ts
@@ -22,6 +22,7 @@ import {
 import { API_NAMESPACE, STORE_KEY } from './constants';
 import { PaymentGateway } from './types';
 
+// Can be removed in WP 5.9.
 const dispatch =
 	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
 

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import {
+	apiFetch,
+	select,
+	dispatch as oldDispatch,
+} from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 import { _n, sprintf } from '@wordpress/i18n';
 
@@ -17,6 +21,11 @@ import {
 	PluginNames,
 	SelectorKeysWithActions,
 } from './types';
+
+const dispatch =
+	controls && controls.dispatch ? controls.dispatch : oldDispatch;
+const resolveSelect =
+	controls && controls.resolveSelect ? controls.resolveSelect : select;
 
 type PluginsResponse< PluginData > = {
 	data: PluginData;
@@ -235,8 +244,8 @@ export function* activatePlugins( plugins: string[] ) {
 
 export function* installAndActivatePlugins( plugins: string[] ) {
 	try {
-		yield controls.dispatch( STORE_NAME, 'installPlugins', plugins );
-		const activations: InstallPluginsResponse = yield controls.dispatch(
+		yield dispatch( STORE_NAME, 'installPlugins', plugins );
+		const activations: InstallPluginsResponse = yield dispatch(
 			STORE_NAME,
 			'activatePlugins',
 			plugins
@@ -248,25 +257,20 @@ export function* installAndActivatePlugins( plugins: string[] ) {
 }
 
 export const createErrorNotice = ( errorMessage: string ) => {
-	return controls.dispatch(
-		'core/notices',
-		'createNotice',
-		'error',
-		errorMessage
-	);
+	return dispatch( 'core/notices', 'createNotice', 'error', errorMessage );
 };
 
 export function* connectToJetpack(
 	getAdminLink: ( endpoint: string ) => string
 ) {
-	const url: string = yield controls.resolveSelect(
+	const url: string = yield resolveSelect(
 		STORE_NAME,
 		'getJetpackConnectUrl',
 		{
 			redirect_url: getAdminLink( 'admin.php?page=wc-admin' ),
 		}
 	);
-	const error: string = yield controls.resolveSelect(
+	const error: string = yield resolveSelect(
 		STORE_NAME,
 		'getPluginsError',
 		'getJetpackConnectUrl'
@@ -284,10 +288,10 @@ export function* installJetpackAndConnect(
 	getAdminLink: ( endpoint: string ) => string
 ) {
 	try {
-		yield controls.dispatch( STORE_NAME, 'installPlugins', [ 'jetpack' ] );
-		yield controls.dispatch( STORE_NAME, 'activatePlugins', [ 'jetpack' ] );
+		yield dispatch( STORE_NAME, 'installPlugins', [ 'jetpack' ] );
+		yield dispatch( STORE_NAME, 'activatePlugins', [ 'jetpack' ] );
 
-		const url: string = yield controls.dispatch(
+		const url: string = yield dispatch(
 			STORE_NAME,
 			'connectToJetpack',
 			getAdminLink
@@ -304,7 +308,7 @@ export function* connectToJetpackWithFailureRedirect(
 	getAdminLink: ( endpoint: string ) => string
 ) {
 	try {
-		const url: string = yield controls.dispatch(
+		const url: string = yield dispatch(
 			STORE_NAME,
 			'connectToJetpack',
 			getAdminLink

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -4,7 +4,7 @@
 import {
 	apiFetch,
 	select,
-	dispatch as oldDispatch,
+	dispatch as depreciatedDispatch,
 } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 import { _n, sprintf } from '@wordpress/i18n';
@@ -23,7 +23,7 @@ import {
 } from './types';
 
 const dispatch =
-	controls && controls.dispatch ? controls.dispatch : oldDispatch;
+	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
 const resolveSelect =
 	controls && controls.resolveSelect ? controls.resolveSelect : select;
 

--- a/packages/data/src/plugins/actions.ts
+++ b/packages/data/src/plugins/actions.ts
@@ -22,6 +22,7 @@ import {
 	SelectorKeysWithActions,
 } from './types';
 
+// Can be removed in WP 5.9, wp.data is supported in >5.7.
 const dispatch =
 	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
 const resolveSelect =

--- a/packages/data/src/plugins/resolvers.ts
+++ b/packages/data/src/plugins/resolvers.ts
@@ -23,6 +23,7 @@ import {
 } from './actions';
 import { PaypalOnboardingStatus, RecommendedTypes } from './types';
 
+// Can be removed in WP 5.9, wp.data is supported in >5.7.
 const resolveSelect =
 	controls && controls.resolveSelect ? controls.resolveSelect : select;
 type PluginGetResponse = {

--- a/packages/data/src/plugins/resolvers.ts
+++ b/packages/data/src/plugins/resolvers.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import { apiFetch, select } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -23,6 +23,8 @@ import {
 } from './actions';
 import { PaypalOnboardingStatus, RecommendedTypes } from './types';
 
+const resolveSelect =
+	controls && controls.resolveSelect ? controls.resolveSelect : select;
 type PluginGetResponse = {
 	plugins: string[];
 } & Response;
@@ -116,7 +118,7 @@ function* setOnboardingStatusWithOptions() {
 		merchant_id_production: string;
 		client_id_production: string;
 		client_secret_production: string;
-	} = yield controls.resolveSelect(
+	} = yield resolveSelect(
 		OPTIONS_STORE_NAME,
 		'getOption',
 		'woocommerce-ppcp-settings'
@@ -139,7 +141,7 @@ export function* getPaypalOnboardingStatus() {
 
 	const errorData: {
 		data?: { status: number };
-	} = yield controls.resolveSelect(
+	} = yield resolveSelect(
 		STORE_NAME,
 		'getPluginsError',
 		'getPaypalOnboardingStatus'

--- a/packages/data/src/settings/actions.js
+++ b/packages/data/src/settings/actions.js
@@ -3,7 +3,7 @@
  */
 
 import { __ } from '@wordpress/i18n';
-import { apiFetch } from '@wordpress/data-controls';
+import { apiFetch, select } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 import { concat } from 'lodash';
 
@@ -13,6 +13,9 @@ import { concat } from 'lodash';
 import { NAMESPACE } from '../constants';
 import { STORE_NAME } from './constants';
 import TYPES from './action-types';
+
+const resolveSelect =
+	controls && controls.resolveSelect ? controls.resolveSelect : select;
 
 export function updateSettingsForGroup( group, data, time = new Date() ) {
 	return {
@@ -59,11 +62,7 @@ export function* persistSettingsForGroup( group ) {
 	// first dispatch the is persisting action
 	yield setIsRequesting( group, true );
 	// get all dirty keys with select control
-	const dirtyKeys = yield controls.resolveSelect(
-		STORE_NAME,
-		'getDirtyKeys',
-		group
-	);
+	const dirtyKeys = yield resolveSelect( STORE_NAME, 'getDirtyKeys', group );
 	// if there is nothing dirty, bail
 	if ( dirtyKeys.length === 0 ) {
 		yield setIsRequesting( group, false );
@@ -71,7 +70,7 @@ export function* persistSettingsForGroup( group ) {
 	}
 
 	// get data slice for keys
-	const dirtyData = yield controls.resolveSelect(
+	const dirtyData = yield resolveSelect(
 		STORE_NAME,
 		'getSettingsForGroup',
 		group,

--- a/packages/data/src/settings/actions.js
+++ b/packages/data/src/settings/actions.js
@@ -14,6 +14,7 @@ import { NAMESPACE } from '../constants';
 import { STORE_NAME } from './constants';
 import TYPES from './action-types';
 
+// Can be removed in WP 5.9, wp.data is supported in >5.7.
 const resolveSelect =
 	controls && controls.resolveSelect ? controls.resolveSelect : select;
 

--- a/packages/data/src/settings/resolvers.js
+++ b/packages/data/src/settings/resolvers.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch as oldDispatch } from '@wordpress/data-controls';
+import {
+	apiFetch,
+	dispatch as depreciatedDispatch,
+} from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 
 /**
@@ -12,7 +15,7 @@ import { STORE_NAME } from './constants';
 import { updateSettingsForGroup, updateErrorForGroup } from './actions';
 
 const dispatch =
-	controls && controls.dispatch ? controls.dispatch : oldDispatch;
+	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
 
 function settingsToSettingsResource( settings ) {
 	return settings.reduce( ( resource, setting ) => {

--- a/packages/data/src/settings/resolvers.js
+++ b/packages/data/src/settings/resolvers.js
@@ -14,6 +14,7 @@ import { NAMESPACE } from '../constants';
 import { STORE_NAME } from './constants';
 import { updateSettingsForGroup, updateErrorForGroup } from './actions';
 
+// Can be removed in WP 5.9.
 const dispatch =
 	controls && controls.dispatch ? controls.dispatch : depreciatedDispatch;
 

--- a/packages/data/src/settings/resolvers.js
+++ b/packages/data/src/settings/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { apiFetch } from '@wordpress/data-controls';
+import { apiFetch, dispatch as oldDispatch } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 
 /**
@@ -11,6 +11,9 @@ import { NAMESPACE } from '../constants';
 import { STORE_NAME } from './constants';
 import { updateSettingsForGroup, updateErrorForGroup } from './actions';
 
+const dispatch =
+	controls && controls.dispatch ? controls.dispatch : oldDispatch;
+
 function settingsToSettingsResource( settings ) {
 	return settings.reduce( ( resource, setting ) => {
 		resource[ setting.id ] = setting.value;
@@ -19,7 +22,7 @@ function settingsToSettingsResource( settings ) {
 }
 
 export function* getSettings( group ) {
-	yield controls.dispatch( STORE_NAME, 'setIsRequesting', group, true );
+	yield dispatch( STORE_NAME, 'setIsRequesting', group, true );
 
 	try {
 		const url = NAMESPACE + '/settings/' + group;


### PR DESCRIPTION
This fixes an issue with WP ~5.5, which doesn't include `wp.data.controls` yet. This uses the `wp.data.controls` first and the `data-controls` package as a fallback.

No changelog, given the changelog in https://github.com/woocommerce/woocommerce-admin/pull/7007

### Detailed test instructions:

Check on WP version 5.5 & 5.7 (latest)
- Step through the onboarding flow, make sure to keep some of the recommended (free) plugins selected
- After the onboarding flow it should trigger the jetpack connection correctly
- Check the installed plugins and make sure the items you selected for the free extensions where installed.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
