### PR TITLE
Delete free extensions transient on WCA update

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -347,7 +347,7 @@ export function getAllTasks( {
 					.length > 0,
 			visible:
 				window.wcAdminFeatures &&
-				window.wcAdminFeatures[ 'remote-extensions-list' ],
+				window.wcAdminFeatures[ 'remote-free-extensions' ],
 			time: __( '1 minute', 'woocommerce-admin' ),
 			type: 'setup',
 		},

--- a/config/core.json
+++ b/config/core.json
@@ -11,7 +11,7 @@
 		"navigation": false,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
-		"remote-extensions-list": true,
+		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,
 		"settings": false,
 		"shipping-label-banner": true,

--- a/config/development.json
+++ b/config/development.json
@@ -12,7 +12,7 @@
 		"onboarding": true,
 		"payment-gateway-suggestions": true,
 		"remote-inbox-notifications": true,
-		"remote-extensions-list": true,
+		"remote-free-extensions": true,
 		"settings": false,
 		"shipping-label-banner": true,
 		"store-alerts": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -11,7 +11,7 @@
 		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
-		"remote-extensions-list": true,
+		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,
 		"settings": false,
 		"shipping-label-banner": true,

--- a/src/Features/RemoteFreeExtensions/Init.php
+++ b/src/Features/RemoteFreeExtensions/Init.php
@@ -21,6 +21,7 @@ class Init {
 	 */
 	public function __construct() {
 		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
+		add_action( 'woocommerce_admin_updated', array( __CLASS__, 'delete_specs_transient' ) );
 	}
 
 	/**


### PR DESCRIPTION
I think this is an edge case, but just in case users have already cached values for free extensions, this deletes that transient when WooCommerce Admin is updated.

Since there are breaking changes between the v1.0 and v2.0 REST API, this just confirms the data is fetched again using the new API.

### Detailed test instructions:

1. Visit the marketing task or business details step to set the transient
2. Modify the value of the transient at `woocommerce_admin_remote_free_extensions_specs` to something you can recognize.
3. Bump the WooCommerce Admin version.
4. Note that the transient is deleted and a new one is stored when visiting the task.