### PR TITLE
Set default value for performanceIndicators var

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,6 +1,12 @@
 # Testing instructions
 
 ## Unreleased
+
+### Fix WC Home crash when the Analytics is disabled.
+
+1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
+2. Navigate to WooCommerce -> Home and confirm the page loads without an error.
+
 ### Fix missing translation strings for CES #7270
 
 1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).

--- a/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
+++ b/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Set default value for performanceIndicators variable

--- a/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
+++ b/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Set default value for performanceIndicators variable
+Set default value for performanceIndicators variable #7343

--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -33,9 +33,10 @@ import { DEFAULT_STATS, DEFAULT_HIDDEN_STATS } from './defaults';
 import StatsList from './stats-list';
 import { InstallJetpackCTA } from './install-jetpack-cta';
 
-const { performanceIndicators } = getSetting( 'dataEndpoints', {
+const { performanceIndicators = [] } = getSetting( 'dataEndpoints', {
 	performanceIndicators: [],
 } );
+
 const stats = performanceIndicators.filter( ( indicator ) => {
 	return DEFAULT_STATS.includes( indicator.stat );
 } );


### PR DESCRIPTION
Fixes #7339 

This PR sets the default value for `performanceIndicators` variable to prevent WC Home crash when the analytics is disabled.

### Detailed test instructions:

1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
2. Navigate to WooCommerce -> Home and confirm the page loads without an error.