### PR TITLE
Fixed OBW - Business details style

### DIFF
--- a/changelogs/fix-7324
+++ b/changelogs/fix-7324
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fixed OBW - Business details style #7353

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
@@ -13,7 +13,7 @@
 		}
 		.woocommerce-admin__business-details__selective-extensions-bundle__extension {
 			display: flex;
-			padding: $gap-large 0 $gap-large 30px;
+			padding: $gap-large 30px;
 			border-bottom: 1px solid $gray-200;
 			align-items: center;
 		}


### PR DESCRIPTION
Fixes #7324

This PR fixes a style error on the Business step in the OBW. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-crowded-galliform jurassic ninja-2021 07 14-14_53_19](https://user-images.githubusercontent.com/1314156/125669476-5d713df7-1fa7-4322-9692-140671c4d7cc.png)


### Detailed test instructions:

- Create a brand new site using JN.
- Set the site language to any non-English language (E.g: Espanol).
- Go to the 4th step of the OBW
- Verify that everything looks as expected. (No text should appear misaligned for any extensions suggestions).

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
