### PR TITLE
Enable Subscriptions inclusion for every environment

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -15,7 +15,7 @@
 		"payment-gateway-suggestions": true,
 		"settings": false,
 		"shipping-label-banner": true,
-		"subscriptions": false,
+		"subscriptions": true,
 		"store-alerts": true,
 		"transient-notices": true,
 		"wc-pay-promotion": true

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -15,7 +15,7 @@
 		"payment-gateway-suggestions": true,
 		"settings": false,
 		"shipping-label-banner": true,
-		"subscriptions": false,
+		"subscriptions": true,
 		"store-alerts": true,
 		"transient-notices": true,
 		"wc-pay-promotion": true


### PR DESCRIPTION
This PR enables Subscriptions inclusion for every environment.

No changelog is necessary

### Detailed test instructions:

- Make a test build: `npm run test:zip`
- Try it on a brand new site (e.g.: a JN site).
- Verify the new Subscriptions inclusion is enabled by following [these testing instructions](https://github.com/woocommerce/woocommerce-admin/pull/7777#issue-1021403900).

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
