### PR TITLE
Fix analytics filter Gutenberg CSS conflict

### DIFF
--- a/changelogs/fix-7362-analytics-filter-gutenberg-conflict
+++ b/changelogs/fix-7362-analytics-filter-gutenberg-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix analytics filter Gutenberg CSS conflict #7410

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -3,6 +3,7 @@
 
 	.components-card__body {
 		background-color: $gray-100;
+		overflow: initial;
 
 		&.is-size-small:hover,
 		ul li:hover {


### PR DESCRIPTION
Fixes #7362

This PR fixes style conflicts caused by Gutenberg changes in Add Filter dropdown in Analytics pages.

### Screenshots

![image](https://user-images.githubusercontent.com/3747241/126782431-5b36470e-c5d1-43c1-af10-9e6af264a930.png)

### Detailed test instructions:

1. Install & activate the latest Gutenberg plugin.
2. Store must have at least one product.
2. Open WooCommerce > Analytics > Downloads.
3. In "Show", Pick Advanced Filters.
4. Add a filter > Product.
5. In the search bar, put the name of your product and wait until the dropdown is rendered.
6. Make sure the dropdown is shown properly (not partially covered by surrounding divs).
