### PR TITLE
Add check before changing the state

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -215,8 +215,10 @@ export const SelectiveExtensionsBundle = ( {
 	}, [ freeExtensions, profileItems ] );
 
 	useEffect( () => {
-		const initialValues = createInitialValues( installableExtensions );
-		setValues( initialValues );
+		if ( ! isInstallingActivating ) {
+			const initialValues = createInitialValues( installableExtensions );
+			setValues( initialValues );
+		}
 	}, [ installableExtensions ] );
 
 	const getCheckboxChangeHandler = ( key ) => {


### PR DESCRIPTION
Fixes #7776

This PR fixes the error that showed "All extensions" as selected after clicking "Continue" on the "Free Features" screen in the OBW.

No changelog needed.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Capture on 2021-10-12 at 11-41-19](https://user-images.githubusercontent.com/1314156/136977919-97871237-2b0f-49dc-b18f-442aefe5fe8f.gif)


### Detailed test instructions:

- Go to step four of the OBW and press `Free features`.
- Press `Add recommended business features to my site` and unselect all.
- Select just one item (e.g. `Level up your email marketing with MailPoet`) and press `Continue`
- Verify that the selected items remain selected and that there aren't any new items selected.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
