### PR TITLE
Add Klarna Payments to default payment gateway suggestions

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -61,12 +61,37 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'kco',
-				'title'      => __( 'Klarna', 'woocommerce-admin' ),
+				'title'      => __( 'Klarna Checkout', 'woocommerce-admin' ),
 				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
 				'plugins'    => array( 'klarna-checkout-for-woocommerce' ),
 				'is_visible' => array(
 					self::get_rules_for_countries( array( 'SE', 'FI', 'NO' ) ),
+					self::get_rules_for_cbd( false ),
+				),
+			),
+			array(
+				'id'         => 'klarna_payments',
+				'title'      => __( 'Klarna Payments', 'woocommerce-admin' ),
+				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
+				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
+				'plugins'    => array( 'klarna-payments-for-woocommerce' ),
+				'is_visible' => array(
+					self::get_rules_for_countries(
+						array(
+							'DK',
+							'DE',
+							'AT',
+							'NL',
+							'CH',
+							'BE',
+							'SP',
+							'PL',
+							'FR',
+							'IT',
+							'GB',
+						)
+					),
 					self::get_rules_for_cbd( false ),
 				),
 			),


### PR DESCRIPTION
Fixes #7240 

Adds distinct Klarna Checkout and Klarna Payments.

### Screenshots

<img width="692" alt="Screen Shot 2021-06-29 at 1 51 45 PM" src="https://user-images.githubusercontent.com/10561050/123844548-2c746980-d8e1-11eb-81f5-4d5af57bbab8.png">
<img width="698" alt="Screen Shot 2021-06-29 at 1 51 15 PM" src="https://user-images.githubusercontent.com/10561050/123844551-2d0d0000-d8e1-11eb-9e62-04c7dd5cd66d.png">


### Detailed test instructions:

1. For both gateways, make sure you haven't selected CBD industry during onboarding.
2. For Klarna Checkout, set your store to one of: `SE, FI, NO`
3. For Klarna Payments, set your store to one of: `DK, DE, AT, NL, CH, BE, SP, PL, FR, IT, GB`
4. Make sure each respective gateway is installed and renders the correct settings or "Set up" button linking to the settings page.
5. Bonus points for making sure the WCCOM endpoint gateways are also updated with this gateway - https://github.com/Automattic/woocommerce.com/pull/10565