### PR TITLE
Adjust marketing completion logic

### DIFF
--- a/changelogs/update-7567_marketing_task_completion_logic
+++ b/changelogs/update-7567_marketing_task_completion_logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Update marketing task completion logic. #7586

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -46,8 +46,9 @@ const taskDashboardSelect = ( select ) => {
 		getOption( 'woocommerce_task_list_tracked_completed_tasks' ) ||
 		EMPTY_ARRAY;
 
-	const visitedTasks =
-		getOption( 'woocommerce_task_list_visited_tasks' ) || EMPTY_ARRAY;
+	const trackedCompletedActions =
+		getOption( 'woocommerce_task_list_tracked_completed_actions' ) ||
+		EMPTY_ARRAY;
 
 	const { general: generalSettings = {} } = getSettings( 'general' );
 	const countryCode = getCountryCode(
@@ -84,7 +85,7 @@ const taskDashboardSelect = ( select ) => {
 		isTaskListComplete:
 			getOption( 'woocommerce_task_list_complete' ) === 'yes',
 		installedPlugins,
-		visitedTasks,
+		trackedCompletedActions,
 		onboardingStatus,
 		profileItems,
 		trackedCompletedTasks,
@@ -134,7 +135,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		isExtendedTaskListHidden,
 		isExtendedTaskListComplete,
 		hasCompleteAddress,
-		visitedTasks,
+		trackedCompletedActions,
 		isResolving,
 	} = useSelect( taskDashboardSelect );
 
@@ -180,14 +181,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,
 		} );
-		if ( visitedTasks && ! visitedTasks.includes( taskName ) ) {
-			updateOptions( {
-				woocommerce_task_list_visited_tasks: [
-					...visitedTasks,
-					taskName,
-				],
-			} );
-		}
+
 		if ( ! isTaskCompleted( taskName ) ) {
 			updateTrackStartedCount( taskName, trackStartedCount + 1 );
 		}
@@ -254,7 +248,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		toggleCartModal,
 		onTaskSelect,
 		hasCompleteAddress,
-		visitedTasks,
+		trackedCompletedActions,
 	} );
 
 	const { extension, setup: setupTasks } = allTasks;

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -28,6 +28,7 @@ import { DisplayOption } from '../header/activity-panel/display-options';
 import { TaskStep } from './task-step';
 import TaskListPlaceholder from './placeholder';
 
+const EMPTY_ARRAY = [];
 const taskDashboardSelect = ( select ) => {
 	const { getFreeExtensions, getProfileItems, getTasksStatus } = select(
 		ONBOARDING_STORE_NAME
@@ -42,7 +43,11 @@ const taskDashboardSelect = ( select ) => {
 	const profileItems = getProfileItems();
 
 	const trackedCompletedTasks =
-		getOption( 'woocommerce_task_list_tracked_completed_tasks' ) || [];
+		getOption( 'woocommerce_task_list_tracked_completed_tasks' ) ||
+		EMPTY_ARRAY;
+
+	const visitedTasks =
+		getOption( 'woocommerce_task_list_visited_tasks' ) || EMPTY_ARRAY;
 
 	const { general: generalSettings = {} } = getSettings( 'general' );
 	const countryCode = getCountryCode(
@@ -79,6 +84,7 @@ const taskDashboardSelect = ( select ) => {
 		isTaskListComplete:
 			getOption( 'woocommerce_task_list_complete' ) === 'yes',
 		installedPlugins,
+		visitedTasks,
 		onboardingStatus,
 		profileItems,
 		trackedCompletedTasks,
@@ -128,6 +134,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		isExtendedTaskListHidden,
 		isExtendedTaskListComplete,
 		hasCompleteAddress,
+		visitedTasks,
 		isResolving,
 	} = useSelect( taskDashboardSelect );
 
@@ -173,6 +180,14 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		recordEvent( 'tasklist_click', {
 			task_name: taskName,
 		} );
+		if ( visitedTasks && ! visitedTasks.includes( taskName ) ) {
+			updateOptions( {
+				woocommerce_task_list_visited_tasks: [
+					...visitedTasks,
+					taskName,
+				],
+			} );
+		}
 		if ( ! isTaskCompleted( taskName ) ) {
 			updateTrackStartedCount( taskName, trackStartedCount + 1 );
 		}
@@ -239,6 +254,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		toggleCartModal,
 		onTaskSelect,
 		hasCompleteAddress,
+		visitedTasks,
 	} );
 
 	const { extension, setup: setupTasks } = allTasks;

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -59,6 +59,7 @@ export function getAllTasks( {
 	toggleCartModal,
 	onTaskSelect,
 	hasCompleteAddress,
+	visitedTasks,
 } ) {
 	const {
 		hasPaymentGateway,
@@ -351,7 +352,9 @@ export function getAllTasks( {
 				onTaskSelect( 'marketing' );
 				updateQueryString( { task: 'marketing' } );
 			},
-			completed: !! installedMarketingExtensions.length,
+			completed:
+				!! installedMarketingExtensions.length &&
+				visitedTasks.includes( 'marketing' ),
 			visible:
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures[ 'remote-free-extensions' ] &&

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -358,9 +358,7 @@ export function getAllTasks( {
 			},
 			completed:
 				!! installedMarketingExtensions.length &&
-				trackedCompletedActions.includes(
-					'marketing_task_installed_extension_via_task'
-				),
+				trackedCompletedActions.includes( 'marketing' ),
 			visible:
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures[ 'remote-free-extensions' ] &&

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -59,7 +59,7 @@ export function getAllTasks( {
 	toggleCartModal,
 	onTaskSelect,
 	hasCompleteAddress,
-	visitedTasks,
+	trackedCompletedActions,
 } ) {
 	const {
 		hasPaymentGateway,
@@ -347,14 +347,20 @@ export function getAllTasks( {
 				'Add recommended marketing tools to reach new customers and grow your business',
 				'woocommerce-admin'
 			),
-			container: <Marketing />,
+			container: (
+				<Marketing
+					trackedCompletedActions={ trackedCompletedActions }
+				/>
+			),
 			onClick: () => {
 				onTaskSelect( 'marketing' );
 				updateQueryString( { task: 'marketing' } );
 			},
 			completed:
 				!! installedMarketingExtensions.length &&
-				visitedTasks.includes( 'marketing' ),
+				trackedCompletedActions.includes(
+					'marketing_task_installed_extension_via_task'
+				),
 			visible:
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures[ 'remote-free-extensions' ] &&

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -357,8 +357,9 @@ export function getAllTasks( {
 				updateQueryString( { task: 'marketing' } );
 			},
 			completed:
-				!! installedMarketingExtensions.length &&
-				trackedCompletedActions.includes( 'marketing' ),
+				( !! installedMarketingExtensions.length &&
+					trackedCompletedActions.includes( 'marketing' ) ) ||
+				! marketingExtensionsLists.length,
 			visible:
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures[ 'remote-free-extensions' ] &&

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -152,7 +152,7 @@ export const Marketing: React.FC< MarketingProps > = ( {
 				updateOptions( {
 					woocommerce_task_list_tracked_completed_actions: [
 						...trackedCompletedActions,
-						'marketing_task_installed_extension_via_task',
+						'marketing',
 					],
 				} );
 				createNoticesFromResponse( response );

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, Spinner } from '@wordpress/components';
 import {
 	ONBOARDING_STORE_NAME,
 	PLUGINS_STORE_NAME,
+	OPTIONS_STORE_NAME,
 	WCDataSelector,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -95,11 +96,18 @@ export const getMarketingExtensionLists = (
 	return [ installed, lists ];
 };
 
-export const Marketing: React.FC = () => {
+export type MarketingProps = {
+	trackedCompletedActions: string[];
+};
+
+export const Marketing: React.FC< MarketingProps > = ( {
+	trackedCompletedActions,
+} ) => {
 	const [ currentPlugin, setCurrentPlugin ] = useState< string | null >(
 		null
 	);
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const {
 		activePlugins,
 		freeExtensions,
@@ -140,6 +148,12 @@ export const Marketing: React.FC = () => {
 					installed_extensions: installedExtensions.map(
 						( extension ) => extension.slug
 					),
+				} );
+				updateOptions( {
+					woocommerce_task_list_tracked_completed_actions: [
+						...trackedCompletedActions,
+						'marketing_task_installed_extension_via_task',
+					],
 				} );
 				createNoticesFromResponse( response );
 				setCurrentPlugin( null );

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -149,12 +149,16 @@ export const Marketing: React.FC< MarketingProps > = ( {
 						( extension ) => extension.slug
 					),
 				} );
-				updateOptions( {
-					woocommerce_task_list_tracked_completed_actions: [
-						...trackedCompletedActions,
-						'marketing',
-					],
-				} );
+
+				if ( ! trackedCompletedActions.includes( 'marketing' ) ) {
+					updateOptions( {
+						woocommerce_task_list_tracked_completed_actions: [
+							...trackedCompletedActions,
+							'marketing',
+						],
+					} );
+				}
+
 				createNoticesFromResponse( response );
 				setCurrentPlugin( null );
 			} )


### PR DESCRIPTION
Fixes #7567 

Adds a `woocommerce_task_list_visited_tasks` option that is set once a task is visited, it only adds a task when it was not previously visited. Meaning it only keeps track if a task has been visited at-least once.
I added this logic to the marketing completion state.
@joshuatf we will have to add this logic to the task list REST api, I think just having a `isVisited` or `visited` boolean should suffice.

### Screenshots

![marketing-task-completion](https://user-images.githubusercontent.com/2240960/131265010-83dac267-578c-4ac8-b10b-c0495d0aaeb2.gif)

### Detailed test instructions:

- Load this branch and start a new store
- Finish the onboarding flow, and install a marketing plugin through (**Plugins > Add New** NOT the marketing task) You can install MailPoet or Mailchimp.
- Go to **WooCommerce > Home** and notice how the **Set up marketing tools** shows as uncompleted.
- Visit the marketing task and notice how your marketing plugin shows as installed (do nothing)
- Go back to **WooCommerce > Home** and notice how the marking task is complete now.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
