### PR TITLE
Add missing translation strings in the business features section

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -4,12 +4,18 @@
 
 ### Fix missing translation strings for CES #7270
 
-
 1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).
 2. You might need to update the language file if it's your first time using the selected language. Update the language file from Dashboard -> Updates
 3. Go to WooCommerce -> Settings
 4. Click the [ Save Changes ] button to trigger the CES modal.
 5. Confirm the modal has correct translations (Refer to the screenshots)
+
+### Add missing translation strings in the business features section #7268
+
+1. Checkout this branch and run `npm start`
+2. Navigate to Settings -> General and change the site language to non-English (I've used Espanol for testing purposes)
+3. You might need to download the new language in Dashboard -> Updates
+4. Navigate to wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features and confirm the translation is working as expected.
 
 ### Use saved values if available when switching tabs #7226
 

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -529,7 +529,8 @@ export const SelectiveExtensionsBundle = ( {
 						/>
 						<p className="woocommerce-admin__business-details__selective-extensions-bundle__description">
 							{ __(
-								'Add recommended business features to my site'
+								'Add recommended business features to my site',
+								'woocommerce-admin'
 							) }
 						</p>
 						<Button
@@ -588,7 +589,7 @@ export const SelectiveExtensionsBundle = ( {
 						disabled={ isInstallingActivating }
 						isPrimary
 					>
-						Continue
+						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
 				</div>
 			</Card>

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Cache product/variation revenue query results. #7067
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
 - Fix: Fix missing translation strings for CES #7270
+- Fix: Add missing translation strings in the business features section #7268
 - Tweak: Revert Card component removal #7167
 - Tweak: Removed unused feature flags #7233 and #7273
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232


### PR DESCRIPTION
Fixes #7212 

This PR adds missing translation strings in the business features section.

### Detailed test instructions:

1. Checkout this branch and run `npm start`
2. Navigate to Settings -> General and change the site language to non-English (I've used Espanol for testing purposes)
3. You might need to download the new language in Dashboard -> Updates
4. Navigate to wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features and confirm the translation is working as expected.

