### PR TITLE
Sync changelog (directory) and changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -56,6 +56,16 @@
 - Tweak: Repurpose disable wc-admin filter to remove optional features #7232
 - Update: Notes to use a date range. #7222
 
+== 2.4.4 7/21/2021 ==
+- Fix: Fix homepage stock panel regression in 2.4.3. #7389
+
+== 2.4.3 7/21/2021 ==
+- Fix: Add a new low stock products endpoint to improve the performance. #7377
+
+== 2.4.2 7/19/2021 ==
+- Fix: Add lazy loading by checking panel open status #7376
+- Fix: Add cache-control header to low stock REST API response #7364
+
 == 2.4.1 7/1/2021 ==
 - Fix: Fix and refactor explat polling to use setTimeout #7274
 

--- a/changelogs/add-7313
+++ b/changelogs/add-7313
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add marketing extensions task to task list

--- a/changelogs/add-7314
+++ b/changelogs/add-7314
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add installed marketing extensions card to extensions task

--- a/changelogs/add-7329-marketing-help-links
+++ b/changelogs/add-7329-marketing-help-links
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Adding links to help panel for marketing task

--- a/changelogs/add-placeholder-TableSummary
+++ b/changelogs/add-placeholder-TableSummary
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add TableSummaryPlaceholder to support skeleton loading #7294

--- a/changelogs/add-reverse-trend-support-summary-number
+++ b/changelogs/add-reverse-trend-support-summary-number
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add boolean isReverseTrend prop to SummaryNumber to show "positive" delta for negative numbers.

--- a/changelogs/dev-add-utm-medium
+++ b/changelogs/dev-add-utm-medium
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Added utm_medium=product to woocommerce.com links. #7408

--- a/changelogs/fix-6820
+++ b/changelogs/fix-6820
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fixing issues with ReportTable component data not populating correctly #7355

--- a/changelogs/fix-7239-tos-link-disappears-from-setup-tax-screen
+++ b/changelogs/fix-7239-tos-link-disappears-from-setup-tax-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Render a spinner while woocommerce_setup_jetpack_opted_in is being loaded

--- a/changelogs/fix-7283-stock-report-has-inconsistent-word-for-status
+++ b/changelogs/fix-7283-stock-report-has-inconsistent-word-for-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Update status values in CSV download to match the table #7284

--- a/changelogs/fix-7322-unable-to-dismiss-inbox-note
+++ b/changelogs/fix-7322-unable-to-dismiss-inbox-note
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix links on the dismiss dropdown are not clickable #7342

--- a/changelogs/fix-7324
+++ b/changelogs/fix-7324
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fixed OBW - Business details style #7353

--- a/changelogs/fix-7340-unable-to-setup-automated-tax-via-tasklist
+++ b/changelogs/fix-7340-unable-to-setup-automated-tax-via-tasklist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix undefined method error when setting up WC Tax #7344

--- a/changelogs/fix-7347_wcpay_get_started_alignment
+++ b/changelogs/fix-7347_wcpay_get_started_alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fixes action button mis-alignment within card footer. #7412

--- a/changelogs/fix-7358-stock-api-performance-improvement
+++ b/changelogs/fix-7358-stock-api-performance-improvement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Performance
-
-Add a new low stock products endpoint to improve the performance. #7377

--- a/changelogs/fix-7362-analytics-filter-gutenberg-conflict
+++ b/changelogs/fix-7362-analytics-filter-gutenberg-conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix analytics filter Gutenberg CSS conflict #7410

--- a/changelogs/fix-7376-lazy-load-activity-panel
+++ b/changelogs/fix-7376-lazy-load-activity-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Performance
-
-Add lazy loading by checking panel open status

--- a/changelogs/fix-7382_orders_panel_loading
+++ b/changelogs/fix-7382_orders_panel_loading
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Fix
-
-Fix orders panel not displaying any orders when analytics is disabled #7395

--- a/changelogs/fix-7393
+++ b/changelogs/fix-7393
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Add limit clause to coupons data store query

--- a/changelogs/fix-7394-recommended-card-gutenberg-conflict
+++ b/changelogs/fix-7394-recommended-card-gutenberg-conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix recommended card Gutenberg CSS conflict #7409

--- a/changelogs/fix-7413_help_tooltip_styling
+++ b/changelogs/fix-7413_help_tooltip_styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Update tooltip styling to fix new Gutenberg updates. #7414

--- a/changelogs/fix-gateway-suggestions-tracks
+++ b/changelogs/fix-gateway-suggestions-tracks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix tracks events for payment gateway suggestions #7304

--- a/changelogs/fix-gb-task-card
+++ b/changelogs/fix-gb-task-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix Gutenberg CardBody styles for task card

--- a/changelogs/fix-slow-low-stock
+++ b/changelogs/fix-slow-low-stock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Performance
-
-Add cache-control header to low stock REST API response

--- a/changelogs/refactor-payment-recommendations-eligibiility
+++ b/changelogs/refactor-payment-recommendations-eligibiility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Refactor on payment settings recommendations eligibility component for reuse. #7447

--- a/changelogs/test-changelogger-lint
+++ b/changelogs/test-changelogger-lint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Point the changelog linter to updated changelog entry location #7318

--- a/changelogs/try-7061
+++ b/changelogs/try-7061
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Register wc-admin page for all users and handle authorization in client

--- a/changelogs/try-calypso-like-package-structure
+++ b/changelogs/try-calypso-like-package-structure
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Allow packages to be build independently, fix commonjs module builds. #7286

--- a/changelogs/update-6790-increase-per-page-for-search
+++ b/changelogs/update-6790-increase-per-page-for-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Increase per_page value for search results on the Analytics pages. #7385

--- a/changelogs/update-7282-remove-facebook-extension
+++ b/changelogs/update-7282-remove-facebook-extension
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Remove facebook extension from onboarding extensions fallback list

--- a/changelogs/update-7295-wcpay-add-more-countries
+++ b/changelogs/update-7295-wcpay-add-more-countries
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Add additional countries to WCPay for business features and payment task fallback #7436

--- a/changelogs/update-7312-remove-grow-from-obw
+++ b/changelogs/update-7312-remove-grow-from-obw
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Removing grow section from local free extensions in OBW

--- a/changelogs/update-business-details-extensions-data-store
+++ b/changelogs/update-business-details-extensions-data-store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Use the free extensions data store in the onboarding profiler

--- a/changelogs/update-jest-27
+++ b/changelogs/update-jest-27
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Dev
-
-Update Jest to version 27. #7430

--- a/changelogs/update-obw-free-extensions-locale
+++ b/changelogs/update-obw-free-extensions-locale
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Add locale param as part of free extensions request


### PR DESCRIPTION
This PR removes changelog files that are already released in 2.5.0 or 2.6.0.
It also adds missing changelog entries for 2.4.2, 2.4.3, and 2.4.4

no changelog needed