### PR TITLE
Invalidate task status when enabling a payment gateway

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/index.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/index.js
@@ -21,6 +21,9 @@ import { WCPaySuggestion } from './components/WCPay';
 import './plugins/Bacs';
 
 export const PaymentGatewaySuggestions = ( { query } ) => {
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		ONBOARDING_STORE_NAME
+	);
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
 	const { getPaymentGateway, paymentGateways, isResolving } = useSelect(
 		( select ) => {
@@ -95,6 +98,8 @@ export const PaymentGatewaySuggestions = ( { query } ) => {
 
 		updatePaymentGateway( id, {
 			enabled: true,
+		} ).then( () => {
+			invalidateResolutionForStoreSelector( 'getTasksStatus' );
 		} );
 	};
 


### PR DESCRIPTION
Fixes #7325

Fixes an issue where the payment task was not marked complete.

### Screenshots

<img width="709" alt="Screen Shot 2021-07-09 at 4 24 40 PM" src="https://user-images.githubusercontent.com/10561050/125132366-3745b000-e0d2-11eb-8300-d9647613524f.png">


### Detailed test instructions:

1. Disable/deactivate all payment gateways so that the payment task is not marked complete
2. Visit the payments task
3. Enable a gateway
4. Visit the homepage task list again without refreshing (via the back button or "Home" menu item)
5. Note that task is now marked complete