### PR TITLE
Fixes for analytics bugs introduced in 2.6

### DIFF
--- a/changelogs/fix-7473-blank-screen-search-categories
+++ b/changelogs/fix-7473-blank-screen-search-categories
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix blank screen on analytics screens when searching #7482

--- a/changelogs/fix-analytics-categories-fatal-on-search
+++ b/changelogs/fix-analytics-categories-fatal-on-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix fatal error and unrelated results in analytics.

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -70,6 +70,10 @@ class CategoriesReportTable extends Component {
 			formatDecimal: getCurrencyFormatDecimal,
 			getCurrencyConfig,
 		} = this.context;
+		const { categories, query } = this.props;
+		if ( ! categories ) {
+			return [];
+		}
 		const currency = getCurrencyConfig();
 
 		return map( categoryStats, ( categoryStat ) => {
@@ -80,7 +84,6 @@ class CategoriesReportTable extends Component {
 				products_count: productsCount,
 				orders_count: ordersCount,
 			} = categoryStat;
-			const { categories, query } = this.props;
 			const category = categories.get( categoryId );
 			const persistedQuery = getPersistedQuery( query );
 

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -7,7 +7,7 @@ import { withSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import { find } from 'lodash';
 import { getQuery, getSearchWords } from '@woocommerce/navigation';
-import { searchItemsByString } from '@woocommerce/data';
+import { searchItemsByString, ITEMS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -89,6 +89,9 @@ export default compose(
 		const query = getQuery();
 		const { search } = query;
 
+		/* eslint @wordpress/no-unused-vars-before-return: "off" */
+		const itemsSelector = select( ITEMS_STORE_NAME );
+
 		if ( ! search ) {
 			return {};
 		}
@@ -101,7 +104,7 @@ export default compose(
 				? 'products'
 				: report;
 		const itemsResult = searchItemsByString(
-			select,
+			itemsSelector,
 			mappedReport,
 			searchWords,
 			{

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -106,7 +106,10 @@ export default compose(
 		const itemsResult = searchItemsByString(
 			itemsSelector,
 			mappedReport,
-			searchWords
+			searchWords,
+			{
+				per_page: 100,
+			}
 		);
 		const { isError, isRequesting, items } = itemsResult;
 		const ids = Object.keys( items );

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -106,10 +106,7 @@ export default compose(
 		const itemsResult = searchItemsByString(
 			itemsSelector,
 			mappedReport,
-			searchWords,
-			{
-				per_page: 100,
-			}
+			searchWords
 		);
 		const { isError, isRequesting, items } = itemsResult;
 		const ids = Object.keys( items );

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -66,9 +66,15 @@ export function getLeaderboard( options ) {
  * @param  {Object}   selector    Instance of @wordpress/select response
  * @param  {string}   endpoint  Report API Endpoint
  * @param  {string[]} search    Array of search strings.
+ * @param  {Object}   options  Query options.
  * @return {Object}   Object containing API request information and the matching items.
  */
-export function searchItemsByString( selector, endpoint, search ) {
+export function searchItemsByString(
+	selector,
+	endpoint,
+	search,
+	options = {}
+) {
 	const { getItems, getItemsError, isResolving } = selector;
 
 	const items = {};
@@ -78,6 +84,7 @@ export function searchItemsByString( selector, endpoint, search ) {
 		const query = {
 			search: searchWord,
 			per_page: 10,
+			...options,
 		};
 		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -63,14 +63,13 @@ export function getLeaderboard( options ) {
 /**
  * Returns items based on a search query.
  *
- * @param {Object} select    Instance of @wordpress/select
- * @param {string} endpoint  Report API Endpoint
- * @param {string[]} search    Array of search strings.
- * @param {Object} options  Query options.
+ * @param  {Object}   selector    Instance of @wordpress/select response
+ * @param  {string}   endpoint  Report API Endpoint
+ * @param  {string[]} search    Array of search strings.
  * @return {Object}   Object containing API request information and the matching items.
  */
-export function searchItemsByString( select, endpoint, search, options ) {
-	const { getItems, getItemsError, isResolving } = select( STORE_NAME );
+export function searchItemsByString( selector, endpoint, search ) {
+	const { getItems, getItemsError, isResolving } = selector;
 
 	const items = {};
 	let isRequesting = false;
@@ -79,9 +78,7 @@ export function searchItemsByString( select, endpoint, search, options ) {
 		const query = {
 			search: searchWord,
 			per_page: 10,
-			...options,
 		};
-
 		const newItems = getItems( endpoint, query );
 		newItems.forEach( ( item, id ) => {
 			items[ id ] = item;


### PR DESCRIPTION
Fixes the following:

1. Fatal error when searching in Analytics > Categories.
2. Analytics > Products search showing unrelated results.

Note: Currently if you search for any non-existing products names, it will still produce unrelated results. I think fixing that should be a follow-up since it's not critical. 

### Detailed test instructions:

**Testing fatal error**:

1. Make sure you have at least a few categories.
1. Go to Analytics > Categories (it needs to be a fresh page without previous searches to make sure the results were not cached).
2. Search for a category name.
3. Wait for the results, make sure no fatal error occurs.

**Testing products unrelated results**:

1. Make sure you have a few products with orders.
1. Go to Analytics > Products.
2. Search for a product name.
3. Wait for the results and observe that no unrelated products is shown in results.

Sorry, no changelog PR number was included