### PR TITLE
Fix task list placeholder not showing

### DIFF
--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -33,7 +33,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	const { isResolving, taskLists } = useSelect( ( select ) => {
 		return {
 			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
-				'getTasks'
+				'getTaskLists'
 			),
 			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
 		};


### PR DESCRIPTION
Fixes #7717 

Fixes the resolver check so the place holder shows.

### Screenshots

<img width="761" alt="Screen Shot 2021-09-28 at 12 45 24 PM" src="https://user-images.githubusercontent.com/10561050/135130350-aa217fcb-9742-4d2e-867f-71a3a8825ef0.png">

### Detailed test instructions:


1. Load the homepage
2. Check that the placeholder for the task list is shown while loading