### PR TITLE
Add waits to make E2E tests more robust

### DIFF
--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Make unchecking free features more robust. #7761
+
 # 0.1.2
 
 -   Add Customers to analytics pages tested #7573

--- a/packages/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/admin-e2e-tests/src/pages/BasePage.ts
@@ -9,7 +9,7 @@ import { ElementHandle, Page } from 'puppeteer';
 import { DropdownField } from '../elements/DropdownField';
 import { DropdownTypeaheadField } from '../elements/DropdownTypeaheadField';
 import { FormToggle } from '../elements/FormToggle';
-import { getElementByText } from '../utils/actions';
+import { getElementByText, waitForTimeout } from '../utils/actions';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const config = require( 'config' );
@@ -99,6 +99,7 @@ export abstract class BasePage {
 		// Uncheck all checkboxes, to avoid installing plugins
 		for ( const checkbox of checkboxes ) {
 			await this.toggleCheckbox( checkbox, false );
+			await waitForTimeout( 200 );
 		}
 	}
 
@@ -107,6 +108,7 @@ export abstract class BasePage {
 		// Uncheck all checkboxes, to avoid installing plugins
 		for ( const checkbox of checkboxes ) {
 			await this.toggleCheckbox( checkbox, true );
+			await waitForTimeout( 200 );
 		}
 	}
 

--- a/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
+++ b/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
@@ -87,6 +87,7 @@ export class WcHomescreen extends BasePage {
 		);
 		await taskListOptions?.click();
 		await waitForElementByText( 'button', 'Hide this' );
+		await waitForTimeout( 200 ); // Transition of popup.
 		const hideThisButton = await getElementByText( 'button', 'Hide this' );
 		await hideThisButton?.click();
 		await waitForTimeout( 500 );


### PR DESCRIPTION
I added waits in two places, reasoning below:
**uncheck checkboxes** - It appeared that sometimes the free extensions weren't unselected and Jetpack was still installed, I added a timeout as we loop through the checkboxes, given the first checkbox technically de-selects all of them. I think there might of been a timing issue between when the checkbox was unchecked and when we get the last value of the checkbox, the timing might help with this.

**Hide tasklist** - When we click on the 3 dot menu, there is a short animation before the **Hide this** becomes available, I think this animation prevented the `click` on **Hide this** to happen at times.

No changelog as it is in the package.

### Detailed test instructions:

-   Make sure the E2E tests are passing in Github actions