### PR TITLE
Add sort_by config option to the sort_tasks method

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -124,21 +124,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'get_tasks' ),
 					'permission_callback' => array( $this, 'get_tasks_permission_check' ),
-					'args'                => array(
-						'extended_tasks' => array(
-							'description'       => __( 'List of extended deprecated tasks from the client side filter.', 'woocommerce-admin' ),
-							'type'              => 'array',
-							'validate_callback' => function( $param, $request, $key ) {
-								$has_valid_keys = true;
-								foreach ( $param as $task ) {
-									if ( $has_valid_keys ) {
-										$has_valid_keys = array_key_exists( 'list_id', $task ) && array_key_exists( 'id', $task );
-									}
-								}
-								return $has_valid_keys;
-							},
-						),
-					),
+					'args'                => $this->get_task_list_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -738,6 +724,29 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		);
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for task lists.
+	 *
+	 * @return array
+	 */
+	public function get_task_list_params() {
+		$params                   = array();
+		$params['extended_tasks'] = array(
+			'description'       => __( 'List of extended deprecated tasks from the client side filter.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'validate_callback' => function( $param, $request, $key ) {
+				$has_valid_keys = true;
+				foreach ( $param as $task ) {
+					if ( $has_valid_keys ) {
+						$has_valid_keys = array_key_exists( 'list_id', $task ) && array_key_exists( 'id', $task );
+					}
+				}
+				return $has_valid_keys;
+			},
+		);
+		return $params;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -437,4 +437,31 @@ class Task {
 		return in_array( $id, $actioned, true );
 	}
 
+	/**
+	 * Sorting function for tasks.
+	 *
+	 * @param Task  $a Task a.
+	 * @param Task  $b Task b.
+	 * @param array $sort_by list of columns with sort order.
+	 * @return int
+	 */
+	public static function sort( $a, $b, $sort_by = array() ) {
+		$result = 0;
+		foreach ( $sort_by as $data ) {
+			$key   = $data['key'];
+			$a_val = $a->$key ?? false;
+			$b_val = $b->$key ?? false;
+			if ( 'asc' === $data['order'] ) {
+				$result = $a_val <=> $b_val;
+			} else {
+				$result = $b_val <=> $a_val;
+			}
+
+			if ( 0 !== $result ) {
+				break;
+			}
+		}
+		return $result;
+	}
+
 }

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -173,7 +173,7 @@ class Task {
 			'action_url'      => null,
 			'is_complete'     => false,
 			'can_view'        => true,
-			'level'           => null,
+			'level'           => 3,
 			'time'            => null,
 			'is_dismissable'  => false,
 			'is_snoozeable'   => false,

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -206,39 +206,20 @@ class TaskList {
 	/**
 	 * Sorts the attached tasks array.
 	 *
+	 * @param array $sort_by list of columns with sort order.
 	 * @return TaskList returns $this, for chaining.
 	 */
-	public function sort_tasks() {
-		if ( 0 !== count( $this->sort_by ) ) {
-			usort( $this->tasks, array( $this, 'sort' ) );
+	public function sort_tasks( $sort_by = array() ) {
+		$sort_by = count( $sort_by ) > 0 ? $sort_by : $this->sort_by;
+		if ( 0 !== count( $sort_by ) ) {
+			usort(
+				$this->tasks,
+				function( $a, $b ) use ( $sort_by ) {
+					return Task::sort( $a, $b, $sort_by );
+				}
+			);
 		}
 		return $this;
-	}
-
-	/**
-	 * Sorting function for tasks.
-	 *
-	 * @param Task $a Task a.
-	 * @param Task $b Task b.
-	 * @return int
-	 */
-	private function sort( $a, $b ) {
-		$result = 0;
-		foreach ( $this->sort_by as $data ) {
-			$key   = $data['key'];
-			$a_val = $a->$key ?? false;
-			$b_val = $b->$key ?? false;
-			if ( 'asc' === $data['order'] ) {
-				$result = $a_val <=> $b_val;
-			} else {
-				$result = $b_val <=> $a_val;
-			}
-
-			if ( 0 !== $result ) {
-				break;
-			}
-		}
-		return $result;
 	}
 
 	/**

--- a/tests/features/onboarding-tasks/task-list.php
+++ b/tests/features/onboarding-tasks/task-list.php
@@ -191,6 +191,7 @@ class WC_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 		$this->assertContains( 'isComplete', $json['tasks'][0] );
 	}
 
+	/**
 	 * Adds a couple tasks to the provided list.
 	 *
 	 * @param TaskList $list list to add tasks to.

--- a/tests/features/onboarding-tasks/task-list.php
+++ b/tests/features/onboarding-tasks/task-list.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
  * class WC_Tests_OnboardingTasks_TaskList
  */
 class WC_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
+
 	/**
 	 * Task list.
 	 *
@@ -190,4 +191,129 @@ class WC_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 		$this->assertContains( 'isComplete', $json['tasks'][0] );
 	}
 
+	 * Adds a couple tasks to the provided list.
+	 *
+	 * @param TaskList $list list to add tasks to.
+	 */
+	public function add_test_tasks( $list ) {
+		$list->add_task(
+			array(
+				'id'          => 'task-1',
+				'can_view'    => true,
+				'level'       => 1,
+				'is_complete' => true,
+			)
+		);
+		$list->add_task(
+			array(
+				'id'          => 'task-2',
+				'can_view'    => true,
+				'is_complete' => false,
+			)
+		);
+		$list->add_task(
+			array(
+				'id'          => 'task-3',
+				'can_view'    => true,
+				'level'       => 2,
+				'is_complete' => false,
+			)
+		);
+		$list->add_task(
+			array(
+				'id'          => 'task-4',
+				'can_view'    => true,
+				'level'       => 1,
+				'is_complete' => false,
+			)
+		);
+	}
+
+	/**
+	 * Test task list sort_tasks without sort_by config.
+	 */
+	public function test_sort_tasks_without_sort_by() {
+		$this->add_test_tasks( $this->list );
+		$this->list->sort_tasks();
+		$json = $this->list->get_json();
+		$this->assertEquals( array_column( $json['tasks'], 'id' ), array( 'task-1', 'task-2', 'task-3', 'task-4' ) );
+	}
+
+	/**
+	 * Test task list sort_tasks with sort_by config for is_complete.
+	 */
+	public function test_sort_tasks_with_sort_by() {
+		$list = new TaskList(
+			array(
+				'id'      => 'setup',
+				'sort_by' => array(
+					array(
+						'key'   => 'is_complete',
+						'order' => 'asc',
+					),
+				),
+			)
+		);
+		$this->add_test_tasks( $list );
+		$list->sort_tasks();
+		$json = $list->get_json();
+		$this->assertEquals( $json['tasks'][3]['id'], 'task-1' );
+	}
+
+	/**
+	 * Test task list sort_tasks with sort_by config for is_complete and level.
+	 */
+	public function test_sort_tasks_with_sort_by_multiple_items() {
+		$list = new TaskList(
+			array(
+				'id'      => 'setup',
+				'sort_by' => array(
+					array(
+						'key'   => 'is_complete',
+						'order' => 'asc',
+					),
+					array(
+						'key'   => 'level',
+						'order' => 'asc',
+					),
+				),
+			)
+		);
+		$this->add_test_tasks( $list );
+		$list->sort_tasks();
+		$json = $list->get_json();
+		$this->assertEquals( array_column( $json['tasks'], 'id' ), array( 'task-4', 'task-3', 'task-2', 'task-1' ) );
+	}
+
+	/**
+	 * Test task list sort_tasks with custom config.
+	 */
+	public function test_sort_tasks_with_passed_in_sort_by_config() {
+		$list = new TaskList(
+			array(
+				'id'      => 'setup',
+				'sort_by' => array(
+					array(
+						'key'   => 'is_complete',
+						'order' => 'asc',
+					),
+					array(
+						'key'   => 'level',
+						'order' => 'asc',
+					),
+				),
+			)
+		);
+		$this->add_test_tasks( $list );
+		$list->sort_tasks(
+			array(
+				array(
+					'key'   => 'level',
+					'order' => 'desc',
+				),
+			)
+		);
+		$json = $list->get_json();
+		$this->assertEquals( array_column( $json['tasks'], 'id' ), array( 'task-2', 'task-3', 'task-1', 'task-4' ) );
+	}
 }

--- a/tests/features/onboarding-tasks/task.php
+++ b/tests/features/onboarding-tasks/task.php
@@ -223,5 +223,145 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		$this->assertContains( $task->id, $actioned );
 	}
 
+	/**
+	 * Test task sort with empty config.
+	 */
+	public function test_sort_with_empty_sort_by_config() {
+		$task_a = new Task(
+			array(
+				'id' => 'a',
+			)
+		);
+		$task_b = new Task(
+			array(
+				'id' => 'b',
+			)
+		);
+		$result = Task::sort( $task_a, $task_b );
+		$this->assertEquals( 0, $result );
+	}
+
+	/**
+	 * Test task sort with config with invalid key.
+	 */
+	public function test_sort_with_sort_by_config_with_invalid_key() {
+		$task_a = new Task(
+			array(
+				'id' => 'a',
+			)
+		);
+		$task_b = new Task(
+			array(
+				'id' => 'b',
+			)
+		);
+		$result = Task::sort(
+			$task_a,
+			$task_b,
+			array(
+				array(
+					'key'   => 'invalid',
+					'order' => 'asc',
+				),
+			)
+		);
+		$this->assertEquals( 0, $result );
+	}
+
+	/**
+	 * Test task sort with config with valid key asc.
+	 */
+	public function test_sort_with_sort_by_config_with_valid_key_asc() {
+		$task_a = new Task(
+			array(
+				'id'    => 'a',
+				'level' => 1,
+			)
+		);
+		$task_b = new Task(
+			array(
+				'id'    => 'b',
+				'level' => 2,
+			)
+		);
+		$result = Task::sort(
+			$task_a,
+			$task_b,
+			array(
+				array(
+					'key'   => 'level',
+					'order' => 'asc',
+				),
+			)
+		);
+		$this->assertEquals( -1, $result );
+	}
+
+	/**
+	 * Test task sort with config with valid key desc.
+	 */
+	public function test_sort_with_sort_by_config_with_valid_key_desc() {
+		$task_a = new Task(
+			array(
+				'id'    => 'a',
+				'level' => 1,
+			)
+		);
+		$task_b = new Task(
+			array(
+				'id'    => 'b',
+				'level' => 2,
+			)
+		);
+		$result = Task::sort(
+			$task_a,
+			$task_b,
+			array(
+				array(
+					'key'   => 'level',
+					'order' => 'desc',
+				),
+			)
+		);
+		$this->assertEquals( 1, $result );
+	}
+
+	/**
+	 * Test task sort with config with multiple keys.
+	 */
+	public function test_sort_with_sort_by_config_with_multiple_keys() {
+		$task_a  = new Task(
+			array(
+				'id'          => 'a',
+				'level'       => 2,
+				'is_complete' => false,
+			)
+		);
+		$task_b  = new Task(
+			array(
+				'id'          => 'b',
+				'level'       => 2,
+				'is_complete' => true,
+			)
+		);
+		$sort_by = array(
+			array(
+				'key'   => 'level',
+				'order' => 'asc',
+			),
+			array(
+				'key'   => 'is_complete',
+				'order' => 'asc',
+			),
+		);
+		$result  = Task::sort( $task_a, $task_b, $sort_by );
+		// Given levels are the same it should return the comparison of is_complete.
+		$this->assertEquals( -1, $result );
+
+		$task_a->is_complete = true;
+		$result              = Task::sort( $task_a, $task_b, $sort_by );
+		// Given levels are the same it should return the comparison of is_complete.
+		$this->assertEquals( 0, $result );
+	}
 }
 


### PR DESCRIPTION
Allow the sort_by config to be overwritten when calling the sort function.

These changes were suggested in this PR https://github.com/woocommerce/woocommerce-admin/pull/7749

No changelog necessary

### Screenshots

### Detailed test instructions:

- Load this branch and install the Google Listings & Ads plugin ( available under the marketing tools task)
- Run `npm run example -- --ext=add-task` locally and enable the **WooCommerce Admin add task** plugin
- Add another task with a different `key` to [the example](https://github.com/woocommerce/woocommerce-admin/blob/main/docs/examples/extensions/add-task/js/index.js) with `level: 1` and make sure it shows up at the top of the list.
- Then update the Example task, setting `completed` to `true`, and make sure it's displayed at the bottom of the list now.
- The main task list should not be affected by this sorting.

