### PR TITLE
Fixing error thrown when dimissing/snoozing tasks via API

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -777,7 +777,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$is_dismissable = false;
 
-		$task = OnboardingTasksFeature::get_task_by_id( $id );
+		$task = TaskLists::get_task( $id );
 
 		if ( $task && isset( $task['isDismissable'] ) && $task['isDismissable'] ) {
 			$is_dismissable = true;
@@ -801,7 +801,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			wc_admin_record_tracks_event( 'tasklist_dismiss_task', array( 'task_name' => $id ) );
 		}
 
-		$task = OnboardingTasksFeature::get_task_by_id( $id );
+		$task = TaskLists::get_task( $id );
 
 		return rest_ensure_response( $task );
 	}
@@ -823,7 +823,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			wc_admin_record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $id ) );
 		}
 
-		$task = OnboardingTasksFeature::get_task_by_id( $id );
+		$task = TaskLists::get_task( $id );
 
 		return rest_ensure_response( $task );
 	}
@@ -842,7 +842,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$is_snoozeable = false;
 
-		$snooze_task = OnboardingTasksFeature::get_task_by_id( $task_id, $task_list_id );
+		$snooze_task = TaskLists::get_task( $task_id, $task_list_id );
 
 		if ( $snooze_task && isset( $snooze_task['isSnoozeable'] ) && $snooze_task['isSnoozeable'] ) {
 			$is_snoozeable = true;
@@ -903,7 +903,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $id ) );
 		}
 
-		return rest_ensure_response( OnboardingTasksFeature::get_task_by_id( $id ) );
+		return rest_ensure_response( TaskLists::get_task( $id ) );
 	}
 
 	/**


### PR DESCRIPTION
Recent changes broke the snooze/dismiss API endpoints, as they were pointing to a function that had been moved. This is a quick PR to fix those references and point to the correct functions.

### Detailed test instructions:

-   Checkout branch
-   Make a task snoozeable/dismissible in `TaskLists.php`
- Hit the endpoint(s) via postman or another application to ensure correct behavior:
`/wc-admin/onboarding/tasks/{TASK_ID}/snooze`
`/wc-admin/onboarding/tasks/{TASK_ID}/dismiss`