### PR TITLE
Import createElement to fix build issues with SlotFill

### DIFF
--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.1.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286
+-   Import createElement to fix build issues with SlotFill #7403
 
 # 2.0.0
 

--- a/packages/onboarding/src/components/WooPaymentGatewayConfigure/WooPaymentGatewayConfigure.js
+++ b/packages/onboarding/src/components/WooPaymentGatewayConfigure/WooPaymentGatewayConfigure.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { createElement } from '@wordpress/element';
 import { Slot, Fill } from '@wordpress/components';
 
 export const WooPaymentGatewayConfigure = ( { id, ...props } ) => (


### PR DESCRIPTION
Fixes #7402

Fixes the SlotFill due to a broken webpack build.  Resolved by manually importing `createElement`.

Huge shoutout to @louwie17 for getting to the bottom of this.

### Screenshots

<img width="699" alt="Screen Shot 2021-07-22 at 1 19 44 PM" src="https://user-images.githubusercontent.com/10561050/126682743-52b2c4eb-f1b2-4fd0-83b4-53d18e367f17.png">

### Detailed test instructions:

1. Install and build this WC Paypal plugin https://github.com/woocommerce/woocommerce-paypal-payments/pull/164
2. Run `yarn link` inside `packages/onboarding` in WooCommerce Admin.
3. In the `modules/ppcp-onboarding` folder in PayPal, run `yarn link @woocommerce/onboarding && yarn build`
2. Set your store to any country besides India and don't select "CBD" as an industry during onboarding.
2. Navigate to the payment gateways task
3. Go through the PayPal gateway task.
4. Note that the PayPal configure step loads with a connection button or form shown above.