### PR TITLE
Add Task API

### DIFF
--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Handles task related methods.
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+/**
+ * Task class.
+ */
+class Task {
+	/**
+	 * ID.
+	 *
+	 * @var string
+	 */
+	protected $id = '';
+
+	/**
+	 * Title.
+	 *
+	 * @var string
+	 */
+	protected $title = '';
+
+	/**
+	 * Title.
+	 *
+	 * @var string
+	 */
+	protected $content = '';
+
+	/**
+	 * Action label.
+	 *
+	 * @var string
+	 */
+	protected $action_label = '';
+
+	/**
+	 * Action URL.
+	 *
+	 * @var string|null
+	 */
+	protected $action_url = null;
+
+	/**
+	 * Task completion.
+	 *
+	 * @var bool
+	 */
+	protected $is_complete = false;
+
+	/**
+	 * Viewing capability.
+	 *
+	 * @var bool
+	 */
+	protected $can_view = true;
+
+	/**
+	 * Time string.
+	 *
+	 * @var string|null
+	 */
+	protected $time = null;
+
+	/**
+	 * Dismissability.
+	 *
+	 * @var bool
+	 */
+	protected $is_dismissable = false;
+
+	/**
+	 * Snoozeability.
+	 *
+	 * @var bool
+	 */
+	protected $is_snoozeable = false;
+
+	/**
+	 * Snoozeability.
+	 *
+	 * @var string|null
+	 */
+	protected $snoozed_until = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $data Task list data.
+	 */
+	public function __construct( $data = array() ) {
+		$defaults = array(
+			'id'             => null,
+			'title'          => '',
+			'content'        => '',
+			'action_label'   => __( "Let's go", 'woocommerce-admin' ),
+			'action_url'     => null,
+			'is_complete'    => false,
+			'can_view'       => true,
+			'time'           => null,
+			'is_dismissable' => false,
+			'is_snoozeable'  => false,
+			'snoozed_until'  => null,
+		);
+
+		$data = wp_parse_args( $data, $defaults );
+
+		$this->id             = (int) $data['id'];
+		$this->title          = (string) $data['title'];
+		$this->content        = (string) $data['content'];
+		$this->action_label   = (string) $data['action_label'];
+		$this->action_url     = (string) $data['action_url'];
+		$this->is_complete    = (bool) $data['is_complete'];
+		$this->can_view       = (bool) $data['can_view'];
+		$this->time           = (string) $data['time'];
+		$this->is_dismissable = (bool) $data['is_dismissable'];
+		$this->is_snoozeable  = (bool) $data['is_snoozeable'];
+
+		$snoozed_tasks = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+		if ( isset( $snoozed_tasks[ $this->id ] ) ) {
+			$this->snoozed_until = $snoozed_tasks[ $this->id ];
+		}
+	}
+
+	/**
+	 * Bool for task dismissal.
+	 */
+	public function is_dismissed() {
+		if ( ! $this->is_dismissable ) {
+			return false;
+		}
+
+		$dismissed = get_option( 'woocommerce_task_list_dismissed_tasks', array() );
+
+		return in_array( $this->id, $dismissed, true );
+	}
+
+	/**
+	 * Bool for task snoozed.
+	 */
+	public function is_snoozed() {
+		if ( ! $this->is_snoozeable ) {
+			return false;
+		}
+
+		$snoozed = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+
+		return in_array( $this->id, $snoozed, true );
+	}
+
+	/**
+	 * Bool for task visibility.
+	 */
+	public function is_visible() {
+		return $this->can_view && ! $this->is_snoozed() && ! $this->is_dismissed();
+	}
+
+	/**
+	 * Get the task as JSON.
+	 */
+	public function get_json() {
+		return array(
+			'id'            => $this->id,
+			'title'         => $this->title,
+			'content'       => $this->content,
+			'actionLabel'   => $this->action_label,
+			'actionUrl'     => $this->action_url,
+			'isComplete'    => $this->is_complete,
+			'isVisible'     => $this->is_visible(),
+			'time'          => $this->time,
+			'isDismissed'   => $this->is_dismissed(),
+			'isDismissable' => $this->is_dismissable,
+			'isSnoozed'     => $this->is_snoozed(),
+			'isSnoozeable'  => $this->is_snoozeable,
+			'snoozedUntil'  => $this->snoozed_until,
+		);
+	}
+
+}

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -215,7 +215,7 @@ class Task {
 
 		$snoozed = get_option( self::SNOOZED_OPTION, array() );
 
-		return isset( $snoozed[ $this->id ] ) && $snoozed > ( time() * 1000 );
+		return isset( $snoozed[ $this->id ] ) && $snoozed[ $this->id ] > ( time() * 1000 );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -14,35 +14,35 @@ class Task {
 	 *
 	 * @var string
 	 */
-	protected $id = '';
+	public $id = '';
 
 	/**
 	 * Title.
 	 *
 	 * @var string
 	 */
-	protected $title = '';
+	public $title = '';
 
 	/**
 	 * Title.
 	 *
 	 * @var string
 	 */
-	protected $content = '';
+	public $content = '';
 
 	/**
 	 * Action label.
 	 *
 	 * @var string
 	 */
-	protected $action_label = '';
+	public $action_label = '';
 
 	/**
 	 * Action URL.
 	 *
 	 * @var string|null
 	 */
-	protected $action_url = null;
+	public $action_url = null;
 
 	/**
 	 * Task completion.
@@ -63,7 +63,7 @@ class Task {
 	 *
 	 * @var string|null
 	 */
-	protected $time = null;
+	public $time = null;
 
 	/**
 	 * Dismissability.
@@ -84,7 +84,7 @@ class Task {
 	 *
 	 * @var string|null
 	 */
-	protected $snoozed_until = null;
+	public $snoozed_until = null;
 
 	/**
 	 * Name of the dismiss option.
@@ -133,7 +133,7 @@ class Task {
 
 		$data = wp_parse_args( $data, $defaults );
 
-		$this->id             = (int) $data['id'];
+		$this->id             = (string) $data['id'];
 		$this->title          = (string) $data['title'];
 		$this->content        = (string) $data['content'];
 		$this->action_label   = (string) $data['action_label'];
@@ -144,7 +144,7 @@ class Task {
 		$this->is_dismissable = (bool) $data['is_dismissable'];
 		$this->is_snoozeable  = (bool) $data['is_snoozeable'];
 
-		$snoozed_tasks = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+		$snoozed_tasks = get_option( self::SNOOZED_OPTION, array() );
 		if ( isset( $snoozed_tasks[ $this->id ] ) ) {
 			$this->snoozed_until = $snoozed_tasks[ $this->id ];
 		}
@@ -215,7 +215,7 @@ class Task {
 
 		$snoozed = get_option( self::SNOOZED_OPTION, array() );
 
-		return in_array( $this->id, $snoozed, true );
+		return isset( $snoozed[ $this->id ] ) && $snoozed > ( time() * 1000 );
 	}
 
 	/**
@@ -250,8 +250,8 @@ class Task {
 	 * @return bool
 	 */
 	public function undo_snooze() {
+		$snoozed = get_option( self::SNOOZED_OPTION, array() );
 		unset( $snoozed[ $this->id ] );
-
 		$update = update_option( self::SNOOZED_OPTION, $snoozed );
 
 		if ( $update ) {

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
 /**
  * Task List class.
  */
@@ -107,7 +109,7 @@ class TaskList {
 	 * @param array $args Task properties.
 	 */
 	public function add_task( $args ) {
-		$this->tasks[] = $args;
+		$this->tasks[] = new Task( $args );
 	}
 
 	/**
@@ -121,7 +123,12 @@ class TaskList {
 			'title'      => $this->title,
 			'isHidden'   => $this->is_hidden(),
 			'isComplete' => $this->is_complete(),
-			'tasks'      => $this->tasks,
+			'tasks'      => array_map(
+				function( $task ) {
+					return $task->get_json();
+				},
+				$this->tasks
+			),
 		);
 	}
 

--- a/tests/features/onboarding-tasks/task.php
+++ b/tests/features/onboarding-tasks/task.php
@@ -181,7 +181,7 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests a non snoozeable task cannot be snoozed.
+	 * Tests that a non snoozeable task cannot be snoozed.
 	 */
 	public function test_not_snoozeable() {
 		$task = new Task(
@@ -192,6 +192,25 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		);
 
 		$task->snooze();
+		$this->assertEquals( false, $task->is_snoozed() );
+	}
+
+	/**
+	 * Tests that a task is no longer consider snoozed after the time has passed.
+	 */
+	public function test_snooze_time() {
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-snoozeable-task',
+				'is_snoozeable' => true,
+			)
+		);
+
+		$time                                    = time() * 1000 - 1;
+		$snoozed                                 = get_option( Task::SNOOZED_OPTION, array() );
+		$snoozed['wc-unit-test-snoozeable-task'] = $time;
+		update_option( Task::SNOOZED_OPTION, $snoozed );
+
 		$this->assertEquals( false, $task->is_snoozed() );
 	}
 

--- a/tests/features/onboarding-tasks/task.php
+++ b/tests/features/onboarding-tasks/task.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Test the Task class.
+ *
+ * @package WooCommerce\Admin\Tests\OnboardingTasks
+ */
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * class WC_Tests_OnboardingTasks_Task
+ */
+class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
+	/**
+	 * Task.
+	 *
+	 * @var Task|null
+	 */
+	protected $task = null;
+
+	/**
+	 * Tests that a task is visible by default.
+	 */
+	public function test_capability_visible() {
+		$task = new Task(
+			array(
+				'id' => 'wc-unit-test-task',
+			)
+		);
+
+		$this->assertEquals( true, $task->is_visible() );
+	}
+
+	/**
+	 * Tests that a task is not visible when not capable of being viewed.
+	 */
+	public function test_capability_not_visible() {
+		$task = new Task(
+			array(
+				'id'       => 'wc-unit-test-task',
+				'can_view' => false,
+			)
+		);
+
+		$this->assertEquals( false, $task->is_visible() );
+	}
+
+	/**
+	 * Tests that a task can be dismissed.
+	 */
+	public function test_dismiss() {
+		$task = new Task(
+			array(
+				'id'             => 'wc-unit-test-task',
+				'is_dismissable' => true,
+			)
+		);
+
+		$update    = $task->dismiss();
+		$dismissed = get_option( Task::DISMISSED_OPTION, array() );
+		$this->assertEquals( true, $update );
+		$this->assertContains( $task->id, $dismissed );
+	}
+
+	/**
+	 * Tests that a dismissal can be undone.
+	 */
+	public function test_undo_dismiss() {
+		$task = new Task(
+			array(
+				'id'             => 'wc-unit-test-task',
+				'is_dismissable' => true,
+			)
+		);
+
+		$task->dismiss();
+		$task->undo_dismiss();
+		$dismissed = get_option( Task::DISMISSED_OPTION, array() );
+		$this->assertNotContains( $task->id, $dismissed );
+	}
+
+	/**
+	 * Tests that a non-dismissable task cannot be dismissed.
+	 */
+	public function test_not_dismissable() {
+		$task = new Task(
+			array(
+				'id'             => 'wc-unit-test-non-dismissable-task',
+				'is_dismissable' => false,
+			)
+		);
+
+		$update    = $task->dismiss();
+		$dismissed = get_option( Task::DISMISSED_OPTION, array() );
+		$this->assertEquals( false, $update );
+		$this->assertNotContains( $task->id, $dismissed );
+	}
+
+	/**
+	 * Tests that a dismissed task is not visible.
+	 */
+	public function test_dismissed_visibility() {
+		$task = new Task(
+			array(
+				'id'             => 'wc-unit-test-task',
+				'is_dismissable' => true,
+			)
+		);
+
+		$task->dismiss();
+		$this->assertEquals( false, $task->is_visible() );
+	}
+
+	/**
+	 * Tests that a task can be snoozed.
+	 */
+	public function test_snooze() {
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-snoozeable-task',
+				'is_snoozeable' => true,
+			)
+		);
+
+		$update  = $task->snooze();
+		$snoozed = get_option( Task::SNOOZED_OPTION, array() );
+		$this->assertEquals( true, $update );
+		$this->assertArrayHasKey( $task->id, $snoozed );
+	}
+
+	/**
+	 * Tests that a task can be unsnoozed.
+	 */
+	public function test_undo_snooze() {
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-snoozeable-task',
+				'is_snoozeable' => true,
+			)
+		);
+
+		$task->snooze();
+		$task->undo_snooze();
+		$snoozed = get_option( Task::SNOOZED_OPTION, array() );
+		$this->assertArrayNotHasKey( $task->id, $snoozed );
+	}
+
+	/**
+	 * Tests that a task is not visible when snoozed.
+	 */
+	public function test_snoozed_visibility() {
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-snoozeable-task',
+				'is_snoozeable' => true,
+			)
+		);
+
+		$task->snooze();
+		$this->assertEquals( false, $task->is_visible() );
+	}
+
+	/**
+	 * Tests that a task's snooze time is automatically added.
+	 */
+	public function test_snoozed_until() {
+		$time                         = time() * 1000;
+		$snoozed                      = get_option( Task::SNOOZED_OPTION, array() );
+		$snoozed['wc-unit-test-task'] = $time;
+		update_option( Task::SNOOZED_OPTION, $snoozed );
+
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-task',
+				'is_snoozeable' => true,
+			)
+		);
+
+		$this->assertEquals( $time, $task->snoozed_until );
+
+	}
+
+	/**
+	 * Tests a non snoozeable task cannot be snoozed.
+	 */
+	public function test_not_snoozeable() {
+		$task = new Task(
+			array(
+				'id'            => 'wc-unit-test-snoozeable-task',
+				'is_snoozeable' => false,
+			)
+		);
+
+		$task->snooze();
+		$this->assertEquals( false, $task->is_snoozed() );
+	}
+
+
+	/**
+	 * Tests that a task's properties are returned as JSON.
+	 */
+	public function test_json() {
+		$task = new Task(
+			array(
+				'id' => 'wc-unit-test-task',
+			)
+		);
+
+		$json = $task->get_json();
+
+		$this->assertArrayHasKey( 'id', $json );
+		$this->assertArrayHasKey( 'title', $json );
+		$this->assertArrayHasKey( 'content', $json );
+		$this->assertArrayHasKey( 'actionLabel', $json );
+		$this->assertArrayHasKey( 'actionUrl', $json );
+		$this->assertArrayHasKey( 'isComplete', $json );
+		$this->assertArrayHasKey( 'isVisible', $json );
+		$this->assertArrayHasKey( 'time', $json );
+		$this->assertArrayHasKey( 'isDismissed', $json );
+		$this->assertArrayHasKey( 'isDismissable', $json );
+		$this->assertArrayHasKey( 'isSnoozed', $json );
+		$this->assertArrayHasKey( 'isSnoozeable', $json );
+		$this->assertArrayHasKey( 'snoozedUntil', $json );
+	}
+
+}
+


### PR DESCRIPTION
Fixes (part of) #7661 

Adds in task API methods and tests.

Follow-ups remaining:
* Migrate current tasks
* Update REST API to use new task methods

### Detailed test instructions:

Not much to test here yet:

1. Make sure tests are passing.
2. Optionally add a `wp_die(var_dump(self::$lists['setup']->get_json()));` at the end of `TaskLists::add_task()` to see the task data.