### PR TITLE
Adding links to help panel for marketing task

### DIFF
--- a/changelogs/add-7329-marketing-help-links
+++ b/changelogs/add-7329-marketing-help-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Adding links to help panel for marketing task

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -89,6 +89,37 @@ function getAppearanceItems() {
 	];
 }
 
+function getMarketingItems( props ) {
+	const { activePlugins } = props;
+
+	return [
+		activePlugins.includes( 'mailpoet' ) && {
+			title: __( 'Get started with Mailpoet', 'woocommerce-admin' ),
+			link: 'https://kb.mailpoet.com/category/114-getting-started',
+		},
+		activePlugins.includes( 'google-listings-and-ads' ) && {
+			title: __( 'Set up Google Listing & Ads', 'woocommerce-admin' ),
+			link:
+				'https://docs.woocommerce.com/document/google-listings-and-ads/#get-started',
+		},
+		activePlugins.includes( 'mailchimp-for-woocommerce' ) && {
+			title: __(
+				'Connect Mailchimp for WooCommerce',
+				'woocommerce-admin'
+			),
+			link:
+				'https://mailchimp.com/help/connect-or-disconnect-mailchimp-for-woocommerce/',
+		},
+		activePlugins.includes( 'creative-mail-by-constant-contact' ) && {
+			title: __(
+				'Set up Creative Mail for WooCommerce',
+				'woocommerce-admin'
+			),
+			link: 'https://app.creativemail.com/kb/help/WooCommerce',
+		},
+	].filter( Boolean );
+}
+
 function getPaymentGatewaySuggestions( props ) {
 	const { paymentGatewaySuggestions } = props;
 
@@ -280,6 +311,8 @@ function getItems( props ) {
 			return getTaxItems( props );
 		case 'payments':
 			return getPaymentGatewaySuggestions( props );
+		case 'marketing':
+			return getMarketingItems( props );
 		default:
 			return getHomeItems();
 	}


### PR DESCRIPTION
Fixes #7329 

Adding the following requested links to the help panel, currently only visible in the marketing task, and only when the relevant plugin has been installed (which hasn't been added yet). 

* [Get started with Mailpoet](https://kb.mailpoet.com/category/114-getting-started)
* [Set up Google Listing & Ads](https://docs.woocommerce.com/document/google-listings-and-ads/#get-started)
* [Connect Mailchimp for WooCommerce](https://mailchimp.com/help/connect-or-disconnect-mailchimp-for-woocommerce/)
* [Set up Creative Mail for WooCommerce](https://app.creativemail.com/kb/help/WooCommerce)

### Detailed test instructions:

-   Navigate to the marketing task at `admin.php?page=wc-admin&task=marketing`. As of this PR there is no UI added, but that doesn't matter for our purposes.
-   Click the help panel, and notice that only one listing is present for "WooCommerce Docs."
- Install each plugin referenced above (Mailchimp, Google Listings and Ads, Creative Mail & Mailpoet), and confirm that the correct link appears in this help panel after activation.
