### PR TITLE
Use target: es2019 for backward compatibility

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "esnext",
+		"target": "es2019",
 		"module": "esnext",
 		"moduleResolution": "node",
 		"allowJs": true,


### PR DESCRIPTION
Fixes #7657

This PR uses `target: 2019` to improve backward compatibility.

### Detailed test instructions:

Run `npm run build:packages` and confirm no errors.

no changelog