### PR TITLE
Use payment gateway suggestion title instead of local plugin names

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -8,7 +8,6 @@ import {
 	OPTIONS_STORE_NAME,
 	PAYMENT_GATEWAYS_STORE_NAME,
 	PLUGINS_STORE_NAME,
-	pluginNames,
 } from '@woocommerce/data';
 import { Plugins, Stepper } from '@woocommerce/components';
 import { WooPaymentGatewaySetup } from '@woocommerce/onboarding';
@@ -87,18 +86,14 @@ export const Setup = ( {
 		setIsPluginLoaded( true );
 	}, [ postInstallScripts, needsPluginInstall ] );
 
-	const pluginNamesString = plugins
-		.map( ( pluginSlug ) => pluginNames[ pluginSlug ] )
-		.join( ' ' + __( 'and', 'woocommerce-admin' ) + ' ' );
-
 	const installStep = useMemo( () => {
 		return plugins && plugins.length
 			? {
 					key: 'install',
 					label: sprintf(
-						/* translators: %s = one or more plugin names joined by "and" */
+						/* translators: %s = title of the payment gateway to install */
 						__( 'Install %s', 'woocommerce-admin' ),
-						pluginNamesString
+						title
 					),
 					content: (
 						<Plugins

--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/test/setup.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/Setup/test/setup.js
@@ -58,7 +58,7 @@ describe( 'Setup', () => {
 
 		const { queryByText } = render( <Setup { ...props } /> );
 
-		expect( queryByText( 'Install' ) ).toBeInTheDocument();
+		expect( queryByText( 'Install Mock Gateway' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should enqueue post install scripts when plugin installation completes', async () => {

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -38,7 +38,7 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'stripe',
-				'title'                   => __( 'Credit cards - powered by Stripe', 'woocommerce-admin' ),
+				'title'                   => __( ' Stripe', 'woocommerce-admin' ),
 				'content'                 => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
 				'image'                   => WC()->plugin_url() . '/assets/images/stripe.png',
 				'plugins'                 => array( 'woocommerce-gateway-stripe' ),


### PR DESCRIPTION
Fixes #7188 

Uses the gateway suggestion title for installation text

The previous method was to store all plugin names in the data store, but if one was missing, the text would ready "Install " instead of "Install {pluginName}."

Note that the current method does not actually show the plugin name (or multiple plugin names) but instead shows the suggestion title text from the REST API.  I think this is a better solution as it's less prone to becoming out of date.

### Screenshots

<img width="698" alt="Screen Shot 2021-06-29 at 1 35 16 PM" src="https://user-images.githubusercontent.com/10561050/123842947-5331a080-d8df-11eb-8b29-16b696ea3abf.png">


### Detailed test instructions:

1. Navigate to the payment gateway task.
2. Note that the install step contains the payment gateway task title.
