### PR TITLE
Sync the category lookup table when a new category gets created

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -24,6 +24,15 @@
 3. Click "Dismiss" on a note. Confirm the position of the popover is correct.
 4. Click anywhere outside of the popover content and confirm the popover is closed.
 
+### Sync the category lookup table when a new category gets created #7290
+
+1. Navigate to Products -> Add New
+2. Add a new category on the Add New page and assign the product to it.
+3. Place an order with the product
+4. Navigate to Analytics -> Categories
+5. You should see the category.
+>>>>>>> cdc813055 (Add changelog)
+
 ### Use saved values if available when switching tabs #7226
 
 1. Start onboarding wizard and continue to step 4.

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Fix and refactor explat polling to use setTimeout #7274
 - Fix: Cache product/variation revenue query results. #7067
 - Fix: Transient overlapping adjacent content. #7302
+- Sync the category lookup table when a new category gets created #7290
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
 - Fix: Fix missing translation strings for CES #7270
 - Fix: Add missing translation strings in the business features section #7268

--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -133,7 +133,7 @@ class CategoryLookup {
 	}
 
 	/**
-	 * When a product category gets created, add a new lookup data.
+	 * When a product category gets created, add a new lookup row.
 	 *
 	 * @param int $category_id Term ID being created.
 	 */

--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -52,6 +52,8 @@ class CategoryLookup {
 		add_action( 'generate_category_lookup_table', array( $this, 'regenerate' ) );
 		add_action( 'edit_product_cat', array( $this, 'before_edit' ), 99 );
 		add_action( 'edited_product_cat', array( $this, 'on_edit' ), 99 );
+		add_action( 'created_product_cat', array( $this, 'on_create' ), 99 );
+
 	}
 
 	/**
@@ -127,6 +129,15 @@ class CategoryLookup {
 		}
 
 		$this->delete( $category_id, $prev_parent );
+		$this->update( $category_id );
+	}
+
+	/**
+	 * When a product category gets created, add a new lookup data.
+	 *
+	 * @param int $category_id Term ID being created.
+	 */
+	public function on_create( $category_id ) {
 		$this->update( $category_id );
 	}
 


### PR DESCRIPTION
Fixes #6613 

This PR syncs the category lookup table when a new category gets created.

The issue described in 6613 is caused due to missing category values in the lookup table.
We never created a new row when a new category gets added.

For those users who are already having the category lookup sync issue, they can deactivate and activate the plugin again. It should sync the table.

### Detailed test instructions:

Testing the table

1. Start with `trunk` branch to see the issue.
2. Open `wp_wc_category_lookup` table.
2. Navigate to Products -> Categories
3. Add a new category.
4. Confirm that the table doesn't have a matching record for the category you just created.
5. Switch to `fix/6613-new-categories-are-not-being-displayed` branch
6. Repeat the same step and confirm that you now have a matching row in the table.

Testing the Analytics data

1. Navigate to Products -> Add New
2. Add a new category on the Add New page and assign the product to it.
3. Place an order with the product
4. Navigate to Analytics -> Categories
5. You should see the category.
