### PR TITLE
Fix track properties and add warning for wrong track format

### DIFF
--- a/changelogs/fix-7630_track_event_props
+++ b/changelogs/fix-7630_track_event_props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix naming of event names and properties. #7677

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -233,7 +233,7 @@ const ReportTable = ( props ) => {
 		recordEvent( 'analytics_table_download', {
 			report: endpoint,
 			rows: totalResults,
-			downloadType,
+			download_type: downloadType,
 		} );
 	};
 

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -14,6 +14,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
+import { snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,14 +57,17 @@ export const ActivityPanel = () => {
 	const panels = getAllPanels( panelsData );
 
 	useEffect( () => {
-		const visiblePanels = panels.reduce(
-			( acc, panel ) => {
-				acc[ panel.id ] = true;
-				return acc;
-			},
-			{ taskList: panelsData.isTaskListHidden !== 'yes' }
-		);
-		recordEvent( 'activity_panel_visible_panels', visiblePanels );
+		if ( panelsData.isTaskListHidden !== undefined ) {
+			const visiblePanels = panels.reduce(
+				( acc, panel ) => {
+					const panelId = snakeCase( panel.id );
+					acc[ panelId ] = true;
+					return acc;
+				},
+				{ task_list: panelsData.isTaskListHidden !== 'yes' }
+			);
+			recordEvent( 'activity_panel_visible_panels', visiblePanels );
+		}
 	}, [ panelsData.isTaskListHidden ] );
 
 	if ( panels.length === 0 ) {

--- a/packages/tracks/src/index.js
+++ b/packages/tracks/src/index.js
@@ -14,8 +14,8 @@ const tracksDebug = debug( 'wc-admin:tracks' );
  * @param {string} eventName The name of the event to record, don't include the wcadmin_ prefix
  * @param {Object} eventProperties event properties to include in the event
  */
-
 export function recordEvent( eventName, eventProperties ) {
+	checkEventNameAndPropsCase( eventName, eventProperties );
 	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties, {
 		_tqk: window._tkq,
 		shouldRecord:
@@ -34,6 +34,28 @@ export function recordEvent( eventName, eventProperties ) {
 	}
 
 	window.wcTracks.recordEvent( eventName, eventProperties );
+}
+
+const validRegExpString = '^[a-z_][a-z0-9_]*$';
+const validRegExp = new RegExp( validRegExpString );
+function checkEventNameAndPropsCase( eventName, eventProperties ) {
+	let valid = true;
+	if ( ! validRegExp.test( eventName ) ) {
+		console.warn(
+			`Event name ${ eventName } failed pattern ${ validRegExpString }`
+		);
+		valid = false;
+	}
+	const propertyKeys = Object.keys( eventProperties || {} );
+	for ( const key of propertyKeys ) {
+		if ( ! validRegExp.test( key ) ) {
+			console.warn(
+				`Event prop ${ key } failed pattern ${ validRegExpString } of '${ eventName }' event`
+			);
+			valid = false;
+		}
+	}
+	return valid;
 }
 
 const tracksQueue = {

--- a/packages/tracks/src/index.js
+++ b/packages/tracks/src/index.js
@@ -41,6 +41,7 @@ const validRegExp = new RegExp( validRegExpString );
 function checkEventNameAndPropsCase( eventName, eventProperties ) {
 	let valid = true;
 	if ( ! validRegExp.test( eventName ) ) {
+		// eslint-disable-next-line no-console
 		console.warn(
 			`Event name ${ eventName } failed pattern ${ validRegExpString }`
 		);
@@ -49,6 +50,7 @@ function checkEventNameAndPropsCase( eventName, eventProperties ) {
 	const propertyKeys = Object.keys( eventProperties || {} );
 	for ( const key of propertyKeys ) {
 		if ( ! validRegExp.test( key ) ) {
+			// eslint-disable-next-line no-console
 			console.warn(
 				`Event prop ${ key } failed pattern ${ validRegExpString } of '${ eventName }' event`
 			);

--- a/packages/tracks/src/index.js
+++ b/packages/tracks/src/index.js
@@ -15,7 +15,6 @@ const tracksDebug = debug( 'wc-admin:tracks' );
  * @param {Object} eventProperties event properties to include in the event
  */
 export function recordEvent( eventName, eventProperties ) {
-	checkEventNameAndPropsCase( eventName, eventProperties );
 	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties, {
 		_tqk: window._tkq,
 		shouldRecord:
@@ -34,30 +33,6 @@ export function recordEvent( eventName, eventProperties ) {
 	}
 
 	window.wcTracks.recordEvent( eventName, eventProperties );
-}
-
-const validRegExpString = '^[a-z_][a-z0-9_]*$';
-const validRegExp = new RegExp( validRegExpString );
-function checkEventNameAndPropsCase( eventName, eventProperties ) {
-	let valid = true;
-	if ( ! validRegExp.test( eventName ) ) {
-		// eslint-disable-next-line no-console
-		console.warn(
-			`Event name ${ eventName } failed pattern ${ validRegExpString }`
-		);
-		valid = false;
-	}
-	const propertyKeys = Object.keys( eventProperties || {} );
-	for ( const key of propertyKeys ) {
-		if ( ! validRegExp.test( key ) ) {
-			// eslint-disable-next-line no-console
-			console.warn(
-				`Event prop ${ key } failed pattern ${ validRegExpString } of '${ eventName }' event`
-			);
-			valid = false;
-		}
-	}
-	return valid;
 }
 
 const tracksQueue = {


### PR DESCRIPTION
Fixes #7630 

Update track properties to follow snake case format.

Cases from the original ticket:
* `wcadmin_activity_panel_visible_panels` - fixed
* `wcadmin_page_view` - looks to be an old version of WC fixed here: https://github.com/woocommerce/woocommerce-admin/pull/4533
* `wcadmin_analytics_table_download` - fixed
* `wcadmin_aw_workflow_before_run` - can't find this, triggered on `/wp-admin/admin-ajax.php?action=as_async_request_queue_runner` urls?
* `wcadmin_order_edit_recalc_totals` - in [wc core](https://github.com/woocommerce/woocommerce/blob/69203f29243ad66bdf4c7ce94cf295f38b66dce9/assets/js/admin/meta-boxes-order.js#L817-L820) [issue](https://github.com/woocommerce/woocommerce/issues/30736)
* `wcadmin_analytics_filters_filter` - fixed in previous WC version - https://github.com/woocommerce/woocommerce-admin/pull/5079

### Detailed test instructions:

-  Load this branch and run this in your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
-  Check if both the event name and properties are in snake case for the events listed below:

`wcadmin_activity_panel_visible_panels`
- Go to **WooCommerce > Home** and hide the task list
- Refresh the page (you might want to add products to see at-least one of the panels)

`wcadmin_analytics_table_download`
- Go to one of the analytics tables and trigger a in browser download ( make sure there is no pagination)

- Change one of the event names to a none snake case or property key's
- A warning should show in the console.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
