### PR TITLE
Pass empty string instead of null to init

### DIFF
--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -105,7 +105,7 @@ class Init {
 			return false;
 		}
 
-		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : null;
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
 		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
 		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
 			$anon_id,


### PR DESCRIPTION
The `Experimental_Abtest` init function doesn't accept null as the `anon_id`, this just uses an empty string instead. This also fixes the failed php unit tests.

No changelog necessary

### Detailed test instructions:

- Make sure that php unit tests pass correctly `npm run test:php`