### PR TITLE
Add Marketplace and My Subscriptions to the new WooCommerce Navigation.

### DIFF
--- a/changelogs/new-7529-marketplace-nav-items
+++ b/changelogs/new-7529-marketplace-nav-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Tweak
+
+Add navigation items for the Marketplace menu. #7529

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -110,10 +110,10 @@ class CoreMenu {
 				'order' => 40,
 			),
 			array(
-				'title'      => __( 'Marketplace', 'woocommerce-admin' ),
-				'id'         => 'woocommerce-marketplace',
-				'menuId'     => 'secondary',
-				'order'      => 10,
+				'title'  => __( 'Marketplace', 'woocommerce-admin' ),
+				'id'     => 'woocommerce-marketplace',
+				'menuId' => 'secondary',
+				'order'  => 10,
 			),
 			array(
 				'title'  => __( 'Settings', 'woocommerce-admin' ),

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -110,6 +110,12 @@ class CoreMenu {
 				'order' => 40,
 			),
 			array(
+				'title'      => __( 'Marketplace', 'woocommerce-admin' ),
+				'id'         => 'woocommerce-marketplace',
+				'menuId'     => 'secondary',
+				'order'      => 10,
+			),
+			array(
 				'title'  => __( 'Settings', 'woocommerce-admin' ),
 				'id'     => 'woocommerce-settings',
 				'menuId' => 'secondary',
@@ -218,16 +224,9 @@ class CoreMenu {
 				),
 				array_merge( $product_items['new'], array( 'order' => 50 ) ),
 				$coupon_items['default'],
-				// Marketplace category.
-				array(
-					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
-					'capability' => 'manage_woocommerce',
-					'id'         => 'woocommerce-marketplace',
-					'url'        => 'wc-addons',
-					'menuId'     => 'secondary',
-					'order'      => 10,
-				),
 			),
+			// Marketplace category.
+			self::get_marketplace_items(),
 			// Tools category.
 			self::get_tool_items(),
 			// WooCommerce Admin items.
@@ -240,9 +239,37 @@ class CoreMenu {
 	}
 
 	/**
+	 * Get marketplace menu items.
+	 *
+	 * @return array
+	 */
+	public static function get_marketplace_items() {
+		return array(
+			array(
+				'parent'     => 'woocommerce-marketplace',
+				'title'      => __( 'Browse', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'marketplace-browse',
+				'url'        => 'admin.php?page=wc-addons',
+				'migrate'    => false,
+				'order'      => 0,
+			),
+			array(
+				'parent'     => 'woocommerce-marketplace',
+				'title'      => __( 'My Subscriptions', 'woocommerce-admin' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'marketplace-my-subscriptions',
+				'url'        => 'admin.php?page=wc-addons&section=helper',
+				'migrate'    => false,
+				'order'      => 1,
+			),
+		);
+	}
+
+	/**
 	 * Get items for tools category.
 	 *
-	 * @returna array
+	 * @return array
 	 */
 	public static function get_tool_items() {
 		$tabs = array(
@@ -391,6 +418,8 @@ class CoreMenu {
 			'wc-reports',
 			'wc-settings',
 			'wc-status',
+			'wc-addons',
+			'wc-addons&section=helper',
 		);
 
 		return apply_filters( 'woocommerce_navigation_core_excluded_items', $excluded_items );


### PR DESCRIPTION
We're redesigning the WooCommerce Extensions page in WooCommerce core, and this requires splitting it into two separate menu items - Marketplace and My Subscriptions.

We've previously connected these pages in #7471 but now we also need to add them to the new navigation, as it's already used on some WordPress.com Business plan sites.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![](https://d.pr/i/ehIHs9+)

![](https://d.pr/i/nM2JF1+)

### Detailed test instructions:

- Make sure that `navigation` feature is enabled (i.e. by adding this snippet on your test site):

```
add_filter( 'woocommerce_admin_features', 'enable_new_woocommerce_navigation' );

function enable_new_woocommerce_navigation( $features ) {
	$features[] = 'navigation';
	return $features;
}
```
- in **WooCommerce > Settings > Advanced > Features** enable **Navigation**
- observe there's a new top-level menu called Marketplace with two items: Browse and My Subscriptions
- make sure the items link to their respective pages and everything looks good on all screen sizes.
<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
