### PR TITLE
Update Email Prefill Endpoint as Experimental

### DIFF
--- a/packages/data/src/onboarding/resolvers.js
+++ b/packages/data/src/onboarding/resolvers.js
@@ -35,7 +35,9 @@ export function* getProfileItems() {
 export function* getEmailPrefill() {
 	try {
 		const results = yield apiFetch( {
-			path: WC_ADMIN_NAMESPACE + '/onboarding/profile/get_email_prefill',
+			path:
+				WC_ADMIN_NAMESPACE +
+				'/onboarding/profile/experimental_get_email_prefill',
 			method: 'GET',
 		} );
 

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -61,9 +61,11 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+
+		// This endpoint is experimental. For internal use only.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/get_email_prefill',
+			'/' . $this->rest_base . '/experimental_get_email_prefill',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,


### PR DESCRIPTION
This is a follow-up to PR #7570 .

The `onboarding/profile/get_email_prefill` endpoint has been made experimental because it is likely to have a short-lived life.

Discussion was held internally to move forward with a new endpoint returning various data about the current user, including this email address. The plan is to switch the OBW over to the newer endpoint when ready and remove `get_email_prefill`.

The `get_email_prefill` endpoint has not previously been included in a WC Admin release. It has been made experimental by prefixing the name with `experimental_` to discourage use.

### Detailed test instructions:

-   Start the Onboarding Wizard
-   See that the email address is prefilled with the user’s email address.

<img width="528" alt="Screen Shot 2021-08-31 at 1 01 53 pm" src="https://user-images.githubusercontent.com/9312929/131445020-8d48a61f-eafd-47ad-987d-c87cd02f1a1e.png">


No changelog.