### PR TITLE
Add cache-control header to low stock response

### DIFF
--- a/changelogs/fix-slow-low-stock
+++ b/changelogs/fix-slow-low-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Add cache-control header to low stock REST API response

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -154,6 +154,7 @@ class Products extends \WC_REST_Products_Controller {
 		if (
 			$request->get_param( 'low_in_stock' ) === true &&
 			$request->get_param( 'page' ) === 1 &&
+			is_array( $request->get_param( '_fields' ) ) &&
 			count( $request->get_param( '_fields' ) ) === 1 &&
 			in_array( 'id', $request->get_param( '_fields' ), true )
 		) {

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -121,7 +121,46 @@ class Products extends \WC_REST_Products_Controller {
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
 		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10 );
+
+		/**
+		 * The low stock query caused performance issues in WooCommerce 5.5.1
+		 * due to a) being slow, and b) multiple requests being made to this endpoint
+		 * from WC Admin.
+		 *
+		 * This is a temporary measure to trigger the user’s browser to cache the
+		 * endpoint response for 1 minute, limiting the amount of requests overall.
+		 *
+		 * https://github.com/woocommerce/woocommerce-admin/issues/7358
+		 */
+		if ( $this->is_low_in_stock_request( $request ) ) {
+			$response->header( 'Cache-Control', 'max-age=60' );
+		}
 		return $response;
+	}
+
+	/**
+	 * Check whether the request is for products low in stock.
+	 *
+	 * It matches requests with paramaters:
+	 *
+	 * low_in_stock = true
+	 * page = 1
+	 * fields[0] = id
+	 *
+	 * @param string $request WP REST API request.
+	 * @return boolean Whether the request matches.
+	 */
+	private function is_low_in_stock_request( $request ) {
+		if (
+			$request->get_param( 'low_in_stock' ) === true &&
+			$request->get_param( 'page' ) === 1 &&
+			count( $request->get_param( '_fields' ) ) === 1 &&
+			in_array( 'id', $request->get_param( '_fields' ), true )
+		) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -133,7 +133,7 @@ class Products extends \WC_REST_Products_Controller {
 		 * https://github.com/woocommerce/woocommerce-admin/issues/7358
 		 */
 		if ( $this->is_low_in_stock_request( $request ) ) {
-			$response->header( 'Cache-Control', 'max-age=60' );
+			$response->header( 'Cache-Control', 'max-age=300' );
 		}
 		return $response;
 	}


### PR DESCRIPTION
Fixes (partially) #7358

A performance issue is introduced in WooCommerce 5.5, where the combination of slow SQL query made multiple times via REST API request is impacting server load.

This PR mitigates the issue by adding a cache header to the response, directing clients to cache the response for 60 seconds. This has the effect of reducing the amount of times the slow SQL query is made.

This is intended as a temporary measure until a permanent solution is found.

### Questions

Is 60 seconds a good max age value? Should it be increased?

### Alternative approach

I considered caching the response server-side using WordPress transients. However I didn't feel comfortable I could create unique key names given all the different combination of parameters available in the REST API.  

### Detailed test instructions:

- Ideally, add 1000+ products to the site using WC Smooth Generator. 

- Open the browser console and filter XHR requests by `low_in_stock`

<img width="1495" alt="Screen Shot 2021-07-16 at 8 32 39 pm" src="https://user-images.githubusercontent.com/9312929/125948106-e1fa848a-7894-4626-a7a3-ac45214f0759.png">

- Wait 60 seconds.
- Visit the WooCommerce homepage.
- See that the `/wc-analytics/products` request, with parameter of `low_in_stock=true` is fetched. If the site has enough products, this should be marked as a slow query as well. There’s a turtle in Firefox for example 🐢 

<img width="1021" alt="Screen Shot 2021-07-16 at 8 19 17 pm" src="https://user-images.githubusercontent.com/9312929/125948997-04d5389a-b1c0-444f-aea8-c7c65967d1ba.png">

- Within 60 seconds, browse to another WC Admin screen.
- See that the next request is retrieved from cache.

<img width="1022" alt="Screen Shot 2021-07-16 at 8 19 23 pm" src="https://user-images.githubusercontent.com/9312929/125949100-758c55c7-d2f2-4267-a55b-bb9d640f438d.png">

- Continue to browse other WC Admin screens.
- See that after 60 seconds the request is re-fetched.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
