### PR TITLE
Bump experimental version

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.0.0
+
 -   Adjust task-item css class to prevent css conflicts. #7593
 -   Update task-item logic to only display content when expanded is true. #7611
 -   Add expandable tasklist item. #7632

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.5.1",
+	"version": "2.0.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bumps version number for the experimental package ahead of publishing to npm.

No changelog.