### PR TITLE
Add tests to Subscriptions inclusion

### DIFF
--- a/changelogs/7445_add_tests_to_subscriptions_inclusion
+++ b/changelogs/7445_add_tests_to_subscriptions_inclusion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Add tests to Subscriptions inclusion #7804

--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Unreleased
+
 -   Add E2E tests for checking store currency if it matches the onboarded country. #7712
 
 -   Make unchecking free features more robust. #7761
 
 -   Fix typescript type error in admin-e2e-tests package #7765
+
+-   Add extension deactivation util function addition. #7804
+
+-   Add tests to Subscriptions inclusion. #7804
 
 # 0.1.2
 

--- a/packages/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/admin-e2e-tests/src/pages/BasePage.ts
@@ -76,8 +76,17 @@ export abstract class BasePage {
 		await el?.click();
 	}
 
-	async setCheckboxWithLabel( labelText: string ) {
-		const checkbox = await getElementByText( 'label', labelText );
+	async clickElementWithText( element: string, text: string ) {
+		const el = await getElementByText( element, text );
+		await el?.click();
+	}
+
+	async setCheckboxWithText( text: string ) {
+		let checkbox = await getElementByText( 'label', text );
+
+		if ( ! checkbox ) {
+			checkbox = await getElementByText( 'span', text );
+		}
 
 		if ( checkbox ) {
 			const checkboxStatus = await (
@@ -88,9 +97,7 @@ export abstract class BasePage {
 				await checkbox.click();
 			}
 		} else {
-			throw new Error(
-				`Could not find checkbox with label "${ labelText }"`
-			);
+			throw new Error( `Could not find checkbox with text "${ text }"` );
 		}
 	}
 

--- a/packages/admin-e2e-tests/src/pages/OnboardingWizard.ts
+++ b/packages/admin-e2e-tests/src/pages/OnboardingWizard.ts
@@ -75,4 +75,8 @@ export class OnboardingWizard extends BasePage {
 			timeout: 4000,
 		} );
 	}
+
+	async goToOBWStep( step: string ) {
+		await this.clickElementWithText( 'span', step );
+	}
 }

--- a/packages/admin-e2e-tests/src/pages/ProductsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/ProductsSetup.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { waitForElementByText, getElementByText } from '../utils/actions';
+import { BasePage } from './BasePage';
+
+export class ProductsSetup extends BasePage {
+	url = 'wp-admin/admin.php?page=wc-admin&task=products';
+
+	async isDisplayed() {
+		await waitForElementByText( 'h1', 'Add products' );
+	}
+
+	async isStartWithATemplateDisplayed( templatesCount: number ) {
+		await waitForElementByText( 'h1', 'Start with a template' );
+		const length = await this.page.$$eval(
+			'.components-radio-control__input',
+			( items ) => items.length
+		);
+		expect( length === templatesCount ).toBeTruthy();
+	}
+
+	async clickStartWithTemplate() {
+		const startWithATemplate = await getElementByText(
+			'span',
+			'Start with a template'
+		);
+		await startWithATemplate?.click();
+	}
+}

--- a/packages/admin-e2e-tests/src/pages/ProductsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/ProductsSetup.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { waitForElementByText, getElementByText } from '../utils/actions';
+import { waitForElementByText } from '../utils/actions';
 import { BasePage } from './BasePage';
 
 export class ProductsSetup extends BasePage {
@@ -21,10 +21,6 @@ export class ProductsSetup extends BasePage {
 	}
 
 	async clickStartWithTemplate() {
-		const startWithATemplate = await getElementByText(
-			'span',
-			'Start with a template'
-		);
-		await startWithATemplate?.click();
+		await this.clickElementWithText( '*', 'Start with a template' );
 	}
 }

--- a/packages/admin-e2e-tests/src/pages/WcSettings.ts
+++ b/packages/admin-e2e-tests/src/pages/WcSettings.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getAttribute, waitForElementByText } from '../utils/actions';
+import { getAttribute, hasClass, waitForElementByText } from '../utils/actions';
 import { BasePage } from './BasePage';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -40,5 +40,23 @@ export class WcSettings extends BasePage {
 			'strong',
 			'Your settings have been saved.'
 		);
+	}
+
+	async cleanPaymentMethods() {
+		this.navigate( 'checkout' );
+		await waitForElementByText( 'h2', 'Payment methods' );
+		const paymentMethods = await page.$$( 'span.woocommerce-input-toggle' );
+		for ( const method of paymentMethods ) {
+			if (
+				method &&
+				( await hasClass(
+					method,
+					'woocommerce-input-toggle--enabled'
+				) )
+			) {
+				await method?.click();
+			}
+		}
+		await this.saveSettings();
 	}
 }

--- a/packages/admin-e2e-tests/src/sections/onboarding/IndustrySection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/IndustrySection.ts
@@ -32,6 +32,6 @@ export class IndustrySection extends BasePage {
 	}
 
 	async selectIndustry( industryLabel: string ) {
-		await this.setCheckboxWithLabel( industryLabel );
+		await this.setCheckboxWithText( industryLabel );
 	}
 }

--- a/packages/admin-e2e-tests/src/sections/onboarding/ProductTypesSection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/ProductTypesSection.ts
@@ -22,6 +22,6 @@ export class ProductTypeSection extends BasePage {
 	}
 
 	async selectProduct( productLabel: string ) {
-		await this.setCheckboxWithLabel( productLabel );
+		await this.setCheckboxWithText( productLabel );
 	}
 }

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -352,7 +352,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 };
 
 const testSubscriptionsInclusion = () => {
-	describe( 'A non US store will not see the Subscriptions inclusion', () => {
+	describe( 'A non-US store will not see the Subscriptions inclusion', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const login = new Login( page );
 
@@ -425,7 +425,7 @@ const testSubscriptionsInclusion = () => {
 			expect( tasks ).toContain( 'Add Subscriptions to my store' );
 		} );
 
-		it( 'can select the Subscription option in "Start with a template" modal', async () => {
+		it( 'can select the Subscription option in the "Start with a template" modal', async () => {
 			const productsSetup = new ProductsSetup( page );
 			await productsSetup.navigate();
 			await productsSetup.isDisplayed();
@@ -457,7 +457,7 @@ const testSubscriptionsInclusion = () => {
 			await profileWizard.optionallySelectUsageTracking();
 		} );
 
-		it( 'can complete the product types section, Subscriptions copy not visible', async () => {
+		it( 'can complete the product types section, the Subscriptions copy now is visible', async () => {
 			// Query for the industries checkboxes
 			await profileWizard.industry.isDisplayed();
 			await profileWizard.industry.uncheckIndustries();
@@ -488,7 +488,7 @@ const testSubscriptionsInclusion = () => {
 			await profileWizard.continue();
 		} );
 
-		it( 'can not see the WooCommerce Payments extension after been installed', async () => {
+		it( 'can not see the WooCommerce Payments extension after it has been installed', async () => {
 			await profileWizard.business.freeFeaturesIsDisplayed();
 			await profileWizard.business.expandRecommendedBusinessFeatures();
 
@@ -507,7 +507,7 @@ const testSubscriptionsInclusion = () => {
 			expect( tasks ).not.toContain( 'Add Subscriptions to my store' );
 		} );
 
-		it( 'can select the Subscription option in "Start with a template" modal', async () => {
+		it( 'can select the Subscription option in the "Start with a template" modal', async () => {
 			const productsSetup = new ProductsSetup( page );
 			await productsSetup.navigate();
 			await productsSetup.isDisplayed();

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -6,6 +6,8 @@ import { WcHomescreen } from '../../pages/WcHomescreen';
 import { TaskTitles } from '../../constants/taskTitles';
 import { Login } from '../../pages/Login';
 import { WcSettings } from '../../pages/WcSettings';
+import { ProductsSetup } from '../../pages/ProductsSetup';
+import { deactivateAndDeleteExtension } from '../../utils/actions';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const {
@@ -349,8 +351,175 @@ const testDifferentStoreCurrenciesWCPay = () => {
 	} );
 };
 
+const testSubscriptionsInclusion = () => {
+	describe( 'A non US store will not see the Subscriptions inclusion', () => {
+		const profileWizard = new OnboardingWizard( page );
+		const login = new Login( page );
+
+		beforeAll( async () => {
+			await login.login();
+		} );
+
+		it( 'can complete the store details section', async () => {
+			await profileWizard.navigate();
+			await profileWizard.storeDetails.completeStoreDetailsSection( {
+				countryRegionSubstring: 'fran',
+				countryRegionSelector: 'FR',
+				countryRegion: 'France',
+			} );
+
+			// Wait for "Continue" button to become active
+			await profileWizard.continue();
+
+			// Wait for usage tracking pop-up window to appear
+			await profileWizard.optionallySelectUsageTracking();
+		} );
+
+		it( 'can complete the product types section, Subscriptions copy is not visible', async () => {
+			// Query for the industries checkboxes
+			await profileWizard.industry.isDisplayed();
+			await profileWizard.industry.uncheckIndustries();
+			await profileWizard.industry.selectIndustry( 'Health and beauty' );
+			await profileWizard.continue();
+			await profileWizard.productTypes.isDisplayed( 7 );
+			await profileWizard.productTypes.uncheckProducts();
+			await profileWizard.productTypes.selectProduct( 'Subscriptions' );
+			await expect( page ).not.toMatchElement( 'p', {
+				text:
+					'The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature.',
+			} );
+
+			await profileWizard.continue();
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		} );
+
+		it( 'can complete the business details tab', async () => {
+			await profileWizard.business.isDisplayed();
+
+			await profileWizard.business.selectProductNumber(
+				config.get( 'onboardingwizard.numberofproducts' )
+			);
+			await profileWizard.business.selectCurrentlySelling(
+				config.get( 'onboardingwizard.sellingelsewhere' )
+			);
+
+			await profileWizard.continue();
+		} );
+
+		it( 'can not see the WooCommerce Payments extension after been installed', async () => {
+			await profileWizard.business.freeFeaturesIsDisplayed();
+			await profileWizard.business.expandRecommendedBusinessFeatures();
+
+			expect( page ).toMatchElement( 'a', {
+				text: 'WooCommerce Payments',
+			} );
+		} );
+
+		it( 'should display the task "Add Subscriptions to my store"', async () => {
+			await profileWizard.goToOBWStep( 'Store Details' );
+			await profileWizard.skipStoreSetup();
+			const homescreen = new WcHomescreen( page );
+			await homescreen.isDisplayed();
+			await homescreen.possiblyDismissWelcomeModal();
+			const tasks = await homescreen.getTaskList();
+			expect( tasks ).toContain( 'Add Subscriptions to my store' );
+		} );
+
+		it( 'can select the Subscription option in "Start with a template" modal', async () => {
+			const productsSetup = new ProductsSetup( page );
+			await productsSetup.navigate();
+			await productsSetup.isDisplayed();
+			await productsSetup.clickStartWithTemplate();
+			await productsSetup.isStartWithATemplateDisplayed( 3 );
+		} );
+	} );
+	describe( 'A US store will see the Subscriptions inclusion', () => {
+		const profileWizard = new OnboardingWizard( page );
+		const login = new Login( page );
+
+		afterAll( async () => {
+			await deactivateAndDeleteExtension( 'woocommerce-payments' );
+			await login.logout();
+		} );
+
+		it( 'can complete the store details section', async () => {
+			await profileWizard.navigate();
+			await profileWizard.storeDetails.completeStoreDetailsSection( {
+				countryRegionSubstring: 'cali',
+				countryRegionSelector: 'US\\:CA',
+				countryRegion: 'United States (US) — California',
+			} );
+
+			// Wait for "Continue" button to become active
+			await profileWizard.continue();
+
+			// Wait for usage tracking pop-up window to appear
+			await profileWizard.optionallySelectUsageTracking();
+		} );
+
+		it( 'can complete the product types section, Subscriptions copy not visible', async () => {
+			// Query for the industries checkboxes
+			await profileWizard.industry.isDisplayed();
+			await profileWizard.industry.uncheckIndustries();
+			await profileWizard.industry.selectIndustry( 'Health and beauty' );
+			await profileWizard.continue();
+			await profileWizard.productTypes.isDisplayed( 7 );
+			await profileWizard.productTypes.uncheckProducts();
+			await profileWizard.productTypes.selectProduct( 'Subscriptions' );
+			await expect( page ).toMatchElement( 'p', {
+				text:
+					'The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature.',
+			} );
+
+			await profileWizard.continue();
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		} );
+
+		it( 'can complete the business details tab', async () => {
+			await profileWizard.business.isDisplayed();
+
+			await profileWizard.business.selectProductNumber(
+				config.get( 'onboardingwizard.numberofproducts' )
+			);
+			await profileWizard.business.selectCurrentlySelling(
+				config.get( 'onboardingwizard.sellingelsewhere' )
+			);
+
+			await profileWizard.continue();
+		} );
+
+		it( 'can not see the WooCommerce Payments extension after been installed', async () => {
+			await profileWizard.business.freeFeaturesIsDisplayed();
+			await profileWizard.business.expandRecommendedBusinessFeatures();
+
+			expect( page ).not.toMatchElement( 'a', {
+				text: 'WooCommerce Payments',
+			} );
+		} );
+
+		it( 'should not display the task "Add Subscriptions to my store"', async () => {
+			await profileWizard.goToOBWStep( 'Store Details' );
+			await profileWizard.skipStoreSetup();
+			const homescreen = new WcHomescreen( page );
+			await homescreen.isDisplayed();
+			await homescreen.possiblyDismissWelcomeModal();
+			const tasks = await homescreen.getTaskList();
+			expect( tasks ).not.toContain( 'Add Subscriptions to my store' );
+		} );
+
+		it( 'can select the Subscription option in "Start with a template" modal', async () => {
+			const productsSetup = new ProductsSetup( page );
+			await productsSetup.navigate();
+			await productsSetup.isDisplayed();
+			await productsSetup.clickStartWithTemplate();
+			await productsSetup.isStartWithATemplateDisplayed( 4 );
+		} );
+	} );
+};
+
 module.exports = {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
 	testDifferentStoreCurrenciesWCPay,
+	testSubscriptionsInclusion,
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -406,7 +406,7 @@ const testSubscriptionsInclusion = () => {
 			await profileWizard.continue();
 		} );
 
-		it( 'can not see the WooCommerce Payments extension after been installed', async () => {
+		it( 'cannot see the WooCommerce Payments extension after it has been installed', async () => {
 			await profileWizard.business.freeFeaturesIsDisplayed();
 			await profileWizard.business.expandRecommendedBusinessFeatures();
 
@@ -488,7 +488,7 @@ const testSubscriptionsInclusion = () => {
 			await profileWizard.continue();
 		} );
 
-		it( 'can not see the WooCommerce Payments extension after it has been installed', async () => {
+		it( 'cannot see the WooCommerce Payments extension after it has been installed', async () => {
 			await profileWizard.business.freeFeaturesIsDisplayed();
 			await profileWizard.business.expandRecommendedBusinessFeatures();
 

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -406,7 +406,7 @@ const testSubscriptionsInclusion = () => {
 			await profileWizard.continue();
 		} );
 
-		it( 'cannot see the WooCommerce Payments extension after it has been installed', async () => {
+		it( 'should display the WooCommerce Payments extension after it has been installed', async () => {
 			await profileWizard.business.freeFeaturesIsDisplayed();
 			await profileWizard.business.expandRecommendedBusinessFeatures();
 

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -12,6 +12,7 @@ import { PaymentsSetup } from '../../pages/PaymentsSetup';
 import { WcHomescreen } from '../../pages/WcHomescreen';
 import { BankAccountTransferSetup } from '../../sections/payment-setup/BankAccountTransferSetup';
 import { waitForTimeout } from '../../utils/actions';
+import { WcSettings } from '../../pages/WcSettings';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
@@ -24,6 +25,7 @@ const testAdminPaymentSetupTask = () => {
 		const paymentsSetup = new PaymentsSetup( page );
 		const bankTransferSetup = new BankAccountTransferSetup( page );
 		const login = new Login( page );
+		const settings = new WcSettings( page );
 
 		beforeAll( async () => {
 			await login.login();
@@ -69,7 +71,13 @@ const testAdminPaymentSetupTask = () => {
 		} );
 
 		it( 'Enabling cash on delivery enables the payment method', async () => {
+			await settings.cleanPaymentMethods();
+			await homeScreen.navigate();
+			await homeScreen.isDisplayed();
+			await waitForTimeout( 1000 );
+			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.enableCashOnDelivery();
+			await homeScreen.navigate();
 			await homeScreen.isDisplayed();
 			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );

--- a/packages/admin-e2e-tests/src/utils/actions.ts
+++ b/packages/admin-e2e-tests/src/utils/actions.ts
@@ -10,6 +10,7 @@ import { NewOrder } from '../pages/NewOrder';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { expect } = require( '@jest/globals' );
+const config = require( 'config' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 /**
@@ -167,6 +168,23 @@ export const waitForElementByTextWithoutThrow = async (
 	return Boolean( selected );
 };
 
+const deactivateAndDeleteExtension = async ( extension: string ) => {
+	const baseUrl = config.get( 'url' );
+	const pluginsAdmin = 'wp-admin/plugins.php?plugin_status=all&paged=1&s';
+	await page.goto( baseUrl + pluginsAdmin, {
+		waitUntil: 'networkidle0',
+		timeout: 10000,
+	} );
+	await waitForElementByText( 'h1', 'Plugins' );
+	// deactivate extension
+	const deactivateExtension = await page.$( `#deactivate-${ extension }` );
+	await deactivateExtension?.click();
+	await waitForElementByText( 'p', 'Plugin deactivated.' );
+	// delete extension
+	const deleteExtension = await page.$( `#delete-${ extension }` );
+	await deleteExtension?.click();
+};
+
 export {
 	uiUnblocked,
 	verifyPublishAndTrash,
@@ -177,4 +195,5 @@ export {
 	waitForElementByText,
 	hasClass,
 	waitForTimeout,
+	deactivateAndDeleteExtension,
 };

--- a/tests/api/onboarding-product-types.php
+++ b/tests/api/onboarding-product-types.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Onboarding Product Types REST API Test
+ *
+ * @package WooCommerce\Admin\Tests\API
+ */
+
+use \Automattic\WooCommerce\Admin\API\OnboardingProductTypes;
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * WC Tests API Onboarding Product Types
+ */
+class WC_Tests_API_Onboarding_Product_Types extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-admin/onboarding/product-types';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
+	}
+
+	/**
+	 * Test that the allowed product types data is returned by the endpoint.
+	 */
+	public function test_get_product_types() {
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$properties = Onboarding::get_allowed_product_types();
+		foreach ( $properties as $key => $property ) {
+			$this->assertArrayHasKey( $key, $data );
+		}
+	}
+
+	/**
+	 * Test subscriptions inclusion only for US stores.
+	 */
+	public function test_subscriptions_inclusion() {
+		// The store location is: US.
+		update_option( 'woocommerce_default_country', 'US' );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( array_key_exists( 'product', $data['subscriptions'] ) );
+
+		// Now the store location is: France.
+		update_option( 'woocommerce_default_country', 'FR' );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( array_key_exists( 'product', $data['subscriptions'] ) );
+
+		// Now the store location is: Uruguay.
+		update_option( 'woocommerce_default_country', 'UY' );
+
+		$request_another_country  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response_another_country = $this->server->dispatch( $request_another_country );
+		$data_another_country     = $response_another_country->get_data();
+
+		$this->assertTrue( array_key_exists( 'product', $data_another_country['subscriptions'] ) );
+	}
+}

--- a/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
+++ b/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
@@ -2,8 +2,10 @@ const {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
 	testDifferentStoreCurrenciesWCPay,
+	testSubscriptionsInclusion,
 } = require( '@woocommerce/admin-e2e-tests' );
 
 testAdminOnboardingWizard();
 testSelectiveBundleWCPay();
 testDifferentStoreCurrenciesWCPay();
+testSubscriptionsInclusion();


### PR DESCRIPTION
This is a follow-up to [PR 7777](https://github.com/woocommerce/woocommerce-admin/pull/7777) to add tests for the Subscriptions inclusion.

### Detailed test instructions:

Run unit and e2e tests and verify that everything is working well.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
