### PR TITLE
Add E2E tests for analytics overview screen section removal

### DIFF
--- a/client/dashboard/section-controls.js
+++ b/client/dashboard/section-controls.js
@@ -68,10 +68,10 @@ class SectionControls extends Component {
 							<Icon
 								icon={ <ChevronDownIcon /> }
 								size={ 20 }
-								label={ __( 'Move Down' ) }
+								label={ __( 'Move down' ) }
 								className="icon-control"
 							/>
-							{ __( 'Move Down', 'woocommerce-admin' ) }
+							{ __( 'Move down', 'woocommerce-admin' ) }
 						</MenuItem>
 					) }
 					<MenuItem isClickable onInvoke={ onRemove }>

--- a/tests/e2e/pages/AnalyticsOverview.ts
+++ b/tests/e2e/pages/AnalyticsOverview.ts
@@ -14,7 +14,7 @@ export class AnalyticsOverview extends Analytics {
 			list.map( async ( item ) => ( {
 				title: await item.evaluate( ( element ) => {
 					const header = element.querySelector( 'h2' );
-					return header.textContent;
+					return header?.textContent;
 				} ),
 				element: item,
 			} ) )
@@ -29,20 +29,20 @@ export class AnalyticsOverview extends Analytics {
 			const ellipsisMenu = await section.element.$(
 				'.woocommerce-ellipsis-menu button'
 			);
-			ellipsisMenu.click();
+			ellipsisMenu?.click();
 		}
 	}
 
 	async removeSection( sectionTitle: string ) {
 		await this.openSectionEllipsis( sectionTitle );
 		const item = await waitForElementByText( 'div', 'Remove section' );
-		await item.click();
+		await item?.click();
 	}
 
 	async addSection( sectionTitle: string ) {
 		await this.page.waitForSelector( "button[title='Add more sections']" );
 		await this.page.click( "button[title='Add more sections']" );
 		const item = await waitForElementByText( 'span', sectionTitle );
-		await item.click();
+		await item?.click();
 	}
 }

--- a/tests/e2e/pages/AnalyticsOverview.ts
+++ b/tests/e2e/pages/AnalyticsOverview.ts
@@ -1,0 +1,48 @@
+import { waitForElementByText } from '../utils/actions';
+import { Analytics } from './Analytics';
+
+export class AnalyticsOverview extends Analytics {
+	async navigateTo() {
+		await this.navigateToSection( 'overview' );
+	}
+
+	async getSections() {
+		const list = await this.page.$$(
+			'.woocommerce-dashboard-section .woocommerce-section-header'
+		);
+		return Promise.all(
+			list.map( async ( item ) => ( {
+				title: await item.evaluate( ( element ) => {
+					const header = element.querySelector( 'h2' );
+					return header.textContent;
+				} ),
+				element: item,
+			} ) )
+		);
+	}
+
+	async openSectionEllipsis( sectionTitle: string ) {
+		const section = ( await this.getSections() ).find(
+			( section ) => section.title === sectionTitle
+		);
+		if ( section ) {
+			const ellipsisMenu = await section.element.$(
+				'.woocommerce-ellipsis-menu button'
+			);
+			ellipsisMenu.click();
+		}
+	}
+
+	async removeSection( sectionTitle: string ) {
+		await this.openSectionEllipsis( sectionTitle );
+		const item = await waitForElementByText( 'div', 'Remove section' );
+		await item.click();
+	}
+
+	async addSection( sectionTitle: string ) {
+		await this.page.waitForSelector( "button[title='Add more sections']" );
+		await this.page.click( "button[title='Add more sections']" );
+		const item = await waitForElementByText( 'span', sectionTitle );
+		await item.click();
+	}
+}

--- a/tests/e2e/pages/AnalyticsOverview.ts
+++ b/tests/e2e/pages/AnalyticsOverview.ts
@@ -1,8 +1,17 @@
+import { ElementHandle } from 'puppeteer';
 import { waitForElementByText } from '../utils/actions';
 import { Analytics } from './Analytics';
 
+type Section = {
+	title: string;
+	element: ElementHandle< Element >;
+};
+const isSection = ( item: Section | undefined ): item is Section => {
+	return !! item;
+};
+
 export class AnalyticsOverview extends Analytics {
-	async navigateTo() {
+	async navigate() {
 		await this.navigateToSection( 'overview' );
 	}
 
@@ -10,15 +19,22 @@ export class AnalyticsOverview extends Analytics {
 		const list = await this.page.$$(
 			'.woocommerce-dashboard-section .woocommerce-section-header'
 		);
-		return Promise.all(
-			list.map( async ( item ) => ( {
-				title: await item.evaluate( ( element ) => {
+		const sections = await Promise.all(
+			list.map( async ( item ) => {
+				const title = await item.evaluate( ( element ) => {
 					const header = element.querySelector( 'h2' );
 					return header?.textContent;
-				} ),
-				element: item,
-			} ) )
+				} );
+				if ( title ) {
+					return {
+						title,
+						element: item,
+					};
+				}
+				return undefined;
+			} )
 		);
+		return sections.filter( isSection );
 	}
 
 	async openSectionEllipsis( sectionTitle: string ) {
@@ -27,9 +43,30 @@ export class AnalyticsOverview extends Analytics {
 		);
 		if ( section ) {
 			const ellipsisMenu = await section.element.$(
-				'.woocommerce-ellipsis-menu button'
+				'.woocommerce-ellipsis-menu .woocommerce-ellipsis-menu__toggle'
 			);
-			ellipsisMenu?.click();
+			await ellipsisMenu?.click();
+			await this.page.waitForSelector(
+				'.woocommerce-ellipsis-menu div[role=menu]'
+			);
+		}
+	}
+
+	async closeSectionEllipsis( sectionTitle: string ) {
+		const section = ( await this.getSections() ).find(
+			( section ) => section.title === sectionTitle
+		);
+		if ( section ) {
+			const ellipsisMenu = await section.element.$(
+				'.woocommerce-ellipsis-menu .woocommerce-ellipsis-menu__toggle'
+			);
+			await ellipsisMenu?.click();
+			await page.waitFor(
+				() =>
+					! document.querySelector(
+						'.woocommerce-ellipsis-menu div[role=menu]'
+					)
+			);
 		}
 	}
 
@@ -44,5 +81,47 @@ export class AnalyticsOverview extends Analytics {
 		await this.page.click( "button[title='Add more sections']" );
 		const item = await waitForElementByText( 'span', sectionTitle );
 		await item?.click();
+	}
+
+	async moveSectionDown( sectionTitle: string ) {
+		await this.openSectionEllipsis( sectionTitle );
+		const item = await waitForElementByText( 'div', 'Move down' );
+		await item?.click();
+	}
+
+	async moveSectionUp( sectionTitle: string ) {
+		await this.openSectionEllipsis( sectionTitle );
+		const item = await waitForElementByText( 'div', 'Move up' );
+		await item?.click();
+	}
+
+	async getEllipsisMenuItems( sectionTitle: string ) {
+		await this.openSectionEllipsis( sectionTitle );
+		const list = await this.page.$$(
+			'.woocommerce-ellipsis-menu div[role=menuitem]'
+		);
+		return Promise.all(
+			list.map( async ( item ) => ( {
+				title: await item.evaluate(
+					( element ) => element?.textContent
+				),
+				element: item,
+			} ) )
+		);
+	}
+
+	async getEllipsisMenuCheckboxItems( sectionTitle: string ) {
+		await this.openSectionEllipsis( sectionTitle );
+		const list = await this.page.$$(
+			'.woocommerce-ellipsis-menu div[role=menuitemcheckbox]'
+		);
+		return Promise.all(
+			list.map( async ( item ) => ( {
+				title: await item.evaluate(
+					( element ) => element?.textContent
+				),
+				element: item,
+			} ) )
+		);
 	}
 }

--- a/tests/e2e/specs/analytics/analytics-overview.test.ts
+++ b/tests/e2e/specs/analytics/analytics-overview.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { AnalyticsOverview } from '../../pages/AnalyticsOverview';
+import { Login } from '../../pages/Login';
+
+describe( 'Analytics pages', () => {
+	const analyticsPage = new AnalyticsOverview( page );
+	const login = new Login( page );
+
+	beforeAll( async () => {
+		await login.login();
+		await analyticsPage.navigate();
+		await analyticsPage.isDisplayed();
+	} );
+	afterAll( async () => {
+		await login.logout();
+	} );
+
+	it( 'a user should see 3 sections by default - Performance, Charts, and Leaderboards', async () => {
+		const sections = ( await analyticsPage.getSections() ).map(
+			( section ) => section.title
+		);
+		expect( sections ).toContain( 'Performance' );
+		expect( sections ).toContain( 'Charts' );
+		expect( sections ).toContain( 'Leaderboards' );
+	} );
+
+	it( 'should allow a user to remove a section', async () => {
+		await analyticsPage.removeSection( 'Performance' );
+		const sections = ( await analyticsPage.getSections() ).map(
+			( section ) => section.title
+		);
+		expect( sections ).not.toContain( 'Performance' );
+	} );
+
+	it( 'should allow a user to add a section back in', async () => {
+		let sections = ( await analyticsPage.getSections() ).map(
+			( section ) => section.title
+		);
+		expect( sections ).not.toContain( 'Performance' );
+		await analyticsPage.addSection( 'Performance' );
+
+		sections = ( await analyticsPage.getSections() ).map(
+			( section ) => section.title
+		);
+		expect( sections ).toContain( 'Performance' );
+	} );
+} );

--- a/tests/e2e/specs/analytics/analytics-overview.test.ts
+++ b/tests/e2e/specs/analytics/analytics-overview.test.ts
@@ -46,4 +46,43 @@ describe( 'Analytics pages', () => {
 		);
 		expect( sections ).toContain( 'Performance' );
 	} );
+
+	describe( 'moving sections', () => {
+		it( 'should not display move up for the top, or move down for the bottom section', async () => {
+			const sections = await analyticsPage.getSections();
+			for ( const section of sections ) {
+				const index = sections.indexOf( section );
+				const menuItems = (
+					await analyticsPage.getEllipsisMenuItems( section.title )
+				 ).map( ( item ) => item.title );
+				if ( index === 0 ) {
+					expect( menuItems ).toContain( 'Move down' );
+					expect( menuItems ).not.toContain( 'Move up' );
+				} else if ( index === sections.length - 1 ) {
+					expect( menuItems ).not.toContain( 'Move down' );
+					expect( menuItems ).toContain( 'Move up' );
+				} else {
+					expect( menuItems ).toContain( 'Move down' );
+					expect( menuItems ).toContain( 'Move up' );
+				}
+				await analyticsPage.closeSectionEllipsis( section.title );
+			}
+		} );
+
+		it( 'should allow a user to move a section down', async () => {
+			const sections = await analyticsPage.getSections();
+			await analyticsPage.moveSectionDown( sections[ 0 ].title );
+			const newSections = await analyticsPage.getSections();
+			expect( sections[ 0 ].title ).toEqual( newSections[ 1 ].title );
+			expect( sections[ 1 ].title ).toEqual( newSections[ 0 ].title );
+		} );
+
+		it( 'should allow a user to move a section up', async () => {
+			const sections = await analyticsPage.getSections();
+			await analyticsPage.moveSectionUp( sections[ 1 ].title );
+			const newSections = await analyticsPage.getSections();
+			expect( sections[ 0 ].title ).toEqual( newSections[ 1 ].title );
+			expect( sections[ 1 ].title ).toEqual( newSections[ 0 ].title );
+		} );
+	} );
 } );


### PR DESCRIPTION
We had a recent bug with opening the ellipsis menu within the analytics overview screen, given this is a vital part of WC Admin, I added some E2E tests for it.
Currently only for the overview screen, checking if the 3 sections appear and if you can remove one and add it back in.

These tests should fail right now ([failed run](https://github.com/woocommerce/woocommerce-admin/actions/runs/968240211)), until https://github.com/woocommerce/woocommerce-admin/pull/7237 has been merged in and this branch is rebased.

No changelog necessary (in my opinion)

### Detailed test instructions:

-   Check if E2E tests pass in Github actions

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
