### PR TITLE
Fix broken PHP linter workflow

### DIFF
--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -4,7 +4,7 @@ PHP_FILES_CHANGED=""
 for FILE in $(echo $CHANGED_FILES | tr ',' '\n')
 do
 	if [[ $FILE =~ ".php" ]]; then
-		$PHP_FILES_CHANGED += "$FILE,"
+		PHP_FILES_CHANGED+="$FILE,"
 	fi	
 done
 

--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -4,7 +4,7 @@ PHP_FILES_CHANGED=""
 for FILE in $(echo $CHANGED_FILES | tr ',' '\n')
 do
 	if [[ $FILE =~ ".php" ]]; then
-		PHP_FILES_CHANGED+="$FILE,"
+		PHP_FILES_CHANGED+="$FILE "
 	fi	
 done
 


### PR DESCRIPTION
Fixes #7525 

This PR fixes broken PHP lint workflow.

### Detailed test instructions:

1. Set CHANGED_FILES variable by running `export CHANGED_FILES=src/Loader.php`. 
2. Run `./bin/phpcs.sh`. You should not see an error from phpcs. 

no changelog