### PR TITLE
Create snooze task endpoint 

### DIFF
--- a/changelogs/add-7368-tasks-snooze-endpoint
+++ b/changelogs/add-7368-tasks-snooze-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Adding endpoint to snooze onboarding task

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -742,9 +742,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$is_dismissable = false;
 
-		$dismiss_task = OnboardingTasksFeature::get_task_by_id( $id );
+		$task = OnboardingTasksFeature::get_task_by_id( $id );
 
-		if ( $dismiss_task && isset( $dismiss_task['isDismissable'] ) && $dismiss_task['isDismissable'] ) {
+		if ( $task && isset( $task['isDismissable'] ) && $task['isDismissable'] ) {
 			$is_dismissable = true;
 		}
 

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -813,11 +813,14 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$snooze_option = get_option( 'woocommerce_task_list_remind_me_later_tasks' );
 		$duration      = is_null( $snooze_duration ) ? 'day' : $snooze_duration;
+		$snoozed_until = $this->duration_to_ms[ $duration ] + ( time() * 1000 );
 
-		$snooze_option[ $task_id ] = $this->duration_to_ms[ $duration ];
+		$snooze_option[ $task_id ] = $snoozed_until;
 
 		update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
-		$snooze_task['isSnoozed'] = true;
+
+		$snooze_task['isSnoozed']    = true;
+		$snooze_task['snoozedUntil'] = $snoozed_until;
 
 		return rest_ensure_response( $snooze_task );
 	}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -821,7 +821,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$snooze_option[ $task_id ] = $snoozed_until;
 
-		update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
+		$update = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
+
+		if ( $update ) {
+			wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $task_id ) );
+		}
 
 		$snooze_task['isSnoozed']    = true;
 		$snooze_task['snoozedUntil'] = $snoozed_until;

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -742,14 +742,10 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$is_dismissable = false;
 
-		foreach ( OnboardingTasksFeature::get_task_lists() as $task_list ) {
-			foreach ( $task_list['tasks'] as $task ) {
-				// @todo Use the reusable methods to get the task introduced in https://github.com/woocommerce/woocommerce-admin/pull/7539
-				if ( $id === $task['id'] && isset( $task['isDismissable'] ) && $task['isDismissable'] ) {
-					$is_dismissable = true;
-					break;
-				}
-			}
+		$dismiss_task = OnboardingTasksFeature::get_task_by_id( $id );
+
+		if ( $dismiss_task && isset( $dismiss_task['isDismissable'] ) && $dismiss_task['isDismissable'] ) {
+			$is_dismissable = true;
 		}
 
 		if ( ! $is_dismissable ) {
@@ -820,8 +816,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$snoozed_until = $this->duration_to_ms[ $duration ] + ( time() * 1000 );
 
 		$snooze_option[ $task_id ] = $snoozed_until;
-
-		$update = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
+		$update                    = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
 
 		if ( $update ) {
 			wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $task_id ) );

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -154,11 +154,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			'/' . $this->rest_base . '/(?P<id>[a-z0-9_-]+)/snooze',
 			array(
 				'args'   => array(
-					'task_id'      => array(
-						'description' => __( 'Unique ID for the resource.', 'woocommerce-admin' ),
-						'type'        => 'string',
-						'required'    => true,
-					),
 					'duration'     => array(
 						'description'       => __( 'Time period to snooze the task.', 'woocommerce-admin' ),
 						'type'              => 'string',
@@ -798,7 +793,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function snooze_task( $request ) {
 
-		$task_id         = $request->get_param( 'task_id' );
+		$task_id         = $request->get_param( 'id' );
 		$task_list_id    = $request->get_param( 'task_list_id' );
 		$snooze_duration = $request->get_param( 'duration' );
 

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -39,9 +39,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @var string
 	 */
 	protected $duration_to_ms = array(
-		'day'  => 24 * 60 * 60 * 1000,
-		'hour' => 60 * 60 * 1000,
-		'week' => 7 * 24 * 60 * 60 * 1000,
+		'day'  => DAY_IN_SECONDS * 1000,
+		'hour' => HOUR_IN_SECONDS * 1000,
+		'week' => WEEK_IN_SECONDS * 1000,
 	);
 
 	/**

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -802,12 +802,18 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$task_list_id    = $request->get_param( 'task_list_id' );
 		$snooze_duration = $request->get_param( 'duration' );
 
+		$is_snoozeable = false;
+
 		$snooze_task = OnboardingTasksFeature::get_task_by_id( $task_id, $task_list_id );
 
-		if ( is_null( $snooze_task ) ) {
+		if ( $snooze_task && isset( $snooze_task['isSnoozeable'] ) && $snooze_task['isSnoozeable'] ) {
+			$is_snoozeable = true;
+		}
+
+		if ( ! $is_snoozeable ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
-				__( 'You must provide a valid task ID', 'woocommerce-admin' )
+				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' )
 			);
 		}
 

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -808,11 +808,14 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $is_snoozeable ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
-				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' )
+				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
+				array(
+					'status' => 404,
+				)
 			);
 		}
 
-		$snooze_option = get_option( 'woocommerce_task_list_remind_me_later_tasks' );
+		$snooze_option = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
 		$duration      = is_null( $snooze_duration ) ? 'day' : $snooze_duration;
 		$snoozed_until = $this->duration_to_ms[ $duration ] + ( time() * 1000 );
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -741,7 +741,7 @@ class OnboardingTasks {
 	 *
 	 * @return Object
 	 */
-	public static function get_task_by_id( $task_id, $task_list_id ) {
+	public static function get_task_by_id( $task_id, $task_list_id = null ) {
 
 		$task_list = $task_list_id ? self::get_task_list_by_id( $task_list_id ) : null;
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -50,6 +50,7 @@ class OnboardingTasks {
 		add_action( 'update_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_option_extended_task_list' ), 15 );
 		add_action( 'woocommerce_admin_onboarding_tasks', array( $this, 'add_task_dismissal' ), 20 );
+		add_action( 'woocommerce_admin_onboarding_tasks', array( $this, 'add_task_snoozed' ), 20 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -785,5 +786,27 @@ class OnboardingTasks {
 		}
 
 		return $task_lists;
+	}
+
+	/**
+	 * Add the snoozed status to each task.
+	 *
+	 * @param array $task_lists Task lists.
+	 * @return array
+	 */
+	public function add_task_snoozed( $task_lists ) {
+		$snoozed_tasks = get_option( 'woocommerce_task_list_remind_me_later_tasks' );
+
+		foreach ( $task_lists as $task_list_key => $task_list ) {
+			foreach ( $task_list['tasks'] as $task_key => $task ) {
+				if ( in_array( $task['id'], array_keys( $snoozed_tasks ), true ) ) {
+					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['isSnoozed']    = true;
+					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['snoozedUntil'] = $snoozed_tasks[ $task['id'] ];
+				}
+			}
+		}
+
+		return $task_lists;
+
 	}
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -800,7 +800,7 @@ class OnboardingTasks {
 		foreach ( $task_lists as $task_list_key => $task_list ) {
 			foreach ( $task_list['tasks'] as $task_key => $task ) {
 				if ( isset( $task['isSnoozeable'] ) && in_array( $task['id'], array_keys( $snoozed_tasks ), true ) ) {
-					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['isSnoozed']    = true;
+					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['isSnoozed']    = $snoozed_tasks[ $task['id'] ] > ( time() * 1000 );
 					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['snoozedUntil'] = $snoozed_tasks[ $task['id'] ];
 				}
 			}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -799,7 +799,7 @@ class OnboardingTasks {
 
 		foreach ( $task_lists as $task_list_key => $task_list ) {
 			foreach ( $task_list['tasks'] as $task_key => $task ) {
-				if ( in_array( $task['id'], array_keys( $snoozed_tasks ), true ) ) {
+				if ( isset( $task['isSnoozeable'] ) && in_array( $task['id'], array_keys( $snoozed_tasks ), true ) ) {
 					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['isSnoozed']    = true;
 					$task_lists[ $task_list_key ]['tasks'][ $task_key ]['snoozedUntil'] = $snoozed_tasks[ $task['id'] ];
 				}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -717,6 +717,57 @@ class OnboardingTasks {
 	}
 
 	/**
+	 * Retrieve a task list by ID.
+	 *
+	 * @param String $task_list_id Task list ID.
+	 *
+	 * @return Object
+	 */
+	public static function get_task_list_by_id( $task_list_id ) {
+		foreach ( self::get_task_lists() as $task_list ) {
+			if ( $task_list['id'] === $task_list_id ) {
+				return $task_list;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieve single task.
+	 *
+	 * @param String $task_id Task ID.
+	 * @param String $task_list_id Task list ID.
+	 *
+	 * @return Object
+	 */
+	public static function get_task_by_id( $task_id, $task_list_id ) {
+
+		$task_list = $task_list_id ? self::get_task_list_by_id( $task_list_id ) : null;
+
+		if ( $task_list_id && ! $task_list ) {
+			return null;
+		}
+
+		$tasks_to_search = $task_list_id ? $task_list['tasks'] : array_reduce(
+			self::get_task_lists(),
+			function ( $all, $curr ) {
+
+				return array_merge( $all, $curr['tasks'] );
+			},
+			array()
+		);
+
+		foreach ( $tasks_to_search as $task ) {
+			if ( $task_id === $task['id'] ) {
+				return $task;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Add the dismissal status to each task.
 	 *
 	 * @param array $task_lists Task lists.

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -750,10 +750,9 @@ class OnboardingTasks {
 			return null;
 		}
 
-		$tasks_to_search = $task_list_id ? $task_list['tasks'] : array_reduce(
+		$tasks_to_search = $task_list ? $task_list['tasks'] : array_reduce(
 			self::get_task_lists(),
 			function ( $all, $curr ) {
-
 				return array_merge( $all, $curr['tasks'] );
 			},
 			array()

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -795,7 +795,7 @@ class OnboardingTasks {
 	 * @return array
 	 */
 	public function add_task_snoozed( $task_lists ) {
-		$snoozed_tasks = get_option( 'woocommerce_task_list_remind_me_later_tasks' );
+		$snoozed_tasks = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
 
 		foreach ( $task_lists as $task_list_key => $task_list ) {
 			foreach ( $task_list['tasks'] as $task_key => $task ) {


### PR DESCRIPTION
Fixes #7368

**Add Endpoint**:
`POST - /wc-admin/onboarding/tasks/<task_id>/snooze`

**Parameters:**
- `duration`: Optional, currently supports `day|hour|week`, and defaults to `day`
- `task_list_id`: Optional, constrains search to specific task list

**Response**
Currently returns an error if the task does not exist, or the modified task definition. 


**Notes:**
- Also adding `isSnoozed` and `snoozedUntil` properties to the task definitions returned by `GET /wc-admin/onboarding/tasks`
- ~~Haven't implemented tracks yet (I'll be able to get this done early Monday)~~

### Detailed test instructions:

-   Checkout branch
-   Use a tools such as PostMan to send a request to `POST - /wc-admin/onboarding/tasks/invalid-task/snooze`
- Confirm that an error response is returned
- Now take a valid task ID and do the same request to `POST - /wc-admin/onboarding/tasks/<task_id>/snooze`
- Ensure that it returns the modified task definition with valid `isSnoozed` and `snoozedUntil` properties.
- Make a request to `GET - /wc-admin/onboarding/tasks` and check the definition of that task to ensure those properties are present and valid.

