### PR TITLE
Add status param support for dismissing all notes

### DIFF
--- a/changelogs/fix-7741_dismiss_all_notes
+++ b/changelogs/fix-7741_dismiss_all_notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -192,7 +192,9 @@ const InboxPanel = () => {
 			try {
 				let notesRemoved = [];
 				if ( removeAll ) {
-					notesRemoved = await removeAllNotes();
+					notesRemoved = await removeAllNotes( {
+						status: INBOX_QUERY.status,
+					} );
 				} else {
 					const noteRemoved = await removeNote( noteId );
 					notesRemoved = [ noteRemoved ];

--- a/packages/data/src/notes/actions.js
+++ b/packages/data/src/notes/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -42,11 +43,14 @@ export function* removeNote( noteId ) {
 	}
 }
 
-export function* removeAllNotes() {
+export function* removeAllNotes( query = {} ) {
 	yield setIsRequesting( 'removeAllNotes', true );
 
 	try {
-		const url = `${ NAMESPACE }/admin/notes/delete/all`;
+		const url = addQueryArgs(
+			`${ NAMESPACE }/admin/notes/delete/all`,
+			query
+		);
 		const notes = yield apiFetch( { path: url, method: 'DELETE' } );
 		yield setNotes( notes );
 		yield setIsRequesting( 'removeAllNotes', false );

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -96,6 +96,18 @@ class Notes extends \WC_REST_CRUD_Controller {
 					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'delete_all_items' ),
 					'permission_callback' => array( $this, 'update_items_permissions_check' ),
+					'args'                => array(
+						'status' => array(
+							'description'       => __( 'Status of note.', 'woocommerce-admin' ),
+							'type'              => 'array',
+							'sanitize_callback' => 'wp_parse_slug_list',
+							'validate_callback' => 'rest_validate_request_arg',
+							'items'             => array(
+								'enum' => Note::get_allowed_statuses(),
+								'type' => 'string',
+							),
+						),
+					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -291,7 +303,11 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function delete_all_items( $request ) {
-		$notes = NotesRepository::delete_all_notes();
+		$args = array();
+		if ( isset( $request['status'] ) ) {
+			$args['status'] = $request['status'];
+		}
+		$notes = NotesRepository::delete_all_notes( $args );
 		$data  = array();
 		foreach ( (array) $notes as $note_obj ) {
 			$data[] = $this->prepare_note_data_for_response( $note_obj, $request );

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -160,26 +160,27 @@ class Notes {
 	/**
 	 * Soft delete of all the admin notes. Returns the deleted items.
 	 *
+	 * @param array $args Arguments to pass to the query (ex: status).
 	 * @return array Array of notes.
 	 */
-	public static function delete_all_notes() {
+	public static function delete_all_notes( $args = array() ) {
 		$data_store = self::load_data_store();
-		// Here we filter for the same params we are using to show the note list in client side.
-		$raw_notes = $data_store->get_notes(
-			array(
-				'order'      => 'desc',
-				'orderby'    => 'date_created',
-				'per_page'   => 25,
-				'page'       => 1,
-				'type'       => array(
-					Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
-					Note::E_WC_ADMIN_NOTE_MARKETING,
-					Note::E_WC_ADMIN_NOTE_WARNING,
-					Note::E_WC_ADMIN_NOTE_SURVEY,
-				),
-				'is_deleted' => 0,
-			)
+		$defaults   = array(
+			'order'      => 'desc',
+			'orderby'    => 'date_created',
+			'per_page'   => 25,
+			'page'       => 1,
+			'type'       => array(
+				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+				Note::E_WC_ADMIN_NOTE_MARKETING,
+				Note::E_WC_ADMIN_NOTE_WARNING,
+				Note::E_WC_ADMIN_NOTE_SURVEY,
+			),
+			'is_deleted' => 0,
 		);
+		$args       = wp_parse_args( $args, $defaults );
+		// Here we filter for the same params we are using to show the note list in client side.
+		$raw_notes = $data_store->get_notes( $args );
 
 		$notes = array();
 		foreach ( (array) $raw_notes as $raw_note ) {

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -492,6 +492,26 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test deleting all the notes with a specific status.
+	 */
+	public function test_delete_all_notes_with_status() {
+		wp_set_current_user( $this->user );
+
+		// It deletes only unactioned notes.
+		$request = new WP_REST_Request( 'DELETE', $this->endpoint . '/delete/all' );
+		$request->set_query_params(
+			array(
+				'status' => 'unactioned',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $notes ) );
+	}
+
+	/**
 	 * Test deleting all the notes without permission. It should fail.
 	 */
 	public function test_delete_all_notes_without_permission() {


### PR DESCRIPTION
Fixes #7741 

Add status query param to `delete_all_notes` so query is run correctly.
The underlying issue was that the `delete/all` query queried for any status, causing the notes to be returned to be greater than 25 (the page limit). Although on our client we only display `unactioned` notes, I added support for this query arg.

**note**
I only added support for **status** to fix this particular issue. We could potentially support any query arg in the same way we support this for the `notes/all` endpoint.

### Screenshots

![dismiss-all-notes](https://user-images.githubusercontent.com/2240960/135876276-0a1844e2-128f-4cc4-814a-5a4eb032bf4e.gif)

### Detailed test instructions:

- Load this branch
- On a fresh WC installation finish the Onboarding flow, make sure you install all the free extensions (important).
- Go to **WooCommerce > Home** and scroll down to the notes
- Click on **Dismiss** of one of the notes and click **Dismiss all messages**
- Click **Yes, I'm sure**
- Note that all notes should be removed and the empty inbox message should show up (see GIF as well)
- Click **undo** on the little notice that pops up in the bottom left, and make sure all the notes appeared again.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
