### PR TITLE
Update Packages for Publishing

### DIFF
--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/explat",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "WooCommerce component and utils for A/B testing.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
--   Update WCPayCard CSS to handle @wordpress/card updates. #7412
+# 2.2.0
 
+-   Update WCPayCard CSS to handle @wordpress/card updates. #7412
 # 2.1.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/onboarding",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Onboarding utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bumps version numbers for the `explat` and `onboarding` packages ahead of publishing to npm.

No changelog.