### PR TITLE
Skip scheduling action if Action Scheduler tables have not been set up

### DIFF
--- a/changelogs/fix-7398
+++ b/changelogs/fix-7398
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Skip scheduling action if Action Scheduler tables have not been set up
+Skip scheduling action if Action Scheduler tables have not been set up #7521

--- a/changelogs/fix-7398
+++ b/changelogs/fix-7398
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Skip scheduling action if Action Scheduler tables have not been set up

--- a/src/Schedulers/SchedulerTraits.php
+++ b/src/Schedulers/SchedulerTraits.php
@@ -303,7 +303,11 @@ trait SchedulerTraits {
 			return;
 		}
 
-		if ( apply_filters( 'woocommerce_analytics_disable_action_scheduling', false ) ) {
+		if (
+			// Skip scheduling if Action Scheduler tables have not been initialized.
+			! get_option( 'schema-ActionScheduler_StoreSchema' ) ||
+			apply_filters( 'woocommerce_analytics_disable_action_scheduling', false )
+		) {
 			call_user_func_array( array( static::class, $action_name ), $args );
 			return;
 		}


### PR DESCRIPTION
Fixes #7398 

If a user is deleted on a network site prior to visiting that site, Action Scheduler has not yet set up tables and will error when attempting to schedule an action.

This is a temporary fix in WooCommerce Admin to skip scheduling if those tables have not been set up.

### Screenshots

<img width="439" alt="Screen Shot 2021-08-17 at 12 26 27 PM" src="https://user-images.githubusercontent.com/10561050/129766050-d1f445b0-6f40-488f-a643-d979f00b2f95.png">
<img width="834" alt="Screen Shot 2021-08-17 at 12 30 38 PM" src="https://user-images.githubusercontent.com/10561050/129766051-3d429285-0d3c-433e-9927-94638dd8831b.png">


### Detailed test instructions:

1. Create a multi-site and network enable WC 5.5 and optionally add (WC admin 2.5 beta 2)
2. Go to Network admin > Users and create a new user.
3. Create a new subsite in Network admin > Sites and assign the new user.
4. Go to Network admin > Users and delete the user with the option "Delete all content." selected.
5. Note that the user is deleted without issue.
6. Repeat the above process on an existing site with Action Scheduler tables.
7. Quickly check the scheduled actions under Tools -> Scheduled Actions to make sure that the action was scheduled and not directly run.