### PR TITLE
Don't show the marketing task if no marketing tasks exist

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -159,7 +159,10 @@ export function getAllTasks( {
 		);
 	}
 
-	const [ installedMarketingExtensions ] = getMarketingExtensionLists(
+	const [
+		installedMarketingExtensions,
+		marketingExtensionsLists,
+	] = getMarketingExtensionLists(
 		freeExtensions,
 		activePlugins,
 		installedPlugins
@@ -351,7 +354,8 @@ export function getAllTasks( {
 			completed: !! installedMarketingExtensions.length,
 			visible:
 				window.wcAdminFeatures &&
-				window.wcAdminFeatures[ 'remote-free-extensions' ],
+				window.wcAdminFeatures[ 'remote-free-extensions' ] &&
+				!! marketingExtensionsLists.length,
 			time: __( '1 minute', 'woocommerce-admin' ),
 			type: 'setup',
 		},


### PR DESCRIPTION
Hides the marketing task if no marketing tasks are found.  Also fixes (partially) https://github.com/woocommerce/woocommerce-admin/issues/7459 by hiding the task prior to marketing extensions being loaded.

### Screenshots

<img width="704" alt="Screen Shot 2021-08-04 at 11 51 13 AM" src="https://user-images.githubusercontent.com/10561050/128215052-36362a33-b7a0-47e2-813d-ee4f877d5050.png">


### Detailed test instructions:

* Delete the `woocommerce_admin_remote_free_extensions_specs` transient
* Change the data source in `src/Features/RemoteFreeExtensions/DataSourcePoller.php` to an invalid URL
* Check that no marketing task is shown in the task list since no marketing extensions were fetched