### PR TITLE
Add show/hide behavior for task list API

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -47,7 +47,7 @@ export const ActivityPanel = () => {
 			countUnreadOrders,
 			manageStock,
 			isTaskListHidden: Boolean( taskLists.length )
-				? taskLists.find( ( list ) => list.id === 'setup' ).isHidden
+				? ! taskLists.find( ( list ) => list.id === 'setup' ).isVisible
 				: null,
 			publishedProductCount,
 			reviewsEnabled,
@@ -66,7 +66,7 @@ export const ActivityPanel = () => {
 					acc[ panelId ] = true;
 					return acc;
 				},
-				{ task_list: panelsData.isTaskListHidden !== 'yes' }
+				{ task_list: ! panelsData.isTaskListHidden }
 			);
 			recordEvent( 'activity_panel_visible_panels', visiblePanels );
 		}

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { snakeCase } from 'lodash';
@@ -39,14 +39,16 @@ export const ActivityPanel = () => {
 		const countLowStockProducts = getLowStockCount( select );
 		const countUnapprovedReviews = getUnapprovedReviews( select );
 		const publishedProductCount = getSetting( 'publishedProductCount', 0 );
-		const { getOption } = select( OPTIONS_STORE_NAME );
-		const isTaskListHidden = getOption( 'woocommerce_task_list_hidden' );
+		const taskLists = select( ONBOARDING_STORE_NAME ).getTaskLists();
+
 		return {
 			countLowStockProducts,
 			countUnapprovedReviews,
 			countUnreadOrders,
-			isTaskListHidden,
 			manageStock,
+			isTaskListHidden: Boolean( taskLists.length )
+				? taskLists.find( ( list ) => list.id === 'setup' ).isHidden
+				: null,
 			publishedProductCount,
 			reviewsEnabled,
 			totalOrderCount,

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -14,14 +14,14 @@ export function getAllPanels( {
 	countLowStockProducts,
 	countUnapprovedReviews,
 	countUnreadOrders,
-	isTaskListHidden,
 	manageStock,
+	isTaskListHidden,
 	orderStatuses,
 	publishedProductCount,
 	reviewsEnabled,
 	totalOrderCount,
 } ) {
-	if ( isTaskListHidden !== 'yes' ) {
+	if ( ! isTaskListHidden ) {
 		return [];
 	}
 

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -57,7 +57,7 @@ describe( 'ActivityPanel', () => {
 			publishedProductCount: 0,
 			manageStock: 'yes',
 			reviewsEnabled: 'yes',
-			isTaskListHidden: 'no',
+			isTaskListHidden: false,
 		} );
 
 		expect( panels ).toEqual(

--- a/client/tasks/task-list-menu.tsx
+++ b/client/tasks/task-list-menu.tsx
@@ -4,9 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { EllipsisMenu } from '@woocommerce/components';
-import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 
 export type TaskListMenuProps = {
 	id: string;
@@ -15,22 +14,13 @@ export type TaskListMenuProps = {
 export const TaskListMenu: React.FC< TaskListMenuProps > = ( { id } ) => {
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 
-	const { invalidateResolutionForStoreSelector } = useDispatch(
-		OPTIONS_STORE_NAME
-	);
-
-	const onHideTaskList = useCallback( () => {
-		hideTaskList( id );
-		invalidateResolutionForStoreSelector( 'getOption' );
-	}, [ id ] );
-
 	return (
 		<div className="woocommerce-card__menu woocommerce-card__header-item">
 			<EllipsisMenu
 				label={ __( 'Task List Options', 'woocommerce-admin' ) }
 				renderContent={ () => (
 					<div className="woocommerce-task-card__section-controls">
-						<Button onClick={ () => onHideTaskList() }>
+						<Button onClick={ () => hideTaskList( id ) }>
 							{ __( 'Hide this', 'woocommerce-admin' ) }
 						</Button>
 					</div>

--- a/client/tasks/task-list-menu.tsx
+++ b/client/tasks/task-list-menu.tsx
@@ -4,8 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { EllipsisMenu } from '@woocommerce/components';
-import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 
 export type TaskListMenuProps = {
 	id: string;
@@ -14,13 +15,22 @@ export type TaskListMenuProps = {
 export const TaskListMenu: React.FC< TaskListMenuProps > = ( { id } ) => {
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		OPTIONS_STORE_NAME
+	);
+
+	const onHideTaskList = useCallback( () => {
+		hideTaskList( id );
+		invalidateResolutionForStoreSelector( 'getOption' );
+	}, [ id ] );
+
 	return (
 		<div className="woocommerce-card__menu woocommerce-card__header-item">
 			<EllipsisMenu
 				label={ __( 'Task List Options', 'woocommerce-admin' ) }
 				renderContent={ () => (
 					<div className="woocommerce-task-card__section-controls">
-						<Button onClick={ () => hideTaskList( id ) }>
+						<Button onClick={ () => onHideTaskList() }>
 							{ __( 'Hide this', 'woocommerce-admin' ) }
 						</Button>
 					</div>

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -110,13 +110,13 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		const {
 			id,
 			isComplete,
-			isHidden,
+			isVisible,
 			isToggleable,
 			title,
 			tasks,
 		} = taskList;
 
-		if ( isHidden ) {
+		if ( ! isVisible ) {
 			return null;
 		}
 

--- a/packages/data/src/onboarding/reducer.js
+++ b/packages/data/src/onboarding/reducer.js
@@ -275,7 +275,7 @@ const onboarding = (
 					if ( taskListId === list.id ) {
 						return {
 							...list,
-							isHidden: false,
+							isVisible: true,
 						};
 					}
 					return list;
@@ -292,7 +292,7 @@ const onboarding = (
 					if ( taskListId === list.id ) {
 						return {
 							...list,
-							isHidden: true,
+							isVisible: false,
 						};
 					}
 					return list;

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -948,25 +948,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$update = $task_list->hide();
 		$json   = $task_list->get_json();
 
-		if ( $update ) {
-			$completed_task_count = array_reduce(
-				$json['tasks'],
-				function( $total, $task ) {
-					return $task['isComplete'] ? $total + 1 : $total;
-				},
-				0
-			);
-
-			wc_admin_record_tracks_event(
-				$id . '_completed',
-				array(
-					'action'                => 'remove_card',
-					'completed_task_count'  => $completed_task_count,
-					'incomplete_task_count' => count( $json['tasks'] ) - $completed_task_count,
-				)
-			);
-		}
-
 		return rest_ensure_response( $json );
 	}
 

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -56,7 +56,7 @@ class Task {
 	 *
 	 * @var bool
 	 */
-	protected $is_complete = false;
+	public $is_complete = false;
 
 	/**
 	 * Viewing capability.

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -62,6 +62,20 @@ class TaskList {
 	}
 
 	/**
+	 * Prefix event for backwards compatibility with tracks event naming.
+	 *
+	 * @param string $event_name Event name.
+	 * @return string
+	 */
+	public function prefix_event( $event_name ) {
+		if ( 'setup' === $this->id ) {
+			return $event_name;
+		}
+
+		return $this->id . '_' . $event_name;
+	}
+
+	/**
 	 * Check if the task list is hidden.
 	 *
 	 * @return bool
@@ -77,6 +91,28 @@ class TaskList {
 	 * @return bool
 	 */
 	public function hide() {
+		if ( $this->is_hidden() ) {
+			return;
+		}
+
+		$viewable_tasks  = $this->get_viewable_tasks();
+		$completed_count = array_reduce(
+			$viewable_tasks,
+			function( $total, $task ) {
+				return $task->is_complete ? $total + 1 : $total;
+			},
+			0
+		);
+
+		wc_admin_record_tracks_event(
+			$this->prefix_event( 'tasklist_completed' ),
+			array(
+				'action'                => 'remove_card',
+				'completed_task_count'  => $completed_count,
+				'incomplete_task_count' => count( $viewable_tasks ) - $completed_count,
+			)
+		);
+
 		$hidden   = get_option( self::HIDDEN_OPTION, array() );
 		$hidden[] = $this->id;
 		return update_option( self::HIDDEN_OPTION, array_unique( $hidden ) );

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -138,6 +138,7 @@ class TaskList {
 			'id'         => $this->id,
 			'title'      => $this->title,
 			'isHidden'   => $this->is_hidden(),
+			'isVisible'  => ! $this->is_hidden(),
 			'isComplete' => $this->is_complete(),
 			'tasks'      => array_map(
 				function( $task ) {

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -36,7 +36,7 @@ class TaskList {
 	public $title = '';
 
 	/**
-	 * Title.
+	 * Tasks.
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
Fixes #7721

Add ability to show/hide task list in the new API-driven tasks feature. 

- [x] Allow user to hide the task list without having to refresh the page
- [x] Activity panels (Reviews/Orders/Stock) should show once the task list has been hidden
- [x] Should trigger a `tasklist_completed` track when user hides the list
- [x] List can be re-shown through the Help panel in a none wc homescreen page

### Screenshots

![image](https://user-images.githubusercontent.com/444632/135349757-e08908ac-ae80-4386-8139-07d318788f66.png)


![image](https://user-images.githubusercontent.com/444632/135349833-cd505506-2ae8-4a6e-95d8-cb4460374efc.png)


### Detailed test instructions:

-   Checkout branch
-   Ensure tasks feature is enabled
- Navigate to Homescreen
- Click context menu on `setup` task on homescreen, and click "Hide this."
- Ensure task list disappears, and is replaced by the Activity Panel show in the second screenshot. This should happen without a page refresh.