### PR TITLE
Bump experimental version to 2.0.2

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 2.0.1
+# 2.0.2
 
 -   Adjust task-item css class to prevent css conflicts. #7593
 -   Update task-item logic to only display content when expanded is true. #7611

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bumps version number for the experimental package ahead of publishing to npm.
Version 2.0.2

No changelog.