### PR TITLE
Set default value for orders var

### DIFF
--- a/changelogs/fix-7504-blank-screen-when-actionable-status-are-disabled
+++ b/changelogs/fix-7504-blank-screen-when-actionable-status-are-disabled
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix blank screen by setting a default value
+Fix blank screen by setting a default value #7506

--- a/changelogs/fix-7504-blank-screen-when-actionable-status-are-disabled
+++ b/changelogs/fix-7504-blank-screen-when-actionable-status-are-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix blank screen by setting a default value

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -253,6 +253,7 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 				isError: Boolean(
 					getItemsError( 'orders', actionableOrdersQuery )
 				),
+				orders: [],
 				isRequesting: true,
 				orderStatuses,
 			};

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -227,7 +227,7 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 		} ),
 		[ orderStatuses ]
 	);
-	const { orders, isRequesting, isError } = useSelect( ( select ) => {
+	const { orders = [], isRequesting, isError } = useSelect( ( select ) => {
 		const { getItems, getItemsError, isResolving } = select(
 			ITEMS_STORE_NAME
 		);

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -227,13 +227,13 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 		} ),
 		[ orderStatuses ]
 	);
-	const { orders = [], isRequesting, isError } = useSelect( ( select ) => {
+	const { orders, isRequesting, isError } = useSelect( ( select ) => {
 		const { getItems, getItemsError, isResolving } = select(
 			ITEMS_STORE_NAME
 		);
 
 		if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
-			return { isRequesting: false };
+			return { isRequesting: false, orders: [] };
 		}
 
 		/* eslint-disable @wordpress/no-unused-vars-before-return */

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -227,13 +227,13 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 		} ),
 		[ orderStatuses ]
 	);
-	const { orders, isRequesting, isError } = useSelect( ( select ) => {
+	const { orders = [], isRequesting, isError } = useSelect( ( select ) => {
 		const { getItems, getItemsError, isResolving } = select(
 			ITEMS_STORE_NAME
 		);
 
 		if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
-			return { isRequesting: false, orders: [] };
+			return { isRequesting: false };
 		}
 
 		/* eslint-disable @wordpress/no-unused-vars-before-return */
@@ -253,7 +253,6 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 				isError: Boolean(
 					getItemsError( 'orders', actionableOrdersQuery )
 				),
-				orders: [],
 				isRequesting: true,
 				orderStatuses,
 			};


### PR DESCRIPTION
Fixes #7504 

This PR fixes the blank screen issue by setting default value ([]) to `orders`  variable.


### Detailed test instructions:

1. Checkout this branch
2. Run `npm start`
3. Add a new product and a new order.
4. Go to Analytics->Settings.
5. Disabled all the options for Actionable statuses and save the settings.
6. Go to WooCommerce->Home screen and hide the setup task list if enabled.
7. Click on dropdown arrow button on Orders task.
8. Orders panel should expand as expected. 

