### PR TITLE
Update Packages for Publishing

### DIFF
--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.2
+
+- Fix missing build-module folder
 # 1.1.1
 
 - Update add woo_country_code param when fetching an assignment #7533

--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/explat",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "WooCommerce component and utils for A/B testing.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 2.2.1
+
+-   Fix missing build-module folder
 # 2.2.0
 
 -   Update WCPayCard CSS to handle @wordpress/card updates. #7412

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/onboarding",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "Onboarding utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
In PR #7534, packages were published without a `build-module` folder.

This bumps the versions to re-publish the `explat` and `onboarding` packages.

 The publish script will be run from a fresh clone of the wc-admin repo this time, which has been confirmed to create the `build-module` folder correctly.
 
 No changelog.