### PR TITLE
Add task list components to consume task list REST API

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -122,7 +122,7 @@ export const Layout = ( {
 		if ( window.wcAdminFeatures && window.wcAdminFeatures.tasks ) {
 			return (
 				<Suspense fallback={ <TasksPlaceholder query={ query } /> }>
-					<Tasks />
+					<Tasks query={ query } />
 				</Suspense>
 			);
 		}

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -2,9 +2,14 @@
  * External dependencies
  */
 import { __, _n } from '@wordpress/i18n';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
-import { ONBOARDING_STORE_NAME, useDispatch } from '@wordpress/data';
+import {
+	getHistory,
+	getNewPath,
+	updateQueryString,
+} from '@woocommerce/navigation';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { TaskItem } from '@woocommerce/experimental';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,18 +24,38 @@ export type TaskListItemProps = {
 	task: TaskProps;
 };
 
-export const TaskListItem: React.FC< TaskListItemProps > = ( { isExpandable = false, isExpanded = false, setExpandedTask, task } ) => {
+export const TaskListItem: React.FC< TaskListItemProps > = ( {
+	isExpandable = false,
+	isExpanded = false,
+	setExpandedTask,
+	task,
+} ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { dismissTask, snoozeTask, undoDismissTask, undoSnoozeTask } = useDispatch( ONBOARDING_STORE_NAME );
-	const { actionLabel, actionUrl, content, id, isComplete, isDismissable, isSnoozable, time, title,  } = task;
+	const {
+		dismissTask,
+		snoozeTask,
+		undoDismissTask,
+		undoSnoozeTask,
+	} = useDispatch( ONBOARDING_STORE_NAME );
+	const {
+		actionLabel,
+		actionUrl,
+		content,
+		id,
+		isComplete,
+		isDismissable,
+		isSnoozable,
+		time,
+		title,
+	} = task;
 
-	const onDismiss = ( { key, onDismiss } ) => {
+	const onDismiss = () => {
 		dismissTask();
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
 					label: __( 'Undo', 'woocommerce-admin' ),
-					onClick: () => undoDismissTask( key ),
+					onClick: () => undoDismissTask( id ),
 				},
 			],
 		} );
@@ -53,14 +78,17 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( { isExpandable = fa
 	};
 
 	const onClick = () => {
-		if ( actionUrl.startsWith( 'http' ) ) {
-			window.location = actionUrl;
-		} else {
-			getHistory().push(
-				getNewPath( {}, actionUrl, {} )
-			);
+		if ( actionUrl ) {
+			if ( actionUrl.startsWith( 'http' ) ) {
+				window.location.href = actionUrl;
+			} else {
+				getHistory().push( getNewPath( {}, actionUrl, {} ) );
+			}
+			return;
 		}
-	}
+
+		updateQueryString( { task: id } );
+	};
 
 	return (
 		<TaskItem

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	getHistory,
 	getNewPath,

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -1,0 +1,12 @@
+export type TaskListItemProps = {
+	isExpandable: boolean;
+	isExpanded: boolean;
+	setExpandedTask: ( id: string ) => void;
+	task: {
+		id: string;
+	};
+};
+
+export const TaskListItem: React.FC< TaskListItemProps > = ( { task } ) => (
+	<div>Task list item: { task.id }</div>
+);

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -121,6 +121,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 			return;
 		}
 
+		window.document.documentElement.scrollTop = 0;
 		updateQueryString( { task: id } );
 	};
 

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -7,22 +7,26 @@ import {
 	getNewPath,
 	updateQueryString,
 } from '@woocommerce/navigation';
-import { ONBOARDING_STORE_NAME, useUserPreferences } from '@woocommerce/data';
+import {
+	ONBOARDING_STORE_NAME,
+	TaskType,
+	useUserPreferences,
+} from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskItem } from '@woocommerce/experimental';
+import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { TaskProps } from './task-list';
 import './task-list.scss';
 
 export type TaskListItemProps = {
 	isExpandable: boolean;
 	isExpanded: boolean;
 	setExpandedTask: ( id: string ) => void;
-	task: TaskProps;
+	task: TaskType;
 };
 
 export const TaskListItem: React.FC< TaskListItemProps > = ( {
@@ -52,7 +56,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		title,
 	} = task;
 
-	const onDismiss = () => {
+	const onDismiss = useCallback( () => {
 		dismissTask();
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
@@ -62,9 +66,9 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				},
 			],
 		} );
-	};
+	}, [ id ] );
 
-	const onSnooze = () => {
+	const onSnooze = useCallback( () => {
 		snoozeTask();
 		createNotice(
 			'success',
@@ -78,7 +82,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				],
 			}
 		);
-	};
+	}, [ id ] );
 
 	const getTaskStartedCount = () => {
 		const trackedStartedTasks =
@@ -103,7 +107,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		} );
 	};
 
-	const onClick = () => {
+	const onClick = useCallback( () => {
 		recordEvent( 'tasklist_click', {
 			task_name: id,
 		} );
@@ -123,7 +127,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 
 		window.document.documentElement.scrollTop = 0;
 		updateQueryString( { task: id } );
-	};
+	}, [ id, isComplete, actionUrl ] );
 
 	return (
 		<TaskItem

--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -1,12 +1,85 @@
+/**
+ * External dependencies
+ */
+import { __, _n } from '@wordpress/i18n';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { ONBOARDING_STORE_NAME, useDispatch } from '@wordpress/data';
+import { TaskItem } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import { TaskProps } from './task-list';
+import './task-list.scss';
+
 export type TaskListItemProps = {
 	isExpandable: boolean;
 	isExpanded: boolean;
 	setExpandedTask: ( id: string ) => void;
-	task: {
-		id: string;
-	};
+	task: TaskProps;
 };
 
-export const TaskListItem: React.FC< TaskListItemProps > = ( { task } ) => (
-	<div>Task list item: { task.id }</div>
-);
+export const TaskListItem: React.FC< TaskListItemProps > = ( { isExpandable = false, isExpanded = false, setExpandedTask, task } ) => {
+	const { createNotice } = useDispatch( 'core/notices' );
+	const { dismissTask, snoozeTask, undoDismissTask, undoSnoozeTask } = useDispatch( ONBOARDING_STORE_NAME );
+	const { actionLabel, actionUrl, content, id, isComplete, isDismissable, isSnoozable, time, title,  } = task;
+
+	const onDismiss = ( { key, onDismiss } ) => {
+		dismissTask();
+		createNotice( 'success', __( 'Task dismissed' ), {
+			actions: [
+				{
+					label: __( 'Undo', 'woocommerce-admin' ),
+					onClick: () => undoDismissTask( key ),
+				},
+			],
+		} );
+	};
+
+	const onSnooze = () => {
+		snoozeTask();
+		createNotice(
+			'success',
+			__( 'Task postponed until tomorrow', 'woocommerce-admin' ),
+			{
+				actions: [
+					{
+						label: __( 'Undo', 'woocommerce-admin' ),
+						onClick: () => undoSnoozeTask( id ),
+					},
+				],
+			}
+		);
+	};
+
+	const onClick = () => {
+		if ( actionUrl.startsWith( 'http' ) ) {
+			window.location = actionUrl;
+		} else {
+			getHistory().push(
+				getNewPath( {}, actionUrl, {} )
+			);
+		}
+	}
+
+	return (
+		<TaskItem
+			key={ id }
+			title={ title }
+			completed={ isComplete }
+			content={ content }
+			onClick={
+				! isExpandable || isComplete
+					? onClick
+					: () => setExpandedTask( id )
+			}
+			expandable={ isExpandable }
+			expanded={ isExpandable && isExpanded }
+			onDismiss={ isDismissable && onDismiss }
+			remindMeLater={ isSnoozable && onSnooze }
+			time={ time }
+			action={ onClick }
+			actionLabel={ actionLabel }
+		/>
+	);
+};

--- a/client/tasks/task-list-menu.tsx
+++ b/client/tasks/task-list-menu.tsx
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { EllipsisMenu } from '@woocommerce/components';
-import { ONBOARDING_STORE_NAME, useDispatch } from '@wordpress/data';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { useDispatch } from '@wordpress/data';
 
 export type TaskListMenuProps = {
 	id: string;

--- a/client/tasks/task-list-menu.tsx
+++ b/client/tasks/task-list-menu.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { EllipsisMenu } from '@woocommerce/components';
+import { ONBOARDING_STORE_NAME, useDispatch } from '@wordpress/data';
+
+export type TaskListMenuProps = {
+	id: string;
+};
+
+export const TaskListMenu: React.FC< TaskListMenuProps > = ( { id } ) => {
+	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
+
+	return (
+		<div className="woocommerce-card__menu woocommerce-card__header-item">
+			<EllipsisMenu
+				label={ __( 'Task List Options', 'woocommerce-admin' ) }
+				renderContent={ () => (
+					<div className="woocommerce-task-card__section-controls">
+						<Button onClick={ () => hideTaskList( id ) }>
+							{ __( 'Hide this', 'woocommerce-admin' ) }
+						</Button>
+					</div>
+				) }
+			/>
+		</div>
+	);
+};

--- a/client/tasks/task-list.scss
+++ b/client/tasks/task-list.scss
@@ -1,0 +1,24 @@
+.woocommerce-task-list__item {
+	overflow: hidden;
+	&.woocommerce-list__item-enter {
+		opacity: 0;
+		max-height: 0;
+	}
+
+	&.woocommerce-list__item-enter-active {
+		opacity: 1;
+		max-height: 100px;
+		transition: opacity 500ms, max-height 500ms;
+	}
+
+	&.woocommerce-list__item-exit {
+		opacity: 1;
+		max-height: 100px;
+	}
+
+	&.woocommerce-list__item-exit-active {
+		opacity: 0;
+		max-height: 0;
+		transition: opacity 500ms, max-height 500ms;
+	}
+}

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -27,11 +27,18 @@ export const getEventPrefix = ( id: string ): string => {
 };
 
 export type TaskProps = {
+	actionLabel?: string;
+	actionUrl?: string;
+	content: string;
 	id: string;
 	isComplete: boolean;
+	isDismissable: boolean;
 	isDismissed: boolean;
 	isVisible: boolean;
+	isSnoozable: boolean;
 	snoozedUntil: number;
+	time: string;
+	title: string;
 };
 
 export type TaskListProps = {
@@ -149,19 +156,17 @@ export const TaskList: React.FC< TaskListProps > = ( {
 						</div>
 						<TaskListMenu id={ id } />
 					</CardHeader>
-					<CardBody>
-						<ListComp animation="custom" { ...listProps }>
-							{ visibleTasks.map( ( task ) => (
-								<TaskListItem
-									key={ task.id }
-									isExpanded={ expandedTask === task.id }
-									isExpandable={ isExpandable }
-									task={ task }
-									setExpandedTask={ setExpandedTask }
-								/>
-							) ) }
-						</ListComp>
-					</CardBody>
+					<ListComp animation="custom" { ...listProps }>
+						{ visibleTasks.map( ( task ) => (
+							<TaskListItem
+								key={ task.id }
+								isExpanded={ expandedTask === task.id }
+								isExpandable={ isExpandable }
+								task={ task }
+								setExpandedTask={ setExpandedTask }
+							/>
+						) ) }
+					</ListComp>
 				</Card>
 			</div>
 		</>

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -3,10 +3,10 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { Card, CardBody, CardHeader } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { Card, CardHeader } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { Badge } from '@woocommerce/components';
-import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME, TaskListType } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text, List, CollapsibleList } from '@woocommerce/experimental';
 
@@ -26,28 +26,7 @@ export const getEventPrefix = ( id: string ): string => {
 	return `${ id }_tasklist_`;
 };
 
-export type TaskProps = {
-	actionLabel?: string;
-	actionUrl?: string;
-	content: string;
-	id: string;
-	isComplete: boolean;
-	isDismissable: boolean;
-	isDismissed: boolean;
-	isVisible: boolean;
-	isSnoozable: boolean;
-	snoozedUntil: number;
-	time: string;
-	title: string;
-};
-
-export type TaskListProps = {
-	id: string;
-	isCollapsible?: boolean;
-	isComplete: boolean;
-	isExpandable?: boolean;
-	tasks: TaskProps[];
-	title: string;
+export type TaskListProps = TaskListType & {
 	query: {
 		task: string;
 	};
@@ -61,7 +40,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isExpandable = false,
 	query,
 } ) => {
-	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -1,0 +1,185 @@
+/**
+ * External dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { EllipsisMenu, Badge } from '@woocommerce/components';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+import { Text, List, CollapsibleList } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import { TaskListItem } from './task-list-item';
+import './task-list.scss';
+
+export const getEventPrefix = ( id: string ): string => {
+	// This helps retain backwards compatibility with the old event naming.
+	if ( id === 'setup' ) {
+		return 'tasklist_';
+	}
+
+	return `${ id }_tasklist_`;
+};
+
+export type TaskProps = {
+	id: string;
+	isComplete: boolean;
+	isDismissed: boolean;
+	isVisible: boolean;
+	snoozedUntil: number;
+};
+
+export type TaskListProps = {
+	id: string;
+	isCollapsible?: boolean;
+	isComplete: boolean;
+	isExpandable?: boolean;
+	tasks: TaskProps[];
+	title: string;
+	query: {
+		task: string;
+	};
+};
+
+export const TaskList: React.FC< TaskListProps > = ( {
+	id,
+	tasks,
+	title: listTitle,
+	isCollapsible = false,
+	isExpandable = false,
+	query,
+} ) => {
+	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
+	const { profileItems } = useSelect( ( select ) => {
+		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
+
+		return {
+			profileItems: getProfileItems(),
+		};
+	} );
+	const eventPrefix = getEventPrefix( id );
+	const prevQueryRef = useRef( query );
+	const nowTimestamp = Date.now();
+	const visibleTasks = tasks.filter(
+		( task ) =>
+			task.isVisible &&
+			! task.isDismissed &&
+			( ! task.snoozedUntil || task.snoozedUntil < nowTimestamp )
+	);
+
+	const incompleteTasks = tasks.filter(
+		( task ) => task.isVisible && ! task.isComplete && ! task.isDismissed
+	);
+
+	const [ expandedTask, setExpandedTask ] = useState(
+		incompleteTasks[ 0 ]?.id
+	);
+
+	const recordTaskListView = () => {
+		recordEvent( `${ eventPrefix }_view`, {
+			number_tasks: visibleTasks.length,
+			store_connected: profileItems.wccom_connected,
+		} );
+	};
+
+	useEffect( () => {
+		recordTaskListView();
+	}, [] );
+
+	useEffect( () => {
+		const { task: prevTask } = prevQueryRef.current;
+		const { task } = query;
+
+		if ( prevTask !== task ) {
+			window.document.documentElement.scrollTop = 0;
+			prevQueryRef.current = query;
+		}
+	}, [ query ] );
+
+	const renderMenu = () => {
+		return (
+			<div className="woocommerce-card__menu woocommerce-card__header-item">
+				<EllipsisMenu
+					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					renderContent={ () => (
+						<div className="woocommerce-task-card__section-controls">
+							<Button onClick={ () => hideTaskList( id ) }>
+								{ __( 'Hide this', 'woocommerce-admin' ) }
+							</Button>
+						</div>
+					) }
+				/>
+			</div>
+		);
+	};
+
+	if ( ! visibleTasks.length ) {
+		return <div className="woocommerce-task-dashboard__container"></div>;
+	}
+
+	const expandLabel = sprintf(
+		/* translators: %d = number of hidden tasks */
+		_n(
+			'Show %d more task.',
+			'Show %d more tasks.',
+			visibleTasks.length - 2,
+			'woocommerce-admin'
+		),
+		visibleTasks.length - 2
+	);
+	const collapseLabel = __( 'Show less', 'woocommerce-admin' );
+	const ListComp = isCollapsible ? CollapsibleList : List;
+
+	const listProps = isCollapsible
+		? {
+				collapseLabel,
+				expandLabel,
+				show: 2,
+				onCollapse: () =>
+					recordEvent( `${ eventPrefix }_collapse`, {} ),
+				onExpand: () => recordEvent( `${ eventPrefix }_expand`, {} ),
+		  }
+		: {};
+
+	return (
+		<>
+			<div className="woocommerce-task-dashboard__container">
+				<Card
+					size="large"
+					className="woocommerce-task-card woocommerce-homescreen-card"
+				>
+					<CardHeader size="medium">
+						<div className="wooocommerce-task-card__header">
+							<Text
+								size="20"
+								lineHeight="28px"
+								variant="title.small"
+							>
+								{ listTitle }
+							</Text>
+							<Badge count={ incompleteTasks.length } />
+						</div>
+						{ renderMenu() }
+					</CardHeader>
+					<CardBody>
+						<ListComp animation="custom" { ...listProps }>
+							{ visibleTasks.map( ( task ) => (
+								<TaskListItem
+									key={ task.id }
+									isExpanded={ expandedTask === task.id }
+									isExpandable={ isExpandable }
+									task={ task }
+									setExpandedTask={ setExpandedTask }
+								/>
+							) ) }
+						</ListComp>
+					</CardBody>
+				</Card>
+			</div>
+		</>
+	);
+};

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -3,9 +3,9 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { EllipsisMenu, Badge } from '@woocommerce/components';
+import { Badge } from '@woocommerce/components';
 import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text, List, CollapsibleList } from '@woocommerce/experimental';
@@ -14,6 +14,7 @@ import { Text, List, CollapsibleList } from '@woocommerce/experimental';
  * Internal dependencies
  */
 import { TaskListItem } from './task-list-item';
+import { TaskListMenu } from './task-list-menu';
 import './task-list.scss';
 
 export const getEventPrefix = ( id: string ): string => {
@@ -100,23 +101,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		}
 	}, [ query ] );
 
-	const renderMenu = () => {
-		return (
-			<div className="woocommerce-card__menu woocommerce-card__header-item">
-				<EllipsisMenu
-					label={ __( 'Task List Options', 'woocommerce-admin' ) }
-					renderContent={ () => (
-						<div className="woocommerce-task-card__section-controls">
-							<Button onClick={ () => hideTaskList( id ) }>
-								{ __( 'Hide this', 'woocommerce-admin' ) }
-							</Button>
-						</div>
-					) }
-				/>
-			</div>
-		);
-	};
-
 	if ( ! visibleTasks.length ) {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
@@ -163,7 +147,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 							</Text>
 							<Badge count={ incompleteTasks.length } />
 						</div>
-						{ renderMenu() }
+						<TaskListMenu id={ id } />
 					</CardHeader>
 					<CardBody>
 						<ListComp animation="custom" { ...listProps }>

--- a/client/tasks/task.tsx
+++ b/client/tasks/task.tsx
@@ -1,0 +1,7 @@
+export type TaskProps = {
+	query: { task: string };
+};
+
+export const Task: React.FC< TaskProps > = ( { query } ) => (
+	<div>Task: { query.task }</div>
+);

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -1,3 +1,146 @@
-export const Tasks: React.FC = () => (
-	<div>Task lists will be rendered here.</div>
-);
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import { Fragment, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useExperiment } from '@woocommerce/explat';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { DisplayOption } from '../header/activity-panel/display-options';
+import { Task } from './task';
+import { TaskList } from './task-list';
+import { TasksPlaceholder } from './placeholder';
+
+export type TasksProps = {
+	query: { task: string };
+};
+
+export const Tasks: React.FC< TasksProps > = ( { query } ) => {
+	const { task } = query;
+	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'woocommerce_tasklist_progression'
+	);
+
+	const { isResolving, taskLists } = useSelect( ( select ) => {
+		return {
+			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
+				'getTasks'
+			),
+			taskLists: select( ONBOARDING_STORE_NAME ).getTasks(),
+		};
+	} );
+
+	const getCurrentTask = () => {
+		if ( ! task ) {
+			return null;
+		}
+
+		const tasks = taskLists.reduce(
+			( acc, taskList ) => [ ...acc, ...taskList.tasks ],
+			[]
+		);
+
+		const currentTask = tasks.find( ( t ) => t.id === task );
+
+		if ( ! currentTask ) {
+			return null;
+		}
+
+		return currentTask;
+	};
+
+	const toggleTaskList = ( taskList ) => {
+		const { id, isHidden } = taskList;
+		const newValue = ! isHidden;
+
+		recordEvent(
+			newValue ? `${ id }_tasklist_hide` : `${ id }_tasklist_show`,
+			{}
+		);
+
+		hideTaskList();
+	};
+
+	useEffect( () => {
+		// @todo Update this when all task lists have been hidden or completed.
+		const taskListsFinished = false;
+		updateOptions( {
+			woocommerce_task_list_prompt_shown: true,
+			woocommerce_default_homepage_layout: 'two_columns',
+		} );
+	}, [ taskLists, isResolving ] );
+
+	const currentTask = getCurrentTask();
+
+	if ( task && ! currentTask ) {
+		return null;
+	}
+
+	if ( isResolving ) {
+		return <TasksPlaceholder query={ query } />;
+	}
+
+	if ( currentTask ) {
+		return <Task query={ query } />;
+	}
+
+	if ( isLoadingExperiment ) {
+		return <TasksPlaceholder query={ query } />;
+	}
+
+	return taskLists.map( ( taskList ) => {
+		const {
+			id,
+			isComplete,
+			isHidden,
+			isToggleable,
+			title,
+			tasks,
+		} = taskList;
+
+		return (
+			<Fragment key={ id }>
+				<TaskList
+					id={ id }
+					isComplete={ isComplete }
+					isExpandable={
+						experimentAssignment?.variationName === 'treatment'
+					}
+					query={ query }
+					tasks={ tasks }
+					title={ title }
+				/>
+				{ isToggleable && (
+					<DisplayOption>
+						<MenuGroup
+							className="woocommerce-layout__homescreen-display-options"
+							label={ __( 'Display', 'woocommerce-admin' ) }
+						>
+							<MenuItem
+								className="woocommerce-layout__homescreen-extension-tasklist-toggle"
+								icon={ ! isHidden && check }
+								isSelected={ ! isHidden }
+								role="menuitemcheckbox"
+								onClick={ () => toggleTaskList( taskList ) }
+							>
+								{ __(
+									'Show things to do next',
+									'woocommerce-admin'
+								) }
+							</MenuItem>
+						</MenuGroup>
+					</DisplayOption>
+				) }
+			</Fragment>
+		);
+	} );
+};

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -35,7 +35,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
 				'getTasks'
 			),
-			taskLists: select( ONBOARDING_STORE_NAME ).getTasks(),
+			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
 		};
 	} );
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -32,6 +32,7 @@ export { withPluginsHydration } from './plugins/with-plugins-hydration';
 
 export { ONBOARDING_STORE_NAME } from './onboarding';
 export { withOnboardingHydration } from './onboarding/with-onboarding-hydration';
+export type { TaskType, TaskListType } from './onboarding/types';
 
 export { USER_STORE_NAME } from './user';
 export { withCurrentUserHydration } from './user/with-current-user-hydration';

--- a/packages/data/src/onboarding/selectors.ts
+++ b/packages/data/src/onboarding/selectors.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { TaskListType } from './types';
 import { WPDataSelectors, RuleProcessor } from '../types';
 
 export const getFreeExtensions = (
@@ -21,9 +22,9 @@ export const getTasksStatus = (
 	return state.tasksStatus || {};
 };
 
-const initialTaskLists: TaskList[] = [];
+const initialTaskLists: TaskListType[] = [];
 
-export const getTaskLists = ( state: OnboardingState ): TaskList[] => {
+export const getTaskLists = ( state: OnboardingState ): TaskListType[] => {
 	return state.taskLists || initialTaskLists;
 };
 
@@ -185,25 +186,4 @@ export type Extension = {
 	manage_url: string;
 	name: string;
 	slug: string;
-};
-
-export type Task = {
-	id: string;
-	title: string;
-	content: string;
-	actionLabel: string;
-	actionUrl: string;
-	isComplete: boolean;
-	isVisibile: boolean;
-	isDismissable?: boolean;
-	isSnoozeable?: boolean;
-	time: string;
-};
-
-export type TaskList = {
-	id: string;
-	title: string;
-	isComplete: boolean;
-	isHidden: boolean;
-	tasks: Task[];
 };

--- a/packages/data/src/onboarding/selectors.ts
+++ b/packages/data/src/onboarding/selectors.ts
@@ -66,7 +66,7 @@ export type OnboardingSelectors = {
 export type OnboardingState = {
 	freeExtensions: ExtensionList[];
 	profileItems: ProfileItemsState;
-	taskLists: TaskList[];
+	taskLists: TaskListType[];
 	tasksStatus: TasksStatusState;
 	paymentMethods: PaymentMethodsState[];
 	emailPrefill: string;

--- a/packages/data/src/onboarding/types.ts
+++ b/packages/data/src/onboarding/types.ts
@@ -1,0 +1,23 @@
+export type TaskType = {
+	actionLabel?: string;
+	actionUrl?: string;
+	content: string;
+	id: string;
+	isComplete: boolean;
+	isDismissable: boolean;
+	isDismissed: boolean;
+	isVisible: boolean;
+	isSnoozable: boolean;
+	snoozedUntil: number;
+	time: string;
+	title: string;
+};
+
+export type TaskListType = {
+	id: string;
+	isCollapsible?: boolean;
+	isComplete: boolean;
+	isExpandable?: boolean;
+	tasks: TaskType[];
+	title: string;
+};


### PR DESCRIPTION
Fixes #7367 

Adds components for the task list and task list items to consume the task list REST API.

### Screenshots
<img width="732" alt="Screen Shot 2021-08-31 at 11 04 20 AM" src="https://user-images.githubusercontent.com/10561050/131576215-fadf86f5-3a55-48a6-bd5d-facb2cee9902.png">


### Detailed test instructions:

1. Visit the task list.
2. Make sure that items with an action URL (like the "Store details" task) take you to the intended URL.
3. Make sure that clicking on other tasks renders text for the item (SlotFill is not yet in place, so these won't render the full tasks).
4. Open your network tab and make sure a call to update the user task started count is made when clicking into an individual task.
5. Complete the criteria for any task.
6. Refresh the page to make sure it is marked complete.

Note that this PR does not address SlotFill for tasks and does not address cache invalidation when a task is completed, so this will not work yet.  The hide task functionality is also pending in another PR - https://github.com/woocommerce/woocommerce-admin/pull/7578