### PR TITLE
Avoid caching extended info on Analytics -> Products

### DIFF
--- a/changelogs/fix-7540-product-stocks-fails-to-update-on-analytics
+++ b/changelogs/fix-7540-product-stocks-fails-to-update-on-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Avoid caching extended info

--- a/changelogs/fix-7540-product-stocks-fails-to-update-on-analytics
+++ b/changelogs/fix-7540-product-stocks-fails-to-update-on-analytics
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Tweak
 
-Avoid caching extended info
+Avoid caching extended info #7819

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -360,8 +360,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				return $data;
 			}
 
-			$this->include_extended_info( $product_data, $query_args );
-
 			$product_data = array_map( array( $this, 'cast_numbers' ), $product_data );
 			$data         = (object) array(
 				'data'    => $product_data,
@@ -372,6 +370,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$this->set_cached_data( $cache_key, $data );
 		}
+
+		$this->include_extended_info( $data->data, $query_args );
 
 		return $data;
 	}


### PR DESCRIPTION
Fixes #7540 

This PR removes the extended info from the cache to show the users real-time data for the products.

I first attempted to invalidate the cache when a product's metadata gets updated. 

Product metadata gets updated in the following cases.

1. When a store owner manually updates a metadata field such as stock.
2. When a customer places a new order. A new order decreases a product's stock value. 

The cache invalidation approach isn't ideal in a busy store since it would happen very frequently as a new order comes in.

I looked into the [include_extended_info](https://github.com/woocommerce/woocommerce-admin/blob/main/src/API/Reports/Products/DataStore.php#L200) method and concluded that the method is okay not to be cached. It uses `wc_get_product` in a loop, but we also do the same in **WooCommerce -> Products** and the function is fast.


### Detailed test instructions:

1. Create a new product and set a stock value for it.
2. Place a new order with the product.
3. Navigate to Analytics -> Products and confirm the order and product you just placed. 
4. Check the stock value.
5. Place a new order with the same product.
6. Navigate back to Analytics -> Products and observe the stock value has decreased. 


