### PR TITLE
Check if onboarding is defined before finding themes

### DIFF
--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -144,9 +144,12 @@ export function getProductList(
 	} );
 
 	const onboarding = getSetting( 'onboarding', {} );
-	const theme = onboarding.themes.find(
-		( themeData ) => themeData.slug === profileItems.theme
-	);
+	let theme = null;
+	if ( onboarding && onboarding.themes ) {
+		theme = onboarding.themes.find(
+			( themeData ) => themeData.slug === profileItems.theme
+		);
+	}
 
 	if (
 		theme &&


### PR DESCRIPTION
Fixes a blank screen issue when the task list is hidden, this checks if onboarding is defined before looking through the themes.

### Detailed test instructions:

- Load the `main` branch first and hide the task list and refresh the **WooCommerce > Home**, with at-least 1 order and products
- Notice how the there is an error in the console and the screen is blank.
- Load this branch and refresh **WooCommerce > Home**
- It should load the home screen correctly

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
