### PR TITLE
Make sure batch fetch resolved data remains consistent

### DIFF
--- a/packages/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
+++ b/packages/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
@@ -99,7 +99,7 @@ const testAdminHomescreenActivityPanel = () => {
 		describe( 'Orders panel', () => {
 			it( 'should show: "you have fullfilled all your orders" when expanding Orders panel if no actionable orders', async () => {
 				await homeScreen.expandActivityPanel( 'Orders' );
-				expect( page ).toMatchElement( 'h4', {
+				await expect( page ).toMatchElement( 'h4', {
 					text: 'You’ve fulfilled all your orders',
 				} );
 			} );

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Fix the batch fetch logic for the options data store. #7587
+
 # 1.4.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286

--- a/packages/data/src/options/controls.js
+++ b/packages/data/src/options/controls.js
@@ -29,7 +29,14 @@ export const controls = {
 				const names = optionNames.join( ',' );
 				if ( fetches[ names ] ) {
 					return fetches[ names ].then( ( result ) => {
-						resolve( { [ optionName ]: result[ optionName ] } );
+						resolve(
+							names.split( ',' ).reduce( ( optionData, name ) => {
+								return {
+									...optionData,
+									[ name ]: result[ name ],
+								};
+							}, {} )
+						);
 					} );
 				}
 

--- a/packages/data/src/options/controls.js
+++ b/packages/data/src/options/controls.js
@@ -29,7 +29,7 @@ export const controls = {
 				const names = optionNames.join( ',' );
 				if ( fetches[ names ] ) {
 					return fetches[ names ].then( ( result ) => {
-						resolve( result[ optionName ] );
+						resolve( { [ optionName ]: result[ optionName ] } );
 					} );
 				}
 

--- a/packages/data/src/options/controls.js
+++ b/packages/data/src/options/controls.js
@@ -29,14 +29,7 @@ export const controls = {
 				const names = optionNames.join( ',' );
 				if ( fetches[ names ] ) {
 					return fetches[ names ].then( ( result ) => {
-						resolve(
-							names.split( ',' ).reduce( ( optionData, name ) => {
-								return {
-									...optionData,
-									[ name ]: result[ name ],
-								};
-							}, {} )
-						);
+						resolve( result );
 					} );
 				}
 


### PR DESCRIPTION
Fixes an issue (which isn't directly noticeable in the UI) that appended the option values to the redux store instead of the key:value format.

This would probably only be noticeable when we call `getOption` and it triggers a single batch every time, as it would not persist the data and always trigger a new request. Given this is a rare case, I found it hard to really find it breaking the UI.

No changelog as it is in the package.

### Screenshots

Old - notice the "yes" value as individual values for each character:
<img width="646" alt="Screen Shot 2021-08-29 at 6 02 49 PM" src="https://user-images.githubusercontent.com/2240960/131265265-ffb7f2ef-6bd8-4888-9b5d-cf40562ce472.png">

New - notice how the data looks correctly:
<img width="624" alt="Screen Shot 2021-08-29 at 6 02 13 PM" src="https://user-images.githubusercontent.com/2240960/131265272-791b91f9-adea-4a60-a92a-969fbfa9d164.png">

### Detailed test instructions:

- Install the [redux devtools plugin](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
- Load `main` and go to **WooCommerce > Home**
- Open your console and click on the **Redux** tab and select the **wc/admin/options** store on the right.
- Click on **State** and notice the weird behaviour as shown in the bad screenshot above
- Load this branch
- Do the same as the above and notice how the state looks fine.


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
