### PR TITLE
Use action to verify appearance task completion

### DIFF
--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -91,7 +91,7 @@ class Appearance extends Component {
 		}
 	}
 
-	completeStep() {
+	async completeStep() {
 		const { stepIndex } = this.state;
 		const { actionTask, onComplete } = this.props;
 		const nextStep = this.getSteps()[ stepIndex + 1 ];
@@ -99,7 +99,8 @@ class Appearance extends Component {
 		if ( nextStep ) {
 			this.setState( { stepIndex: stepIndex + 1 } );
 		} else {
-			actionTask( 'appearance' );
+			this.setState( { isPending: true } );
+			await actionTask( 'appearance' );
 			onComplete();
 		}
 	}

--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -93,12 +93,13 @@ class Appearance extends Component {
 
 	completeStep() {
 		const { stepIndex } = this.state;
-		const { onComplete } = this.props;
+		const { actionTask, onComplete } = this.props;
 		const nextStep = this.getSteps()[ stepIndex + 1 ];
 
 		if ( nextStep ) {
 			this.setState( { stepIndex: stepIndex + 1 } );
 		} else {
+			actionTask( 'appearance' );
 			onComplete();
 		}
 	}
@@ -234,7 +235,6 @@ class Appearance extends Component {
 
 		this.setState( { isUpdatingNotice: true } );
 		const update = await updateOptions( {
-			woocommerce_task_list_appearance_complete: true,
 			woocommerce_demo_store: storeNoticeText.length ? 'yes' : 'no',
 			woocommerce_demo_store_notice: storeNoticeText,
 		} );
@@ -432,11 +432,12 @@ const AppearanceWrapper = compose(
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
 		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
-		const { invalidateResolutionForStoreSelector } = dispatch(
+		const { actionTask, invalidateResolutionForStoreSelector } = dispatch(
 			ONBOARDING_STORE_NAME
 		);
 
 		return {
+			actionTask,
 			clearTaskStatusCache: () =>
 				invalidateResolutionForStoreSelector( 'getTasksStatus' ),
 			createNotice,

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -8,6 +8,7 @@
  */
 
 use \Automattic\WooCommerce\Admin\Install as Installer;
+use \Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
 use \Automattic\WooCommerce\Admin\Notes\UnsecuredReportFiles;
 use \Automattic\WooCommerce\Admin\Notes\DeactivatePlugin;
@@ -293,4 +294,25 @@ function wc_admin_update_280_order_status() {
  */
 function wc_admin_update_280_db_version() {
 	Installer::update_db_version( '2.8.0' );
+}
+
+/**
+ * Update the old task list options.
+ */
+function wc_admin_update_290_update_apperance_task_option() {
+	$is_actioned = get_option( 'woocommerce_task_list_appearance_complete', false );
+
+	$task = TaskLists::get_task( 'appearance' );
+	if ( $task && $is_actioned ) {
+		$task->mark_actioned();
+	}
+
+	delete_option( 'woocommerce_task_list_appearance_complete' );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_290_db_version() {
+	Installer::update_db_version( '2.9.0' );
 }

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -427,4 +427,15 @@ class Task {
 		return in_array( $this->id, $actioned, true );
 	}
 
+	/**
+	 * Check if a provided task ID has been actioned.
+	 *
+	 * @param string $id Task ID.
+	 * @return bool
+	 */
+	public static function is_task_actioned( $id ) {
+		$actioned = get_option( self::ACTIONED_OPTION, array() );
+		return in_array( $id, $actioned, true );
+	}
+
 }

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -423,8 +423,7 @@ class Task {
 	 * @return bool
 	 */
 	public function is_actioned() {
-		$actioned = get_option( self::ACTIONED_OPTION, array() );
-		return in_array( $this->id, $actioned, true );
+		return self::is_task_actioned( $this->id );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -31,7 +31,7 @@ class Appearance {
 				'woocommerce-admin'
 			),
 			'action_label' => __( "Let's go", 'woocommerce-admin' ),
-			'is_complete'  => get_option( 'woocommerce_task_list_appearance_complete' ),
+			'is_complete'  => Task::is_task_actioned( 'appearance' ),
 			'can_view'     => true,
 			'time'         => __( '2 minutes', 'woocommerce-admin' ),
 		);

--- a/src/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/src/Features/OnboardingTasks/Tasks/Marketing.php
@@ -81,8 +81,7 @@ class Marketing {
 		}
 
 		// Make sure the task has been actioned and at least one extension is installed.
-		$task = new Task( array( 'id' => 'marketing' ) );
-		if ( count( $installed ) > 0 && $task->is_actioned() ) {
+		if ( count( $installed ) > 0 && Task::is_task_actioned( 'marketing' ) ) {
 			return true;
 		}
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -69,6 +69,10 @@ class Install {
 			'wc_admin_update_280_order_status',
 			'wc_admin_update_280_db_version',
 		),
+		'2.9.0'  => array(
+			'wc_admin_update_290_update_apperance_task_option',
+			'wc_admin_update_290_db_version',
+		),
 	);
 
 	/**


### PR DESCRIPTION
Fixes #7750

Updates the appearance task to use the "actioned" option on tasks.

cc @louwie17 In the previous task list it looks like skipping the logo still required hitting "Complete task" to mark the task complete on the notice step.  Could you confirm this is the case or was there an even older version where this happened?

### Screenshots
![Screen Shot 2021-10-07 at 1 42 19 PM](https://user-images.githubusercontent.com/10561050/136436132-942991fd-f2f1-43b0-8c1c-bc7a97b9da7b.png)



### Detailed test instructions:

1. Before this branch, complete the appearance task so that the `woocommerce_task_list_appearance_complete` option exists in your database.
1. Reduce your `woocommerce_admin_version` in your database to `2.8.0` or lower to trigger migrations.
2. Check that `woocommerce_task_list_appearance_complete` is removed and that `woocommerce_task_list_tracked_completed_actions` is now an array including `appearance`
3. Delete `woocommerce_task_list_tracked_completed_actions`
4. Navigate to the task list and note that the appearance task is complete
5. Walk through the task, completing it
6. Note that the appearance task is complete and remains complete on refresh