### PR TITLE
Remove docs command from pre-release command

### DIFF
--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -80,10 +80,6 @@ status "Run scripts to propagate version numbers and update dependencies."
 
 npm run bump-version
 
-status "Run docs script to make sure docs are updated."
-
-npm run docs
-
 status "Here are the changes so far. Make sure the following changes are reflected."
 
 echo "- docs/: folder will have changes to documentation, if any."


### PR DESCRIPTION
Fixes #7605

This PR removes `npm run docs`. This command is unnecessary. Details are explained in #7605 

### Detailed test instructions:

Run `npm run pre-release` and confirm the process completes without `npm run docs`

no changelog