### PR TITLE
Bump admin-e2e-tests version to 0.1.2

### DIFF
--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.2
+
 -   Add Customers to analytics pages tested #7573
 -   Add `waitForTimeout` utility function #7572
 -   Update analytics overview tests to allow re-running the tests.

--- a/packages/admin-e2e-tests/package.json
+++ b/packages/admin-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-e2e-tests",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"author": "Automattic",
 	"description": "E2E tests for the new WooCommerce interface.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/admin-e2e-tests/README.md",


### PR DESCRIPTION
Bump admin-e2e-tests to 0.1.2 prior to publishing to npm

No changelog