### PR TITLE
Add locale param as part of free extensions request

### DIFF
--- a/changelogs/update-obw-free-extensions-locale
+++ b/changelogs/update-obw-free-extensions-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Add locale param as part of free extensions request

--- a/src/Features/RemoteFreeExtensions/DataSourcePoller.php
+++ b/src/Features/RemoteFreeExtensions/DataSourcePoller.php
@@ -65,7 +65,13 @@ class DataSourcePoller {
 	private static function read_data_source( $url ) {
 		$logger_context = array( 'source' => $url );
 		$logger         = self::get_logger();
-		$response       = wp_remote_get( $url );
+		$response       = wp_remote_get(
+			add_query_arg(
+				'_locale',
+				get_user_locale(),
+				$url
+			)
+		);
 
 		if ( is_wp_error( $response ) || ! isset( $response['body'] ) ) {
 			$logger->error(

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -55,46 +55,9 @@ class Init {
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
 			// We are running too early, need to poll data sources first.
 			$specs = DataSourcePoller::read_specs_from_data_sources();
-			// Localize top level.
-			$specs = self::localize( $specs );
-			// Localize plugins.
-			foreach ( $specs as $spec ) {
-				$spec->plugins = self::localize( $spec->plugins );
-			}
-
 			set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
 		}
 
 		return $specs;
-	}
-
-	/**
-	 * Localize the provided method.
-	 *
-	 * @param array $specs The specs to localize.
-	 * @return array Localized specs.
-	 */
-	public static function localize( $specs ) {
-		$localized_specs = array();
-
-		foreach ( $specs as $spec ) {
-			if ( ! isset( $spec->locales ) ) {
-				continue;
-			}
-
-			$locale = SpecRunner::get_locale( $spec->locales );
-
-			// Skip specs where no matching locale is found.
-			if ( ! $locale ) {
-				continue;
-			}
-
-			$data = (object) array_merge( (array) $locale, (array) $spec );
-			unset( $data->locales );
-
-			$localized_specs[] = $data;
-		}
-
-		return $localized_specs;
 	}
 }


### PR DESCRIPTION
This PR mimics the `locale` param behavior used in payment gateway suggestions by sending a `locale` param to WCCOM so that translations can be made use i18n.

### Detailed test instructions:

1. Checkout this WCCOM PR - https://github.com/Automattic/woocommerce.com/pull/10826
2. In `src/Features/RemoteFreeExtensions/DataSourcePoller.php` update your data source to `https://woocommerce.com/wp-json/wccom/obw-free-extensions/1.0/extensions.json`.
3. Check that changing your locale on your WP site is sent via the request and updates the returned value from `get_locale()` on the WCCOM side (you can just dump the value of `get_locale()` in `extensions.json.php`)