### PR TITLE
Add ability to override payment gateway settings URL

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -36,7 +36,9 @@ class PaymentGatewaysController {
 
 		$data['needs_setup']          = $gateway->needs_setup();
 		$data['post_install_scripts'] = self::get_post_install_scripts( $gateway );
-		$data['settings_url']         = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
+		$data['settings_url']         = method_exists( $gateway, 'get_settings_url' )
+			? $gateway->get_settings_url()
+			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 
 		$return_url             = wc_admin_url( '&task=payments&connection-return=' . strtolower( $gateway->id ) );
 		$data['connection_url'] = method_exists( $gateway, 'get_connection_url' )


### PR DESCRIPTION
Fixes #7280 

Allows overriding the settings URL but falls back to default gateway settings URL if none provided.

### Screenshots

<img width="693" alt="Screen Shot 2021-06-30 at 7 17 37 PM" src="https://user-images.githubusercontent.com/10561050/124043030-2c0aca00-d9d8-11eb-8b0a-8160094954fe.png">

### Detailed test instructions:

1. Clone this Mollie branch - https://github.com/mollie/WooCommerce/pull/553
2. Check that the "Set up" and "Manage" buttons direct to the Mollie settings URL (`admin.php?page=wc-settings&tab=mollie_settings`)
2. Check that other button URLs have not regressed