### PR TITLE
Add Powered by Mailchimp

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -348,12 +348,22 @@ class StoreDetails extends Component {
 
 							<CardFooter>
 								<FlexItem>
-									<div>
+									<div className="woocommerce-profile-wizard__newsletter-signup">
 										<CheckboxControl
-											label={ __(
-												'Get tips, product updates and inspiration straight to your mailbox',
-												'woocommerce-admin'
-											) }
+											label={
+												<>
+													{ __(
+														'Get tips, product updates and inspiration straight to your mailbox.',
+														'woocommerce-admin'
+													) }{ ' ' }
+													<span className="woocommerce-profile-wizard__powered-by-mailchimp">
+														{ __(
+															'Powered by Mailchimp',
+															'woocommerce-admin'
+														) }
+													</span>
+												</>
+											}
 											{ ...getInputProps(
 												'isAgreeMarketing'
 											) }

--- a/client/profile-wizard/steps/store-details/style.scss
+++ b/client/profile-wizard/steps/store-details/style.scss
@@ -8,3 +8,9 @@
 		min-width: 360px;
 	}
 }
+
+.woocommerce-profile-wizard__newsletter-signup {
+	.woocommerce-profile-wizard__powered-by-mailchimp {
+		color: $studio-gray-20;
+	}
+}

--- a/client/profile-wizard/steps/store-details/style.scss
+++ b/client/profile-wizard/steps/store-details/style.scss
@@ -10,6 +10,11 @@
 }
 
 .woocommerce-profile-wizard__newsletter-signup {
+	.components-base-control__field {
+		display: flex;
+		align-items: center;
+	}
+
 	.woocommerce-profile-wizard__powered-by-mailchimp {
 		color: $studio-gray-20;
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/7450#issuecomment-908931486

Adds "Powered by Mailchimp" to the newsletter signup confirmation checkbox label.

This extra text now causes the label to span 2 lines. I've also used flexbox to enable the checkbox to center vertically.

### Screenshots

<img width="537" alt="Screen Shot 2021-09-03 at 6 24 33 pm" src="https://user-images.githubusercontent.com/9312929/131990849-590dbdc0-dfc2-42ed-81f8-514ed44d8e3a.png">

### Detailed test instructions:

No functionality is changed in this PR.

-   Start the OBW and see "Powered by Mailchimp" in the label.

<!--- Please add a Changelog note

No changelog.