### PR TITLE
Fix Google Analytics tracking for static docs site.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,17 @@
 				width: 100%;
 			}
 		</style>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-8KCYZ2CYMS', {
+				'content_group' : 'WooCommerce Admin Docs',
+			});
+		</script>
 	</head>
 	<body>
 		<div id="app"></div>


### PR DESCRIPTION
This is a follow-up to an earlier PR (#7380) with the changes applied to the correct file and branch. Thanks again to @samueljseay for the guidance here. 🙌  :smiley:

This PR re-adds the code for tracking and grouping Google Analytics data for the WooCommerce Admin docs, which was inadvertently removed during #7055.

Detailed test instructions:

- To test locally, make sure dependencies are installed and run `npx docsify serve` from the `./docs` directory
- View the page source for http://localhost:3000 and ensure that the following script tag appears on all of the pages

```html
<!-- Global site tag (gtag.js) - Google Analytics -->
		<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
		<script>
			window.dataLayer = window.dataLayer || [];
			function gtag(){dataLayer.push(arguments);}
			gtag('js', new Date());

			gtag('config', 'G-8KCYZ2CYMS', {
				'content_group' : 'WooCommerce Admin Docs',
			});
		</script>
```

Note: I didn't include a changelog note or testing instructions in the corresponding files since this change only impacts the content that gets deployed to gh-pages, but I'm happy to add them if I need to. Just let me know. 😃

No changelog required