### PR TITLE
Fix recommended card Gutenberg CSS conflict

### DIFF
--- a/changelogs/fix-7394-recommended-card-gutenberg-conflict
+++ b/changelogs/fix-7394-recommended-card-gutenberg-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix recommended card Gutenberg CSS conflict #7409

--- a/client/embedded-body-layout/style.scss
+++ b/client/embedded-body-layout/style.scss
@@ -1,5 +1,9 @@
 .woocommerce-embedded-layout__primary {
 	padding: 0 20px;
+
+	.components-card__header {
+		box-sizing: border-box;
+	}
 }
 @media (max-width: #{ ($break-medium) }) {
 	.woocommerce-embedded-layout__primary {

--- a/client/embedded-body-layout/style.scss
+++ b/client/embedded-body-layout/style.scss
@@ -4,6 +4,10 @@
 	.components-card__header {
 		box-sizing: border-box;
 	}
+
+	.components-card__footer {
+		box-sizing: border-box;
+	}
 }
 @media (max-width: #{ ($break-medium) }) {
 	.woocommerce-embedded-layout__primary {

--- a/client/payments/payment-recommendations.scss
+++ b/client/payments/payment-recommendations.scss
@@ -27,7 +27,7 @@
 	}
 
 	.components-card__body {
-		padding: 0;
+		padding: 0 !important; // Gutenberg override
 	}
 
 	.woocommerce-pill {

--- a/client/payments/payment-recommendations.scss
+++ b/client/payments/payment-recommendations.scss
@@ -26,10 +26,6 @@
 		text-align: center;
 	}
 
-	.components-card__body {
-		padding: 0;
-	}
-
 	.woocommerce-pill {
 		margin-left: 4px;
 		padding: 2px 8px;

--- a/client/payments/payment-recommendations.scss
+++ b/client/payments/payment-recommendations.scss
@@ -27,7 +27,7 @@
 	}
 
 	.components-card__body {
-		padding: 0 !important; // Gutenberg override
+		padding: 0;
 	}
 
 	.woocommerce-pill {

--- a/client/payments/payment-recommendations.scss
+++ b/client/payments/payment-recommendations.scss
@@ -39,8 +39,6 @@
 	}
 
 	.components-card__footer {
-		padding: $gap $gap-large;
-
 		.gridicon {
 			margin-left: $gap-smallest;
 		}

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -221,9 +221,7 @@ const PaymentRecommendations: React.FC = () => {
 					/>
 				</div>
 			</CardHeader>
-			<div>
-				<List items={ pluginsList } />
-			</div>
+			<List items={ pluginsList } />
 			<CardFooter>
 				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
 					{ __( 'See more options', 'woocommerce-admin' ) }

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -171,8 +171,8 @@ const PaymentRecommendations: React.FC = () => {
 	);
 
 	return (
-		<Card size="large" className="woocommerce-recommended-payments-card">
-			<CardHeader size="medium">
+		<Card size="medium" className="woocommerce-recommended-payments-card">
+			<CardHeader>
 				<div className="woocommerce-recommended-payments-card__header">
 					<Text
 						variant="title.small"

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -221,9 +221,9 @@ const PaymentRecommendations: React.FC = () => {
 					/>
 				</div>
 			</CardHeader>
-			<CardBody>
+			<div>
 				<List items={ pluginsList } />
-			</CardBody>
+			</div>
 			<CardFooter>
 				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
 					{ __( 'See more options', 'woocommerce-admin' ) }

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -4,13 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	CardFooter,
-	Button,
-} from '@wordpress/components';
+import { Card, CardHeader, CardFooter, Button } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { EllipsisMenu, List, Pill } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';


### PR DESCRIPTION
Fixes #7394

This PR fixes style conflicts caused by Gutenberg changes.

### Screenshots

![image](https://user-images.githubusercontent.com/3747241/126779306-aeabfc36-92bf-426d-af3a-bcb131f33d34.png)

### Detailed test instructions:

1. Install & activate the latest Gutenberg plugin.
1. Open WooCommerce > Settings > Payments.
2. Wait for a little, and observe the recommended card rendered fine as per screenshot.
3. Optionally, deactivate Gutenberg plugin and observe the card renders correctly as well.