### PR TITLE
Update add task extension example

### DIFF
--- a/client/tasks/task.tsx
+++ b/client/tasks/task.tsx
@@ -26,6 +26,9 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 	}, [ id ] );
 
 	return (
-		<WooOnboardingTask.Slot id={ id } fillProps={ { onComplete, query } } />
+		<WooOnboardingTask.Slot
+			id={ id }
+			fillProps={ { onComplete, query, task } }
+		/>
 	);
 };

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -16,11 +16,12 @@ const Task = ( { onComplete, task } ) => {
 	return (
 		<Card className="woocommerce-task-card">
 			<CardBody>
-				{ __( 'Example task card content.', 'plugin-domain' ) }
 				{ __(
 					"This task's completion status is dependent on being actioned. The action button below will action this task, while the complete button will optimistically complete the task in the task list and redirect back to the task list. Note that in this example, the task must be actioned for completion to persist.",
 					'plugin-domain'
 				) }{ ' ' }
+				<br />
+				<br />
 				{ __( 'Task actioned status: ', 'plugin-domain' ) }{ ' ' }
 				{ isActioned ? 'actioned' : 'not actioned' }
 				<br />

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -3,99 +3,52 @@
  */
 
 import { __ } from '@wordpress/i18n';
-import { addFilter } from '@wordpress/hooks';
-import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
 import { Card, CardBody } from '@wordpress/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { useDispatch } from '@wordpress/data';
+import { WooOnboardingTask } from '@woocommerce/onboarding';
 
-/* global addTaskData */
-const markTaskComplete = () => {
-	apiFetch( {
-		path: '/wc-admin/options',
-		method: 'POST',
-		data: { woocommerce_admin_add_task_example_complete: true },
-	} )
-		.then( () => {
-			// Set the local `isComplete` to `true` so that task appears complete on the list.
-			addTaskData.isComplete = true;
-			// Redirect back to the root WooCommerce Admin page.
-			getHistory().push( getNewPath( {}, '/', {} ) );
-		} )
-		.catch( ( error ) => {
-			// Something went wrong with our update.
-			console.log( error );
-		} );
-};
+const Task = ( { onComplete, task } ) => {
+	const { actionTask } = useDispatch( ONBOARDING_STORE_NAME );
+	const { isActioned } = task;
 
-const markTaskIncomplete = () => {
-	apiFetch( {
-		path: '/wc-admin/options',
-		method: 'POST',
-		data: { woocommerce_admin_add_task_example_complete: false },
-	} )
-		.then( () => {
-			addTaskData.isComplete = false;
-			getHistory().push( getNewPath( {}, '/', {} ) );
-		} )
-		.catch( ( error ) => {
-			console.log( error );
-		} );
-};
-
-const Task = () => {
 	return (
 		<Card className="woocommerce-task-card">
 			<CardBody>
 				{ __( 'Example task card content.', 'plugin-domain' ) }
+				{ __(
+					"This task's completion status is dependent on being actioned. The action button below will action this task, while the complete button will optimistically complete the task in the task list and redirect back to the task list. Note that in this example, the task must be actioned for completion to persist.",
+					'plugin-domain'
+				) }{ ' ' }
+				{ __( 'Task actioned status: ', 'plugin-domain' ) }{ ' ' }
+				{ isActioned ? 'actioned' : 'not actioned' }
 				<br />
 				<br />
 				<div>
-					{ addTaskData.isComplete ? (
-						<button onClick={ markTaskIncomplete }>
-							{ __( 'Mark task incomplete', 'plugin-domain' ) }
-						</button>
-					) : (
-						<button onClick={ markTaskComplete }>
-							{ __( 'Mark task complete', 'plugin-domain' ) }
-						</button>
-					) }
+					<button
+						onClick={ () => {
+							actionTask( 'my-task' );
+						} }
+					>
+						{ __( 'Action task', 'plugin-domain' ) }
+					</button>
+					<button onClick={ onComplete }>
+						{ __( 'Complete', 'plugin-domain' ) }
+					</button>
 				</div>
 			</CardBody>
 		</Card>
 	);
 };
 
-/**
- * Use the 'woocommerce_admin_onboarding_task_list' filter to add a task page.
- */
-addFilter(
-	'woocommerce_admin_onboarding_task_list',
-	'plugin-domain',
-	( tasks ) => {
-		return [
-			...tasks,
-			{
-				key: 'example',
-				title: __( 'Example', 'plugin-domain' ),
-				content: __( 'This is an example task.', 'plugin-domain' ),
-				container: <Task />,
-				completed: addTaskData.isComplete,
-				visible: true,
-				additionalInfo: __(
-					'Additional info here',
-					'woocommerce-admin'
-				),
-				time: __( '2 minutes', 'woocommerce-admin' ),
-				isDismissable: true,
-				onDelete: () => console.log( 'The task was deleted' ),
-				onDismiss: () => console.log( 'The task was dismissed' ),
-				allowRemindMeLater: true,
-				remindMeLater: () => console.log( 'Remind me later' ),
-			},
-		];
-	}
-);
+registerPlugin( 'add-task-content', {
+	render: () => (
+		<WooOnboardingTask id="my-task">
+			{ ( { onComplete, query, task } ) => (
+				<Task onComplete={ onComplete } task={ task } />
+			) }
+		</WooOnboardingTask>
+	),
+	scope: 'woocommerce-tasks',
+} );

--- a/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
+++ b/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
@@ -8,7 +8,32 @@
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 
 /**
- * Register the task list item and the JS.
+ * Register the task.
+ */
+function add_task_register_task() {
+	TaskLists::add_task(
+		'extended',
+		array(
+			'id'             => 'my-task',
+			'title'          => __( 'My task', 'woocommerce-admin' ),
+			'content'        => __(
+				'Add your task description here for display in the task list.',
+				'woocommerce-admin'
+			),
+			'action_label'   => __( 'Do action', 'woocommerce-admin' ),
+			'is_complete'    => Task::is_task_actioned( 'my-task' ),
+			'can_view'       => 'US' === WC()->countries->get_base_country(),
+			'time'           => __( '2 minutes', 'woocommerce-admin' ),
+			'is_dismissable' => true,
+			'is_snoozeable'  => true,
+		)
+	);
+}
+
+add_action( 'admin_init', 'add_task_register_task' );
+
+/**
+ * Register the scripts to fill the task content on the frontend.
  */
 function add_task_register_script() {
 
@@ -28,25 +53,7 @@ function add_task_register_script() {
 		true
 	);
 
-	$client_data = array(
-		'isComplete' => get_option( 'woocommerce_admin_add_task_example_complete', false ),
-	);
-	wp_localize_script( 'add-task', 'addTaskData', $client_data );
 	wp_enqueue_script( 'add-task' );
-	add_filter( 'woocommerce_get_registered_extended_tasks', 'pluginprefix_register_extended_task', 10, 1 );
-}
-
-/**
- * Register task.
- *
- * @param array $registered_tasks_list_items List of registered extended task list items.
- */
-function pluginprefix_register_extended_task( $registered_tasks_list_items ) {
-	$new_task_name = 'woocommerce_admin_add_task_example_name';
-	if ( ! in_array( $new_task_name, $registered_tasks_list_items, true ) ) {
-		array_push( $registered_tasks_list_items, $new_task_name );
-	}
-	return $registered_tasks_list_items;
 }
 
 add_action( 'admin_enqueue_scripts', 'add_task_register_script' );

--- a/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
+++ b/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
@@ -32,7 +32,7 @@ function add_task_my_task() {
 	);
 }
 
-add_action( 'admin_init', 'add_task_my_task' );
+add_action( 'init', 'add_task_my_task' );
 
 /**
  * Register the scripts to fill the task content on the frontend.

--- a/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
+++ b/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
@@ -6,11 +6,13 @@
  */
 
 use Automattic\WooCommerce\Admin\Features\Onboarding;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 /**
  * Register the task.
  */
-function add_task_register_task() {
+function add_task_my_task() {
 	TaskLists::add_task(
 		'extended',
 		array(
@@ -30,13 +32,12 @@ function add_task_register_task() {
 	);
 }
 
-add_action( 'admin_init', 'add_task_register_task' );
+add_action( 'admin_init', 'add_task_my_task' );
 
 /**
  * Register the scripts to fill the task content on the frontend.
  */
 function add_task_register_script() {
-
 	if (
 		! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) ||
 		! \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page()


### PR DESCRIPTION
Fixes #7760

Updates the example extension to work with the new API.

Note that testing for this is blocked by https://github.com/woocommerce/woocommerce-admin/pull/7747


### Screenshots


![Screen Shot 2021-10-15 at 4 27 23 PM](https://user-images.githubusercontent.com/10561050/137549702-c42f15e4-cf6c-4878-8104-28afbf2e09fb.png)
![Screen Shot 2021-10-15 at 4 27 20 PM](https://user-images.githubusercontent.com/10561050/137549703-c8bda92b-1ed2-42a3-8ed0-663534f20ae4.png)

### Detailed test instructions:

1. Run the extension  `npm run example -- --ext=add-task`
2. Activate the extension
3. Set your store's base country to `US`
3. Navigate to the task list and note the new task
4. Click on the task
5. Make sure that the card content is shown
6. Action the task and note the change of status text in the card
7. Complete the task with the respective button
8. Note the task is marked complete and persists on refresh (if actioned)