### PR TITLE
Add toggle to experimental task item

### DIFF
--- a/changelogs/add-experimental_tasklist_toggle
+++ b/changelogs/add-experimental_tasklist_toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add expandable tasklist item

--- a/changelogs/add-experimental_tasklist_toggle
+++ b/changelogs/add-experimental_tasklist_toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add expandable tasklist item

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { Button, Card, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu, Badge } from '@woocommerce/components';
@@ -84,10 +84,6 @@ export const TaskList = ( {
 			task.visible &&
 			! task.completed &&
 			! dismissedTasks.includes( task.key )
-	);
-
-	const [ currentTask, setCurrentTask ] = useState(
-		incompleteTasks[ 0 ]?.key
 	);
 
 	const possiblyCompleteTaskList = () => {
@@ -349,15 +345,9 @@ export const TaskList = ( {
 								title={ task.title }
 								completed={ task.completed }
 								content={ task.content }
-								onClick={
-									! expandingItems || task.completed
-										? task.onClick
-										: () => setCurrentTask( task.key )
-								}
-								expandable={ expandingItems }
-								expanded={
-									expandingItems && currentTask === task.key
-								}
+								expandable={ expandingItems && task.expandable }
+								expanded={ expandingItems && task.expanded }
+								onClick={ task.onClick }
 								onDismiss={
 									task.isDismissable
 										? () => dismissTask( task )
@@ -370,9 +360,10 @@ export const TaskList = ( {
 								}
 								time={ task.time }
 								level={ task.level }
-								action={ task.onClick }
-								actionLabel={ task.action }
+								action={ task.action }
+								actionLabel={ task.actionLabel }
 								additionalInfo={ task.additionalInfo }
+								showActionButton={ task.showActionButton }
 							/>
 						) ) }
 					</ListComp>

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -364,6 +364,8 @@ export const TaskList = ( {
 								actionLabel={ task.actionLabel }
 								additionalInfo={ task.additionalInfo }
 								showActionButton={ task.showActionButton }
+								onExpand={ task.onExpand }
+								onCollapse={ task.onCollapse }
 							/>
 						) ) }
 					</ListComp>

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -106,8 +106,8 @@ describe( 'TaskDashboard and TaskList', () => {
 				isDismissable: false,
 				type: 'setup',
 				action: 'CTA (required)',
+				actionLabel: 'This is the action label',
 				content: 'This is the required task content',
-				additionalInfo: 'This is the required task additional info',
 				expandable: false,
 			},
 			{
@@ -735,24 +735,15 @@ describe( 'TaskDashboard and TaskList', () => {
 			},
 		] );
 		await act( async () => {
-			const { container, queryByText } = render(
-				<TaskDashboard query={ {} } />
-			);
+			const { queryByText } = render( <TaskDashboard query={ {} } /> );
 
 			// Expect the first incomplete task to be expanded
 			expect(
-				(
-					await findByText(
-						container,
-						'This is the optional task content'
-					)
-				 ).parentElement.style.maxHeight
-			).not.toBe( '0' );
+				queryByText( 'This is the optional task content' )
+			).not.toBeNull();
 
 			// Expect the second not to be.
-			expect(
-				queryByText( 'This is the required task additional info' )
-			).not.toBeNull();
+			expect( queryByText( 'This is the action label' ) ).toBeNull();
 		} );
 	} );
 

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -92,6 +92,9 @@ describe( 'TaskDashboard and TaskList', () => {
 				type: 'setup',
 				action: 'CTA (optional)',
 				content: 'This is the optional task content',
+				additionalInfo: 'This is the task additional info',
+				expandable: true,
+				expanded: true,
 			},
 			{
 				key: 'required',
@@ -104,6 +107,8 @@ describe( 'TaskDashboard and TaskList', () => {
 				type: 'setup',
 				action: 'CTA (required)',
 				content: 'This is the required task content',
+				additionalInfo: 'This is the required task additional info',
+				expandable: false,
 			},
 			{
 				key: 'completed',
@@ -746,9 +751,8 @@ describe( 'TaskDashboard and TaskList', () => {
 
 			// Expect the second not to be.
 			expect(
-				queryByText( 'This is the required task content' ).parentElement
-					.style.maxHeight
-			).toBe( '0' );
+				queryByText( 'This is the required task additional info' )
+			).not.toBeNull();
 		} );
 	} );
 

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Adjust task-item css class to prevent css conflicts. #7593
 -   Update task-item logic to only display content when expanded is true. #7611
+-   Add expandable tasklist item. #7632
 
 # 1.5.1
 

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -223,11 +223,9 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 		'woocommerce-experimental-list'
 	);
 
-	const wrapperClasses = classnames(
-		{
-			'woocommerce-experimental-list-wrapper': ! isCollapsed,
-		}
-	)
+	const wrapperClasses = classnames( {
+		'woocommerce-experimental-list-wrapper': ! isCollapsed,
+	} )
 
 	return (
 		<ExperimentalList { ...listProps } className={ listClasses }>

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -225,7 +225,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 
 	const wrapperClasses = classnames( {
 		'woocommerce-experimental-list-wrapper': ! isCollapsed,
-	} )
+	} );
 
 	return (
 		<ExperimentalList { ...listProps } className={ listClasses }>

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -223,6 +223,12 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 		'woocommerce-experimental-list'
 	);
 
+	const wrapperClasses = classnames(
+		{
+			'woocommerce-experimental-list-wrapper': ! isCollapsed,
+		}
+	)
+
 	return (
 		<ExperimentalList { ...listProps } className={ listClasses }>
 			{ [
@@ -244,7 +250,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 						);
 						return (
 							<div
-								className="woocommerce-experimental-list-wrapper"
+								className={ wrapperClasses }
 								ref={ collapseContainerRef }
 								style={ transitionStyles }
 							>

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -244,6 +244,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 						);
 						return (
 							<div
+								className="woocommerce-experimental-list-wrapper"
 								ref={ collapseContainerRef }
 								style={ transitionStyles }
 							>

--- a/packages/experimental/src/experimental-list/collapsible-list/style.scss
+++ b/packages/experimental/src/experimental-list/collapsible-list/style.scss
@@ -37,3 +37,7 @@
 		transition: max-height 500ms;
 	}
 }
+
+.woocommerce-experimental-list-wrapper {
+	border-top: 1px solid $gray-100;
+}

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement, Fragment, useState } from '@wordpress/element';
+import {
+	createElement,
+	Fragment,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { Button, Tooltip } from '@wordpress/components';
@@ -119,6 +124,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	...listItemProps
 } ) => {
 	const [ isTaskExpanded, setTaskExpanded ] = useState( expanded );
+	useEffect( () => {
+		setTaskExpanded( ! isTaskExpanded );
+	}, [ expanded ] );
 
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -35,8 +35,10 @@ type TaskItemProps = {
 	title: string;
 	completed: boolean;
 	onClick: () => void;
+	onCollapse?: () => void;
 	onDelete?: () => void;
 	onDismiss?: () => void;
+	onExpand?: () => void;
 	remindMeLater?: () => void;
 	additionalInfo?: string;
 	time?: string;
@@ -100,7 +102,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	completed,
 	title,
 	onDelete,
+	onCollapse,
 	onDismiss,
+	onExpand,
 	remindMeLater,
 	onClick,
 	additionalInfo,
@@ -132,6 +136,12 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 
 	const toggleActionVisibility = () => {
 		setTaskExpanded( ! isTaskExpanded );
+		if ( isTaskExpanded && onExpand ) {
+			onExpand();
+		}
+		if ( ! isTaskExpanded && onCollapse ) {
+			onCollapse();
+		}
 	};
 
 	return (

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -125,7 +125,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 } ) => {
 	const [ isTaskExpanded, setTaskExpanded ] = useState( expanded );
 	useEffect( () => {
-		setTaskExpanded( ! isTaskExpanded );
+		setTaskExpanded( expanded );
 	}, [ expanded ] );
 
 	const className = classnames( 'woocommerce-task-list__item', {

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -139,7 +139,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 			disableGutters
 			className={ className }
 			onClick={
-				expandable && ! onClick ? toggleActionVisibility : onClick
+				expandable && showActionButton
+					? toggleActionVisibility
+					: onClick
 			}
 			{ ...listItemProps }
 		>

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -122,7 +122,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
-		isTaskExpanded,
+		expanded: isTaskExpanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, Fragment } from '@wordpress/element';
+import { createElement, Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { Button, Tooltip } from '@wordpress/components';
@@ -114,9 +114,11 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	actionLabel,
 	...listItemProps
 } ) => {
+	const [ isTaskExpanded, setTaskExpanded ] = useState( expanded );
+
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
-		expanded,
+		isTaskExpanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );
@@ -128,11 +130,17 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 		( ( onDismiss || remindMeLater ) && ! completed ) ||
 		( onDelete && completed );
 
+	const toggleActionVisibility = () => {
+		setTaskExpanded( ! isTaskExpanded );
+	};
+
 	return (
 		<ListItem
 			disableGutters
 			className={ className }
-			onClick={ onClick }
+			onClick={
+				expandable && ! onClick ? toggleActionVisibility : onClick
+			}
 			{ ...listItemProps }
 		>
 			<OptionalTaskTooltip level={ level } completed={ completed }>
@@ -159,7 +167,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					</span>
 					<OptionalExpansionWrapper
 						expandable={ expandable }
-						expanded={ expanded }
+						expanded={ isTaskExpanded }
 					>
 						<div className="woocommerce-task-list__item-expandable-content">
 							{ content }


### PR DESCRIPTION
This PR adds a toggle to the experimental task item.


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-one wordpress test-2021 09 07-11_11_03](https://user-images.githubusercontent.com/1314156/132359747-7a70e784-d6ed-418c-bc70-684d70b01863.png)


### Detailed test instructions:

- I created the branch `add/experimental_tasklist_toggle_test` to make this PR easier to test.
- Checkout `add/experimental_tasklist_toggle_test` and run `npm run example -- --ext=add-expandable-task` to create an expandable task item.
- Go to plugins and activate the plugin `WooCommerce Admin Add Expandable Task`.
- Go to the `Home` screen.
- Click the `Example` task item (under `Things to do next` task list) and verify that the task expands after clicking. The button `My action button` should be visible.
- Open the browser console and click the button. The text `This is an action!` should be printed in the console after clicking the button. 

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
No changelog is needed here.