### PR TITLE
Disabling wc-admin: Repurpose filter to remove optional features

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -97,13 +97,11 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: WCPay not working in local payments task #7151
 - Fix: WordPress 5.8 compatibility UI fixes #7255
 - Fix: CurrencyFactory constructor to use proper function #7261
-- Fix: Load Analytics API only when feature is turned on #7193
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
 - Fix:  Use tab char for the CSV injection prevention. #7154
 - Tweak: Revert Card component removal #7167
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232
-- Tweak: Revert Card component removal #7167
 - Tweak: Removed unused feature flags #7233
 - Update: Notes to use a date range. #7222
 

--- a/readme.txt
+++ b/readme.txt
@@ -97,9 +97,12 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: WCPay not working in local payments task #7151
 - Fix: WordPress 5.8 compatibility UI fixes #7255
 - Fix: CurrencyFactory constructor to use proper function #7261
+- Fix: Load Analytics API only when feature is turned on #7193
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
 - Fix:  Use tab char for the CSV injection prevention. #7154
+- Tweak: Revert Card component removal #7167
+- Tweak: Repurpose disable wc-admin filter to remove optional features #7232
 - Tweak: Revert Card component removal #7167
 - Tweak: Removed unused feature flags #7233
 - Update: Notes to use a date range. #7222

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -65,16 +65,6 @@ class FeaturePlugin {
 		// Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin.
 		$this->define_constants();
 		require_once WC_ADMIN_ABSPATH . '/includes/page-controller-functions.php';
-
-		/**
-		 * Filter allowing WooCommerce Admin to be disabled.
-		 *
-		 * @param bool $disabled False.
-		 */
-		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
-			return;
-		}
-
 		require_once WC_ADMIN_ABSPATH . '/src/Notes/DeprecatedNotes.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -268,20 +268,25 @@ class Features {
 			array()
 		);
 
-		if ( empty( $features ) ) {
+		$features_disabled = apply_filters( 'woocommerce_admin_disabled', false );
+
+		if ( ! $features_disabled && empty( $features ) ) {
 			return $settings;
 		}
+
+		$desc          = __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' );
+		$disabled_desc = __( 'WooCommerce features have been disabled.', 'woocommerce-admin' );
 
 		return array_merge(
 			array(
 				array(
 					'title' => __( 'Features', 'woocommerce-admin' ),
 					'type'  => 'title',
-					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
+					'desc'  => $features_disabled ? $disabled_desc : $desc,
 					'id'    => 'features_options',
 				),
 			),
-			$features,
+			$features_disabled ? array() : $features,
 			array(
 				array(
 					'type' => 'sectionend',

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -134,9 +134,19 @@ class Features {
 	 */
 	public static function get_available_features() {
 		$features                      = self::get_features();
+		$optional_feature_keys         = array_keys( self::$optional_features );
 		$optional_features_unavailable = [];
 
-		foreach ( array_keys( self::$optional_features ) as $optional_feature_key ) {
+		/**
+		 * Filter allowing WooCommerce Admin optional features to be disabled.
+		 *
+		 * @param bool $disabled False.
+		 */
+		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
+			return array_values( array_diff( $features, $optional_feature_keys ) );
+		}
+
+		foreach ( $optional_feature_keys as $optional_feature_key ) {
 			$feature_class = self::get_feature_class( $optional_feature_key );
 
 			if ( $feature_class ) {

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -277,6 +277,10 @@ class Features {
 		$desc          = __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' );
 		$disabled_desc = __( 'WooCommerce features have been disabled.', 'woocommerce-admin' );
 
+		if ( $features_disabled ) {
+			$GLOBALS['hide_save_button'] = true;
+		}
+
 		return array_merge(
 			array(
 				array(


### PR DESCRIPTION
The previous attempt to remove the `woocommerce_admin_disabled` revealed some great feedback about why it was being used in https://github.com/woocommerce/woocommerce-admin/pull/6568.

This pull requests attempts to honour those use cases by turning off optional features of wc-admin which, as of now, are Navigation and Analytics. By turning off Analytics, this removes Reports, associated API's, data stores, and order processing. This allows WooCommerce to continue being a lean CMS delivering only content without including extensive reporting.

### Detailed test instructions:

1. Make sure all optional features are turned on via the UI WooCommerce > Settings > Advanced > Features

<img width="722" alt="Screen Shot 2021-06-24 at 1 14 18 PM" src="https://user-images.githubusercontent.com/1922453/123187412-387db700-d4ee-11eb-9a2d-17f076a14e1d.png">

2. Add `add_filter( 'woocommerce_admin_disabled', '__return_true' );` to an external plugin.
3. Go to WooCommerce and confirm Analytics and Navigation aren't available.
4. Optionally, make a request to `/wp-json/wc-admin/features` and confirm those features are excluded.
