### PR TITLE
Fix broken PHP tests with the latest WC

### DIFF
--- a/tests/reports/class-wc-tests-reports-coupons.php
+++ b/tests/reports/class-wc-tests-reports-coupons.php
@@ -314,7 +314,11 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 		// Run the export and compare values.
 		$export = new ReportCSVExporter( 'coupons', $args );
 		$export->generate_file();
-		$actual_csv = $export->get_file();
+		if ( method_exists( $export, 'get_headers_row_file' ) ) {
+			$actual_csv = $export->get_headers_row_file() . $export->get_file();
+		} else {
+			$actual_csv = $export->get_file();
+		}
 
 		$this->assertEquals( 100, $export->get_percent_complete() );
 		$this->assertEquals( 2, $export->get_total_exported() );

--- a/tests/reports/class-wc-tests-reports-products.php
+++ b/tests/reports/class-wc-tests-reports-products.php
@@ -480,7 +480,11 @@ class WC_Tests_Reports_Products extends WC_Unit_Test_Case {
 
 		$export = new ReportCSVExporter( 'products', $args );
 		$export->generate_file();
-		$actual_csv = $export->get_file();
+		if ( method_exists( $export, 'get_headers_row_file' ) ) {
+			$actual_csv = $export->get_headers_row_file() . $export->get_file();
+		} else {
+			$actual_csv = $export->get_file();
+		}
 
 		$this->assertEquals( 100, $export->get_percent_complete() );
 		$this->assertEquals( 0, $export->get_total_exported() );


### PR DESCRIPTION
This PR fixes broken PHP tests with PHP 7.2, WP 5.5. and the latest WC.


The latest version of [write_csv_data](https://github.com/woocommerce/woocommerce/blob/trunk/includes/export/abstract-wc-csv-batch-exporter.php#L127) doesn't write the CSV headers with the rows. Instead, it temporarily saves the headers into a file. Calling `$export->print()` doesn't return expected CSV headers anymore.

This PR fixes the broken tests by calling [get_headers_row_file](https://github.com/woocommerce/woocommerce/blob/trunk/includes/export/abstract-wc-csv-batch-exporter.php#L64) method to get the expected CSV headers.

![Screen Shot 2021-08-26 at 4 31 20 PM](https://user-images.githubusercontent.com/4723145/131048924-9ff43744-e3ab-4a0e-8660-fb277791b919.jpg)


### Detailed test instructions:

1. Checkout this branch
2. Open `docker/wc-admin-php-test-suite/docker-compose.yml` and change the `WC_VERSION` environment variable to `5.6.0` 
 
`WC_VERSION=${WC_VERSION:-5.6.0}`

3. Run the following tests and confirm the tests pass without an error.

`npm run test:php -- --filter=WC_Tests_Reports_Coupons`
`npm run test:php -- --filter=WC_Tests_Reports_Products`

no changelog