### PR TITLE
Only return viewable tasks from tasks endpoint

### DIFF
--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -52,13 +52,12 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	const nowTimestamp = Date.now();
 	const visibleTasks = tasks.filter(
 		( task ) =>
-			task.canView &&
 			! task.isDismissed &&
 			( ! task.isSnoozed || task.snoozedUntil < nowTimestamp )
 	);
 
 	const incompleteTasks = tasks.filter(
-		( task ) => task.canView && ! task.isComplete && ! task.isDismissed
+		( task ) => ! task.isComplete && ! task.isDismissed
 	);
 
 	const [ expandedTask, setExpandedTask ] = useState(

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -94,7 +94,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		_n(
 			'Show %d more task.',
 			'Show %d more tasks.',
-			tasks.length - 2,
+			visibleTasks.length - 2,
 			'woocommerce-admin'
 		),
 		visibleTasks.length - 2

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -94,7 +94,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		_n(
 			'Show %d more task.',
 			'Show %d more tasks.',
-			visibleTasks.length - 2,
+			tasks.length - 2,
 			'woocommerce-admin'
 		),
 		visibleTasks.length - 2

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -115,7 +115,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			'/' . $this->rest_base,
 			array(
 				'args'   => array(
-					'only_visible' => array(
+					'only_viewable' => array(
 						'description' => __( 'Only return visible tasks. Defaults to true.', 'woocommerce-admin' ),
 						'type'        => 'boolean',
 					),
@@ -760,15 +760,16 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_tasks( $request ) {
-		$only_visible = null !== $request->get_param( 'only_visible' ) ? $request->get_param( 'only_visible' ) : true;
+		$only_viewable = null !== $request->get_param( 'only_viewable' ) ? $request->get_param( 'only_viewable' ) : true;
 
 		$lists = TaskLists::get_lists();
 		$json  = array_map(
-			function( $list ) use ( $only_visible ) {
-				return $list->get_json( $only_visible );
+			function( $list ) use ( $only_viewable ) {
+				return $list->get_json( $only_viewable );
 			},
 			$lists
 		);
+
 		return rest_ensure_response( array_values( apply_filters( 'woocommerce_admin_onboarding_tasks', $json ) ) );
 	}
 

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -114,12 +114,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			$this->namespace,
 			'/' . $this->rest_base,
 			array(
-				'args'   => array(
-					'only_viewable' => array(
-						'description' => __( 'Only return visible tasks. Defaults to true.', 'woocommerce-admin' ),
-						'type'        => 'boolean',
-					),
-				),
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_tasks' ),

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -114,6 +114,12 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			$this->namespace,
 			'/' . $this->rest_base,
 			array(
+				'args'   => array(
+					'only_visible' => array(
+						'description' => __( 'Only return visible tasks. Defaults to true.', 'woocommerce-admin' ),
+						'type'        => 'boolean',
+					),
+				),
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_tasks' ),
@@ -750,13 +756,16 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	/**
 	 * Get the onboarding tasks.
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function get_tasks() {
+	public function get_tasks( $request ) {
+		$only_visible = null !== $request->get_param( 'only_visible' ) ? $request->get_param( 'only_visible' ) : true;
+
 		$lists = TaskLists::get_lists();
 		$json  = array_map(
-			function( $list ) {
-				return $list->get_json();
+			function( $list ) use ( $only_visible ) {
+				return $list->get_json( $only_visible );
 			},
 			$lists
 		);

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -756,16 +756,13 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	/**
 	 * Get the onboarding tasks.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function get_tasks( $request ) {
-		$only_viewable = null !== $request->get_param( 'only_viewable' ) ? $request->get_param( 'only_viewable' ) : true;
-
+	public function get_tasks() {
 		$lists = TaskLists::get_lists();
 		$json  = array_map(
-			function( $list ) use ( $only_viewable ) {
-				return $list->get_json( $only_viewable );
+			function( $list ) {
+				return $list->get_json();
 			},
 			$lists
 		);

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -285,6 +285,7 @@ class Task {
 			'actionUrl'     => $this->action_url,
 			'isComplete'    => $this->is_complete,
 			'isVisible'     => $this->is_visible(),
+			'canView'       => $this->can_view,
 			'time'          => $this->time,
 			'isDismissed'   => $this->is_dismissed(),
 			'isDismissable' => $this->is_dismissable,

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -56,7 +56,7 @@ class Task {
 	 *
 	 * @var bool
 	 */
-	protected $can_view = true;
+	public $can_view = true;
 
 	/**
 	 * Time string.
@@ -262,15 +262,6 @@ class Task {
 	}
 
 	/**
-	 * Bool for task visibility.
-	 *
-	 * @return bool
-	 */
-	public function is_visible() {
-		return $this->can_view && ! $this->is_snoozed() && ! $this->is_dismissed();
-	}
-
-	/**
 	 * Get the task as JSON.
 	 *
 	 * @return array
@@ -284,7 +275,6 @@ class Task {
 			'actionLabel'   => $this->action_label,
 			'actionUrl'     => $this->action_url,
 			'isComplete'    => $this->is_complete,
-			'isVisible'     => $this->is_visible(),
 			'canView'       => $this->can_view,
 			'time'          => $this->time,
 			'isDismissed'   => $this->is_dismissed(),

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -115,12 +115,12 @@ class TaskList {
 	/**
 	 * Get only visible tasks in list.
 	 */
-	public function get_visible_tasks() {
+	public function get_viewable_tasks() {
 		return array_values(
 			array_filter(
 				$this->tasks,
 				function( $task ) {
-					return $task->is_visible();
+					return $task->can_view;
 				}
 			)
 		);
@@ -129,10 +129,10 @@ class TaskList {
 	/**
 	 * Get the list for use in JSON.
 	 *
-	 * @param boolean $only_visible Only display visible tasks.
+	 * @param boolean $only_viewable Only display visible tasks.
 	 * @return array
 	 */
-	public function get_json( $only_visible = false ) {
+	public function get_json( $only_viewable = false ) {
 		return array(
 			'id'         => $this->id,
 			'title'      => $this->title,
@@ -142,7 +142,7 @@ class TaskList {
 				function( $task ) {
 					return $task->get_json();
 				},
-				$only_visible ? $this->get_visible_tasks() : $this->tasks
+				$only_viewable ? $this->get_viewable_tasks() : $this->tasks
 			),
 
 		);

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -114,6 +114,8 @@ class TaskList {
 
 	/**
 	 * Get only visible tasks in list.
+	 *
+	 * @return array
 	 */
 	public function get_viewable_tasks() {
 		return array_values(

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -113,11 +113,26 @@ class TaskList {
 	}
 
 	/**
+	 * Get only visible tasks in list.
+	 */
+	public function get_visible_tasks() {
+		return array_values(
+			array_filter(
+				$this->tasks,
+				function( $task ) {
+					return $task->is_visible();
+				}
+			)
+		);
+	}
+
+	/**
 	 * Get the list for use in JSON.
 	 *
+	 * @param boolean $only_visible Only display visible tasks.
 	 * @return array
 	 */
-	public function get_json() {
+	public function get_json( $only_visible = false ) {
 		return array(
 			'id'         => $this->id,
 			'title'      => $this->title,
@@ -127,8 +142,9 @@ class TaskList {
 				function( $task ) {
 					return $task->get_json();
 				},
-				$this->tasks
+				$only_visible ? $this->get_visible_tasks() : $this->tasks
 			),
+
 		);
 	}
 

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -129,10 +129,9 @@ class TaskList {
 	/**
 	 * Get the list for use in JSON.
 	 *
-	 * @param boolean $only_viewable Only display visible tasks.
 	 * @return array
 	 */
-	public function get_json( $only_viewable = false ) {
+	public function get_json() {
 		return array(
 			'id'         => $this->id,
 			'title'      => $this->title,
@@ -142,7 +141,7 @@ class TaskList {
 				function( $task ) {
 					return $task->get_json();
 				},
-				$only_viewable ? $this->get_viewable_tasks() : $this->tasks
+				$this->get_viewable_tasks()
 			),
 
 		);

--- a/tests/features/onboarding-tasks/task.php
+++ b/tests/features/onboarding-tasks/task.php
@@ -28,7 +28,7 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertEquals( true, $task->is_visible() );
+		$this->assertEquals( true, $task->can_view );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertEquals( false, $task->is_visible() );
+		$this->assertEquals( false, $task->can_view );
 	}
 
 	/**
@@ -96,20 +96,6 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		$this->assertNotContains( $task->id, $dismissed );
 	}
 
-	/**
-	 * Tests that a dismissed task is not visible.
-	 */
-	public function test_dismissed_visibility() {
-		$task = new Task(
-			array(
-				'id'             => 'wc-unit-test-task',
-				'is_dismissable' => true,
-			)
-		);
-
-		$task->dismiss();
-		$this->assertEquals( false, $task->is_visible() );
-	}
 
 	/**
 	 * Tests that a task can be snoozed.
@@ -143,21 +129,6 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		$task->undo_snooze();
 		$snoozed = get_option( Task::SNOOZED_OPTION, array() );
 		$this->assertArrayNotHasKey( $task->id, $snoozed );
-	}
-
-	/**
-	 * Tests that a task is not visible when snoozed.
-	 */
-	public function test_snoozed_visibility() {
-		$task = new Task(
-			array(
-				'id'            => 'wc-unit-test-snoozeable-task',
-				'is_snoozeable' => true,
-			)
-		);
-
-		$task->snooze();
-		$this->assertEquals( false, $task->is_visible() );
 	}
 
 	/**
@@ -233,7 +204,7 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'actionLabel', $json );
 		$this->assertArrayHasKey( 'actionUrl', $json );
 		$this->assertArrayHasKey( 'isComplete', $json );
-		$this->assertArrayHasKey( 'isVisible', $json );
+		$this->assertArrayHasKey( 'canView', $json );
 		$this->assertArrayHasKey( 'time', $json );
 		$this->assertArrayHasKey( 'isDismissed', $json );
 		$this->assertArrayHasKey( 'isDismissable', $json );


### PR DESCRIPTION
Fixes #7647 

This PR results in the `get_tasks` endpoint, by default, only returning visible tasks. These are filtered out on snooze/dismissed status, as well as the `canView` property associated with the individual task. 

~~Also added optional `only_visible` parameter to the endpoint that defaults to `true`. That way future use-cases that demand access to snoozed/dismissed tasks wouldn't require changes to the endpoint.~~

To do:
~~- Potentially update data-store to support `is_visible` parameter, although perhaps not urgent as we don't currently have a use-case.~~ 

### Detailed test instructions:

-   Checkout branch
-   Navigate to Homescreen.
- Ensure only tasks that should be visible are (ie if you don't have WCPay installed, the WCPay task shouldn't not be shown)

