### PR TITLE
Add limit clause to coupons data store query

### DIFF
--- a/changelogs/fix-7393
+++ b/changelogs/fix-7393
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Add limit clause to coupons data store query

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -280,6 +280,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$coupons_query = $this->get_query_statement();
 			} else {
 				$this->subquery->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
+				$this->subquery->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
 				$coupons_query = $this->subquery->get_query_statement();
 
 				$this->subquery->clear_sql_clause( array( 'select', 'order_by' ) );


### PR DESCRIPTION
Fixes #7393 

The coupons data store was missing a limit clause, causing any number of rows to show up on the leaderboard.

### Screenshots

#### Before

<img width="664" alt="Screen Shot 2021-07-22 at 10 38 36 AM" src="https://user-images.githubusercontent.com/10561050/126658186-7c176dab-21ee-4682-8da5-440f5d05f08f.png">


#### After

<img width="675" alt="Screen Shot 2021-07-22 at 10 38 16 AM" src="https://user-images.githubusercontent.com/10561050/126658188-8a226ce8-ec57-4399-a9a6-d2187239b1d8.png">

<img width="680" alt="Screen Shot 2021-07-22 at 10 42 00 AM" src="https://user-images.githubusercontent.com/10561050/126658502-ab3cf946-fa7b-4373-a0cf-9017e038ef27.png">


### Detailed test instructions:

1. Create at least 2 orders with 2 different coupons
1. Navigate to the leaderboards in Overview
2. Enable the coupons leaderboard
3. Update the rows per table to a smaller number than you have
4. Note the correct number of rows is shown (occasionally this needs a page refresh if the state doesn't update, but that appears to be an unrelated bug)