### PR TITLE
Add missing task events

### DIFF
--- a/client/tasks/task-list.tsx
+++ b/client/tasks/task-list.tsx
@@ -20,10 +20,10 @@ import './task-list.scss';
 export const getEventPrefix = ( id: string ): string => {
 	// This helps retain backwards compatibility with the old event naming.
 	if ( id === 'setup' ) {
-		return 'tasklist_';
+		return 'tasklist';
 	}
 
-	return `${ id }_tasklist_`;
+	return `${ id }_tasklist`;
 };
 
 export type TaskListProps = TaskListType & {

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -785,6 +785,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				array(
 					'id'             => $id,
 					'is_dismissable' => true,
+					'parent_id'      => 'extended',
 				)
 			);
 		}
@@ -818,6 +819,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				array(
 					'id'             => $id,
 					'is_dismissable' => true,
+					'parent_id'      => 'extended',
 				)
 			);
 		}
@@ -856,6 +858,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				array(
 					'id'            => $task_id,
 					'is_snoozeable' => true,
+					'parent_id'     => 'extended',
 				)
 			);
 		}
@@ -889,6 +892,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				array(
 					'id'            => $id,
 					'is_snoozeable' => true,
+					'parent_id'     => 'extended',
 				)
 			);
 		}
@@ -947,7 +951,8 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task && $id ) {
 			$task = new Task(
 				array(
-					'id' => $id,
+					'id'        => $id,
+					'parent_id' => 'extended',
 				)
 			);
 		}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -885,7 +885,7 @@ class Onboarding {
 			wc_admin_record_tracks_event(
 				'tasklist_toggled',
 				array(
-					'status' => $show ? 'disabled' : 'enabled',
+					'status' => $show ? 'enabled' : 'disabled',
 				)
 			);
 		}

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -22,6 +22,13 @@ class Task {
 	public $id = '';
 
 	/**
+	 * Parent task list ID.
+	 *
+	 * @var string
+	 */
+	public $parent_id = '';
+
+	/**
 	 * Title.
 	 *
 	 * @var string
@@ -152,6 +159,7 @@ class Task {
 	public function __construct( $data = array() ) {
 		$defaults = array(
 			'id'              => null,
+			'parent_id'       => null,
 			'title'           => '',
 			'content'         => '',
 			'action_label'    => __( "Let's go", 'woocommerce-admin' ),
@@ -169,6 +177,7 @@ class Task {
 		$data = wp_parse_args( $data, $defaults );
 
 		$this->id              = (string) $data['id'];
+		$this->parent_id       = (string) $data['parent_id'];
 		$this->title           = (string) $data['title'];
 		$this->content         = (string) $data['content'];
 		$this->action_label    = (string) $data['action_label'];
@@ -341,6 +350,7 @@ class Task {
 
 		return array(
 			'id'             => $this->id,
+			'parentId'       => $this->parent_id,
 			'title'          => $this->title,
 			'canView'        => $this->can_view,
 			'content'        => $this->content,

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -10,6 +10,11 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
  */
 class Task {
 	/**
+	 * Task traits.
+	 */
+	use TaskTraits;
+
+	/**
 	 * ID.
 	 *
 	 * @var string
@@ -212,7 +217,7 @@ class Task {
 		$update      = update_option( self::DISMISSED_OPTION, array_unique( $dismissed ) );
 
 		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_dismiss_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'tasklist_dismiss_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;
@@ -229,7 +234,7 @@ class Task {
 		$update    = update_option( self::DISMISSED_OPTION, $dismissed );
 
 		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;
@@ -268,7 +273,7 @@ class Task {
 
 		if ( $update ) {
 			if ( $update ) {
-				wc_admin_record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $this->id ) );
+				$this->record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $this->id ) );
 				$this->snoozed_until = $snoozed_until;
 			}
 		}
@@ -287,7 +292,7 @@ class Task {
 		$update = update_option( self::SNOOZED_OPTION, $snoozed );
 
 		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -327,7 +327,7 @@ class Task {
 		$completed_tasks   = get_option( self::COMPLETED_OPTION, array() );
 		$completed_tasks[] = $this->id;
 		update_option( self::COMPLETED_OPTION, $completed_tasks );
-		wc_admin_record_tracks_event( 'tasklist_task_completed', array( 'task_name' => $this->id ) );
+		$this->record_tracks_event( 'task_completed', array( 'task_name' => $this->id ) );
 	}
 
 
@@ -372,7 +372,7 @@ class Task {
 		$update     = update_option( self::ACTIONED_OPTION, array_unique( $actioned ) );
 
 		if ( $update ) {
-			wc_admin_record_tracks_event( 'tasklist_actioned_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'actioned_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -217,7 +217,7 @@ class Task {
 		$update      = update_option( self::DISMISSED_OPTION, array_unique( $dismissed ) );
 
 		if ( $update ) {
-			$this->record_tracks_event( 'tasklist_dismiss_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'dismiss_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;
@@ -234,7 +234,7 @@ class Task {
 		$update    = update_option( self::DISMISSED_OPTION, $dismissed );
 
 		if ( $update ) {
-			$this->record_tracks_event( 'tasklist_undo_dismiss_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'undo_dismiss_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;
@@ -273,7 +273,7 @@ class Task {
 
 		if ( $update ) {
 			if ( $update ) {
-				$this->record_tracks_event( 'tasklist_remindmelater_task', array( 'task_name' => $this->id ) );
+				$this->record_tracks_event( 'remindmelater_task', array( 'task_name' => $this->id ) );
 				$this->snoozed_until = $snoozed_until;
 			}
 		}
@@ -292,7 +292,7 @@ class Task {
 		$update = update_option( self::SNOOZED_OPTION, $snoozed );
 
 		if ( $update ) {
-			$this->record_tracks_event( 'tasklist_undo_remindmelater_task', array( 'task_name' => $this->id ) );
+			$this->record_tracks_event( 'undo_remindmelater_task', array( 'task_name' => $this->id ) );
 		}
 
 		return $update;

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -153,7 +153,11 @@ class TaskList {
 	 * @param array $args Task properties.
 	 */
 	public function add_task( $args ) {
-		$this->tasks[] = new Task( $args );
+		$task_args     = wp_parse_args(
+			$args,
+			array( 'parent_id' => $this->id )
+		);
+		$this->tasks[] = new Task( $task_args );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -12,7 +12,12 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
  */
 class TaskList {
 	/**
-	 * Option name of hidden task lists.
+	 * Task traits.
+	 */
+	use TaskTraits;
+
+	/**
+	 * Option name hidden task lists.
 	 */
 	const HIDDEN_OPTION = 'woocommerce_task_list_hidden_lists';
 
@@ -62,20 +67,6 @@ class TaskList {
 	}
 
 	/**
-	 * Prefix event for backwards compatibility with tracks event naming.
-	 *
-	 * @param string $event_name Event name.
-	 * @return string
-	 */
-	public function prefix_event( $event_name ) {
-		if ( 'setup' === $this->id ) {
-			return $event_name;
-		}
-
-		return $this->id . '_' . $event_name;
-	}
-
-	/**
 	 * Check if the task list is hidden.
 	 *
 	 * @return bool
@@ -104,8 +95,8 @@ class TaskList {
 			0
 		);
 
-		wc_admin_record_tracks_event(
-			$this->prefix_event( 'tasklist_completed' ),
+		$this->record_tracks_event(
+			'completed',
 			array(
 				'action'                => 'remove_card',
 				'completed_task_count'  => $completed_count,

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -187,7 +187,7 @@ class TaskList {
 		$completed_lists   = get_option( self::COMPLETED_OPTION, array() );
 		$completed_lists[] = $this->id;
 		update_option( self::COMPLETED_OPTION, $completed_lists );
-		wc_admin_record_tracks_event( $this->prefix_event( 'tasklist_tasks_completed' ) );
+		$this->record_tracks_event( 'tasks_completed' );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/TaskTraits.php
+++ b/src/Features/OnboardingTasks/TaskTraits.php
@@ -18,11 +18,13 @@ trait TaskTraits {
 	 * @return string
 	 */
 	public function prefix_event( $event_name ) {
-		if ( 'setup' === $this->id ) {
+		$id = self::get_list_id();
+
+		if ( 'setup' === $id ) {
 			return 'tasklist_' . $event_name;
 		}
 
-		return 'tasklist_' . $this->id . '_' . $event_name;
+		return 'tasklist_' . $id . '_' . $event_name;
 	}
 
 	/**
@@ -31,10 +33,25 @@ trait TaskTraits {
 	 * @param string $event_name Event name.
 	 * @param array  $args Array of tracks arguments.
 	 */
-	public function record_tracks_event( $event_name, $args ) {
+	public function record_tracks_event( $event_name, $args = array() ) {
+		if ( ! $this->get_list_id() ) {
+			return;
+		}
+
 		wc_admin_record_tracks_event(
 			$this->prefix_event( $event_name ),
 			$args
 		);
+	}
+
+	/**
+	 * Get the task list ID.
+	 *
+	 * @return string
+	 */
+	public function get_list_id() {
+		$namespaced_class = get_class( $this );
+		$short_class      = substr( $namespaced_class, strrpos( $namespaced_class, '\\' ) + 1 );
+		return 'Task' === $short_class ? $this->parent_id : $this->id;
 	}
 }

--- a/src/Features/OnboardingTasks/TaskTraits.php
+++ b/src/Features/OnboardingTasks/TaskTraits.php
@@ -24,7 +24,7 @@ trait TaskTraits {
 			return 'tasklist_' . $event_name;
 		}
 
-		return 'tasklist_' . $id . '_' . $event_name;
+		return $id . '_tasklist_' . $event_name;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/TaskTraits.php
+++ b/src/Features/OnboardingTasks/TaskTraits.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Task and TaskList Traits
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * TaskTraits class.
+ */
+trait TaskTraits {
+	/**
+	 * Prefix event for backwards compatibility with tracks event naming.
+	 *
+	 * @param string $event_name Event name.
+	 * @return string
+	 */
+	public function prefix_event( $event_name ) {
+		if ( 'setup' === $this->id ) {
+			return 'tasklist_' . $event_name;
+		}
+
+		return 'tasklist_' . $this->id . '_' . $event_name;
+	}
+
+	/**
+	 * Record a tracks event with the prefixed event name.
+	 *
+	 * @param string $event_name Event name.
+	 * @param array  $args Array of tracks arguments.
+	 */
+	public function record_tracks_event( $event_name, $args ) {
+		wc_admin_record_tracks_event(
+			$this->prefix_event( $event_name ),
+			$args
+		);
+	}
+}


### PR DESCRIPTION
* Adds missing events
* Adds traits to handle prefixing and recording events in task/task lists

@pmcpinto If you want to give this list a glance to make sure we've covered everything that would be great!  No changes were made to events inside individual tasks, so these events just cover general task/task list events.

### Detailed test instructions:

1. Add an error log to `wc_admin_record_tracks_event()` in `includes/core-functions.php`:
```php
error_log( $event_name );
```
2. Enable the logging of Tracks events to your browser dev console `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
3. Under one of the tasks in `src/Features/OnboardingTasks/Tasks/*.php` add `'is_dismissable' => true;` and `'is_snoozeable' => true`
3. Check to make sure the following events can all be triggered with the correct task names:

(C) - denotes client-side events, found in your console
(S) - denotes server-side events, found in debug log

`tasklist_task_completed` - (S) Complete any task in the list, on or off the homepage.  Note you may have to revisit the task list if completing on a different page.
`tasklist_click` - (C) View the task list and click on any task in the list
`tasklist_dismiss_task` - (S) Dismiss a task via the dropdown
`tasklist_undo_remindmelater_task` - (S) Undo task dismissal via the transient notice
`tasklist_remindmelater_task` - (S) Snooze any task via dropdown
`tasklist_undo_dismiss_task` - (S) Undo the snoozing of a task via transient notice
`task_view` - (C) View a single task on the frontend
`tasklist_view` - (C) View any of the task lists on the frontend
`tasklist_completed` - (S) Hide the task list via the dropdown
`tasklist_toggled` - (S) Should be triggered when toggling the tasklist on/off under "Screen Options" on core Orders screen.  I'm missing the toggles in my screen options (also in previous versions) - can anyone replicate?
`tasklist_skip` - (S) Seems to have been removed, but could use a sanity check.

These tasks are part of https://github.com/woocommerce/woocommerce-admin/pull/7736 :
`tasklist_tasks_completed` - (S) Complete all visible tasks in the task list
`extended_tasklist_tasks_completed` - (S) Complete all visible tasks in the extended task list