### PR TITLE
Skip category creation on WC install

### DIFF
--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -139,9 +139,7 @@ class CategoryLookup {
 	 */
 	public function on_create( $category_id ) {
 		// If WooCommerce is being installed on a multisite, lookup tables haven't been created yet.
-		// Create the tables and regenerate so that the default categories can be created.
 		if ( 'yes' === get_transient( 'wc_installing' ) ) {
-			wp_schedule_single_event( time() + 10, 'generate_category_lookup_table' );
 			return;
 		}
 

--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -138,6 +138,13 @@ class CategoryLookup {
 	 * @param int $category_id Term ID being created.
 	 */
 	public function on_create( $category_id ) {
+		// If WooCommerce is being installed on a multisite, lookup tables haven't been created yet.
+		// Create the tables and regenerate so that the default categories can be created.
+		if ( 'yes' === get_transient( 'wc_installing' ) ) {
+			wp_schedule_single_event( time() + 10, 'generate_category_lookup_table' );
+			return;
+		}
+
 		$this->update( $category_id );
 	}
 


### PR DESCRIPTION
Fixes #7396 

The WooCommerce "uncategorized" category is created when a multisite is created.  However, WooCommerce Admin hasn't generated tables yet, resulting in this error.

This PR skips the initial category creation hook and relies on `generate_category_lookup_table` to handle creation.

### Detailed test instructions:

1. Create a multisite network
2. Add a new site to your multisite
3. Quickly open the dashboard of the created site
4. Note the lack of errors