### PR TITLE
Making business details sticky in OBW

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -6,7 +6,7 @@
 
 1. Start out with a fresh store
 2. Start the on-boarding wizard and move through to the "Business details" step
-3. Fill out items, and then hit Continue to move to "Free features" tab
+3. Fill out items, and then hit Continue to move to the "Free features" tab
 4. Then, before hitting Continue again, click the "Business details" tab above to move back to that step
 5. Confirm that the previously selected values are still correct
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -4,7 +4,7 @@
 
 ### Making business details sticky in OBW #7426
 
-1. Start out with fresh store
+1. Start out with a fresh store
 2. Start the on-boarding wizard and move through to the "Business details" step
 3. Fill out items, and then hit Continue to move to "Free features" tab
 4. Then, before hitting Continue again, click "Business details" tab above to move back to that step

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -7,7 +7,7 @@
 1. Start out with a fresh store
 2. Start the on-boarding wizard and move through to the "Business details" step
 3. Fill out items, and then hit Continue to move to "Free features" tab
-4. Then, before hitting Continue again, click "Business details" tab above to move back to that step
+4. Then, before hitting Continue again, click the "Business details" tab above to move back to that step
 5. Confirm that the previously selected values are still correct
 
 ### Match stock status value in CSV download to the table #7284

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Making business details sticky in OBW #7426
+
+1. Start out with fresh store
+2. Start the on-boarding wizard and move through to the "Business details" step
+3. Fill out items, and then hit Continue to move to "Free features" tab
+4. Then, before hitting Continue again, click "Business details" tab above to move back to that step
+5. Confirm that the previously selected values are still correct
+
 ### Match stock status value in CSV download to the table #7284
 
 1. Clone this branch and run npm start
@@ -12,6 +20,7 @@
 6. Open the downloaded file and confirm the status values match the table.
 
 ### Fix end date for last periods #6584
+
 1. Update your system clock to March 2021
 2. Create a completed order on 29th February 2020
 3. Go to Analytics > Revenue
@@ -23,6 +32,7 @@
 9. Observe that the end date is the same as the selected quarter and subtract 1 year
 10. In the date range filter, select "Last Year" preset and compare to "Previous Year"
 11. Observe that the end date is the same as the selected year and subtract 1 year
+
 ## 2.5.0
 
 ### Fix WC Home crash when the Analytics is disabled #7339
@@ -87,25 +97,26 @@ Please make sure to test it on Safari as well.
 1. Go to the OBW and look at the Free features tab
 1. Observe no Facebook extension in the list
 
-###  "Terms of service" link disappears from "Set up Tax" screen #7269
+### "Terms of service" link disappears from "Set up Tax" screen #7269
 
 1. Go to OBW setup wizard.
 2. Uncheck the "WooCommerce shipping" and "WooCommerce Tax" options at Free features step.
 3. Complete the OBW setup.
 4. Go to WooCommerce->Home.
 5. Click on "Set up Tax" option on Task list.
-6. TOS should not blink. 
+6. TOS should not blink.
 
 ### Use saved values if available when switching tabs #7226
 
 1. Start onboarding wizard and continue to step 4.
 2. Enter selections for business details and choose "Continue"
 3. Select the tab "Business details" to go back
-4. Confirm that the previously selected values are shown. 
+4. Confirm that the previously selected values are shown.
 
 ### Change the emailed report file name #7178
 
 **Confirm the default behaviour remains the same**
+
 1. Create a new store and install the [WP Mail Logging by MailPoet plugin](https://wordpress.org/plugins/wp-mail-logging/)
 2. Go to Analytics -> Revenue and change the date range to last month
 3. Click the download button and make sure you see the "Your revenue report will be emailed to you" notification
@@ -113,13 +124,17 @@ Please make sure to test it on Safari as well.
 5. Go to Tools -> WP Mail Log and check the latest email. The URL linked to the "Download your Revenue report" should work as usual. The URL will be something like `filename=wc-revenue-report-export-16236128226138`
 
 **Confirm the new filter is working**
+
 1. Add this code to the `woocommerce-admin.php` file
+
 ```php
 add_filter( 'woocommerce_admin_export_id', function ($export_id) {
 	return 'different_export_id';
 } );
 ```
+
 2. Repeat the same steps from above. The filename in the link now should be `different_export_id`.
+
 ### Payment gateway suggestions feature
 
 1. Navigate to the homescreen via WooCommerce -> Home
@@ -176,12 +191,10 @@ Individual payment gateway plugins dictate the settings and connection flow. For
 4. In Chrome, open the console "Network" tab and right-click on the `get-params` request and select "Block request URL"
 5. Refresh the page and note that the manual settings flow is shown
 
-
 ##### Klarna
 
 1. Set your store country to one of the following: `SE, FI, NO`
 2. Don't select CBD as an industry during onboarding
-
 
 ##### Mollie
 
@@ -204,7 +217,6 @@ Individual payment gateway plugins dictate the settings and connection flow. For
 
 1. Make sure "Enable" is shown and clicking this enables the gateway
 2. Make sure the "Manage" button is shown after enabling the gateway
-
 
 ##### Direct bank transfer
 

--- a/changelogs/fix-6718
+++ b/changelogs/fix-6718
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Making Business Details sticky in onboarding wizard

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -395,9 +395,9 @@ class BusinessDetails extends Component {
 								<CardFooter isBorderless justify="center">
 									<Button
 										isPrimary
-										onClick={ () => {
+										onClick={ async () => {
+											await handleSubmit();
 											this.persistProfileItems();
-											handleSubmit();
 										} }
 										disabled={ ! isValidForm }
 										isBusy={ isInstallingActivating }

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -130,7 +130,7 @@ class BusinessDetails extends Component {
 	}
 
 	async persistProfileItems( additions = {} ) {
-		const { updateProfileItems } = this.props;
+		const { updateProfileItems, createNotice } = this.props;
 
 		const {
 			other_platform: otherPlatform,
@@ -166,7 +166,13 @@ class BusinessDetails extends Component {
 		);
 
 		return updateProfileItems( finalUpdates ).catch( () => {
-			throw new Error();
+			createNotice(
+				'error',
+				__(
+					'There was a problem updating your business details',
+					'woocommerce-admin'
+				)
+			);
 		} );
 	}
 

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -96,7 +96,7 @@ class BusinessDetails extends Component {
 		} );
 
 		const promises = [
-			this.pushProfileUpdates( {
+			this.persistProfileItems( {
 				business_extensions: businessExtensions,
 			} ),
 		];
@@ -129,7 +129,7 @@ class BusinessDetails extends Component {
 			} );
 	}
 
-	async pushProfileUpdates( additions = {} ) {
+	async persistProfileItems( additions = {} ) {
 		const { updateProfileItems } = this.props;
 
 		const {
@@ -379,7 +379,10 @@ class BusinessDetails extends Component {
 								<CardFooter isBorderless justify="center">
 									<Button
 										isPrimary
-										onClick={ handleSubmit }
+										onClick={ () => {
+											this.persistProfileItems();
+											handleSubmit();
+										} }
 										disabled={ ! isValidForm }
 										isBusy={ isInstallingActivating }
 									>
@@ -396,7 +399,7 @@ class BusinessDetails extends Component {
 									{ hasInstallActivateError && (
 										<Button
 											onClick={ () => {
-												this.pushProfileUpdates();
+												this.persistProfileItems();
 												goToNextStep();
 											} }
 										>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -76,16 +76,7 @@ class BusinessDetails extends Component {
 			createNotice,
 			goToNextStep,
 			installAndActivatePlugins,
-			updateProfileItems,
 		} = this.props;
-
-		const {
-			other_platform: otherPlatform,
-			other_platform_name: otherPlatformName,
-			product_count: productCount,
-			revenue,
-			selling_venues: sellingVenues,
-		} = this.state.savedValues;
 
 		const businessExtensions = filterBusinessExtensions(
 			extensionInstallationOptions
@@ -104,24 +95,9 @@ class BusinessDetails extends Component {
 				extensionInstallationOptions[ 'woocommerce-payments' ],
 		} );
 
-		const updates = {
-			other_platform: otherPlatform,
-			other_platform_name:
-				otherPlatform === 'other' ? otherPlatformName : '',
-			product_count: productCount,
-			revenue,
-			selling_venues: sellingVenues,
-			business_extensions: businessExtensions,
-		};
-
-		// Remove possible empty values like `revenue` and `other_platform`.
-		Object.keys( updates ).forEach(
-			( key ) => updates[ key ] === '' && delete updates[ key ]
-		);
-
 		const promises = [
-			updateProfileItems( updates ).catch( () => {
-				throw new Error();
+			this.pushProfileUpdates( {
+				business_extensions: businessExtensions,
 			} ),
 		];
 
@@ -151,6 +127,37 @@ class BusinessDetails extends Component {
 					)
 				);
 			} );
+	}
+
+	async pushProfileUpdates( additions = {} ) {
+		const { updateProfileItems } = this.props;
+
+		const {
+			other_platform: otherPlatform,
+			other_platform_name: otherPlatformName,
+			product_count: productCount,
+			revenue,
+			selling_venues: sellingVenues,
+		} = this.state.savedValues;
+
+		const updates = {
+			other_platform: otherPlatform,
+			other_platform_name:
+				otherPlatform === 'other' ? otherPlatformName : '',
+			product_count: productCount,
+			revenue,
+			selling_venues: sellingVenues,
+			...additions,
+		};
+
+		// Remove possible empty values like `revenue` and `other_platform`.
+		Object.keys( updates ).forEach(
+			( key ) => updates[ key ] === '' && delete updates[ key ]
+		);
+
+		return updateProfileItems( updates ).catch( () => {
+			throw new Error();
+		} );
 	}
 
 	validate( values ) {
@@ -388,7 +395,10 @@ class BusinessDetails extends Component {
 									</Button>
 									{ hasInstallActivateError && (
 										<Button
-											onClick={ () => goToNextStep() }
+											onClick={ () => {
+												this.pushProfileUpdates();
+												goToNextStep();
+											} }
 										>
 											{ __(
 												'Continue without installing',

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -151,11 +151,21 @@ class BusinessDetails extends Component {
 		};
 
 		// Remove possible empty values like `revenue` and `other_platform`.
-		Object.keys( updates ).forEach(
-			( key ) => updates[ key ] === '' && delete updates[ key ]
+		const finalUpdates = Object.entries( updates ).reduce(
+			( acc, [ key, val ] ) => {
+				if ( val !== '' ) {
+					return {
+						...acc,
+						[ key ]: val,
+					};
+				}
+
+				return acc;
+			},
+			{}
 		);
 
-		return updateProfileItems( updates ).catch( () => {
+		return updateProfileItems( finalUpdates ).catch( () => {
 			throw new Error();
 		} );
 	}


### PR DESCRIPTION
Fixes #6718

Refactor of the business details step in the OBW to ensure that the selected items are saved when moving forward to the "Free Details" section and then back again.

### Detailed test instructions:

-   Likely best to start out with a clean store, with OBW values uninitialized
-   Checkout branch
- Move through OBW to the business details step, and then "Free "Features"
- Before moving past "Free Features," got back to the "Business Details" tab by selecting it above
- The previously selected values should still be filled out


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
