### PR TITLE
Fix marketing task visibility

### DIFF
--- a/changelogs/fixed_marketing_task_visibility_7580
+++ b/changelogs/fixed_marketing_task_visibility_7580
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix marketing task visibility

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -355,7 +355,8 @@ export function getAllTasks( {
 			visible:
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures[ 'remote-free-extensions' ] &&
-				!! marketingExtensionsLists.length,
+				( !! marketingExtensionsLists.length ||
+					!! installedMarketingExtensions.length ),
 			time: __( '1 minute', 'woocommerce-admin' ),
 			type: 'setup',
 		},


### PR DESCRIPTION
Fixes #7565

This PR fixes the marketing task visibility.
In order to be able to test this PR, don't forget to [set this](https://github.com/woocommerce/woocommerce-admin/blob/main/config/development.json#L19) as `false` and use WooCommerce 5.6.

### Screenshots

![screenshot-managing-lamprey jurassic ninja-2021 08 26-17_12_25](https://user-images.githubusercontent.com/1314156/131030271-b0db992a-99a3-4d29-869f-ebe2e016fe18.png)


### Detailed test instructions:

1. Create a new store with WC 5.7 beta installed
2. Visit the home screen and go to the marketing task
3. Install every marketing extension.
4. Pick one of them and click "Manage".
4. Go back to the home screen
5. The marketing task should be displayed

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
