### PR TITLE
Add eslint rule to prevent missing createElement imports.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,13 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'client/**/*.js', 'client/**/*.jsx' ],
+			files: [
+				'client/**/*.js',
+				'client/**/*.jsx',
+				'**/stories/*.js',
+				'**/stories/*.jsx',
+				'**/docs/example.js',
+			],
 			rules: {
 				'react/react-in-jsx-scope': 'off',
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
 	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
 	settings: {
 		'import/resolver': 'typescript',
+		react: {
+			pragma: 'createElement',
+		},
 	},
 	rules: {
 		// temporary conversion to warnings until the below are all handled.
@@ -33,6 +36,7 @@ module.exports = {
 				varsIgnorePattern: 'createElement',
 			},
 		],
+		'react/react-in-jsx-scope': 'error',
 	},
 	overrides: [
 		{
@@ -54,12 +58,12 @@ module.exports = {
 				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': [ 'error' ],
 				'@typescript-eslint/no-empty-function': 'off',
-				'@typescript-eslint/no-unused-vars': [
-					'error',
-					{
-						varsIgnorePattern: 'createElement',
-					},
-				],
+			},
+		},
+		{
+			files: [ 'client/**/*.js', 'client/**/*.jsx' ],
+			rules: {
+				'react/react-in-jsx-scope': 'off',
 			},
 		},
 	],

--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
 		"eslint-import-resolver-typescript": "2.4.0",
 		"eslint-import-resolver-webpack": "0.13.1",
 		"eslint-plugin-import": "2.22.1",
+		"eslint-plugin-react": "7.24.0",
 		"fork-ts-checker-webpack-plugin": "6.2.10",
 		"fs-extra": "8.1.0",
 		"grunt": "1.3.0",


### PR DESCRIPTION
Hopefully prevents more occurrences like https://github.com/woocommerce/woocommerce-admin/issues/7402.

This PR adds an eslint rule to catch missing `createElement` imports in JSX files outside of the `client/` directory (where they're added with Babel).

### Detailed test instructions:

- `npm install`
- Remove the `createElement` import from a JS file containing JSX in the `packages/` directory
- Verify the first line of JSX errors from eslint (I tested using VS Code's integration)
- Remove the `createElement` import from a TS file containing JSX in the `packages/` directory
- Verify the first line of JSX errors from eslint

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.

No changelog.