### PR TITLE
Sync changelog from 2.8.0-rc.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
-== 2.8.0 09/29/2021 ==
+== 2.8.0 10/06/2021 ==
 
+- Fix: Allow already installed marketing extensions to be activated #7740
 - Fix: Add missing title text for marketing task. #7640
 - Fix: Assign parent order status as children order status if refund order #7253
 - Fix: Fix category lookup logic to update children correctly. #7709
@@ -10,11 +11,11 @@
 - Update: Enable Square in France. #7679
 - Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. #7666
 
-== 2.7.2 10/11/2021 == 
+== 2.7.2 10/11/2021 ==
 
 - Fix: Fix analytics crashing on daylight saving #7763
 
-== 2.7.1 10/01/2021 == 
+== 2.7.1 10/01/2021 ==
 
 - Fix: Allow super admins all capabilities within WooCommerce Admin #7489
 - Fix: Fix end date for last periods #6584

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 == 2.8.0 10/06/2021 ==
 
+- Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743
 - Fix: Allow already installed marketing extensions to be activated #7740
 - Fix: Add missing title text for marketing task. #7640
 - Fix: Assign parent order status as children order status if refund order #7253

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-== 2.8.0 10/12/2021 ==
+== 2.8.0 10/14/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
 - Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771
@@ -10,6 +10,7 @@
 - Fix: Fixing an unwanted page refresh when using Woo Navigation. #7615
 - Fix: Fix naming of event names and properties. #7677
 - Fix: Fix white screen for variation analytic data without a name. #7686
+- Update: Update back up copy of free extension for Google Listing & Ads plugin. #7798
 - Update: Update Eway payment gateway capitalization (was eWAY). #7678
 - Update: Enable Square in France. #7679
 - Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. #7666

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
-== 2.8.0 10/06/2021 ==
+== 2.8.0 10/12/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
+- Fix: Fix analytics crashing on daylight saving #7763
+- Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771
 - Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743
 - Fix: Allow already installed marketing extensions to be activated #7740
 - Fix: Add missing title text for marketing task. #7640

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 == 2.8.0 10/06/2021 ==
 
+- Add: Store Profiler and Product task - include Subscriptions #7734
 - Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743
 - Fix: Allow already installed marketing extensions to be activated #7740
 - Fix: Add missing title text for marketing task. #7640

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 == 2.8.0 10/12/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
-- Fix: Fix analytics crashing on daylight saving #7763
 - Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771
 - Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743
 - Fix: Allow already installed marketing extensions to be activated #7740

--- a/changelogs/add-7445_include_subscriptions
+++ b/changelogs/add-7445_include_subscriptions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Store Profiler and Product task - include Subscriptions #7734

--- a/changelogs/fix-7690
+++ b/changelogs/fix-7690
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Allow already installed marketing extensions to be activated #7740

--- a/changelogs/fix-7741_dismiss_all_notes
+++ b/changelogs/fix-7741_dismiss_all_notes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743

--- a/changelogs/fix-nav-style
+++ b/changelogs/fix-nav-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fixed navigation menu text color after Gutenberg 11.6.0 #7771

--- a/changelogs/update-7796_google_listing_copy
+++ b/changelogs/update-7796_google_listing_copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Update back up copy of free extension for Google Listing & Ads plugin. #7798


### PR DESCRIPTION
This PR syncs the changelog from `2.8.0-rc.2` back to `main`.

## Testing instructions

1. Confidence check - make sure changelog changes look correct.

(no changelog is needed here)
