### PR TITLE
 Separate installed plugins from plugin lists

### DIFF
--- a/changelogs/add-7314
+++ b/changelogs/add-7314
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add installed marketing extensions card to extensions task

--- a/client/task-list/tasks/Marketing/Marketing.scss
+++ b/client/task-list/tasks/Marketing/Marketing.scss
@@ -5,10 +5,13 @@
 
 		h2 {
 			color: $gray-900;
-			margin-bottom: $gap-smaller;
+			font-size: 20px;
+			margin-bottom: 0;
 		}
 
-		p {
+		span {
+			margin-left: 0;
+			margin-top: $gap-smaller;
 			color: $gray-700;
 		}
 	}

--- a/client/task-list/tasks/Marketing/Plugin.scss
+++ b/client/task-list/tasks/Marketing/Plugin.scss
@@ -3,8 +3,8 @@
 	padding: $gap-large;
 	border-top: 1px solid #e5e5e5;
 
-	&:last-child {
-		border-bottom: 1px solid #e5e5e5;
+	&:first-child {
+		border-top: 0;
 	}
 
 	h4 {

--- a/client/task-list/tasks/Marketing/Plugin.scss
+++ b/client/task-list/tasks/Marketing/Plugin.scss
@@ -1,7 +1,7 @@
 .woocommerce-plugin-list__plugin {
 	display: flex;
 	padding: $gap-large;
-	border-top: 1px solid #e5e5e5;
+	border-top: 1px solid $gray-200;
 
 	&:first-child {
 		border-top: 0;
@@ -16,7 +16,6 @@
 	p {
 		color: $gray-700;
 		font-weight: 400;
-		color: #3c434a;
 	}
 }
 

--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -84,7 +84,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
-						{ __( 'Install', 'woocommmerce-admin' ) }
+						{ __( 'Get started', 'woocommmerce-admin' ) }
 					</Button>
 				) }
 			</div>

--- a/client/task-list/tasks/Marketing/PluginList.scss
+++ b/client/task-list/tasks/Marketing/PluginList.scss
@@ -1,8 +1,6 @@
 .woocommerce-plugin-list__title {
 	padding: $gap-small 30px;
 	background: $gray-200;
-	margin-bottom: 1px;
-	margin-top: 1px;
 	position: relative;
 
 	h3 {

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -11,7 +11,7 @@ import './PluginList.scss';
 
 export type PluginListProps = {
 	currentPlugin?: string | null;
-	key: string;
+	key?: string;
 	installAndActivate?: ( slug: string ) => void;
 	plugins?: PluginProps[];
 	title?: string;

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -103,7 +103,10 @@ export const Marketing: React.FC = () => {
 				listPlugins.push( plugin );
 			} );
 
-			if ( ! ALLOWED_PLUGIN_LISTS.includes( list.key ) ) {
+			if (
+				! ALLOWED_PLUGIN_LISTS.includes( list.key ) ||
+				! listPlugins.length
+			) {
 				return;
 			}
 
@@ -153,56 +156,60 @@ export const Marketing: React.FC = () => {
 
 	return (
 		<div className="woocommerce-task-marketing">
-			<Card className="woocommerce-task-card">
-				<CardHeader>
-					<Text
-						variant="title.small"
-						as="h2"
-						className="woocommerce-task-card__title"
-					>
-						{ __(
-							'Installed marketing extensions',
-							'woocommerce-admin'
-						) }
-					</Text>
-				</CardHeader>
-				<PluginList
-					currentPlugin={ currentPlugin }
-					plugins={ installedExtensions }
-				/>
-			</Card>
-			<Card className="woocommerce-task-card">
-				<CardHeader>
-					<Text
-						variant="title.small"
-						as="h2"
-						className="woocommerce-task-card__title"
-					>
-						{ __(
-							'Recommended marketing extensions',
-							'woocommerce-admin'
-						) }
-					</Text>
-					<Text>
-						{ __(
-							'We recommend adding one of the following marketing tools for your store. The extension will be installed and activated for you when you click "Get started".',
-							'woocommerce-admin'
-						) }
-					</Text>
-				</CardHeader>
-				{ pluginLists.map( ( list ) => {
-					const { key, title, plugins } = list;
-					return (
-						<PluginList
-							currentPlugin={ currentPlugin }
-							installAndActivate={ installAndActivate }
-							key={ key }
-							plugins={ plugins }
-							title={ title }
-						/>
-					);
-				} ) }
-			</Card>
+			{ installedExtensions.length && (
+				<Card className="woocommerce-task-card">
+					<CardHeader>
+						<Text
+							variant="title.small"
+							as="h2"
+							className="woocommerce-task-card__title"
+						>
+							{ __(
+								'Installed marketing extensions',
+								'woocommerce-admin'
+							) }
+						</Text>
+					</CardHeader>
+					<PluginList
+						currentPlugin={ currentPlugin }
+						plugins={ installedExtensions }
+					/>
+				</Card>
+			) }
+			{ pluginLists.length && (
+				<Card className="woocommerce-task-card">
+					<CardHeader>
+						<Text
+							variant="title.small"
+							as="h2"
+							className="woocommerce-task-card__title"
+						>
+							{ __(
+								'Recommended marketing extensions',
+								'woocommerce-admin'
+							) }
+						</Text>
+						<Text>
+							{ __(
+								'We recommend adding one of the following marketing tools for your store. The extension will be installed and activated for you when you click "Get started".',
+								'woocommerce-admin'
+							) }
+						</Text>
+					</CardHeader>
+					{ pluginLists.map( ( list ) => {
+						const { key, title, plugins } = list;
+						return (
+							<PluginList
+								currentPlugin={ currentPlugin }
+								installAndActivate={ installAndActivate }
+								key={ key }
+								plugins={ plugins }
+								title={ title }
+							/>
+						);
+					} ) }
+				</Card>
+			) }
 		</div>
 	);
 };

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -145,7 +145,7 @@ export const Marketing: React.FC = () => {
 
 	return (
 		<div className="woocommerce-task-marketing">
-			{ installedExtensions.length && (
+			{ !! installedExtensions.length && (
 				<Card className="woocommerce-task-card">
 					<CardHeader>
 						<Text
@@ -165,7 +165,7 @@ export const Marketing: React.FC = () => {
 					/>
 				</Card>
 			) }
-			{ pluginLists.length && (
+			{ !! pluginLists.length && (
 				<Card className="woocommerce-task-card">
 					<CardHeader>
 						<Text

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -120,26 +120,15 @@ export const Marketing: React.FC = () => {
 		return [ installed, lists ];
 	}, [ installedPlugins, activePlugins, fetchedExtensions ] );
 
-	const getInstalledMarketingPlugins = () => {
-		const installed: string[] = [];
-		pluginLists.forEach( ( list: PluginListProps ) => {
-			return list.plugins?.forEach( ( plugin ) => {
-				if ( plugin.isInstalled ) {
-					installed.push( plugin.slug );
-				}
-			} );
-		} );
-
-		return installed;
-	};
-
 	const installAndActivate = ( slug: string ) => {
 		setCurrentPlugin( slug );
 		installAndActivatePlugins( [ slug ] )
 			.then( ( response: { errors: Record< string, string > } ) => {
 				recordEvent( 'tasklist_marketing_install', {
 					selected_extension: slug,
-					installed_extensions: getInstalledMarketingPlugins(),
+					installed_extensions: installedExtensions.map(
+						( extension ) => extension.slug
+					),
 				} );
 				createNoticesFromResponse( response );
 				setCurrentPlugin( null );

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -89,17 +89,32 @@ export const Marketing: React.FC = () => {
 			} );
 	}, [] );
 
-	const pluginLists: PluginListProps[] = useMemo( () => {
-		return fetchedExtensions
-			.map( ( list ) => {
-				return {
-					...list,
-					plugins: list.plugins.map( ( extension ) =>
-						transformExtensionToPlugin( extension )
-					),
-				};
-			} )
-			.filter( ( list ) => ALLOWED_PLUGIN_LISTS.includes( list.key ) );
+	const [ installedExtensions, pluginLists ] = useMemo( () => {
+		const installed: PluginProps[] = [];
+		const lists: PluginListProps[] = [];
+		fetchedExtensions.forEach( ( list ) => {
+			const listPlugins: PluginProps[] = [];
+			list.plugins.forEach( ( extension ) => {
+				const plugin = transformExtensionToPlugin( extension );
+				if ( plugin.isInstalled ) {
+					installed.push( plugin );
+					return;
+				}
+				listPlugins.push( plugin );
+			} );
+
+			if ( ! ALLOWED_PLUGIN_LISTS.includes( list.key ) ) {
+				return;
+			}
+
+			const transformedList: PluginListProps = {
+				...list,
+				plugins: listPlugins,
+			};
+			lists.push( transformedList );
+		} );
+
+		return [ installed, lists ];
 	}, [ installedPlugins, activePlugins, fetchedExtensions ] );
 
 	const getInstalledMarketingPlugins = () => {
@@ -138,6 +153,24 @@ export const Marketing: React.FC = () => {
 
 	return (
 		<div className="woocommerce-task-marketing">
+			<Card className="woocommerce-task-card">
+				<CardHeader>
+					<Text
+						variant="title.small"
+						as="h2"
+						className="woocommerce-task-card__title"
+					>
+						{ __(
+							'Installed marketing extensions',
+							'woocommerce-admin'
+						) }
+					</Text>
+				</CardHeader>
+				<PluginList
+					currentPlugin={ currentPlugin }
+					plugins={ installedExtensions }
+				/>
+			</Card>
 			<Card className="woocommerce-task-card">
 				<CardHeader>
 					<Text

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -93,6 +93,10 @@ export const Marketing: React.FC = () => {
 		const installed: PluginProps[] = [];
 		const lists: PluginListProps[] = [];
 		fetchedExtensions.forEach( ( list ) => {
+			if ( ! ALLOWED_PLUGIN_LISTS.includes( list.key ) ) {
+				return;
+			}
+
 			const listPlugins: PluginProps[] = [];
 			list.plugins.forEach( ( extension ) => {
 				const plugin = transformExtensionToPlugin( extension );
@@ -103,10 +107,7 @@ export const Marketing: React.FC = () => {
 				listPlugins.push( plugin );
 			} );
 
-			if (
-				! ALLOWED_PLUGIN_LISTS.includes( list.key ) ||
-				! listPlugins.length
-			) {
+			if ( ! listPlugins.length ) {
 				return;
 			}
 

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -178,7 +178,7 @@ export const Marketing: React.FC = () => {
 								'woocommerce-admin'
 							) }
 						</Text>
-						<Text>
+						<Text as="span">
 							{ __(
 								'We recommend adding one of the following marketing tools for your store. The extension will be installed and activated for you when you click "Get started".',
 								'woocommerce-admin'


### PR DESCRIPTION
Fixes #7314 

Separate the installed plugins into their own card in the marketing extensions task.

cc @pmcpinto @elizaan36 Just want to double check if this is expected behavior: this separates lists into installed and not yet installed plugins; deactivated plugins will appears in the "installed" list.  I'm not sure if the intention is to create an "actionable" list, in which case we may want to use "Active marketing extensions."

### Screenshots

<img width="701" alt="Screen Shot 2021-07-27 at 3 02 13 PM" src="https://user-images.githubusercontent.com/10561050/127233555-be90c9dd-9237-4d1a-99b2-607e98e80a06.png">



### Detailed test instructions:

1. Checkout this WCCOM PR - https://github.com/Automattic/woocommerce.com/pull/10826
2. Note that you may need to rebase this with https://github.com/woocommerce/woocommerce-admin/pull/7391 if not merged yet
3. In `src/Features/RemoteFreeExtensions/DataSourcePoller.php` update the data source to `https://woocommerce.test/wp-json/wccom/obw-free-extensions/2.0/extensions.json`
3. Delete the remote extensions transient `woocommerce_admin_remote_free_extensions_specs`
4. Navigate to the marketing tasks
5. Note that installed extensions are shown in the upper list
6. Make sure that on installation, the extensions are moved to the installed list
7. Make sure that on installation, the `wcadmin_tasklist_marketing_install` event is fired with the slugs of the already installed marketing extensions