### PR TITLE
Add method to check for install status

### DIFF
--- a/changelogs/fix-7806
+++ b/changelogs/fix-7806
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Add method to check for install status

--- a/changelogs/fix-7806
+++ b/changelogs/fix-7806
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Dev
 
-Add method to check for install status
+Add method to check for install status #7808

--- a/src/Features/OnboardingTasks/DeprecatedOptions.php
+++ b/src/Features/OnboardingTasks/DeprecatedOptions.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TaskList;
+use Automattic\WooCommerce\Admin\Install;
 
 /**
  * DeprecatedOptions class.
@@ -29,7 +30,7 @@ class DeprecatedOptions {
 	 * @return string
 	 */
 	public static function get_deprecated_options( $pre_option, $option ) {
-		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
+		if ( Install::is_installing() ) {
 			return $pre_option;
 		};
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -192,13 +192,12 @@ class Install {
 		}
 
 		// Check if we are not already running this routine.
-		if ( 'yes' === get_transient( 'wc_admin_installing' ) ) {
+		if ( self::is_installing() ) {
 			return;
 		}
 
 		// If we made it till here nothing is running yet, lets set the transient now.
 		set_transient( 'wc_admin_installing', 'yes', MINUTE_IN_SECONDS * 10 );
-		wc_maybe_define_constant( 'WC_ADMIN_INSTALLING', true );
 
 		self::migrate_options();
 		self::create_tables();
@@ -212,6 +211,15 @@ class Install {
 		// plugin version update. We base plugin age off of this value.
 		add_option( 'woocommerce_admin_install_timestamp', time() );
 		do_action( 'woocommerce_admin_installed' );
+	}
+
+	/**
+	 * Check if the installer is installing.
+	 *
+	 * @return bool
+	 */
+	public static function is_installing() {
+		return 'yes' === get_transient( 'wc_admin_installing' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7806 

* Removes unreliable `WC_ADMIN_INSTALLING` constant
* Adds method to check for install status

### Detailed test instructions:

1. Before checking out this branch, install a version of WCA or WC with WCA version <= 2.6.2
2. Hide the task list.
3. Upgrade to this branch
6. Note that the task list is hidden as expected
7. Unhide the task list by deleting the `woocommerce_task_list_hidden_lists` option
8. Note the task list shown.
9. Hide the task list via the dropdown in the tasklist.
10. Note the task list is hidden and persists on refresh.
11. Check that no errors have occurred in the debug log during upgrade