### PR TITLE
Allow already installed marketing extensions to be activated

### DIFF
--- a/changelogs/fix-7690
+++ b/changelogs/fix-7690
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Allow already installed marketing extensions to be activated #7740

--- a/client/task-list/tasks/Marketing/PluginList.tsx
+++ b/client/task-list/tasks/Marketing/PluginList.tsx
@@ -12,7 +12,7 @@ import './PluginList.scss';
 export type PluginListProps = {
 	currentPlugin?: string | null;
 	key?: string;
-	installAndActivate?: ( slug: string ) => void;
+	installAndActivate: ( slug: string ) => void;
 	plugins?: PluginProps[];
 	title?: string;
 };

--- a/client/task-list/tasks/Marketing/index.tsx
+++ b/client/task-list/tasks/Marketing/index.tsx
@@ -190,6 +190,7 @@ export const Marketing: React.FC< MarketingProps > = ( {
 					</CardHeader>
 					<PluginList
 						currentPlugin={ currentPlugin }
+						installAndActivate={ installAndActivate }
 						plugins={ installedExtensions }
 					/>
 				</Card>

--- a/client/tasks/fills/Marketing/PluginList.tsx
+++ b/client/tasks/fills/Marketing/PluginList.tsx
@@ -12,7 +12,7 @@ import './PluginList.scss';
 export type PluginListProps = {
 	currentPlugin?: string | null;
 	key?: string;
-	installAndActivate?: ( slug: string ) => void;
+	installAndActivate: ( slug: string ) => void;
 	plugins?: PluginProps[];
 	title?: string;
 };

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -207,6 +207,7 @@ const Marketing: React.FC = () => {
 					</CardHeader>
 					<PluginList
 						currentPlugin={ currentPlugin }
+						installAndActivate={ installAndActivate }
 						plugins={ installedExtensions }
 					/>
 				</Card>


### PR DESCRIPTION
Fixes #7690 

One of the `PluginList`s was missing the `installAndActivate` function.  This passes that as a prop and also requires it as an argument via TS.

cc @mattsherman I'm not sure if this is too late to put into `2.8.0`, but it would be nice to have this fix in there.

### Screenshots


![Screen Shot 2021-09-30 at 5 14 27 PM](https://user-images.githubusercontent.com/10561050/135531213-b51c82a3-49b0-4070-890e-201ccf4c47c1.png)

### Detailed test instructions:

1. Install one of the marketing extensions, but don't activate it.
2. Navigate to the marketing task in the task list.
3. Attempt to activate the plugin.
4. Note the successful activation.