### PR TITLE
Sync readme.txt with release 2.4.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,39 +87,26 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Include onboarding settings on the analytic pages #7109
 - Fix: Load Analytics API only when feature is turned on #7193
 - Fix: Localize string for description #7219
-- Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
 - Add: Adding tests for PaymentGatewaySuggestions > List component #7201
 - Fix: Report export filtering bug. #7165
 - Fix: Use tab char for the CSV injection prevention. #7154
 - Fix: Use saved form values if available when switching tabs #7226
 - Fix: Skip schedule customer data deletion on site deletion #7214
-- Fix: The use of gridicons for Analytics section controls. #7237
 - Fix: WCPay not working in local payments task #7151
-- Fix: WordPress 5.8 compatibility UI fixes #7255
-- Fix: CurrencyFactory constructor to use proper function #7261
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
 - Fix:  Use tab char for the CSV injection prevention. #7154
-- Fix: Fix and refactor explat polling to use setTimeout #7274
+- Fix: Attribute filter bug with "any X" variations. #7046
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
-- Tweak: Revert Card component removal #7167
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232
 - Tweak: Removed unused feature flags #7233
 - Update: Notes to use a date range. #7222
 
-== 2.4.0 6/10/2021 ==
-- Dev: Add Jetpack Backup admin note #6738
-- Add: Adding WCPay payment configuration defaults. #7097
-- Fix: Transformer casing is incorrect and creates an error on case-sensitive systems #7104
-- Dev: Reduce the specificity and complexity of the ReportError component #6846
-- Add: Create onboarding package to house refactored WCPay card and relevant components #7058
-- Fix: Preventing redundant notices when installing plugins via payments task list. #7026
-- Fix: Autocompleter for custom Search in CompareFilter #6911
-- Fix: Include onboarding settings on the analytic pages #7109
-- Dev: Converting <SettingsForm /> component to TypeScript. #6981
-- Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
-- Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
-- Fix: Set autoload to false for all remote inbox notifications options. #7060
+== 2.4.1 7/1/2021 ==
+- Fix: Fix and refactor explat polling to use setTimeout #7274
+
+== 2.4.0 6/29/2021 ==
+- Add: SlotFill to Abbreviated Notification panel #7091
 - Add: Consume remote payment methods on frontend #6867
 - Add: Extend payment gateways REST endpoint #6919
 - Add: Add remote payment gateway recommendations initial docs #6962
@@ -170,6 +157,10 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Enhancement: Add remind me later option to task list. #6923
 - Enhancement: Enable Remote Free Extensions List #7144
 - Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
+- Fix: Update the wordpress/babel-preset to avoid crashes in WP5.8 beta2 #7202
+- Fix: Add fallback for the select/dispatch data-controls for older WP versions #7204
+- Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
+- Fix: Issue where summary stats were not showing in Analytics > Stock. #7161
 - Fix: Rule Processing Transformer to handle dotNotation default value #7009
 - Fix: Remove Navigation's uneeded SlotFill context #6832
 - Fix: Report filters expecting specific ordering. #6847
@@ -188,7 +179,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Deprecated warnings from select control @wordpress/data-controls. #7007
 - Fix: Bug with Orders Report coupon exclusion filter. #7021
 - Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
-- Fix: Attribute filter bug with "any X" variations. #7046
 - Fix: Notices not dissapearing. #7077
 - Fix: Keyboard accessibility on the free features tab. #7149
 - Fix: Fix error handling when remote free extension API returns empty array. #7147
@@ -198,9 +188,11 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Add target to the button to open it in a new tab  #7110
 - Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
 - Fix: Set autoload to false for all remote inbox notifications options. #7060
-- Fix: Issue where summary stats were not showing in Analytics > Stock. #7161
-- Tweak: Only fetch remote payment gateway recommendations when opted in #6964
+- Fix: The use of gridicons for Analytics section controls. #7237
+- Fix: WordPress 5.8 compatibility UI fixes #7255
+- Fix: CurrencyFactory constructor to use proper function #7261
 - Tweak: Setup checklist copy revert. #7015
+- Tweak: Revert Card component removal #7167
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Optimize payment gateway resolution #7124
 - Update: Experimental task list import to the experimental package. #6950


### PR DESCRIPTION
This PR syncs readme.txt with latest release 2.4.1. No changelog required.

### Detailed test instructions:

- Check `readme.txt` to see if anything out of place.