### PR TITLE
Add error handling for email validation errors from backend

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -167,13 +167,19 @@ class StoreDetails extends Component {
 			profileItemsToUpdate.industry = trimmedIndustries;
 		}
 
+		let errorMessages = [];
 		try {
 			await updateProfileItems( profileItemsToUpdate );
-		} catch ( _ ) {}
+		} catch ( error ) {
+			// Array of error messages obtained from API response.
+			if ( error?.data?.params ) {
+				errorMessages = Object.values( error.data.params );
+			}
+		}
 
 		if (
 			! Boolean( errorsRef.current.settings ) &&
-			! Boolean( errorsRef.current.onboarding )
+			! errorMessages.length
 		) {
 			goToNextStep();
 		} else {
@@ -183,6 +189,10 @@ class StoreDetails extends Component {
 					'There was a problem saving your store details',
 					'woocommerce-admin'
 				)
+			);
+
+			errorMessages.forEach( ( message ) =>
+				createNotice( 'error', message )
 			);
 		}
 	}
@@ -420,7 +430,6 @@ export default compose(
 			isUpdateSettingsRequesting,
 		} = select( SETTINGS_STORE_NAME );
 		const {
-			getOnboardingError,
 			getProfileItems,
 			isOnboardingRequesting,
 			getEmailPrefill,
@@ -440,11 +449,9 @@ export default compose(
 			! hasFinishedResolutionOnboarding( 'getEmailPrefill' );
 		const errorsRef = useRef( {
 			settings: null,
-			onboarding: null,
 		} );
 		errorsRef.current = {
 			settings: getSettingsError( 'general' ),
-			onboarding: getOnboardingError( 'updateProfileItems' ),
 		};
 		// Check if a store address is set so that we don't default
 		// to WooCommerce's default country of the UK.

--- a/packages/data/src/onboarding/actions.js
+++ b/packages/data/src/onboarding/actions.js
@@ -191,7 +191,7 @@ export function* updateProfileItems( items ) {
 	} catch ( error ) {
 		yield setError( 'updateProfileItems', error );
 		yield setIsRequesting( 'updateProfileItems', false );
-		throw new Error();
+		throw error;
 	}
 }
 


### PR DESCRIPTION
Follow-up for #7517.

This PR adds a notification using `createNotice` for all error messages that returned from `/wc-admin/onboarding/profile` API call. I've attempted to add the error messages below the form fields themselves but found out that the current `<Form>` component does not support external error messages via props.

Thus I think this is the simplest solution.

### Screenshots

![image](https://user-images.githubusercontent.com/3747241/131321789-5c7f5a26-be88-48c4-9bed-c2bbd3b2f24e.png)

### Detailed test instructions:

- Go to OBW store details page and fill up the form.
- In the email field, use an invalid email such as `test@`.
- Click on continue.
- Observe the error message appears.

No changelog required.
