### PR TITLE
Fix business step auto installing

### DIFF
--- a/changelogs/fix-7564_business_step_auto_installing
+++ b/changelogs/fix-7564_business_step_auto_installing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Use installable extensions for local state versus free extensions. #7585

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -189,16 +189,16 @@ export const SelectiveExtensionsBundle = ( {
 		};
 	} );
 
-	useEffect( () => {
-		const initialValues = createInitialValues( freeExtensions );
-		setValues( initialValues );
-	}, [ freeExtensions ] );
-
 	const installableExtensions = useMemo( () => {
 		return freeExtensions.filter( ( list ) => {
 			return ALLOWED_PLUGIN_LISTS.includes( list.key );
 		} );
 	}, [ freeExtensions ] );
+
+	useEffect( () => {
+		const initialValues = createInitialValues( installableExtensions );
+		setValues( initialValues );
+	}, [ installableExtensions ] );
 
 	const getCheckboxChangeHandler = ( key ) => {
 		return ( checked ) => {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { render } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import userEvent from '@testing-library/user-event';
+import { pluginNames } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { SelectiveExtensionsBundle } from '../';
+
+jest.mock( '../../app-illustration', () => ( {
+	AppIllustration: jest.fn().mockReturnValue( '[illustration]' ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	useDispatch: jest.fn().mockImplementation( () => ( {
+		updateOptions: jest.fn(),
+		installAndActivatePlugins: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@woocommerce/data', () => ( {
+	pluginNames: {
+		'woocommerce-payments': 'WooCommerce Payments',
+		mailpoet: 'Mailpoet',
+		random: 'Random',
+		'google-listings-and-ads': 'Google Listings and Ads',
+	},
+} ) );
+
+const freeExtensions = [
+	{
+		key: 'basics',
+		title: 'Get the basics',
+		plugins: [
+			{
+				key: 'woocommerce-payments',
+				description: 'WC Pay Description',
+				is_visible: true,
+				is_installed: true,
+			},
+			{
+				key: 'mailpoet',
+				description: 'Mailpoet Description',
+				manage_url: 'admin.php?page=mailpoet-newsletters',
+				is_visible: true,
+				is_installed: true,
+			},
+		],
+	},
+	{
+		key: 'reach',
+		title: 'Reach out to customers',
+		plugins: [
+			{
+				key: 'random',
+				name: 'Random',
+				description: 'Random description',
+				manage_url: 'admin.php?page=mailpoet-newsletters',
+				is_visible: true,
+				is_installed: true,
+			},
+		],
+	},
+	{
+		key: 'grow',
+		title: 'Grow your store',
+		plugins: [
+			{
+				key: 'google-listings-and-ads',
+				name: 'Google Ads & Marketing by Kliken',
+				description: 'Google Description',
+				manage_url: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				is_visible: true,
+				is_installed: false,
+			},
+		],
+	},
+];
+
+describe( 'Selective extensions bundle', () => {
+	it( 'should list installable free extensions in footer only basics', () => {
+		useSelect.mockReturnValue( {
+			freeExtensions: freeExtensions,
+			isResolving: false,
+		} );
+		const { getByText, queryByText } = render(
+			<SelectiveExtensionsBundle isInstallingActivating={ false } />
+		);
+		expect(
+			getByText( new RegExp( pluginNames.mailpoet ) )
+		).toBeInTheDocument();
+		expect(
+			getByText( new RegExp( pluginNames[ 'woocommerce-payments' ] ) )
+		).toBeInTheDocument();
+		expect(
+			queryByText(
+				new RegExp( pluginNames[ 'google-listings-and-ads' ] )
+			)
+		).not.toBeInTheDocument();
+		expect(
+			queryByText( new RegExp( pluginNames.random ) )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should list installable extensions when dropdown is clicked', () => {
+		useSelect.mockReturnValue( {
+			freeExtensions: freeExtensions,
+			isResolving: false,
+		} );
+		const { getAllByRole, getByText, queryByText } = render(
+			<SelectiveExtensionsBundle isInstallingActivating={ false } />
+		);
+		const collapseButton = getAllByRole( 'button' ).find(
+			( item ) => item.textContent === ''
+		);
+		userEvent.click( collapseButton );
+		expect( getByText( 'WC Pay Description' ) ).toBeInTheDocument();
+		expect( getByText( 'Mailpoet Description' ) ).toBeInTheDocument();
+		expect( queryByText( 'Google Description' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'Random Description' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -87,7 +87,7 @@ const freeExtensions = [
 describe( 'Selective extensions bundle', () => {
 	it( 'should list installable free extensions in footer only basics', () => {
 		useSelect.mockReturnValue( {
-			freeExtensions: freeExtensions,
+			freeExtensions,
 			isResolving: false,
 		} );
 		const { getByText, queryByText } = render(
@@ -111,7 +111,7 @@ describe( 'Selective extensions bundle', () => {
 
 	it( 'should list installable extensions when dropdown is clicked', () => {
 		useSelect.mockReturnValue( {
-			freeExtensions: freeExtensions,
+			freeExtensions,
 			isResolving: false,
 		} );
 		const { getAllByRole, getByText, queryByText } = render(


### PR DESCRIPTION
Fixes #7564 

Makes use of the installable extensions instead of the free extensions to handle free extension state.

### Screenshots

<img width="754" alt="Screen Shot 2021-08-29 at 5 07 27 PM" src="https://user-images.githubusercontent.com/2240960/131263987-534c31b1-dedf-43e9-8e7d-dabad2ab91a0.png">

### Detailed test instructions:

1. Create a new store wit this branch
2. In the store details step, select a country where we should be promoting all the extensions to make sure they're being displayed in the business features step (eg. US or CA)
3. Complete all the steps until the business free features step, expand the free feature list
4. See that the footer (feature plugins will be installed: ) list matches that of the items listed with checkboxes. Google Ads and Mailchimp should not be included in the footnote.
5. Visit the marketing task
6. See that the Google Ads and Mailchimp are not installed

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
