### PR TITLE
Fix eway payment gateway key

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -168,7 +168,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'         => 'eway_payments',
+				'id'         => 'eway',
 				'title'      => __( 'eWAY', 'woocommerce-admin' ),
 				'content'    => __( 'The eWAY extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/eway-logo.jpg',


### PR DESCRIPTION
Fixes a broken payment gateway key after moving to the correct eWAY gateway repo.

### Screenshots

#### Before

<img width="694" alt="Screen Shot 2021-06-23 at 4 01 25 PM" src="https://user-images.githubusercontent.com/10561050/123160581-5f7bb080-d43c-11eb-8522-bae85a9a7ce3.png">


#### After

<img width="701" alt="Screen Shot 2021-06-23 at 4 00 44 PM" src="https://user-images.githubusercontent.com/10561050/123160588-6276a100-d43c-11eb-8395-d0047571be11.png">


### Detailed test instructions:

1. Install the gateway from this branch - https://github.com/woocommerce/woocommerce-gateway-eway/pull/112
2. Visit the payments task
3. Note that the fields and setup help text are shown.