### PR TITLE
Make task item action button optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9836,7 +9836,6 @@
 				"@woocommerce/currency": "file:packages/currency",
 				"@woocommerce/data": "file:packages/data",
 				"@woocommerce/date": "file:packages/date",
-				"@woocommerce/experimental": "file:packages/experimental",
 				"@woocommerce/navigation": "file:packages/navigation",
 				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,6 @@
 		"@woocommerce/currency": "file:../currency",
 		"@woocommerce/data": "file:../data",
 		"@woocommerce/date": "file:../date",
-		"@woocommerce/experimental": "file:../experimental",
 		"@woocommerce/navigation": "file:../navigation",
 		"@wordpress/api-fetch": "^3.21.5",
 		"@wordpress/components": "10.2.0",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 -   Add new VerticalCSSTransition component for handling height transitions. #7203
 -   Update TaskItem to make use of the VerticalCSSTransition. #7203
+-   Make the action button optionable in TaskItem. #7263
+-   Update CollapsibleList to support nested transitional items. #7263
 
 # 1.3.0
 

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -42,8 +42,8 @@ function getContainerHeight( collapseContainer: HTMLDivElement | null ) {
 			containerHeight += child.clientHeight;
 			const style = window.getComputedStyle( child );
 
-			containerHeight += parseInt( style.marginTop ) || 0;
-			containerHeight += parseInt( style.marginBottom ) || 0;
+			containerHeight += parseInt( style.marginTop, 10 ) || 0;
+			containerHeight += parseInt( style.marginBottom, 10 ) || 0;
 		}
 	}
 	return containerHeight;

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -26,8 +26,6 @@ type CollapsibleListProps = {
 	show?: number;
 	onCollapse?: () => void;
 	onExpand?: () => void;
-	mountOnEnter?: boolean;
-	unmountOnExit?: boolean;
 } & ListProps;
 
 const defaultStyle = {
@@ -118,14 +116,13 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 	show = 0,
 	onCollapse,
 	onExpand,
-	mountOnEnter = true,
-	unmountOnExit = false,
 	...listProps
 } ): JSX.Element => {
 	const [ isCollapsed, setCollapsed ] = useState( collapsed );
-	const [ isTransitionCollapsed, setTransitionCollapsed ] = useState(
-		collapsed
-	);
+	const [
+		isTransitionComponentCollapsed,
+		setTransitionComponentCollapsed,
+	] = useState( collapsed );
 	const [ footerLabels, setFooterLabels ] = useState( {
 		collapse: collapseLabel,
 		expand: expandLabel,
@@ -167,7 +164,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 	// This allows for an extra render cycle that adds the maxHeight back in before the exiting transition.
 	// This way the exiting transition still works correctly.
 	useEffect( () => {
-		setTransitionCollapsed( isCollapsed );
+		setTransitionComponentCollapsed( isCollapsed );
 	}, [ isCollapsed ] );
 
 	useEffect( () => {
@@ -223,9 +220,9 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 				<Transition
 					key="remaining-children"
 					timeout={ 500 }
-					in={ ! isTransitionCollapsed }
-					mountOnEnter={ mountOnEnter }
-					unmountOnExit={ unmountOnExit }
+					in={ ! isTransitionComponentCollapsed }
+					mountOnEnter={ true }
+					unmountOnExit={ false }
 				>
 					{ (
 						state: 'entering' | 'entered' | 'exiting' | 'exited'

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -40,6 +40,10 @@ function getContainerHeight( collapseContainer: HTMLDivElement | null ) {
 	if ( collapseContainer ) {
 		for ( const child of collapseContainer.children ) {
 			containerHeight += child.clientHeight;
+			const style = window.getComputedStyle( child );
+
+			containerHeight += parseInt( style.marginTop ) || 0;
+			containerHeight += parseInt( style.marginBottom ) || 0;
 		}
 	}
 	return containerHeight;

--- a/packages/experimental/src/experimental-list/style.scss
+++ b/packages/experimental/src/experimental-list/style.scss
@@ -17,11 +17,11 @@ a.woocommerce-experimental-list__item {
 		padding: $gap $gap-large;
 	}
 
-	&.has-action {
+	&.has-action:not(.expanded) {
 		cursor: pointer;
 	}
 
-	&:focus {
+	&:focus:not(.expanded) {
 		box-shadow: inset 0 0 0 1px $studio-wordpress-blue,
 			inset 0 0 0 2px $studio-white;
 	}

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -49,6 +49,10 @@ $task-alert-yellow: #f0b849;
 		font-size: 12px;
 	}
 
+	.woocommerce-task__estimated-time {
+		margin-top: $gap-smallest;
+	}
+
 	.woocommerce-task-list__item-before {
 		display: flex;
 		align-items: center;

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -42,6 +42,7 @@ type TaskItemProps = {
 	content: string;
 	expandable?: boolean;
 	expanded?: boolean;
+	showActionButton?: boolean;
 	level?: TaskLevel;
 	action: (
 		event?: React.MouseEvent | React.KeyboardEvent,
@@ -73,6 +74,27 @@ const OptionalTaskTooltip: React.FC< {
 	return <Tooltip text={ tooltip }>{ children }</Tooltip>;
 };
 
+const OptionalExpansionWrapper: React.FC< {
+	expandable: boolean;
+	expanded: boolean;
+} > = ( { children, expandable, expanded } ) => {
+	if ( ! expandable ) {
+		return <>{ children }</>;
+	}
+	return (
+		<VerticalCSSTransition
+			timeout={ 500 }
+			in={ expanded }
+			classNames="woocommerce-task-list__item-content"
+			defaultStyle={ {
+				transitionProperty: 'max-height, opacity',
+			} }
+		>
+			{ children }
+		</VerticalCSSTransition>
+	);
+};
+
 export const TaskItem: React.FC< TaskItemProps > = ( {
 	completed,
 	title,
@@ -85,6 +107,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	content,
 	expandable = false,
 	expanded = false,
+	showActionButton,
 	level = 3,
 	action,
 	actionLabel,
@@ -94,6 +117,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );
+	if ( showActionButton === undefined ) {
+		showActionButton = expandable;
+	}
 
 	const showEllipsisMenu =
 		( ( onDismiss || remindMeLater ) && ! completed ) ||
@@ -123,13 +149,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					<span className="woocommerce-task-list__item-title">
 						{ title }
 					</span>
-					<VerticalCSSTransition
-						timeout={ 500 }
-						in={ expanded }
-						classNames="woocommerce-task-list__item-content"
-						defaultStyle={ {
-							transitionProperty: 'max-height, opacity',
-						} }
+					<OptionalExpansionWrapper
+						expandable={ expandable }
+						expanded={ expanded }
 					>
 						<div className="woocommerce-task-list__item-content">
 							{ content }
@@ -141,7 +163,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 									) }
 								></div>
 							) }
-							{ ! completed && (
+							{ ! completed && showActionButton && (
 								<Button
 									className="woocommerce-task-list__item-action"
 									isPrimary
@@ -158,7 +180,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 								</Button>
 							) }
 						</div>
-					</VerticalCSSTransition>
+					</OptionalExpansionWrapper>
 
 					{ ! expandable && ! completed && additionalInfo && (
 						<div

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -114,6 +114,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
+		expanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );

--- a/packages/experimental/src/experimental-list/test/index.tsx
+++ b/packages/experimental/src/experimental-list/test/index.tsx
@@ -255,6 +255,7 @@ describe( 'Experimental List', () => {
 					expandLabel="Show more items"
 					onExpand={ onExpand }
 					onCollapse={ onCollapse }
+					unmountOnExit
 				>
 					<div id="test">Test</div>
 					<div>Test 2</div>

--- a/packages/experimental/src/experimental-list/test/index.tsx
+++ b/packages/experimental/src/experimental-list/test/index.tsx
@@ -255,7 +255,6 @@ describe( 'Experimental List', () => {
 					expandLabel="Show more items"
 					onExpand={ onExpand }
 					onCollapse={ onCollapse }
-					unmountOnExit
 				>
 					<div id="test">Test</div>
 					<div>Test 2</div>
@@ -277,11 +276,6 @@ describe( 'Experimental List', () => {
 			if ( listItem ) {
 				userEvent.click( listItem );
 			}
-			await waitForElementToBeRemoved(
-				container.querySelector( '#test' )
-			);
-			expect( container ).not.toHaveTextContent( 'Test' );
-			expect( container ).not.toHaveTextContent( 'Test 2' );
 			expect( container ).toHaveTextContent( 'Show more items' );
 			expect( container ).not.toHaveTextContent( 'Show less' );
 			expect( onExpand ).toHaveBeenCalledTimes( 1 );

--- a/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
@@ -34,33 +34,29 @@ describe( 'VerticalCSSTransition', () => {
 		}
 	} );
 
-	it( 'should set maxHeight of children to container on render', () => {
+	it( 'should set maxHeight of children to container on entering and remove it when entered', ( done ) => {
 		const nodeRef = createRef< undefined | HTMLDivElement >();
-		render(
-			<VerticalCSSTransition
-				in={ true }
-				timeout={ 0 }
-				nodeRef={ nodeRef as React.RefObject< undefined > }
-				classNames="test"
-			>
-				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
-					Test
-				</div>
-			</VerticalCSSTransition>
-		);
-
-		expect(
-			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
-		).toBe( '100px' );
-	} );
-
-	it( 'should update maxHeight when children are updated', () => {
-		const nodeRef = createRef< undefined | HTMLDivElement >();
+		let count = 0;
 		const props: VerticalCSSTransitionProps = {
-			in: true,
+			in: false,
 			timeout: 0,
 			nodeRef: nodeRef as React.RefObject< undefined >,
 			classNames: 'test',
+			onEntering: () => {
+				count++;
+				expect(
+					nodeRef.current &&
+						nodeRef.current.parentElement?.style.maxHeight
+				).toBe( '100px' );
+			},
+			onEntered: () => {
+				expect(
+					nodeRef.current &&
+						nodeRef.current.parentElement?.style.maxHeight
+				).toBe( '' );
+				expect( count ).toEqual( 1 );
+				done();
+			},
 		};
 		const { rerender } = render(
 			<VerticalCSSTransition { ...props }>
@@ -70,12 +66,49 @@ describe( 'VerticalCSSTransition', () => {
 			</VerticalCSSTransition>
 		);
 
-		expect(
-			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
-		).toBe( '100px' );
+		rerender(
+			<VerticalCSSTransition { ...props } in={ true }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+	} );
+
+	it( 'should update maxHeight when children are updated', ( done ) => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		let count = 0;
+		const props: VerticalCSSTransitionProps = {
+			in: false,
+			timeout: 0,
+			nodeRef: nodeRef as React.RefObject< undefined >,
+			classNames: 'test',
+			onEntering: () => {
+				count++;
+				expect(
+					nodeRef.current &&
+						nodeRef.current.parentElement?.style.maxHeight
+				).toBe( '200px' );
+			},
+			onEntered: () => {
+				expect(
+					nodeRef.current &&
+						nodeRef.current.parentElement?.style.maxHeight
+				).toBe( '' );
+				expect( count ).toEqual( 1 );
+				done();
+			},
+		};
+		const { rerender } = render(
+			<VerticalCSSTransition { ...props }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
 
 		rerender(
-			<VerticalCSSTransition { ...props }>
+			<VerticalCSSTransition { ...props } in={ true }>
 				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
 					Test
 				</div>

--- a/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useCallback, useRef } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 import { CSSTransition } from 'react-transition-group';
 
@@ -15,6 +15,10 @@ function getContainerHeight( container: HTMLDivElement ) {
 	let containerHeight = 0;
 	for ( const child of container.children ) {
 		containerHeight += child.clientHeight;
+		const style = window.getComputedStyle( child );
+
+		containerHeight += parseInt( style.marginTop ) || 0;
+		containerHeight += parseInt( style.marginBottom ) || 0;
 	}
 	return containerHeight;
 }
@@ -29,6 +33,7 @@ export const VerticalCSSTransition: React.FC< VerticalCSSTransitionProps > = ( {
 	...props
 } ) => {
 	const [ containerHeight, setContainerHeight ] = useState( 0 );
+	const [ transitionIn, setTransitionIn ] = useState( props.in || false );
 	const cssTransitionRef = useRef< CSSTransition< HTMLElement > | null >(
 		null
 	);
@@ -40,6 +45,10 @@ export const VerticalCSSTransition: React.FC< VerticalCSSTransitionProps > = ( {
 		},
 		[ children ]
 	);
+
+	useEffect( () => {
+		setTransitionIn( props.in || false );
+	}, [ props.in ] );
 
 	const getTimeouts = () => {
 		const { timeout } = props;
@@ -93,11 +102,19 @@ export const VerticalCSSTransition: React.FC< VerticalCSSTransitionProps > = ( {
 			delete styles.transition;
 			delete styles.transitionProperty;
 		}
+		// Remove maxHeight when entered, so we do not need to worry about nested items changing height while expanded.
+		if ( state === 'entered' && props.in ) {
+			delete styles.maxHeight;
+		}
 		return styles;
 	};
 
 	return (
-		<CSSTransition { ...props } ref={ cssTransitionRef }>
+		<CSSTransition
+			{ ...props }
+			in={ transitionIn }
+			ref={ cssTransitionRef }
+		>
 			{ ( state: 'entering' | 'entered' | 'exiting' | 'exited' ) => (
 				<div
 					className="vertical-css-transition-container"

--- a/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
@@ -17,8 +17,8 @@ function getContainerHeight( container: HTMLDivElement ) {
 		containerHeight += child.clientHeight;
 		const style = window.getComputedStyle( child );
 
-		containerHeight += parseInt( style.marginTop ) || 0;
-		containerHeight += parseInt( style.marginBottom ) || 0;
+		containerHeight += parseInt( style.marginTop, 10 ) || 0;
+		containerHeight += parseInt( style.marginBottom, 10 ) || 0;
 	}
 	return containerHeight;
 }


### PR DESCRIPTION
Fixes #7199 

This PR make a couple different changes, the main one being that we can make the action button optional with using the `showActionButton` prop.
This change revealed a couple more issues with the collapsible list and the vertical transition list, which I fixed as part of this PR.
The issue: Using a nested VerticalCSSTransition item inside a Collapsible list revealed that the height would not be calculated correctly, and some of it getting cut off.
The other issue was that when expanding/collapsing a single item within a collapsible list (we don't have this yet) would cause a height recalculation that wasn't always right.

I left comments in the changes with the fixes for the above.

No changelog as it is in the experimental package.

### Screenshots

<img width="779" alt="Screen Shot 2021-06-28 at 2 27 39 PM" src="https://user-images.githubusercontent.com/2240960/123678679-01284680-d81d-11eb-98d3-0e04ea0b7313.png">

### Detailed test instructions:

Testing on WC Admin:
- Set `expandingItems` to true [here](https://github.com/woocommerce/woocommerce-admin/blob/main/client/task-list/index.js#L250)
- Check the task list and make sure expanding/collapsing individual items works correctly
- Show the extendable task list with more then 2 items (you can use this [WC Admin test helper branch](https://github.com/woocommerce/woocommerce-admin-test-helper/pull/17) ) having `dismissable` enabled for a task list item.
- Expand/collapse the extendable task list and dismiss an item and revert that change (make sure the transitions look good still)

Testing on WC Pay
- Load this branch, and run `build:packages`
- `cd packages/experimental` and `npm link`
- Now in your WC Pay developer repo run `npm link @woocommerce/experimental`
- With one of the task lists shown, make sure the action button doesn't show ( I end up commenting out [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/client/overview/task-list/tasks.js#L59))

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
