### PR TITLE
Quick fixes for snooze/dismiss functionality in tasks API

### DIFF
--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -62,7 +62,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const hasFills = Boolean( slot?.fills?.length );
 
 	const onDismiss = useCallback( () => {
-		dismissTask();
+		dismissTask( id );
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
@@ -74,7 +74,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	}, [ id ] );
 
 	const onSnooze = useCallback( () => {
-		snoozeTask();
+		snoozeTask( id );
 		createNotice(
 			'success',
 			__( 'Task postponed until tomorrow', 'woocommerce-admin' ),

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -772,15 +772,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function dismiss_task( $request ) {
 		$id = $request->get_param( 'id' );
 
-		$is_dismissable = false;
-
 		$task = TaskLists::get_task( $id );
 
-		if ( $task && isset( $task['isDismissable'] ) && $task['isDismissable'] ) {
-			$is_dismissable = true;
-		}
-
-		if ( ! $is_dismissable ) {
+		if ( ! ( $task && $task->is_dismissable ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
@@ -790,17 +784,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			);
 		}
 
-		$dismissed   = get_option( 'woocommerce_task_list_dismissed_tasks', array() );
-		$dismissed[] = $id;
-		$update      = update_option( 'woocommerce_task_list_dismissed_tasks', array_unique( $dismissed ) );
+		$task->dismiss();
 
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_dismiss_task', array( 'task_name' => $id ) );
-		}
-
-		$task = TaskLists::get_task( $id );
-
-		return rest_ensure_response( $task );
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**
@@ -812,17 +798,21 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function undo_dismiss_task( $request ) {
 		$id = $request->get_param( 'id' );
 
-		$dismissed = get_option( 'woocommerce_task_list_dismissed_tasks', array() );
-		$dismissed = array_diff( $dismissed, array( $id ) );
-		$update    = update_option( 'woocommerce_task_list_dismissed_tasks', $dismissed );
-
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $id ) );
-		}
-
 		$task = TaskLists::get_task( $id );
 
-		return rest_ensure_response( $task );
+		if ( ! ( $task && $task->is_dismissable ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_invalid_task',
+				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$task->undo_dismiss();
+
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**
@@ -837,15 +827,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$task_list_id    = $request->get_param( 'task_list_id' );
 		$snooze_duration = $request->get_param( 'duration' );
 
-		$is_snoozeable = false;
+		$task = TaskLists::get_task( $task_id, $task_list_id );
 
-		$snooze_task = TaskLists::get_task( $task_id, $task_list_id );
-
-		if ( $snooze_task && isset( $snooze_task['isSnoozeable'] ) && $snooze_task['isSnoozeable'] ) {
-			$is_snoozeable = true;
-		}
-
-		if ( ! $is_snoozeable ) {
+		if ( ! ( $task && $task->is_snoozeable ) ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
 				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
@@ -855,20 +839,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			);
 		}
 
-		$snooze_option = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
-		$duration      = is_null( $snooze_duration ) ? 'day' : $snooze_duration;
-		$snoozed_until = $this->duration_to_ms[ $duration ] + ( time() * 1000 );
+		$task->snooze();
 
-		$snooze_option[ $task_id ] = $snoozed_until;
-		$update                    = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snooze_option );
-
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $task_id ) );
-			$snooze_task['isSnoozed']    = true;
-			$snooze_task['snoozedUntil'] = $snoozed_until;
-		}
-
-		return rest_ensure_response( $snooze_task );
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**
@@ -880,9 +853,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function undo_snooze_task( $request ) {
 		$id = $request->get_param( 'id' );
 
-		$snoozed = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+		$task = TaskLists::get_task( $id );
 
-		if ( ! isset( $snoozed[ $id ] ) ) {
+		if ( ! ( $task && $task->is_snoozed() ) ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
 				__( 'Sorry, no snoozed task with that ID was found.', 'woocommerce-admin' ),
@@ -892,15 +865,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			);
 		}
 
-		unset( $snoozed[ $id ] );
+		$task->undo_snooze();
 
-		$update = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snoozed );
-
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $id ) );
-		}
-
-		return rest_ensure_response( TaskLists::get_task( $id ) );
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -70,14 +70,14 @@ class Task {
 	 *
 	 * @var bool
 	 */
-	protected $is_dismissable = false;
+	public $is_dismissable = false;
 
 	/**
 	 * Snoozeability.
 	 *
 	 * @var bool
 	 */
-	protected $is_snoozeable = false;
+	public $is_snoozeable = false;
 
 	/**
 	 * Snoozeability.

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -40,7 +40,7 @@ class TaskList {
 	 *
 	 * @var array
 	 */
-	protected $tasks = array();
+	public $tasks = array();
 
 	/**
 	 * Constructor

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -165,7 +165,8 @@ class TaskLists {
 		$tasks_to_search = $task_list ? $task_list['tasks'] : array_reduce(
 			self::get_lists(),
 			function ( $all, $curr ) {
-				return array_merge( $all, $curr['tasks'] );
+				$json = $curr->get_json();
+				return array_merge( $all, $json['tasks'] );
 			},
 			array()
 		);

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -156,17 +156,16 @@ class TaskLists {
 	 * @return Object
 	 */
 	public static function get_task( $id, $task_list_id = null ) {
-		$task_list = $task_list_id ? self::get_task_list_by_id( $task_list_id ) : null;
+		$task_list = $task_list_id ? self::get_list( $task_list_id ) : null;
 
 		if ( $task_list_id && ! $task_list ) {
 			return null;
 		}
 
-		$tasks_to_search = $task_list ? $task_list['tasks'] : array_reduce(
+		$tasks_to_search = $task_list ? $task_list->get_json()['tasks'] : array_reduce(
 			self::get_lists(),
 			function ( $all, $curr ) {
-				$json = $curr->get_json();
-				return array_merge( $all, $json['tasks'] );
+				return array_merge( $all, $curr->get_json()['tasks'] );
 			},
 			array()
 		);

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -162,16 +162,16 @@ class TaskLists {
 			return null;
 		}
 
-		$tasks_to_search = $task_list ? $task_list->get_json()['tasks'] : array_reduce(
+		$tasks_to_search = $task_list ? $task_list->tasks : array_reduce(
 			self::get_lists(),
 			function ( $all, $curr ) {
-				return array_merge( $all, $curr->get_json()['tasks'] );
+				return array_merge( $all, $curr->tasks );
 			},
 			array()
 		);
 
 		foreach ( $tasks_to_search as $task ) {
-			if ( $id === $task['id'] ) {
+			if ( $id === $task->id ) {
 				return $task;
 			}
 		}


### PR DESCRIPTION
Quick fixes to snooze and dismiss endpoints on task list API. 

### Detailed test instructions:

-   Checkout branch
-   Ensure one of the tasks `isDismissible` by adding `'is_dismissable' => true` to a task file such as [this one](https://github.com/woocommerce/woocommerce-admin/blob/31e0e4988171cf997b2ab995d0475d4b780b8a20/src/Features/OnboardingTasks/Tasks/Appearance.php?plain=1#L26). 
- Go to the homescreen and dismiss the task.
- Ensure it disappears is added to the option `woocommerce_task_list_dismissed_tasks`

