### PR TITLE
Fix inbox note dismiss dropdown not closing on Safari

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -17,6 +17,13 @@
 3. You might need to download the new language in Dashboard -> Updates
 4. Navigate to wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features and confirm the translation is working as expected.
 
+### Fix inbox note dismiss dropdown not closing on Safari #7278
+
+1. Checkout this branch and run npm start
+2. Navigate to WooCommerce -> Home
+3. Click "Dismiss" on a note. Confirm the position of the popover is correct.
+4. Click anywhere outside of the popover content and confirm the popover is closed.
+
 ### Use saved values if available when switching tabs #7226
 
 1. Start onboarding wizard and continue to step 4.

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -140,7 +140,10 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 				renderToggle={ ( { onClose, onToggle } ) => (
 					<Button
 						isTertiary
-						onClick={ onToggle }
+						onClick={ ( event: React.MouseEvent ) => {
+							( event.target as HTMLElement ).focus();
+							onToggle();
+						} }
 						ref={ toggleButtonRef }
 						onBlur={ ( event: React.FocusEvent ) =>
 							handleBlur( event, onClose )

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -128,6 +128,7 @@
 	}
 	.components-dropdown {
 		display: inline;
+		position: absolute;
 
 		.components-popover__content {
 			min-width: 195px;

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
 - Fix: Fix missing translation strings for CES #7270
 - Fix: Add missing translation strings in the business features section #7268
+- Fix: Fix inbox note dismiss dropdown not closing on Safari #7278
 - Tweak: Revert Card component removal #7167
 - Tweak: Removed unused feature flags #7233 and #7273
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232


### PR DESCRIPTION
Fixes #7032 

This PR fixes incorrect position and close event of the dismiss popover content.


### Detailed test instructions:

*This bug only occurs on Safari*

1.  Checkout this branch and run `npm start`
2. Navigate to WooCommerce -> Home
3. Click "Dismiss" on a note. Confirm the position of the popover is correct.
4. Click anywhere outside of the popover content and confirm the popover is closed. 

