### PR TITLE
Make use of memoization to prevent DynamicForm re-initialization

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Configure.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Configure.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PAYMENT_GATEWAYS_STORE_NAME } from '@woocommerce/data';
 import { DynamicForm } from '@woocommerce/components';
@@ -101,24 +100,21 @@ export const Configure = ( {
 	const helpText = setupHelpText && (
 		<p dangerouslySetInnerHTML={ sanitizeHTML( setupHelpText ) } />
 	);
-	const DefaultForm = useRef( ( props ) => {
-		return (
-			<DynamicForm
-				fields={ fields }
-				isBusy={ isUpdating }
-				onSubmit={ handleSubmit }
-				submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
-				validate={ ( values ) => validateFields( values, fields ) }
-				{ ...props }
-			/>
-		);
-	} );
+	const defaultForm = (
+		<DynamicForm
+			fields={ fields }
+			isBusy={ isUpdating }
+			onSubmit={ handleSubmit }
+			submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
+			validate={ ( values ) => validateFields( values, fields ) }
+		/>
+	);
 
 	if ( hasFills ) {
 		return (
 			<WooPaymentGatewayConfigure.Slot
 				fillProps={ {
-					defaultForm: DefaultForm.current,
+					defaultForm,
 					defaultSubmit: handleSubmit,
 					defaultFields: fields,
 					markConfigured: () => markConfigured( id ),
@@ -144,7 +140,7 @@ export const Configure = ( {
 		return (
 			<>
 				{ helpText }
-				<DefaultForm.current />
+				{ defaultForm }
 			</>
 		);
 	}

--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Configure.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Configure.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PAYMENT_GATEWAYS_STORE_NAME } from '@woocommerce/data';
 import { DynamicForm } from '@woocommerce/components';
@@ -100,22 +101,24 @@ export const Configure = ( {
 	const helpText = setupHelpText && (
 		<p dangerouslySetInnerHTML={ sanitizeHTML( setupHelpText ) } />
 	);
-	const DefaultForm = ( props ) => (
-		<DynamicForm
-			fields={ fields }
-			isBusy={ isUpdating }
-			onSubmit={ handleSubmit }
-			submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
-			validate={ ( values ) => validateFields( values, fields ) }
-			{ ...props }
-		/>
-	);
+	const DefaultForm = useRef( ( props ) => {
+		return (
+			<DynamicForm
+				fields={ fields }
+				isBusy={ isUpdating }
+				onSubmit={ handleSubmit }
+				submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
+				validate={ ( values ) => validateFields( values, fields ) }
+				{ ...props }
+			/>
+		);
+	} );
 
 	if ( hasFills ) {
 		return (
 			<WooPaymentGatewayConfigure.Slot
 				fillProps={ {
-					defaultForm: DefaultForm,
+					defaultForm: DefaultForm.current,
 					defaultSubmit: handleSubmit,
 					defaultFields: fields,
 					markConfigured: () => markConfigured( id ),
@@ -141,7 +144,7 @@ export const Configure = ( {
 		return (
 			<>
 				{ helpText }
-				<DefaultForm />
+				<DefaultForm.current />
 			</>
 		);
 	}

--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -13,7 +13,7 @@ import {
 import { Plugins, Stepper } from '@woocommerce/components';
 import { WooPaymentGatewaySetup } from '@woocommerce/onboarding';
 import { recordEvent } from '@woocommerce/tracks';
-import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useSlot } from '@woocommerce/experimental';
 
@@ -151,17 +151,13 @@ export const Setup = ( {
 		isPaymentGatewayResolving ||
 		! isPluginLoaded;
 
-	const DefaultStepper = useCallback(
-		( props ) => (
-			<Stepper
-				isVertical
-				isPending={ stepperPending }
-				currentStep={ needsPluginInstall ? 'install' : 'configure' }
-				steps={ [ installStep, configureStep ].filter( Boolean ) }
-				{ ...props }
-			/>
-		),
-		[ stepperPending, installStep, configureStep ]
+	const defaultStepper = (
+		<Stepper
+			isVertical
+			isPending={ stepperPending }
+			currentStep={ needsPluginInstall ? 'install' : 'configure' }
+			steps={ [ installStep, configureStep ].filter( Boolean ) }
+		/>
 	);
 
 	return (
@@ -170,7 +166,7 @@ export const Setup = ( {
 				{ hasFills ? (
 					<WooPaymentGatewaySetup.Slot
 						fillProps={ {
-							defaultStepper: DefaultStepper,
+							defaultStepper,
 							defaultInstallStep: installStep,
 							defaultConfigureStep: configureStep,
 							markConfigured: () => markConfigured( id ),
@@ -179,7 +175,7 @@ export const Setup = ( {
 						id={ id }
 					/>
 				) : (
-					<DefaultStepper />
+					defaultStepper
 				) }
 			</CardBody>
 		</Card>

--- a/packages/components/src/dynamic-form/dynamic-form.tsx
+++ b/packages/components/src/dynamic-form/dynamic-form.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -38,6 +39,16 @@ const fieldTypeMap = {
 	default: TextField,
 };
 
+const getInitialConfigValues = ( fields: Field[] ) =>
+	fields.reduce(
+		( data, field ) => ( {
+			...data,
+			[ field.id ]:
+				field.type === 'checkbox' ? field.value === 'yes' : field.value,
+		} ),
+		{}
+	);
+
 export const DynamicForm: React.FC< DynamicFormProps > = ( {
 	fields: baseFields = [],
 	isBusy = false,
@@ -50,21 +61,13 @@ export const DynamicForm: React.FC< DynamicFormProps > = ( {
 	const fields =
 		baseFields instanceof Array ? baseFields : Object.values( baseFields );
 
-	const getInitialConfigValues = () =>
-		fields.reduce(
-			( data, field ) => ( {
-				...data,
-				[ field.id ]:
-					field.type === 'checkbox'
-						? field.value === 'yes'
-						: field.value,
-			} ),
-			{}
-		);
+	const initialValues = useMemo( () => getInitialConfigValues( fields ), [
+		fields,
+	] );
 
 	return (
 		<Form
-			initialValues={ getInitialConfigValues() }
+			initialValues={ initialValues }
 			onChange={ onChange }
 			onSubmit={ onSubmit }
 			validate={ validate }

--- a/packages/onboarding/src/components/WooPaymentGatewayConfigure/README.md
+++ b/packages/onboarding/src/components/WooPaymentGatewayConfigure/README.md
@@ -6,7 +6,13 @@ A Slotfill component that will replace the <DynamicForm /> component involved in
 
 ```jsx
 <WooPaymentGatewayConfigure id={ key }>
-  {({defaultForm: DefaultForm}) => <p>Fill Content</p>}
+  {({defaultForm: DefaultForm}) => {
+    return <>
+    <p>Fill Content
+    </p>
+    { defaultForm }
+    </>;
+}}
 </WooPaymentGatewayConfigure>
 
 <WooPaymentGatewayConfigure.Slot id={ key } />
@@ -16,13 +22,13 @@ A Slotfill component that will replace the <DynamicForm /> component involved in
 
 This is the fill component. You must provide the `id` prop to identify the slot that this will occupy. If you provide a function as the child of your fill (as shown above), you will receive some helper props to assist in creating your fill:
 
-| Name             | Type      | Description                                                                                              |
-| ---------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| `defaultForm`    | Component | The default instance of the <DynamicForm> component. Any provided props will override the given defaults |
-| `defaultSubmit`  | Function  | The default submit handler that is provided to the <Form> component                                      |
-| `defaultFields`  | Array     | An array of the field configuration objects provided by the API                                          |
-| `markConfigured` | Function  | A helper function that will mark your gateway as configured                                              |
-| `paymentGateway` | Object    | An object describing all of the relevant data pertaining to this payment gateway                         |
+| Name             | Type     | Description                                                                                                              |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `defaultForm`    | Element  | The default instance of the <DynamicForm> component. Can overwrite props using React.cloneElement(defaultForm, newProps) |
+| `defaultSubmit`  | Function | The default submit handler that is provided to the <Form> component                                                      |
+| `defaultFields`  | Array    | An array of the field configuration objects provided by the API                                                          |
+| `markConfigured` | Function | A helper function that will mark your gateway as configured                                                              |
+| `paymentGateway` | Object   | An object describing all of the relevant data pertaining to this payment gateway                                         |
 
 ### WooPaymentGatewayConfigure.Slot (slot)
 

--- a/packages/onboarding/src/components/WooPaymentGatewayConfigure/README.md
+++ b/packages/onboarding/src/components/WooPaymentGatewayConfigure/README.md
@@ -8,9 +8,10 @@ A Slotfill component that will replace the <DynamicForm /> component involved in
 <WooPaymentGatewayConfigure id={ key }>
   {({defaultForm: DefaultForm}) => {
     return <>
-    <p>Fill Content
-    </p>
-    { defaultForm }
+      <p>
+        Fill Content
+      </p>
+      { defaultForm }
     </>;
 }}
 </WooPaymentGatewayConfigure>


### PR DESCRIPTION
Fixes #7249 

Make use of memoization to prevent DynamicForm re-initialization during submission.
This fixes an issue where the form quickly clears before the payment gateway finishes (see GIF).

No changelog as the payment gateway stuff isn't live yet.

### Screenshots

![dynamic-form-reset](https://user-images.githubusercontent.com/2240960/123439154-d2556a80-d5a7-11eb-8d2b-70b12c8cc7d2.gif)

### Detailed test instructions:

- Add one of the enhanced gateways ([eWay for example](112-gh-woocommerce/woocommerce-gateway-eway) (have to use that branch), using a New Zealand address).
- Navigate to the payment task.
- Fill out the fields and proceed.
- Notice that the fields stay filled in until the redirect.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->