### PR TITLE
Fix Gutenberg CardBody styles for task card

### DIFF
--- a/changelogs/fix-gb-task-card
+++ b/changelogs/fix-gb-task-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Gutenberg CardBody styles for task card

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -346,7 +346,6 @@
 	.woocommerce-task-card.is-loading {
 		.woocommerce-card__body {
 			border-top: 1px solid $studio-gray-5;
-			padding: 0;
 		}
 
 		.is-placeholder {

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -3,7 +3,7 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { Button, Card, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu, Badge } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
@@ -342,43 +342,40 @@ export const TaskList = ( {
 						</div>
 						{ renderMenu() }
 					</CardHeader>
-					<CardBody>
-						<ListComp animation="custom" { ...listProps }>
-							{ listTasks.map( ( task ) => (
-								<TaskItem
-									key={ task.key }
-									title={ task.title }
-									completed={ task.completed }
-									content={ task.content }
-									onClick={
-										! expandingItems || task.completed
-											? task.onClick
-											: () => setCurrentTask( task.key )
-									}
-									expandable={ expandingItems }
-									expanded={
-										expandingItems &&
-										currentTask === task.key
-									}
-									onDismiss={
-										task.isDismissable
-											? () => dismissTask( task )
-											: undefined
-									}
-									remindMeLater={
-										task.allowRemindMeLater
-											? () => remindTaskLater( task )
-											: undefined
-									}
-									time={ task.time }
-									level={ task.level }
-									action={ task.onClick }
-									actionLabel={ task.action }
-									additionalInfo={ task.additionalInfo }
-								/>
-							) ) }
-						</ListComp>
-					</CardBody>
+					<ListComp animation="custom" { ...listProps }>
+						{ listTasks.map( ( task ) => (
+							<TaskItem
+								key={ task.key }
+								title={ task.title }
+								completed={ task.completed }
+								content={ task.content }
+								onClick={
+									! expandingItems || task.completed
+										? task.onClick
+										: () => setCurrentTask( task.key )
+								}
+								expandable={ expandingItems }
+								expanded={
+									expandingItems && currentTask === task.key
+								}
+								onDismiss={
+									task.isDismissable
+										? () => dismissTask( task )
+										: undefined
+								}
+								remindMeLater={
+									task.allowRemindMeLater
+										? () => remindTaskLater( task )
+										: undefined
+								}
+								time={ task.time }
+								level={ task.level }
+								action={ task.onClick }
+								actionLabel={ task.action }
+								additionalInfo={ task.additionalInfo }
+							/>
+						) ) }
+					</ListComp>
 				</Card>
 			</div>
 		</>


### PR DESCRIPTION
Removes the `CardBody` to resolve added padding issues in newer versions of GB.

### Screenshots

#### Before

<img width="748" alt="Screen Shot 2021-07-23 at 9 32 34 AM" src="https://user-images.githubusercontent.com/10561050/126789259-42b98ac2-1759-43a5-82db-538d3148dcfd.png">


#### After

<img width="716" alt="Screen Shot 2021-07-23 at 9 27 34 AM" src="https://user-images.githubusercontent.com/10561050/126789207-2bf96612-4dd4-4b9b-b8c9-f21ca3bc211c.png">


### Detailed test instructions:

1. Activate the latest GB plugin
2. Navigate to the task list
3. Note that padding on the task card is correct