### PR TITLE
Add missing ---> tag in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
 
 <!--- Please add a Changelog note
 
-Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
+Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->


### PR DESCRIPTION
I was working on #7481 and noticed that our PR template is missing the closing tag `--->` at the end. This caused my script to pull unexpected comment text.

This PR adds the closing tag to fix the issue.

no changelog needed


