### PR TITLE
refactor: payment recommendations eligibility

### DIFF
--- a/changelogs/refactor-payment-recommendations-eligibiility
+++ b/changelogs/refactor-payment-recommendations-eligibiility
@@ -1,5 +1,4 @@
 Significance: patch
 Type: Tweak
-Comment: This is a slight refactor on how the recommendations on the payment settings are displayed. I extracted the eligibility part to a separate component, to be reused in an upcoming PR.
 
-
+Refactor on payment settings recommendations eligibility component for reuse.

--- a/changelogs/refactor-payment-recommendations-eligibiility
+++ b/changelogs/refactor-payment-recommendations-eligibiility
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Tweak
 
-Refactor on payment settings recommendations eligibility component for reuse.
+Refactor on payment settings recommendations eligibility component for reuse. #7447

--- a/changelogs/refactor-payment-recommendations-eligibiility
+++ b/changelogs/refactor-payment-recommendations-eligibiility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: Tweak
+Comment: This is a slight refactor on how the recommendations on the payment settings are displayed. I extracted the eligibility part to a separate component, to be reused in an upcoming PR.
+
+

--- a/client/payments/payment-recommendations-wrapper.tsx
+++ b/client/payments/payment-recommendations-wrapper.tsx
@@ -7,6 +7,7 @@ import { lazy, Suspense } from '@wordpress/element';
  * Internal dependencies
  */
 import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
+import RecommendationsEligibilityWrapper from '../settings-recommendations/recommendations-eligibility-wrapper';
 
 const PaymentRecommendationsChunk = lazy(
 	() =>
@@ -22,9 +23,11 @@ export const PaymentRecommendations: React.FC< EmbeddedBodyProps > = ( {
 } ) => {
 	if ( page === 'wc-settings' && tab === 'checkout' && ! section ) {
 		return (
-			<Suspense fallback={ null }>
-				<PaymentRecommendationsChunk />
-			</Suspense>
+			<RecommendationsEligibilityWrapper>
+				<Suspense fallback={ null }>
+					<PaymentRecommendationsChunk />
+				</Suspense>
+			</RecommendationsEligibilityWrapper>
 		);
 	}
 	return null;

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -31,8 +31,6 @@ import { isWCPaySupported } from '~/task-list/tasks/PaymentGatewaySuggestions/co
 const SEE_MORE_LINK =
 	'https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations';
 const DISMISS_OPTION = 'woocommerce_setting_payments_recommendations_hidden';
-const SHOW_MARKETPLACE_SUGGESTION_OPTION =
-	'woocommerce_show_marketplace_suggestions';
 type SettingsSelector = WPDataSelectors & {
 	getSettings: (
 		type: string
@@ -55,9 +53,6 @@ export function getPaymentRecommendationData(
 	const { getSettings } = select( SETTINGS_STORE_NAME ) as SettingsSelector;
 	const { getRecommendedPlugins } = select( PLUGINS_STORE_NAME );
 	const { general: settings = {} } = getSettings( 'general' );
-	const marketplaceSuggestions = getOption(
-		SHOW_MARKETPLACE_SUGGESTION_OPTION
-	);
 
 	const hidden = getOption( DISMISS_OPTION );
 	const countryCode = settings.woocommerce_default_country
@@ -66,17 +61,12 @@ export function getPaymentRecommendationData(
 	const countrySupported = countryCode
 		? isWCPaySupported( countryCode )
 		: false;
-	const isRequestingOptions =
-		isResolvingOption( 'getOption', [ DISMISS_OPTION ] ) ||
-		isResolvingOption( 'getOption', [
-			SHOW_MARKETPLACE_SUGGESTION_OPTION,
-		] );
+	const isRequestingOptions = isResolvingOption( 'getOption', [
+		DISMISS_OPTION,
+	] );
 
 	const displayable =
-		! isRequestingOptions &&
-		hidden !== 'yes' &&
-		marketplaceSuggestions === 'yes' &&
-		countrySupported;
+		! isRequestingOptions && hidden !== 'yes' && countrySupported;
 	let plugins;
 	if ( displayable ) {
 		// don't get recommended plugins until it is displayable.

--- a/client/payments/test/payment-recommendations.test.tsx
+++ b/client/payments/test/payment-recommendations.test.tsx
@@ -166,9 +166,7 @@ describe( 'Payment recommendations', () => {
 					...baseSelectValues,
 					country: 'US',
 					plugins: [ plugin ],
-					optionValues: {
-						woocommerce_show_marketplace_suggestions: 'yes',
-					},
+					optionValues: {},
 				} )
 			);
 
@@ -202,7 +200,6 @@ describe( 'Payment recommendations', () => {
 					optionValues: {
 						woocommerce_setting_payments_recommendations_hidden:
 							'no',
-						woocommerce_show_marketplace_suggestions: 'yes',
 					},
 				} )
 			);
@@ -218,22 +215,6 @@ describe( 'Payment recommendations', () => {
 					country: 'US',
 					plugins: [ plugin ],
 					optionsResolving: true,
-				} )
-			);
-
-			expect( selectData.displayable ).toBeFalsy();
-		} );
-
-		it( 'should not render if showMarketplaceSuggestion is set to "no"', () => {
-			( isWCPaySupported as jest.Mock ).mockReturnValue( true );
-			const selectData = getPaymentRecommendationData(
-				createFakeSelect( {
-					...baseSelectValues,
-					country: 'US',
-					plugins: [ plugin ],
-					optionValues: {
-						woocommerce_show_marketplace_suggestions: 'no',
-					},
 				} )
 			);
 

--- a/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
+++ b/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
@@ -11,15 +11,17 @@ const RecommendationsEligibilityWrapper: React.FC = ( { children } ) => {
 	const { currentUserCan } = useUser();
 
 	const isMarketplaceSuggestionsEnabled = useSelect( ( select ) => {
-		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select(
+			OPTIONS_STORE_NAME
+		);
 
-		const isRequestingOptions = isResolving( 'getOption', [
+		const hasFinishedResolving = hasFinishedResolution( 'getOption', [
 			SHOW_MARKETPLACE_SUGGESTION_OPTION,
 		] );
 		const canShowMarketplaceSuggestions =
 			getOption( SHOW_MARKETPLACE_SUGGESTION_OPTION ) === 'yes';
 
-		return ! isRequestingOptions && canShowMarketplaceSuggestions;
+		return hasFinishedResolving && canShowMarketplaceSuggestions;
 	} );
 
 	if ( ! currentUserCan( 'install_plugins' ) ) {

--- a/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
+++ b/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useUser, OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+const SHOW_MARKETPLACE_SUGGESTION_OPTION =
+	'woocommerce_show_marketplace_suggestions';
+
+const RecommendationsEligibilityWrapper: React.FC = ( { children } ) => {
+	const { currentUserCan } = useUser();
+
+	const isMarketplaceSuggestionsEnabled = useSelect( ( select ) => {
+		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+
+		const isRequestingOptions = isResolving( 'getOption', [
+			SHOW_MARKETPLACE_SUGGESTION_OPTION,
+		] );
+		const canShowMarketplaceSuggestions =
+			getOption( SHOW_MARKETPLACE_SUGGESTION_OPTION ) === 'yes';
+
+		return ! isRequestingOptions && canShowMarketplaceSuggestions;
+	} );
+
+	if ( ! currentUserCan( 'install_plugins' ) ) {
+		return null;
+	}
+
+	if ( ! isMarketplaceSuggestionsEnabled ) {
+		return null;
+	}
+
+	return <>{ children }</>;
+};
+
+export default RecommendationsEligibilityWrapper;

--- a/client/settings-recommendations/test/recommendations-eligibility-wrapper.test.js
+++ b/client/settings-recommendations/test/recommendations-eligibility-wrapper.test.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useUser } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import RecommendationsEligibilityWrapper from '../recommendations-eligibility-wrapper';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '@woocommerce/data', () => ( {
+	...jest.requireActual( '@woocommerce/data' ),
+	useUser: jest.fn(),
+} ) );
+
+const RecommendationsEligibilityMock = () => (
+	<RecommendationsEligibilityWrapper>
+		<span>mocked children</span>
+	</RecommendationsEligibilityWrapper>
+);
+
+describe( 'RecommendationsEligibilityWrapper', () => {
+	beforeEach( () => {
+		useUser.mockReturnValue( {
+			currentUserCan: () => true,
+		} );
+
+		useSelect.mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'yes',
+				isResolving: () => false,
+			} ) )
+		);
+	} );
+
+	it( 'should not render its children when the user cannot install plugins', () => {
+		const currentUserCanMock = jest.fn().mockReturnValue( false );
+		useUser.mockReturnValue( {
+			currentUserCan: currentUserCanMock,
+		} );
+
+		const { rerender } = render( <RecommendationsEligibilityMock /> );
+
+		expect(
+			screen.queryByText( 'mocked children' )
+		).not.toBeInTheDocument();
+		expect( currentUserCanMock ).toHaveBeenCalledWith( 'install_plugins' );
+
+		// changing the "currentUserCanMock" to return `true` will render the children
+		currentUserCanMock.mockReturnValue( true );
+		rerender( <RecommendationsEligibilityMock /> );
+		expect( screen.queryByText( 'mocked children' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not render its children when the marketplace suggestions are being loaded', () => {
+		useSelect.mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'yes',
+				isResolving: () => true,
+			} ) )
+		);
+
+		const { rerender } = render( <RecommendationsEligibilityMock /> );
+
+		expect(
+			screen.queryByText( 'mocked children' )
+		).not.toBeInTheDocument();
+
+		// changing the "isResolving" to return `false` will render the children
+		useSelect.mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'yes',
+				isResolving: () => false,
+			} ) )
+		);
+		rerender( <RecommendationsEligibilityMock /> );
+		expect( screen.queryByText( 'mocked children' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render its children', () => {
+		useSelect.mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getOption: () => 'yes',
+				isResolving: () => false,
+			} ) )
+		);
+		useUser.mockReturnValue( {
+			currentUserCan: () => true,
+		} );
+
+		render( <RecommendationsEligibilityMock /> );
+
+		expect( screen.queryByText( 'mocked children' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/settings-recommendations/test/recommendations-eligibility-wrapper.test.js
+++ b/client/settings-recommendations/test/recommendations-eligibility-wrapper.test.js
@@ -34,7 +34,7 @@ describe( 'RecommendationsEligibilityWrapper', () => {
 		useSelect.mockImplementation( ( fn ) =>
 			fn( () => ( {
 				getOption: () => 'yes',
-				isResolving: () => false,
+				hasFinishedResolution: () => true,
 			} ) )
 		);
 	} );
@@ -62,7 +62,7 @@ describe( 'RecommendationsEligibilityWrapper', () => {
 		useSelect.mockImplementation( ( fn ) =>
 			fn( () => ( {
 				getOption: () => 'yes',
-				isResolving: () => true,
+				hasFinishedResolution: () => false,
 			} ) )
 		);
 
@@ -72,11 +72,11 @@ describe( 'RecommendationsEligibilityWrapper', () => {
 			screen.queryByText( 'mocked children' )
 		).not.toBeInTheDocument();
 
-		// changing the "isResolving" to return `false` will render the children
+		// changing the "hasFinishedResolution" to return `false` will render the children
 		useSelect.mockImplementation( ( fn ) =>
 			fn( () => ( {
 				getOption: () => 'yes',
-				isResolving: () => false,
+				hasFinishedResolution: () => true,
 			} ) )
 		);
 		rerender( <RecommendationsEligibilityMock /> );
@@ -87,7 +87,7 @@ describe( 'RecommendationsEligibilityWrapper', () => {
 		useSelect.mockImplementation( ( fn ) =>
 			fn( () => ( {
 				getOption: () => 'yes',
-				isResolving: () => false,
+				hasFinishedResolution: () => true,
 			} ) )
 		);
 		useUser.mockReturnValue( {


### PR DESCRIPTION
Fixes #

In an upcoming PR ( https://github.com/woocommerce/woocommerce-admin/pull/7446 ) we'll be adding recommended plugins to the shipping settings page.
Recommended plugins are already displayed on the payments page.
I thought about starting to split a bigger PR in smaller chunks that might make more sense.

Since both areas will share a little bit of eligibility logic, I thought about extracting that logic to a separate component.

The component checks for the validity of the `woocommerce_show_marketplace_suggestions` option.
When recommendations are enabled (`woocommerce_show_marketplace_suggestions` option set to `'yes'`), it renders its children.
When they aren't enabled, the children are not rendered.

~I didn't add a changelog entry for this, it doesn't seem necessary.~

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2021-07-30 at 4 56 46 PM](https://user-images.githubusercontent.com/273592/127715489-09285660-ef8f-484e-8846-b831daae66ff.png)


### Detailed test instructions:

- As an admin, ensure you have the `woocommerce_show_marketplace_suggestions` option set to `yes` in your DB (or go to http://localhost:8084/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com to change it)
- Go to http://localhost:8084/wp-admin/admin.php?page=wc-settings&tab=checkout
- Recommendations are displayed
- As an admin, ensure you have the `woocommerce_show_marketplace_suggestions` option set to `no` in your DB
- Go to http://localhost:8084/wp-admin/admin.php?page=wc-settings&tab=checkout
- Recommendations are _not_ displayed

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
