### PR TITLE
Fix/7812 activity panel styling

### DIFF
--- a/changelogs/fix-7812_activity_panel_styling
+++ b/changelogs/fix-7812_activity_panel_styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Increase CSS specificity to avoid conflicts and broken panel styling. #7813

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -209,7 +209,7 @@
 }
 
 // Needs the double-class for specificity
-.woocommerce-activity-card.woocommerce-order-activity-card {
+.woocommerce-activity-panel .woocommerce-activity-card.woocommerce-order-activity-card {
 	grid-template-columns: 1fr;
 	grid-template-areas:
 		'header'
@@ -232,7 +232,7 @@
 }
 
 // Needs the double-class for specificity
-.woocommerce-activity-card.woocommerce-inbox-activity-card {
+.woocommerce-activity-panel .woocommerce-activity-card.woocommerce-inbox-activity-card {
 	grid-template-columns: 72px 1fr;
 	height: 100%;
 	opacity: 1;

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -1,4 +1,4 @@
-.woocommerce-activity-card {
+.woocommerce-activity-panel .woocommerce-activity-card {
 	position: relative;
 	padding: $fallback-gutter;
 	padding: $gutter;

--- a/client/homescreen/activity-panel/style.scss
+++ b/client/homescreen/activity-panel/style.scss
@@ -43,9 +43,9 @@
 	}
 
 	.woocommerce-activity-card {
-		padding: math.div( $gap-largest, 2 ) $gutter $gutter;
+		padding: math.div($gap-largest, 2) $gutter $gutter;
 
-		&:not( :last-of-type ) {
+		&:not(:last-of-type) {
 			border-bottom: 1px solid $gray-200;
 		}
 

--- a/client/homescreen/activity-panel/style.scss
+++ b/client/homescreen/activity-panel/style.scss
@@ -1,4 +1,4 @@
-.woocommerce-activity-panel {
+.woocommerce-homescreen .woocommerce-activity-panel {
 	background: transparent;
 	border: 0;
 
@@ -43,9 +43,9 @@
 	}
 
 	.woocommerce-activity-card {
-		padding: math.div($gap-largest, 2) $gutter $gutter;
+		padding: math.div( $gap-largest, 2 ) $gutter $gutter;
 
-		&:not(:last-of-type) {
+		&:not( :last-of-type ) {
 			border-bottom: 1px solid $gray-200;
 		}
 


### PR DESCRIPTION
Fixes #7812

Increase CSS specificity to avoid conflicts in the activity panel.

### Screenshots

<img width="579" alt="Screen Shot 2021-10-18 at 12 46 26 PM" src="https://user-images.githubusercontent.com/2240960/137765097-197f4871-8b44-4141-9116-f6d4be11a98d.png">

### Detailed test instructions:

1. Load WC
2. Finish the onboarding flow, and add some products and an order for those products
3. Go to WooCommerce Home and hide the task list
4. Expand the Orders panel make sure it looks good 


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
