### PR TITLE
Add changelog and enable promotion in core and plugin configs

### DIFF
--- a/changelogs/update-7319_enable_wc_pay_experiment
+++ b/changelogs/update-7319_enable_wc_pay_experiment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Enhancement
 
-Adds experiment for promoting wcpay in payment methods table. #7666
+Adds experiment for promoting WooCommerce Payments in payment methods table. #7666

--- a/changelogs/update-7319_enable_wc_pay_experiment
+++ b/changelogs/update-7319_enable_wc_pay_experiment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Enhancement
 
-Adds experiment for promoting WooCommerce Payments in payment methods table. #7666
+Add experiment for promoting WooCommerce Payments in payment methods table. #7666

--- a/changelogs/update-7319_enable_wc_pay_experiment
+++ b/changelogs/update-7319_enable_wc_pay_experiment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Enhancement
 
-Adds experiment for promoting wcpay in payment methods table.
+Adds experiment for promoting wcpay in payment methods table. #7666

--- a/changelogs/update-7319_enable_wc_pay_experiment
+++ b/changelogs/update-7319_enable_wc_pay_experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Adds experiment for promoting wcpay in payment methods table.

--- a/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
+++ b/client/settings-recommendations/recommendations-eligibility-wrapper.tsx
@@ -19,7 +19,7 @@ const RecommendationsEligibilityWrapper: React.FC = ( { children } ) => {
 			SHOW_MARKETPLACE_SUGGESTION_OPTION,
 		] );
 		const canShowMarketplaceSuggestions =
-			getOption( SHOW_MARKETPLACE_SUGGESTION_OPTION ) === 'yes';
+			getOption( SHOW_MARKETPLACE_SUGGESTION_OPTION ) !== 'no';
 
 		return hasFinishedResolving && canShowMarketplaceSuggestions;
 	} );

--- a/config/core.json
+++ b/config/core.json
@@ -18,6 +18,6 @@
 		"store-alerts": true,
 		"tasks": false,
 		"transient-notices": true,
-		"wc-pay-promotion": false
+		"wc-pay-promotion": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -18,6 +18,6 @@
 		"store-alerts": true,
 		"tasks": false,
 		"transient-notices": true,
-		"wc-pay-promotion": false
+		"wc-pay-promotion": true
 	}
 }

--- a/src/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
+++ b/src/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
@@ -16,12 +16,12 @@ class EvaluateSuggestion {
 	/**
 	 * Evaluates the spec and returns the suggestion.
 	 *
-	 * @param array $spec The suggestion to evaluate.
-	 * @return array The evaluated suggestion.
+	 * @param object $spec The suggestion to evaluate.
+	 * @return object The evaluated suggestion.
 	 */
 	public static function evaluate( $spec ) {
 		$rule_evaluator = new RuleEvaluator();
-		$suggestion     = (object) $spec;
+		$suggestion     = clone $spec;
 
 		if ( isset( $suggestion->is_visible ) ) {
 			$is_visible             = $rule_evaluator->evaluate( $suggestion->is_visible );

--- a/src/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
+++ b/src/Features/PaymentGatewaySuggestions/EvaluateSuggestion.php
@@ -16,12 +16,12 @@ class EvaluateSuggestion {
 	/**
 	 * Evaluates the spec and returns the suggestion.
 	 *
-	 * @param object $spec The suggestion to evaluate.
+	 * @param object|array $spec The suggestion to evaluate.
 	 * @return object The evaluated suggestion.
 	 */
 	public static function evaluate( $spec ) {
 		$rule_evaluator = new RuleEvaluator();
-		$suggestion     = clone $spec;
+		$suggestion     = is_array( $spec ) ? (object) $spec : clone $spec;
 
 		if ( isset( $suggestion->is_visible ) ) {
 			$is_visible             = $rule_evaluator->evaluate( $suggestion->is_visible );

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -15,8 +15,8 @@ use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\EvaluateSugg
  * WC Pay Promotion engine.
  */
 class Init {
-	const SPECS_TRANSIENT_NAME = 'woocommerce_admin_payment_method_promotion_specs';
-	const EXPLAT_VARIATION_PREFIX = 'woocommerce_wc_pay_promotion_payment_methods_table_';
+	const SPECS_TRANSIENT_NAME    = 'woocommerce_admin_payment_method_promotion_specs';
+	const EXPLAT_VARIATION_PREFIX = 'explat_test_v4_woocommerce_wc_pay_promotion_payment_methods_table_';
 
 	/**
 	 * Constructor.

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -16,7 +16,7 @@ use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\EvaluateSugg
  */
 class Init {
 	const SPECS_TRANSIENT_NAME    = 'woocommerce_admin_payment_method_promotion_specs';
-	const EXPLAT_VARIATION_PREFIX = 'explat_test_v4_woocommerce_wc_pay_promotion_payment_methods_table_';
+	const EXPLAT_VARIATION_PREFIX = 'woocommerce_wc_pay_promotion_payment_methods_table_';
 
 	/**
 	 * Constructor.

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\EvaluateSugg
  */
 class Init {
 	const SPECS_TRANSIENT_NAME = 'woocommerce_admin_payment_method_promotion_specs';
+	const EXPLAT_VARIATION_PREFIX = 'woocommerce_wc_pay_promotion_payment_methods_table_';
 
 	/**
 	 * Constructor.
@@ -113,7 +114,7 @@ class Init {
 			$allow_tracking
 		);
 
-		$variation_name = $abtest->get_variation( 'woocommerce_wc_pay_promotion_payment_methods_table_' . $wc_pay_spec->additional_info->experiment_version );
+		$variation_name = $abtest->get_variation( self::EXPLAT_VARIATION_PREFIX . $wc_pay_spec->additional_info->experiment_version );
 
 		if ( 'treatment' === $variation_name ) {
 			return true;

--- a/tests/features/payment-gateway-suggestions/evaluate-suggestion.php
+++ b/tests/features/payment-gateway-suggestions/evaluate-suggestion.php
@@ -31,7 +31,7 @@ class WC_Tests_PaymentGatewaySuggestions_EvaluateSuggestion extends WC_Unit_Test
 		$suggestion = array(
 			'id' => 'mock-gateway',
 		);
-		$evaluated  = EvaluateSuggestion::evaluate( $suggestion );
+		$evaluated  = EvaluateSuggestion::evaluate( (object) $suggestion );
 		$this->assertEquals( (object) $suggestion, $evaluated );
 	}
 
@@ -49,7 +49,7 @@ class WC_Tests_PaymentGatewaySuggestions_EvaluateSuggestion extends WC_Unit_Test
 				'operation'   => '=',
 			),
 		);
-		$evaluated  = EvaluateSuggestion::evaluate( $suggestion );
+		$evaluated  = EvaluateSuggestion::evaluate( (object) $suggestion );
 		$this->assertFalse( $evaluated->is_visible );
 	}
 
@@ -68,7 +68,7 @@ class WC_Tests_PaymentGatewaySuggestions_EvaluateSuggestion extends WC_Unit_Test
 			),
 		);
 		update_option( self::MOCK_OPTION, 'a' );
-		$evaluated = EvaluateSuggestion::evaluate( $suggestion );
+		$evaluated = EvaluateSuggestion::evaluate( (object) $suggestion );
 		$this->assertTrue( $evaluated->is_visible );
 	}
 }


### PR DESCRIPTION
Fixes #7319 

This is the final change enabling the feature in all environments.

I will also generate a zip after the above merge for easier testing on Jurassic.

Previous PRs:
#7550
#7553
#7554

### Screenshots

<img width="1454" alt="Screen Shot 2021-08-27 at 3 44 28 PM" src="https://user-images.githubusercontent.com/2240960/131174683-c3edd596-db11-4086-810c-6d91de7513d3.png">

### Detailed test instructions:
*once the above PR is merged this might only work with Jetpack enabled (so I thought) the actual experiment is still in staging so it might not work. Instead you can test with [this zip - woocommerce-admin.zip](https://github.com/woocommerce/woocommerce-admin/files/7236255/woocommerce-admin.zip), which uses the `explat_test_v4_woocommerce_wc_pay_promotion_payment_methods_table_v1` experiment, which is active.

1. Grab the attached zip or load this branch locally
2. Finish the onboarding flow and make sure you click 'yes' for collecting data also **don't** install WC Pay. 
3. Go to the Abacus experiment `woocommerce_wc_pay_promotion_payment_methods_table_v1` and grab the treatment bookmarklet (save it to your bookmarks tab) with the above zip, grab the treatment bookmarklet from this experiment instead: 
`explat-test-v4-woocommerce-wc-pay-promotion-payment-methods-table-v1`  (ping me for the link as you can find it in Abacus)
4. Go back to your WC page and click the bookmarklet, a success message should popup.
5. Navigate to **WooCommerce > Settings > Payments**
6. **WooCommerce Payments** should be at the top of the payment method table with a **Install** button, a **Recommended ways to get paid** box will show up below the table, **WooCommerce Payments** should **Not** be part of this.
7. Click **Install**, it should show as busy and redirect you to the WC Pay set up screen when installed.
8. Navigate to **WooCommerce > Settings > Payments** again
9. **WooCommerce Payments** should still be at the top but with a **Set up** button now instead of an Install button.
10. You might have to wait 24 hours, but go to the Abacus experiment it should contain results from the test (this might require the experiment to be running)
11. Follow the above steps again but with the `control` variation, which would make the WC Pay **not** show up in the payment method table, but in the recommended card instead.
Note: This might require a new site as the experiment variation is saved in a transient.


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->