### PR TITLE
Use gridicons as ReactElement versus SVG to fix blank screen

### DIFF
--- a/client/dashboard/section-controls.js
+++ b/client/dashboard/section-controls.js
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 import { trash, Icon } from '@wordpress/icons';
-import arrowUp from 'gridicons/dist/chevron-up';
-import arrowDown from 'gridicons/dist/chevron-down';
+import ChevronUpIcon from 'gridicons/dist/chevron-up';
+import ChevronDownIcon from 'gridicons/dist/chevron-down';
 import { Component, Fragment } from '@wordpress/element';
 import { MenuItem } from '@woocommerce/components';
 
@@ -55,7 +55,7 @@ class SectionControls extends Component {
 					{ ! isFirst && (
 						<MenuItem isClickable onInvoke={ this.onMoveUp }>
 							<Icon
-								icon={ arrowUp }
+								icon={ <ChevronUpIcon /> }
 								label={ __( 'Move up' ) }
 								size={ 20 }
 								className="icon-control"
@@ -66,7 +66,7 @@ class SectionControls extends Component {
 					{ ! isLast && (
 						<MenuItem isClickable onInvoke={ this.onMoveDown }>
 							<Icon
-								icon={ arrowDown }
+								icon={ <ChevronDownIcon /> }
 								size={ 20 }
 								label={ __( 'Move Down' ) }
 								className="icon-control"

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Report export filtering bug. #7165
 - Fix: Use tab char for the CSV injection prevention. #7154
 - Fix: Use saved form values if available when switching tabs #7226
+- Fix: The use of gridicons for Analytics section controls. #7237
 - Dev: Add `woocommerce_admin_export_id` filter for customizing the export file name #7178
 
 == 2.4.0 6/10/2021 ==


### PR DESCRIPTION
Fixes #7235 

Gridicons are exported as React elements, we were using them as SVG's in section controls, this updates it, so we don't get a fatal error.

### Screenshots

<img width="717" alt="Screen Shot 2021-06-24 at 9 12 24 AM" src="https://user-images.githubusercontent.com/2240960/123260747-4d495300-d4cc-11eb-8079-676795d41754.png">

### Detailed test instructions:

- Go to Analytics > Overview.
- Click on Chart's MenuItem (ellipsis button).
- The dropdown should open up correctly

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
