### PR TITLE
Add marketing extensions task to task list

### DIFF
--- a/changelogs/add-7313
+++ b/changelogs/add-7313
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add marketing extensions task to task list

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -17,6 +17,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import Appearance from './tasks/appearance';
 import { getCategorizedOnboardingProducts } from '../dashboard/utils';
+import { Marketing } from './tasks/Marketing';
 import { Products } from './tasks/products';
 import Shipping from './tasks/shipping';
 import Tax from './tasks/tax';
@@ -325,6 +326,28 @@ export function getAllTasks( {
 			visible:
 				( productTypes && productTypes.includes( 'physical' ) ) ||
 				hasPhysicalProducts,
+			time: __( '1 minute', 'woocommerce-admin' ),
+			type: 'setup',
+		},
+		{
+			key: 'marketing',
+			title: __( 'Set up marketing tools', 'woocommerce-admin' ),
+			content: __(
+				'Add recommended marketing tools to reach new customers and grow your business',
+				'woocommerce-admin'
+			),
+			container: <Marketing />,
+			onClick: () => {
+				onTaskSelect( 'marketing' );
+				updateQueryString( { task: 'marketing' } );
+			},
+			// @todo This should use the free extensions data store.
+			completed:
+				[].filter( ( plugin ) => installedPlugins.includes( plugin ) )
+					.length > 0,
+			visible:
+				window.wcAdminFeatures &&
+				window.wcAdminFeatures[ 'remote-extensions-list' ],
 			time: __( '1 minute', 'woocommerce-admin' ),
 			type: 'setup',
 		},

--- a/client/task-list/tasks/Marketing/Marketing.scss
+++ b/client/task-list/tasks/Marketing/Marketing.scss
@@ -1,0 +1,15 @@
+.woocommerce-task-marketing {
+	.components-card__header {
+		flex-direction: column;
+		align-items: flex-start;
+
+		h2 {
+			color: $gray-900;
+			margin-bottom: $gap-smaller;
+		}
+
+		p {
+			color: $gray-700;
+		}
+	}
+}

--- a/client/task-list/tasks/Marketing/Plugin.scss
+++ b/client/task-list/tasks/Marketing/Plugin.scss
@@ -1,0 +1,41 @@
+.woocommerce-plugin-list__plugin {
+	display: flex;
+	padding: $gap-large;
+	border-top: 1px solid #e5e5e5;
+
+	&:last-child {
+		border-bottom: 1px solid #e5e5e5;
+	}
+
+	h4 {
+		margin-bottom: $gap-small;
+		font-weight: 600;
+		color: $gray-900;
+	}
+
+	p {
+		color: $gray-700;
+		font-weight: 400;
+		color: #3c434a;
+	}
+}
+
+.woocommerce-plugin-list__plugin-logo {
+	margin-right: 45px;
+	display: flex;
+	align-items: center;
+
+	img {
+		width: 50px;
+	}
+}
+
+.woocommerce-plugin-list__plugin-action {
+	display: flex;
+	align-items: center;
+	margin-left: 104px;
+
+	@media ( max-width: 782px ) {
+		margin-left: $gap;
+	}
+}

--- a/client/task-list/tasks/Marketing/Plugin.scss
+++ b/client/task-list/tasks/Marketing/Plugin.scss
@@ -30,12 +30,13 @@
 	}
 }
 
+.woocommerce-plugin-list__plugin-text {
+	max-width: 370px;
+	margin-right: $gap;
+}
+
 .woocommerce-plugin-list__plugin-action {
 	display: flex;
 	align-items: center;
-	margin-left: 104px;
-
-	@media ( max-width: 782px ) {
-		margin-left: $gap;
-	}
+	margin-left: auto;
 }

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { Text } from '@woocommerce/experimental';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { createNoticesFromResponse } from '~/lib/notices';
+
+export type PluginProps = {
+	isInstalled: boolean;
+	description?: string;
+	imageUrl?: string;
+	manageUrl?: string;
+	name: string;
+	slug: string;
+};
+
+export const Plugin: React.FC< PluginProps > = ( {
+	description,
+	imageUrl,
+	isInstalled,
+	manageUrl,
+	name,
+	slug,
+} ) => {
+	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+
+	const installPlugin = () => {
+		installAndActivatePlugins( [ slug ] )
+			.then( ( response: { errors: Record< string, string > } ) => {
+				createNoticesFromResponse( response );
+			} )
+			.catch( ( response: { errors: Record< string, string > } ) => {
+				createNoticesFromResponse( response );
+			} );
+	};
+
+	return (
+		<div className="woocommerce-plugin-list__plugin">
+			{ imageUrl && (
+				<img
+					src={ imageUrl }
+					alt={ sprintf(
+						/* translators: %s = name of the plugin */
+						__( '%s logo', 'woocommerce-admin' ),
+						name
+					) }
+				/>
+			) }
+			<Text variant="title.small" size="20" lineHeight="28px">
+				{ name }
+			</Text>
+			<Text variant="title.small" size="20" lineHeight="28px">
+				{ description }
+			</Text>
+			{ isInstalled && manageUrl && (
+				<Button isPrimary href={ manageUrl }>
+					{ __( 'Manage', 'woocommmerce-admin' ) }
+				</Button>
+			) }
+			{ ! isInstalled && (
+				<Button isPrimary onClick={ installPlugin }>
+					{ __( 'Install', 'woocommmerce-admin' ) }
+				</Button>
+			) }
+		</div>
+	);
+};

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
 import { useDispatch } from '@wordpress/data';
@@ -11,6 +12,7 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { createNoticesFromResponse } from '~/lib/notices';
+import './Plugin.scss';
 
 export type PluginProps = {
 	isInstalled: boolean;
@@ -44,31 +46,35 @@ export const Plugin: React.FC< PluginProps > = ( {
 	return (
 		<div className="woocommerce-plugin-list__plugin">
 			{ imageUrl && (
-				<img
-					src={ imageUrl }
-					alt={ sprintf(
-						/* translators: %s = name of the plugin */
-						__( '%s logo', 'woocommerce-admin' ),
-						name
-					) }
-				/>
+				<div className="woocommerce-plugin-list__plugin-logo">
+					<img
+						src={ imageUrl }
+						alt={ sprintf(
+							/* translators: %s = name of the plugin */
+							__( '%s logo', 'woocommerce-admin' ),
+							name
+						) }
+					/>
+				</div>
 			) }
-			<Text variant="title.small" size="20" lineHeight="28px">
-				{ name }
-			</Text>
-			<Text variant="title.small" size="20" lineHeight="28px">
-				{ description }
-			</Text>
-			{ isInstalled && manageUrl && (
-				<Button isPrimary href={ manageUrl }>
-					{ __( 'Manage', 'woocommmerce-admin' ) }
-				</Button>
-			) }
-			{ ! isInstalled && (
-				<Button isPrimary onClick={ installPlugin }>
-					{ __( 'Install', 'woocommmerce-admin' ) }
-				</Button>
-			) }
+			<div className="woocommerce-plugin-list__plugin-text">
+				<Text variant="subtitle.small" as="h4">
+					{ name }
+				</Text>
+				<Text variant="subtitle.small">{ description }</Text>
+			</div>
+			<div className="woocommerce-plugin-list__plugin-action">
+				{ isInstalled && manageUrl && (
+					<Button isSecondary href={ getAdminLink( manageUrl ) }>
+						{ __( 'Manage', 'woocommmerce-admin' ) }
+					</Button>
+				) }
+				{ ! isInstalled && (
+					<Button isSecondary onClick={ installPlugin }>
+						{ __( 'Install', 'woocommmerce-admin' ) }
+					</Button>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -15,6 +15,7 @@ import { createNoticesFromResponse } from '~/lib/notices';
 import './Plugin.scss';
 
 export type PluginProps = {
+	isActive: boolean;
 	isInstalled: boolean;
 	description?: string;
 	imageUrl?: string;
@@ -26,6 +27,7 @@ export type PluginProps = {
 export const Plugin: React.FC< PluginProps > = ( {
 	description,
 	imageUrl,
+	isActive,
 	isInstalled,
 	manageUrl,
 	name,
@@ -33,7 +35,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 } ) => {
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 
-	const installPlugin = () => {
+	const installAndActivate = () => {
 		installAndActivatePlugins( [ slug ] )
 			.then( ( response: { errors: Record< string, string > } ) => {
 				createNoticesFromResponse( response );
@@ -64,13 +66,18 @@ export const Plugin: React.FC< PluginProps > = ( {
 				<Text variant="subtitle.small">{ description }</Text>
 			</div>
 			<div className="woocommerce-plugin-list__plugin-action">
-				{ isInstalled && manageUrl && (
+				{ isActive && manageUrl && (
 					<Button isSecondary href={ getAdminLink( manageUrl ) }>
 						{ __( 'Manage', 'woocommmerce-admin' ) }
 					</Button>
 				) }
+				{ isInstalled && ! isActive && (
+					<Button isSecondary onClick={ installAndActivate }>
+						{ __( 'Activate', 'woocommmerce-admin' ) }
+					</Button>
+				) }
 				{ ! isInstalled && (
-					<Button isSecondary onClick={ installPlugin }>
+					<Button isSecondary onClick={ installAndActivate }>
 						{ __( 'Install', 'woocommmerce-admin' ) }
 					</Button>
 				) }

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -4,20 +4,18 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { createNoticesFromResponse } from '~/lib/notices';
 import './Plugin.scss';
 
 export type PluginProps = {
 	isActive: boolean;
 	isInstalled: boolean;
 	description?: string;
+	installAndActivate?: ( slug: string ) => void;
 	imageUrl?: string;
 	manageUrl?: string;
 	name: string;
@@ -27,24 +25,13 @@ export type PluginProps = {
 export const Plugin: React.FC< PluginProps > = ( {
 	description,
 	imageUrl,
+	installAndActivate = () => {},
 	isActive,
 	isInstalled,
 	manageUrl,
 	name,
 	slug,
 } ) => {
-	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
-
-	const installAndActivate = () => {
-		installAndActivatePlugins( [ slug ] )
-			.then( ( response: { errors: Record< string, string > } ) => {
-				createNoticesFromResponse( response );
-			} )
-			.catch( ( response: { errors: Record< string, string > } ) => {
-				createNoticesFromResponse( response );
-			} );
-	};
-
 	return (
 		<div className="woocommerce-plugin-list__plugin">
 			{ imageUrl && (
@@ -72,12 +59,18 @@ export const Plugin: React.FC< PluginProps > = ( {
 					</Button>
 				) }
 				{ isInstalled && ! isActive && (
-					<Button isSecondary onClick={ installAndActivate }>
+					<Button
+						isSecondary
+						onClick={ () => installAndActivate( slug ) }
+					>
 						{ __( 'Activate', 'woocommmerce-admin' ) }
 					</Button>
 				) }
 				{ ! isInstalled && (
-					<Button isSecondary onClick={ installAndActivate }>
+					<Button
+						isSecondary
+						onClick={ () => installAndActivate( slug ) }
+					>
 						{ __( 'Install', 'woocommmerce-admin' ) }
 					</Button>
 				) }

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -13,6 +13,8 @@ import './Plugin.scss';
 
 export type PluginProps = {
 	isActive: boolean;
+	isBusy?: boolean;
+	isDisabled?: boolean;
 	isInstalled: boolean;
 	description?: string;
 	installAndActivate?: ( slug: string ) => void;
@@ -27,6 +29,8 @@ export const Plugin: React.FC< PluginProps > = ( {
 	imageUrl,
 	installAndActivate = () => {},
 	isActive,
+	isBusy,
+	isDisabled,
 	isInstalled,
 	manageUrl,
 	name,
@@ -54,12 +58,19 @@ export const Plugin: React.FC< PluginProps > = ( {
 			</div>
 			<div className="woocommerce-plugin-list__plugin-action">
 				{ isActive && manageUrl && (
-					<Button isSecondary href={ getAdminLink( manageUrl ) }>
+					<Button
+						disabled={ isDisabled }
+						isBusy={ isBusy }
+						isSecondary
+						href={ getAdminLink( manageUrl ) }
+					>
 						{ __( 'Manage', 'woocommmerce-admin' ) }
 					</Button>
 				) }
 				{ isInstalled && ! isActive && (
 					<Button
+						disabled={ isDisabled }
+						isBusy={ isBusy }
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
@@ -68,6 +79,8 @@ export const Plugin: React.FC< PluginProps > = ( {
 				) }
 				{ ! isInstalled && (
 					<Button
+						disabled={ isDisabled }
+						isBusy={ isBusy }
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>

--- a/client/task-list/tasks/Marketing/PluginList.scss
+++ b/client/task-list/tasks/Marketing/PluginList.scss
@@ -1,0 +1,12 @@
+.woocommerce-plugin-list__title {
+	padding: $gap-small 30px;
+	background: $gray-200;
+	margin-bottom: 1px;
+	margin-top: 1px;
+	position: relative;
+
+	h3 {
+		font-weight: 500;
+		color: $black;
+	}
+}

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -10,6 +10,7 @@ import { Plugin, PluginProps } from './Plugin';
 import './PluginList.scss';
 
 export type PluginListProps = {
+	currentPlugin?: string | null;
 	key: string;
 	installAndActivate?: ( slug: string ) => void;
 	plugins?: PluginProps[];
@@ -17,6 +18,7 @@ export type PluginListProps = {
 };
 
 export const PluginList: React.FC< PluginListProps > = ( {
+	currentPlugin,
 	installAndActivate = () => {},
 	plugins = [],
 	title,
@@ -49,6 +51,8 @@ export const PluginList: React.FC< PluginListProps > = ( {
 						imageUrl={ imageUrl }
 						installAndActivate={ installAndActivate }
 						isActive={ isActive }
+						isBusy={ currentPlugin === slug }
+						isDisabled={ !! currentPlugin }
 						isInstalled={ isInstalled }
 						slug={ slug }
 					/>

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -11,11 +11,13 @@ import './PluginList.scss';
 
 export type PluginListProps = {
 	key: string;
-	title?: string;
+	installAndActivate?: ( slug: string ) => void;
 	plugins?: PluginProps[];
+	title?: string;
 };
 
 export const PluginList: React.FC< PluginListProps > = ( {
+	installAndActivate = () => {},
 	plugins = [],
 	title,
 } ) => {
@@ -45,6 +47,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 						manageUrl={ manageUrl }
 						name={ name }
 						imageUrl={ imageUrl }
+						installAndActivate={ installAndActivate }
 						isActive={ isActive }
 						isInstalled={ isInstalled }
 						slug={ slug }

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -7,6 +7,7 @@ import { Text } from '@woocommerce/experimental';
  * Internal dependencies
  */
 import { Plugin, PluginProps } from './Plugin';
+import './PluginList.scss';
 
 export type PluginListProps = {
 	key: string;
@@ -21,15 +22,18 @@ export const PluginList: React.FC< PluginListProps > = ( {
 	return (
 		<div className="woocommerce-plugin-list">
 			{ title && (
-				<Text variant="title.small" size="20" lineHeight="28px">
-					{ title }
-				</Text>
+				<div className="woocommerce-plugin-list__title">
+					<Text variant="sectionheading" as="h3">
+						{ title }
+					</Text>
+				</div>
 			) }
 			{ plugins.map( ( plugin ) => {
 				const {
 					description,
 					imageUrl,
 					isInstalled,
+					manageUrl,
 					slug,
 					name,
 				} = plugin;
@@ -37,6 +41,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 					<Plugin
 						key={ slug }
 						description={ description }
+						manageUrl={ manageUrl }
 						name={ name }
 						imageUrl={ imageUrl }
 						isInstalled={ isInstalled }

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { Text } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import { Plugin, PluginProps } from './Plugin';
+
+export type PluginListProps = {
+	key: string;
+	title?: string;
+	plugins?: PluginProps[];
+};
+
+export const PluginList: React.FC< PluginListProps > = ( {
+	plugins = [],
+	title,
+} ) => {
+	return (
+		<div className="woocommerce-plugin-list">
+			{ title && (
+				<Text variant="title.small" size="20" lineHeight="28px">
+					{ title }
+				</Text>
+			) }
+			{ plugins.map( ( plugin ) => {
+				const {
+					description,
+					imageUrl,
+					isInstalled,
+					slug,
+					name,
+				} = plugin;
+				return (
+					<Plugin
+						key={ slug }
+						description={ description }
+						name={ name }
+						imageUrl={ imageUrl }
+						isInstalled={ isInstalled }
+						slug={ slug }
+					/>
+				);
+			} ) }
+		</div>
+	);
+};

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -32,6 +32,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 				const {
 					description,
 					imageUrl,
+					isActive,
 					isInstalled,
 					manageUrl,
 					slug,
@@ -44,6 +45,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 						manageUrl={ manageUrl }
 						name={ name }
 						imageUrl={ imageUrl }
+						isActive={ isActive }
 						isInstalled={ isInstalled }
 						slug={ slug }
 					/>

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -39,6 +39,9 @@ export const Marketing: React.FC = () => {
 	const [ fetchedExtensions, setFetchedExtensions ] = useState<
 		ExtensionList[]
 	>( [] );
+	const [ currentPlugin, setCurrentPlugin ] = useState< string | null >(
+		null
+	);
 	const [ isFetching, setIsFetching ] = useState( true );
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 	const { activePlugins, installedPlugins } = useSelect(
@@ -86,7 +89,7 @@ export const Marketing: React.FC = () => {
 			} );
 	}, [] );
 
-	const pluginLists = useMemo( () => {
+	const pluginLists: PluginListProps[] = useMemo( () => {
 		return fetchedExtensions
 			.map( ( list ) => {
 				return {
@@ -113,6 +116,7 @@ export const Marketing: React.FC = () => {
 	};
 
 	const installAndActivate = ( slug: string ) => {
+		setCurrentPlugin( slug );
 		installAndActivatePlugins( [ slug ] )
 			.then( ( response: { errors: Record< string, string > } ) => {
 				recordEvent( 'tasklist_marketing_install', {
@@ -120,9 +124,11 @@ export const Marketing: React.FC = () => {
 					installed_extensions: getInstalledMarketingPlugins(),
 				} );
 				createNoticesFromResponse( response );
+				setCurrentPlugin( null );
 			} )
 			.catch( ( response: { errors: Record< string, string > } ) => {
 				createNoticesFromResponse( response );
+				setCurrentPlugin( null );
 			} );
 	};
 
@@ -155,10 +161,11 @@ export const Marketing: React.FC = () => {
 					const { key, title, plugins } = list;
 					return (
 						<PluginList
-							key={ key }
-							title={ title }
-							plugins={ plugins }
+							currentPlugin={ currentPlugin }
 							installAndActivate={ installAndActivate }
+							key={ key }
+							plugins={ plugins }
+							title={ title }
 						/>
 					);
 				} ) }

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Card, CardBody, Spinner } from '@wordpress/components';
+import { PLUGINS_STORE_NAME, WCDataSelector } from '@woocommerce/data';
+import { useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PluginList, PluginListProps } from './PluginList';
+import { PluginProps } from './Plugin';
+
+type ExtensionList = {
+	key: string;
+	title: string;
+	plugins: Extension[];
+};
+
+type Extension = {
+	description: string;
+	key: string;
+	image_url: string;
+	manage_url: string;
+	name: string;
+	slug: string;
+};
+
+export const Marketing: React.FC = () => {
+	const [ pluginLists, setPluginLists ] = useState< PluginListProps[] >( [] );
+	const [ isFetching, setIsFetching ] = useState( true );
+	const { installedPlugins } = useSelect( ( select: WCDataSelector ) => {
+		const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
+
+		return {
+			installedPlugins: getInstalledPlugins(),
+		};
+	} );
+
+	const transformExtensionToPlugin = (
+		extension: Extension
+	): PluginProps => {
+		const { description, image_url, key, name } = extension;
+		const slug = key.split( ':' )[ 0 ];
+		return {
+			description,
+			slug,
+			imageUrl: image_url,
+			isInstalled: installedPlugins.includes( slug ),
+			name,
+		};
+	};
+
+	useEffect( () => {
+		apiFetch( {
+			path: '/wc-admin/onboarding/free-extensions',
+		} )
+			.then( ( results: ExtensionList[] ) => {
+				if ( results?.length ) {
+					const transformedExtensions = results.map( ( list ) => {
+						return {
+							...list,
+							plugins: list.plugins.map( ( extension ) =>
+								transformExtensionToPlugin( extension )
+							),
+						};
+					} );
+					setPluginLists( transformedExtensions );
+				}
+				setIsFetching( false );
+			} )
+			.catch( () => {
+				// @todo Handle error checking.
+				setIsFetching( false );
+			} );
+	}, [] );
+
+	if ( isFetching ) {
+		return <Spinner />;
+	}
+
+	return (
+		<div className="woocommerce-task-marketing">
+			<Card className="woocommerce-task-card">
+				<CardBody>
+					{ pluginLists.map( ( list ) => {
+						const { key, title, plugins } = list;
+						return (
+							<PluginList
+								key={ key }
+								title={ title }
+								plugins={ plugins }
+							/>
+						);
+					} ) }
+				</CardBody>
+			</Card>
+		</div>
+	);
+};

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -1,15 +1,18 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { Card, CardBody, Spinner } from '@wordpress/components';
+import { Card, CardHeader, Spinner } from '@wordpress/components';
 import { PLUGINS_STORE_NAME, WCDataSelector } from '@woocommerce/data';
+import { Text } from '@woocommerce/experimental';
 import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import './Marketing.scss';
 import { PluginList, PluginListProps } from './PluginList';
 import { PluginProps } from './Plugin';
 
@@ -42,13 +45,14 @@ export const Marketing: React.FC = () => {
 	const transformExtensionToPlugin = (
 		extension: Extension
 	): PluginProps => {
-		const { description, image_url, key, name } = extension;
+		const { description, image_url, key, manage_url, name } = extension;
 		const slug = key.split( ':' )[ 0 ];
 		return {
 			description,
 			slug,
 			imageUrl: image_url,
 			isInstalled: installedPlugins.includes( slug ),
+			manageUrl: manage_url,
 			name,
 		};
 	};
@@ -84,18 +88,34 @@ export const Marketing: React.FC = () => {
 	return (
 		<div className="woocommerce-task-marketing">
 			<Card className="woocommerce-task-card">
-				<CardBody>
-					{ pluginLists.map( ( list ) => {
-						const { key, title, plugins } = list;
-						return (
-							<PluginList
-								key={ key }
-								title={ title }
-								plugins={ plugins }
-							/>
-						);
-					} ) }
-				</CardBody>
+				<CardHeader>
+					<Text
+						variant="title.small"
+						as="h2"
+						className="woocommerce-task-card__title"
+					>
+						{ __(
+							'Recommended marketing extensions',
+							'woocommerce-admin'
+						) }
+					</Text>
+					<Text>
+						{ __(
+							'We recommend adding one of the following marketing tools for your store. The extension will be installed and activated for you when you click "Get started".',
+							'woocommerce-admin'
+						) }
+					</Text>
+				</CardHeader>
+				{ pluginLists.map( ( list ) => {
+					const { key, title, plugins } = list;
+					return (
+						<PluginList
+							key={ key }
+							title={ title }
+							plugins={ plugins }
+						/>
+					);
+				} ) }
 			</Card>
 		</div>
 	);

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -36,13 +36,18 @@ const ALLOWED_PLUGIN_LISTS = [ 'reach', 'grow' ];
 export const Marketing: React.FC = () => {
 	const [ pluginLists, setPluginLists ] = useState< PluginListProps[] >( [] );
 	const [ isFetching, setIsFetching ] = useState( true );
-	const { installedPlugins } = useSelect( ( select: WCDataSelector ) => {
-		const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
+	const { activePlugins, installedPlugins } = useSelect(
+		( select: WCDataSelector ) => {
+			const { getActivePlugins, getInstalledPlugins } = select(
+				PLUGINS_STORE_NAME
+			);
 
-		return {
-			installedPlugins: getInstalledPlugins(),
-		};
-	} );
+			return {
+				activePlugins: getActivePlugins(),
+				installedPlugins: getInstalledPlugins(),
+			};
+		}
+	);
 
 	const transformExtensionToPlugin = (
 		extension: Extension
@@ -53,6 +58,7 @@ export const Marketing: React.FC = () => {
 			description,
 			slug,
 			imageUrl: image_url,
+			isActive: activePlugins.includes( slug ),
 			isInstalled: installedPlugins.includes( slug ),
 			manageUrl: manage_url,
 			name,

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -31,6 +31,8 @@ type Extension = {
 	slug: string;
 };
 
+const ALLOWED_PLUGIN_LISTS = [ 'reach', 'grow' ];
+
 export const Marketing: React.FC = () => {
 	const [ pluginLists, setPluginLists ] = useState< PluginListProps[] >( [] );
 	const [ isFetching, setIsFetching ] = useState( true );
@@ -63,14 +65,18 @@ export const Marketing: React.FC = () => {
 		} )
 			.then( ( results: ExtensionList[] ) => {
 				if ( results?.length ) {
-					const transformedExtensions = results.map( ( list ) => {
-						return {
-							...list,
-							plugins: list.plugins.map( ( extension ) =>
-								transformExtensionToPlugin( extension )
-							),
-						};
-					} );
+					const transformedExtensions = results
+						.map( ( list ) => {
+							return {
+								...list,
+								plugins: list.plugins.map( ( extension ) =>
+									transformExtensionToPlugin( extension )
+								),
+							};
+						} )
+						.filter( ( list ) =>
+							ALLOWED_PLUGIN_LISTS.includes( list.key )
+						);
 					setPluginLists( transformedExtensions );
 				}
 				setIsFetching( false );

--- a/packages/data/src/plugins/selectors.ts
+++ b/packages/data/src/plugins/selectors.ts
@@ -69,4 +69,5 @@ export type PluginSelectors = {
 	getInstalledPlugins: WPDataSelector< typeof getInstalledPlugins >;
 	getRecommendedPlugins: WPDataSelector< typeof getRecommendedPlugins >;
 	isJetpackConnected: WPDataSelector< typeof isJetpackConnected >;
+	isPluginsRequesting: WPDataSelector< typeof isPluginsRequesting >;
 } & WPDataSelectors;

--- a/src/Features/RemoteFreeExtensions/DataSourcePoller.php
+++ b/src/Features/RemoteFreeExtensions/DataSourcePoller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DataSourcePoller {
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/obw-free-extensions/1.0/extensions.json',
+		'https://woocommerce.com/wp-json/wccom/obw-free-extensions/2.0/extensions.json',
 	);
 
 	/**


### PR DESCRIPTION
Fixes #7313 

Adds the marketing task to install marketing extensions from the free extensions REST API.

Note that this PR does not cover:
* Separating into multiple lists
* Task completion
* Changes to the free extensions REST API
* Changes to extensions in the profiler

### Screenshots

<img width="699" alt="Screen Shot 2021-07-20 at 1 38 20 PM" src="https://user-images.githubusercontent.com/10561050/126382376-82a87ca7-5ba5-48ad-9a99-1074061eb31c.png">

### Detailed test instructions:

1. Checkout this WCCOM PR - https://github.com/Automattic/woocommerce.com/pull/10826
2. In `src/Features/RemoteFreeExtensions/DataSourcePoller.php` update the data source to `https://woocommerce.test/wp-json/wccom/obw-free-extensions/2.0/extensions.json`
3. Visit the marketing task in the task list
4. Note that buttons show `Activate|Manage|Install` depending on the plugin's state
5. Check that the buttons work as expected
6. Check that the "basics" plugin list is not shown
6. In your console, run `localStorage.setItem( 'debug', 'wc-admin:*' );`
7. Check that the `wcadmin_tasklist_marketing_install` event fires with the installed plugins and selected installed/activate plugin.