### PR TITLE
Add E2E tests for initial store currencies with different onboarding countries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == 2.6.5 09/22/2021 ==
 
 - Fix: Add filters to get new hidden options #7698
+- Add: E2E tests for checking store currency if it matches the onboarded country #7712
 
 == 2.6.4 09/21/2021 ==
 
@@ -19,7 +20,7 @@
 
 - Update: Update marketing task completion logic. #7586
 
-== 2.6.0 08/31/2021 == 
+== 2.6.0 08/31/2021 ==
 
 - Fix: Fixes action button mis-alignment within card footer. #7412
 - Fix: Fixing issues with ReportTable component data not populating correctly #7355
@@ -55,7 +56,7 @@
 - Tweak: Refactor on payment settings recommendations eligibility component for reuse. #7447
 - Tweak: Register wc-admin page for all users and handle authorization in client #7285
 
-== 2.5.1 08/16/2021 == 
+== 2.5.1 08/16/2021 ==
 
 - Fix: Fix blank screen by setting a default value #7506
 
@@ -234,7 +235,7 @@
 - Update: Remove original business step flow #7103
 - Update: WooCommerce Shipping copy on onboarding steps #7148
 
-== 2.3.1 05/24/2021 == 
+== 2.3.1 05/24/2021 ==
 
 - Tweak: Store profiler  Changed MailPoet's title and description #6990
 - Tweak: Adjust WC Pay supported countries #7048
@@ -242,7 +243,7 @@
 - Fix: A JS exception being thrown on the product tags page. #7053
 - Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
 
-== 2.3.0 05/13/2021 == 
+== 2.3.0 05/13/2021 ==
 
 - Add: Add plugin installer to allow installation of plugins via URL #6805
 - Add: Optional children prop to SummaryNumber component #6748
@@ -283,30 +284,30 @@
 - Update: Update payment gateway suggestions semantics to be more consistent #7130
 - Update: Adding setup required icon for nonconfigured payment methods #6811
 
-== 2.2.6 05/07/2021 == 
+== 2.2.6 05/07/2021 ==
 
 - Fix: Address an issue with OBW when installing only WooCommerce payments and Jetpack. #6957
 
-== 2.2.5 05/07/2021 == 
+== 2.2.5 05/07/2021 ==
 
 - Fix: Calling of get_script_asset_filename with extra parameter #6955
 
-== 2.2.4 05/07/2021 == 
+== 2.2.4 05/07/2021 ==
 
 - Dev: Fix a bug where trying to load an asset registry causes a crash. #6951
 
-== 2.2.3 05/06/2021 == 
+== 2.2.3 05/06/2021 ==
 
 - Dev: Do a git clean before the core release. #6945
 
-== 2.2.2 04/28/2021 == 
+== 2.2.2 04/28/2021 ==
 
 - Fix: Disable the continue btn on OBW when requested are being made #6838
 - Tweak: Revert WCPay international support for bundled package #6901
 - Tweak: Store profiler  Changed MailPoet's title and description #6886
 - Tweak: Update PayU logo #6829
 
-== 2.2.0 03/30/2021 == 
+== 2.2.0 03/30/2021 ==
 
 - Fix: Check if features are currently being enabled #6688
 - Fix: Fix the activity panel toggle not closing on click #6679
@@ -382,26 +383,26 @@
 - Dev: Ensure script asset.php files are included in builds #6635
 - Dev: Ensure production script asset names don't include .min suffix #6681
 
-== 2.1.4 03/29/2021 == 
+== 2.1.4 03/29/2021 ==
 
 - Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
 
-== 2.1.3 03/14/2021 == 
+== 2.1.3 03/14/2021 ==
 
 - Feature: Increase target audience for business feature step. #6508
 - Fix: Correct a bug where the JP connection flow would not happen when installing JP in the OBW. #6521
 - Fix: Add customer name column to CSV export #6556
 
-== 2.1.2 03/10/2021 == 
+== 2.1.2 03/10/2021 ==
 
 - Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.1.1 03/04/2021 == 
+== 2.1.1 03/04/2021 ==
 
 - Fix: Restore missing Correct the Klarna slug #6440
 
-== 2.1.0 03/04/2021 == 
+== 2.1.0 03/04/2021 ==
 
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 - Dev: Remove Google fonts and material icons. #6343
@@ -451,15 +452,15 @@
 - Enhancement: override wpbody styles when nav present #6354
 - Enhancement: Move favorited menu items to primary menu #6290
 
-== 2.0.3 03/10/2021 == 
+== 2.0.3 03/10/2021 ==
 
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.0.2 05/25/2021 == 
+== 2.0.2 05/25/2021 ==
 
 - Fix: Correct the Klarna slug #6440
 
-== 2.0.0 02/05/2021 == 
+== 2.0.0 02/05/2021 ==
 
 - Tweak: Bump minimum supported version of PHP to 7.0. #6046
 - Tweak: update the content and timing of the NeedSomeInspiration note. #6076
@@ -483,7 +484,7 @@
 - Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 
-== 1.9.0 01/15/2021 == 
+== 1.9.0 01/15/2021 ==
 
 - Fix: Add Customer Type column to the Orders report table. #5820
 - Fix: Product exclusion filter on Orders Report.
@@ -516,21 +517,21 @@
 - Add: Note for users coming from Calypso. #6030
 - Add: Manage activity from home screen inbox message. #6072
 
-== 1.8.3 01/05/2021 == 
+== 1.8.3 01/05/2021 ==
 
 - Fix: Compile the debug module so it can be used in older browsers like IE11. #5987
 
-== 1.8.2 12/22/2020 == 
+== 1.8.2 12/22/2020 ==
 
 - Fix: Completed tasks tracking causing infinite loop #5941
 - Fix: Remove Navigation access #5940
 
-== 1.8.1 12/15/2020 == 
+== 1.8.1 12/15/2020 ==
 
 - Fix: Product exclusion filter on Orders Report.
 - Fix: Typo in Variation Stats DataStore context filter value. #5784
 
-== 1.8.0 12/07/2020 == 
+== 1.8.0 12/07/2020 ==
 
 - Enhancement: Add "filter by variations in reports" inbox note. #5208
 - Enhancement: Tasks extensibility in Home Screen. #5794
@@ -566,7 +567,7 @@
 - Fix: Load wctracks to avoid fatal errors. #5645 #5638
 - Fix: Preventing desktopsized navigation placeholder from appearing on mobile during load. #5616
 
-== 1.7.0 11/11/2020 == 
+== 1.7.0 11/11/2020 ==
 
 - Enhancement: Variations report.  #5167
 - Enhancement: Add ability to toggle homescreen layouts. #5429
@@ -625,7 +626,7 @@
 - Dev: Rearrange the store management links under categories add filter woocommerce_admin_homescreen_quicklinks. #5476
 - Dev: Restyle the setup task list header to display incomplete tasks #5520
 
-== 1.6.2 10/16/2020 == 
+== 1.6.2 10/16/2020 ==
 
 - Fix: Missing activity panels on ugraded sites #5400
 - Fix: Casting of onboarding profile data to array #5415
@@ -633,12 +634,12 @@
 - Fix: i18n of Performance Indicator strings #5405
 - Fix: Gutenberg 9.1.1 compat for empty data sets #5409
 
-== 1.6.1 10/13/2020 == 
+== 1.6.1 10/13/2020 ==
 
 - Fix: Hide setup checklist shortcut when setup checklist skipped #5360
 - Fix: use of undefined function on WC < 4.0.0.
 
-== 1.6.0 10/09/2020 == 
+== 1.6.0 10/09/2020 ==
 
 - Dev: Reviews wp.data store #4941
 - Dev: Notes wp.data store #4943
@@ -687,7 +688,7 @@
 - Fix: Search all variation attribute values #5141
 - Fix: Force float before addition in taxes #5149
 
-== 1.5.0 08/07/2020 == 
+== 1.5.0 08/07/2020 ==
 
 - Dev: New notification
 - Dev: Enable tax calculation before redirecting to standard tax rates page. #4878
@@ -699,7 +700,7 @@
 - Fix: Use clipRule and fillRule props. #4889, part of #4864
 - Enhancement: Add eWAY to Payment Setup for AU/NZ Stores. #4947
 
-== 1.4.0 07/22/2020 == 
+== 1.4.0 07/22/2020 ==
 
 - Fix: Update returning customer total to include customers whose first order was within the report date range #4430
 - Fix: Fix an error in the Analytics/Orders table when there is an order deleted directly from the database #4630
@@ -738,15 +739,15 @@
 - Dev: Customize webpack jsonpFunction to avoid potential collision with other Webpack bundles #4644 🎉 @aaemnnosttv
 - Dev: Update @wordpress/basestyles and replace deprecated variables #4759
 
-== 1.3.2 07/29/2020 == 
+== 1.3.2 07/29/2020 ==
 
 - Fix: bug preventing saving user preferences on WP 5.3. #4869
 
-== 1.3.1 07/20/2020 == 
+== 1.3.1 07/20/2020 ==
 
 - Fix: PHP Fatal errors when columns are missing from the Notes table. #4831
 
-== 1.3.0 07/08/2020 == 
+== 1.3.0 07/08/2020 ==
 
 - Enhancement: Add Jetpack stats to performance indicatorts / homepage #4291
 - Enhancement: New "Store Management" quick links card on WooCommerce home screen. #4350
@@ -794,21 +795,21 @@
 - Tweak: Remove duplicate/redundant inbox note after first order received. #4659
 - Tweak: Fix the embed page CSS so the top content sits better #4622
 
-== 1.2.4 06/11/2020 == 
+== 1.2.4 06/11/2020 ==
 
 - Tweak: reduce asset filename length and remove tilde characters. #4535
 - Fix: RTL stylesheet loading for split code chunks. #4542
 
-== 1.2.3 05/22/2020 == 
+== 1.2.3 05/22/2020 ==
 
 - Tweak: Updates to WooCommerce Payments in Setup Checklist #4293
 
-== 1.2.2 05/18/2020 == 
+== 1.2.2 05/18/2020 ==
 
 - Fix: Respect tracking optin before new page load. #4368
 - Enhancement: Add Jetpack connection to plugin benefits step #4374
 
-== 1.2.0 05/18/2020 == 
+== 1.2.0 05/18/2020 ==
 
 - Enhancement: Add onboarding payments note #4157
 - Enhancement: Marketing Inbox Note #4030
@@ -839,20 +840,20 @@
 - Dev: Dynamic Currency with Context API #4027
 - Dev: Remove Duplicate array entry #4049 🎉 @tivnet
 
-== 1.1.3 05/18/2020 == 
+== 1.1.3 05/18/2020 ==
 
 - Tweak: Onboarding
 - Fix: Respect tracking optin before new page load. #4368
 
 == 1.1.2 05/12/2020 ==
 
-== 1.1.1 05/05/2020 == 
+== 1.1.1 05/05/2020 ==
 
 - Fix: Storefront should show at top of theme options in onboarding wizard. #4187
 - Tweak: Remove Stripe autoconnect from payment task. #4164
 - Tweak: Hide suggested extensions in Marketing Tab if opted out of "Marketplace Suggestions"
 
-== 1.1.0 04/23/2020 == 
+== 1.1.0 04/23/2020 ==
 
 - Tweak: Added link to "go shopping" button #3712
 - Tweak: Add PayFast payment gateway option for sites in South Africa #3738
@@ -897,19 +898,19 @@
 - Dev: Handle orphaned order statuses in analytics settings. #4090
 - Dev: Fix usage of WP_Error in nonglobal namespaces. #4115
 
-== 1.0.3 03/22/2020 == 
+== 1.0.3 03/22/2020 ==
 
 - Fix: Stop calling protected has_satisfied_dependencies() on outdated plugin. #3938
 - Fix: Rename image assets in OBW business details step. #3931
 - Fix: Stop using WP Post store for Action Scheduler. #3936
 
-== 1.0.2 03/18/2020 == 
+== 1.0.2 03/18/2020 ==
 
 - Enhancement: Onboarding
 - Dev: Update prestart script so readme.txt stable tag is updated #3911
 - Tweak: create database tables on an earlier hook to avoid conflicts with core WooCommerce. #3896
 
-== 1.0.1 03/12/2020 == 
+== 1.0.1 03/12/2020 ==
 
 - Fix: Add Report Extension Example
 - Fix: Product report sorting by SKU when some products don't have SKUs
@@ -921,7 +922,7 @@
 - Dev: Fix failing tests after WC core merge.
 - Dev: Bump WooCommerce tested up to tag
 
-== 1.0.0 03/05/2020 == 
+== 1.0.0 03/05/2020 ==
 
 - Fix: Customers Report
 - Fix: OBW Connect
@@ -935,7 +936,7 @@
 - Fix: Tracking on migrated options #3828
 - Dev: Onboarding
 
-== 0.26.1 02/26/2020 == 
+== 0.26.1 02/26/2020 ==
 
 - Fix: Remove free text Search option when no query exists #3755
 - Fix: StoreAlert
@@ -946,7 +947,7 @@
 - Fix: Add deactivation hook to Package.php #3770
 - Fix: Add active version functions #3772
 
-== 0.26.0 02/21/2020 == 
+== 0.26.0 02/21/2020 ==
 
 - Fix: Warning in product data store when tax amount is nonnumeric. #3656
 - Fix: Enable onboarding in production. #3680
@@ -963,12 +964,12 @@
 - Dev: Travis tests on Github for release branch #3751
 - Add: Deactivation note for feature plugin #3687
 
-== 0.25.1 02/07/2020 == 
+== 0.25.1 02/07/2020 ==
 
 - Dev: Enable onboarding #3651 (Onboarding)
 - Fix: Fix styling of search control in report table header and filters. #3603 (Analytics, Components, Packages)
 
-== 0.25.0 01/29/2020 == 
+== 0.25.0 01/29/2020 ==
 
 - Fix: Onboarding
 - Fix: Fix styling of search control in report table header and filters. #3603 (Analytics, Components, Packages)
@@ -1026,7 +1027,7 @@
 - Bug: Onboarding
 - Bug: Onboarding
 
-== 0.24.0 01/06/2020 == 
+== 0.24.0 01/06/2020 ==
 
 - Bug: Add SelectControl debouncing and keyboard fixes #3507 (Components, Packages)
 - Bug: Onboarding
@@ -1065,11 +1066,11 @@
 - Tweak: Add/disable plugin filter #3361
 - Enhancement: allow report cache layer to be turned off. #3434
 
-== 0.23.3 12/26/2019 == 
+== 0.23.3 12/26/2019 ==
 
 - Fix: don't run database migrations on new installs. #3473
 
-== 0.23.2 12/19/2019 == 
+== 0.23.2 12/19/2019 ==
 
 - Enhancement: allow filtering of hidden WP notices. #3391 (Activity Panel, Extensibility)
 - Fix: error when trying to download report data. #3429 (Analytics)
@@ -1078,11 +1079,11 @@
 - Fix: remove the header when user doesn't have required permissions #3386 (Activity Panel)
 - Bug: Fix user data fields filter name. #3428 (Dashboard)
 
-== 0.23.1 12/08/2019 == 
+== 0.23.1 12/08/2019 ==
 
 - Fix: undefined function error.
 
-== 0.23.0 12/06/2019 == 
+== 0.23.0 12/06/2019 ==
 
 - Dev: Add currency extension #3328 (Packages)
 - Dev: Packages
@@ -1114,7 +1115,7 @@
 - Tweak: remove global settings dependency from Navigation package. #3294 (Components, Packages)
 - Tweak: Search component
 
-== 0.22.0 11/13/2019 == 
+== 0.22.0 11/13/2019 ==
 
 - Fix: Incorrect calculation of tax summary on Taxes screen. #3158 (Analytics)
 - Fix: Correct product and coupon count on edited orders. #3103 (Analytics)
@@ -1130,7 +1131,7 @@
 - Tweak: Field misalignment in product edit screen. #3145
 - Task: Fix PHP linter errors. #3188
 
-== 0.21.0 10/30/2019 == 
+== 0.21.0 10/30/2019 ==
 
 - Fix: report export format when generated serverside. #2987 (Analytics, Packages)
 - Fix: Address discrepancies in Revenue totals between Analytics screens. #3095 (Analytics)
@@ -1145,12 +1146,12 @@
 - Dev: Add the ability to create custom plugin builds #3044 (Build)
 - Enhancement: add management link to Reviews panel. #3011 (Activity Panel)
 
-== 0.20.1 09/24/2019 == 
+== 0.20.1 09/24/2019 ==
 
 - Fix: use category lookup id instead of term taxonomy id (#3027)
 - Fix: Update order stats table status index length. (#3022)
 
-== 0.20.0 09/24/2019 == 
+== 0.20.0 09/24/2019 ==
 
 - Dev: Fix issue #2992 (order number in orders panel) #2994
 - Dev: Replace lodash isNaN() with native Number.isNaN() #2998 (Build, Packages)
@@ -1173,7 +1174,7 @@
 - Performance: reduce JS bundle size. #2933 (Build)
 - Bug: Fix conflict with Blocks 2.4 #2846
 
-== 0.19.0 09/24/2019 == 
+== 0.19.0 09/24/2019 ==
 
 - Dev: Use upstream webpackrtlplugin #2870 (Build)
 - Dev: Fix variable name typo #2922
@@ -1185,7 +1186,7 @@
 - Tweak: change report charts filter name. #2843 (Components, Documentation, Packages)
 - Bug: Fix chart type buttons misalignment #2871 (Components, Packages)
 
-== 0.18.0 08/28/2019 == 
+== 0.18.0 08/28/2019 ==
 
 - Fix: Product in dropdown clickable in FF/Safari #2839 (Components, Packages) 👏 @cojennin
 - Fix: gross order total calculation. #2817 (Analytics)
@@ -1203,7 +1204,7 @@
 - Dev: Update List actionable items to be wrapped with Link #2779 (Components, Packages)
 - Tweak: add empty dataset treatment for report tables. #2801 (Analytics, Components, Packages)
 
-== 0.17.0 08/15/2019 == 
+== 0.17.0 08/15/2019 ==
 
 - Fix: chart data fetch/render over long time periods #2785 (Analytics)
 - Fix: chart display when comparing categories. #2710 (Analytics)
@@ -1223,7 +1224,7 @@
 - Bug: Only apply current submenu CSS reset on nonembed pages. #2687
 - Dev: Add `wc_admin_get_feature_config` filter to feature config array. #2689
 
-== 0.16.0 07/24/2019 == 
+== 0.16.0 07/24/2019 ==
 
 - Tweak: Change verbiage of feedback notification. #2677
 - Dev: Update unit tests to work with PHPUnit 7+. #2678
@@ -1242,7 +1243,7 @@
 - Task: Add priority 3 Tracks events #2638 (Components, Packages)
 - Task: Add instructions for translating to contributing docs. #2618 (Documentation)
 
-== 0.15.0 07/11/2019 == 
+== 0.15.0 07/11/2019 ==
 
 - Fix: Compare checkboxes in report tables #2571
 - Fix: Use correct links in DevDocs. #2602 (Documentation)
@@ -1279,7 +1280,7 @@
 - Tweak: fix some report endpoint default params. #2496 (REST API)
 - Bug: Fix batch queue range bug. #2521
 
-== 0.14.0 06/24/2019 == 
+== 0.14.0 06/24/2019 ==
 
 - Dev: Action Scheduler
 - Dev: Fix Activity Panel being overlapped by editor toolbar #2446 (Activity Panel)
@@ -1302,15 +1303,15 @@
 - Tweak: Reduce style dependencies on WP core, avoid errantly including WP core's Google Fonts. #2432 (Components)
 - Task: Remove test menu from Orders panel #2438 (Activity Panel)
 
-== 0.13.2 06/13/2019 == 
+== 0.13.2 06/13/2019 ==
 
 - Fix: Bump plugin version for database update.
 
-== 0.13.1 06/12/2019 == 
+== 0.13.1 06/12/2019 ==
 
 - Fix: Exit deactivate early if WooCommerce not active. #2410
 
-== 0.13.0 06/12/2019 == 
+== 0.13.0 06/12/2019 ==
 
 - Fix: Notes
 - Fix: Double space at 191 row #2369  👏 @shoheitanaka
@@ -1353,7 +1354,7 @@
 - Task: Remove second beta warning from readme #2362
 - Task: Remove beta warning from readme. #2340
 
-== 0.12.0 05/14/2019 == 
+== 0.12.0 05/14/2019 ==
 
 - Fix: dashboard issues #2194
 - Fix: Dashboard
@@ -1385,7 +1386,7 @@
 - Dev: Scroll to top of the table when navigating table pages #2051
 - Dev: Add empty state for the Reviews panels #2124
 
-== 0.11.0 04/17/2019 == 
+== 0.11.0 04/17/2019 ==
 
 - Dev: Extend report submenu items #2033
 - Dev: Extension Examples #2018
@@ -1420,7 +1421,7 @@
 - Enhancement: Scroll to top only when URL changes #1989
 - Enhancement: Allow negative values in charts #1979
 
-== 0.10.0 04/02/2019 == 
+== 0.10.0 04/02/2019 ==
 
 - Dev: Properly namespaced methods in wcadmin.php. props @ronakganatra9 #1804
 - Dev: Changed textdomain to `woocommerceadmin` #1795
@@ -1479,7 +1480,7 @@
 - Performance: Don't dispatch REST API requests when window/tab is hidden #1732
 - Performance: Only check for unsnooze note on admin_init #1960
 
-== 0.8.0 02/28/2019 == 
+== 0.8.0 02/28/2019 ==
 
 - Table Component: Reset search on compare
 - Table Component: Fix search positioning in small viewports

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 == 2.6.5 09/22/2021 ==
 
 - Fix: Add filters to get new hidden options #7698
-- Add: E2E tests for checking store currency if it matches the onboarded country #7712
+- Add: E2E tests for checking store currency if it matches the onboarded country. #7712
 
 == 2.6.4 09/21/2021 ==
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 == 2.6.5 09/22/2021 ==
 
 - Fix: Add filters to get new hidden options #7698
-- Add: E2E tests for checking store currency if it matches the onboarded country. #7712
 
 == 2.6.4 09/21/2021 ==
 

--- a/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
+++ b/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
@@ -1,4 +1,4 @@
 Significance: minor
-Type: Dev
+Type: Add
 
-Add: E2E tests for checking store currency if it matches the onboarded country
+Add: E2E tests for checking store currency if it matches the onboarded country. #7712

--- a/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
+++ b/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add: E2E tests for checking store currency if it matches the onboarded country. #7712

--- a/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
+++ b/changelogs/add-7711-e2e-tests-for-different-locale-onboarding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Dev
+
+Add: E2E tests for checking store currency if it matches the onboarded country

--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+-   Add E2E tests for checking store currency if it matches the onboarded country. #7712
 
 # 0.1.1
 

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -225,36 +225,42 @@ const testDifferentStoreCurrenciesWCPay = () => {
 			countryRegionSelector: 'AU\\:QLD',
 			countryRegion: 'Australia — Queensland',
 			expectedCurrency: 'AUD',
+			isWCPaySupported: true,
 		},
 		{
 			countryRegionSubstring: 'canada',
 			countryRegionSelector: 'CA\\:QC',
 			countryRegion: 'Canada — Quebec',
 			expectedCurrency: 'CAD',
+			isWCPaySupported: true,
 		},
 		{
 			countryRegionSubstring: 'china',
 			countryRegionSelector: 'CN\\:CN2',
 			countryRegion: 'China — Beijing',
 			expectedCurrency: 'CNY',
+			isWCPaySupported: false,
 		},
 		{
 			countryRegionSubstring: 'spain',
 			countryRegionSelector: 'ES\\:CO',
 			countryRegion: 'Spain — Córdoba',
 			expectedCurrency: 'EUR',
+			isWCPaySupported: true,
 		},
 		{
 			countryRegionSubstring: 'india',
 			countryRegionSelector: 'IN\\:DL',
 			countryRegion: 'India — Delhi',
 			expectedCurrency: 'INR',
+			isWCPaySupported: false,
 		},
 		{
 			countryRegionSubstring: 'kingd',
 			countryRegionSelector: 'GB',
 			countryRegion: 'United Kingdom (UK)',
 			expectedCurrency: 'GBP',
+			isWCPaySupported: true,
 		},
 	];
 
@@ -311,13 +317,17 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				await profileWizard.continue();
 				await profileWizard.business.freeFeaturesIsDisplayed();
 				// Add WC Pay check
-				await profileWizard.business
-					.expandRecommendedBusinessFeatures()
-					.then( () => {
-						expect( page ).not.toMatchElement( 'a', {
-							text: 'WooCommerce Payments',
-						} );
+				await profileWizard.business.expandRecommendedBusinessFeatures();
+
+				if ( spec.isWCPaySupported ) {
+					expect( page ).toMatchElement( 'a', {
+						text: 'WooCommerce Payments',
 					} );
+				} else {
+					expect( page ).not.toMatchElement( 'a', {
+						text: 'WooCommerce Payments',
+					} );
+				}
 
 				await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
 				await profileWizard.continue();

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -270,7 +270,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				await login.logout();
 			} );
 
-			it(`can complete the profile wizard with selecting ${ spec.countryRegion } as the country`,
+			it(`can complete the profile wizard with selecting ${spec.countryRegion} as the country`,
 				async () => {
 					await profileWizard.navigate();
 					await profileWizard.storeDetails.completeStoreDetailsSection(
@@ -316,11 +316,11 @@ const testDifferentStoreCurrenciesWCPay = () => {
 					await profileWizard.continue();
 					await profileWizard.business.freeFeaturesIsDisplayed();
 					// Add WC Pay check
-					await profileWizard.business.expandRecommendedBusinessFeatures();
-
-					expect( page ).not.toMatchElement( 'a', {
-						text: 'WooCommerce Payments',
-					} );
+					await profileWizard.business.expandRecommendedBusinessFeatures().then(() => {
+						expect( page ).not.toMatchElement( 'a', {
+							text: 'WooCommerce Payments',
+						} );
+					});
 
 					await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
 					await profileWizard.continue();
@@ -331,7 +331,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				}
 			);
 
-			it(`can select ${ spec.expectedCurrency } as the currency for ${ spec.countryRegion }`,
+			it(`can select ${spec.expectedCurrency} as the currency for ${spec.countryRegion}`,
 				async () => {
 					const settingsScreen = new WcSettings( page );
 					await settingsScreen.navigate();

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -16,6 +16,8 @@ const {
 	expect,
 } = require( '@jest/globals' );
 const config = require( 'config' );
+
+const { verifyValueOfInputField } = require( '@woocommerce/e2e-utils' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 /**
@@ -108,10 +110,7 @@ const testAdminOnboardingWizard = () => {
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
 			await settingsScreen.navigate();
-			const currencySettings = settingsScreen.getDropdownField(
-				'#woocommerce_currency'
-			);
-			await currencySettings.checkSelected( 'USD' );
+			verifyValueOfInputField( '#wc_currency', 'USD' );
 		} );
 	} );
 };
@@ -211,13 +210,11 @@ const testSelectiveBundleWCPay = () => {
 			expect( tasks ).not.toContain( TaskTitles.wooPayments );
 		} );
 
+
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
 			await settingsScreen.navigate();
-			const currencySettings = settingsScreen.getDropdownField(
-				'#woocommerce_currency'
-			);
-			await currencySettings.checkSelected( 'JPY' );
+			verifyValueOfInputField( '#wc_currency', 'JPY' );
 		} );
 	} );
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -235,13 +235,13 @@ const testDifferentStoreCurrenciesWCPay = () => {
 		{
 			countryRegionSubstring: 'china',
 			countryRegionSelector: 'CN\\:CN2',
-			countryRegion: 'China — Beijing Shi',
+			countryRegion: 'China — Beijing',
 			expectedCurrency: 'CNY',
 		},
 		{
 			countryRegionSubstring: 'spain',
 			countryRegionSelector: 'ES\\:CO',
-			countryRegion: 'Spain — Cordoba',
+			countryRegion: 'Spain — Córdoba',
 			expectedCurrency: 'EUR',
 		},
 		{

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -219,57 +219,57 @@ const testSelectiveBundleWCPay = () => {
 };
 
 const testDifferentStoreCurrenciesWCPay = () => {
-	describe( 'A store can onboard with any country and have the correct currency selected after onboarding.', () => {
-		const profileWizard = new OnboardingWizard( page );
-		const login = new Login( page );
+	const testCountryCurrencyPairs = [
+		{
+			countryRegionSubstring: 'australia',
+			countryRegionSelector: 'AU\\:QLD',
+			countryRegion: 'Australia — Queensland',
+			expectedCurrency: 'AUD',
+		},
+		{
+			countryRegionSubstring: 'canada',
+			countryRegionSelector: 'CA\\:QC',
+			countryRegion: 'Canada — Quebec',
+			expectedCurrency: 'CAD',
+		},
+		{
+			countryRegionSubstring: 'china',
+			countryRegionSelector: 'CN\\:CN2',
+			countryRegion: 'China — Beijing Shi',
+			expectedCurrency: 'CNY',
+		},
+		{
+			countryRegionSubstring: 'spain',
+			countryRegionSelector: 'ES\\:CO',
+			countryRegion: 'Spain — Cordoba',
+			expectedCurrency: 'EUR',
+		},
+		{
+			countryRegionSubstring: 'india',
+			countryRegionSelector: 'IN\\:DL',
+			countryRegion: 'India — Delhi',
+			expectedCurrency: 'INR',
+		},
+		{
+			countryRegionSubstring: 'united-kingdom',
+			countryRegionSelector: 'UK',
+			countryRegion: 'United Kingdom (UK)',
+			expectedCurrency: 'GBP',
+		},
+	];
 
-		beforeAll( async () => {
-			await login.login();
-		} );
-		afterAll( async () => {
-			await login.logout();
-		} );
+	testCountryCurrencyPairs.forEach( ( spec ) => {
+		describe( 'A store can onboard with any country and have the correct currency selected after onboarding.', () => {
+			const profileWizard = new OnboardingWizard( page );
+			const login = new Login( page );
 
-		const testCountryCurrencyPairs = [
-			{
-				countryRegionSubstring: 'australia',
-				countryRegionSelector: 'AU\\:QLD',
-				countryRegion: 'Australia — Queensland',
-				expectedCurrency: 'AUD',
-			},
-			{
-				countryRegionSubstring: 'canada',
-				countryRegionSelector: 'CA\\:QC',
-				countryRegion: 'Canada — Quebec',
-				expectedCurrency: 'CAD',
-			},
-			{
-				countryRegionSubstring: 'china',
-				countryRegionSelector: 'CN\\:CN2',
-				countryRegion: 'China — Beijing Shi',
-				expectedCurrency: 'CNY',
-			},
-			{
-				countryRegionSubstring: 'spain',
-				countryRegionSelector: 'ES\\:CO',
-				countryRegion: 'Spain — Cordoba',
-				expectedCurrency: 'EUR',
-			},
-			{
-				countryRegionSubstring: 'india',
-				countryRegionSelector: 'IN\\:DL',
-				countryRegion: 'India — Delhi',
-				expectedCurrency: 'INR',
-			},
-			{
-				countryRegionSubstring: 'united-kingdom',
-				countryRegionSelector: 'UK',
-				countryRegion: 'United Kingdom (UK)',
-				expectedCurrency: 'GBP',
-			},
-		];
+			beforeAll( async () => {
+				await login.login();
+			} );
+			afterAll( async () => {
+				await login.logout();
+			} );
 
-		testCountryCurrencyPairs.forEach( ( spec ) => {
 			it(
 				'can complete the profile wizard with selecting "' +
 					spec.countryRegion +

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -251,8 +251,8 @@ const testDifferentStoreCurrenciesWCPay = () => {
 			expectedCurrency: 'INR',
 		},
 		{
-			countryRegionSubstring: 'united-kingdom',
-			countryRegionSelector: 'UK',
+			countryRegionSubstring: 'kingd',
+			countryRegionSelector: 'GB',
 			countryRegion: 'United Kingdom (UK)',
 			expectedCurrency: 'GBP',
 		},

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -107,6 +107,7 @@ const testAdminOnboardingWizard = () => {
 
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
+			await settingsScreen.navigate();
 			const currencySettings = settingsScreen.getDropdownField(
 				'#woocommerce_currency'
 			);
@@ -212,6 +213,7 @@ const testSelectiveBundleWCPay = () => {
 
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
+			await settingsScreen.navigate();
 			const currencySettings = settingsScreen.getDropdownField(
 				'#woocommerce_currency'
 			);

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -270,77 +270,71 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				await login.logout();
 			} );
 
-			it(`can complete the profile wizard with selecting ${spec.countryRegion} as the country`,
-				async () => {
-					await profileWizard.navigate();
-					await profileWizard.storeDetails.completeStoreDetailsSection(
-						{
-							countryRegionSubstring: spec.countryRegionSubstring,
-							countryRegionSelector: spec.countryRegionSelector,
-							countryRegion: spec.countryRegion,
-						}
-					);
+			it( `can complete the profile wizard with selecting ${ spec.countryRegion } as the country`, async () => {
+				await profileWizard.navigate();
+				await profileWizard.storeDetails.completeStoreDetailsSection( {
+					countryRegionSubstring: spec.countryRegionSubstring,
+					countryRegionSelector: spec.countryRegionSelector,
+					countryRegion: spec.countryRegion,
+				} );
 
-					// Wait for "Continue" button to become active
-					await profileWizard.continue();
+				// Wait for "Continue" button to become active
+				await profileWizard.continue();
 
-					// Wait for usage tracking pop-up window to appear
-					await profileWizard.optionallySelectUsageTracking();
-					// Query for the industries checkboxes
-					await profileWizard.industry.isDisplayed();
-					await profileWizard.industry.uncheckIndustries();
-					await profileWizard.industry.selectIndustry( 'Other' );
-					await profileWizard.continue();
-					await profileWizard.productTypes.isDisplayed( 7 );
-					await profileWizard.productTypes.uncheckProducts();
-					await profileWizard.productTypes.selectProduct(
-						'Physical products'
-					);
-					await profileWizard.productTypes.selectProduct(
-						'Downloads'
-					);
+				// Wait for usage tracking pop-up window to appear
+				await profileWizard.optionallySelectUsageTracking();
+				// Query for the industries checkboxes
+				await profileWizard.industry.isDisplayed();
+				await profileWizard.industry.uncheckIndustries();
+				await profileWizard.industry.selectIndustry( 'Other' );
+				await profileWizard.continue();
+				await profileWizard.productTypes.isDisplayed( 7 );
+				await profileWizard.productTypes.uncheckProducts();
+				await profileWizard.productTypes.selectProduct(
+					'Physical products'
+				);
+				await profileWizard.productTypes.selectProduct( 'Downloads' );
 
-					await profileWizard.continue();
-					await page.waitForNavigation( {
-						waitUntil: 'networkidle0',
-					} );
-					await profileWizard.business.isDisplayed();
+				await profileWizard.continue();
+				await page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} );
+				await profileWizard.business.isDisplayed();
 
-					await profileWizard.business.selectProductNumber(
-						config.get( 'onboardingwizard.numberofproducts' )
-					);
-					await profileWizard.business.selectCurrentlySelling(
-						config.get( 'onboardingwizard.sellingelsewhere' )
-					);
+				await profileWizard.business.selectProductNumber(
+					config.get( 'onboardingwizard.numberofproducts' )
+				);
+				await profileWizard.business.selectCurrentlySelling(
+					config.get( 'onboardingwizard.sellingelsewhere' )
+				);
 
-					await profileWizard.continue();
-					await profileWizard.business.freeFeaturesIsDisplayed();
-					// Add WC Pay check
-					await profileWizard.business.expandRecommendedBusinessFeatures().then(() => {
+				await profileWizard.continue();
+				await profileWizard.business.freeFeaturesIsDisplayed();
+				// Add WC Pay check
+				await profileWizard.business
+					.expandRecommendedBusinessFeatures()
+					.then( () => {
 						expect( page ).not.toMatchElement( 'a', {
 							text: 'WooCommerce Payments',
 						} );
-					});
+					} );
 
-					await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
-					await profileWizard.continue();
-					await profileWizard.themes.isDisplayed();
+				await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
+				await profileWizard.continue();
+				await profileWizard.themes.isDisplayed();
 
-					//  This navigates to the home screen
-					await profileWizard.themes.continueWithActiveTheme();
-				}
-			);
+				//  This navigates to the home screen
+				await profileWizard.themes.continueWithActiveTheme();
+			} );
 
-			it(`can select ${spec.expectedCurrency} as the currency for ${spec.countryRegion}`,
-				async () => {
-					const settingsScreen = new WcSettings( page );
-					await settingsScreen.navigate();
-					verifyValueOfInputField(
-						'#woocommerce_currency',
-						spec.expectedCurrency
-					);
-				}
-			);
+			it( `can select ${ spec.expectedCurrency } as the currency for ${ spec.countryRegion }`, async () => {
+				const settingsScreen = new WcSettings( page );
+				await settingsScreen.navigate();
+				verifyValueOfInputField(
+					'#woocommerce_currency',
+					spec.expectedCurrency
+				);
+			} );
 		} );
 	} );
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -110,7 +110,7 @@ const testAdminOnboardingWizard = () => {
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
 			await settingsScreen.navigate();
-			verifyValueOfInputField( '#wc_currency', 'USD' );
+			verifyValueOfInputField( '#woocommerce_currency', 'USD' );
 		} );
 	} );
 };
@@ -214,7 +214,7 @@ const testSelectiveBundleWCPay = () => {
 		it( 'can select the right currency on settings page related to the onboarding country', async () => {
 			const settingsScreen = new WcSettings( page );
 			await settingsScreen.navigate();
-			verifyValueOfInputField( '#wc_currency', 'JPY' );
+			verifyValueOfInputField( '#woocommerce_currency', 'JPY' );
 		} );
 	} );
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -5,6 +5,7 @@ import { OnboardingWizard } from '../../pages/OnboardingWizard';
 import { WcHomescreen } from '../../pages/WcHomescreen';
 import { TaskTitles } from '../../constants/taskTitles';
 import { Login } from '../../pages/Login';
+import { WcSettings } from '../../pages/WcSettings';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const {
@@ -103,6 +104,14 @@ const testAdminOnboardingWizard = () => {
 			await profileWizard.themes.isDisplayed();
 			await profileWizard.themes.continueWithActiveTheme();
 		} );
+
+		it( 'can select the right currency on settings page related to the onboarding country', async () => {
+			const settingsScreen = new WcSettings( page );
+			const currencySettings = settingsScreen.getDropdownField(
+				'#woocommerce_currency'
+			);
+			await currencySettings.checkSelected( 'USD' );
+		} );
 	} );
 };
 
@@ -199,6 +208,14 @@ const testSelectiveBundleWCPay = () => {
 			const tasks = await homescreen.getTaskList();
 			expect( tasks ).toContain( TaskTitles.addPayments );
 			expect( tasks ).not.toContain( TaskTitles.wooPayments );
+		} );
+
+		it( 'can select the right currency on settings page related to the onboarding country', async () => {
+			const settingsScreen = new WcSettings( page );
+			const currencySettings = settingsScreen.getDropdownField(
+				'#woocommerce_currency'
+			);
+			await currencySettings.checkSelected( 'JPY' );
 		} );
 	} );
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -270,10 +270,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				await login.logout();
 			} );
 
-			it(
-				'can complete the profile wizard with selecting "' +
-					spec.countryRegion +
-					'" as the country',
+			it(`can complete the profile wizard with selecting ${ spec.countryRegion } as the country`,
 				async () => {
 					await profileWizard.navigate();
 					await profileWizard.storeDetails.completeStoreDetailsSection(
@@ -334,12 +331,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 				}
 			);
 
-			it(
-				'can select "' +
-					spec.expectedCurrency +
-					'" as the currency for "' +
-					spec.countryRegion +
-					'"',
+			it(`can select ${ spec.expectedCurrency } as the currency for ${ spec.countryRegion }`,
 				async () => {
 					const settingsScreen = new WcSettings( page );
 					await settingsScreen.navigate();

--- a/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
+++ b/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
@@ -1,7 +1,9 @@
 const {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
+	testDifferentStoreCurrenciesWCPay,
 } = require( '@woocommerce/admin-e2e-tests' );
 
 testAdminOnboardingWizard();
 testSelectiveBundleWCPay();
+testDifferentStoreCurrenciesWCPay();


### PR DESCRIPTION
Fixes #7711

This PR adds tests for automatic currency selection after an user completed the KYC flow. The tests are checking if these country selections end with the corresponding currencies listed below:

```
Australia — Queensland => AUD
Canada — Quebec => CAD
China — Beijing => CNY
Spain — Córdoba => EUR
India — Delhi => INR
United Kingdom (UK) => GBP
```

No changelog
No interaction change

### Detailed test instructions:

- Run E2E tests locally `npm install && npx wc-e2e docker:up` and then `npx wc-e2e test:e2e`
- Check if the github action passed correctly