### PR TITLE
Fixing logic around recommended gateways in payment suggestions feature

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/List/Item.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/List/Item.js
@@ -65,7 +65,9 @@ export const Item = ( {
 					<img src={ image } alt={ title } />
 				</CardMedia>
 				<div className="woocommerce-task-payment__description">
-					{ showRecommendedRibbon && <RecommendedRibbon /> }
+					{ showRecommendedRibbon && (
+						<RecommendedRibbon gatewayId={ id } />
+					) }
 					<Text as="h3" className="woocommerce-task-payment__title">
 						{ title }
 						{ isInstalled && needsSetup && !! plugins.length && (

--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/List/Item.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/List/Item.js
@@ -32,6 +32,7 @@ export const Item = ( {
 		needsSetup = true,
 		requiredSettings,
 		settingsUrl: manageUrl,
+		is_local_partner: isLocalPartner,
 	} = paymentGateway;
 
 	const connectSlot = useSlot(
@@ -66,7 +67,7 @@ export const Item = ( {
 				</CardMedia>
 				<div className="woocommerce-task-payment__description">
 					{ showRecommendedRibbon && (
-						<RecommendedRibbon gatewayId={ id } />
+						<RecommendedRibbon isLocalPartner={ isLocalPartner } />
 					) }
 					<Text as="h3" className="woocommerce-task-payment__title">
 						{ title }

--- a/client/task-list/tasks/PaymentGatewaySuggestions/index.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/index.js
@@ -126,8 +126,11 @@ export const PaymentGatewaySuggestions = ( { query } ) => {
 	const recommendation = useMemo(
 		() =>
 			Array.from( paymentGateways.values() )
-				.filter( ( gateway ) => gateway.is_recommended )
-				.sort( ( a, b ) => a.is_recommended - b.is_recommended )
+				.filter( ( gateway ) => gateway.recommendation_priority )
+				.sort(
+					( a, b ) =>
+						a.recommendation_priority - b.recommendation_priority
+				)
 				.map( ( gateway ) => gateway.id )
 				.shift(),
 		[ paymentGateways ]

--- a/client/task-list/tasks/PaymentGatewaySuggestions/index.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/index.js
@@ -20,12 +20,6 @@ import { Setup, Placeholder as SetupPlaceholder } from './components/Setup';
 import { WCPaySuggestion } from './components/WCPay';
 import './plugins/Bacs';
 
-const RECOMMENDED_GATEWAY_IDS = [
-	'woocommerce_payments',
-	'woo-mercado-pago-custom',
-	'stripe',
-];
-
 export const PaymentGatewaySuggestions = ( { query } ) => {
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
 	const { getPaymentGateway, paymentGateways, isResolving } = useSelect(
@@ -129,15 +123,15 @@ export const PaymentGatewaySuggestions = ( { query } ) => {
 		} );
 	}, [] );
 
-	const recommendation = useMemo( () => {
-		for ( const id of RECOMMENDED_GATEWAY_IDS ) {
-			const gateway = paymentGateways.get( id );
-			if ( gateway ) {
-				return id;
-			}
-		}
-		return null;
-	}, [ paymentGateways ] );
+	const recommendation = useMemo(
+		() =>
+			Array.from( paymentGateways.values() )
+				.filter( ( gateway ) => gateway.is_recommended )
+				.sort( ( a, b ) => a.is_recommended - b.is_recommended )
+				.map( ( gateway ) => gateway.id )
+				.shift(),
+		[ paymentGateways ]
+	);
 
 	const currentGateway = useMemo( () => {
 		if ( ! query.id || isResolving || ! paymentGateways.size ) {

--- a/client/task-list/tasks/PaymentGatewaySuggestions/index.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/index.js
@@ -22,7 +22,7 @@ import './plugins/Bacs';
 
 const RECOMMENDED_GATEWAY_IDS = [
 	'woocommerce_payments',
-	'mercadopago',
+	'woo-mercado-pago-custom',
 	'stripe',
 ];
 
@@ -130,10 +130,10 @@ export const PaymentGatewaySuggestions = ( { query } ) => {
 	}, [] );
 
 	const recommendation = useMemo( () => {
-		for ( const id in RECOMMENDED_GATEWAY_IDS ) {
+		for ( const id of RECOMMENDED_GATEWAY_IDS ) {
 			const gateway = paymentGateways.get( id );
 			if ( gateway ) {
-				return gateway;
+				return id;
 			}
 		}
 		return null;

--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -44,18 +44,18 @@ Information concerning the configuration and status of the payment gateway is de
 
 Additional information is added to the existing payment gateway in the WooCommerce REST API response. The following public methods can be added to the payment gateway class to pass information to the recommended payment gateways task:
 
-Name | Return | Default | Description
---- | --- | --- | ---
-`needs_setup()` | boolean | `false` | Used to determine if the gateway still requires setup in order to be used.
-`get_required_settings_keys()` | array | `[]` | An array of keys for fields required to properly configure the gateway.  The keys must match those of already registered form fields in the payment gateway.
-`get_connection_url()` | string | `null` | The connection URL to be used to quickly connect a payment gateway provider. If provided, this will be used in place of required setting fields. 
-`get_post_install_script_handles()` | array | `[]` | An array of script handles previously registered with `wp_register_script` to enqueue after the payment gateway has been installed.  This is primarily used to `SlotFill` the payment connection step, but can allow any script to be added to assist in payment gateway setup.
-`get_setup_help_text()` | string | `null` | Help text to be shown above the connection step's submit button.
+| Name                                | Return  | Default | Description                                                                                                                                                                                                                                                                    |
+| ----------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `needs_setup()`                     | boolean | `false` | Used to determine if the gateway still requires setup in order to be used.                                                                                                                                                                                                     |
+| `get_required_settings_keys()`      | array   | `[]`    | An array of keys for fields required to properly configure the gateway. The keys must match those of already registered form fields in the payment gateway.                                                                                                                    |
+| `get_connection_url()`              | string  | `null`  | The connection URL to be used to quickly connect a payment gateway provider. If provided, this will be used in place of required setting fields.                                                                                                                               |
+| `get_post_install_script_handles()` | array   | `[]`    | An array of script handles previously registered with `wp_register_script` to enqueue after the payment gateway has been installed. This is primarily used to `SlotFill` the payment connection step, but can allow any script to be added to assist in payment gateway setup. |
+| `get_setup_help_text()`             | string  | `null`  | Help text to be shown above the connection step's submit button.                                                                                                                                                                                                               |
 
 ## SlotFill
 
 Payment gateway tasks can be SlotFilled to provide custom experiences. This is useful if a gateway cannot follow the generic payment steps to be fully set up.
 
-The entire payment gateway card can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/tasks/src/WooPaymentGatewaySetup) or simply SlotFill [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/tasks/src/WooPaymentGatewayConfigure) to leave the default installation and stepper in place.
+The entire payment gateway card can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewaySetup) or simply SlotFill [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewayConfigure) to leave the default installation and stepper in place.
 
-Note that since plugin installation happens asynchronously, a full page reload will not occur between gateway installation and configuration.  This renders functions like `wp_enqueue_script` ineffective.  To solve this issue and allow `SlotFill` to work on a newly installed plugin, the gateway can provide a URL to be loaded immediately after installation using `get_post_install_script_handles()`.
+Note that since plugin installation happens asynchronously, a full page reload will not occur between gateway installation and configuration. This renders functions like `wp_enqueue_script` ineffective. To solve this issue and allow `SlotFill` to work on a newly installed plugin, the gateway can provide a URL to be loaded immediately after installation using `get_post_install_script_handles()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15305,9 +15305,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+					"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
 					"dev": true
 				},
 				"yallist": {

--- a/packages/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
+++ b/packages/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
@@ -3,10 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const localPartners = [ 'mercadopago' ];
+const localPartners = [ 'woo-mercado-pago-custom' ];
 
-export const RecommendedRibbon = ( { methodKey } ) => {
-	const text = localPartners.includes( methodKey )
+export const RecommendedRibbon = ( { gatewayId } ) => {
+	const text = localPartners.includes( gatewayId )
 		? __( 'Local Partner', 'woocommerce-admin' )
 		: __( 'Recommended', 'woocommerce-admin' );
 

--- a/packages/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
+++ b/packages/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
@@ -3,10 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const localPartners = [ 'woo-mercado-pago-custom' ];
-
-export const RecommendedRibbon = ( { gatewayId } ) => {
-	const text = localPartners.includes( gatewayId )
+export const RecommendedRibbon = ( { isLocalPartner = false } ) => {
+	const text = isLocalPartner
 		? __( 'Local Partner', 'woocommerce-admin' )
 		: __( 'Recommended', 'woocommerce-admin' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Fix obsolete key property in gateway defaults #7229
 - Fix: Fixing button state logic for remote payment gateways #7200
+- Fix: Recommended gateway suggestions not displayed properly #7231
 - Fix: Include onboarding settings on the analytic pages #7109
 - Fix: Load Analytics API only when feature is turned on #7193
 - Fix: Localize string for description #7219

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -38,15 +38,16 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'         => 'stripe',
-				'title'      => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
-				'content'    => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
-				'image'      => WC()->plugin_url() . '/assets/images/stripe.png',
-				'plugins'    => array( 'woocommerce-gateway-stripe' ),
-				'is_visible' => array(
+				'id'             => 'stripe',
+				'title'          => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
+				'content'        => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
+				'image'          => WC()->plugin_url() . '/assets/images/stripe.png',
+				'plugins'        => array( 'woocommerce-gateway-stripe' ),
+				'is_visible'     => array(
 					self::get_rules_for_countries( OnboardingTasks::get_stripe_supported_countries() ),
 					self::get_rules_for_cbd( false ),
 				),
+				'is_recommended' => 3,
 			),
 			array(
 				'id'         => 'paystack',
@@ -60,7 +61,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'        => 'kco',
+				'id'         => 'kco',
 				'title'      => __( 'Klarna', 'woocommerce-admin' ),
 				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
@@ -71,7 +72,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'        => 'mollie_wc_gateway_banktransfer',
+				'id'         => 'mollie_wc_gateway_banktransfer',
 				'title'      => __( 'Mollie', 'woocommerce-admin' ),
 				'content'    => __( 'Effortless payments by Mollie: Offer global and local payment methods, get onboarded in minutes, and supported in your language.', 'woocommerce-admin' ),
 				'image'      => plugins_url( 'images/onboarding/mollie.svg', WC_ADMIN_PLUGIN_FILE ),
@@ -95,14 +96,16 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'         => 'woo-mercado-pago-custom',
-				'title'      => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
-				'content'    => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
-				'image'      => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),
-				'plugins'    => array( 'woocommerce-mercadopago' ),
-				'is_visible' => array(
+				'id'               => 'woo-mercado-pago-custom',
+				'title'            => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
+				'content'          => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
+				'image'            => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'          => array( 'woocommerce-mercadopago' ),
+				'is_visible'       => array(
 					self::get_rules_for_countries( array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ) ),
 				),
+				'is_recommended'   => 2,
+				'is_local_partner' => true,
 			),
 			array(
 				'id'         => 'ppcp-gateway',
@@ -138,19 +141,20 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'          => 'woocommerce_payments',
-				'title'       => __( 'WooCommerce Payments', 'woocommerce-admin' ),
-				'content'     => __(
+				'id'             => 'woocommerce_payments',
+				'title'          => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'content'        => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
 					'woocommerce-admin'
 				),
-				'image'       => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
-				'plugins'     => array( 'woocommerce-payments' ),
-				'description' => 'Try the new way to get paid. Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.',
-				'is_visible'  => array(
+				'image'          => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'        => array( 'woocommerce-payments' ),
+				'description'    => 'Try the new way to get paid. Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.',
+				'is_visible'     => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( self::get_wcpay_countries() ),
 				),
+				'is_recommended' => 1,
 			),
 			array(
 				'id'         => 'razorpay',
@@ -179,7 +183,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'        => 'square_credit_card',
+				'id'         => 'square_credit_card',
 				'title'      => __( 'Square', 'woocommerce-admin' ),
 				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/square-black.png',

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -38,16 +38,16 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'             => 'stripe',
-				'title'          => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
-				'content'        => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
-				'image'          => WC()->plugin_url() . '/assets/images/stripe.png',
-				'plugins'        => array( 'woocommerce-gateway-stripe' ),
-				'is_visible'     => array(
+				'id'                      => 'stripe',
+				'title'                   => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
+				'content'                 => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
+				'image'                   => WC()->plugin_url() . '/assets/images/stripe.png',
+				'plugins'                 => array( 'woocommerce-gateway-stripe' ),
+				'is_visible'              => array(
 					self::get_rules_for_countries( OnboardingTasks::get_stripe_supported_countries() ),
 					self::get_rules_for_cbd( false ),
 				),
-				'is_recommended' => 3,
+				'recommendation_priority' => 3,
 			),
 			array(
 				'id'         => 'paystack',
@@ -96,16 +96,16 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'               => 'woo-mercado-pago-custom',
-				'title'            => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
-				'content'          => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
-				'image'            => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),
-				'plugins'          => array( 'woocommerce-mercadopago' ),
-				'is_visible'       => array(
+				'id'                      => 'woo-mercado-pago-custom',
+				'title'                   => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
+				'content'                 => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
+				'image'                   => plugins_url( 'images/onboarding/mercadopago.png', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'                 => array( 'woocommerce-mercadopago' ),
+				'is_visible'              => array(
 					self::get_rules_for_countries( array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ) ),
 				),
-				'is_recommended'   => 2,
-				'is_local_partner' => true,
+				'recommendation_priority' => 2,
+				'is_local_partner'        => true,
 			),
 			array(
 				'id'         => 'ppcp-gateway',
@@ -141,20 +141,20 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'id'             => 'woocommerce_payments',
-				'title'          => __( 'WooCommerce Payments', 'woocommerce-admin' ),
-				'content'        => __(
+				'id'                      => 'woocommerce_payments',
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'content'                 => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
 					'woocommerce-admin'
 				),
-				'image'          => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
-				'plugins'        => array( 'woocommerce-payments' ),
-				'description'    => 'Try the new way to get paid. Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.',
-				'is_visible'     => array(
+				'image'                   => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'                 => array( 'woocommerce-payments' ),
+				'description'             => 'Try the new way to get paid. Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.',
+				'is_visible'              => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( self::get_wcpay_countries() ),
 				),
-				'is_recommended' => 1,
+				'recommendation_priority' => 1,
 			),
 			array(
 				'id'         => 'razorpay',

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Admin
+ * Plugin Name: WooCommerce Admin (DEV fix recommendations)
  * Plugin URI: https://github.com/woocommerce/woocommerce-admin
  * Description: A new JavaScript-driven interface for managing your store. The plugin includes new and improved reports, and a dashboard to monitor all the important key metrics of your site.
  * Author: WooCommerce

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Admin (DEV fix recommendations)
+ * Plugin Name: WooCommerce Admin
  * Plugin URI: https://github.com/woocommerce/woocommerce-admin
  * Description: A new JavaScript-driven interface for managing your store. The plugin includes new and improved reports, and a dashboard to monitor all the important key metrics of your site.
  * Author: WooCommerce


### PR DESCRIPTION
There were a number of logic errors or id mismatches that were preventing the recommended gateway UI from being displayed for any of the currently recommended gateways (except for WCPay). 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/123170162-0c4f3100-d42f-11eb-9b49-1edccfc1c323.png)


![image](https://user-images.githubusercontent.com/444632/123170434-5fc17f00-d42f-11eb-85d4-9140d3b95b71.png)



### Detailed test instructions:

-   Checkout branch
-   Ensure payment gateways suggestions is enabled
- Set store country to Argentina
- Mercado Pago should display with the "Local Partners" banner, and a highlighted button (as per screenshot)
- Set country to US
- WCPay should now display as Recommended up top, and no other gateway should be marked as recommended.
- Set country to Netherlands
- Now WCPay should not display at all, and Stripe should be marked as recommended as per the screenshot.