### PR TITLE
Fix issue where variation name might not exist in analytics

### DIFF
--- a/changelogs/fix-7443_analytics_variations_table
+++ b/changelogs/fix-7443_analytics_variations_table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix white screen for variation analytic data without a name. #7686

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -98,11 +98,11 @@ export const getTaxRateLabels = getRequestByIdString(
 export function getVariationName( { attributes, name } ) {
 	const separator = getSetting( 'variationTitleAttributesSeparator', ' - ' );
 
-	if ( name.indexOf( separator ) > -1 ) {
+	if ( name && name.indexOf( separator ) > -1 ) {
 		return name;
 	}
 
-	const attributeList = attributes
+	const attributeList = ( attributes || [] )
 		.map( ( { option } ) => option )
 		.join( ', ' );
 


### PR DESCRIPTION
Fixes #7443 

Some users are running into an issue with displaying older variation analytics data that have an `undefined` name. I have yet to reproduce this, but this change makes sure to check the name before using `indexOf`.

### Screenshots

### Detailed test instructions:

- Load this branch and finish the onboarding flow
- Create a variation and create an order with that variation and run the action scheduler (if you have pending items)
- Go to **Analytics > Variations**
- Variations should still display correctly

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
