### PR TITLE
Use !important to force padding:0

### DIFF
--- a/client/homescreen/stats-overview/index.js
+++ b/client/homescreen/stats-overview/index.js
@@ -4,13 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
-import {
-	TabPanel,
-	Card,
-	CardHeader,
-	CardBody,
-	CardFooter,
-} from '@wordpress/components';
+import { TabPanel, Card, CardHeader, CardFooter } from '@wordpress/components';
 import { get, xor } from 'lodash';
 import {
 	EllipsisMenu,
@@ -122,46 +116,44 @@ export const StatsOverview = () => {
 					) }
 				/>
 			</CardHeader>
-			<CardBody>
-				<TabPanel
-					className="woocommerce-stats-overview__tabs"
-					onSelect={ ( period ) => {
-						recordEvent( 'statsoverview_date_picker_update', {
-							period,
-						} );
-					} }
-					tabs={ [
-						{
-							title: __( 'Today', 'woocommerce-admin' ),
-							name: 'today',
-						},
-						{
-							title: __( 'Week to date', 'woocommerce-admin' ),
-							name: 'week',
-						},
-						{
-							title: __( 'Month to date', 'woocommerce-admin' ),
-							name: 'month',
-						},
-					] }
-				>
-					{ ( tab ) => (
-						<Fragment>
-							{ ! jetPackIsConnected &&
-								! userDismissedJetpackInstall && (
-									<InstallJetpackCTA />
-								) }
-							<StatsList
-								query={ {
-									period: tab.name,
-									compare: 'previous_period',
-								} }
-								stats={ activeStats }
-							/>
-						</Fragment>
-					) }
-				</TabPanel>
-			</CardBody>
+			<TabPanel
+				className="woocommerce-stats-overview__tabs"
+				onSelect={ ( period ) => {
+					recordEvent( 'statsoverview_date_picker_update', {
+						period,
+					} );
+				} }
+				tabs={ [
+					{
+						title: __( 'Today', 'woocommerce-admin' ),
+						name: 'today',
+					},
+					{
+						title: __( 'Week to date', 'woocommerce-admin' ),
+						name: 'week',
+					},
+					{
+						title: __( 'Month to date', 'woocommerce-admin' ),
+						name: 'month',
+					},
+				] }
+			>
+				{ ( tab ) => (
+					<Fragment>
+						{ ! jetPackIsConnected &&
+							! userDismissedJetpackInstall && (
+								<InstallJetpackCTA />
+							) }
+						<StatsList
+							query={ {
+								period: tab.name,
+								compare: 'previous_period',
+							} }
+							stats={ activeStats }
+						/>
+					</Fragment>
+				) }
+			</TabPanel>
 			<CardFooter>
 				<Link
 					className="woocommerce-stats-overview__more-btn"

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -80,10 +80,6 @@
 		}
 	}
 
-	.components-card__body {
-		padding: 0 !important;
-	}
-
 	.components-card__footer.is-size-large {
 		padding: 0 $gap-smaller;
 	}

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -81,7 +81,7 @@
 	}
 
 	.components-card__body {
-		padding: 0;
+		padding: 0 !important;
 	}
 
 	.components-card__footer.is-size-large {


### PR DESCRIPTION
Fixes #7576 

This PR uses `!important` to force `padding:0` to fix the unexpected padding with `components-card__body` class.

### Detailed test instructions:


Note: I wasn't able to reproduce it when WCA is activated separately as a plugin. I think it's because WCA loads the style first.

**This is what I see when I activate WCA.**

Notice `padding: 0` is active. 

![Screen Shot 2021-08-30 at 10 30 49 AMth_](https://user-images.githubusercontent.com/4723145/131380798-afca7568-debd-4dca-a19b-e2403f352f3f.jpg)

**CSS with WC 5.7 beta alone:**

Notice `padding: 0` is grayed out.

![Screen Shot 2021-08-30 at 10 34 33 AMth_](https://user-images.githubusercontent.com/4723145/131380809-b62de850-a3f2-4e8b-826c-02221df930fe.jpg)



1.  Checkout this branch and build the css with `npm start`
2. Navigate to WooCommerce -> Home
3. Open the inspector and find `woocommerce-stats-overview__tabs` class.
4. Click the parent div and make sure `.woocommerce-homescreen-card .components-card__body` class has `padding: 0 !important;`


no changelog