### PR TITLE
Increase per_page value for search results on the Analytics pages.

### DIFF
--- a/changelogs/update-6790-increase-per-page-for-search
+++ b/changelogs/update-6790-increase-per-page-for-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Increase per_page value for search results on the Analytics pages. #7385

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -106,7 +106,10 @@ export default compose(
 		const itemsResult = searchItemsByString(
 			itemsSelector,
 			mappedReport,
-			searchWords
+			searchWords,
+			{
+				per_page: 100,
+			}
 		);
 		const { isError, isRequesting, items } = itemsResult;
 		const ids = Object.keys( items );

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -63,13 +63,14 @@ export function getLeaderboard( options ) {
 /**
  * Returns items based on a search query.
  *
- * @param  {Object}   selector    Instance of @wordpress/select response
- * @param  {string}   endpoint  Report API Endpoint
- * @param  {string[]} search    Array of search strings.
+ * @param {Object} select    Instance of @wordpress/select
+ * @param {string} endpoint  Report API Endpoint
+ * @param {string[]} search    Array of search strings.
+ * @param {Object} options  Query options.
  * @return {Object}   Object containing API request information and the matching items.
  */
-export function searchItemsByString( selector, endpoint, search ) {
-	const { getItems, getItemsError, isResolving } = selector;
+export function searchItemsByString( select, endpoint, search, options ) {
+	const { getItems, getItemsError, isResolving } = select( STORE_NAME );
 
 	const items = {};
 	let isRequesting = false;
@@ -77,8 +78,10 @@ export function searchItemsByString( selector, endpoint, search ) {
 	search.forEach( ( searchWord ) => {
 		const query = {
 			search: searchWord,
-			per_page: 10,
+			...{ per_page: 10 },
+			...options,
 		};
+
 		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {
 			items[ id ] = item;

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -78,7 +78,7 @@ export function searchItemsByString( select, endpoint, search, options ) {
 	search.forEach( ( searchWord ) => {
 		const query = {
 			search: searchWord,
-			...{ per_page: 10 },
+			per_page: 10,
 			...options,
 		};
 


### PR DESCRIPTION
Fixes woocommerce/woocommerce-admin#6790 

This PR increases the # of per_page value when a search is performed on the report pages.

This should work for many stores until we implement pagination.

I've opened an [issue](woocommerce/woocommerce#32244) to implement pagination.

Note: Merging this PR will close https://github.com/woocommerce/woocommerce-admin/issues/6790. We should reopen it as this PR doesn't fix the root cause.

### Detailed test instructions:

1. Navigate to Analytics -> Products
2. Open browser inspector
3. Type a keyword in the search input and click "All products with titles that include" link.
4. Click "Network" in your browser inspector and filter by "search"
5. Confirm that the value of `per_page` is `100`
