### PR TITLE
Update option list migrations to run on 2.7.1

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -156,25 +156,6 @@ function wc_admin_update_170_db_version() {
 }
 
 /**
- * Update the old task list options.
- */
-function wc_admin_update_270_update_task_list_options() {
-	$hidden_lists         = get_option( 'woocommerce_task_list_hidden_lists', array() );
-	$setup_list_hidden    = get_option( 'woocommerce_task_list_hidden', 'no' );
-	$extended_list_hidden = get_option( 'woocommerce_extended_task_list_hidden', 'no' );
-	if ( 'yes' === $setup_list_hidden ) {
-		$hidden_lists[] = 'setup';
-	}
-	if ( 'yes' === $extended_list_hidden ) {
-		$hidden_lists[] = 'extended';
-	}
-
-	update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden_lists ) );
-	delete_option( 'woocommerce_task_list_hidden' );
-	delete_option( 'woocommerce_extended_task_list_hidden' );
-}
-
-/**
  * Delete the preexisting export files.
  */
 function wc_admin_update_270_delete_report_downloads() {
@@ -266,9 +247,35 @@ function wc_admin_update_270_db_version() {
 	Installer::update_db_version( '2.7.0' );
 }
 
- /**
-  * Update order stats `status`.
-  */
+/**
+ * Update the old task list options.
+ */
+function wc_admin_update_271_update_task_list_options() {
+	$hidden_lists         = get_option( 'woocommerce_task_list_hidden_lists', array() );
+	$setup_list_hidden    = get_option( 'woocommerce_task_list_hidden', 'no' );
+	$extended_list_hidden = get_option( 'woocommerce_extended_task_list_hidden', 'no' );
+	if ( 'yes' === $setup_list_hidden ) {
+		$hidden_lists[] = 'setup';
+	}
+	if ( 'yes' === $extended_list_hidden ) {
+		$hidden_lists[] = 'extended';
+	}
+
+	update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden_lists ) );
+	delete_option( 'woocommerce_task_list_hidden' );
+	delete_option( 'woocommerce_extended_task_list_hidden' );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_271_db_version() {
+	Installer::update_db_version( '2.7.1' );
+}
+
+/**
+ * Update order stats `status`.
+ */
 function wc_admin_update_280_order_status() {
 	global $wpdb;
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -58,9 +58,12 @@ class Install {
 			'wc_admin_update_170_db_version',
 		),
 		'2.7.0'  => array(
-			'wc_admin_update_270_update_task_list_options',
 			'wc_admin_update_270_delete_report_downloads',
 			'wc_admin_update_270_db_version',
+		),
+		'2.7.1'  => array(
+			'wc_admin_update_271_update_task_list_options',
+			'wc_admin_update_271_db_version',
 		),
 		'2.8.0'  => array(
 			'wc_admin_update_280_order_status',


### PR DESCRIPTION
Several of the `2.6.x` versions include a migration to update the DB to `2.7.0` which breaks migrations for that version. 

We're skipping `2.7.0` and going straight to `2.7.1` to fix this along with updating migration names.

### Detailed test instructions:

1. Install WCA 2.6.4
2. Hide the task list
3. Upgrade to this version/branch
4. Note that the task list is still hidden and the option has been migrated to `woocommerce_task_list_hidden_lists`