### PR TITLE
Sync changelog from 2.7.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,10 @@
 - Update: Enable Square in France. #7679
 - Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. #7666
 
+== 2.7.2 10/11/2021 == 
+
+- Fix: Fix analytics crashing on daylight saving #7763
+
 == 2.7.1 10/01/2021 == 
 
 - Fix: Allow super admins all capabilities within WooCommerce Admin #7489

--- a/changelogs/fix-7748-analytics-crashing-daylight-saving
+++ b/changelogs/fix-7748-analytics-crashing-daylight-saving
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix analytics crashing on daylight saving #7763


### PR DESCRIPTION
Syncs up the changelog from 2.7.2.

### Detailed test instructions:

Check that the changelog includes updates in 2.7.2 - https://github.com/woocommerce/woocommerce-admin/compare/release/2.7.1...release/2.7.2?expand=1

(No changelog required for this PR)