### PR TITLE
Adding undo snooze endpoint

### DIFF
--- a/changelogs/add-7559-snooze-undo-endpoint
+++ b/changelogs/add-7559-snooze-undo-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Adding undo snooze task endpoint

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -174,6 +174,19 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-z0-9_\-]+)/undo_snooze',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'undo_snooze_task' ),
+					'permission_callback' => array( $this, 'snooze_task_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -826,11 +839,39 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $task_id ) );
 		}
 
-		$snooze_task['isSnoozed']    = true;
-		$snooze_task['snoozedUntil'] = $snoozed_until;
-
-		return rest_ensure_response( $snooze_task );
+		return rest_ensure_response( $update );
 	}
 
+	/**
+	 * Undo snooze of a single task.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Request|WP_Error
+	 */
+	public function undo_snooze_task( $request ) {
+		$id = $request->get_param( 'id' );
+
+		$snoozed = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+
+		if ( ! isset( $snoozed[ $id ] ) ) {
+			return new \WP_Error(
+				'woocommerce_tasks_invalid_task',
+				__( 'Sorry, no snoozed task with that ID was found.', 'woocommerce-admin' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		unset( $snoozed[ $id ] );
+
+		$update = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snoozed );
+
+		if ( $update ) {
+			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $id ) );
+		}
+
+		return rest_ensure_response( $update );
+	}
 
 }

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -805,7 +805,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function snooze_task( $request ) {
-
 		$task_id         = $request->get_param( 'id' );
 		$task_list_id    = $request->get_param( 'task_list_id' );
 		$snooze_duration = $request->get_param( 'duration' );
@@ -837,9 +836,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( $update ) {
 			wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $task_id ) );
+			$snooze_task['isSnoozed']    = true;
+			$snooze_task['snoozedUntil'] = $snoozed_until;
 		}
 
-		return rest_ensure_response( $update );
+		return rest_ensure_response( $snooze_task );
 	}
 
 	/**
@@ -871,7 +872,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $id ) );
 		}
 
-		return rest_ensure_response( $update );
+		return rest_ensure_response( OnboardingTasksFeature::get_task_by_id( $id ) );
 	}
 
 }


### PR DESCRIPTION
Fixes #7559

Adding endpoint to undo a snoozed task. 

**Endpoint**
`POST` - `/wc-admin/onboarding/tasks/<task_id>/undo_snooze`

**Response**

- `404` error if task ID provided is not a snoozed task
- Boolean value representing whether the option was updated successfully.

### Detailed test instructions:

-   Checkout branch
-   You may need to add the `isSnoozeable=true` property to one of the tasks in [Features/OnboardingTasks.php](https://github.com/woocommerce/woocommerce-admin/blob/0f7a85c247bbe6ac360c6bd4de7062292777df1d/src/Features/OnboardingTasks.php).
- Send request to `POST /wc-admin/onboarding/tasks/<task-id>/snooze` in order to snooze the task.
- Send request to `GET /wc-admin/onboarding/tasks` to view tasks and ensure that `isSnoozed` is true for that task.
- Send request to `POST /wc-admin/onboarding/tasks/<task-id>/undo_snooze` in order to UNDO the snooze of the task.
- Hit `GET /wc-admin/onboarding/tasks` one more time, and verify that the `isSnoozed` property is no longer on that task. 
