### PR TITLE
Fix typescript type error in admin-e2e-tests package

### DIFF
--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Fix typescript type error in admin-e2e-tests package #7765
+
 # 0.1.2
 
 -   Add Customers to analytics pages tested #7573

--- a/packages/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/admin-e2e-tests/src/pages/BasePage.ts
@@ -139,12 +139,12 @@ export abstract class BasePage {
 				waitUntil: 'networkidle0',
 				timeout: 10000,
 			} );
-		} catch ( e: unknown ) {
-			throw new Error(
-				`Could not navigate to url: ${ fullUrl } with error: ${
-					( e as Error )?.message
-				}`
-			);
+		} catch ( e ) {
+			if ( e instanceof Error ) {
+				throw new Error(
+					`Could not navigate to url: ${ fullUrl } with error: ${ e.message }`
+				);
+			}
 		}
 	}
 }

--- a/packages/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/admin-e2e-tests/src/pages/BasePage.ts
@@ -139,9 +139,11 @@ export abstract class BasePage {
 				waitUntil: 'networkidle0',
 				timeout: 10000,
 			} );
-		} catch ( e ) {
+		} catch ( e: unknown ) {
 			throw new Error(
-				`Could not navigate to url: ${ fullUrl } with error: ${ e.message }`
+				`Could not navigate to url: ${ fullUrl } with error: ${
+					( e as Error )?.message
+				}`
 			);
 		}
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3747241/136325040-561e161d-f376-4d89-933f-3dab72105c09.png)

This PR fixes typescript type error during build in admin-e2e-tests package, shown in above screenshot.

### Detailed test instructions:

- In your terminal, go to `packages/admin-e2e-tests`
- Run `npm run build`
- Observe no build errors

No changelog