### PR TITLE
Add France to list of countries that get Square as an option…

### DIFF
--- a/changelogs/tweak-7631_include_square_in_fr
+++ b/changelogs/tweak-7631_include_square_in_fr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Enable Square in France. #7679

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -236,7 +236,7 @@ class DefaultPaymentGateways {
 								self::get_rules_for_cbd( true ),
 							),
 							array(
-								self::get_rules_for_countries( array( 'US', 'CA', 'JP', 'GB', 'AU', 'IE' ) ),
+								self::get_rules_for_countries( array( 'US', 'CA', 'JP', 'GB', 'AU', 'IE', 'FR' ) ),
 								self::get_rules_for_selling_venues( array( 'brick-mortar', 'brick-mortar-other' ) ),
 							),
 						),


### PR DESCRIPTION
Fixes #7631 

For merchants with a location in France who select either "physical store or event" option for "Currently selling elsewhere", the "Set up Payment" task should suggest Square as an option. This PR only covers the fallback values that are used when the Woocommerce.com API can't be reached.

### Detailed test instructions:

- Check out this branch on your local environment
- Delete the `woocommerce_admin_payment_gateway_suggestions_specs` transient, if any
- Disable the `tasks` feature locally (edit config/development.json and rebuild) so the Set Up Payments task will appear
- To make sure the fallback payment suggestions file is used, break the connection between your local woocommerce-admin site and woocommerce.com:
<details><summary>use a hook</summary>
`add_filter(
  'woocommerce_admin_payment_gateway_suggestions_data_sources',
  function() { return array('http://this.link.is.broke.n/and/this/part/is/nonsense'); }
);`
</details>

or change this [URL](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php#L24) to something that won't return json

- Re-run the setup wizard and choose France as your location and one of the "physical stores or events" options for Currently selling elsewhere.
- Verify that Square is one of the options in the Set Up Payments interface.
 


