### PR TITLE
Fix/7358 stock api performance improvement

### DIFF
--- a/changelogs/fix-7358-stock-api-performance-improvement
+++ b/changelogs/fix-7358-stock-api-performance-improvement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Add a new low stock products endpoint to improve the performance. #7377

--- a/client/homescreen/activity-panel/orders/utils.js
+++ b/client/homescreen/activity-panel/orders/utils.js
@@ -75,16 +75,16 @@ export function getLowStockCount( select ) {
 	// depend on `getItemsTotalCount` to have been called.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const totalLowStockProducts = getItemsTotalCount(
-		'products',
+		'products/low-in-stock',
 		getLowStockCountQuery,
 		defaultValue
 	);
 
 	const isError = Boolean(
-		getItemsError( 'products', getLowStockCountQuery )
+		getItemsError( 'products/low-in-stock', getLowStockCountQuery )
 	);
 	const isRequesting = isResolving( 'getItemsTotalCount', [
-		'products',
+		'products/low-in-stock',
 		getLowStockCountQuery,
 		defaultValue,
 	] );

--- a/client/homescreen/activity-panel/stock/index.js
+++ b/client/homescreen/activity-panel/stock/index.js
@@ -19,7 +19,6 @@ import { getLowStockCountQuery } from '../orders/utils';
 const productsQuery = {
 	page: 1,
 	per_page: 5,
-	low_in_stock: true,
 	status: 'publish',
 	_fields: [
 		'attributes',
@@ -51,7 +50,10 @@ export class StockPanel extends Component {
 
 		if ( success ) {
 			// Request more low stock products.
-			invalidateResolution( 'getItems', [ 'products', productsQuery ] );
+			invalidateResolution( 'getItems', [
+				'products/low-in-stock',
+				productsQuery,
+			] );
 			if ( products.length < 2 ) {
 				invalidateResolution( 'getItemsTotalCount', [
 					'products',
@@ -147,11 +149,13 @@ export default compose(
 		);
 
 		const products = Array.from(
-			getItems( 'products', productsQuery ).values()
+			getItems( 'products/low-in-stock', productsQuery ).values()
 		);
-		const isError = Boolean( getItemsError( 'products', productsQuery ) );
+		const isError = Boolean(
+			getItemsError( 'products/low-in-stock', productsQuery )
+		);
 		const isRequesting = isResolving( 'getItems', [
-			'products',
+			'products/low-in-stock',
 			productsQuery,
 		] );
 

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -70,6 +70,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\ProductVariations',
 			'Automattic\WooCommerce\Admin\API\ProductReviews',
 			'Automattic\WooCommerce\Admin\API\ProductVariations',
+			'Automattic\WooCommerce\Admin\API\ProductsLowInStock',
 			'Automattic\WooCommerce\Admin\API\SettingOptions',
 			'Automattic\WooCommerce\Admin\API\Themes',
 			'Automattic\WooCommerce\Admin\API\Plugins',

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -70,7 +70,7 @@ class Products extends \WC_REST_Products_Controller {
 	public function get_collection_params() {
 		$params                 = parent::get_collection_params();
 		$params['low_in_stock'] = array(
-			'description'       => __( 'Limit result set to products that are low or out of stock.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to products that are low or out of stock. (Deprecated)', 'woocommerce-admin' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -70,7 +70,7 @@ class Products extends \WC_REST_Products_Controller {
 	public function get_collection_params() {
 		$params                 = parent::get_collection_params();
 		$params['low_in_stock'] = array(
-			'description'       => __( 'Limit result set to products that are low or out of stock. (Deprecated)', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to products that are low or out of stock.', 'woocommerce-admin' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -82,6 +82,7 @@ class Products extends \WC_REST_Products_Controller {
 		);
 		return $params;
 	}
+
 
 	/**
 	 * Add product name and sku filtering to the WC API.
@@ -111,14 +112,12 @@ class Products extends \WC_REST_Products_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		if ( true === $request->get_param( 'low_in_stock' ) ) {
-			return ( new ProductsLowInStock() )->get_items( $request );
-		}
-
+		add_filter( 'posts_fields', array( __CLASS__, 'add_wp_query_fields' ), 10, 2 );
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
+		remove_filter( 'posts_fields', array( __CLASS__, 'add_wp_query_fields' ), 10 );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10 );
 		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10 );
@@ -190,11 +189,38 @@ class Products extends \WC_REST_Products_Controller {
 		$object_data = $object->get_data();
 		$product_id  = $object_data['id'];
 
+		if ( $request->get_param( 'low_in_stock' ) ) {
+			if ( is_numeric( $object_data['low_stock_amount'] ) ) {
+				$data->data['low_stock_amount'] = $object_data['low_stock_amount'];
+			}
+			if ( isset( $this->last_order_dates[ $product_id ] ) ) {
+				$data->data['last_order_date'] = wc_rest_prepare_date_response( $this->last_order_dates[ $product_id ] );
+			}
+		}
 		if ( isset( $data->data['name'] ) ) {
 			$data->data['name'] = wp_strip_all_tags( $data->data['name'] );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Add in conditional select fields to the query.
+	 *
+	 * @param string $select Select clause used to select fields from the query.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public static function add_wp_query_fields( $select, $wp_query ) {
+		if ( $wp_query->get( 'low_in_stock' ) ) {
+			$fields  = array(
+				'low_stock_amount_meta.meta_value AS low_stock_amount',
+				'MAX( product_lookup.date_created ) AS last_order_date',
+			);
+			$select .= ', ' . implode( ', ', $fields );
+		}
+
+		return $select;
 	}
 
 	/**
@@ -214,20 +240,52 @@ class Products extends \WC_REST_Products_Controller {
 			$where     .= wc_product_sku_enabled() ? $wpdb->prepare( ' OR wc_product_meta_lookup.sku LIKE %s)', $search ) : ')';
 		}
 
+		if ( $wp_query->get( 'low_in_stock' ) ) {
+			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+			$where           .= "
+			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+			AND wc_product_meta_lookup.stock_status IN('instock','outofstock')
+			AND (
+				(
+					low_stock_amount_meta.meta_value > ''
+					AND wc_product_meta_lookup.stock_quantity <= CAST(low_stock_amount_meta.meta_value AS SIGNED)
+				)
+				OR (
+					(
+						low_stock_amount_meta.meta_value IS NULL OR low_stock_amount_meta.meta_value <= ''
+					)
+					AND wc_product_meta_lookup.stock_quantity <= {$low_stock_amount}
+				)
+			)";
+		}
+
 		return $where;
 	}
 
 	/**
-	 * Join posts meta tables when product search query is present.
+	 * Join posts meta tables when product search or low stock query is present.
 	 *
 	 * @param string $join Join clause used to search posts.
 	 * @param object $wp_query WP_Query object.
 	 * @return string
 	 */
 	public static function add_wp_query_join( $join, $wp_query ) {
+		global $wpdb;
+
 		$search = $wp_query->get( 'search' );
 		if ( $search && wc_product_sku_enabled() ) {
 			$join = self::append_product_sorting_table_join( $join );
+		}
+
+		if ( $wp_query->get( 'low_in_stock' ) ) {
+			$product_lookup_table = $wpdb->prefix . 'wc_order_product_lookup';
+
+			$join  = self::append_product_sorting_table_join( $join );
+			$join .= " LEFT JOIN {$wpdb->postmeta} AS low_stock_amount_meta ON {$wpdb->posts}.ID = low_stock_amount_meta.post_id AND low_stock_amount_meta.meta_key = '_low_stock_amount' ";
+			$join .= " LEFT JOIN {$product_lookup_table} product_lookup ON {$wpdb->posts}.ID = CASE
+				WHEN {$wpdb->posts}.post_type = 'product' THEN product_lookup.product_id
+				WHEN {$wpdb->posts}.post_type = 'product_variation' THEN product_lookup.variation_id
+			END";
 		}
 
 		return $join;
@@ -258,9 +316,9 @@ class Products extends \WC_REST_Products_Controller {
 	public static function add_wp_query_group_by( $groupby, $wp_query ) {
 		global $wpdb;
 
-		$search = $wp_query->get( 'search' );
-
-		if ( empty( $groupby ) && $search ) {
+		$search       = $wp_query->get( 'search' );
+		$low_in_stock = $wp_query->get( 'low_in_stock' );
+		if ( empty( $groupby ) && ( $search || $low_in_stock ) ) {
 			$groupby = $wpdb->posts . '.ID';
 		}
 		return $groupby;

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -111,6 +111,10 @@ class Products extends \WC_REST_Products_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
+		if ( true === $request->get_param( 'low_in_stock' ) ) {
+			return ( new ProductsLowInStock() )->get_items( $request );
+		}
+
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_join' ), 10, 2 );
 		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_group_by' ), 10, 2 );

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -77,6 +77,7 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$response = rest_ensure_response( array_values( $query_results['results'] ) );
 		$response->header( 'X-WP-Total', $query_results['total'] );
 		$response->header( 'X-WP-TotalPages', $query_results['pages'] );
+		$response->header( 'Cache-Control', 'max-age=300' );
 
 		return $response;
 	}

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @extends WC_REST_Products_Controller
  */
-class ProductsLowInStock extends \WC_REST_Products_Controller {
+final class ProductsLowInStock extends \WC_REST_Products_Controller {
 
 	/**
 	 * Endpoint namespace.

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -167,7 +167,7 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 *
 	 * @return bool
 	 */
-	public function is_using_sitewide_stock_threshold_only() {
+	protected function is_using_sitewide_stock_threshold_only() {
 		global $wpdb;
 		$count = $wpdb->get_var( "select count(*) as total from {$wpdb->postmeta} where meta_key='_low_stock_amount'" );
 		return 0 === (int) $count;

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -136,15 +136,10 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 	protected function get_low_in_stock_products( $page = 1, $per_page = 1, $status = 'publish' ) {
 		global $wpdb;
 
-		$offset                       = ( $page - 1 ) * $per_page;
-		$low_stock_threshold          = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
-		$use_sitewide_stock_threshold = $this->is_using_sitewide_stock_threshold_only();
+		$offset              = ( $page - 1 ) * $per_page;
+		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
-		if ( $use_sitewide_stock_threshold ) {
-			$query_string = $this->get_query( $use_sitewide_stock_threshold );
-		} else {
-			$query_string = $this->get_query();
-		}
+		$query_string = $this->get_query( $this->is_using_sitewide_stock_threshold_only() );
 
 		$query_results = $wpdb->get_results(
 			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -141,7 +141,7 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$use_sitewide_stock_threshold = $this->is_using_sitewide_stock_threshold_only();
 
 		if ( $use_sitewide_stock_threshold ) {
-			$query_string = $this->get_query( false );
+			$query_string = $this->get_query( $use_sitewide_stock_threshold );
 		} else {
 			$query_string = $this->get_query();
 		}
@@ -194,7 +194,7 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 			'images'           => $query_result->images,
 			'attributes'       => $query_result->attributes,
 			'low_stock_amount' => $query_result->low_stock_amount,
-			'last_order_date'  => $query_result->last_order_date,
+			'last_order_date'  => wc_rest_prepare_date_response( $query_result->last_order_date ),
 			'name'             => $query_result->post_title,
 			'parent_id'        => $query_result->post_parent,
 			'stock_quantity'   => (int) $query_result->stock_quantity,
@@ -296,10 +296,10 @@ class ProductsLowInStock extends \WC_REST_Products_Controller {
 		);
 
 		$params['status'] = array(
-			'default'           => 'any',
+			'default'           => 'publish',
 			'description'       => __( 'Limit result set to products assigned a specific status.', 'woocommerce-admin' ),
 			'type'              => 'string',
-			'enum'              => array_merge( array( 'any', 'future', 'trash' ), array_keys( get_post_statuses() ) ),
+			'enum'              => array_merge( array_keys( get_post_statuses() ), array( 'future' ) ),
 			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/tests/api/products-lowinstock.php
+++ b/tests/api/products-lowinstock.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Products REST API Test
+ *
+ * @package WooCommerce\Admin\Tests\API
+ */
+
+/**
+ * WC Tests API ProductsLowInStock
+ */
+class WC_Tests_API_ProductsLowInStock extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-analytics/products/low-in-stock';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test low stock query.
+	 */
+	public function test_low_stock() {
+		wp_set_current_user( $this->user );
+
+		// Create a product with stock management.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_low_stock_amount( 2 );
+		$product->set_stock_quantity( 5 );
+		$product->save();
+
+		// Order enough of the product to trigger low stock status.
+		$order_time = '2020-11-24T10:00:00';
+		$order      = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_date_created( $order_time );
+		$order->save();
+
+		// Sync analytics data (used for last order date).
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/low-in-stock' );
+		$request->set_param( 'low_in_stock', true );
+		$request->set_param( 'status', 'publish' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $product->get_id(), $data[0]['id'] );
+		$this->assertEquals( $order_time, $data[0]['last_order_date'] );
+	}
+}

--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -61,38 +61,4 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 
 		$product->delete( true );
 	}
-
-	/**
-	 * Test low stock query.
-	 */
-	public function test_low_stock() {
-		wp_set_current_user( $this->user );
-
-		// Create a product with stock management.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_manage_stock( true );
-		$product->set_low_stock_amount( 2 );
-		$product->set_stock_quantity( 5 );
-		$product->save();
-
-		// Order enough of the product to trigger low stock status.
-		$order_time = '2020-11-24T10:00:00';
-		$order      = WC_Helper_Order::create_order( 1, $product );
-		$order->set_status( 'completed' );
-		$order->set_date_created( $order_time );
-		$order->save();
-
-		// Sync analytics data (used for last order date).
-		WC_Helper_Queue::run_all_pending();
-
-		$request = new WP_REST_Request( 'GET', '/wc-analytics/products' );
-		$request->set_param( 'low_in_stock', true );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $data );
-		$this->assertEquals( $product->get_id(), $data[0]['id'] );
-		$this->assertEquals( $order_time, $data[0]['last_order_date'] );
-	}
 }

--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -61,4 +61,40 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 
 		$product->delete( true );
 	}
+
+
+	/**
+	 * Test low stock query.
+	 */
+	public function test_low_stock() {
+		wp_set_current_user( $this->user );
+
+		// Create a product with stock management.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_low_stock_amount( 2 );
+		$product->set_stock_quantity( 5 );
+		$product->save();
+
+		// Order enough of the product to trigger low stock status.
+		$order_time = '2020-11-24T10:00:00';
+		$order      = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_date_created( $order_time );
+		$order->save();
+
+		// Sync analytics data (used for last order date).
+		WC_Helper_Queue::run_all_pending();
+
+		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/low-in-stock' );
+		$request->set_param( 'low_in_stock', true );
+		$request->set_param( 'status', 'publish' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $product->get_id(), $data[0]['id'] );
+		$this->assertEquals( $order_time, $data[0]['last_order_date'] );
+	}
 }


### PR DESCRIPTION
Fixes #7358 

This PR attempts to improve `low in stock` products REST API endpoint performance.

It adds a new endpoint: `/wp-json/wc-analytics/products/low-in-stock?page=1&per_page=5`

Original query: [gist](https://gist.github.com/moon0326/683fa74d8c606aa60f2ce8ed3b0d07db)
New query: [gist](https://gist.github.com/moon0326/bb49d48b257a1edaa22172759d604c74)

EXPLAIN of the original query (based on a store with 4k products):
![Screen Shot 2021-07-17 at 10 15 59 PM](https://user-images.githubusercontent.com/4723145/126056605-1b3c525e-f556-4c5c-9e04-c31e7f3de781.jpg)

EXPLAIN of the new query (based on a store with 4k products):

![Screen Shot 2021-07-17 at 10 16 28 PM](https://user-images.githubusercontent.com/4723145/126056612-e0dac81d-431a-4c4b-aea9-a398bb09310f.jpg)

In a store with about 10k products, the original query exceeds 30 seconds and times out. The new query takes around 200ms on average. The total query execution time should be 200ms (avg) + 60~80ms (wc_product_meta_lookup query). The query execution can be less than 100ms if the site is using sitewide low stock threshold only.     

### Changes

**The query selects `wc_product_meta_lookup` first then join `wp_posts`**

- This was suggested by @louwie17. I first thought we would not gain much performance, but realized that a store with a large dataset most likely has a higher # of rows in `wp_posts` than `wc_product_meta_lookup`. In a store with 10k products, this change showed 3x performance gain. This is the primary reason why I'm adding a new endpoint since modifying the existing endpoint to use `wc_product_meta_lookup` is quite tricky or nearly impossible without changing almost all of it.

- MySQL always uses `wp_posts` first with the original query, but MariaDB uses `wp_wc_order_product_lookup` depending on the # of rows in each table. This is optimized by the query optimizer automatically. If the query optimizer uses `wp_wc_order_product_lookup` internally anyway, it's safe to select `wp_wc_order_product_lookup` first.

**does not join wp_postmeta if the store is using sitewide stock threshold only**

If a store does not have any custom stock threshold set on a product then we don't have to join `wp_postmeta` table. You can see the method [here](https://github.com/woocommerce/woocommerce-admin/pull/7377/files#diff-d5ee2ec2a16bb74f2d14349119970c8a1725570fe70d1721523df9d40b0ad109R169).

The count query is an extra query, but the execution time is less than 0.1 ms and it can make the main query 2x+ faster if the store is using sitewide low stock threshold only.

**last_order_date is queried separately**

As you see in the EXPLAIN output of the original query, joining `wp_wc_order_product_lookup` is quite expensive. The estimated # of rows to be examined is 10062. The `last_order_date` is now [queried](https://github.com/woocommerce/woocommerce-admin/pull/7377/files#diff-d5ee2ec2a16bb74f2d14349119970c8a1725570fe70d1721523df9d40b0ad109R111) separately.


The query takes between 60~80ms in a store with the following `wc_order_product_lookup` dataset. This store has 10k products.

![Screen Shot 2021-07-17 at 10 40 22 PMth_](https://user-images.githubusercontent.com/4723145/126057042-700d9ff8-6e33-4b8a-a382-60cd407f1562.jpg)

**order by post_date is removed and we now order by wc_product_meta_lookup only**

Since we now select `wp_wc_order_product_lookup` first, ordering by a field that is not in the first selected table triggers `Using temporary; Using filesort`. These two should be avoided whenever possible for the best performance. 

Since `post_date` never gets updated and product_id is the same as post_id, it's safe to use the id field alone in this case.

### Notes

- I noticed that getting product images is also an expensive process as we query each product in a loop. This should be avoided whenever possible, but I'm leaving it as it is for now. We might want to work on this in a separate PR.

### Detailed test instructions:

[4kproducts.sql.zip](https://github.com/woocommerce/woocommerce-admin/files/6835729/4kproducts.sql.zip)

1. Download the `4kproducts.zip`. This SQL dump includes 4297 products for testing purposes.
2. Start with a fresh installation and DB. Import the SQL dump file. 
3. Navigate to WooCommerce -> Status -> Tools and click [ Regenerate ] button on the `Product lookup tables` row.
4. Confirm you have 9k+ rows in `wp_wc_order_product_lookup` table.
5. Navigate to WooCommerce -> Home and hide the task list then refresh.
6. You should see the activity panel with Orders, Stock, and Reviews.
7. Open inspector -> Network -> choose XHR then search for "low_in_stock". The API endpoint should be `products/low-in-stock`

If you want to compare how the new API performs against the existing API, checkout `b341b62b1d4eb7dcc5f088aa77c530ac893b65ec` commit. This commit still makes low-in-stock APIs to the existing endpoint.


