### PR TITLE
Add super admin check to preloaded user data

### DIFF
--- a/changelogs/fix-7397
+++ b/changelogs/fix-7397
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Allow super admins all capabilities within WooCommerce Admin

--- a/packages/data/src/user/use-user.js
+++ b/packages/data/src/user/use-user.js
@@ -31,11 +31,11 @@ export const useUser = () => {
 	} );
 
 	const currentUserCan = ( capability ) => {
-		if (
-			userData.user &&
-			userData.user &&
-			userData.user.capabilities[ capability ]
-		) {
+		if ( userData.user && userData.user.is_super_admin ) {
+			return true;
+		}
+
+		if ( userData.user && userData.user.capabilities[ capability ] ) {
 			return true;
 		}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1070,10 +1070,6 @@ class Loader {
 		$user_response     = $user_controller->get_current_item( $request );
 		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
 
-		if ( isset( $current_user_data['id'] ) ) {
-			$current_user_data['is_super_admin'] = is_super_admin( $current_user_data['id'] );
-		}
-
 		$settings['currentUserData']      = $current_user_data;
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );
 		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );
@@ -1262,6 +1258,16 @@ class Loader {
 	 * Registers WooCommerce specific user data to the WordPress user API.
 	 */
 	public static function register_user_data() {
+		register_rest_field(
+			'user',
+			'is_super_admin',
+			array(
+				'get_callback' => function() {
+					return is_super_admin();
+				},
+				'schema'       => null,
+			)
+		);
 		register_rest_field(
 			'user',
 			'woocommerce_meta',

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1070,6 +1070,10 @@ class Loader {
 		$user_response     = $user_controller->get_current_item( $request );
 		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
 
+		if ( isset( $current_user_data['id'] ) ) {
+			$current_user_data['is_super_admin'] = is_super_admin( $current_user_data['id'] );
+		}
+
 		$settings['currentUserData']      = $current_user_data;
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );
 		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );


### PR DESCRIPTION
Fixes #7397 

Adds the super admin check to preloaded user data and passes all capabilities on the front-end.

### Detailed test instructions:

1. Create a multisite and subsite.
2. With the super admin account, attempt to visit the WC Admin dashboard of the subsite.
3. Check that you are now able to see the dashboard.
4. Check that non-super admin users have not regressed and are still capable of seeing pages/sites they have been assigned capabilities for.