### PR TITLE
Update WC requires/tested versions

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -11,8 +11,8 @@
  * Requires at least: 5.4
  * Requires PHP: 7.0
  *
- * WC requires at least: 4.8.0
- * WC tested up to: 5.7.1
+ * WC requires at least: 5.6.0
+ * WC tested up to: 5.8.0
  *
  * @package WooCommerce\Admin
  */


### PR DESCRIPTION
This PR updates the minimum version of WC to the upcoming L-2 for the WooCommerce 5.8 release (so, WooCommerce 5.6 is the minimum) and the tested up to version of WC to WooCommerce 5.8.


### Detailed test instructions:

-   Verify versions are correct

No changelog required.