### PR TITLE
Prepare Packages for Publishing

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 8.1.0
+
 -   Fix a bug in the deprecated callback handlers of Form component. #7356
 -   Fix a bug in the `<DateFilter>` component where values were retained when switching between rules #7423
 -   Add `hidden` legend position to `Chart`. #7378

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "8.0.0",
+	"version": "8.1.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 1.5.1
+
 -   Fix animations for collapsible list. #7429
 
 # 1.5.0

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
This bumps the versions and prepares the changelog for the following components:

| Package  | Old Version | New Version |
| --- | --- | --- |
| @woocommerce/components | 8.0.0  | **8.1.0** |
| @woocommerce/experimental  | 1.5.0  | **1.5.1**  |
