### PR TITLE
Fix up onboarding profiler not working when opted out of tracking

### DIFF
--- a/changelogs/fix-7487
+++ b/changelogs/fix-7487
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix up onboarding profiler not working when opted out of tracking

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -31,6 +31,16 @@ class Features {
 	);
 
 	/**
+	 * Beta features
+	 *
+	 * @var array
+	 */
+	protected static $beta_features = array(
+		'navigation',
+		'settings',
+	);
+
+	/**
 	 * Get class instance.
 	 */
 	public static function get_instance() {
@@ -227,7 +237,7 @@ class Features {
 			return;
 		}
 
-		foreach ( self::get_features() as $feature ) {
+		foreach ( self::$beta_features as $feature ) {
 			self::disable( $feature );
 		}
 	}
@@ -315,6 +325,10 @@ class Features {
 			return;
 		}
 		$tracking_enabled = get_option( 'woocommerce_allow_tracking', 'no' );
+
+		if ( empty( self::$beta_features ) ) {
+			return;
+		}
 
 		if ( 'yes' === $tracking_enabled ) {
 			return;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -218,6 +218,18 @@ class Onboarding {
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
+		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
+	}
+
+	/**
+	 * Preload data from the countries endpoint.
+	 *
+	 * @param array $endpoints Array of preloaded endpoints.
+	 * @return array
+	 */
+	public function add_preload_endpoints( $endpoints ) {
+		$endpoints['countries'] = '/wc-analytics/data/countries';
+		return $endpoints;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7487 

The "Analytics" feature housed necessary data to load the onboarding profiler.  This PR:
* Adds the required data to the Onboarding feature so it's not dependent on Analytics
* Only opts out of beta features when toggling off tracking

### Screenshots

<img width="637" alt="Screen Shot 2021-08-09 at 3 18 59 PM" src="https://user-images.githubusercontent.com/10561050/128762334-50562606-b047-436f-b04e-c63daedc625a.png">
<img width="771" alt="Screen Shot 2021-08-09 at 3 18 53 PM" src="https://user-images.githubusercontent.com/10561050/128762338-c185920b-56c1-4695-af49-5c6f4301ad9d.png">

### Detailed test instructions:

1. Opt in to tracking at `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
2. Navigate to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and make sure all features are toggled on.
3. Turn off tracking.
4. Navigate back to the features page and verify that only beta features are turned off (not analytics).
5. Turn off the "Analytics" feature.
6. Navigate to the setup wizard `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
7. Verify that Onboarding still works without the Analytics feature toggled on.