### PR TITLE
Add testing instructions to 7445

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -8,7 +8,7 @@
 
 1. Deactivate and delete `WooCommerce Payments` if you have it installed.
 2. Go to the 3rd step of the store profiler (`Product Types`).
-3. Verify `Subscriptions` is shown as paid extension (with a price chip).
+3. Verify `Subscriptions` is shown as a paid extension (with a price chip).
 4. Check `Subscriptions` and continue with the OBW.
 5. Go back to the `Home` screen. Check that the task item `Add Subscriptions to my store` is visible in the setup task list.
 6. Press `Add my products` in the setup task list.

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.8.0
+
 ### Store Profiler and Product task - include Subscriptions #7734
 
 ##### Feature: turned off

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,5 +1,49 @@
 # Testing instructions
 
+## Unreleased
+
+### Store Profiler and Product task - include Subscriptions #7734
+
+##### Feature: turned off
+
+1. Deactivate and delete `WooCommerce Payments` if you have it installed.
+2. Go to the 3rd step of the store profiler (`Product Types`).
+3. Verify `Subscriptions` is shown as paid extension (with a price chip).
+4. Check `Subscriptions` and continue with the OBW.
+5. Go back to the `Home` screen. Check that the task item `Add Subscriptions to my store` is visible in the setup task list.
+6. Press `Add my products` in the setup task list.
+7. Select `Start with a template`. Verify that the option `Subscription product` is not visible in the popup.
+
+##### Feature: turned on
+
+1. Install and activate this plugin to turn on the subscriptions inclusion -> https://gist.github.com/octaedro/455eb4c85887608c253249bad533ccb3
+2. Deactivate and delete `WooCommerce Payments` if you have it installed.
+3. Go to the 3rd step of the store profiler (`Product Types`).
+4. Verify `Subscriptions` is shown as free (without a price chip). Also, verify that the text
+
+```
+The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature
+```
+
+is visible at the bottom when `WooCommerce Payments` is not installed.
+
+![screenshot-one wordpress test-2021 09 30-14_12_58](https://user-images.githubusercontent.com/1314156/135506696-b7812f7e-437f-4d89-956a-b73248f70f6b.png)
+
+5. Press `Continue` and verify that the `WooCommerce Payments` plugin is installed and activated and it's not shown in the `Free features` list
+
+![screenshot-one wordpress test-2021 09 30-14_32_20](https://user-images.githubusercontent.com/1314156/135506727-d8888f2b-3424-4cf5-a4bf-b67a14a198b6.png)
+
+6. Go back to the `Home` screen. Check that the task item `Add Subscriptions to my store` is not visible in the setup task list.
+
+![screenshot-one wordpress test-2021 09 30-14_39_28](https://user-images.githubusercontent.com/1314156/135506770-91571f8f-2e2e-43a7-b092-b9e5fdf56df8.png)
+
+7. Press `Add my products` in the setup task list.
+8. Select `Start with a template`. Verify that the option `Subscription product` is visible in the popup
+
+![screenshot-one wordpress test-2021 09 30-14_35_22](https://user-images.githubusercontent.com/1314156/135506748-0b7bdce5-b006-47f9-9289-03ed26e4950c.png)
+
+9. Select `Subscription product` and press `Ok`. You should have been redirected to `post-new.php?post_type=product&subscription_pointers=true`
+
 ## 2.7.1
 
 ### Add Newsletter Signup #7601


### PR DESCRIPTION
This is a follow-up to PR [7734](https://github.com/woocommerce/woocommerce-admin/pull/7734) to add testing instructions.

No changelog is necessary.

### Detailed test instructions:

-   Verify that the testing instructions are correct.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
