### PR TITLE
Fix blank screen on analytics categories when searching

### DIFF
--- a/changelogs/fix-7473-blank-screen-search-categories
+++ b/changelogs/fix-7473-blank-screen-search-categories
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix blank screen on analytics categories when searching #7482
+Fix blank screen on analytics screens when searching #7482

--- a/changelogs/fix-7473-blank-screen-search-categories
+++ b/changelogs/fix-7473-blank-screen-search-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix blank screen on analytics categories when searching #7482

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -7,7 +7,7 @@ import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import { find } from 'lodash';
 import { getQuery, getSearchWords } from '@woocommerce/navigation';
-import { searchItemsByString, ITEMS_STORE_NAME } from '@woocommerce/data';
+import { searchItemsByString } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -89,9 +89,6 @@ export default compose(
 		const query = getQuery();
 		const { search } = query;
 
-		/* eslint @wordpress/no-unused-vars-before-return: "off" */
-		const itemsSelector = select( ITEMS_STORE_NAME );
-
 		if ( ! search ) {
 			return {};
 		}
@@ -104,7 +101,7 @@ export default compose(
 				? 'products'
 				: report;
 		const itemsResult = searchItemsByString(
-			itemsSelector,
+			select,
 			mappedReport,
 			searchWords,
 			{


### PR DESCRIPTION
Fixes #7473

`searchItemsByString` function consumer did not get updated with an API change, since `select` now refers to the select function instead of a pre-selecting the store.

### Detailed test instructions:

- Create or import some products with categories set.
- Place orders for some products.
- Go to "Analytics->Category" screen.
- Search for any category.
- Observe no blank screen after searching.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
