### PR TITLE
Get email prefill to avoid infinite loading state

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -438,6 +438,7 @@ export default compose(
 		const { isResolving } = select( OPTIONS_STORE_NAME );
 
 		const profileItems = getProfileItems();
+		const emailPrefill = getEmailPrefill();
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isBusy =
@@ -473,7 +474,7 @@ export default compose(
 			storeEmail:
 				typeof profileItems.store_email === 'string'
 					? profileItems.store_email
-					: getEmailPrefill(),
+					: emailPrefill,
 		};
 
 		return {


### PR DESCRIPTION
Fixes #7604 

Email prefill was a condition for loading state of the store details step, but in some cases is never fetched, creating an infinite spinner/loading state.

@adrianduffell can you give this a look to make sure I haven't created any errors in the prefill logic?

### Screenshots

#### Before
<img width="1036" alt="Screen Shot 2021-08-31 at 5 58 42 PM" src="https://user-images.githubusercontent.com/10561050/131866744-23b832d5-b241-45fe-ba0d-6aa83d737992.png">


#### After

<img width="1032" alt="Screen Shot 2021-09-02 at 10 55 40 AM" src="https://user-images.githubusercontent.com/10561050/131866805-7c7e8239-869c-4e1c-8cac-ebdfc9b9764c.png">


### Detailed test instructions:

1. Complete the store profiler (change the email address in store details if you have previously filled it in)
2. Navigate to the task list and refresh the page.
3. Click on the task to finish store details.
4. Note the page finishes loading.