### PR TITLE
Components, Experimental, Data package release prep

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,8 +1,12 @@
-# Unreleased
+# 7.1.0
 
--   Revert Card component removal #7167.
--   Filters: On update respect all other queries, not just persistedQueries #7155
 -   Add rowKey prop to Table and TableCard component. #7196
+-   Filters: On update respect all other queries, not just persistedQueries #7155
+-   Fix non-string query prop warning in SelectControl component. #7046
+-   Fix WordPress 5.8 compatibility UI fixes #7255
+-   Revert Card component removal #7167.
+-   Update DynamicForm, adding initial config memoization. #7256
+-   Update package dependencies
 
 # 7.0.0
 
@@ -16,7 +20,6 @@
 -   Deprecate the Count component, with plan to remove in next major version. #7115
 -   Remove the long deprecated Card component (use Card from `@wordpress/components` instead). #7114
 -   Add `<AbbreviatedCard />` component. #7017
--   Fix non-string query prop warning in SelectControl component. #7046
 -   Remove support for IE11. #7112
 
 # 6.2.0

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 1.3.2
 
+-   Add fallback for the select/dispatch data-controls for older WP versions. #7204
 -   Fix error parsing of plugin data package. #7164
 -   Update dependencies
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Unreleased
+# 1.4.0
 
 -   Add new VerticalCSSTransition component for handling height transitions. #7203
--   Update TaskItem to make use of the VerticalCSSTransition. #7203
+-   Add a delete option to completed tasks #7300
 -   Make the action button optionable in TaskItem. #7263
+-   Fix WordPress 5.8 compatibility UI fixes #7255
+-   Fix inbox note dismiss dropdown not closing on Safari #7278
+-   Update TaskItem to make use of the VerticalCSSTransition. #7203
 -   Update CollapsibleList to support nested transitional items. #7263
 
 # 1.3.0

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bump versions in packages, originally was only going to do `experimental`, but given I removed the `experimental` dependency from `components` I decided to do that one as well.
Also release the `data` package, mostly because of a missing package dependency left over from the last release.

I added several changelogs that I noticed where in history, please check if those look ok. I decided to only do a patch for the data package, given the changes where minimal.

No changelog necessary.

## Test instructions

Read through the changes, make sure they make sense