### PR TITLE
Fix task snooze and dismiss functions

### DIFF
--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -53,7 +53,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		id,
 		isComplete,
 		isDismissable,
-		isSnoozable,
+		isSnoozeable,
 		time,
 		title,
 	} = task;
@@ -62,7 +62,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const hasFills = Boolean( slot?.fills?.length );
 
 	const onDismiss = useCallback( () => {
-		dismissTask();
+		dismissTask( id );
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
@@ -74,7 +74,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	}, [ id ] );
 
 	const onSnooze = useCallback( () => {
-		snoozeTask();
+		snoozeTask( id );
 		createNotice(
 			'success',
 			__( 'Task postponed until tomorrow', 'woocommerce-admin' ),
@@ -140,7 +140,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		expandable: isExpandable,
 		expanded: isExpandable && isExpanded,
 		completed: isComplete,
-		onSnooze: isSnoozable && onSnooze,
+		onSnooze: isSnoozeable && onSnooze,
 		onDismiss: isDismissable && onDismiss,
 	};
 

--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -52,13 +52,13 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	const nowTimestamp = Date.now();
 	const visibleTasks = tasks.filter(
 		( task ) =>
-			task.isVisible &&
+			task.canView &&
 			! task.isDismissed &&
-			( ! task.snoozedUntil || task.snoozedUntil < nowTimestamp )
+			( ! task.isSnoozed || task.snoozedUntil < nowTimestamp )
 	);
 
 	const incompleteTasks = tasks.filter(
-		( task ) => task.isVisible && ! task.isComplete && ! task.isDismissed
+		( task ) => task.canView && ! task.isComplete && ! task.isDismissed
 	);
 
 	const [ expandedTask, setExpandedTask ] = useState(

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -796,6 +796,17 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function undo_dismiss_task( $request ) {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
+
+		if ( ! $task || ! $task->is_dismissable ) {
+			return new \WP_Error(
+				'woocommerce_rest_invalid_task',
+				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
 		$task->undo_dismiss();
 		return rest_ensure_response( $task->get_json() );
 	}
@@ -837,6 +848,17 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function undo_snooze_task( $request ) {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
+
+		if ( ! $task || ! $task->is_snoozeable ) {
+			return new \WP_Error(
+				'woocommerce_tasks_invalid_task',
+				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
 		$task->undo_snooze();
 		return rest_ensure_response( $task->get_json() );
 	}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -794,19 +794,10 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function undo_dismiss_task( $request ) {
-		$id = $request->get_param( 'id' );
-
-		$dismissed = get_option( 'woocommerce_task_list_dismissed_tasks', array() );
-		$dismissed = array_diff( $dismissed, array( $id ) );
-		$update    = update_option( 'woocommerce_task_list_dismissed_tasks', $dismissed );
-
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $id ) );
-		}
-
+		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
-
-		return rest_ensure_response( $task );
+		$task->undo_dismiss();
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**
@@ -844,29 +835,10 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function undo_snooze_task( $request ) {
-		$id = $request->get_param( 'id' );
-
-		$snoozed = get_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
-
-		if ( ! isset( $snoozed[ $id ] ) ) {
-			return new \WP_Error(
-				'woocommerce_tasks_invalid_task',
-				__( 'Sorry, no snoozed task with that ID was found.', 'woocommerce-admin' ),
-				array(
-					'status' => 404,
-				)
-			);
-		}
-
-		unset( $snoozed[ $id ] );
-
-		$update = update_option( 'woocommerce_task_list_remind_me_later_tasks', $snoozed );
-
-		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $id ) );
-		}
-
-		return rest_ensure_response( TaskLists::get_task( $id ) );
+		$id   = $request->get_param( 'id' );
+		$task = TaskLists::get_task( $id );
+		$task->undo_snooze();
+		return rest_ensure_response( $task->get_json() );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -279,6 +279,7 @@ class Task {
 		return array(
 			'id'            => $this->id,
 			'title'         => $this->title,
+			'canView'       => $this->can_view,
 			'content'       => $this->content,
 			'actionLabel'   => $this->action_label,
 			'actionUrl'     => $this->action_url,

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -70,14 +70,14 @@ class Task {
 	 *
 	 * @var bool
 	 */
-	protected $is_dismissable = false;
+	public $is_dismissable = false;
 
 	/**
 	 * Snoozeability.
 	 *
 	 * @var bool
 	 */
-	protected $is_snoozeable = false;
+	public $is_snoozeable = false;
 
 	/**
 	 * Snoozeability.

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -40,7 +40,7 @@ class TaskList {
 	 *
 	 * @var array
 	 */
-	protected $tasks = array();
+	public $tasks = array();
 
 	/**
 	 * Constructor

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -156,7 +156,7 @@ class TaskLists {
 	 * @return Object
 	 */
 	public static function get_task( $id, $task_list_id = null ) {
-		$task_list = $task_list_id ? self::get_task_list_by_id( $task_list_id ) : null;
+		$task_list = $task_list_id ? self::get_list( $task_list_id ) : null;
 
 		if ( $task_list_id && ! $task_list ) {
 			return null;

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -162,16 +162,16 @@ class TaskLists {
 			return null;
 		}
 
-		$tasks_to_search = $task_list ? $task_list['tasks'] : array_reduce(
+		$tasks_to_search = $task_list ? $task_list->tasks : array_reduce(
 			self::get_lists(),
 			function ( $all, $curr ) {
-				return array_merge( $all, $curr['tasks'] );
+				return array_merge( $all, $curr->tasks );
 			},
 			array()
 		);
 
 		foreach ( $tasks_to_search as $task ) {
-			if ( $id === $task['id'] ) {
+			if ( $id === $task->id ) {
 				return $task;
 			}
 		}


### PR DESCRIPTION
Fixes #7726

Fixes the task snooze and dismissal functions and endpoints

### Screenshots

<img width="742" alt="Screen Shot 2021-09-28 at 1 36 26 PM" src="https://user-images.githubusercontent.com/10561050/135141976-c6b369fe-c1d2-4e64-b8f2-35b9b746b78a.png">
### Detailed test instructions:

1. Add `is_snoozeable` and `is_dismissable` to a task under `src/Features/OnboardingTasks/Tasks/`
2. View the (incomplete) task in the task list.
3. Attempt to dismiss and snooze the task
4. Make sure the task is removed from the list on snooze/dismiss
5. Attempt to undo task dismissal and make sure the task is shown again
6. Attempt to undo task snooze and make sure the task is shown again

Note that you can delete the options `woocommerce_task_list_remind_me_later_tasks` or `woocommerce_task_list_dismissed_tasks` to reset items back to their original state.