### PR TITLE
Add missing single quote

### DIFF
--- a/src/Notes/NeedSomeInspiration.php
+++ b/src/Notes/NeedSomeInspiration.php
@@ -60,7 +60,7 @@ class NeedSomeInspiration {
 		$note->add_action(
 			'need-some-inspiration',
 			__( 'See success stories', 'woocommerce-admin' ),
-			'https://woocommerce.com/success-stories/?utm_source=inbox&utm_medium=product
+			'https://woocommerce.com/success-stories/?utm_source=inbox&utm_medium=product',
 			true
 		);
 		return $note;


### PR DESCRIPTION
Fixes #7523 

This PR adds missing `'` to fix the PHP parse error.


### Detailed test instructions:

1. Run `wc_admin_daily` corn job
2. Make sure there is no error from NeedSomeInspiration class.

no changelog