### PR TITLE
Fix all links with hash to behind query parameters

### DIFF
--- a/changelogs/fix-7477-link-hash-issue
+++ b/changelogs/fix-7477-link-hash-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix all links with hash to behind query parameters #7483

--- a/client/header/activity-panel/panels/help.js
+++ b/client/header/activity-panel/panels/help.js
@@ -42,22 +42,22 @@ function getHomeItems() {
 		{
 			title: __( 'Inbox', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-2?utm_medium=product',
+				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-2',
 		},
 		{
 			title: __( 'Stats Overview', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-4?utm_medium=product',
+				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-4',
 		},
 		{
 			title: __( 'Store Management', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen/#section-5?utm_medium=product',
+				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-5',
 		},
 		{
 			title: __( 'Store Setup Checklist', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-setup-wizard/#store-setup-checklist?utm_medium=product',
+				'https://docs.woocommerce.com/document/woocommerce-setup-wizard?utm_medium=product#store-setup-checklist',
 		},
 	];
 }
@@ -102,7 +102,7 @@ function getMarketingItems( props ) {
 		activePlugins.includes( 'google-listings-and-ads' ) && {
 			title: __( 'Set up Google Listing & Ads', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/google-listings-and-ads/#get-started?utm_medium=product',
+				'https://docs.woocommerce.com/document/google-listings-and-ads/?utm_medium=product#get-started',
 		},
 		activePlugins.includes( 'mailchimp-for-woocommerce' ) && {
 			title: __(
@@ -158,7 +158,7 @@ function getPaymentGatewaySuggestions( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/2-0/woocommerce-paypal-payments/#section-3?utm_medium=product',
+				'https://docs.woocommerce.com/document/2-0/woocommerce-paypal-payments/?utm_medium=product#section-3',
 		},
 		paymentGatewaySuggestions.square_credit_card && {
 			title: __( 'Square - Get started', 'woocommerce-admin' ),
@@ -258,7 +258,7 @@ function getShippingItems( { activePlugins, countryCode } ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-services/#section-3/?utm_source=help_panel&utm_medium=product',
+				'https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/?utm_source=help_panel&utm_medium=product#section-3',
 		},
 		{
 			title: __(
@@ -294,7 +294,7 @@ function getTaxItems( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel#section-10?utm_medium=product',
+				'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel&utm_medium=product#section-10',
 		},
 	].filter( Boolean );
 }

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -386,7 +386,7 @@ class Tax extends Component {
 									components: {
 										link: (
 											<Link
-												href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-1?utm_medium=product"
+												href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_medium=product#section-1"
 												target="_blank"
 												type="external"
 											/>

--- a/src/Notes/FilterByProductVariationsInReports.php
+++ b/src/Notes/FilterByProductVariationsInReports.php
@@ -48,7 +48,7 @@ class FilterByProductVariationsInReports {
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://docs.woocommerce.com/document/woocommerce-analytics/#variations-report?utm_medium=product'
+			'https://docs.woocommerce.com/document/woocommerce-analytics/?utm_medium=product#variations-report'
 		);
 
 		return $note;


### PR DESCRIPTION
Fixes #7477

It seems the previous change in links to mass-add `utm_medium=product` inadvertently adds it behind hash in some URLs. This PR fixes all of these instances.

### Detailed test instructions:

-   Check all changed links to have the hash behind the query parameters.
- Optionally, you may cross-check with https://github.com/woocommerce/woocommerce-admin/pull/7408/files to see if I missed anything.