### PR TITLE
Adding PHP unit tests for tasks rest endpoints

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -769,7 +769,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function get_tasks( $request ) {
 		$extended_tasks = $request->get_param( 'extended_tasks' );
 
-		TaskLists::maybe_add_default_tasks();
 		TaskLists::maybe_add_extended_tasks( $extended_tasks );
 
 		$lists = TaskLists::get_lists();

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -874,7 +874,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task || ! $task->is_snoozeable ) {
 			return new \WP_Error(
-				'woocommerce_tasks_invalid_task',
+				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
 				array(
 					'status' => 404,
@@ -908,7 +908,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task || ! $task->is_snoozeable ) {
 			return new \WP_Error(
-				'woocommerce_tasks_invalid_task',
+				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
 				array(
 					'status' => 404,
@@ -933,7 +933,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task_list ) {
 			return new \WP_Error(
-				'woocommerce_tasks_invalid_task_list',
+				'woocommerce_rest_invalid_task_list',
 				__( 'Sorry, that task list was not found', 'woocommerce-admin' ),
 				array(
 					'status' => 404,

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -768,7 +768,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function get_tasks( $request ) {
 		$extended_tasks = $request->get_param( 'extended_tasks' );
-		$lists          = TaskLists::get_lists( $extended_tasks );
+		$lists          = TaskLists::get_lists(
+			$extended_tasks ? $extended_tasks : array()
+		);
 		$json           = array_map(
 			function( $list ) {
 				return $list->sort_tasks()->get_json();

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -768,10 +768,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function get_tasks( $request ) {
 		$extended_tasks = $request->get_param( 'extended_tasks' );
-		$lists          = TaskLists::get_lists(
-			$extended_tasks ? $extended_tasks : array()
-		);
-		$json           = array_map(
+		TaskLists::maybe_add_extended_tasks( $extended_tasks );
+
+		$lists = TaskLists::get_lists();
+
+		$json = array_map(
 			function( $list ) {
 				return $list->sort_tasks()->get_json();
 			},

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -768,6 +768,8 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function get_tasks( $request ) {
 		$extended_tasks = $request->get_param( 'extended_tasks' );
+
+		TaskLists::maybe_add_default_tasks();
 		TaskLists::maybe_add_extended_tasks( $extended_tasks );
 
 		$lists = TaskLists::get_lists();

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -65,6 +65,7 @@ class TaskLists {
 	 */
 	public static function init() {
 		self::init_default_lists();
+		add_action( 'init', array( __CLASS__, 'maybe_add_default_tasks' ) );
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
 		add_action( 'admin_init', array( __CLASS__, 'init_tasks' ) );
 	}
@@ -109,7 +110,6 @@ class TaskLists {
 			}
 			$class::init();
 		}
-		self::$default_tasks_loaded = true;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -20,6 +20,26 @@ class TaskLists {
 	protected static $instance = null;
 
 	/**
+	 * Initialize default lists
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		self::$lists['setup']    = new TaskList(
+			array(
+				'id'    => 'setup',
+				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
+			),
+		);
+		self::$lists['extended'] = new TaskList(
+			array(
+				'id'    => 'extended',
+				'title' => __( 'Things to do next', 'woocommerce-admin' ),
+			)
+		);
+	}
+
+	/**
 	 * An array of all registered lists.
 	 *
 	 * @var array
@@ -133,7 +153,7 @@ class TaskLists {
 	 * Add default task lists.
 	 */
 	public static function maybe_add_default_tasks() {
-		$added = isset( self::$lists['setup'] );
+		$added = ! empty( self::$lists['setup']->tasks );
 
 		if ( ! apply_filters( 'woocommerce_admin_onboarding_tasks_add_default_tasks', ! $added ) ) {
 			return;
@@ -188,7 +208,6 @@ class TaskLists {
 	 * @return array
 	 */
 	public static function get_lists() {
-		self::maybe_add_default_tasks();
 		return self::$lists;
 	}
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -174,8 +174,10 @@ class TaskLists {
 	 *
 	 * @param array $extended_tasks list of extended tasks.
 	 */
-	public static function maybe_add_extended_tasks( $extended_tasks = array() ) {
-		foreach ( $extended_tasks as $extended_task ) {
+	public static function maybe_add_extended_tasks( $extended_tasks ) {
+		$tasks = $extended_tasks ? $extended_tasks : array();
+
+		foreach ( $tasks as $extended_task ) {
 			self::add_task( $extended_task['list_id'], $extended_task );
 		}
 	}
@@ -183,12 +185,10 @@ class TaskLists {
 	/**
 	 * Get all task lists.
 	 *
-	 * @param array $extended_tasks array of optional extended tasks.
 	 * @return array
 	 */
-	public static function get_lists( $extended_tasks = array() ) {
+	public static function get_lists() {
 		self::maybe_add_default_tasks();
-		self::maybe_add_extended_tasks( $extended_tasks );
 		return self::$lists;
 	}
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -193,6 +193,14 @@ class TaskLists {
 	}
 
 	/**
+	 * Clear all task lists.
+	 */
+	public static function clear_lists() {
+		self::$lists = array();
+		return self::$lists;
+	}
+
+	/**
 	 * Get visible task lists.
 	 */
 	public static function get_visible() {

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -27,6 +27,13 @@ class TaskLists {
 	protected static $lists = array();
 
 	/**
+	 * Boolean value to indicate if default tasks have been added.
+	 *
+	 * @var boolean
+	 */
+	protected static $default_tasks_loaded = false;
+
+	/**
 	 * Array of default tasks.
 	 *
 	 * @var array
@@ -57,8 +64,8 @@ class TaskLists {
 	 * Initialize the task lists.
 	 */
 	public static function init() {
+		self::init_default_lists();
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
-		add_action( 'admin_init', array( __CLASS__, 'init_default_lists' ) );
 		add_action( 'admin_init', array( __CLASS__, 'init_tasks' ) );
 	}
 
@@ -72,10 +79,21 @@ class TaskLists {
 				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
 			)
 		);
+
 		self::add_list(
 			array(
-				'id'    => 'extended',
-				'title' => __( 'Things to do next', 'woocommerce-admin' ),
+				'id'      => 'extended',
+				'title'   => __( 'Things to do next', 'woocommerce-admin' ),
+				'sort_by' => array(
+					array(
+						'key'   => 'is_complete',
+						'order' => 'asc',
+					),
+					array(
+						'key'   => 'level',
+						'order' => 'asc',
+					),
+				),
 			)
 		);
 	}
@@ -91,6 +109,7 @@ class TaskLists {
 			}
 			$class::init();
 		}
+		self::$default_tasks_loaded = true;
 	}
 
 	/**
@@ -152,35 +171,11 @@ class TaskLists {
 	 * Add default task lists.
 	 */
 	public static function maybe_add_default_tasks() {
-		$added = ! empty( self::$lists['setup']->tasks );
-
-		if ( ! apply_filters( 'woocommerce_admin_onboarding_tasks_add_default_tasks', ! $added ) ) {
+		if ( ! apply_filters( 'woocommerce_admin_onboarding_tasks_add_default_tasks', ! self::$default_tasks_loaded ) ) {
 			return;
 		}
 
-		self::add_list(
-			array(
-				'id'    => 'setup',
-				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
-			)
-		);
-
-		self::add_list(
-			array(
-				'id'      => 'extended',
-				'title'   => __( 'Things to do next', 'woocommerce-admin' ),
-				'sort_by' => array(
-					array(
-						'key'   => 'is_complete',
-						'order' => 'asc',
-					),
-					array(
-						'key'   => 'level',
-						'order' => 'asc',
-					),
-				),
-			)
-		);
+		self::$default_tasks_loaded = true;
 
 		foreach ( self::DEFAULT_TASKS as $task ) {
 			$class = 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\\' . $task;

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -20,26 +20,6 @@ class TaskLists {
 	protected static $instance = null;
 
 	/**
-	 * Initialize default lists
-	 *
-	 * @return void
-	 */
-	public static function init() {
-		self::$lists['setup']    = new TaskList(
-			array(
-				'id'    => 'setup',
-				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
-			),
-		);
-		self::$lists['extended'] = new TaskList(
-			array(
-				'id'    => 'extended',
-				'title' => __( 'Things to do next', 'woocommerce-admin' ),
-			)
-		);
-	}
-
-	/**
 	 * An array of all registered lists.
 	 *
 	 * @var array
@@ -78,7 +58,26 @@ class TaskLists {
 	 */
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
+		add_action( 'admin_init', array( __CLASS__, 'init_default_lists' ) );
 		add_action( 'admin_init', array( __CLASS__, 'init_tasks' ) );
+	}
+
+	/**
+	 * Initialize default lists.
+	 */
+	public static function init_default_lists() {
+		self::add_list(
+			array(
+				'id'    => 'setup',
+				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
+			)
+		);
+		self::add_list(
+			array(
+				'id'    => 'extended',
+				'title' => __( 'Things to do next', 'woocommerce-admin' ),
+			)
+		);
 	}
 
 	/**

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -474,4 +474,51 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $response_data['code'], 'woocommerce_rest_invalid_task_list' );
 	}
 
+
+	/**
+	 * Test that task lists can be fetched.
+	 * @group tasklist
+	 */
+	public function test_task_list_can_be_fetched() {
+		wp_set_current_user( $this->user );
+
+		TaskLists::add_list(
+			array(
+				'id' => 'test-list',
+			)
+		);
+
+		TaskLists::add_task(
+			'test-list',
+			array(
+				'id'             => 'test-task',
+				'title'          => 'Test Task',
+				'is_dismissable' => true,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$setup_list = null;
+		$test_list  = null;
+
+		foreach ( $response_data as $task_list ) {
+			if ( 'setup' === $task_list['id'] ) {
+				$setup_list = $task_list;
+			}
+			if ( 'test-list' === $task_list['id'] ) {
+				$test_list = $task_list;
+			}
+		}
+
+		$test_task = $test_list['tasks'][0];
+
+		$this->assertGreaterThan( 0, count( $setup_list ), true );
+		$this->assertEquals( $test_task['id'], 'test-task' );
+		$this->assertEquals( $test_task['isDismissable'], true );
+	}
+
 }

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -505,13 +505,9 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		$response      = $this->server->dispatch( $request );
 		$response_data = $response->get_data();
 
-		$setup_list = null;
-		$test_list  = null;
+		$test_list = null;
 
 		foreach ( $response_data as $task_list ) {
-			if ( 'setup' === $task_list['id'] ) {
-				$setup_list = $task_list;
-			}
 			if ( 'test-list' === $task_list['id'] ) {
 				$test_list = $task_list;
 			}
@@ -519,7 +515,6 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 
 		$test_task = $test_list['tasks'][0];
 
-		$this->assertGreaterThan( 0, count( $setup_list ), true );
 		$this->assertEquals( $test_task['id'], 'test-task' );
 		$this->assertEquals( $test_task['isDismissable'], true );
 	}

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -327,6 +327,7 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	 * @group tasklist
 	 */
 	public function test_snoozed_task_invalid() {
+		$this->markTestSkipped( 'Skipped temporarily due to change in endpoint behavior.' );
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/test-task/snooze' );
@@ -414,6 +415,7 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	 * @group tasklist
 	 */
 	public function test_dismissed_task_invalid() {
+		$this->markTestSkipped( 'Skipped temporarily due to change in endpoint behavior.' );
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/test-task/dismiss' );

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -339,7 +339,7 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a task can be snoozed with determined duration
+	 * Test that a task can be dismissed.
 	 * @group tasklist
 	 */
 	public function test_task_can_be_dismissed() {
@@ -409,10 +409,10 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $task_after_request->is_dismissed(), false );
 	}
 
-		/**
-		 * Test that dismiss endpoint returns error for invalid task.
-		 * @group tasklist
-		 */
+	/**
+	 * Test that dismiss endpoint returns error for invalid task.
+	 * @group tasklist
+	 */
 	public function test_dismissed_task_invalid() {
 		wp_set_current_user( $this->user );
 
@@ -423,6 +423,55 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( $response_data['data']['status'], 404 );
 		$this->assertEquals( $response_data['code'], 'woocommerce_rest_invalid_task' );
+	}
+
+	/**
+	 * Test that a task list can be hidden.
+	 * @group tasklist
+	 */
+	public function test_task_list_can_be_hidden() {
+		wp_set_current_user( $this->user );
+
+		TaskLists::add_list(
+			array(
+				'id' => 'test-list',
+			)
+		);
+
+		TaskLists::add_task(
+			'test-list',
+			array(
+				'id'             => 'test-task',
+				'title'          => 'Test Task',
+				'is_dismissable' => true,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint . '/test-list/hide' );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$list = TaskLists::get_list( 'test-list' );
+
+		$this->assertEquals( $list->is_hidden(), true );
+		$this->assertEquals( $response_data['isHidden'], true );
+	}
+
+	/**
+	 * Test that hide endpoint returns error for invalid task.
+	 * @group tasklist
+	 */
+	public function test_task_list_hidden_invalid_list() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint . '/test-list/hide' );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$this->assertEquals( $response_data['data']['status'], 404 );
+		$this->assertEquals( $response_data['code'], 'woocommerce_rest_invalid_task_list' );
 	}
 
 }

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -7,6 +7,7 @@
 
 use \Automattic\WooCommerce\Admin\API\OnboardingTasks;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 
 /**
  * WC Tests API Onboarding Tasks
@@ -40,8 +41,8 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 		}
 
 		// Resetting task list options and lists.
-		update_option( 'woocommerce_task_list_dismissed_tasks', array() );
-		update_option( 'woocommerce_task_list_remind_me_later_tasks', array() );
+		update_option( Task::DISMISSED_OPTION, array() );
+		update_option( Task::SNOOZED_OPTION, array() );
 		TaskLists::clear_lists();
 
 	}


### PR DESCRIPTION
Fixes partially #7649

Adding PHP unit tests for tasks endpoints. 

**Note:**
Ended up skipping a couple tests I had written after a rebase, as the behavior for the various endpoints changed in https://github.com/woocommerce/woocommerce-admin/pull/7730. We're now just automatically creating a new task if the given ID doesn't exists. This feels a little risky to me, since there wouldn't be an obvious signal if you simply have a typo in the task ID (it would just create a new one and snooze it, instead of telling you it doesn't exist). Just wanted to confirm this is the desired behavior? @louwie17 @joshuatf 

Perhaps we could have a boolean parameter `failWhenInvalid` that defaults to `true`? 


### Screenshots

### Detailed test instructions:

-   Checkout branch
-   `npm run test:php`
- Ensure all tests pass
- You can also run just the added tests with `npm run test:php -- --group tasklist`
