### PR TITLE
Localize payment gateway suggestions on wccom

### DIFF
--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -18,19 +18,14 @@ The data source schema defines the recommended payment gateways and required plu
 [
   {
     "key": "gateway-key",
-    "locales": [
-      {
-        "locale": "en_US",
-        "title": "Gateway Example",
-        "content": "Content to be displayed in the recommended payment gateway list."
-      }
-    ],
+    "title": "Gateway Example",
+    "content": "Content to be displayed in the recommended payment gateway list.",
     "image": "https://paymentgateway.com/path/to/image.png",
     "plugins": ["wp-org-plugin-slug"],
-	"is_visible": [
-		<Rule>,
-		...
-	]
+    "is_visible": [
+      <Rule>,
+      ...
+    ]
   }
   ...
 ]

--- a/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php
+++ b/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php
@@ -21,7 +21,7 @@ class DataSourcePoller {
 	 * Default data sources array.
 	 */
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/payment-methods/1.0/methods.json',
+		'https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json',
 	);
 
 	/**
@@ -73,7 +73,13 @@ class DataSourcePoller {
 	private static function read_data_source( $url ) {
 		$logger_context = array( 'source' => $url );
 		$logger         = self::get_logger();
-		$response       = wp_remote_get( $url );
+		$response       = wp_remote_get(
+			add_query_arg(
+				'_locale',
+				get_user_locale(),
+				$url
+			)
+		);
 
 		if ( is_wp_error( $response ) || ! isset( $response['body'] ) ) {
 			$logger->error(

--- a/src/Features/PaymentGatewaySuggestions/Init.php
+++ b/src/Features/PaymentGatewaySuggestions/Init.php
@@ -75,40 +75,9 @@ class Init {
 				return DefaultPaymentGateways::get_all();
 			}
 
-			$specs = self::localize( $specs );
 			set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
 		}
 
 		return $specs;
-	}
-
-	/**
-	 * Localize the provided suggestion.
-	 *
-	 * @param array $specs The specs to localize.
-	 * @return array Localized specs.
-	 */
-	public static function localize( $specs ) {
-		$localized_specs = array();
-
-		foreach ( $specs as $spec ) {
-			if ( ! isset( $spec->locales ) ) {
-				continue;
-			}
-
-			$locale = SpecRunner::get_locale( $spec->locales );
-
-			// Skip specs where no matching locale is found.
-			if ( ! $locale ) {
-				continue;
-			}
-
-			$data = (object) array_merge( (array) $locale, (array) $spec );
-			unset( $data->locales );
-
-			$localized_specs[] = $data;
-		}
-
-		return $localized_specs;
 	}
 }

--- a/tests/features/payment-gateway-suggestions/data-source-poller.php
+++ b/tests/features/payment-gateway-suggestions/data-source-poller.php
@@ -30,7 +30,9 @@ class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_Test_C
 		add_filter(
 			'pre_http_request',
 			function( $pre, $parsed_args, $url ) {
-				if ( 'payment-gateway-suggestions-data-source.json' === $url ) {
+				$locale = get_locale();
+
+				if ( 'payment-gateway-suggestions-data-source.json?_locale=' . $locale === $url ) {
 					return array(
 						'body' => wp_json_encode(
 							array(
@@ -48,7 +50,7 @@ class WC_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_Test_C
 					);
 				}
 
-				if ( 'payment-gateway-suggestions-data-source2.json' === $url ) {
+				if ( 'payment-gateway-suggestions-data-source2.json?_locale=' . $locale === $url ) {
 					return array(
 						'body' => wp_json_encode(
 							array(

--- a/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/tests/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -154,31 +154,4 @@ class WC_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		$this->assertEquals( 'default-gateway', $suggestions[0]->id );
 	}
 
-	/**
-	 * Test that the locale is filter based on current store locale.
-	 */
-	public function test_localization() {
-		$wp_locale_switcher = new WP_Locale_switcher();
-		$wp_locale_switcher->switch_to_locale( 'en_US' );
-
-		$specs = array(
-			(object) array(
-				'id'      => 'mock-gateway',
-				'locales' => array(
-					(object) array(
-						'locale' => 'en_US',
-						'title'  => 'Mock Gateway',
-					),
-					(object) array(
-						'locale' => 'zh_TW',
-						'title'  => '測試付款方式',
-					),
-				),
-			),
-		);
-
-		$localized_specs = PaymentGatewaySuggestions::localize( $specs );
-		$this->assertEquals( 'Mock Gateway', $localized_specs[0]->title );
-		$this->assertCount( 1, $localized_specs );
-	}
 }


### PR DESCRIPTION
Removes the `locales` property in payment gateway suggestion specs in favor of localizing using i18n on WCCOM.

NOTE- Wait for WCCOM PR approval before merging

### Detailed test instructions:

Test using the WCCOM config PR - https://github.com/Automattic/woocommerce.com/pull/10565