### PR TITLE
Fixing an unwanted page refresh when using Woo Navigation

### DIFF
--- a/changelogs/fix-woonav-page-refresh
+++ b/changelogs/fix-woonav-page-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fixing an unwanted page refresh when using Woo Navigation

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -174,6 +174,9 @@ class _Layout extends Component {
 					) }
 				</div>
 				<PluginArea scope="woocommerce-admin" />
+				{ window.wcAdminFeatures.navigation && (
+					<PluginArea scope="woocommerce-navigation" />
+				) }
 			</SlotFillProvider>
 		);
 	}

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -93,5 +93,5 @@ const NavigationPlugin = () => {
 
 registerPlugin( 'wc-admin-navigation', {
 	render: NavigationPlugin,
-	scope: 'woocommerce-admin',
+	scope: 'woocommerce-navigation',
 } );

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -93,4 +93,5 @@ const NavigationPlugin = () => {
 
 registerPlugin( 'wc-admin-navigation', {
 	render: NavigationPlugin,
+	scope: 'woocommerce-admin',
 } );

--- a/docs/examples/extensions/add-navigation-items/js/index.js
+++ b/docs/examples/extensions/add-navigation-items/js/index.js
@@ -20,4 +20,7 @@ const MyPlugin = () => {
 	);
 };
 
-registerPlugin( 'my-plugin', { render: MyPlugin, scope: 'woocommerce-admin' } );
+registerPlugin( 'my-plugin', {
+	render: MyPlugin,
+	scope: 'woocommerce-navigation',
+} );

--- a/docs/examples/extensions/add-navigation-items/js/index.js
+++ b/docs/examples/extensions/add-navigation-items/js/index.js
@@ -3,21 +3,21 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { registerPlugin } from "@wordpress/plugins";
-import { WooNavigationItem } from "@woocommerce/navigation";
+import { registerPlugin } from '@wordpress/plugins';
+import { WooNavigationItem } from '@woocommerce/navigation';
 
 const MyPlugin = () => {
-    const handleClick = () => {
-        alert( 'Menu item clicked!' );
-    }
+	const handleClick = () => {
+		alert( 'Menu item clicked!' );
+	};
 
-    return (
-        <WooNavigationItem item="example-category-child-2">
-            <Button onClick={ handleClick }>
-                { __( 'JavaScript Example', 'plugin-domain' ) }
-            </Button>
-        </WooNavigationItem>
-    );
+	return (
+		<WooNavigationItem item="example-category-child-2">
+			<Button onClick={ handleClick }>
+				{ __( 'JavaScript Example', 'plugin-domain' ) }
+			</Button>
+		</WooNavigationItem>
+	);
 };
 
-registerPlugin('my-plugin', { render: MyPlugin });
+registerPlugin( 'my-plugin', { render: MyPlugin, scope: 'woocommerce-admin' } );

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -121,5 +121,5 @@ const MyPlugin = () => {
     );
 };
 
-registerPlugin( 'my-plugin', { render: MyPlugin, scope: 'woocommerce-admin' } );
+registerPlugin( 'my-plugin', { render: MyPlugin, scope: 'woocommerce-navigation' } );
 ```

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -121,5 +121,5 @@ const MyPlugin = () => {
     );
 };
 
-registerPlugin('my-plugin', { render: MyPlugin });
+registerPlugin( 'my-plugin', { render: MyPlugin, scope: 'woocommerce-admin' } );
 ```


### PR DESCRIPTION
I noticed that navigating with the Woo Navigation was resulting in page refreshes when it shouldn't. This was just a quick fix due to a breaking change a while ago with `registerPlugin` needing a `scope` parameter.

Note that my prettier wants to completely reformat the markdown files for some reason, which is obfuscating the diff. Just adding the `scope` parameter in the docs as well.

### Detailed test instructions:

-   Enable Woo Navigation
-   Go to the Homepage
- Then use the Woo Navigation to go to "Customers," or an analytics report
- There should be no page refresh
- If you want, comment out the added `scope` option and notice that the page refresh returns