### PR TITLE
Update business details to use extensions data store

### DIFF
--- a/changelogs/update-business-details-extensions-data-store
+++ b/changelogs/update-business-details-extensions-data-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Use the free extensions data store in the onboarding profiler

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { Button, Card, CheckboxControl, Spinner } from '@wordpress/components';
 import { Text } from '@woocommerce/experimental';
 import { Link } from '@woocommerce/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
-import { pluginNames, SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { pluginNames, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -18,133 +17,10 @@ import { useSelect } from '@wordpress/data';
  */
 import { AppIllustration } from '../app-illustration';
 import './style.scss';
+import sanitizeHTML from '~/lib/sanitize-html';
 import { setAllPropsToValue } from '~/lib/collections';
-import { getCountryCode } from '~/dashboard/utils';
-import { isWCPaySupported } from '~/task-list/tasks/PaymentGatewaySuggestions/components/WCPay';
 
 const ALLOWED_PLUGIN_LISTS = [ 'basics' ];
-
-const generatePluginDescriptionWithLink = (
-	description,
-	productName,
-	linkURL
-) => {
-	const url =
-		linkURL ??
-		`https://woocommerce.com/products/${ productName }?utm_medium=product`;
-	return interpolateComponents( {
-		mixedString: description,
-		components: {
-			link: (
-				<Link
-					type="external"
-					target="_blank"
-					className="woocommerce-admin__business-details__selective-extensions-bundle__link"
-					href={ url }
-					onClick={ () => {
-						recordEvent(
-							'storeprofiler_store_business_features_link_click',
-							{
-								extension_name: productName,
-							}
-						);
-					} }
-				/>
-			),
-		},
-	} );
-};
-
-const installableExtensionsData = [
-	{
-		title: __( 'Get the basics', 'woocommerce-admin' ),
-		key: 'basics',
-		plugins: [
-			{
-				key: 'woocommerce-payments',
-				description: generatePluginDescriptionWithLink(
-					__(
-						'Accept credit cards with {{link}}WooCommerce Payments{{/link}}',
-						'woocommerce-admin'
-					),
-					'woocommerce-payments'
-				),
-				isVisible: ( countryCode, industry ) => {
-					const hasCbdIndustry = ( industry || [] ).some(
-						( { industrySlug } ) => {
-							return (
-								industrySlug ===
-								'cbd-other-hemp-derived-products'
-							);
-						}
-					);
-					return isWCPaySupported( countryCode ) && ! hasCbdIndustry;
-				},
-			},
-			{
-				key: 'woocommerce-services:shipping',
-				description: generatePluginDescriptionWithLink(
-					__(
-						'Print shipping labels with {{link}}WooCommerce Shipping{{/link}}',
-						'woocommerce-admin'
-					),
-					'shipping'
-				),
-				isVisible: ( countryCode, industry, productTypes ) => {
-					// Exclude the WooCommerce Shipping mention if the user is not in the US.
-					// Exclude the WooCommerce Shipping mention if the user is in the US but
-					// only selected digital products in the Product Types step.
-					if (
-						countryCode !== 'US' ||
-						( countryCode === 'US' &&
-							productTypes.length === 1 &&
-							productTypes[ 0 ] === 'downloads' )
-					) {
-						return false;
-					}
-
-					return true;
-				},
-			},
-			{
-				key: 'woocommerce-services:tax',
-				description: generatePluginDescriptionWithLink(
-					__(
-						'Get automated sales tax with {{link}}WooCommerce Tax{{/link}}',
-						'woocommerce-admin'
-					),
-					'tax'
-				),
-				isVisible: ( countryCode ) => {
-					return [
-						'US',
-						'FR',
-						'GB',
-						'DE',
-						'CA',
-						'PL',
-						'AU',
-						'GR',
-						'BE',
-						'PT',
-						'DK',
-						'SE',
-					].includes( countryCode );
-				},
-			},
-			{
-				key: 'jetpack',
-				description: generatePluginDescriptionWithLink(
-					__(
-						'Enhance speed and security with {{link}}Jetpack{{/link}}',
-						'woocommerce-admin'
-					),
-					'jetpack'
-				),
-			},
-		],
-	},
-];
 
 const FreeBadge = () => {
 	return (
@@ -245,98 +121,24 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
 				checked={ isChecked }
 				onChange={ onChange }
 			/>
-			<p className="woocommerce-admin__business-details__selective-extensions-bundle__description">
-				{ description }
-			</p>
+			<p
+				className="woocommerce-admin__business-details__selective-extensions-bundle__description"
+				dangerouslySetInnerHTML={ sanitizeHTML( description ) }
+			/>
 			<FreeBadge />
 		</div>
 	);
 };
 
-/**
- * Returns plugins that either don't have the acceptedCountryCodes param or one defined
- * that includes the passed in country.
- *
- * @param {Array} plugins  list of plugins
- * @param {string} country  Woo store country
- * @param {Array} industry List of selected industries
- * @param {Array} productTypes List of selected product types
- *
- * @return {Array} Array of visible plugins
- */
-const getVisiblePlugins = ( plugins, country, industry, productTypes ) => {
-	const countryCode = getCountryCode( country );
-
-	return plugins.filter(
-		( plugin ) =>
-			! plugin.isVisible ||
-			plugin.isVisible( countryCode, industry, productTypes )
-	);
-};
-
-/**
- * Returns bundles that have at least 1 visible plugin.
- *
- * @param {Array} bundles  list of bundles
- * @param {string} country  Woo store country
- * @param {Array} industry List of selected industries
- * @param {Array} productTypes List of selected product types
- *
- * @return {Array} Array of visible bundles
- */
-const getVisibleBundles = ( bundles, country, industry, productTypes ) => {
-	return bundles
-		.map( ( bundle ) => {
-			return {
-				...bundle,
-				plugins: getVisiblePlugins(
-					bundle.plugins,
-					country,
-					industry,
-					productTypes
-				),
-			};
-		} )
-		.filter( ( bundle ) => {
-			return bundle.plugins.length;
-		} );
-};
-
-const transformRemoteExtensions = ( extensionData ) => {
-	return extensionData.map( ( section ) => {
-		const plugins = section.plugins.map( ( plugin ) => {
-			return {
-				...plugin,
-				description: generatePluginDescriptionWithLink(
-					plugin.description,
-					plugin.product
-				),
-				isVisible: () => plugin.is_visible,
-			};
-		} );
-		return {
-			...section,
-			plugins,
-		};
-	} );
-};
-
 const baseValues = { install_extensions: true };
-export const createInitialValues = (
-	extensions,
-	country,
-	industry,
-	productTypes
-) => {
+export const createInitialValues = ( extensions ) => {
 	return extensions.reduce( ( acc, curr ) => {
-		const plugins = getVisiblePlugins(
-			curr.plugins,
-			country,
-			industry,
-			productTypes
-		).reduce( ( pluginAcc, { key, selected } ) => {
-			return { ...pluginAcc, [ key ]: selected ?? true };
-		}, {} );
+		const plugins = curr.plugins.reduce(
+			( pluginAcc, { key, selected } ) => {
+				return { ...pluginAcc, [ key ]: selected ?? true };
+			},
+			{}
+		);
 
 		return {
 			...acc,
@@ -348,92 +150,31 @@ export const createInitialValues = (
 export const SelectiveExtensionsBundle = ( {
 	isInstallingActivating,
 	onSubmit,
-	country,
-	industry,
-	productTypes,
 } ) => {
 	const [ showExtensions, setShowExtensions ] = useState( false );
 	const [ values, setValues ] = useState( baseValues );
-	const [ installableExtensions, setInstallableExtensions ] = useState( [
-		{ key: 'spinner', plugins: [] },
-	] );
-	const [ isFetching, setIsFetching ] = useState( true );
 
-	const allowMarketplaceSuggestions = useSelect( ( select ) =>
-		select( SETTINGS_STORE_NAME ).getSetting(
-			'wc_admin',
-			'allowMarketplaceSuggestions'
-		)
-	);
+	const { freeExtensions, isResolving } = useSelect( ( select ) => {
+		const { getFreeExtensions, hasFinishedResolution } = select(
+			ONBOARDING_STORE_NAME
+		);
+
+		return {
+			freeExtensions: getFreeExtensions(),
+			isResolving: ! hasFinishedResolution( 'getFreeExtensions' ),
+		};
+	} );
 
 	useEffect( () => {
-		const setLocalInstallableExtensions = () => {
-			const initialValues = createInitialValues(
-				installableExtensionsData,
-				country,
-				industry,
-				productTypes
-			);
-			setInstallableExtensions(
-				getVisibleBundles(
-					installableExtensionsData,
-					country,
-					industry,
-					productTypes
-				)
-			);
-			setValues( initialValues );
-			setIsFetching( false );
-		};
+		const initialValues = createInitialValues( freeExtensions );
+		setValues( initialValues );
+	}, [ freeExtensions ] );
 
-		if (
-			window.wcAdminFeatures &&
-			window.wcAdminFeatures[ 'remote-extensions-list' ] === true &&
-			allowMarketplaceSuggestions
-		) {
-			apiFetch( {
-				path: '/wc-admin/onboarding/free-extensions',
-			} )
-				.then( ( results ) => {
-					if ( ! results?.length ) {
-						// Assuming empty array or null results is err.
-						setLocalInstallableExtensions();
-						return;
-					}
-
-					const extensions = results.filter( ( list ) =>
-						ALLOWED_PLUGIN_LISTS.includes( list.key )
-					);
-
-					const transformedExtensions = transformRemoteExtensions(
-						extensions
-					);
-					const initialValues = createInitialValues(
-						transformedExtensions,
-						country,
-						industry,
-						productTypes
-					);
-					setInstallableExtensions(
-						getVisibleBundles(
-							transformedExtensions,
-							country,
-							industry,
-							productTypes
-						)
-					);
-					setValues( initialValues );
-					setIsFetching( false );
-				} )
-				.catch( () => {
-					// An error has occurred, default to local config
-					setLocalInstallableExtensions();
-				} );
-		} else {
-			// Use local config
-			setLocalInstallableExtensions();
-		}
-	}, [ country, industry, productTypes, allowMarketplaceSuggestions ] );
+	const installableExtensions = useMemo( () => {
+		return freeExtensions.filter( ( list ) => {
+			return ALLOWED_PLUGIN_LISTS.includes( list.key );
+		} );
+	}, [ freeExtensions ] );
 
 	const getCheckboxChangeHandler = ( key ) => {
 		return ( checked ) => {
@@ -508,7 +249,7 @@ export const SelectiveExtensionsBundle = ( {
 						installableExtensions.map(
 							( { plugins, key: sectionKey } ) => (
 								<div key={ sectionKey }>
-									{ isFetching ? (
+									{ isResolving ? (
 										<Spinner />
 									) : (
 										plugins.map(

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -114,6 +114,23 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 };
 
 const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
+	const recordProductLinkClick = ( event ) => {
+		const link = event.target.closest( 'a' );
+		if (
+			! link ||
+			! event.currentTarget.contains( link ) ||
+			! link.href.startsWith( 'https://woocommerce.com/products/' )
+		) {
+			return;
+		}
+
+		recordEvent( 'storeprofiler_store_business_features_link_click', {
+			extension_name: link.href.split(
+				'https://woocommerce.com/products/'
+			)[ 1 ],
+		} );
+	};
+
 	return (
 		<div className="woocommerce-admin__business-details__selective-extensions-bundle__extension">
 			<CheckboxControl
@@ -121,10 +138,17 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
 				checked={ isChecked }
 				onChange={ onChange }
 			/>
+			{
+				// Disable reason: This click handler checks for interaction with anchor tags on
+				// dynamically inserted HTML and records clicks only on interaction with those items.
+				/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+			 }
 			<p
 				className="woocommerce-admin__business-details__selective-extensions-bundle__description"
 				dangerouslySetInnerHTML={ sanitizeHTML( description ) }
+				onClick={ recordProductLinkClick }
 			/>
+			{ /* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */ }
 			<FreeBadge />
 		</div>
 	);

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -28,9 +28,10 @@ class DefaultFreeExtensions {
 					[
 						'key'         => 'woocommerce-payments',
 						'description' => sprintf(
-							/* translators: %s = product URL */
-							__( 'Accept credit cards with <a href="%s" target="_blank">WooCommerce Payments</a>', 'woocommerce-admin' ),
-							'https://woocommerce.com/products/woocommerce-payments'
+							/* translators: 1: opening product link tag. 2: closing link tag */
+							__( 'Accept credit cards with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
+							'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
+							'</a>'
 						),
 						'is_visible'  => [
 							[
@@ -125,9 +126,10 @@ class DefaultFreeExtensions {
 					[
 						'key'         => 'woocommerce-services:shipping',
 						'description' => sprintf(
-							/* translators: %s = product URL */
-							__( 'Print shipping labels with <a href="%s" target="_blank">WooCommerce Shipping</a>', 'woocommerce-admin' ),
-							'https://woocommerce.com/products/shipping'
+							/* translators: 1: opening product link tag. 2: closing link tag */
+							__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
+							'<a href="https://woocommerce.com/products/shipping" target="_blank">',
+							'</a>'
 						),
 						'is_visible'  => [
 							[
@@ -191,9 +193,10 @@ class DefaultFreeExtensions {
 					[
 						'key'         => 'woocommerce-services:tax',
 						'description' => sprintf(
-							/* translators: %s = product URL */
-							__( 'Get automated sales tax with <a href="%s" target="_blank">WooCommerce Tax</a>', 'woocommerce-admin' ),
-							'https://woocommerce.com/products/tax'
+							/* translators: 1: opening product link tag. 2: closing link tag */
+							__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce-admin' ),
+							'<a href="https://woocommerce.com/products/tax" target="_blank">',
+							'</a>'
 						),
 						'is_visible'  => [
 							[
@@ -270,9 +273,10 @@ class DefaultFreeExtensions {
 					[
 						'key'         => 'jetpack',
 						'description' => sprintf(
-							/* translators: %s = product URL */
-							__( 'Enhance speed and security with <a href="%s" target="_blank">Jetpack</a>', 'woocommerce-admin' ),
-							'https://woocommerce.com/products/jetpack'
+							/* translators: 1: opening product link tag. 2: closing link tag */
+							__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce-admin' ),
+							'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
+							'</a>'
 						),
 						'is_visible'  => [
 							[
@@ -291,9 +295,10 @@ class DefaultFreeExtensions {
 						'name'        => __( 'MailPoet', 'woocommerce-admin' ),
 						'description' => __( 'Level up your email marketing with {{link}}MailPoet{{/link}}', 'woocommerce-admin' ),
 						'description' => sprintf(
-							/* translators: %s = product URL */
-							__( 'Level up your email marketing with <a href="%s" target="_blank">MailPoet</a>', 'woocommerce-admin' ),
-							'https://woocommerce.com/products/mailpoet'
+							/* translators: 1: opening product link tag. 2: closing link tag */
+							__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce-admin' ),
+							'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
+							'</a>'
 						),
 						'image_url'   => plugins_url( 'images/mailpoet.png', WCCOM_OBW_FREE_EXTENSIONS_PLUGIN_FILE ),
 						'manage_url'  => 'admin.php?page=mailpoet-newsletters',

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -20,7 +20,7 @@ class DefaultFreeExtensions {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
-		return [
+		$bundles = [
 			[
 				'key'     => 'basics',
 				'title'   => __( 'Get the basics', 'woocommerce-admin' ),
@@ -300,7 +300,6 @@ class DefaultFreeExtensions {
 							'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
 							'</a>'
 						),
-						'image_url'   => plugins_url( 'images/mailpoet.png', WCCOM_OBW_FREE_EXTENSIONS_PLUGIN_FILE ),
 						'manage_url'  => 'admin.php?page=mailpoet-newsletters',
 						'is_visible'  => [
 							[
@@ -317,5 +316,8 @@ class DefaultFreeExtensions {
 				],
 			],
 		];
+
+		$bundles = wp_json_encode( $bundles );
+		return json_decode( $bundles );
 	}
 }

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Gets a list of fallback methods if remote fetching is disabled.
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+/**
+ * Default Free Extensions
+ */
+class DefaultFreeExtensions {
+
+	/**
+	 * Get default specs.
+	 *
+	 * @return array Default specs.
+	 */
+	public static function get_all() {
+		return [
+			[
+				'key'     => 'basics',
+				'title'   => __( 'Get the basics', 'woocommerce-admin' ),
+				'plugins' => [
+					[
+						'key'         => 'woocommerce-payments',
+						'description' => sprintf(
+							/* translators: %s = product URL */
+							__( 'Accept credit cards with <a href="%s" target="_blank">WooCommerce Payments</a>', 'woocommerce-admin' ),
+							'https://woocommerce.com/products/woocommerce-payments'
+						),
+						'is_visible'  => [
+							[
+								'type'     => 'or',
+								'operands' => [
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'US',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'PR',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'AU',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'CA',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'DE',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'ES',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'FR',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'GB',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'IE',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'IT',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'NZ',
+										'operation' => '=',
+									],
+								],
+							],
+							[
+								'type'         => 'option',
+								'transformers' => [
+									[
+										'use'       => 'dot_notation',
+										'arguments' => [
+											'path' => 'industry',
+										],
+									],
+									[
+										'use'       => 'array_column',
+										'arguments' => [
+											'key' => 'slug',
+										],
+									],
+									[
+										'use'       => 'array_search',
+										'arguments' => [
+											'value' => 'cbd-other-hemp-derived-products',
+										],
+									],
+								],
+								'option_name'  => 'woocommerce_onboarding_profile',
+								'value'        => 'cbd-other-hemp-derived-products',
+								'default'      => '',
+								'operation'    => '!=',
+							],
+						],
+					],
+					[
+						'key'         => 'woocommerce-services:shipping',
+						'description' => sprintf(
+							/* translators: %s = product URL */
+							__( 'Print shipping labels with <a href="%s" target="_blank">WooCommerce Shipping</a>', 'woocommerce-admin' ),
+							'https://woocommerce.com/products/shipping'
+						),
+						'is_visible'  => [
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'US',
+								'operation' => '=',
+							],
+							[
+								'type'    => 'not',
+								'operand' => [
+									[
+										'type'    => 'plugins_activated',
+										'plugins' => [ 'woocommerce-services' ],
+									],
+								],
+							],
+							[
+								'type'     => 'or',
+								'operands' => [
+									[
+										[
+											'type'         => 'option',
+											'transformers' => [
+												[
+													'use' => 'dot_notation',
+													'arguments' => [
+														'path' => 'product_types',
+													],
+												],
+												[
+													'use' => 'count',
+												],
+											],
+											'option_name'  => 'woocommerce_onboarding_profile',
+											'value'        => 1,
+											'default'      => '',
+											'operation'    => '!=',
+										],
+									],
+									[
+										[
+											'type'         => 'option',
+											'transformers' => [
+												[
+													'use' => 'dot_notation',
+													'arguments' => [
+														'path' => 'product_types.0',
+													],
+												],
+											],
+											'option_name'  => 'woocommerce_onboarding_profile',
+											'value'        => 'downloads',
+											'default'      => '',
+											'operation'    => '!=',
+										],
+									],
+								],
+							],
+						],
+					],
+					[
+						'key'         => 'woocommerce-services:tax',
+						'description' => sprintf(
+							/* translators: %s = product URL */
+							__( 'Get automated sales tax with <a href="%s" target="_blank">WooCommerce Tax</a>', 'woocommerce-admin' ),
+							'https://woocommerce.com/products/tax'
+						),
+						'is_visible'  => [
+							[
+								'type'     => 'or',
+								'operands' => [
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'US',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'FR',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'GB',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'DE',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'CA',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'AU',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'GR',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'BE',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'PT',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'DK',
+										'operation' => '=',
+									],
+									[
+										'type'      => 'base_location_country',
+										'value'     => 'SE',
+										'operation' => '=',
+									],
+								],
+							],
+							[
+								'type'    => 'not',
+								'operand' => [
+									[
+										'type'    => 'plugins_activated',
+										'plugins' => [ 'woocommerce-services' ],
+									],
+								],
+							],
+						],
+					],
+					[
+						'key'         => 'jetpack',
+						'description' => sprintf(
+							/* translators: %s = product URL */
+							__( 'Enhance speed and security with <a href="%s" target="_blank">Jetpack</a>', 'woocommerce-admin' ),
+							'https://woocommerce.com/products/jetpack'
+						),
+						'is_visible'  => [
+							[
+								'type'    => 'not',
+								'operand' => [
+									[
+										'type'    => 'plugins_activated',
+										'plugins' => [ 'jetpack' ],
+									],
+								],
+							],
+						],
+					],
+					[
+						'key'         => 'mailpoet',
+						'name'        => __( 'MailPoet', 'woocommerce-admin' ),
+						'description' => __( 'Level up your email marketing with {{link}}MailPoet{{/link}}', 'woocommerce-admin' ),
+						'description' => sprintf(
+							/* translators: %s = product URL */
+							__( 'Level up your email marketing with <a href="%s" target="_blank">MailPoet</a>', 'woocommerce-admin' ),
+							'https://woocommerce.com/products/mailpoet'
+						),
+						'image_url'   => plugins_url( 'images/mailpoet.png', WCCOM_OBW_FREE_EXTENSIONS_PLUGIN_FILE ),
+						'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+					],
+				],
+			],
+		];
+	}
+}

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -302,6 +302,17 @@ class DefaultFreeExtensions {
 						),
 						'image_url'   => plugins_url( 'images/mailpoet.png', WCCOM_OBW_FREE_EXTENSIONS_PLUGIN_FILE ),
 						'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+						'is_visible'  => [
+							[
+								'type'    => 'not',
+								'operand' => [
+									[
+										'type'    => 'plugins_activated',
+										'plugins' => [ 'mailpoet' ],
+									],
+								],
+							],
+						],
 					],
 				],
 			],

--- a/src/Features/RemoteFreeExtensions/EvaluateExtension.php
+++ b/src/Features/RemoteFreeExtensions/EvaluateExtension.php
@@ -10,25 +10,25 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RuleEvaluator;
 
 /**
- * Evaluates the spec and returns the evaluated extension.
+ * Evaluates the extension and returns it.
  */
 class EvaluateExtension {
 	/**
-	 * Evaluates the spec and returns the extension.
+	 * Evaluates the extension and returns it.
 	 *
-	 * @param array $spec The extension to evaluate.
-	 * @return array The evaluated extension.
+	 * @param object $extension The extension to evaluate.
+	 * @return object The evaluated extension.
 	 */
-	public static function evaluate( $spec ) {
+	public static function evaluate( $extension ) {
 		$rule_evaluator = new RuleEvaluator();
 
-		if ( isset( $spec->is_visible ) ) {
-			$is_visible       = $rule_evaluator->evaluate( (object) $spec->is_visible );
-			$spec->is_visible = $is_visible;
+		if ( isset( $extension->is_visible ) ) {
+			$is_visible            = $rule_evaluator->evaluate( $extension->is_visible );
+			$extension->is_visible = $is_visible;
 		} else {
-			$plugin->is_visible = true;
+			$extension->is_visible = true;
 		}
 
-		return $spec;
+		return $extension;
 	}
 }

--- a/src/Features/RemoteFreeExtensions/EvaluateExtension.php
+++ b/src/Features/RemoteFreeExtensions/EvaluateExtension.php
@@ -10,26 +10,23 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RuleEvaluator;
 
 /**
- * Evaluates the spec and returns the evaluated method.
+ * Evaluates the spec and returns the evaluated extension.
  */
 class EvaluateExtension {
 	/**
 	 * Evaluates the spec and returns the extension.
 	 *
-	 * @param array $spec The extension section to evaluate.
-	 * @return array The evaluated extension section.
+	 * @param array $spec The extension to evaluate.
+	 * @return array The evaluated extension.
 	 */
 	public static function evaluate( $spec ) {
 		$rule_evaluator = new RuleEvaluator();
 
-		foreach ( $spec->plugins as $plugin ) {
-
-			if ( isset( $plugin->is_visible ) ) {
-				$is_visible         = $rule_evaluator->evaluate( $plugin->is_visible );
-				$plugin->is_visible = $is_visible;
-			} else {
-				$plugin->is_visible = true;
-			}
+		if ( isset( $spec->is_visible ) ) {
+			$is_visible       = $rule_evaluator->evaluate( (object) $spec->is_visible );
+			$spec->is_visible = $is_visible;
+		} else {
+			$plugin->is_visible = true;
 		}
 
 		return $spec;

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -28,15 +28,27 @@ class Init {
 	 * Go through the specs and run them.
 	 */
 	public static function get_extensions() {
-		$methods = array();
+		$bundles = array();
 		$specs   = self::get_specs();
 
 		foreach ( $specs as $spec ) {
-			$method    = EvaluateExtension::evaluate( $spec );
-			$methods[] = $method;
+			$bundle            = $spec;
+			$bundle['plugins'] = array();
+			$extensions        = array();
+			$spec              = (object) $spec;
+
+			foreach ( $spec->plugins as $plugin ) {
+				$extension = EvaluateExtension::evaluate( (object) $plugin );
+
+				if ( ! property_exists( $extension, 'is_visible' ) || $extension->is_visible ) {
+					$bundle['plugins'][] = $extension;
+				}
+			}
+
+			$bundles[] = $bundle;
 		}
 
-		return $methods;
+		return $bundles;
 	}
 
 	/**

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -72,7 +72,7 @@ class Init {
 			$specs = DataSourcePoller::read_specs_from_data_sources();
 
 			// Fall back to default specs if polling failed.
-			if ( ! $specs || is_empty( $specs ) ) {
+			if ( ! $specs || empty( $specs ) ) {
 				return DefaultFreeExtensions::get_all();
 			}
 

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -32,6 +32,7 @@ class Init {
 		$specs   = self::get_specs();
 
 		foreach ( $specs as $spec ) {
+			$spec              = (object) $spec;
 			$bundle            = (array) $spec;
 			$bundle['plugins'] = array();
 
@@ -71,7 +72,7 @@ class Init {
 			$specs = DataSourcePoller::read_specs_from_data_sources();
 
 			// Fall back to default specs if polling failed.
-			if ( ! $specs ) {
+			if ( ! $specs || is_empty( $specs ) ) {
 				return DefaultFreeExtensions::get_all();
 			}
 

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -32,10 +32,8 @@ class Init {
 		$specs   = self::get_specs();
 
 		foreach ( $specs as $spec ) {
-			$bundle            = $spec;
+			$bundle            = (array) $spec;
 			$bundle['plugins'] = array();
-			$extensions        = array();
-			$spec              = (object) $spec;
 
 			foreach ( $spec->plugins as $plugin ) {
 				$extension = EvaluateExtension::evaluate( (object) $plugin );

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
+use Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\DefaultFreeExtensions;
 
 /**
  * Remote Payment Methods engine.
@@ -53,8 +54,17 @@ class Init {
 
 		// Fetch specs if they don't yet exist.
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
-			// We are running too early, need to poll data sources first.
+			if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
+				return DefaultFreeExtensions::get_all();
+			}
+
 			$specs = DataSourcePoller::read_specs_from_data_sources();
+
+			// Fall back to default specs if polling failed.
+			if ( ! $specs ) {
+				return DefaultFreeExtensions::get_all();
+			}
+
 			set_transient( self::SPECS_TRANSIENT_NAME, $specs, 7 * DAY_IN_SECONDS );
 		}
 


### PR DESCRIPTION
* Moves default extensions list to server
* Evaluates visibility of extensions on the server
* Uses the extensions data store to retrieve free extensions

### Screenshots

<img width="541" alt="Screen Shot 2021-08-02 at 12 45 07 PM" src="https://user-images.githubusercontent.com/10561050/127899445-b6924fd5-d7c7-4637-95d4-4aa88ed2aac4.png">

### Detailed test instructions:

1. Check out the https://github.com/Automattic/woocommerce.com/pull/10826 WCCOM PR.
2. Set the data source poller source to `https://woocommerce.test/wp-json/wccom/obw-free-extensions/2.0/extensions.json` in `src/Features/RemoteFreeExtensions/DataSourcePoller.php`.
3. Delete the `woocommerce_admin_remote_free_extensions_specs` transient.
3. Go to the Business Details step in the onboarding wizard.
4. Open the "Free Extensions" tab and check that the correct extensions are still shown.
5. Optionally, provide a bad URL to the data source poller source.
6. Delete the `woocommerce_admin_remote_free_extensions_specs` transient.
7. Go back to the business details step and make sure the defaults are shown.