### PR TITLE
Replace first occurrence of the bullet char only

### DIFF
--- a/bin/changelogger/WCAdminFormatter.php
+++ b/bin/changelogger/WCAdminFormatter.php
@@ -100,7 +100,7 @@ class WCAdminFormatter extends KeepAChangelogParser implements FormatterPlugin {
 				$rows    = explode( "\n", $content );
 				foreach ( $rows as $row ) {
 					$row          = trim( $row );
-					$row          = str_replace( $this->bullet, '', $row );
+					$row = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
 					$row_segments = explode( ':', $row );
 
 					array_push(


### PR DESCRIPTION
Fixes #7462 

This PR replaces the first occurrence of the bullet char only so that the formatter does not alter changelog text in an unexpected way.

### Detailed test instructions:

Start with `main` branch to confirm the bug.

1. Run `npm run changelogger -- add` and add `this-is-a-test` as changelog text.
2. Run `npm run changelogger -- write`
3. Open `changelog.txt` and check the changelog you just added.
4. The text should be `thisisatest` without `-`

Let's confirm the fix

1. Checkout this branch.
2. Repeat the same steps. 
3. Confirm the changelog text still has `-` 

no changelog needed