### PR TITLE
Add lazy loading by checking panel open status and lint fix

### DIFF
--- a/changelogs/fix-7376-lazy-load-activity-panel
+++ b/changelogs/fix-7376-lazy-load-activity-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Add lazy loading by checking panel open status

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -99,15 +99,18 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 	) {
 		const orderStatuses = getOrderStatuses( select );
 
-		const isOrdersCardVisible = setupTaskListHidden
-			? getUnreadOrders( select, orderStatuses ) > 0
-			: false;
-		const isReviewsCardVisible = setupTaskListHidden
-			? getUnapprovedReviews( select )
-			: false;
-		const isLowStockCardVisible = setupTaskListHidden
-			? getLowStockProducts( select )
-			: false;
+		const isOrdersCardVisible =
+			setupTaskListHidden && isPanelOpen
+				? getUnreadOrders( select, orderStatuses ) > 0
+				: false;
+		const isReviewsCardVisible =
+			setupTaskListHidden && isPanelOpen
+				? getUnapprovedReviews( select )
+				: false;
+		const isLowStockCardVisible =
+			setupTaskListHidden && isPanelOpen
+				? getLowStockProducts( select )
+				: false;
 
 		return (
 			thingsToDoNextCount > 0 ||
@@ -217,6 +220,14 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 		);
 	};
 
+	const redirectToHomeScreen = () => {
+		if ( isWCAdmin( window.location.href ) ) {
+			getHistory().push( getNewPath( {}, '/', {} ) );
+		} else {
+			window.location.href = getAdminLink( 'admin.php?page=wc-admin' );
+		}
+	};
+
 	// @todo Pull in dynamic unread status/count
 	const getTabs = () => {
 		const inbox = {
@@ -313,14 +324,6 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 				return <HelpPanel taskName={ task } />;
 			default:
 				return null;
-		}
-	};
-
-	const redirectToHomeScreen = () => {
-		if ( isWCAdmin( window.location.href ) ) {
-			getHistory().push( getNewPath( {}, '/', {} ) );
-		} else {
-			window.location.href = getAdminLink( 'admin.php?page=wc-admin' );
 		}
 	};
 


### PR DESCRIPTION
Fixes #7376

Adds lazy loading to abbreviated notifications by checking panel open status. The downside of the current implementation is there is no loading indicator to signal that something is loading.

### Detailed test instructions:

1. Complete the OBW and hide the task list from the Home.
1. Open inspector and click 'Networks' tab.
1. Navigate to Products and Orders pages
1. Search `low` from your network tab. You should not see an API request to the `products` endpoint.
2. Open the "Inbox" panel on to right of the page, observe the API is called.
