### PR TITLE
Clean up task related functions

### DIFF
--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -169,7 +169,7 @@ class Appearance extends Component {
 											'tasklist_appearance_customize_homepage',
 											{}
 										);
-										window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
+										window.location = `${ response.edit_post_link }&wc_onboarding_active_task=appearance`;
 									},
 								},
 						  ]

--- a/client/tasks/fills/products/products.js
+++ b/client/tasks/fills/products/products.js
@@ -72,7 +72,7 @@ const subTasks = [
 		onClick: () =>
 			recordEvent( 'tasklist_add_product', { method: 'import' } ),
 		href: getAdminLink(
-			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=product-import'
+			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
 		),
 	},
 	{

--- a/src/Features/OnboardingTasks/DeprecatedOptions.php
+++ b/src/Features/OnboardingTasks/DeprecatedOptions.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Filters for maintaining backwards compatibility with deprecated options.
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TaskList;
+
+/**
+ * DeprecatedOptions class.
+ */
+class DeprecatedOptions {
+	/**
+	 * Initialize.
+	 */
+	public static function init() {
+		add_filter( 'pre_option_woocommerce_task_list_hidden', array( __CLASS__, 'get_deprecated_options' ), 10, 2 );
+		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( __CLASS__, 'get_deprecated_options' ), 10, 2 );
+		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( __CLASS__, 'update_deprecated_options' ), 10, 3 );
+		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( __CLASS__, 'update_deprecated_options' ), 10, 3 );
+	}
+
+	/**
+	 * Get the values from the correct source when attempting to retrieve deprecated options.
+	 *
+	 * @param string $pre_option Pre option value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public static function get_deprecated_options( $pre_option, $option ) {
+		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
+			return $pre_option;
+		};
+
+		$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				return in_array( 'setup', $hidden, true ) ? 'yes' : 'no';
+			case 'woocommerce_extended_task_list_hidden':
+				return in_array( 'extended', $hidden, true ) ? 'yes' : 'no';
+		}
+	}
+
+	/**
+	 * Updates the new option names when deprecated options are updated.
+	 * This is a temporary fallback until we can fully remove the old task list components.
+	 *
+	 * @param string $value New value.
+	 * @param string $old_value Old value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public static function update_deprecated_options( $value, $old_value, $option ) {
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				$task_list = TaskLists::get_list( 'setup' );
+				if ( ! $task_list ) {
+					return;
+				}
+				$update = 'yes' === $value ? $task_list->hide() : $task_list->show();
+				delete_option( 'woocommerce_task_list_hidden' );
+				return false;
+			case 'woocommerce_extended_task_list_hidden':
+				$task_list = TaskLists::get_list( 'extended' );
+				if ( ! $task_list ) {
+					return;
+				}
+				$update = 'yes' === $value ? $task_list->hide() : $task_list->show();
+				delete_option( 'woocommerce_extended_task_list_hidden' );
+				return false;
+		}
+	}
+}

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 use \Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore as TaxDataStore;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedOptions;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Appearance;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Products;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Tax;
 
 /**

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
 use \Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore as TaxDataStore;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedOptions;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Tax;
 
 /**
@@ -37,10 +38,7 @@ class Init {
 	public function __construct() {
 		// This hook needs to run when options are updated via REST.
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_option_extended_task_list' ), 15 );
-		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
-		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
-		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
-		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		DeprecatedOptions::init();
 		TaskLists::init();
 
 		if ( ! is_admin() ) {
@@ -136,57 +134,6 @@ class Init {
 				return;
 			}
 			$extended_list->show();
-		}
-	}
-
-	/**
-	 * Get the values from the correct source when attempting to retrieve deprecated options.
-	 *
-	 * @param string $pre_option Pre option value.
-	 * @param string $option Option name.
-	 * @return string
-	 */
-	public function get_deprecated_options( $pre_option, $option ) {
-		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
-			return $pre_option;
-		};
-
-		$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
-		switch ( $option ) {
-			case 'woocommerce_task_list_hidden':
-				return in_array( 'setup', $hidden, true ) ? 'yes' : 'no';
-			case 'woocommerce_extended_task_list_hidden':
-				return in_array( 'extended', $hidden, true ) ? 'yes' : 'no';
-		}
-	}
-
-	/**
-	 * Updates the new option names when deprecated options are updated.
-	 * This is a temporary fallback until we can fully remove the old task list components.
-	 *
-	 * @param string $value New value.
-	 * @param string $old_value Old value.
-	 * @param string $option Option name.
-	 * @return string
-	 */
-	public function update_deprecated_options( $value, $old_value, $option ) {
-		switch ( $option ) {
-			case 'woocommerce_task_list_hidden':
-				$task_list = TaskLists::get_list( 'setup' );
-				if ( ! $task_list ) {
-					return;
-				}
-				$update = 'yes' === $value ? $task_list->hide() : $task_list->show();
-				delete_option( 'woocommerce_task_list_hidden' );
-				return false;
-			case 'woocommerce_extended_task_list_hidden':
-				$task_list = TaskLists::get_list( 'extended' );
-				if ( ! $task_list ) {
-					return;
-				}
-				$update = 'yes' === $value ? $task_list->hide() : $task_list->show();
-				delete_option( 'woocommerce_extended_task_list_hidden' );
-				return false;
 		}
 	}
 }

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -22,13 +22,6 @@ class Init {
 	protected static $instance = null;
 
 	/**
-	 * Name of the active task transient.
-	 *
-	 * @var string
-	 */
-	const ACTIVE_TASK_TRANSIENT = 'wc_onboarding_active_task';
-
-	/**
 	 * Get class instance.
 	 */
 	public static function get_instance() {
@@ -48,6 +41,7 @@ class Init {
 		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
 		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
 		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		TaskLists::init();
 
 		if ( ! is_admin() ) {
 			return;
@@ -60,7 +54,6 @@ class Init {
 		// New settings injection.
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );
 
-		add_action( 'admin_init', array( $this, 'set_active_task' ), 5 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ) );
@@ -129,25 +122,6 @@ class Init {
 		);
 
 		return $settings;
-	}
-
-	/**
-	 * Temporarily store the active task to persist across page loads when neccessary (such as publishing a product). Most tasks do not need to do this.
-	 */
-	public static function set_active_task() {
-		if ( isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ) { // phpcs:ignore csrf ok.
-			$task = sanitize_title_with_dashes( wp_unslash( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ); // phpcs:ignore csrf ok.
-
-			if ( self::check_task_completion( $task ) ) {
-				return;
-			}
-
-			set_transient(
-				self::ACTIVE_TASK_TRANSIENT,
-				$task,
-				DAY_IN_SECONDS
-			);
-		}
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -77,11 +77,9 @@ class Init {
 				: false;
 		}
 
-		// @todo We may want to consider caching some of these and use to check against
-		// task completion along with cache busting for active tasks.
 		$settings['automatedTaxSupportedCountries'] = Tax::get_automated_tax_supported_countries();
-		$settings['hasHomepage']                    = self::check_task_completion( 'homepage' ) || 'classic' === get_option( 'classic-editor-replace' );
-		$settings['hasProducts']                    = self::check_task_completion( 'products' );
+		$settings['hasHomepage']                    = Appearance::has_homepage();
+		$settings['hasProducts']                    = Products::has_products();
 		$settings['stylesheet']                     = get_option( 'stylesheet' );
 		$settings['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 		$settings['themeMods']                      = get_theme_mods();
@@ -117,33 +115,6 @@ class Init {
 		);
 
 		return $settings;
-	}
-
-	/**
-	 * Check for task completion of a given task.
-	 *
-	 * @param string $task Name of task.
-	 * @return bool
-	 */
-	public static function check_task_completion( $task ) {
-		switch ( $task ) {
-			case 'products':
-				$products = wp_count_posts( 'product' );
-				return (int) $products->publish > 0;
-			case 'homepage':
-				$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
-				if ( ! $homepage_id ) {
-					return false;
-				}
-				$post      = get_post( $homepage_id );
-				$completed = $post && 'publish' === $post->post_status;
-				return $completed;
-			case 'tax':
-				return 'yes' === get_option( 'wc_connect_taxes_enabled' ) ||
-					count( TaxDataStore::get_taxes( array() ) ) > 0 ||
-					false !== get_option( 'woocommerce_no_sales_tax' );
-		}
-		return false;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -36,7 +36,6 @@ class Init {
 	 * Constructor
 	 */
 	public function __construct() {
-		// This hook needs to run when options are updated via REST.
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_option_extended_task_list' ), 15 );
 		DeprecatedOptions::init();
 		TaskLists::init();
@@ -45,19 +44,11 @@ class Init {
 			return;
 		}
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_media_scripts' ) );
 		// Old settings injection.
 		// Run after Onboarding.
 		add_filter( 'woocommerce_components_settings', array( __CLASS__, 'component_settings' ), 30 );
 		// New settings injection.
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );
-	}
-
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	public function add_media_scripts() {
-		wp_enqueue_media();
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -129,6 +129,13 @@ class Task {
 	const COMPLETED_OPTION = 'woocommerce_task_list_tracked_completed_tasks';
 
 	/**
+	 * Name of the active task transient.
+	 *
+	 * @var string
+	 */
+	const ACTIVE_TASK_TRANSIENT = 'wc_onboarding_active_task';
+
+	/**
 	 * Duration to milisecond mapping.
 	 *
 	 * @var string
@@ -323,6 +330,28 @@ class Task {
 		$completed_tasks[] = $this->id;
 		update_option( self::COMPLETED_OPTION, $completed_tasks );
 		wc_admin_record_tracks_event( 'tasklist_task_completed', array( 'task_name' => $this->id ) );
+	}
+
+	/**
+	 * Set this as the active task across page loads.
+	 */
+	public function set_active() {
+		if ( $this->is_complete ) {
+			return;
+		}
+
+		set_transient(
+			self::ACTIVE_TASK_TRANSIENT,
+			$this->id,
+			DAY_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Check if this is the active task.
+	 */
+	public function is_active() {
+		return get_transient( self::ACTIVE_TASK_TRANSIENT ) === $this->id;
 	}
 
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -6,16 +6,6 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Appearance;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Marketing;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Payments;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Products;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Purchase;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Tax;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Loader;
 
 /**
@@ -37,6 +27,23 @@ class TaskLists {
 	protected static $lists = array();
 
 	/**
+	 * Array of default tasks.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_TASKS = array(
+		'StoreDetails',
+		'Purchase',
+		'Products',
+		'WooCommercePayments',
+		'Payments',
+		'Tax',
+		'Shipping',
+		'Marketing',
+		'Appearance',
+	);
+
+	/**
 	 * Get class instance.
 	 */
 	final public static function instance() {
@@ -51,6 +58,20 @@ class TaskLists {
 	 */
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
+		add_action( 'admin_init', array( __CLASS__, 'init_tasks' ) );
+	}
+
+	/**
+	 * Initialize tasks.
+	 */
+	public static function init_tasks() {
+		foreach ( self::DEFAULT_TASKS as $task ) {
+			$class = 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\\' . $task;
+			if ( ! method_exists( $class, 'init' ) ) {
+				continue;
+			}
+			$class::init();
+		}
 	}
 
 	/**
@@ -132,15 +153,10 @@ class TaskLists {
 			)
 		);
 
-		self::add_task( 'setup', StoreDetails::get_task() );
-		self::add_task( 'setup', Purchase::get_task() );
-		self::add_task( 'setup', Products::get_task() );
-		self::add_task( 'setup', WooCommercePayments::get_task() );
-		self::add_task( 'setup', Payments::get_task() );
-		self::add_task( 'setup', Tax::get_task() );
-		self::add_task( 'setup', Shipping::get_task() );
-		self::add_task( 'setup', Marketing::get_task() );
-		self::add_task( 'setup', Appearance::get_task() );
+		foreach ( self::DEFAULT_TASKS as $task ) {
+			$class = 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\\' . $task;
+			self::add_task( 'setup', $class::get_task() );
+		}
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -85,7 +85,7 @@ class TaskLists {
 
 		$task_id = sanitize_title_with_dashes( wp_unslash( $_GET[ Task::ACTIVE_TASK_TRANSIENT ] ) ); // phpcs:ignore csrf ok.
 
-		self::get_task( $task_id );
+		$task = self::get_task( $task_id );
 
 		if ( ! $task ) {
 			return;

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Appearance;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Marketing;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Payments;
@@ -43,6 +44,33 @@ class TaskLists {
 			static::$instance = new static();
 		}
 		return static::$instance;
+	}
+
+	/**
+	 * Initialize the task lists.
+	 */
+	public static function init() {
+		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
+	}
+
+	/**
+	 * Temporarily store the active task to persist across page loads when neccessary.
+	 * Most tasks do not need this.
+	 */
+	public static function set_active_task() {
+		if ( ! isset( $_GET[ Task::ACTIVE_TASK_TRANSIENT ] ) ) { // phpcs:ignore csrf ok.
+			return;
+		}
+
+		$task_id = sanitize_title_with_dashes( wp_unslash( $_GET[ Task::ACTIVE_TASK_TRANSIENT ] ) ); // phpcs:ignore csrf ok.
+
+		self::get_task( $task_id );
+
+		if ( ! $task ) {
+			return;
+		}
+
+		$task->set_active();
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -64,4 +64,24 @@ class Appearance {
 			true
 		);
 	}
+
+	/**
+	 * Check if the site has a homepage set up.
+	 */
+	public static function has_homepage() {
+		if ( 'classic' === get_option( 'classic-editor-replace' ) ) {
+			return true;
+		}
+
+		$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
+
+		if ( ! $homepage_id ) {
+			return false;
+		}
+
+		$post      = get_post( $homepage_id );
+		$completed = $post && 'publish' === $post->post_status;
+
+		return $completed;
+	}
 }

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -2,10 +2,20 @@
 
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
+use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
 /**
  * Appearance Task
  */
 class Appearance {
+	/**
+	 * Initialize.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'possibly_add_return_notice_script' ) );
+	}
+
 	/**
 	 * Get the task arguments.
 	 *
@@ -23,6 +33,35 @@ class Appearance {
 			'is_complete'  => get_option( 'woocommerce_task_list_appearance_complete' ),
 			'can_view'     => true,
 			'time'         => __( '2 minutes', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Adds a return to task list notice when completing the task.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public static function possibly_add_return_notice_script( $hook ) {
+		global $post;
+		$task = new Task( self::get_task() );
+
+		if ( $task->is_complete || ! $task->is_active() ) {
+			return;
+		}
+
+		if ( 'post.php' !== $hook || 'page' !== $post->post_type ) {
+			return;
+		}
+
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-homepage-notice' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'onboarding-homepage-notice',
+			Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WC_ADMIN_VERSION_NUMBER,
+			true
 		);
 	}
 }

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -13,6 +13,7 @@ class Appearance {
 	 * Initialize.
 	 */
 	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'add_media_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'possibly_add_return_notice_script' ) );
 	}
 
@@ -35,6 +36,20 @@ class Appearance {
 			'time'         => __( '2 minutes', 'woocommerce-admin' ),
 		);
 	}
+
+	/**
+	 * Add media scripts for image uploader.
+	 */
+	public function add_media_scripts() {
+		$task = new Task( self::get_task() );
+
+		if ( ! $task->can_view ) {
+			return;
+		}
+
+		wp_enqueue_media();
+	}
+
 
 	/**
 	 * Adds a return to task list notice when completing the task.

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -40,7 +40,7 @@ class Appearance {
 	/**
 	 * Add media scripts for image uploader.
 	 */
-	public function add_media_scripts() {
+	public static function add_media_scripts() {
 		$task = new Task( self::get_task() );
 
 		if ( ! $task->can_view ) {

--- a/src/Features/OnboardingTasks/Tasks/Products.php
+++ b/src/Features/OnboardingTasks/Tasks/Products.php
@@ -2,10 +2,79 @@
 
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
+use Automattic\WooCommerce\Admin\Loader;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
 /**
  * Products Task
  */
 class Products {
+	/**
+	 * Initialize.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'possibly_add_manual_return_notice_script' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'possibly_add_import_return_notice_script' ) );
+	}
+
+	/**
+	 * Adds a return to task list notice when completing the manual product task.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public static function possibly_add_manual_return_notice_script( $hook ) {
+		$task = new Task( self::get_task() );
+
+		if ( $task->is_complete || ! $task->is_active() ) {
+			return;
+		}
+
+		global $post;
+		if ( 'post.php' !== $hook || 'product' !== $post->post_type ) {
+			return;
+		}
+
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-notice' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'onboarding-product-notice',
+			Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WC_ADMIN_VERSION_NUMBER,
+			true
+		);
+	}
+
+	/**
+	 * Adds a return to task list notice when completing the import product task.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public static function possibly_add_import_return_notice_script( $hook ) {
+		$task = new Task( self::get_task() );
+		$step = isset( $_GET['step'] ) ? $_GET['step'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+
+		if ( $task->is_complete || ! $task->is_active() ) {
+			return;
+		}
+
+		if ( 'product_page_product_importer' !== $hook || 'done' !== $step ) {
+			return;
+		}
+
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-import-notice' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'onboarding-product-import-notice',
+			Loader::get_url( 'wp-admin-scripts/onboarding-product-import-notice', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WC_ADMIN_VERSION_NUMBER,
+			true
+		);
+	}
+
 	/**
 	 * Get the task arguments.
 	 *

--- a/src/Features/OnboardingTasks/Tasks/Tax.php
+++ b/src/Features/OnboardingTasks/Tasks/Tax.php
@@ -2,13 +2,50 @@
 
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore as TaxDataStore;
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\WooCommerce\Admin\Loader;
 
 /**
  * Tax Task
  */
 class Tax {
+	/**
+	 * Initialize.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'possibly_add_return_notice_script' ) );
+	}
+
+	/**
+	 * Adds a return to task list notice when completing the task.
+	 */
+	public static function possibly_add_return_notice_script() {
+		$task = new Task( self::get_task() );
+		$page = isset( $_GET['page'] ) ? $_GET['page'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		$tab  = isset( $_GET['tab'] ) ? $_GET['tab'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+
+		if ( $task->is_complete || ! $task->is_active() ) {
+			return;
+		}
+
+		if ( 'wc-settings' !== $page || 'tax' !== $tab ) {
+			return;
+		}
+
+		$script_assets_filename = Loader::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-tax-notice' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'onboarding-tax-notice',
+			Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WC_ADMIN_VERSION_NUMBER,
+			true
+		);
+	}
+
 	/**
 	 * Get the task arguments.
 	 *


### PR DESCRIPTION
Fixes #7737 

Cleans up the onboarding init class, migrating functions to individual tasks or classes.

### Detailed test instructions:

1. On a fresh site, walk through task list steps
2. Create a homepage under the apperance task, make sure return notice is shown on publish (this one is giving me trouble on `main` and this branch and may be broken)
3. Configure taxes manually from the tax task, make sure return notice is shown on saving your first tax
4. Add a product manually, making sure the return notice is shown on publish
5. Add products via import, making sure products are shown when import completes