### PR TITLE
Adjust task item class name to prevent conflicts with older versions

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -49,7 +49,7 @@
 	}
 
 	.components-modal__screen-overlay {
-		background: rgba( 43, 45, 47, 0.4 );
+		background: rgba(43, 45, 47, 0.4);
 	}
 
 	.components-modal__frame {

--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -34,13 +34,13 @@
 
 	.woocommerce-task__additional-info,
 	.woocommerce-task__estimated-time,
-	.woocommerce-task-list__item-content {
+	.woocommerce-task-list__item-expandable-content {
 		color: $gray-700;
 		font-weight: 400;
 		font-size: 12px;
 	}
 
-	.woocommerce-task-list__item-content {
+	.woocommerce-task-list__item-expandable-content {
 		font-size: 13px;
 	}
 
@@ -49,7 +49,7 @@
 	}
 
 	.components-modal__screen-overlay {
-		background: rgba(43, 45, 47, 0.4);
+		background: rgba( 43, 45, 47, 0.4 );
 	}
 
 	.components-modal__frame {

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -707,7 +707,9 @@ describe( 'TaskDashboard and TaskList', () => {
 			const { queryByText } = render( <TaskDashboard query={ {} } /> );
 			expect(
 				queryByText( 'This is the optional task content' )
-			).not.toHaveClass( 'woocommerce-task-list__item-content-appear' );
+			).not.toHaveClass(
+				'woocommerce-task-list__item-expandable-content-appear'
+			);
 		} );
 	} );
 

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -31,30 +31,30 @@ a.woocommerce-list__item {
 	}
 
 	// transitions
-	&:not(.transitions-disabled) {
+	&:not( .transitions-disabled ) {
 		&.woocommerce-list__item-enter {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX(50%);
+			transform: translateX( 50% );
 		}
 
 		&.woocommerce-list__item-enter-active {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX(0%);
+			transform: translateX( 0% );
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 
 		&.woocommerce-list__item-exit {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX(0%);
+			transform: translateX( 0% );
 		}
 
 		&.woocommerce-list__item-exit-active {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX(50%);
+			transform: translateX( 50% );
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 	}
@@ -101,12 +101,12 @@ a.woocommerce-list__item {
 	$background-color: $white;
 	$background-color-hover: $gray-100;
 	$border-color: $gray-100;
-	$foreground-color: var(--wp-admin-theme-color);
-	$foreground-color-hover: var(--wp-admin-theme-color);
+	$foreground-color: var( --wp-admin-theme-color );
+	$foreground-color-hover: var( --wp-admin-theme-color );
 
 	background-color: $background-color;
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		border-top: 1px solid $border-color;
 	}
 
@@ -137,7 +137,7 @@ a.woocommerce-list__item {
 
 	&.is-complete {
 		.woocommerce-task__icon {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var( --wp-admin-theme-color );
 		}
 
 		.woocommerce-list__item-title {

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -31,30 +31,30 @@ a.woocommerce-list__item {
 	}
 
 	// transitions
-	&:not( .transitions-disabled ) {
+	&:not(.transitions-disabled) {
 		&.woocommerce-list__item-enter {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX( 50% );
+			transform: translateX(50%);
 		}
 
 		&.woocommerce-list__item-enter-active {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX( 0% );
+			transform: translateX(0%);
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 
 		&.woocommerce-list__item-exit {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX( 0% );
+			transform: translateX(0%);
 		}
 
 		&.woocommerce-list__item-exit-active {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX( 50% );
+			transform: translateX(50%);
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 	}
@@ -101,12 +101,12 @@ a.woocommerce-list__item {
 	$background-color: $white;
 	$background-color-hover: $gray-100;
 	$border-color: $gray-100;
-	$foreground-color: var( --wp-admin-theme-color );
-	$foreground-color-hover: var( --wp-admin-theme-color );
+	$foreground-color: var(--wp-admin-theme-color);
+	$foreground-color-hover: var(--wp-admin-theme-color);
 
 	background-color: $background-color;
 
-	&:not( :first-child ) {
+	&:not(:first-child) {
 		border-top: 1px solid $border-color;
 	}
 
@@ -137,7 +137,7 @@ a.woocommerce-list__item {
 
 	&.is-complete {
 		.woocommerce-task__icon {
-			background-color: var( --wp-admin-theme-color );
+			background-color: var(--wp-admin-theme-color);
 		}
 
 		.woocommerce-list__item-title {

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Adjust task-item css class to prevent css conflicts. #7593
+
 # 1.5.1
 
 -   Fix animations for collapsible list. #7429

--- a/packages/experimental/src/experimental-list/style.scss
+++ b/packages/experimental/src/experimental-list/style.scss
@@ -17,11 +17,11 @@ a.woocommerce-experimental-list__item {
 		padding: $gap $gap-large;
 	}
 
-	&.has-action:not(.expanded) {
+	&.has-action:not( .expanded ) {
 		cursor: pointer;
 	}
 
-	&:focus:not(.expanded) {
+	&:focus:not( .expanded ) {
 		box-shadow: inset 0 0 0 1px $studio-wordpress-blue,
 			inset 0 0 0 2px $studio-white;
 	}
@@ -31,30 +31,30 @@ a.woocommerce-experimental-list__item {
 	}
 
 	// transitions
-	&:not(.transitions-disabled) {
+	&:not( .transitions-disabled ) {
 		&.woocommerce-list__item-enter {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX(50%);
+			transform: translateX( 50% );
 		}
 
 		&.woocommerce-list__item-enter-active {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX(0%);
+			transform: translateX( 0% );
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 
 		&.woocommerce-list__item-exit {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX(0%);
+			transform: translateX( 0% );
 		}
 
 		&.woocommerce-list__item-exit-active {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX(50%);
+			transform: translateX( 50% );
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 	}
@@ -76,7 +76,7 @@ a.woocommerce-experimental-list__item {
 		color: $studio-gray-90;
 	}
 
-	.woocommerce-list__item-content {
+	.woocommerce-list__item-expandable-content {
 		margin-top: $gap-smallest;
 		display: block;
 		font-size: 14px;
@@ -101,12 +101,12 @@ a.woocommerce-experimental-list__item {
 	$background-color: $white;
 	$background-color-hover: $gray-100;
 	$border-color: $gray-100;
-	$foreground-color: var(--wp-admin-theme-color);
-	$foreground-color-hover: var(--wp-admin-theme-color);
+	$foreground-color: var( --wp-admin-theme-color );
+	$foreground-color-hover: var( --wp-admin-theme-color );
 
 	background-color: $background-color;
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		border-top: 1px solid $border-color;
 	}
 
@@ -136,14 +136,14 @@ a.woocommerce-experimental-list__item {
 
 	&.is-complete {
 		.woocommerce-task__icon {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var( --wp-admin-theme-color );
 		}
 
 		.woocommerce-list__item-title {
 			color: $gray-700;
 		}
 
-		.woocommerce-list__item-content {
+		.woocommerce-list__item-expandable-content {
 			display: none;
 		}
 	}
@@ -153,6 +153,6 @@ a.woocommerce-experimental-list__item {
 	color: $studio-gray-80;
 }
 
-.woocommerce-experimental-list__item-content {
+.woocommerce-experimental-list__item-expandable-content {
 	color: $studio-gray-50;
 }

--- a/packages/experimental/src/experimental-list/style.scss
+++ b/packages/experimental/src/experimental-list/style.scss
@@ -17,11 +17,11 @@ a.woocommerce-experimental-list__item {
 		padding: $gap $gap-large;
 	}
 
-	&.has-action:not( .expanded ) {
+	&.has-action:not(.expanded) {
 		cursor: pointer;
 	}
 
-	&:focus:not( .expanded ) {
+	&:focus:not(.expanded) {
 		box-shadow: inset 0 0 0 1px $studio-wordpress-blue,
 			inset 0 0 0 2px $studio-white;
 	}
@@ -31,30 +31,30 @@ a.woocommerce-experimental-list__item {
 	}
 
 	// transitions
-	&:not( .transitions-disabled ) {
+	&:not(.transitions-disabled) {
 		&.woocommerce-list__item-enter {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX( 50% );
+			transform: translateX(50%);
 		}
 
 		&.woocommerce-list__item-enter-active {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX( 0% );
+			transform: translateX(0%);
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 
 		&.woocommerce-list__item-exit {
 			opacity: 1;
 			max-height: 100vh;
-			transform: translateX( 0% );
+			transform: translateX(0%);
 		}
 
 		&.woocommerce-list__item-exit-active {
 			opacity: 0;
 			max-height: 0;
-			transform: translateX( 50% );
+			transform: translateX(50%);
 			transition: opacity 500ms, transform 500ms, max-height 500ms;
 		}
 	}
@@ -101,12 +101,12 @@ a.woocommerce-experimental-list__item {
 	$background-color: $white;
 	$background-color-hover: $gray-100;
 	$border-color: $gray-100;
-	$foreground-color: var( --wp-admin-theme-color );
-	$foreground-color-hover: var( --wp-admin-theme-color );
+	$foreground-color: var(--wp-admin-theme-color);
+	$foreground-color-hover: var(--wp-admin-theme-color);
 
 	background-color: $background-color;
 
-	&:not( :first-child ) {
+	&:not(:first-child) {
 		border-top: 1px solid $border-color;
 	}
 
@@ -136,7 +136,7 @@ a.woocommerce-experimental-list__item {
 
 	&.is-complete {
 		.woocommerce-task__icon {
-			background-color: var( --wp-admin-theme-color );
+			background-color: var(--wp-admin-theme-color);
 		}
 
 		.woocommerce-list__item-title {

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -1,4 +1,4 @@
-$foreground-color: var(--wp-admin-theme-color);
+$foreground-color: var( --wp-admin-theme-color );
 $task-alert-yellow: #f0b849;
 
 .woocommerce-task-list__item {
@@ -42,7 +42,7 @@ $task-alert-yellow: #f0b849;
 	}
 
 	.woocommerce-task__additional-info,
-	.woocommerce-task-list__item-content,
+	.woocommerce-task-list__item-expandable-content,
 	.woocommerce-task__estimated-time {
 		color: $gray-700;
 		font-weight: 400;
@@ -68,27 +68,27 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	.woocommerce-task-list__item-content {
+	.woocommerce-task-list__item-expandable-content {
 		margin-top: $gap-smallest;
 		overflow: hidden;
 
-		&.woocommerce-task-list__item-content-enter {
+		&.woocommerce-task-list__item-expandable-content-enter {
 			opacity: 0;
 		}
 
-		&.woocommerce-task-list__item-content-enter-active {
+		&.woocommerce-task-list__item-expandable-content-enter-active {
 			opacity: 1;
 		}
 
-		&.woocommerce-task-list__item-content-enter-done {
+		&.woocommerce-task-list__item-expandable-content-enter-done {
 			opacity: 1;
 		}
 
-		&.woocommerce-task-list__item-content-exit {
+		&.woocommerce-task-list__item-expandable-content-exit {
 			opacity: 1;
 		}
 
-		&.woocommerce-task-list__item-content-exit-active {
+		&.woocommerce-task-list__item-expandable-content-exit-active {
 			opacity: 0;
 		}
 
@@ -123,20 +123,20 @@ $task-alert-yellow: #f0b849;
 
 	&.complete {
 		.woocommerce-task__icon {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var( --wp-admin-theme-color );
 		}
 
 		.woocommerce-task-list__item-title {
 			color: $gray-700;
 		}
 
-		.woocommerce-task-list__item-content,
+		.woocommerce-task-list__item-expandable-content,
 		.woocommerce-task__estimated-time {
 			display: none;
 		}
 	}
 
-	&:not(.complete) {
+	&:not( .complete ) {
 		.woocommerce-task__icon {
 			border: 1px solid $gray-100;
 			background: $white;

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -1,4 +1,4 @@
-$foreground-color: var( --wp-admin-theme-color );
+$foreground-color: var(--wp-admin-theme-color);
 $task-alert-yellow: #f0b849;
 
 .woocommerce-task-list__item {

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -123,7 +123,7 @@ $task-alert-yellow: #f0b849;
 
 	&.complete {
 		.woocommerce-task__icon {
-			background-color: var( --wp-admin-theme-color );
+			background-color: var(--wp-admin-theme-color);
 		}
 
 		.woocommerce-task-list__item-title {
@@ -136,7 +136,7 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	&:not( .complete ) {
+	&:not(.complete) {
 		.woocommerce-task__icon {
 			border: 1px solid $gray-100;
 			background: $white;

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -86,7 +86,7 @@ const OptionalExpansionWrapper: React.FC< {
 		<VerticalCSSTransition
 			timeout={ 500 }
 			in={ expanded }
-			classNames="woocommerce-task-list__item-content"
+			classNames="woocommerce-task-list__item-expandable-content"
 			defaultStyle={ {
 				transitionProperty: 'max-height, opacity',
 			} }
@@ -161,7 +161,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 						expandable={ expandable }
 						expanded={ expanded }
 					>
-						<div className="woocommerce-task-list__item-content">
+						<div className="woocommerce-task-list__item-expandable-content">
 							{ content }
 							{ expandable && ! completed && additionalInfo && (
 								<div


### PR DESCRIPTION
Fixes #7568 

Adjusting the css class name to prevent css conflicts with older versions, as the css drastically changed over the last version.
**Note:**
This wouldn't happen if we used a js css framework like emotion (that Gutenberg uses for example), given it add's a unique id to the css classes. We currently don't use anything like this so a simple class name change is the easiest solution for this.

There has been previous discussion about this (pbjpUB-8U-p2#comment-305, p90Yrv-2k8-p2 )

No changelog as it is in the package.

### Screenshots

<img width="784" alt="Screen Shot 2021-08-30 at 2 16 32 PM" src="https://user-images.githubusercontent.com/2240960/131378374-c654608a-ebe8-49e0-b6b8-969f83355957.png">

### Detailed test instructions:

1. Create a new store
2. Install **Google Listings and Ads** to have the extended task list show up as well.
2. Visit the home screen without WCPayments installed and notice how the task list looks (content/description is displayed)
3. Install WCPayments and visit the home screen again
4. The task list and extended task list should look identical to what it was before
5. Set [this line](https://github.com/woocommerce/woocommerce-admin/blob/main/client/task-list/index.js#L282) to `true` and test the expand/collapse functionality to see if it still works ok.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->