### PR TITLE
Redirect to homescreen after payment gateway setup

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/index.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/index.js
@@ -110,9 +110,7 @@ export const PaymentGatewaySuggestions = ( { query } ) => {
 				payment_method: id,
 			} );
 
-			getHistory().push(
-				getNewPath( { ...queryParams, task: 'payments' }, '/', {} )
-			);
+			getHistory().push( getNewPath( { ...queryParams }, '/', {} ) );
 		},
 		[ paymentGateways ]
 	);

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -64,7 +64,6 @@ class OnboardingTasks {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_import_notice_admin_script' ) );
-		add_filter( 'woocommerce_paypal_payments_onboarding_redirect_url', array( $this, 'ppcp_ob_after_onboarding_redirect_url' ) );
 	}
 
 	/**
@@ -230,22 +229,6 @@ class OnboardingTasks {
 		}
 		return false;
 	}
-
-
-	/**
-	 * Sets the URL users are redirected to after PayPal Payments has received onboarding information from PayPal.
-	 *
-	 * @param string $url the current redirect url.
-	 * @return string redirect url redirecting to WC Admin home screen.
-	 */
-	public static function ppcp_ob_after_onboarding_redirect_url( $url ) {
-		if ( isset( $_GET['ppcpobw'] ) && 1 === absint( $_GET['ppcpobw'] ) ) { // phpcs:ignore csrf ok, sanitization ok.
-			$url = wc_admin_url( '&task=payments&method=paypal&onboarding=complete' );
-		}
-
-		return $url;
-	}
-
 
 	/**
 	 * Hooks into the product page to add a notice to return to the task list if a product was added.

--- a/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/src/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -144,6 +144,6 @@ class PaymentGatewaysController {
 			)
 		);
 
-		wp_safe_redirect( wc_admin_url( '&task=payments' ) );
+		wp_safe_redirect( wc_admin_url() );
 	}
 }


### PR DESCRIPTION
Fixes #7325 (part 2)

* Goes to the homescreen after payment gateway setup instead of back to the payments task.
* Removes unused redirect handlers that can and should be handled within third party plugins.

### Detailed test instructions:

1. Go to the payment gateway suggestions task.
2. Enable a gateway.
3. Note that you are redirected to the homescreen after setup.