### PR TITLE
Add rimraf dev dependency to admin-e2e-tests package

### DIFF
--- a/packages/admin-e2e-tests/package.json
+++ b/packages/admin-e2e-tests/package.json
@@ -36,6 +36,7 @@
 		"@types/puppeteer": "5.4.3",
 		"@typescript-eslint/eslint-plugin": "4.22.1",
 		"jest-mock-extended": "1.0.18",
+		"rimraf": "3.0.2",
 		"typescript": "4.2.4"
 	},
 	"publishConfig": {


### PR DESCRIPTION
Adds `rimraf` as a dev dependency to `@woocommerce/admin-e2e-tests` because it is used in in the `clean` script.

Previously, `npm publish` would result in an error:

```shell
% npm publish --dry-run   

> @woocommerce/admin-e2e-tests@0.1.0 prepack .
> npm run clean && npm run build


> @woocommerce/admin-e2e-tests@0.1.0 clean /Users/adrian/Code/woocommerce-admin/packages/admin-e2e-tests
> npx rimraf build build-*

npx: installed 12 in 1.999s
command not found: rimraf
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @woocommerce/admin-e2e-tests@0.1.0 clean: `npx rimraf build build-*`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @woocommerce/admin-e2e-tests@0.1.0 clean script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

### Testing Instructions

-  `cd packages/admin-e2e-tests`
-  `npm -i`
-  `npm publish --dry-run`

No changelog.