### PR TITLE
Update free extension copy of the google listings plugin

### DIFF
--- a/changelogs/update-7796_google_listing_copy
+++ b/changelogs/update-7796_google_listing_copy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Update
 
-Update back up copy of free extension. #7798
+Update back up copy of free extension for Google Listing & Ads plugin. #7798

--- a/changelogs/update-7796_google_listing_copy
+++ b/changelogs/update-7796_google_listing_copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update back up copy of free extension. #7798

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -348,8 +348,8 @@ class DefaultFreeExtensions {
 				'plugins' => [
 					[
 						'key'         => 'google-listings-and-ads',
-						'name'        => __( 'Google Ads & Marketing by Kliken', 'woocommerce-admin' ),
-						'description' => __( 'Get in front of shoppers and drive traffic so you can grow your business with Smart Shopping Campaigns and free listings.', 'woocommerce-admin' ),
+						'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+						'description' => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
 						'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
 						'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 					],


### PR DESCRIPTION
Fixes #7796 

Update copy of google listings plugin, should match:
Google Listings & Ads
Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.

### Screenshots

<img width="800" alt="Screen Shot 2021-10-13 at 11 29 19 AM" src="https://user-images.githubusercontent.com/2240960/137153519-dbd7d61e-b5e0-499e-86b8-136f1b360334.png">

### Detailed test instructions:

- On this PR change the DATA_SOURCES url in the [free extensions data source poller](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/RemoteFreeExtensions/DataSourcePoller.php#L16) to an invalid url, like: `https://woocommerce.borkt/...`
- Make sure the `woocommerce_admin_remote_free_extensions_specs` transient is deleted.
- Go to **WooCommerce > Home > Set up Marketing Tools** task
- Make sure the Google Listings plugin shows the correct copy (see description)

