### PR TITLE
Skip schedule customer data deletion on site deletion

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Include onboarding settings on the analytic pages #7109
 - Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
 - Fix: Fixing button state logic for remote payment gateways #7200
+- Fix: Skip schedule customer data deletion on site deletion #7214
 - Tweak: Revert Card component removal #7167
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -172,7 +172,7 @@ class CustomersScheduler extends ImportScheduler {
 	 * @return void
 	 */
 	public static function schedule_user_delete( $user_id ) {
-		if ( (int) $user_id > 0 ) {
+		if ( (int) $user_id > 0 && ! doing_action( 'wp_uninitialize_site' ) ) {
 			// Postpone until any pending updates are completed.
 			self::schedule_action( 'delete_user', array( $user_id ) );
 		}


### PR DESCRIPTION
Fixes #7141 

Fixes an issue where action scheduler tables have not yet been created on new sites by skipping customer deletion scheduling (since the site will be deleted anyway).

### Detailed test instructions:

1. Create a multi-network site.
2. Don't visit that site and immediately delete it.
3. Make sure no error is shown.
4. Follow the testing instructions in https://github.com/woocommerce/woocommerce-admin/pull/6574 to make sure no regressions have occurred.