### PR TITLE
Add  a checkbox to include test instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,5 @@ Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
 <!--- Please add a Changelog note
 
 Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
+
+- [ ] Include test instructions in the release


### PR DESCRIPTION
This is part of #7481 

This PR adds a checkbox in the PR template to include test introductions in the release.

no changelog needed
