### PR TITLE
Add old option back with depreciated notice for backwards compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10901,12 +10901,36 @@
 				"@wordpress/core-data": "3.0.0",
 				"@wordpress/data": "5.0.0",
 				"@wordpress/data-controls": "2.0.0",
+				"@wordpress/deprecated": "^3.1.1",
 				"@wordpress/element": "2.19.0",
 				"@wordpress/hooks": "2.11.0",
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/url": "2.21.0",
 				"md5": "^2.3.0",
 				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/deprecated": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.1.tgz",
+					"integrity": "sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^3.2.0"
+					},
+					"dependencies": {
+						"@wordpress/hooks": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
+							"integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.13.10"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@woocommerce/date": {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Fix the batch fetch logic for the options data store. #7587
+-   Add backwards compability for old function format. #7688
 
 # 1.4.0
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/hooks": "2.11.0",
 		"@wordpress/data": "5.0.0",
 		"@wordpress/data-controls": "2.0.0",
+		"@wordpress/deprecated": "^3.1.1",
 		"@wordpress/i18n": "3.17.0",
 		"@wordpress/url": "2.21.0",
 		"md5": "^2.3.0",

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -13,6 +13,7 @@ import {
 	getActiveFiltersFromQuery,
 	getQueryFromActiveFilters,
 } from '@woocommerce/navigation';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -343,17 +344,30 @@ const getReportChartDataResponse = memoize(
  * @param  {string} options.dataType  'primary' or 'secondary'
  * @param  {Object} options.query     Query parameters in the url
  * @param  {Object} options.selector    Instance of @wordpress/select response
+ * @param  {Object} options.select    (Depreciated) Instance of @wordpress/select
  * @param  {Array}  options.limitBy   Properties used to limit the results. It will be used in the API call to send the IDs.
  * @param  {string}  options.defaultDateRange   User specified default date range.
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( options ) {
 	const { endpoint } = options;
+	let reportSelectors = options.selector;
+	if ( options.select && ! options.selector ) {
+		deprecated(
+			'option.select is depreciated, please use option.selector',
+			{
+				version: '1.7.0',
+				hint:
+					'You can pass the report selectors through option.selector now.',
+			}
+		);
+		reportSelectors = options.select( STORE_NAME );
+	}
 	const {
 		getReportStats,
 		getReportStatsError,
 		isResolving,
-	} = options.selector;
+	} = reportSelectors;
 
 	const requestQuery = getRequestQuery( options );
 	// Disable eslint rule requiring `stats` to be defined below because the next two if statements
@@ -492,17 +506,30 @@ export function getReportTableQuery( options ) {
  * @param  {string} options.endpoint       Report API Endpoint
  * @param  {Object} options.query          Query parameters in the url
  * @param  {Object} options.selector       Instance of @wordpress/select response
+ * @param  {Object} options.select         (depreciated) Instance of @wordpress/select
  * @param  {Object} options.tableQuery     Query parameters specific for that endpoint
  * @param  {string}  options.defaultDateRange   User specified default date range.
  * @return {Object} Object    Table data response
  */
 export function getReportTableData( options ) {
 	const { endpoint } = options;
+	let reportSelectors = options.selector;
+	if ( options.select && ! options.selector ) {
+		deprecated(
+			'option.select is depreciated, please use option.selector',
+			{
+				version: '1.7.0',
+				hint:
+					'You can pass the report selectors through option.selector now.',
+			}
+		);
+		reportSelectors = options.select( STORE_NAME );
+	}
 	const {
 		getReportItems,
 		getReportItemsError,
 		hasFinishedResolution,
-	} = options.selector;
+	} = reportSelectors;
 
 	const tableQuery = reportsUtils.getReportTableQuery( options );
 	const response = {

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -353,14 +353,11 @@ export function getReportChartData( options ) {
 	const { endpoint } = options;
 	let reportSelectors = options.selector;
 	if ( options.select && ! options.selector ) {
-		deprecated(
-			'option.select is depreciated, please use option.selector',
-			{
-				version: '1.7.0',
-				hint:
-					'You can pass the report selectors through option.selector now.',
-			}
-		);
+		deprecated( 'option.select', {
+			version: '1.7.0',
+			hint:
+				'You can pass the report selectors through option.selector now.',
+		} );
 		reportSelectors = options.select( STORE_NAME );
 	}
 	const {
@@ -515,14 +512,11 @@ export function getReportTableData( options ) {
 	const { endpoint } = options;
 	let reportSelectors = options.selector;
 	if ( options.select && ! options.selector ) {
-		deprecated(
-			'option.select is depreciated, please use option.selector',
-			{
-				version: '1.7.0',
-				hint:
-					'You can pass the report selectors through option.selector now.',
-			}
-		);
+		deprecated( 'option.select', {
+			version: '1.7.0',
+			hint:
+				'You can pass the report selectors through option.selector now.',
+		} );
 		reportSelectors = options.select( STORE_NAME );
 	}
 	const {


### PR DESCRIPTION
Fixes #7668 

Fixes an issue with external plugins that are using the data package. This adds backwards compatibility for the time being.

No changelog as it is in the package.

### Screenshots

<img width="1248" alt="Screen Shot 2021-09-21 at 12 52 02 PM" src="https://user-images.githubusercontent.com/2240960/134204308-3224f216-d6a2-47dd-8a3f-b249990faf88.png">

### Detailed test instructions:

- Install [Composite Products](https://docs.woocommerce.com/document/composite-products/) plugin can be found under: https://woocommerce.com/my-account/downloads/
- Create a composite product and make sure the analytics tables are updated ( run action scheduler )
- Go to Analytics > Composites
- The table should load fine, and notice how there is a depreciation notice in the console.

Some test instructions from the original PR:
- Navigate to Analytics -> Products, and scroll down to the Products table
- Enter the first few letters for one of the products, and then click on the auto-complete option when it populates.
- The table should refresh and show the filtered for product.
- Do a hard fresh of the page, and the query should still be applied and the product visible in the table.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
