### PR TITLE
Bump version to 2.9.0-dev

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Testing instructions
 
-## Unreleased
+## 2.7.1
 
 ### Add Newsletter Signup #7601
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,49 @@
+== 2.8.0 09/29/2021 ==
+
+- Fix: Add missing title text for marketing task. #7640
+- Fix: Assign parent order status as children order status if refund order #7253
+- Fix: Fix category lookup logic to update children correctly. #7709
+- Fix: Fixing an unwanted page refresh when using Woo Navigation. #7615
+- Fix: Fix naming of event names and properties. #7677
+- Fix: Fix white screen for variation analytic data without a name. #7686
+- Update: Update Eway payment gateway capitalization (was eWAY). #7678
+- Update: Enable Square in France. #7679
+- Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. #7666
+
+== 2.7.1 09/23/2021 ==
+
+- Fix: Allow super admins all capabilities within WooCommerce Admin
+- Fix: Fix end date for last periods
+- Fix: Fix up onboarding profiler not working when opted out of tracking
+- Fix: Making Business Details sticky in onboarding wizard
+- Fix: Missing RTL for onboarding styles. #7531
+- Fix: No changelog necessary as it is in the component package. #7423
+- Fix: Skip scheduling action if Action Scheduler tables have not been set up #7521
+- Fix: Update country region typeahead for better autofill support. #7497
+- Fix: Use installable extensions for local state versus free extensions. #7585
+- Fix: Fix fatal error and unrelated results in analytics.
+- Fix: Harden the reports directory #7691
+- Fix: Update task-item logic to only display content when expanded is true. #7611
+- Add: Show Pinterest in installed marketing extensions (if installed) #7417
+- Add: Added MailchimpScheduler that runs daily to subscribe store_email in the profile data #7579
+- Add: Added shipping plugin recommendations to settings page (#7446).
+- Add: Adding endpoint to snooze onboarding task
+- Add: Adding undo snooze task endpoint
+- Add: Add task dismissal endpoints #7538
+- Update: Add HK and SG countries to WC Pay intl support. #7558
+- Update: Create task list REST API endpoint #7512
+- Update: Deleted OnboardingEmailMarketing note class #7595
+- Update: Removes the use of the depreciated woocommerce_shared_settings hook. #7480
+- Update: Updating eway logo in payment suggestions defaults
+- Update: Update marketing task completion logic. #7586
+- Dev: Add email address field to OBW #7552
+- Tweak: Add navigation items for the Marketplace menu. #7529
+- Tweak: Change all analytics strings and labels to sentence case. #6501
+- Tweak: Delete unneeded double spaces in text strings. #7502
+- Tweak: Remove the preloaded onboarding options
+- Tweak: Update analytics card header text styles #6506
+- Enhancement: Align Table fields with the fallback on isNumeric. #7431
+
 == 2.6.5 09/22/2021 ==
 
 - Fix: Add filters to get new hidden options #7698
@@ -19,7 +65,7 @@
 
 - Update: Update marketing task completion logic. #7586
 
-== 2.6.0 08/31/2021 == 
+== 2.6.0 08/31/2021 ==
 
 - Fix: Fixes action button mis-alignment within card footer. #7412
 - Fix: Fixing issues with ReportTable component data not populating correctly #7355
@@ -55,7 +101,7 @@
 - Tweak: Refactor on payment settings recommendations eligibility component for reuse. #7447
 - Tweak: Register wc-admin page for all users and handle authorization in client #7285
 
-== 2.5.1 08/16/2021 == 
+== 2.5.1 08/16/2021 ==
 
 - Fix: Fix blank screen by setting a default value #7506
 
@@ -234,7 +280,7 @@
 - Update: Remove original business step flow #7103
 - Update: WooCommerce Shipping copy on onboarding steps #7148
 
-== 2.3.1 05/24/2021 == 
+== 2.3.1 05/24/2021 ==
 
 - Tweak: Store profiler  Changed MailPoet's title and description #6990
 - Tweak: Adjust WC Pay supported countries #7048
@@ -242,7 +288,7 @@
 - Fix: A JS exception being thrown on the product tags page. #7053
 - Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
 
-== 2.3.0 05/13/2021 == 
+== 2.3.0 05/13/2021 ==
 
 - Add: Add plugin installer to allow installation of plugins via URL #6805
 - Add: Optional children prop to SummaryNumber component #6748
@@ -283,30 +329,30 @@
 - Update: Update payment gateway suggestions semantics to be more consistent #7130
 - Update: Adding setup required icon for nonconfigured payment methods #6811
 
-== 2.2.6 05/07/2021 == 
+== 2.2.6 05/07/2021 ==
 
 - Fix: Address an issue with OBW when installing only WooCommerce payments and Jetpack. #6957
 
-== 2.2.5 05/07/2021 == 
+== 2.2.5 05/07/2021 ==
 
 - Fix: Calling of get_script_asset_filename with extra parameter #6955
 
-== 2.2.4 05/07/2021 == 
+== 2.2.4 05/07/2021 ==
 
 - Dev: Fix a bug where trying to load an asset registry causes a crash. #6951
 
-== 2.2.3 05/06/2021 == 
+== 2.2.3 05/06/2021 ==
 
 - Dev: Do a git clean before the core release. #6945
 
-== 2.2.2 04/28/2021 == 
+== 2.2.2 04/28/2021 ==
 
 - Fix: Disable the continue btn on OBW when requested are being made #6838
 - Tweak: Revert WCPay international support for bundled package #6901
 - Tweak: Store profiler  Changed MailPoet's title and description #6886
 - Tweak: Update PayU logo #6829
 
-== 2.2.0 03/30/2021 == 
+== 2.2.0 03/30/2021 ==
 
 - Fix: Check if features are currently being enabled #6688
 - Fix: Fix the activity panel toggle not closing on click #6679
@@ -382,26 +428,26 @@
 - Dev: Ensure script asset.php files are included in builds #6635
 - Dev: Ensure production script asset names don't include .min suffix #6681
 
-== 2.1.4 03/29/2021 == 
+== 2.1.4 03/29/2021 ==
 
 - Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
 
-== 2.1.3 03/14/2021 == 
+== 2.1.3 03/14/2021 ==
 
 - Feature: Increase target audience for business feature step. #6508
 - Fix: Correct a bug where the JP connection flow would not happen when installing JP in the OBW. #6521
 - Fix: Add customer name column to CSV export #6556
 
-== 2.1.2 03/10/2021 == 
+== 2.1.2 03/10/2021 ==
 
 - Fix: Add guard to "Deactivate Plugin" note handlers to prevent fatal error. #6532
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.1.1 03/04/2021 == 
+== 2.1.1 03/04/2021 ==
 
 - Fix: Restore missing Correct the Klarna slug #6440
 
-== 2.1.0 03/04/2021 == 
+== 2.1.0 03/04/2021 ==
 
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 - Dev: Remove Google fonts and material icons. #6343
@@ -451,15 +497,15 @@
 - Enhancement: override wpbody styles when nav present #6354
 - Enhancement: Move favorited menu items to primary menu #6290
 
-== 2.0.3 03/10/2021 == 
+== 2.0.3 03/10/2021 ==
 
 - Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
-== 2.0.2 05/25/2021 == 
+== 2.0.2 05/25/2021 ==
 
 - Fix: Correct the Klarna slug #6440
 
-== 2.0.0 02/05/2021 == 
+== 2.0.0 02/05/2021 ==
 
 - Tweak: Bump minimum supported version of PHP to 7.0. #6046
 - Tweak: update the content and timing of the NeedSomeInspiration note. #6076
@@ -483,7 +529,7 @@
 - Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
 - Dev: Allow highlight tooltip to use body tag as parent. #6309
 
-== 1.9.0 01/15/2021 == 
+== 1.9.0 01/15/2021 ==
 
 - Fix: Add Customer Type column to the Orders report table. #5820
 - Fix: Product exclusion filter on Orders Report.
@@ -516,21 +562,21 @@
 - Add: Note for users coming from Calypso. #6030
 - Add: Manage activity from home screen inbox message. #6072
 
-== 1.8.3 01/05/2021 == 
+== 1.8.3 01/05/2021 ==
 
 - Fix: Compile the debug module so it can be used in older browsers like IE11. #5987
 
-== 1.8.2 12/22/2020 == 
+== 1.8.2 12/22/2020 ==
 
 - Fix: Completed tasks tracking causing infinite loop #5941
 - Fix: Remove Navigation access #5940
 
-== 1.8.1 12/15/2020 == 
+== 1.8.1 12/15/2020 ==
 
 - Fix: Product exclusion filter on Orders Report.
 - Fix: Typo in Variation Stats DataStore context filter value. #5784
 
-== 1.8.0 12/07/2020 == 
+== 1.8.0 12/07/2020 ==
 
 - Enhancement: Add "filter by variations in reports" inbox note. #5208
 - Enhancement: Tasks extensibility in Home Screen. #5794
@@ -566,7 +612,7 @@
 - Fix: Load wctracks to avoid fatal errors. #5645 #5638
 - Fix: Preventing desktopsized navigation placeholder from appearing on mobile during load. #5616
 
-== 1.7.0 11/11/2020 == 
+== 1.7.0 11/11/2020 ==
 
 - Enhancement: Variations report.  #5167
 - Enhancement: Add ability to toggle homescreen layouts. #5429
@@ -625,7 +671,7 @@
 - Dev: Rearrange the store management links under categories add filter woocommerce_admin_homescreen_quicklinks. #5476
 - Dev: Restyle the setup task list header to display incomplete tasks #5520
 
-== 1.6.2 10/16/2020 == 
+== 1.6.2 10/16/2020 ==
 
 - Fix: Missing activity panels on ugraded sites #5400
 - Fix: Casting of onboarding profile data to array #5415
@@ -633,12 +679,12 @@
 - Fix: i18n of Performance Indicator strings #5405
 - Fix: Gutenberg 9.1.1 compat for empty data sets #5409
 
-== 1.6.1 10/13/2020 == 
+== 1.6.1 10/13/2020 ==
 
 - Fix: Hide setup checklist shortcut when setup checklist skipped #5360
 - Fix: use of undefined function on WC < 4.0.0.
 
-== 1.6.0 10/09/2020 == 
+== 1.6.0 10/09/2020 ==
 
 - Dev: Reviews wp.data store #4941
 - Dev: Notes wp.data store #4943
@@ -687,7 +733,7 @@
 - Fix: Search all variation attribute values #5141
 - Fix: Force float before addition in taxes #5149
 
-== 1.5.0 08/07/2020 == 
+== 1.5.0 08/07/2020 ==
 
 - Dev: New notification
 - Dev: Enable tax calculation before redirecting to standard tax rates page. #4878
@@ -699,7 +745,7 @@
 - Fix: Use clipRule and fillRule props. #4889, part of #4864
 - Enhancement: Add eWAY to Payment Setup for AU/NZ Stores. #4947
 
-== 1.4.0 07/22/2020 == 
+== 1.4.0 07/22/2020 ==
 
 - Fix: Update returning customer total to include customers whose first order was within the report date range #4430
 - Fix: Fix an error in the Analytics/Orders table when there is an order deleted directly from the database #4630
@@ -738,15 +784,15 @@
 - Dev: Customize webpack jsonpFunction to avoid potential collision with other Webpack bundles #4644 🎉 @aaemnnosttv
 - Dev: Update @wordpress/basestyles and replace deprecated variables #4759
 
-== 1.3.2 07/29/2020 == 
+== 1.3.2 07/29/2020 ==
 
 - Fix: bug preventing saving user preferences on WP 5.3. #4869
 
-== 1.3.1 07/20/2020 == 
+== 1.3.1 07/20/2020 ==
 
 - Fix: PHP Fatal errors when columns are missing from the Notes table. #4831
 
-== 1.3.0 07/08/2020 == 
+== 1.3.0 07/08/2020 ==
 
 - Enhancement: Add Jetpack stats to performance indicatorts / homepage #4291
 - Enhancement: New "Store Management" quick links card on WooCommerce home screen. #4350
@@ -794,21 +840,21 @@
 - Tweak: Remove duplicate/redundant inbox note after first order received. #4659
 - Tweak: Fix the embed page CSS so the top content sits better #4622
 
-== 1.2.4 06/11/2020 == 
+== 1.2.4 06/11/2020 ==
 
 - Tweak: reduce asset filename length and remove tilde characters. #4535
 - Fix: RTL stylesheet loading for split code chunks. #4542
 
-== 1.2.3 05/22/2020 == 
+== 1.2.3 05/22/2020 ==
 
 - Tweak: Updates to WooCommerce Payments in Setup Checklist #4293
 
-== 1.2.2 05/18/2020 == 
+== 1.2.2 05/18/2020 ==
 
 - Fix: Respect tracking optin before new page load. #4368
 - Enhancement: Add Jetpack connection to plugin benefits step #4374
 
-== 1.2.0 05/18/2020 == 
+== 1.2.0 05/18/2020 ==
 
 - Enhancement: Add onboarding payments note #4157
 - Enhancement: Marketing Inbox Note #4030
@@ -839,20 +885,20 @@
 - Dev: Dynamic Currency with Context API #4027
 - Dev: Remove Duplicate array entry #4049 🎉 @tivnet
 
-== 1.1.3 05/18/2020 == 
+== 1.1.3 05/18/2020 ==
 
 - Tweak: Onboarding
 - Fix: Respect tracking optin before new page load. #4368
 
 == 1.1.2 05/12/2020 ==
 
-== 1.1.1 05/05/2020 == 
+== 1.1.1 05/05/2020 ==
 
 - Fix: Storefront should show at top of theme options in onboarding wizard. #4187
 - Tweak: Remove Stripe autoconnect from payment task. #4164
 - Tweak: Hide suggested extensions in Marketing Tab if opted out of "Marketplace Suggestions"
 
-== 1.1.0 04/23/2020 == 
+== 1.1.0 04/23/2020 ==
 
 - Tweak: Added link to "go shopping" button #3712
 - Tweak: Add PayFast payment gateway option for sites in South Africa #3738
@@ -897,19 +943,19 @@
 - Dev: Handle orphaned order statuses in analytics settings. #4090
 - Dev: Fix usage of WP_Error in nonglobal namespaces. #4115
 
-== 1.0.3 03/22/2020 == 
+== 1.0.3 03/22/2020 ==
 
 - Fix: Stop calling protected has_satisfied_dependencies() on outdated plugin. #3938
 - Fix: Rename image assets in OBW business details step. #3931
 - Fix: Stop using WP Post store for Action Scheduler. #3936
 
-== 1.0.2 03/18/2020 == 
+== 1.0.2 03/18/2020 ==
 
 - Enhancement: Onboarding
 - Dev: Update prestart script so readme.txt stable tag is updated #3911
 - Tweak: create database tables on an earlier hook to avoid conflicts with core WooCommerce. #3896
 
-== 1.0.1 03/12/2020 == 
+== 1.0.1 03/12/2020 ==
 
 - Fix: Add Report Extension Example
 - Fix: Product report sorting by SKU when some products don't have SKUs
@@ -921,7 +967,7 @@
 - Dev: Fix failing tests after WC core merge.
 - Dev: Bump WooCommerce tested up to tag
 
-== 1.0.0 03/05/2020 == 
+== 1.0.0 03/05/2020 ==
 
 - Fix: Customers Report
 - Fix: OBW Connect
@@ -935,7 +981,7 @@
 - Fix: Tracking on migrated options #3828
 - Dev: Onboarding
 
-== 0.26.1 02/26/2020 == 
+== 0.26.1 02/26/2020 ==
 
 - Fix: Remove free text Search option when no query exists #3755
 - Fix: StoreAlert
@@ -946,7 +992,7 @@
 - Fix: Add deactivation hook to Package.php #3770
 - Fix: Add active version functions #3772
 
-== 0.26.0 02/21/2020 == 
+== 0.26.0 02/21/2020 ==
 
 - Fix: Warning in product data store when tax amount is nonnumeric. #3656
 - Fix: Enable onboarding in production. #3680
@@ -963,12 +1009,12 @@
 - Dev: Travis tests on Github for release branch #3751
 - Add: Deactivation note for feature plugin #3687
 
-== 0.25.1 02/07/2020 == 
+== 0.25.1 02/07/2020 ==
 
 - Dev: Enable onboarding #3651 (Onboarding)
 - Fix: Fix styling of search control in report table header and filters. #3603 (Analytics, Components, Packages)
 
-== 0.25.0 01/29/2020 == 
+== 0.25.0 01/29/2020 ==
 
 - Fix: Onboarding
 - Fix: Fix styling of search control in report table header and filters. #3603 (Analytics, Components, Packages)
@@ -1026,7 +1072,7 @@
 - Bug: Onboarding
 - Bug: Onboarding
 
-== 0.24.0 01/06/2020 == 
+== 0.24.0 01/06/2020 ==
 
 - Bug: Add SelectControl debouncing and keyboard fixes #3507 (Components, Packages)
 - Bug: Onboarding
@@ -1065,11 +1111,11 @@
 - Tweak: Add/disable plugin filter #3361
 - Enhancement: allow report cache layer to be turned off. #3434
 
-== 0.23.3 12/26/2019 == 
+== 0.23.3 12/26/2019 ==
 
 - Fix: don't run database migrations on new installs. #3473
 
-== 0.23.2 12/19/2019 == 
+== 0.23.2 12/19/2019 ==
 
 - Enhancement: allow filtering of hidden WP notices. #3391 (Activity Panel, Extensibility)
 - Fix: error when trying to download report data. #3429 (Analytics)
@@ -1078,11 +1124,11 @@
 - Fix: remove the header when user doesn't have required permissions #3386 (Activity Panel)
 - Bug: Fix user data fields filter name. #3428 (Dashboard)
 
-== 0.23.1 12/08/2019 == 
+== 0.23.1 12/08/2019 ==
 
 - Fix: undefined function error.
 
-== 0.23.0 12/06/2019 == 
+== 0.23.0 12/06/2019 ==
 
 - Dev: Add currency extension #3328 (Packages)
 - Dev: Packages
@@ -1114,7 +1160,7 @@
 - Tweak: remove global settings dependency from Navigation package. #3294 (Components, Packages)
 - Tweak: Search component
 
-== 0.22.0 11/13/2019 == 
+== 0.22.0 11/13/2019 ==
 
 - Fix: Incorrect calculation of tax summary on Taxes screen. #3158 (Analytics)
 - Fix: Correct product and coupon count on edited orders. #3103 (Analytics)
@@ -1130,7 +1176,7 @@
 - Tweak: Field misalignment in product edit screen. #3145
 - Task: Fix PHP linter errors. #3188
 
-== 0.21.0 10/30/2019 == 
+== 0.21.0 10/30/2019 ==
 
 - Fix: report export format when generated serverside. #2987 (Analytics, Packages)
 - Fix: Address discrepancies in Revenue totals between Analytics screens. #3095 (Analytics)
@@ -1145,12 +1191,12 @@
 - Dev: Add the ability to create custom plugin builds #3044 (Build)
 - Enhancement: add management link to Reviews panel. #3011 (Activity Panel)
 
-== 0.20.1 09/24/2019 == 
+== 0.20.1 09/24/2019 ==
 
 - Fix: use category lookup id instead of term taxonomy id (#3027)
 - Fix: Update order stats table status index length. (#3022)
 
-== 0.20.0 09/24/2019 == 
+== 0.20.0 09/24/2019 ==
 
 - Dev: Fix issue #2992 (order number in orders panel) #2994
 - Dev: Replace lodash isNaN() with native Number.isNaN() #2998 (Build, Packages)
@@ -1173,7 +1219,7 @@
 - Performance: reduce JS bundle size. #2933 (Build)
 - Bug: Fix conflict with Blocks 2.4 #2846
 
-== 0.19.0 09/24/2019 == 
+== 0.19.0 09/24/2019 ==
 
 - Dev: Use upstream webpackrtlplugin #2870 (Build)
 - Dev: Fix variable name typo #2922
@@ -1185,7 +1231,7 @@
 - Tweak: change report charts filter name. #2843 (Components, Documentation, Packages)
 - Bug: Fix chart type buttons misalignment #2871 (Components, Packages)
 
-== 0.18.0 08/28/2019 == 
+== 0.18.0 08/28/2019 ==
 
 - Fix: Product in dropdown clickable in FF/Safari #2839 (Components, Packages) 👏 @cojennin
 - Fix: gross order total calculation. #2817 (Analytics)
@@ -1203,7 +1249,7 @@
 - Dev: Update List actionable items to be wrapped with Link #2779 (Components, Packages)
 - Tweak: add empty dataset treatment for report tables. #2801 (Analytics, Components, Packages)
 
-== 0.17.0 08/15/2019 == 
+== 0.17.0 08/15/2019 ==
 
 - Fix: chart data fetch/render over long time periods #2785 (Analytics)
 - Fix: chart display when comparing categories. #2710 (Analytics)
@@ -1223,7 +1269,7 @@
 - Bug: Only apply current submenu CSS reset on nonembed pages. #2687
 - Dev: Add `wc_admin_get_feature_config` filter to feature config array. #2689
 
-== 0.16.0 07/24/2019 == 
+== 0.16.0 07/24/2019 ==
 
 - Tweak: Change verbiage of feedback notification. #2677
 - Dev: Update unit tests to work with PHPUnit 7+. #2678
@@ -1242,7 +1288,7 @@
 - Task: Add priority 3 Tracks events #2638 (Components, Packages)
 - Task: Add instructions for translating to contributing docs. #2618 (Documentation)
 
-== 0.15.0 07/11/2019 == 
+== 0.15.0 07/11/2019 ==
 
 - Fix: Compare checkboxes in report tables #2571
 - Fix: Use correct links in DevDocs. #2602 (Documentation)
@@ -1279,7 +1325,7 @@
 - Tweak: fix some report endpoint default params. #2496 (REST API)
 - Bug: Fix batch queue range bug. #2521
 
-== 0.14.0 06/24/2019 == 
+== 0.14.0 06/24/2019 ==
 
 - Dev: Action Scheduler
 - Dev: Fix Activity Panel being overlapped by editor toolbar #2446 (Activity Panel)
@@ -1302,15 +1348,15 @@
 - Tweak: Reduce style dependencies on WP core, avoid errantly including WP core's Google Fonts. #2432 (Components)
 - Task: Remove test menu from Orders panel #2438 (Activity Panel)
 
-== 0.13.2 06/13/2019 == 
+== 0.13.2 06/13/2019 ==
 
 - Fix: Bump plugin version for database update.
 
-== 0.13.1 06/12/2019 == 
+== 0.13.1 06/12/2019 ==
 
 - Fix: Exit deactivate early if WooCommerce not active. #2410
 
-== 0.13.0 06/12/2019 == 
+== 0.13.0 06/12/2019 ==
 
 - Fix: Notes
 - Fix: Double space at 191 row #2369  👏 @shoheitanaka
@@ -1353,7 +1399,7 @@
 - Task: Remove second beta warning from readme #2362
 - Task: Remove beta warning from readme. #2340
 
-== 0.12.0 05/14/2019 == 
+== 0.12.0 05/14/2019 ==
 
 - Fix: dashboard issues #2194
 - Fix: Dashboard
@@ -1385,7 +1431,7 @@
 - Dev: Scroll to top of the table when navigating table pages #2051
 - Dev: Add empty state for the Reviews panels #2124
 
-== 0.11.0 04/17/2019 == 
+== 0.11.0 04/17/2019 ==
 
 - Dev: Extend report submenu items #2033
 - Dev: Extension Examples #2018
@@ -1420,7 +1466,7 @@
 - Enhancement: Scroll to top only when URL changes #1989
 - Enhancement: Allow negative values in charts #1979
 
-== 0.10.0 04/02/2019 == 
+== 0.10.0 04/02/2019 ==
 
 - Dev: Properly namespaced methods in wcadmin.php. props @ronakganatra9 #1804
 - Dev: Changed textdomain to `woocommerceadmin` #1795
@@ -1479,7 +1525,7 @@
 - Performance: Don't dispatch REST API requests when window/tab is hidden #1732
 - Performance: Only check for unsnooze note on admin_init #1960
 
-== 0.8.0 02/28/2019 == 
+== 0.8.0 02/28/2019 ==
 
 - Table Component: Reset search on compare
 - Table Component: Fix search positioning in small viewports

--- a/changelogs/Change eWAY to Eway in payment gateway display text #7678
+++ b/changelogs/Change eWAY to Eway in payment gateway display text #7678
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Update Eway payment gateway capitalization (was eWAY). #7678

--- a/changelogs/add-7365
+++ b/changelogs/add-7365
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Create task list REST API endpoint #7512

--- a/changelogs/add-7368-tasks-snooze-endpoint
+++ b/changelogs/add-7368-tasks-snooze-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Adding endpoint to snooze onboarding task

--- a/changelogs/add-7369
+++ b/changelogs/add-7369
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add task dismissal endpoints #7538

--- a/changelogs/add-7517-add-email-address-field-obw
+++ b/changelogs/add-7517-add-email-address-field-obw
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Add email address field to OBW #7552

--- a/changelogs/add-7519-subscribe-onboarding-email-to-mailchimp
+++ b/changelogs/add-7519-subscribe-onboarding-email-to-mailchimp
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Added MailchimpScheduler that runs daily to subscribe store_email in the profile data #7579

--- a/changelogs/add-7547_wcpay_intl_countries
+++ b/changelogs/add-7547_wcpay_intl_countries
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Add HK and SG countries to WC Pay intl support. #7558

--- a/changelogs/add-7559-snooze-undo-endpoint
+++ b/changelogs/add-7559-snooze-undo-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Adding undo snooze task endpoint

--- a/changelogs/add-marketing-pinterest-info
+++ b/changelogs/add-marketing-pinterest-info
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add: Show Pinterest in installed marketing extensions (if installed) #7417

--- a/changelogs/feat-add-shipping-settings-plugins-recommendations
+++ b/changelogs/feat-add-shipping-settings-plugins-recommendations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Add
-
-Added shipping plugin recommendations to settings page (#7446).

--- a/changelogs/fix-5523_select_control
+++ b/changelogs/fix-5523_select_control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Update country region typeahead for better autofill support. #7497

--- a/changelogs/fix-6471
+++ b/changelogs/fix-6471
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix end date for last periods

--- a/changelogs/fix-6718
+++ b/changelogs/fix-6718
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Making Business Details sticky in onboarding wizard

--- a/changelogs/fix-7197
+++ b/changelogs/fix-7197
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Assign parent order status as children order status if refund order #7253

--- a/changelogs/fix-7350_modifying_overview_screen
+++ b/changelogs/fix-7350_modifying_overview_screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix analytics overview re-arrangement on initial load. #7475

--- a/changelogs/fix-7397
+++ b/changelogs/fix-7397
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Allow super admins all capabilities within WooCommerce Admin

--- a/changelogs/fix-7398
+++ b/changelogs/fix-7398
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Skip scheduling action if Action Scheduler tables have not been set up #7521

--- a/changelogs/fix-7423-date-filter-retains-values
+++ b/changelogs/fix-7423-date-filter-retains-values
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-No changelog necessary as it is in the component package. #7423

--- a/changelogs/fix-7443_analytics_variations_table
+++ b/changelogs/fix-7443_analytics_variations_table
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix white screen for variation analytic data without a name. #7686

--- a/changelogs/fix-7477-link-hash-issue
+++ b/changelogs/fix-7477-link-hash-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix all links with hash to behind query parameters #7483

--- a/changelogs/fix-7479-home-style-issue
+++ b/changelogs/fix-7479-home-style-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix Stats module CSS issue introduced by Gutenberg #7488

--- a/changelogs/fix-7487
+++ b/changelogs/fix-7487
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix up onboarding profiler not working when opted out of tracking

--- a/changelogs/fix-7548_set_up_marketing_tools_title
+++ b/changelogs/fix-7548_set_up_marketing_tools_title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Add missing title text for marketing task. #7640

--- a/changelogs/fix-7564_business_step_auto_installing
+++ b/changelogs/fix-7564_business_step_auto_installing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Use installable extensions for local state versus free extensions. #7585

--- a/changelogs/fix-7609_task_item_content_logic
+++ b/changelogs/fix-7609_task_item_content_logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Update task-item logic to only display content when expanded is true. #7611

--- a/changelogs/fix-7630_track_event_props
+++ b/changelogs/fix-7630_track_event_props
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix naming of event names and properties. #7677

--- a/changelogs/fix-7680_category_lookup_class
+++ b/changelogs/fix-7680_category_lookup_class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix category lookup logic to update children correctly. #7709

--- a/changelogs/fix-analytics-categories-fatal-on-search
+++ b/changelogs/fix-analytics-categories-fatal-on-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix fatal error and unrelated results in analytics.

--- a/changelogs/fix-reports-dir
+++ b/changelogs/fix-reports-dir
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Harden the reports directory #7691

--- a/changelogs/fix-woonav-page-refresh
+++ b/changelogs/fix-woonav-page-refresh
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fixing an unwanted page refresh when using Woo Navigation

--- a/changelogs/new-7529-marketplace-nav-items
+++ b/changelogs/new-7529-marketplace-nav-items
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Add navigation items for the Marketplace menu. #7529

--- a/changelogs/remove-onboarding-preload
+++ b/changelogs/remove-onboarding-preload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Remove the preloaded onboarding options

--- a/changelogs/tweak-7631_include_square_in_fr
+++ b/changelogs/tweak-7631_include_square_in_fr
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Enable Square in France. #7679

--- a/changelogs/update-6900_depreciated_shared_settings
+++ b/changelogs/update-6900_depreciated_shared_settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Removes the use of the depreciated woocommerce_shared_settings hook. #7480

--- a/changelogs/update-7319_enable_wc_pay_experiment
+++ b/changelogs/update-7319_enable_wc_pay_experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Enhancement
-
-Add experiment for promoting WooCommerce Payments in payment methods table. #7666

--- a/changelogs/update-7471-split-extensions-pages
+++ b/changelogs/update-7471-split-extensions-pages
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Split Extensions page into Marketplace and My Subscriptions. #7471

--- a/changelogs/update-7502
+++ b/changelogs/update-7502
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Delete unneeded double spaces in text strings. #7502

--- a/changelogs/update-7514-remove-onboarding-email-marketing-inbox-notification
+++ b/changelogs/update-7514-remove-onboarding-email-marketing-inbox-notification
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Deleted OnboardingEmailMarketing note class #7595

--- a/changelogs/update-analytics-card-hearder-styles
+++ b/changelogs/update-analytics-card-hearder-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Update analytics card header text styles #6506

--- a/changelogs/update-eway-suggestions-defaults
+++ b/changelogs/update-eway-suggestions-defaults
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Updating eway logo in payment suggestions defaults

--- a/changelogs/update-package-sass-build
+++ b/changelogs/update-package-sass-build
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Missing RTL for onboarding styles. #7531

--- a/changelogs/update-sentence-case-analytics
+++ b/changelogs/update-sentence-case-analytics
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Change all analytics strings and labels to sentence case. #6501

--- a/changelogs/update-table-align-isNumeric
+++ b/changelogs/update-table-align-isNumeric
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Enhancement
-
-Update: Align Table fields with the fallback on isNumeric. #7431

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "2.7.0-dev",
+	"version": "2.9.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.7.0-dev",
+	"version": "2.9.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: woocommerce, automattic
 Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activity, notices, insights, stats, woo commerce, woocommerce
 Requires at least: 5.4.0
-Tested up to: 5.7.0
+Tested up to: 5.8.1
 Requires PHP: 7.0
-Stable tag: 2.7.0-dev
+Stable tag: 2.9.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.7.0-dev';
+	const VERSION = '2.9.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -147,7 +147,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.7.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.9.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,12 +7,12 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 2.7.0-dev
+ * Version: 2.9.0-dev
  * Requires at least: 5.4
  * Requires PHP: 7.0
  *
  * WC requires at least: 4.8.0
- * WC tested up to: 5.0.0
+ * WC tested up to: 5.7.1
  *
  * @package WooCommerce\Admin
  */


### PR DESCRIPTION
This PR bumps the version to `2.9.0-dev` and syncs the changelog and testing instructions from 2.7.1 and 2.8.0.

## Testing instructions

1. Confidence check - make sure version bumps and changelog changes look correct.
2. Bonus: Run PR branch and smoke test to make sure nothing is horribly broken due to these seemingly benign changes.

(no changelog is needed here)