### PR TITLE
Remove new tasks feature import to prevent duplicate fills

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -31,7 +31,6 @@ import { IntroModal as NavigationIntroModal } from '../navigation/components/int
 import StatsOverview from './stats-overview';
 import { StoreManagementLinks } from '../store-management-links';
 import TaskListPlaceholder from '../task-list/placeholder';
-import { TasksPlaceholder } from '../tasks';
 import {
 	WELCOME_MODAL_DISMISSED_OPTION_NAME,
 	WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME,
@@ -43,10 +42,6 @@ import '../dashboard/style.scss';
 
 const TaskList = lazy( () =>
 	import( /* webpackChunkName: "task-list" */ '../task-list' )
-);
-
-const Tasks = lazy( () =>
-	import( /* webpackChunkName: "tasks" */ '../tasks' )
 );
 
 export const Layout = ( {
@@ -118,14 +113,6 @@ export const Layout = ( {
 
 	const renderTaskList = () => {
 		const isSingleTask = Boolean( query.task );
-
-		if ( window.wcAdminFeatures && window.wcAdminFeatures.tasks ) {
-			return (
-				<Suspense fallback={ <TasksPlaceholder query={ query } /> }>
-					<Tasks query={ query } />
-				</Suspense>
-			);
-		}
 
 		return (
 			<Suspense


### PR DESCRIPTION
Removes the new tasks feature import.  Note that this entirely prevents the new task feature from running which is okay given 2.8.0 does not contain the tasks feature in its completed state.

### Detailed test instructions:

1. Load up this branch.
2. Toggle the `tasks` feature on/off
3. Open your console
4. Check that the task list in both scenarios does not trigger any errors about plugins already registered

No changelog needed