### PR TITLE
Set padding: 0 to override Gutenberg style

### DIFF
--- a/changelogs/fix-7479-home-style-issue
+++ b/changelogs/fix-7479-home-style-issue
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix Status module CSS issue introduced by Gutenberg #7488
+Fix Stats module CSS issue introduced by Gutenberg #7488

--- a/changelogs/fix-7479-home-style-issue
+++ b/changelogs/fix-7479-home-style-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Status module CSS issue introduced by Gutenberg #7488

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -80,7 +80,7 @@
 		}
 	}
 
-	.components-card__body.is-size-large {
+	.components-card__body {
 		padding: 0;
 	}
 


### PR DESCRIPTION
Fixes #7479 

This PR fixes CSS issue with Stats module on WooCommerce -> Home 

### Screenshots

**Without Fix**
![without-fixth_](https://user-images.githubusercontent.com/4723145/128745364-0ffc16fe-2803-4ff2-ba51-9d142403014e.jpg)


**With Fix**

![with-fixth_](https://user-images.githubusercontent.com/4723145/128745371-088fc318-5ae2-41bb-a332-a82cf74511d8.jpg)


### Detailed test instructions:

1. Install and activate WooCommerce, WooCommerce Admin 2.6.0-beta.2, Gutenberg
2. Navigate to Woocommerce -> Home and confirm that the Stats module doesn't have padding