### PR TITLE
WordPress 5.8 compatibility UI fixes

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -67,7 +67,12 @@ export class Leaderboard extends Component {
 			return (
 				<Card className={ classes }>
 					<CardHeader>
-						<Text variant="title.small" as="h3">
+						<Text
+							variant="title.small"
+							as="h3"
+							size="20"
+							lineHeight="28px"
+						>
 							{ title }
 						</Text>
 					</CardHeader>

--- a/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
+++ b/client/analytics/components/leaderboard/test/__snapshots__/index.js.snap
@@ -10,6 +10,7 @@ exports[`Leaderboard should render correct data in the table 1`] = `
     >
       <h2
         class="css-1ahfdc3-Text e15wbhsk0"
+        size="20"
       />
       <div
         class="woocommerce-table__actions"
@@ -274,6 +275,7 @@ exports[`Leaderboard should render empty message when there are no rows 1`] = `
     >
       <h3
         class="css-1ahfdc3-Text e15wbhsk0"
+        size="20"
       />
     </div>
     <div

--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -56,7 +56,12 @@ class ChartBlock extends Component {
 			>
 				<Card className="woocommerce-dashboard__chart-block">
 					<CardHeader>
-						<Text variant="title.small" as="h3">
+						<Text
+							variant="title.small"
+							as="h3"
+							size="20"
+							lineHeight="28px"
+						>
 							{ selectedChart.label }
 						</Text>
 					</CardHeader>

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -27,8 +27,15 @@ class ActivityHeader extends Component {
 		return (
 			<div className={ cardClassName }>
 				<div className="woocommerce-layout__inbox-title">
-					<Text variant="title.small">{ title }</Text>
-					<Text variant="button">
+					<Text variant="title.small" size="20" lineHeight="28px">
+						{ title }
+					</Text>
+					<Text
+						variant="button"
+						weight="600"
+						size="14"
+						lineHeight="20px"
+					>
 						{ countUnread > 0 && (
 							<span className="woocommerce-layout__inbox-badge">
 								{ unreadMessages }
@@ -38,7 +45,9 @@ class ActivityHeader extends Component {
 				</div>
 				<div className="woocommerce-layout__inbox-subtitle">
 					{ subtitle && (
-						<Text variant="body.small">{ subtitle }</Text>
+						<Text variant="body.small" size="14" lineHeight="20px">
+							{ subtitle }
+						</Text>
 					) }
 				</div>
 				{ menu && (

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -352,7 +352,13 @@ function getListItems( props ) {
 
 	return validatedItems.map( ( item ) => ( {
 		title: (
-			<Text as="div" variant="button">
+			<Text
+				as="div"
+				variant="button"
+				weight="600"
+				size="14"
+				lineHeight="20px"
+			>
 				{ item.title }
 			</Text>
 		),

--- a/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
+++ b/client/header/activity-panel/panels/inbox/abbreviated-notifications-panel.js
@@ -74,7 +74,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					<Text as="h3">
 						{ __( 'Things to do next', 'woocommerce-admin' ) }
 					</Text>
-					<Text>
+					<Text as="p">
 						{ sprintf(
 							/* translators: Things the user has to do */
 							_n(

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -168,7 +168,6 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 				<Text
 					className={ `woocommerce-layout__header-heading ${ backButtonClass }` }
 					as="h1"
-					variant="subtitle.small"
 				>
 					{ getPageTitle( decodeEntities( pageTitle ) ) }
 				</Text>

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -92,7 +92,12 @@ export const ActivityPanel = () => {
 				return collapsible ? (
 					<PanelBody
 						title={ [
-							<Text key={ title } variant="title.small">
+							<Text
+								key={ title }
+								variant="title.small"
+								size="20"
+								lineHeight="28px"
+							>
 								{ title }
 							</Text>,
 							count !== null && (
@@ -127,7 +132,13 @@ export const ActivityPanel = () => {
 								aria-expanded={ false }
 								disabled={ true }
 							>
-								<Text variant="title.small">{ title }</Text>
+								<Text
+									variant="title.small"
+									size="20"
+									lineHeight="28px"
+								>
+									{ title }
+								</Text>
 								{ count !== null && <Badge count={ count } /> }
 							</Button>
 						</h2>

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -71,7 +71,7 @@ export const StatsOverview = () => {
 	);
 
 	const HeaderText = (
-		<Text variant="title.small">
+		<Text variant="title.small" size="20" lineHeight="28px">
 			{ __( 'Stats overview', 'woocommerce-admin' ) }
 		</Text>
 	);

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -208,7 +208,12 @@ export class StoreAlerts extends Component {
 		return (
 			<Card className={ className } size={ null }>
 				<CardHeader isBorderless>
-					<Text variant="title.medium" as="h2">
+					<Text
+						variant="title.medium"
+						as="h2"
+						size="24"
+						lineHeight="32px"
+					>
 						{ alert.title }
 					</Text>
 					{ numberOfAlerts > 1 && (

--- a/client/layout/store-alerts/style.scss
+++ b/client/layout/store-alerts/style.scss
@@ -89,7 +89,7 @@
 	}
 }
 
-.woocommerce-store-alerts__message {
+.components-card__body .woocommerce-store-alerts__message {
 	margin-bottom: 16px;
 }
 
@@ -118,6 +118,7 @@
 		border-color: $button-border;
 		border-style: solid;
 		flex: 1 1;
+		@include font-size( 14 );
 	}
 
 	@include breakpoint( '<782px' ) {

--- a/client/marketing/components/card/index.js
+++ b/client/marketing/components/card/index.js
@@ -23,14 +23,20 @@ const Card = ( props ) => {
 		>
 			<CardHeader>
 				<div>
-					<Text variant="title.small" size="20" lineHeight="28px">
+					<Text
+						variant="title.small"
+						as="p"
+						size="20"
+						lineHeight="28px"
+					>
 						{ title }
 					</Text>
 					<Text
 						variant="subtitle.small"
+						as="p"
 						className="woocommerce-admin-marketing-card-subtitle"
-						size="20"
-						lineHeight="28px"
+						size="14"
+						lineHeight="20px"
 					>
 						{ description }
 					</Text>

--- a/client/marketing/components/card/index.js
+++ b/client/marketing/components/card/index.js
@@ -23,10 +23,14 @@ const Card = ( props ) => {
 		>
 			<CardHeader>
 				<div>
-					<Text variant="title.small">{ title }</Text>
+					<Text variant="title.small" size="20" lineHeight="28px">
+						{ title }
+					</Text>
 					<Text
 						variant="subtitle.small"
 						className="woocommerce-admin-marketing-card-subtitle"
+						size="20"
+						lineHeight="28px"
 					>
 						{ description }
 					</Text>

--- a/client/marketing/overview/installed-extensions/index.js
+++ b/client/marketing/overview/installed-extensions/index.js
@@ -42,7 +42,9 @@ class InstalledExtensions extends Component {
 		return (
 			<Card className="woocommerce-marketing-installed-extensions-card">
 				<CardHeader>
-					<Text variant="title.small">{ title }</Text>
+					<Text variant="title.small" size="20" lineHeight="28px">
+						{ title }
+					</Text>
 				</CardHeader>
 				{ plugins.map( ( plugin ) => {
 					return (

--- a/client/navigation/components/category-title/style.scss
+++ b/client/navigation/components/category-title/style.scss
@@ -1,6 +1,8 @@
 .woocommerce-navigation-category-title {
 	display: flex;
 	align-items: center;
+	font-size: 20px;
+	line-height: 28px;
 
 	.woocommerce-navigation-favorite-button {
 		margin-left: auto;

--- a/client/navigation/components/intro-modal/index.js
+++ b/client/navigation/components/intro-modal/index.js
@@ -76,10 +76,22 @@ export const IntroModal = () => {
 			content: (
 				<div className="woocommerce-navigation-intro-modal__page-wrapper">
 					<div className="woocommerce-navigation-intro-modal__page-text">
-						<Text variant="title.large" as="h2">
+						<Text
+							variant="title.large"
+							as="h2"
+							size="32"
+							lineHeight="40px"
+						>
 							{ title }
 						</Text>
-						<Text variant="body.large">{ description }</Text>
+						<Text
+							as="p"
+							variant="body.large"
+							size="16"
+							lineHeight="24px"
+						>
+							{ description }
+						</Text>
 					</div>
 					<div className="woocommerce-navigation-intro-modal__image-wrapper">
 						<img alt={ title } src={ imageUrl } />

--- a/client/payments/payment-recommendations-wrapper.tsx
+++ b/client/payments/payment-recommendations-wrapper.tsx
@@ -20,7 +20,7 @@ export const PaymentRecommendations: React.FC< EmbeddedBodyProps > = ( {
 	tab,
 	section,
 } ) => {
-	if ( true ) {
+	if ( page === 'wc-settings' && tab === 'checkout' && ! section ) {
 		return (
 			<Suspense fallback={ null }>
 				<PaymentRecommendationsChunk />

--- a/client/payments/payment-recommendations-wrapper.tsx
+++ b/client/payments/payment-recommendations-wrapper.tsx
@@ -20,7 +20,7 @@ export const PaymentRecommendations: React.FC< EmbeddedBodyProps > = ( {
 	tab,
 	section,
 } ) => {
-	if ( page === 'wc-settings' && tab === 'checkout' && ! section ) {
+	if ( true ) {
 		return (
 			<Suspense fallback={ null }>
 				<PaymentRecommendationsChunk />

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -180,7 +180,12 @@ const PaymentRecommendations: React.FC = () => {
 		<Card size="large" className="woocommerce-recommended-payments-card">
 			<CardHeader size="medium">
 				<div className="woocommerce-recommended-payments-card__header">
-					<Text variant="title.small">
+					<Text
+						variant="title.small"
+						as="p"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __(
 							'Recommended ways to get paid',
 							'woocommerce-admin'
@@ -191,6 +196,9 @@ const PaymentRecommendations: React.FC = () => {
 							'woocommerce-recommended-payments__header-heading'
 						}
 						variant="caption"
+						as="p"
+						size="12"
+						lineHeight="16px"
 					>
 						{ __(
 							'We recommend adding one of the following payment extensions to your store. The extension will be installed and activated for you when you click "Get started".',

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -278,13 +278,18 @@ class BusinessDetails extends Component {
 					return (
 						<>
 							<div className="woocommerce-profile-wizard__step-header">
-								<Text variant="title.small" as="h2">
+								<Text
+									variant="title.small"
+									as="h2"
+									size="20"
+									lineHeight="28px"
+								>
 									{ __(
 										'Tell us about your business',
 										'woocommerce-admin'
 									) }
 								</Text>
-								<Text variant="body">
+								<Text variant="body" as="p">
 									{ __(
 										"We'd love to know if you are just getting started or you already have a business in place.",
 										'woocommerce-admin'
@@ -420,19 +425,24 @@ class BusinessDetails extends Component {
 		return (
 			<>
 				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __(
 							'Included business features',
 							'woocommerce-admin'
 						) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __(
 							'We recommend enhancing your store with these free extensions',
 							'woocommerce-admin'
 						) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __(
 							'No commitment required - you can remove them at any time.',
 							'woocommerce-admin'

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -229,7 +229,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 	if ( isInstallingActivating ) {
 		return (
 			<div className="woocommerce-profile-wizard__footnote">
-				<Text variant="caption" as="p">
+				<Text variant="caption" as="p" size="12" lineHeight="16px">
 					{ sprintf(
 						/* translators: %s: a comma separated list of plugins, e.g. Jetpack, Woocommerce Shipping */
 						_n(
@@ -255,7 +255,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 	);
 	return (
 		<div className="woocommerce-profile-wizard__footnote">
-			<Text variant="caption" as="p">
+			<Text variant="caption" as="p" size="12" lineHeight="16px">
 				{ sprintf(
 					/* translators: %1$s: a comma separated list of plugins, e.g. Jetpack, Woocommerce Shipping, %2$s: text: 'User accounts are required to use these features.'  */
 					_n(
@@ -269,7 +269,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 				) }
 			</Text>
 			{ installingJetpackOrWcShipping && (
-				<Text variant="caption" as="p">
+				<Text variant="caption" as="p" size="12" lineHeight="16px">
 					{ interpolateComponents( {
 						mixedString: __(
 							'By installing Jetpack and WooCommerce Shipping plugins for free you agree to our {{link}}Terms of Service{{/link}}.',

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -202,13 +202,18 @@ class Industry extends Component {
 		return (
 			<Fragment>
 				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __(
 							'In which industry does the store operate?',
 							'woocommerce-admin'
 						) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
 					</Text>
 				</div>

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -109,13 +109,18 @@ export class ProductTypes extends Component {
 		return (
 			<div className="woocommerce-profile-wizard__product-types">
 				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __(
 							'What type of products will be listed?',
 							'woocommerce-admin'
 						) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
 					</Text>
 				</div>
@@ -173,7 +178,7 @@ export class ProductTypes extends Component {
 				<div className="woocommerce-profile-wizard__card-help-footnote">
 					<div className="woocommerce-profile-wizard__product-types-pricing-toggle woocommerce-profile-wizard__checkbox">
 						<label htmlFor="woocommerce-product-types__pricing-toggle">
-							<Text variant="body">
+							<Text variant="body" as="p">
 								{ __(
 									'Display monthly prices',
 									'woocommerce-admin'
@@ -190,7 +195,7 @@ export class ProductTypes extends Component {
 							/>
 						</label>
 					</div>
-					<Text variant="caption">
+					<Text variant="caption" size="12" lineHeight="16px">
 						{ __(
 							'Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.',
 							'woocommerce-admin'

--- a/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -10,6 +10,7 @@ exports[`ProductTypes should render product types 1`] = `
     >
       <h2
         class="css-1ahfdc3-Text e15wbhsk0"
+        size="20"
       >
         What type of products will be listed?
       </h2>
@@ -72,6 +73,7 @@ exports[`ProductTypes should render product types 1`] = `
               
               <span
                 class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+                size="12"
               >
                 <span
                   class="screen-reader-text"
@@ -156,6 +158,7 @@ you can purchase and install it later.
       </div>
       <p
         class="css-1qmnemh-Text e15wbhsk0"
+        size="12"
       >
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </p>
@@ -174,6 +177,7 @@ exports[`ProductTypes should show annual prices on toggle 1`] = `
     >
       <h2
         class="css-1ahfdc3-Text e15wbhsk0"
+        size="20"
       >
         What type of products will be listed?
       </h2>
@@ -236,6 +240,7 @@ exports[`ProductTypes should show annual prices on toggle 1`] = `
               
               <span
                 class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+                size="12"
               >
                 <span
                   class="screen-reader-text"
@@ -320,6 +325,7 @@ you can purchase and install it later.
       </div>
       <p
         class="css-1qmnemh-Text e15wbhsk0"
+        size="12"
       >
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </p>

--- a/client/profile-wizard/steps/product-types/test/__snapshots__/product-type.js.snap
+++ b/client/profile-wizard/steps/product-types/test/__snapshots__/product-type.js.snap
@@ -32,6 +32,7 @@ exports[`ProductType should render the product type 1`] = `
     
     <span
       class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+      size="12"
     >
       <span
         class="screen-reader-text"
@@ -78,6 +79,7 @@ exports[`ProductType should render the product type with monthly prices 1`] = `
     
     <span
       class="woocommerce-pill css-1qmnemh-Text e15wbhsk0"
+      size="12"
     >
       <span
         class="screen-reader-text"

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -209,10 +209,15 @@ class StoreDetails extends Component {
 		return (
 			<div className="woocommerce-profile-wizard__store-details">
 				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __( 'Welcome to WooCommerce', 'woocommerce-admin' ) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __(
 							"Tell us about your store and we'll get you set up in no time",
 							'woocommerce-admin'

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -358,10 +358,15 @@ class Theme extends Component {
 		return (
 			<Fragment>
 				<div className="woocommerce-profile-wizard__step-header">
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ __( 'Choose a theme', 'woocommerce-admin' ) }
 					</Text>
-					<Text variant="body">
+					<Text variant="body" as="p">
 						{ __(
 							"Choose how your store appears to customers. And don't worry, you can always switch themes and edit them later.",
 							'woocommerce-admin'

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -13,6 +13,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			line-height: 1.5em;
 
 			.woocommerce-profile-wizard__tooltip-icon {
 				height: 16px;

--- a/client/store-management-links/index.js
+++ b/client/store-management-links/index.js
@@ -176,7 +176,7 @@ export const StoreManagementLinks = () => {
 	return (
 		<Card size="medium">
 			<CardHeader size="medium">
-				<Text variant="title.small">
+				<Text variant="title.small" size="20" lineHeight="28px">
 					{ __( 'Store management', 'woocommerce-admin' ) }
 				</Text>
 			</CardHeader>

--- a/client/store-management-links/quick-link/index.js
+++ b/client/store-management-links/quick-link/index.js
@@ -31,6 +31,9 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 					className="woocommerce-quick-links__item-link__text"
 					as="div"
 					variant="button"
+					weight="600"
+					size="14"
+					lineHeight="20px"
 				>
 					{ title }
 				</Text>

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -331,7 +331,13 @@ export const TaskList = ( {
 				>
 					<CardHeader size="medium">
 						<div className="wooocommerce-task-card__header">
-							<Text variant="title.small">{ listTitle }</Text>
+							<Text
+								size="20"
+								lineHeight="28px"
+								variant="title.small"
+							>
+								{ listTitle }
+							</Text>
 							<Badge count={ incompleteTasks.length } />
 						</div>
 						{ renderMenu() }

--- a/client/task-list/tasks/payments/components/WCPaySuggestion.js
+++ b/client/task-list/tasks/payments/components/WCPaySuggestion.js
@@ -69,7 +69,7 @@ export const WCPaySuggestion = ( {
 
 			<WCPayCardFooter>
 				<>
-					<Text>
+					<Text lineHeight="1.5em">
 						<TosPrompt />
 					</Text>
 					<PaymentAction

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -293,6 +293,8 @@ class Tax extends Component {
 							<Text
 								variant="caption"
 								className="woocommerce-task__caption"
+								size="12"
+								lineHeight="16px"
 							>
 								{ interpolateComponents( {
 									mixedString: agreementText,

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -274,7 +274,16 @@ class AdvancedFilters extends Component {
 		return (
 			<Card className="woocommerce-filters-advanced" size="small">
 				<CardHeader justify="flex-start">
-					<Text variant="subtitle.small">{ this.getTitle() }</Text>
+					<Text
+						variant="subtitle.small"
+						as="p"
+						weight="600"
+						size="14"
+						lineHeight="20px"
+						isBlock="false"
+					>
+						{ this.getTitle() }
+					</Text>
 				</CardHeader>
 				{ !! activeFilters.length && (
 					<CardBody size={ null }>

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -39,9 +39,11 @@
 	}
 }
 
+.woocommerce-card__menu.woocommerce-card__header-item, // Override wp.components
 .woocommerce-card__header-item {
 	@include set-grid-item-position( 3, 3 );
 	-ms-grid-row-align: center;
+	margin-left: initial;
 }
 
 .woocommerce-card__action,

--- a/packages/components/src/compare-filter/index.js
+++ b/packages/components/src/compare-filter/index.js
@@ -96,7 +96,14 @@ export class CompareFilter extends Component {
 		return (
 			<Card className="woocommerce-filters__compare">
 				<CardHeader>
-					<Text variant="subtitle.small">{ labels.title }</Text>
+					<Text
+						variant="subtitle.small"
+						weight="600"
+						size="14"
+						lineHeight="20px"
+					>
+						{ labels.title }
+					</Text>
 				</CardHeader>
 				<CardBody>
 					<Search

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -122,7 +122,7 @@ a.woocommerce-list__item {
 		}
 	}
 
-	.woocommerce-list__item-title {
+	.woocommerce-list__item-title, .woocommerce-list__item-title > div {
 		color: $foreground-color;
 	}
 

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -122,7 +122,8 @@ a.woocommerce-list__item {
 		}
 	}
 
-	.woocommerce-list__item-title, .woocommerce-list__item-title > div {
+	.woocommerce-list__item-title,
+	.woocommerce-list__item-title > div {
 		color: $foreground-color;
 	}
 

--- a/packages/components/src/pill/pill.js
+++ b/packages/components/src/pill/pill.js
@@ -5,7 +5,13 @@ import { Text } from '../experimental';
 
 export function Pill( { children } ) {
 	return (
-		<Text className="woocommerce-pill" variant="caption" as="span">
+		<Text
+			className="woocommerce-pill"
+			variant="caption"
+			as="span"
+			size="12"
+			lineHeight="16px"
+		>
 			{ children }
 		</Text>
 	);

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -103,12 +103,14 @@ const SummaryNumber = ( {
 		<li className={ liClasses }>
 			<Container { ...containerProps }>
 				<div className="woocommerce-summary__item-label">
-					<Text variant="body.small">{ label }</Text>
+					<Text variant="body.small" size="14" lineHeight="20px">
+						{ label }
+					</Text>
 				</div>
 
 				<div className="woocommerce-summary__item-data">
 					<div className="woocommerce-summary__item-value">
-						<Text variant="title.small">
+						<Text variant="title.small" size="20" lineHeight="28px">
 							{ ! isNil( value )
 								? value
 								: __( 'N/A', 'woocommerce-admin' ) }
@@ -128,7 +130,7 @@ const SummaryNumber = ( {
 							role="presentation"
 							aria-label={ screenReaderLabel }
 						>
-							<Text variant="caption">
+							<Text variant="caption" size="12" lineHeight="16px">
 								{ ! isNil( delta )
 									? sprintf(
 											__( '%f%%', 'woocommerce-admin' ),

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -167,7 +167,12 @@ class TableCard extends Component {
 		return (
 			<Card className={ classes }>
 				<CardHeader>
-					<Text variant="title.small" as="h2">
+					<Text
+						variant="title.small"
+						as="h2"
+						size="20"
+						lineHeight="28px"
+					>
 						{ title }
 					</Text>
 					<div className="woocommerce-table__actions">

--- a/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -90,7 +90,13 @@ function CustomerFeedbackModal( {
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ false }
 		>
-			<Text variant="subtitle.small" as="p">
+			<Text
+				variant="subtitle.small"
+				as="p"
+				weight="600"
+				size="14"
+				lineHeight="20px"
+			>
 				{ label }
 			</Text>
 

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -23,7 +23,7 @@ import { Text } from '@woocommerce/experimental';
 
 render() {
 	return (
-		<Text variant="title.small">
+		<Text>
 			…
 		</Text>
 	);

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -109,7 +109,13 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 				</div>
 			</OptionalTaskTooltip>
 			<div className="woocommerce-task-list__item-text">
-				<Text as="div" variant={ completed ? 'body.small' : 'button' }>
+				<Text
+					as="div"
+					size="14"
+					lineHeight={ completed ? '18px' : '20px' }
+					weight={ completed ? 'normal' : '600' }
+					variant={ completed ? 'body.small' : 'button' }
+				>
 					<span className="woocommerce-task-list__item-title">
 						{ title }
 					</span>

--- a/packages/onboarding/src/components/SetupRequired.js
+++ b/packages/onboarding/src/components/SetupRequired.js
@@ -9,7 +9,7 @@ export const SetupRequired = () => {
 	return (
 		<span className="woocommerce-task-payment__setup_required">
 			<NoticeOutlineIcon />
-			<Text variant="small">
+			<Text variant="small" size="14" lineHeight="20px">
 				{ __( 'Setup required', 'woocommerce-admin' ) }
 			</Text>
 		</span>

--- a/packages/onboarding/src/components/WCPayAcceptedMethods.js
+++ b/packages/onboarding/src/components/WCPayAcceptedMethods.js
@@ -20,7 +20,7 @@ import UnionPay from '../images/cards/unionpay.js';
 
 export const WCPayAcceptedMethods = () => (
 	<>
-		<Text as="h3" variant="label">
+		<Text as="h3" variant="label" weight="600" size="12" lineHeight="16px">
 			{ __( 'Accepted payment methods', 'woocommerce-admin' ) }
 		</Text>
 

--- a/packages/onboarding/src/components/WCPayCard/WCPayCard.js
+++ b/packages/onboarding/src/components/WCPayCard/WCPayCard.js
@@ -32,7 +32,11 @@ export const WCPayCardBody = ( {
 	<CardBody>
 		{ heading && <Text as="h2">{ heading }</Text> }
 
-		<Text className="woocommerce-task-payment-wcpay__description">
+		<Text
+			className="woocommerce-task-payment-wcpay__description"
+			as="p"
+			lineHeight="1.5em"
+		>
 			{ description }
 			<br />
 			<Link

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Use tab char for the CSV injection prevention. #7154
 - Fix: Use saved form values if available when switching tabs #7226
 - Fix: The use of gridicons for Analytics section controls. #7237
+- Fix: WordPress 5.8 compatibility UI fixes #7255
 - Dev: Add `woocommerce_admin_export_id` filter for customizing the export file name #7178
 - Update: Notes to use a date range. #7222
 


### PR DESCRIPTION
Fixes #7206

This PR adds support for the API change for `<Text>` component in `@wordpress/components:14.0.0` with backwards compatibility. I've also added classname to increase specificity on some components since `wp.components` override our style in some cases.

You also may notice different font colour in some cases because in the new version, `<Text>` has a default black colour and this PR does not cover overriding that.

Here's a reference of font styles for each variant we used:

| Variant        | size | weight | lineHeight |
|----------------|------|--------|------------|
| title.small    |   20 |    400 | 28px       |
| title.large    |   32 |    400 | 40px       |
| title.medium   |   24 |    400 | 32px       |
| body.small     |   14 |    400 | 20px       |
| body.large     |   16 |    400 | 24px       |
| button         |   14 |    600 | 20px       |
| caption        |   12 |    400 | 16px       |
| subtitle.small |   14 |    600 | 20px       |
| label          |   12 |    600 | 16px       |

### Detailed test instructions:

Start by preparing two sites:

- A JN with WordPress 5.7 and WooCommerce 5.4 installed as a reference
- In your local (or another JN site if you want to export the plugin zip):
  - Install the [WordPress beta tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin configured with Bleeding edge and Beta/RC only to pull in the 5.8 beta update.
  - Update WordPress to the latest 5.8
- In both sites, do a side-by-side comparison preferably on all interfaces that you can and make sure they're not vastly different & everything has to be in place. At least the following interfaces should be covered:
  - WooCommerce > Home
  - Analytics > Overview
  - Marketing > Overview
  - Marketing > Coupons
  - The entire onboarding wizard
  - WooCommerce navigation
  - WooCommerce > Settings > Payments  > Payments Recommendation modal that appears at the bottom of the page (You'll need to wait for a bit for this to appear)
- Optionally, you could also test this in WP 5.7 to make sure no regression is produced.
