### PR TITLE
Add changelog.txt when creating a zip file.

### DIFF
--- a/bin/make-zip.sh
+++ b/bin/make-zip.sh
@@ -38,5 +38,6 @@ zip -r "${ZIP_FILE}" \
 	$asset_files \
 	languages/woocommerce-admin.pot \
 	readme.txt \
+	changelog.txt \
 	src/ \
 	vendor/


### PR DESCRIPTION
Fixes #7461

This PR adds `changelog.txt` when we create a zip file for a release.

This is needed as we're not adding changelog entries to `changelog.txt`

### Detailed test instructions:

1. Run `./bin/make-zip.sh test.zip`
2. Unzip `test.zip` you just created and confirm it contains `changelog.txt`

no changelog needed

- [ ] include test instructions in the release
