### PR TITLE
Add scope to BACS slotfill

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/plugins/Bacs.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/plugins/Bacs.js
@@ -175,4 +175,5 @@ const BacsPaymentGatewaySetup = () => {
 
 registerPlugin( 'wc-admin-payment-gateway-setup-bacs', {
 	render: BacsPaymentGatewaySetup,
+	scope: 'woocommerce-admin',
 } );

--- a/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
+++ b/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
@@ -30,7 +30,7 @@ export class WcHomescreen extends BasePage {
 		await page.waitForSelector(
 			'.woocommerce-task-card .woocommerce-task-list__item-title'
 		);
-		await waitForElementByText( 'p', 'Get ready to start selling' );
+		await waitForElementByText( 'span', 'Get ready to start selling' );
 		const list = await this.page.$$eval(
 			'.woocommerce-task-card .woocommerce-task-list__item-title',
 			( items ) => items.map( ( item ) => item.textContent )


### PR DESCRIPTION
Fixes one of the failing e2e tests

### Screenshots

#### Before
<img width="695" alt="Screen Shot 2021-07-22 at 2 00 02 PM" src="https://user-images.githubusercontent.com/10561050/126690736-d46ab10f-88c0-486a-9b4c-0083b8861b34.png">


#### After
<img width="702" alt="Screen Shot 2021-07-22 at 1 59 40 PM" src="https://user-images.githubusercontent.com/10561050/126690744-aadcb930-fffd-4b54-b510-d6c7e6ecc860.png">
<img width="697" alt="Screen Shot 2021-07-22 at 2 31 04 PM" src="https://user-images.githubusercontent.com/10561050/126690745-5db9093c-06eb-41f6-a7a3-6e9b2442a5b9.png">


### Detailed test instructions:

1. Delete any direct bank transfer details you have under WooCommerce->Settings->Payments
2. Visit the payment gateway task in the task list
3. Note that "Set up" is shown and you can set up BACS