### PR TITLE
Fix CSS layout issue on the marketing task

### DIFF
--- a/client/task-list/tasks/Marketing/Marketing.scss
+++ b/client/task-list/tasks/Marketing/Marketing.scss
@@ -2,8 +2,10 @@
 	.components-card__header {
 		flex-direction: column;
 		align-items: flex-start;
+		display: flex !important;
 
 		h2 {
+			align-self: start !important;
 			color: $gray-900;
 			font-size: 20px;
 			margin-bottom: 0;


### PR DESCRIPTION
Fixes #7566 

This PR fixes the layout issue with the plugin header section on the marketing task.

I'm not a fan of using `!important`, but it was needed to override styles added automatically to the `compoents-card` class. We probably want to revisit this change later.

### Screenshots

**Before**

<img width="1149" alt="before" src="https://user-images.githubusercontent.com/4723145/131423193-d9242740-c57f-4be8-ac62-99ad6bee3735.png">

**After**
![Screen Shot 2021-08-30 at 5 36 57 PM](https://user-images.githubusercontent.com/4723145/131423211-72cde2cb-b4af-4480-9242-dfd496b8724b.jpg)


### Detailed test instructions:

1. Checkout this branch and run `npm start` to compile the css changes.
2. Navigate to WooCommerce -> Home and click `Set up marketing tools` task (wp-admin/admin.php?page=wc-admin&task=marketing)
3. Confirm the header section rendered without breaking the css (refer to the screenshots).

no changelog