### PR TITLE
Add CES to translated scripts list

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Fix missing translation strings for CES #7270
+
+
+1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).
+2. You might need to update the language file if it's your first time using the selected language. Update the language file from Dashboard -> Updates
+3. Go to WooCommerce -> Settings
+4. Click the [ Save Changes ] button to trigger the CES modal.
+5. Confirm the modal has correct translations (Refer to the screenshots)
+
 ### Use saved values if available when switching tabs #7226
 
 1. Start onboarding wizard and continue to step 4.

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix:  Use tab char for the CSV injection prevention. #7154
 - Fix: Fix and refactor explat polling to use setTimeout #7274
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
+- Fix: Fix missing translation strings for CES #7270
 - Tweak: Revert Card component removal #7167
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232
 - Tweak: Removed unused feature flags #7233

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -390,6 +390,7 @@ class Loader {
 			'wc-currency',
 			'wc-date',
 			'wc-components',
+			'wc-customer-effort-score',
 			WC_ADMIN_APP,
 		);
 


### PR DESCRIPTION
Fixes #7221 

This PR adds CES to the translated scripts list so that it can be translated correctly.

### Screenshots

**Before**
![Screen Shot 2021-06-29 at 3 28 25 PM](https://user-images.githubusercontent.com/4723145/123875599-da3a4500-d8ee-11eb-9def-ddceb5e6ce33.jpg)


**After**
![Screen Shot 2021-06-29 at 3 26 03 PM](https://user-images.githubusercontent.com/4723145/123875421-7d3e8f00-d8ee-11eb-85f5-165b01892386.jpg)

### Detailed test instructions:

Make sure CES options are clear by executing the following query.

`delete from wp_options where option_name in ('woocommerce_ces_tracks_queue', 'woocommerce_ces_shown_for_actions','woocommerce_clear_ces_tracks_queue_for_page')`



1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).
2. You might need to update the language file if it's your first time using the selected language. Update the language file from Dashboard -> Updates
3. Go to WooCommerce -> Settings
4. Click the [ Save Changes ] button to trigger the CES modal.
5. Confirm the modal has correct translations (Refer to the screenshots)