### PR TITLE
OBW - Fix WooCommerce Payments installation footnote visibility

### DIFF
--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -40,10 +40,20 @@ export class ProductTypes extends Component {
 			error: null,
 			isMonthlyPricing: true,
 			selected: profileItems.product_types || defaultProductTypes,
+			isWCPayInstalled: false,
 		};
 
 		this.onContinue = this.onContinue.bind( this );
 		this.onChange = this.onChange.bind( this );
+	}
+
+	componentDidMount() {
+		const { installedPlugins = [] } = this.props;
+		this.setState( {
+			isWCPayInstalled: installedPlugins.includes(
+				'woocommerce-payments'
+			),
+		} );
 	}
 
 	validateField() {
@@ -132,12 +142,13 @@ export class ProductTypes extends Component {
 
 	render() {
 		const { productTypes = {} } = getSetting( 'onboarding', {} );
-		const { error, isMonthlyPricing, selected } = this.state;
 		const {
-			installedPlugins = [],
-			isInstallingActivating,
-			isProfileItemsRequesting,
-		} = this.props;
+			error,
+			isMonthlyPricing,
+			isWCPayInstalled,
+			selected,
+		} = this.state;
+		const { isInstallingActivating, isProfileItemsRequesting } = this.props;
 
 		return (
 			<div className="woocommerce-profile-wizard__product-types">
@@ -241,7 +252,7 @@ export class ProductTypes extends Component {
 					</Text>
 					{ window.wcAdminFeatures &&
 						window.wcAdminFeatures.subscriptions &&
-						! installedPlugins.includes( 'woocommerce-payments' ) &&
+						! isWCPayInstalled &&
 						selected.includes( 'subscriptions' ) && (
 							<Text
 								variant="body"

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -40,7 +40,7 @@ export class ProductTypes extends Component {
 			error: null,
 			isMonthlyPricing: true,
 			selected: profileItems.product_types || defaultProductTypes,
-			isWCPayInstalled: false,
+			isWCPayInstalled: null,
 		};
 
 		this.onContinue = this.onContinue.bind( this );
@@ -48,12 +48,16 @@ export class ProductTypes extends Component {
 	}
 
 	componentDidMount() {
-		const { installedPlugins = [] } = this.props;
-		this.setState( {
-			isWCPayInstalled: installedPlugins.includes(
-				'woocommerce-payments'
-			),
-		} );
+		const { installedPlugins } = this.props;
+		const { isWCPayInstalled } = this.state;
+
+		if ( isWCPayInstalled === null && installedPlugins ) {
+			this.setState( {
+				isWCPayInstalled: installedPlugins.includes(
+					'woocommerce-payments'
+				),
+			} );
+		}
 	}
 
 	validateField() {


### PR DESCRIPTION
This is a follow-up to [PR 7734](https://github.com/woocommerce/woocommerce-admin/pull/7734) to fix the `WooCommerce Payments` installation footnote visibility.

No changelog is necessary.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-one wordpress test-2021 10 05-16_59_57](https://user-images.githubusercontent.com/1314156/136095022-0773ca19-0ee2-485a-b59a-8a230a94383c.png)


### Detailed test instructions:

- Checkout this branch.
- Remove `WooCommerce Payments` plugin.
- Go to the 3rd step of the OBW (`Product Types`) and select `Subscriptions`.
- The following text will be added at the bottom:
```
The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature
```
- Press `Continue`.
- Verify that the text is visible until the next OBW step (`Business Details`) is loaded.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
