### PR TITLE
Remove depreciated shared settings hook

### DIFF
--- a/changelogs/update-6900_depreciated_shared_settings
+++ b/changelogs/update-6900_depreciated_shared_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Removes the use of the depreciated woocommerce_shared_settings hook. #7480

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -292,7 +292,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			icon: <Icon icon={ external } />,
 			visible: query.page === 'wc-admin' && query.task === 'appearance',
 			onClick: () => {
-				window.open( window.wcSettings.siteUrl );
+				window.open( window.wcSettings.admin.siteUrl );
 				recordEvent(
 					'wcadmin_tasklist_previewsite',
 					previewSiteBtnTrackData

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -11,7 +11,7 @@ import {
 	inbox as inboxIcon,
 	external,
 } from '@wordpress/icons';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import { H, Section } from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
@@ -292,7 +292,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			icon: <Icon icon={ external } />,
 			visible: query.page === 'wc-admin' && query.task === 'appearance',
 			onClick: () => {
-				window.open( window.wcSettings.admin.siteUrl );
+				window.open( getSetting( 'siteUrl' ) );
 				recordEvent(
 					'wcadmin_tasklist_previewsite',
 					previewSiteBtnTrackData

--- a/client/index.js
+++ b/client/index.js
@@ -7,6 +7,7 @@ import {
 	withCurrentUserHydration,
 	withSettingsHydration,
 } from '@woocommerce/data';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -23,20 +24,21 @@ __webpack_public_path__ = global.wcAdminAssets.path;
 const appRoot = document.getElementById( 'root' );
 const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
 const settingsGroup = 'wc_admin';
-const hydrateUser = window.wcSettings.admin.currentUserData;
+const hydrateUser = getSetting( 'currentUserData' );
 
 if ( appRoot ) {
 	let HydratedPageLayout = withSettingsHydration(
 		settingsGroup,
 		window.wcSettings.admin
 	)( PageLayout );
-	const hydrateSettings =
-		window.wcSettings.admin.preloadSettings &&
-		window.wcSettings.admin.preloadSettings.general;
+	const preloadSettings = window.wcSettings.admin
+		? window.wcSettings.admin.preloadSettings
+		: false;
+	const hydrateSettings = preloadSettings && preloadSettings.general;
 
 	if ( hydrateSettings ) {
 		HydratedPageLayout = withSettingsHydration( 'general', {
-			general: window.wcSettings.admin.preloadSettings.general,
+			general: preloadSettings.general,
 		} )( HydratedPageLayout );
 	}
 	if ( hydrateUser ) {

--- a/client/index.js
+++ b/client/index.js
@@ -23,20 +23,20 @@ __webpack_public_path__ = global.wcAdminAssets.path;
 const appRoot = document.getElementById( 'root' );
 const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
 const settingsGroup = 'wc_admin';
-const hydrateUser = window.wcSettings.currentUserData;
+const hydrateUser = window.wcSettings.admin.currentUserData;
 
 if ( appRoot ) {
 	let HydratedPageLayout = withSettingsHydration(
 		settingsGroup,
-		window.wcSettings
+		window.wcSettings.admin
 	)( PageLayout );
 	const hydrateSettings =
-		window.wcSettings.preloadSettings &&
-		window.wcSettings.preloadSettings.general;
+		window.wcSettings.admin.preloadSettings &&
+		window.wcSettings.admin.preloadSettings.general;
 
 	if ( hydrateSettings ) {
 		HydratedPageLayout = withSettingsHydration( 'general', {
-			general: window.wcSettings.preloadSettings.general,
+			general: window.wcSettings.admin.preloadSettings.general,
 		} )( HydratedPageLayout );
 	}
 	if ( hydrateUser ) {
@@ -48,7 +48,7 @@ if ( appRoot ) {
 } else if ( embeddedRoot ) {
 	let HydratedEmbedLayout = withSettingsHydration(
 		settingsGroup,
-		window.wcSettings
+		window.wcSettings.admin
 	)( EmbedLayout );
 	if ( hydrateUser ) {
 		HydratedEmbedLayout = withCurrentUserHydration( hydrateUser )(

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -54,7 +54,7 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 export const getPages = () => {
 	const pages = [];
 	const initialBreadcrumbs = [
-		[ '', wcSettings.admin.woocommerceTranslation ],
+		[ '', getSetting( 'woocommerceTranslation' ) ],
 	];
 
 	pages.push( {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -53,7 +53,9 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = () => {
 	const pages = [];
-	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
+	const initialBreadcrumbs = [
+		[ '', wcSettings.admin.woocommerceTranslation ],
+	];
 
 	pages.push( {
 		container: Homescreen,

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -257,7 +257,7 @@ const _PageLayout = () => {
 };
 
 export const PageLayout = compose(
-	window.wcSettings.preloadOptions
+	window.wcSettings.admin
 		? withOptionsHydration( {
 				...getSetting( 'preloadOptions', {} ),
 		  } )

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -200,13 +200,12 @@ _Layout.propTypes = {
 	} ).isRequired,
 };
 
+const dataEndpoints = getSetting( 'dataEndpoints' );
 const Layout = compose(
 	withPluginsHydration( {
-		...( window.wcSettings.admin.plugins || {} ),
+		...getSetting( 'plugins', {} ),
 		jetpackStatus:
-			( window.wcSettings.admin.dataEndpoints &&
-				window.wcSettings.admin.dataEndpoints.jetpackStatus ) ||
-			false,
+			( dataEndpoints && dataEndpoints.jetpackStatus ) || false,
 	} ),
 	withSelect( ( select, { isEmbedded } ) => {
 		// Embedded pages don't send plugin info to Tracks.
@@ -260,7 +259,7 @@ const _PageLayout = () => {
 export const PageLayout = compose(
 	window.wcSettings.preloadOptions
 		? withOptionsHydration( {
-				...window.wcSettings.admin.preloadOptions,
+				...getSetting( 'preloadOptions', {} ),
 		  } )
 		: identity
 )( _PageLayout );
@@ -275,9 +274,9 @@ const _EmbedLayout = () => (
 );
 
 export const EmbedLayout = compose(
-	window.wcSettings.admin.preloadOptions
+	getSetting( 'preloadOptions' )
 		? withOptionsHydration( {
-				...window.wcSettings.admin.preloadOptions,
+				...getSetting( 'preloadOptions' ),
 		  } )
 		: identity
 )( _EmbedLayout );

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -202,10 +202,10 @@ _Layout.propTypes = {
 
 const Layout = compose(
 	withPluginsHydration( {
-		...( window.wcSettings.plugins || {} ),
+		...( window.wcSettings.admin.plugins || {} ),
 		jetpackStatus:
-			( window.wcSettings.dataEndpoints &&
-				window.wcSettings.dataEndpoints.jetpackStatus ) ||
+			( window.wcSettings.admin.dataEndpoints &&
+				window.wcSettings.admin.dataEndpoints.jetpackStatus ) ||
 			false,
 	} ),
 	withSelect( ( select, { isEmbedded } ) => {
@@ -260,7 +260,7 @@ const _PageLayout = () => {
 export const PageLayout = compose(
 	window.wcSettings.preloadOptions
 		? withOptionsHydration( {
-				...window.wcSettings.preloadOptions,
+				...window.wcSettings.admin.preloadOptions,
 		  } )
 		: identity
 )( _PageLayout );
@@ -275,9 +275,9 @@ const _EmbedLayout = () => (
 );
 
 export const EmbedLayout = compose(
-	window.wcSettings.preloadOptions
+	window.wcSettings.admin.preloadOptions
 		? withOptionsHydration( {
-				...window.wcSettings.preloadOptions,
+				...window.wcSettings.admin.preloadOptions,
 		  } )
 		: identity
 )( _EmbedLayout );

--- a/client/marketing/overview/index.js
+++ b/client/marketing/overview/index.js
@@ -33,5 +33,5 @@ const MarketingOverview = () => {
 };
 
 export default withOptionsHydration( {
-	...( window.wcSettings.preloadOptions || {} ),
+	...( window.wcSettings.admin.preloadOptions || {} ),
 } )( MarketingOverview );

--- a/client/marketing/overview/index.js
+++ b/client/marketing/overview/index.js
@@ -33,5 +33,5 @@ const MarketingOverview = () => {
 };
 
 export default withOptionsHydration( {
-	...( window.wcSettings.admin.preloadOptions || {} ),
+	...getSetting( 'preloadOptions', {} ),
 } )( MarketingOverview );

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -21,7 +21,7 @@ import {
 	QUERY_DEFAULTS,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -328,11 +328,10 @@ export default compose(
 			updateProfileItems,
 		};
 	} ),
-	window.wcSettings.admin.plugins
+	getSetting( 'plugins' )
 		? withPluginsHydration( {
-				...window.wcSettings.admin.plugins,
-				jetpackStatus:
-					window.wcSettings.admin.dataEndpoints.jetpackStatus,
+				...getSetting( 'plugins' ),
+				jetpackStatus: getSetting( 'dataEndpoints', {} ).jetpackStatus,
 		  } )
 		: identity
 )( ProfileWizard );

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -328,10 +328,11 @@ export default compose(
 			updateProfileItems,
 		};
 	} ),
-	window.wcSettings.plugins
+	window.wcSettings.admin.plugins
 		? withPluginsHydration( {
-				...window.wcSettings.plugins,
-				jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
+				...window.wcSettings.admin.plugins,
+				jetpackStatus:
+					window.wcSettings.admin.dataEndpoints.jetpackStatus,
 		  } )
 		: identity
 )( ProfileWizard );

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -87,12 +87,10 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	margin: 0;
 	position: relative;
 
-	&.is-uploading .components-drop-zone__provider,
 	&.is-uploading .woocommerce-theme-uploader__dropzone-wrapper {
 		min-height: 382px;
 	}
 
-	.components-drop-zone__provider,
 	.woocommerce-theme-uploader__dropzone-wrapper {
 		display: flex;
 		flex-direction: column;

--- a/client/profile-wizard/steps/theme/style.scss
+++ b/client/profile-wizard/steps/theme/style.scss
@@ -1,4 +1,3 @@
-
 .woocommerce-profile-wizard__body .woocommerce-profile-wizard__container {
 	> .woocommerce-profile-wizard__themes-tab-panel {
 		margin-bottom: $gap-large;
@@ -33,7 +32,7 @@
 		background: transparent;
 		height: 48px;
 		width: 100%;
-		@include font-size(14);
+		@include font-size( 14 );
 		font-weight: 500;
 		outline: none;
 		padding: 0 $gap-large;
@@ -60,7 +59,7 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	.woocommerce-profile-wizard__theme-name {
 		margin-top: auto;
 		margin-bottom: $gap-smaller;
-		@include font-size(24);
+		@include font-size( 24 );
 		font-weight: 400;
 
 		svg {
@@ -88,11 +87,13 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 	margin: 0;
 	position: relative;
 
-	&.is-uploading .components-drop-zone__provider {
+	&.is-uploading .components-drop-zone__provider,
+	&.is-uploading .woocommerce-theme-uploader__dropzone-wrapper {
 		min-height: 382px;
 	}
 
-	.components-drop-zone__provider {
+	.components-drop-zone__provider,
+	.woocommerce-theme-uploader__dropzone-wrapper {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -133,12 +134,12 @@ p.woocommerce-profile-wizard__themes-skip-this-step {
 
 	.woocommerce-theme-uploader__title {
 		margin: $gap-smaller 0;
-		@include font-size(24);
+		@include font-size( 24 );
 		font-weight: 400;
 	}
 
 	p {
-		@include font-size(14);
+		@include font-size( 14 );
 		margin: 0;
 	}
 }

--- a/client/profile-wizard/steps/theme/uploader.js
+++ b/client/profile-wizard/steps/theme/uploader.js
@@ -19,6 +19,22 @@ import { withDispatch } from '@wordpress/data';
 import { H, Spinner } from '@woocommerce/components';
 import { isWpVersion } from '@woocommerce/settings';
 
+/**
+ * NOTE: This can be removed after WP version 6.0 and replaced with a div.
+ *
+ * @param {Object} props React props.
+ * @param {Node} [props.children] Children of react component.
+ * @param {string} [props.className] Additional class name to style the component.
+ */
+const DropZoneWrapper = ( { children, className } ) => {
+	const isDropzoneProviderDepreciated = isWpVersion( '5.8', '>=' );
+
+	if ( isDropzoneProviderDepreciated ) {
+		return <div className={ className }>{ children }</div>;
+	}
+	return <DropZoneProvider>{ children }</DropZoneProvider>;
+};
+
 class ThemeUploader extends Component {
 	constructor() {
 		super();
@@ -69,13 +85,10 @@ class ThemeUploader extends Component {
 		const classes = classnames( 'woocommerce-theme-uploader', className, {
 			'is-uploading': isUploading,
 		} );
-		const DropZoneWrapper = isWpVersion( '5.8', '>=' )
-			? Fragment
-			: DropZoneProvider;
 
 		return (
 			<Card className={ classes }>
-				<DropZoneWrapper>
+				<DropZoneWrapper className="woocommerce-theme-uploader__dropzone-wrapper">
 					{ ! isUploading ? (
 						<Fragment>
 							<FormFileUpload

--- a/client/profile-wizard/steps/theme/uploader.js
+++ b/client/profile-wizard/steps/theme/uploader.js
@@ -32,7 +32,11 @@ const DropZoneWrapper = ( { children, className } ) => {
 	if ( isDropzoneProviderDepreciated ) {
 		return <div className={ className }>{ children }</div>;
 	}
-	return <DropZoneProvider>{ children }</DropZoneProvider>;
+	return (
+		<DropZoneProvider>
+			<div className={ className }>{ children }</div>
+		</DropZoneProvider>
+	);
 };
 
 class ThemeUploader extends Component {

--- a/client/profile-wizard/steps/theme/uploader.js
+++ b/client/profile-wizard/steps/theme/uploader.js
@@ -17,6 +17,7 @@ import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
 import { H, Spinner } from '@woocommerce/components';
+import { isWpVersion } from '@woocommerce/settings';
 
 class ThemeUploader extends Component {
 	constructor() {
@@ -68,10 +69,13 @@ class ThemeUploader extends Component {
 		const classes = classnames( 'woocommerce-theme-uploader', className, {
 			'is-uploading': isUploading,
 		} );
+		const DropZoneWrapper = isWpVersion( '5.8', '>=' )
+			? Fragment
+			: DropZoneProvider;
 
 		return (
 			<Card className={ classes }>
-				<DropZoneProvider>
+				<DropZoneWrapper>
 					{ ! isUploading ? (
 						<Fragment>
 							<FormFileUpload
@@ -114,7 +118,7 @@ class ThemeUploader extends Component {
 							</p>
 						</Fragment>
 					) }
-				</DropZoneProvider>
+				</DropZoneWrapper>
 			</Card>
 		);
 	}

--- a/client/wp-admin-scripts/print-shipping-label-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/index.js
@@ -15,7 +15,7 @@ const args =
 
 // Render the header.
 const HydratedShippingBanner = withPluginsHydration( {
-	...window.wcSettings.plugins,
-	jetpackStatus: window.wcSettings.dataEndpoints.jetpackStatus,
+	...window.wcSettings.admin.plugins,
+	jetpackStatus: window.wcSettings.admin.dataEndpoints.jetpackStatus,
 } )( ShippingBanner );
 render( <HydratedShippingBanner itemsCount={ args.items } />, metaBox );

--- a/client/wp-admin-scripts/print-shipping-label-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/index.js
@@ -3,6 +3,7 @@
  */
 import { render } from '@wordpress/element';
 import { withPluginsHydration } from '@woocommerce/data';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ const args =
 
 // Render the header.
 const HydratedShippingBanner = withPluginsHydration( {
-	...window.wcSettings.admin.plugins,
-	jetpackStatus: window.wcSettings.admin.dataEndpoints.jetpackStatus,
+	...getSetting( 'plugins' ),
+	jetpackStatus: getSetting( 'dataEndpoints', {} ).jetpackStatus,
 } )( ShippingBanner );
 render( <HydratedShippingBanner itemsCount={ args.items } />, metaBox );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1573,6 +1573,22 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
+		"@babel/runtime-corejs2": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
+			"integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+				}
+			}
+		},
 		"@babel/runtime-corejs3": {
 			"version": "7.14.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz",
@@ -13161,11 +13177,21 @@
 				}
 			}
 		},
+		"@woocommerce/settings": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@woocommerce/settings/-/settings-1.0.0.tgz",
+			"integrity": "sha512-BjrT56Cz8XTRHw2JNPmANRkYh2rzdF33wOa56lah1qb/MjHUKuVJ0PTSZ19S5Trb92IkxfcIVB26CSdxXnf5Og==",
+			"requires": {
+				"@babel/runtime-corejs2": "7.5.5"
+			}
+		},
 		"@woocommerce/style-build": {
 			"version": "file:packages/style-build",
 			"dev": true,
 			"requires": {
+				"@automattic/color-studio": "2.5.0",
 				"@automattic/mini-css-extract-plugin-with-rtl": "0.8.0",
+				"@wordpress/base-styles": "3.3.0",
 				"@wordpress/postcss-plugins-preset": "1.6.0",
 				"css-loader": "3.6.0",
 				"postcss-loader": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"@automattic/explat-client-react-helpers": "0.0.2",
 		"@woocommerce/e2e-environment": "0.2.2",
 		"@woocommerce/e2e-utils": "0.1.5",
+		"@woocommerce/settings": "^1.0.0",
 		"@wordpress/api-fetch": "2.2.8",
 		"@wordpress/base-styles": "3.3.0",
 		"@wordpress/components": "11.1.3",

--- a/packages/wc-admin-settings/src/index.js
+++ b/packages/wc-admin-settings/src/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 // Remove mutable data from settings object to prevent access. Data stores should be used instead.
 const mutableSources = [ 'wcAdminSettings', 'preloadSettings' ];
-const settings = typeof wcSettings === 'object' && wcSettings ? wcSettings : {};
+const settings = typeof wcSettings === 'object' ? wcSettings : {};
 const SOURCE = Object.keys( settings ).reduce( ( source, key ) => {
 	if ( ! mutableSources.includes( key ) ) {
 		source[ key ] = settings[ key ];

--- a/packages/wc-admin-settings/src/index.js
+++ b/packages/wc-admin-settings/src/index.js
@@ -5,7 +5,8 @@ import { __ } from '@wordpress/i18n';
 
 // Remove mutable data from settings object to prevent access. Data stores should be used instead.
 const mutableSources = [ 'wcAdminSettings', 'preloadSettings' ];
-const settings = typeof wcSettings === 'object' ? wcSettings : {};
+const settings =
+	typeof wcSettings === 'object' && wcSettings.admin ? wcSettings.admin : {};
 const SOURCE = Object.keys( settings ).reduce( ( source, key ) => {
 	if ( ! mutableSources.includes( key ) ) {
 		source[ key ] = settings[ key ];

--- a/packages/wc-admin-settings/src/index.js
+++ b/packages/wc-admin-settings/src/index.js
@@ -5,14 +5,18 @@ import { __ } from '@wordpress/i18n';
 
 // Remove mutable data from settings object to prevent access. Data stores should be used instead.
 const mutableSources = [ 'wcAdminSettings', 'preloadSettings' ];
-const settings =
-	typeof wcSettings === 'object' && wcSettings.admin ? wcSettings.admin : {};
+const settings = typeof wcSettings === 'object' && wcSettings ? wcSettings : {};
 const SOURCE = Object.keys( settings ).reduce( ( source, key ) => {
 	if ( ! mutableSources.includes( key ) ) {
 		source[ key ] = settings[ key ];
 	}
 	return source;
 }, {} );
+Object.keys( settings.admin || {} ).forEach( ( key ) => {
+	if ( ! mutableSources.includes( key ) ) {
+		SOURCE[ key ] = settings.admin[ key ];
+	}
+} );
 
 export const ADMIN_URL = SOURCE.adminUrl;
 export const COUNTRIES = SOURCE.countries;

--- a/src/Features/ActivityPanels.php
+++ b/src/Features/ActivityPanels.php
@@ -37,7 +37,7 @@ class ActivityPanels {
 		// Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
 		// New settings injection.
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 20 );
 	}
 
 	/**

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -50,7 +50,42 @@ class Homescreen {
 			add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
 		}
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
+		\Automattic\WooCommerce\Admin\WCAdminSettingsRegistry::instance()->add( 'orderCount', array( $this, 'component_settings_order_count' ) );
+	}
+
+	/**
+	 * Add data to the shared component settings.
+	 */
+	public function component_settings_order_count() {
+		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
+
+		// Remove the Draft Order status (from the Checkout Block).
+		unset( $allowed_statuses['checkout-draft'] );
+
+		$status_counts = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
+		return array_sum( $status_counts );
+	}
+
+
+	/**
+	 * Add data to the shared component settings.
+	 *
+	 * @param array $settings Shared component settings.
+	 */
+	public function component_settings( $settings ) {
+		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
+
+		// Remove the Draft Order status (from the Checkout Block).
+		unset( $allowed_statuses['checkout-draft'] );
+
+		$status_counts                     = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
+		$product_counts                    = wp_count_posts( 'product' );
+		$settings['orderCount']            = array_sum( $status_counts );
+		$settings['publishedProductCount'] = $product_counts->publish;
+
+		return $settings;
 	}
 
 	/**
@@ -168,22 +203,5 @@ class Homescreen {
 		return $options;
 	}
 
-	/**
-	 * Add data to the shared component settings.
-	 *
-	 * @param array $settings Shared component settings.
-	 */
-	public function component_settings( $settings ) {
-		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
 
-		// Remove the Draft Order status (from the Checkout Block).
-		unset( $allowed_statuses['checkout-draft'] );
-
-		$status_counts                     = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
-		$product_counts                    = wp_count_posts( 'product' );
-		$settings['orderCount']            = array_sum( $status_counts );
-		$settings['publishedProductCount'] = $product_counts->publish;
-
-		return $settings;
-	}
 }

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -55,25 +55,6 @@ class Homescreen {
 	}
 
 	/**
-	 * Add data to the shared component settings.
-	 *
-	 * @param array $settings Shared component settings.
-	 */
-	public function component_settings( $settings ) {
-		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
-
-		// Remove the Draft Order status (from the Checkout Block).
-		unset( $allowed_statuses['checkout-draft'] );
-
-		$status_counts                     = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
-		$product_counts                    = wp_count_posts( 'product' );
-		$settings['orderCount']            = array_sum( $status_counts );
-		$settings['publishedProductCount'] = $product_counts->publish;
-
-		return $settings;
-	}
-
-	/**
 	 * Adds fields so that we can store performance indicators, row settings, and chart type settings for users.
 	 *
 	 * @param array $user_data_fields User data fields.
@@ -188,5 +169,22 @@ class Homescreen {
 		return $options;
 	}
 
+	/**
+	 * Add data to the shared component settings.
+	 *
+	 * @param array $settings Shared component settings.
+	 */
+	public function component_settings( $settings ) {
+		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
 
+		// Remove the Draft Order status (from the Checkout Block).
+		unset( $allowed_statuses['checkout-draft'] );
+
+		$status_counts                     = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
+		$product_counts                    = wp_count_posts( 'product' );
+		$settings['orderCount']            = array_sum( $status_counts );
+		$settings['publishedProductCount'] = $product_counts->publish;
+
+		return $settings;
+	}
 }

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -51,23 +51,8 @@ class Homescreen {
 		}
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
-		\Automattic\WooCommerce\Admin\WCAdminSettingsRegistry::instance()->add( 'orderCount', array( $this, 'component_settings_order_count' ) );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 20 );
 	}
-
-	/**
-	 * Add data to the shared component settings.
-	 */
-	public function component_settings_order_count() {
-		$allowed_statuses = Loader::get_order_statuses( wc_get_order_statuses() );
-
-		// Remove the Draft Order status (from the Checkout Block).
-		unset( $allowed_statuses['checkout-draft'] );
-
-		$status_counts = array_map( 'wc_orders_count', array_keys( $allowed_statuses ) );
-		return array_sum( $status_counts );
-	}
-
 
 	/**
 	 * Add data to the shared component settings.

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -61,7 +61,7 @@ class Marketing {
 		add_action( 'admin_menu', array( $this, 'add_parent_menu_item' ), 6 );
 
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -213,7 +213,7 @@ class Onboarding {
 		// Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
 		// New settings injection.
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -60,7 +60,7 @@ class OnboardingTasks {
 		// Run after Onboarding.
 		add_filter( 'woocommerce_components_settings', array( __CLASS__, 'component_settings' ), 30 );
 		// New settings injection.
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
+		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );
 
 		add_action( 'admin_init', array( $this, 'set_active_task' ), 5 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ) );

--- a/src/Features/Settings.php
+++ b/src/Features/Settings.php
@@ -50,7 +50,7 @@ class Settings {
 			return;
 		}
 
-		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'add_component_settings' ) );
+		add_filter( 'woocommerce_admin_shared_settings', array( __CLASS__, 'add_component_settings' ) );
 		// Run this after the original WooCommerce settings have been added.
 		add_action( 'admin_menu', array( $this, 'register_pages' ), 60 );
 		add_action( 'init', array( $this, 'redirect_core_settings_pages' ) );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -10,6 +10,7 @@ use \_WP_Dependency;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
 use Automattic\WooCommerce\Admin\API\Plugins;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\WCAdminSettingsRegistry;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use WC_Marketplace_Suggestions;
 
@@ -69,6 +70,7 @@ class Loader {
 	 */
 	public function __construct() {
 		Features::get_instance();
+		WCAdminSettingsRegistry::get_instance();
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
@@ -76,7 +78,7 @@ class Loader {
 		// Old settings injection.
 		add_filter( 'woocommerce_components_settings', array( __CLASS__, 'add_component_settings' ) );
 		// New settings injection.
-		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'add_component_settings' ) );
+		add_filter( 'woocommerce_admin_shared_settings', array( __CLASS__, 'add_component_settings' ) );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'register_page_handler' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'register_store_details_page' ) );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -10,7 +10,6 @@ use \_WP_Dependency;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
 use Automattic\WooCommerce\Admin\API\Plugins;
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\WCAdminSettingsRegistry;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use WC_Marketplace_Suggestions;
 
@@ -70,7 +69,7 @@ class Loader {
 	 */
 	public function __construct() {
 		Features::get_instance();
-		WCAdminSettingsRegistry::get_instance();
+		WCAdminSharedSettings::get_instance();
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );

--- a/src/WCAdminSettingsRegistry.php
+++ b/src/WCAdminSettingsRegistry.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Manages the WC Admin settings that need to be pre-loaded.
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * \Automattic\WooCommerce\Admin\CategoryLookup class.
+ */
+class WCAdminSettingsRegistry {
+
+	/**
+	 * Settings is an array of closures that will be invoked just before
+	 * asset data is generated for the enqueued script.
+	 *
+	 * @var array
+	 */
+	public $settings = [];
+
+	/**
+	 * Class instance.
+	 *
+	 * @var Homescreen instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Hook into WooCommerce.
+	 */
+	protected function __construct() {
+		if ( did_action( 'plugins_loaded' ) ) {
+			$this->on_plugins_loaded();
+		} else {
+			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ), 10 );
+		}
+	}
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Setup plugin once all other plugins are loaded.
+	 *
+	 * @return void
+	 */
+	public function on_plugins_loaded() {
+		if ( class_exists( '\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry' ) ) {
+			\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
+				'wcAdminSettings2',
+				function() {
+					return call_user_func( array( $this, 'get_wc_admin_settings' ) );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Loops through each registered lazy data callback and adds the returned
+	 * value to the data array.
+	 *
+	 * This method is executed right before preparing the data for printing to
+	 * the rendered screen.
+	 *
+	 * @return array
+	 */
+	protected function get_wc_admin_settings() {
+		$data = array();
+		foreach ( $this->settings as $key => $callback ) {
+			if ( \is_callable( $callback ) ) {
+				$data[ $key ] = call_user_func( $callback );
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * Interface for adding data to the registry.
+	 *
+	 * You can only register data that is not already in the registry identified by the given key. If there is a
+	 * duplicate found, unless $ignore_duplicates is true, an exception will be thrown.
+	 *
+	 * @param string  $key The key used to reference the data being registered.
+	 * @param mixed   $data_callback If not a function, registered to the registry as is. If a function, then the
+	 *                                     callback is invoked right before output to the screen.
+	 * @param boolean $check_key_exists If set to true, duplicate data will be ignored if the key exists.
+	 *                                  If false, duplicate data will cause an exception.
+	 *
+	 * @throws InvalidArgumentException  Only throws when site is in debug mode. Always logs the error.
+	 */
+	public function add( $key, $data_callback, $check_key_exists = false ) {
+		if ( $check_key_exists && array_key_exists( $key, $this->settings ) ) {
+			return;
+		}
+		$this->settings[ $key ] = $data_callback;
+	}
+}
+

--- a/src/WCAdminSettingsRegistry.php
+++ b/src/WCAdminSettingsRegistry.php
@@ -11,15 +11,7 @@ defined( 'ABSPATH' ) || exit;
  * \Automattic\WooCommerce\Admin\CategoryLookup class.
  */
 class WCAdminSettingsRegistry {
-
-	/**
-	 * Settings is an array of closures that will be invoked just before
-	 * asset data is generated for the enqueued script.
-	 *
-	 * @var array
-	 */
-	public $settings = [];
-
+	private $settings_prefix = 'admin';
 	/**
 	 * Class instance.
 	 *
@@ -31,10 +23,10 @@ class WCAdminSettingsRegistry {
 	 * Hook into WooCommerce.
 	 */
 	protected function __construct() {
-		if ( did_action( 'plugins_loaded' ) ) {
+		if ( did_action( 'woocommerce_blocks_loaded' ) ) {
 			$this->on_plugins_loaded();
 		} else {
-			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ), 10 );
+			add_action( 'woocommerce_blocks_loaded', array( $this, 'on_woocommerce_blocks_loaded' ), 10 );
 		}
 	}
 
@@ -43,7 +35,7 @@ class WCAdminSettingsRegistry {
 	 *
 	 * @return object Instance.
 	 */
-	public static function instance() {
+	public static function get_instance() {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
@@ -55,55 +47,17 @@ class WCAdminSettingsRegistry {
 	 *
 	 * @return void
 	 */
-	public function on_plugins_loaded() {
+	public function on_woocommerce_blocks_loaded() {
 		if ( class_exists( '\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry' ) ) {
 			\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
-				'wcAdminSettings2',
+				$this->settings_prefix,
 				function() {
-					return call_user_func( array( $this, 'get_wc_admin_settings' ) );
-				}
+					error_log('called shared_settings hook');
+					return apply_filters( 'woocommerce_admin_shared_settings', array() );
+				},
+				true
 			);
 		}
-	}
-
-	/**
-	 * Loops through each registered lazy data callback and adds the returned
-	 * value to the data array.
-	 *
-	 * This method is executed right before preparing the data for printing to
-	 * the rendered screen.
-	 *
-	 * @return array
-	 */
-	protected function get_wc_admin_settings() {
-		$data = array();
-		foreach ( $this->settings as $key => $callback ) {
-			if ( \is_callable( $callback ) ) {
-				$data[ $key ] = call_user_func( $callback );
-			}
-		}
-		return $data;
-	}
-
-	/**
-	 * Interface for adding data to the registry.
-	 *
-	 * You can only register data that is not already in the registry identified by the given key. If there is a
-	 * duplicate found, unless $ignore_duplicates is true, an exception will be thrown.
-	 *
-	 * @param string  $key The key used to reference the data being registered.
-	 * @param mixed   $data_callback If not a function, registered to the registry as is. If a function, then the
-	 *                                     callback is invoked right before output to the screen.
-	 * @param boolean $check_key_exists If set to true, duplicate data will be ignored if the key exists.
-	 *                                  If false, duplicate data will cause an exception.
-	 *
-	 * @throws InvalidArgumentException  Only throws when site is in debug mode. Always logs the error.
-	 */
-	public function add( $key, $data_callback, $check_key_exists = false ) {
-		if ( $check_key_exists && array_key_exists( $key, $this->settings ) ) {
-			return;
-		}
-		$this->settings[ $key ] = $data_callback;
 	}
 }
 

--- a/src/WCAdminSharedSettings.php
+++ b/src/WCAdminSharedSettings.php
@@ -8,19 +8,25 @@ namespace Automattic\WooCommerce\Admin;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * \Automattic\WooCommerce\Admin\CategoryLookup class.
+ * \Automattic\WooCommerce\Admin\WCAdminSharedSettings class.
  */
-class WCAdminSettingsRegistry {
+class WCAdminSharedSettings {
+	/**
+	 * Settings prefix used for the window.wcSettings object.
+	 *
+	 * @var string
+	 */
 	private $settings_prefix = 'admin';
+
 	/**
 	 * Class instance.
 	 *
-	 * @var Homescreen instance
+	 * @var WCAdminSharedSettings instance
 	 */
 	protected static $instance = null;
 
 	/**
-	 * Hook into WooCommerce.
+	 * Hook into WooCommerce Blocks.
 	 */
 	protected function __construct() {
 		if ( did_action( 'woocommerce_blocks_loaded' ) ) {
@@ -43,7 +49,7 @@ class WCAdminSettingsRegistry {
 	}
 
 	/**
-	 * Setup plugin once all other plugins are loaded.
+	 * Adds settings to the Blocks AssetDataRegistry when woocommerce_blocks is loaded.
 	 *
 	 * @return void
 	 */
@@ -52,7 +58,6 @@ class WCAdminSettingsRegistry {
 			\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
 				$this->settings_prefix,
 				function() {
-					error_log('called shared_settings hook');
 					return apply_filters( 'woocommerce_admin_shared_settings', array() );
 				},
 				true


### PR DESCRIPTION
Fixes #6900 

Removes the use of the depreciated `woocommerce_shared_settings` hook.

Some of the main changes:
- Add `WCAdminSharedSettings` class to handle new blocks setting addition, created a new filter for this - `woocommerce_admin_shared_settings`
- Removed one unused option `commentModeration` was removed in #3459
- Made use of the `getSetting` function wherever we were using `window.wcSettings` directly (if possible)
- Use `Fragment` instead of `DropZoneWrapper` for wp version 5.8 and up, given it is depreciated.

**A potential extra change?**
[woocommerce-blocks preloads some settings](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Assets/AssetDataRegistry.php#L76-L90), some of which we also load (listed below), should I remove these on our end? They pretty well look the same.
- [`currency`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L1022)
- [`homeUrl`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L1084)
- [`locale`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L1023-L1032)
- [`orderStatuses`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L1020)
- [`wcVersion`](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L1081)

### Screenshots

### Detailed test instructions:

- Smoke test wc-admin, onboarding wizard, analytics pages, marketing page
     - shipping label banner requires jetpack (run a build and `./bin/make-zip woocommerce-admin.zip` and test on Jurassic)
- Run the E2E tests or check the Github action and see if there are no depreciation logs displayed (you should be able to see the depreciated warnings in the E2E test runs of other PRs - https://github.com/woocommerce/woocommerce-admin/actions/workflows/e2e.yml).
Example of the warning that shouldn't appear anymore:
<img width="1287" alt="Screen Shot 2021-08-11 at 10 03 39 AM" src="https://user-images.githubusercontent.com/2240960/129033720-91a2b4e2-6c45-4862-8f35-940259400fee.png">

- Check if theme upload still works on Wordpress 5.7/5.6

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
