### PR TITLE
Parse low_stock_amount to int if it exists

### DIFF
--- a/changelogs/fix-7816_stock_activity_panel
+++ b/changelogs/fix-7816_stock_activity_panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Fix issue where stock activity panel was not rendering correctly. #7817


### PR DESCRIPTION
Fixes #7816 

Fixes issue with the stock panel not displaying items that have a custom low stock amount.

### Screenshots

<img width="574" alt="Screen Shot 2021-10-18 at 2 04 18 PM" src="https://user-images.githubusercontent.com/2240960/137776133-fd62ec8a-bd4e-4953-af1c-d1c25318a3e6.png">

### Detailed test instructions:

1. Load WooCommerce and finish the onboarding
2. Create some products
3. Edit one of you products and go to **Inventory** tab and enable the **Manage stock?**, and set the **Low stock threshold** to `10`, make sure **Stock quantity** is lower than the threshold
4. Go to **WooCommerce > Home** and hide the task list
5. Expand the Stock activity panel, the item should load correctly.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
