### PR TITLE
Fix undefined method error when setting up WC Tax

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -15,6 +15,14 @@ Please make sure to test it on Safari as well.
 2. Click [ Dismiss ] button
 3. Confirm that the links are clickable
 
+### Fix undefined method error when setting up WC Tax #7344
+
+1. Set up your store with US address to make sure automated tax is supported.
+2. Install "WooCommerce Shipping & Tax" plugin.
+3. Go to WooCommerce > Home > Set up tax.
+4. Click on "Yes please"
+5. Confirm that no error has occurred and you're redirected to the home screen.
+
 ### Fix missing translation strings for CES #7270
 
 1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).

--- a/changelogs/fix-7340-unable-to-setup-automated-tax-via-tasklist
+++ b/changelogs/fix-7340-unable-to-setup-automated-tax-via-tasklist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix undefined method error when setting up WC Tax #7344

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -441,7 +441,7 @@ class Tax extends Component {
 					disabled={ isPending }
 					isPrimary
 					isBusy={ isPending }
-					onClick={ this.enableAutomatedTax }
+					onClick={ this.enableAutomatedTax.bind( this ) }
 				>
 					{ __( 'Yes please', 'woocommerce-admin' ) }
 				</Button>


### PR DESCRIPTION
Fixes #7340 

This PR fixes the undefined method error by binding the function to the correct context

### Detailed test instructions:

You need to use `ngrok` or JN site since this test requires Jetpack connected site.

1. Set up your store with US address to make sure automated tax is supported.
2. Install "WooCommerce Shipping & Tax" plugin.
3. Go to WooCommerce > Home > Set up tax.
4. Click on "Yes please"
5. Confirm that no error has occurred and you're redirected to the home screen.
