### PR TITLE
Add tracks to marketing manage button click

### DIFF
--- a/client/task-list/tasks/Marketing/Plugin.tsx
+++ b/client/task-list/tasks/Marketing/Plugin.tsx
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
 
 /**
@@ -63,6 +64,11 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isBusy={ isBusy }
 						isSecondary
 						href={ getAdminLink( manageUrl ) }
+						onClick={ () =>
+							recordEvent( 'marketing_manage', {
+								extension_name: slug,
+							} )
+						}
 					>
 						{ __( 'Manage', 'woocommmerce-admin' ) }
 					</Button>


### PR DESCRIPTION
Adds in a tracks event when "Manage" is clicked for a marketing extension under the task list.

### Screenshots

<img width="723" alt="Screen Shot 2021-08-05 at 11 05 54 AM" src="https://user-images.githubusercontent.com/10561050/128373793-5f1436bf-e913-4aef-9f80-8194135cc437.png">


### Detailed test instructions:

1. Navigate to the marketing extensions task.
2. Install a marketing extension.
3. Open your console and enter `localStorage.setItem( 'debug', 'wc-admin:*' );`.
4. Click on "Manage" on the installed extension.
5. Note the tracks event with the extension slug as a prop.