### PR TITLE
Add explat variation for wc pay promotion

### DIFF
--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -1,5 +1,8 @@
 <?php
 /**
+ * NOTE: this is a temporary class and can be replaced by jetpack-abtest after
+ * https://github.com/Automattic/jetpack/issues/19596 has been fixed.
+ *
  * A class that interacts with Explat A/B tests.
  *
  * This class is experimental. It is a fork of the jetpack-abtest package and

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * A class that interacts with Explat A/B tests.
+ *
+ * This class is experimental. It is a fork of the jetpack-abtest package and
+ * updated for use with ExPlat. These changes are planned to be contributed
+ * back to the upstream Jetpack package. If accepted, this class should then
+ * be superseded by the Jetpack class using Composer.
+ *
+ * This class should not be used externally.
+ *
+ * @package WooCommerce\Admin
+ * @link https://packagist.org/packages/automattic/jetpack-abtest
+ */
+
+namespace WooCommerce\Admin;
+
+/**
+ * This class provides an interface to the Explat A/B tests.
+ *
+ * @internal This class is experimental and should not be used externally due to planned breaking changes.
+ */
+final class Experimental_Abtest {
+
+	/**
+	 * A variable to hold the tests we fetched, and their variations for the current user.
+	 *
+	 * @var array
+	 */
+	private $tests = array();
+
+	/**
+	 * ExPlat Anonymous ID.
+	 *
+	 * @var string
+	 */
+	private $anon_id = null;
+
+	/**
+	 * ExPlat Platform name.
+	 *
+	 * @var string
+	 */
+	private $platform = 'woocommerce';
+
+	/**
+	 * Whether trcking consent is given.
+	 *
+	 * @var bool
+	 */
+	private $consent = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $anon_id ExPlat anonymous ID.
+	 * @param string $platform ExPlat platform name.
+	 * @param bool   $consent Whether tracking consent is given.
+	 */
+	public function __construct( string $anon_id, string $platform, bool $consent ) {
+		$this->anon_id  = $anon_id;
+		$this->platform = $platform;
+		$this->consent  = $consent;
+	}
+
+	/**
+	 * Retrieve the test variation for a provided A/B test.
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return mixed|null A/B test variation, or null on failure.
+	 */
+	public function get_variation( $test_name ) {
+		// Default to the control variation when users haven't consented to tracking.
+		if ( ! $this->consent ) {
+			return 'control';
+		}
+
+		$variation = $this->fetch_variation( $test_name );
+
+		// If there was an error retrieving a variation, conceal the error for the consumer.
+		if ( is_wp_error( $variation ) ) {
+			return 'control';
+		}
+
+		return $variation;
+	}
+
+	/**
+	 * Fetch and cache the test variation for a provided A/B test from WP.com.
+	 *
+	 * ExPlat returns a null value when the assigned variation is control or
+	 * an assignment has not been set. In these instances, this method returns
+	 * a value of "control".
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return array|\WP_Error A/B test variation, or error on failure.
+	 */
+	protected function fetch_variation( $test_name ) {
+		// Make sure test name exists.
+		if ( ! $test_name ) {
+			return new \WP_Error( 'test_name_not_provided', 'A/B test name has not been provided.' );
+		}
+
+		// Make sure test name is a valid one.
+		if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $test_name ) ) {
+			return new \WP_Error( 'invalid_test_name', 'Invalid A/B test name.' );
+		}
+
+		// Return internal-cached test variations.
+		if ( isset( $this->tests[ $test_name ] ) ) {
+			return $this->tests[ $test_name ];
+		}
+
+		// Return external-cached test variations.
+		if ( ! empty( get_transient( 'abtest_variation_' . $test_name ) ) ) {
+			return get_transient( 'abtest_variation_' . $test_name );
+		}
+
+		// Make the request to the WP.com API.
+		$response = $this->request_variation( $test_name );
+
+		// Bail if there was an error or malformed response.
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return new \WP_Error( 'failed_to_fetch_data', 'Unable to fetch the requested data.' );
+		}
+
+		// Decode the results.
+		$results = json_decode( $response['body'], true );
+
+		// Bail if there were no results or there is no test variation returned.
+		if ( ! is_array( $results ) || empty( $results['variations'] ) ) {
+			return new \WP_Error( 'unexpected_data_format', 'Data was not returned in the expected format.' );
+		}
+
+		// Store the variation in our internal cache.
+		$this->tests[ $test_name ] = $results['variations'][ $test_name ];
+
+		$variation = $results['variations'][ $test_name ] ?? 'control';
+
+		// Store the variation in our external cache.
+		if ( ! empty( $results['ttl'] ) ) {
+			set_transient( 'abtest_variation_' . $test_name, $variation, $results['ttl'] );
+		}
+
+		return $variation;
+	}
+
+	/**
+	 * Perform the request for a variation of a provided A/B test from WP.com.
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return array|\WP_Error A/B test variation error on failure.
+	 */
+	protected function request_variation( $test_name ) {
+		$args = array(
+			'experiment_name' => $test_name,
+			'anon_id'         => $this->anon_id,
+		);
+
+		$url = add_query_arg(
+			$args,
+			sprintf(
+				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/%s',
+				$this->platform
+			)
+		);
+
+		$get = wp_remote_get( $url );
+
+		return $get;
+	}
+}
+

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -68,6 +68,7 @@ class FeaturePlugin {
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/wc-admin-update-functions.php';
+		require_once WC_ADMIN_ABSPATH . '/includes/class-experimental-abtest.php';
 
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
 		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );

--- a/src/Features/WcPayPromotion/DataSourcePoller.php
+++ b/src/Features/WcPayPromotion/DataSourcePoller.php
@@ -124,7 +124,7 @@ class DataSourcePoller {
 	 */
 	private static function merge_specs( $specs_to_merge_in, &$specs ) {
 		foreach ( $specs_to_merge_in as $spec ) {
-			$id           = $spec->product;
+			$id           = $spec->id;
 			$specs[ $id ] = $spec;
 		}
 	}

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -101,7 +101,7 @@ class Init {
 		}
 		$wc_pay_spec = self::get_wc_pay_promotion_spec();
 
-		if ( ! $wc_pay_spec || ! isset( $wc_pay_spec->additional_info ) ) {
+		if ( ! $wc_pay_spec || ! isset( $wc_pay_spec->additional_info ) || ! isset( $wc_pay_spec->additional_info->experiment_version ) ) {
 			return false;
 		}
 

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -104,7 +104,22 @@ class Init {
 		if ( ! $wc_pay_spec ) {
 			return false;
 		}
-		return true;
+
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : null;
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
+			$anon_id,
+			'woocommerce',
+			$allow_tracking
+		);
+
+		$variation_name = $abtest->get_variation( 'woocommerce_wc_pay_promotion_payment_methods_table_' . $wc_pay_spec->version );
+
+		if ( 'treatment' === $variation_name ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -101,7 +101,7 @@ class Init {
 		}
 		$wc_pay_spec = self::get_wc_pay_promotion_spec();
 
-		if ( ! $wc_pay_spec ) {
+		if ( ! $wc_pay_spec || ! isset( $wc_pay_spec->additional_info ) ) {
 			return false;
 		}
 
@@ -113,7 +113,7 @@ class Init {
 			$allow_tracking
 		);
 
-		$variation_name = $abtest->get_variation( 'woocommerce_wc_pay_promotion_payment_methods_table_' . $wc_pay_spec->version );
+		$variation_name = $abtest->get_variation( 'woocommerce_wc_pay_promotion_payment_methods_table_' . $wc_pay_spec->additional_info->experiment_version );
 
 		if ( 'treatment' === $variation_name ) {
 			return true;


### PR DESCRIPTION
Changes for #7319 

Adds an experimental ab test class to allow running explat experiments in PHP, this is temporary and will be replace by a Jetpack library once Jetpack has been updated. I talked with @adrianduffell about this (same is happening on WC Pay at the moment).
Making use of the experiment in the WC Pay promotion.

No changelog added, as it will be in the final PR enabling it on all environments.

### Detailed test instructions:

*Make sure you don't have WooCommerce Payments installed or enabled.
*Make sure you have logging enabled

- Have a local version of woocommerce.com running using the branch of this PR (`add/payment-method-recommendation-endpoint`) -> 11084-gh-Automattic/woocommerce.com
- Change the url in the [`DataSourcePoller.php`](https://github.com/woocommerce/woocommerce-admin/blob/feature/7319_add_woocommerce_com_data/src/Features/WCPayPromotion/DataSourcePoller.php#L24) to point to your local version with to `http://woocommerce.test` or using your local ip might work as well - `http://192....`
you might have to remove the `woocommerce_admin_payment_method_promotion_specs` transient.
- To test this locally, pre-fix the experiment name with `explat_test_v3_` [here](https://github.com/woocommerce/woocommerce-admin/blob/feature/7319_add_explat_logic/src/Features/WCPayPromotion/Init.php#L113) so it reads - `explat_test_v3_woocommerce_wc_pay_promotion_payment_methods_table_`
- It should default to `control`, meaning the WooCommerce Payments should not be displayed in the payment method table in **WooCommerce > Settings > Payments**
- Now go to the [Abacus experiment](https://experiments.a8c.com/experiments/20286-explat-test-v3-woocommerce-wc-pay-promotion-payment-methods-table-v1/overview) and add the treatment bookmarklet to your bookmarks ([instructions](https://github.com/Automattic/experimentation-platform/wiki/Experimenter's-Guide#using-the-abacus-assignment-bookmarklet))
- Go back to you local instance and click on the treatment bookmarklet, a pop up should appear with a success message
- Now remove the `abtest_variation_explat_test_v3_woocommerce_wc_pay_promotion_payment_methods_table_v1` transient, you can use `wp transient delete ...`
- Refresh the **WooCommerce > Settings > Payments** page, the treatment experiment should be activated now and WooCommerce Payments displayed in the payment method table with the install button. 

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
