### PR TITLE
Add notice and enable gateway on successful connection

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions;
 
+use Automattic\WooCommerce\Admin\Features\TransientNotices;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -18,6 +20,7 @@ class PaymentGatewaysController {
 	public static function init() {
 		add_filter( 'woocommerce_rest_prepare_payment_gateway', array( __CLASS__, 'extend_response' ), 10, 3 );
 		add_filter( 'admin_init', array( __CLASS__, 'possibly_do_connection_return_action' ) );
+		add_action( 'woocommerce_admin_payment_gateway_connection_return', array( __CLASS__, 'handle_successfull_connection' ) );
 	}
 
 	/**
@@ -96,5 +99,40 @@ class PaymentGatewaysController {
 		// phpcs:enable WordPress.Security.NonceVerification
 
 		do_action( 'woocommerce_admin_payment_gateway_connection_return', $gateway_id );
+	}
+
+	/**
+	 * Handle a successful gateway connection.
+	 *
+	 * @param string $gateway_id Gateway ID.
+	 */
+	public static function handle_successfull_connection( $gateway_id ) {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( ! isset( $_GET['success'] ) || 1 !== intval( $_GET['success'] ) ) {
+			return;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification
+
+		$payment_gateways = WC()->payment_gateways()->payment_gateways();
+		$payment_gateway  = isset( $payment_gateways[ $gateway_id ] ) ? $payment_gateways[ $gateway_id ] : null;
+
+		if ( ! $payment_gateway ) {
+			return;
+		}
+
+		$payment_gateway->update_option( 'enabled', 'yes' );
+
+		TransientNotices::add(
+			array(
+				'user_id' => get_current_user_id(),
+				'id'      => 'payment-gateway-connection-return-' . str_replace( ',', '-', $gateway_id ),
+				'status'  => 'success',
+				'content' => sprintf(
+					/* translators: the title of the payment gateway */
+					__( '%s connected successfully', 'woocommerce-admin' ),
+					$payment_gateway->method_title
+				),
+			)
+		);
 	}
 }

--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -141,5 +141,7 @@ class PaymentGatewaysController {
 				'payment_method' => $gateway_id,
 			)
 		);
+
+		wp_safe_redirect( wc_admin_url( '&task=payments' ) );
 	}
 }

--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -134,5 +134,12 @@ class PaymentGatewaysController {
 				),
 			)
 		);
+
+		wc_admin_record_tracks_event(
+			'tasklist_payment_connect_method',
+			array(
+				'payment_method' => $gateway_id,
+			)
+		);
 	}
 }


### PR DESCRIPTION
Fixes #7208 

* Adds a parameter `success` that can be added to the URL to handle default connection success
* Creates a transient notice on success
* Enables the gateway on success
* Records a tracks event on success

Note that this does not bar gateways from handling custom actions or opting not to use this default behavior altogether.

### Screenshots

<img width="282" alt="Screen Shot 2021-06-18 at 3 00 55 PM" src="https://user-images.githubusercontent.com/10561050/122605840-0085f800-d046-11eb-935d-0f8e077cd37f.png">


### Detailed test instructions:

1. Visit the payments task with `connection-return` and `success` params.  E.g., `wp-admin/admin.php?page=wc-admin&task=payments&connection-return=stripe&success=1`
2. Test with a fake (or uninstalled gateway) ID and note nothing happens
3. Check with an actual gateway ID and note the transient notice and that the gateway is enabled under `wp-admin/admin.php?page=wc-settings&tab=checkout`