### PR TITLE
Fix unsecured report files

### DIFF
--- a/changelogs/fix-reports-dir
+++ b/changelogs/fix-reports-dir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Harden the reports directory #7691

--- a/src/Install.php
+++ b/src/Install.php
@@ -59,6 +59,7 @@ class Install {
 		),
 		'2.7.0'  => array(
 			'wc_admin_update_270_update_task_list_options',
+			'wc_admin_update_270_delete_report_downloads',
 			'wc_admin_update_270_db_version',
 		),
 	);

--- a/src/Notes/UnsecuredReportFiles.php
+++ b/src/Notes/UnsecuredReportFiles.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * WooCommerce Admin Unsecured Files Note.
+ *
+ * Adds a warning about potentially unsecured files.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( Note::class ) ) {
+	class_alias( WC_Admin_Note::class, Note::class );
+}
+
+/**
+ * Unsecured_Report_Files
+ */
+class UnsecuredReportFiles {
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-remove-unsecured-report-files';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		$note = new Note();
+		$note->set_title( __( 'Potentially unsecured files were found in your uploads directory', 'woocommerce-admin' ) );
+		$note->set_content(
+			sprintf(
+				/* translators: 1: opening analytics docs link tag. 2: closing link tag */
+				__( 'Files that may contain %1$sstore analytics%2$s reports were found in your uploads directory - we recommend assessing and deleting any such files.', 'woocommerce-admin' ),
+				'<a href="https://docs.woocommerce.com/document/woocommerce-analytics/" target="_blank">',
+				'</a>'
+			)
+		);
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_ERROR );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://developer.woocommerce.com/?p=10410',
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+		$note->add_action(
+			'dismiss',
+			__( 'Dismiss', 'woocommerce-admin' ),
+			wc_admin_url(),
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 */
+	public static function possibly_add_note() {
+		$note = self::get_note();
+
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note->save();
+	}
+
+	/**
+	 * Check if the note has been previously added.
+	 */
+	public static function note_exists() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		return ! empty( $note_ids );
+	}
+
+}

--- a/tests/reports/class-wc-tests-reports.php
+++ b/tests/reports/class-wc-tests-reports.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Report exporter tests.
+ *
+ * @package WooCommerce\Admin\Tests\Reports
+ */
+
+use Automattic\WooCommerce\Admin\ReportCSVExporter;
+
+/**
+ * Class WC_Tests_Reports
+ */
+class WC_Tests_Reports extends WC_Unit_Test_Case {
+
+	/**
+	 * @var Directory
+	 */
+	private $directory;
+
+	/**
+	 * setUp
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		global $wp_filesystem;
+
+		$upload_dir       = wp_upload_dir();
+		$this->directory  = ReportCSVExporter::get_reports_directory();
+		$this->filesystem = $wp_filesystem;
+	}
+
+	/**
+	 * Test that directory is created.
+	 */
+	public function test_directory_creation() {
+		$this->filesystem->delete( $this->directory );
+		ReportCSVExporter::maybe_create_directory();
+		$this->assertDirectoryExists( $this->directory );
+	}
+
+	/**
+	 * Test that files are created to prevent indexing.
+	 */
+	public function test_indexing_files_creation() {
+		$this->filesystem->delete( $this->directory . 'index.html' );
+		$this->filesystem->delete( $this->directory . '.htaccess' );
+		ReportCSVExporter::maybe_create_directory();
+		$this->assertFileExists( $this->directory . 'index.html' );
+		$this->assertFileExists( $this->directory . '.htaccess' );
+	}
+
+
+}


### PR DESCRIPTION
Hardens the reports directory.  

Note that versions and function names will need to be updated if directly cherry picked into `2.6.x`.

### Detailed test instructions:

See pb22l9-NB-p2 for more context and testing