### PR TITLE
Add filters to get new hidden options

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -47,6 +47,10 @@ class OnboardingTasks {
 		add_action( 'add_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'update_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_option_extended_task_list' ), 15 );
+		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
+		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
+		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -449,6 +453,61 @@ class OnboardingTasks {
 		if ( $registered_extended_tasks_list_items !== $extended_tasks_list_items ) {
 			update_option( 'woocommerce_extended_task_list_items', $registered_extended_tasks_list_items );
 			update_option( 'woocommerce_extended_task_list_hidden', 'no' );
+		}
+	}
+
+	/**
+	 * Get the values from the correct source when attempting to retrieve deprecated options.
+	 *
+	 * @param string $pre_option Pre option value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public function get_deprecated_options( $pre_option, $option ) {
+		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
+			return $pre_option;
+		};
+
+		$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				return in_array( 'setup', $hidden, true ) ? 'yes' : 'no';
+			case 'woocommerce_extended_task_list_hidden':
+				return in_array( 'extended', $hidden, true ) ? 'yes' : 'no';
+		}
+	}
+
+	/**
+	 * Updates the new option names when deprecated options are updated.
+	 * This is a temporary fallback until we can fully remove the old task list components.
+	 *
+	 * @param string $value New value.
+	 * @param string $old_value Old value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public function update_deprecated_options( $value, $old_value, $option ) {
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+				if ( 'yes' === $value ) {
+					$hidden[] = 'setup';
+				} else {
+					array_diff( $hidden, array( 'setup' ) );
+				}
+				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
+				delete_option( 'woocommerce_task_list_hidden' );
+				return false;
+			case 'woocommerce_extended_task_list_hidden':
+				$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+				if ( 'yes' === $value ) {
+					$hidden[] = 'extended';
+				} else {
+					array_diff( $hidden, array( 'extended' ) );
+				}
+				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
+				delete_option( 'woocommerce_extended_task_list_hidden' );
+				return false;
 		}
 	}
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -493,7 +493,7 @@ class OnboardingTasks {
 				if ( 'yes' === $value ) {
 					$hidden[] = 'setup';
 				} else {
-					array_diff( $hidden, array( 'setup' ) );
+					$hidden = array_diff( $hidden, array( 'setup' ) );
 				}
 				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
 				delete_option( 'woocommerce_task_list_hidden' );
@@ -503,7 +503,7 @@ class OnboardingTasks {
 				if ( 'yes' === $value ) {
 					$hidden[] = 'extended';
 				} else {
-					array_diff( $hidden, array( 'extended' ) );
+					$hidden = array_diff( $hidden, array( 'extended' ) );
 				}
 				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
 				delete_option( 'woocommerce_extended_task_list_hidden' );


### PR DESCRIPTION
Adds filters to get and update the correct option values for the new task list options.

The new task list migration options were prematurely added to 2.6.4, causing the task list hidden options to not work as expected.

See p1632314327153200-slack for more discussion.

### Screenshots

<img width="1117" alt="Screen Shot 2021-09-22 at 4 52 17 PM" src="https://user-images.githubusercontent.com/10561050/134420290-6e53e7f3-d0da-4501-860d-9331aefb7b54.png">


### Detailed test instructions:

1. Before checking out this branch, install a version of WCA or WC with WCA version <= 2.6.2
2. Hide the task list.
3. Upgrade to WCA 2.6.4 or WC 5.7.
4. Note the task list is shown on the homescreen.
5. Checkout this branch
6. Note that the task list is hidden as expected
7. Unhide the task list by deleting the `woocommerce_task_list_hidden_lists` option
8. Note the task list shown.
9. Hide the task list via the dropdown in the tasklist.
10. Note the task list is hidden and persists on refresh