### PR TITLE
Add country validation for old task list

### DIFF
--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -230,13 +230,7 @@ class StoreDetails extends Component {
 			isStoreDetailsPopoverVisible,
 			isSkipSetupPopoverVisible,
 		} = this.state;
-		const {
-			skipProfiler,
-			isLoading,
-			isBusy,
-			initialValues,
-			invalidateResolutionForStoreSelector,
-		} = this.props;
+		const { skipProfiler, isLoading, isBusy, initialValues } = this.props;
 
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 		const skipSetupText = __(
@@ -396,9 +390,6 @@ class StoreDetails extends Component {
 						isLink
 						className="woocommerce-profile-wizard__footer-link"
 						onClick={ () => {
-							invalidateResolutionForStoreSelector(
-								'getTaskLists'
-							);
 							this.setState( {
 								showUsageModal: true,
 								skipping: true,
@@ -507,17 +498,13 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
-		const {
-			invalidateResolutionForStoreSelector,
-			updateProfileItems,
-		} = dispatch( ONBOARDING_STORE_NAME );
+		const { updateProfileItems } = dispatch( ONBOARDING_STORE_NAME );
 		const { updateAndPersistSettingsForGroup } = dispatch(
 			SETTINGS_STORE_NAME
 		);
 
 		return {
 			createNotice,
-			invalidateResolutionForStoreSelector,
 			updateProfileItems,
 			updateAndPersistSettingsForGroup,
 		};

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -30,9 +30,12 @@ import TaskListPlaceholder from './placeholder';
 
 const EMPTY_ARRAY = [];
 const taskDashboardSelect = ( select ) => {
-	const { getFreeExtensions, getProfileItems, getTasksStatus } = select(
-		ONBOARDING_STORE_NAME
-	);
+	const {
+		getFreeExtensions,
+		getProductTypes,
+		getProfileItems,
+		getTasksStatus,
+	} = select( ONBOARDING_STORE_NAME );
 	const { getSettings } = select( SETTINGS_STORE_NAME );
 	const { getOption, hasFinishedResolution } = select( OPTIONS_STORE_NAME );
 	const {
@@ -66,6 +69,7 @@ const taskDashboardSelect = ( select ) => {
 	const activePlugins = getActivePlugins();
 	const installedPlugins = getInstalledPlugins();
 	const onboardingStatus = getTasksStatus();
+	const productTypes = getProductTypes();
 
 	return {
 		activePlugins,
@@ -85,6 +89,7 @@ const taskDashboardSelect = ( select ) => {
 		isTaskListComplete:
 			getOption( 'woocommerce_task_list_complete' ) === 'yes',
 		installedPlugins,
+		productTypes,
 		trackedCompletedActions,
 		onboardingStatus,
 		profileItems,
@@ -125,6 +130,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		countryCode,
 		freeExtensions,
 		installedPlugins,
+		productTypes,
 		isJetpackConnected,
 		onboardingStatus,
 		profileItems,
@@ -249,6 +255,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		onTaskSelect,
 		hasCompleteAddress,
 		trackedCompletedActions,
+		productTypes,
 	} );
 
 	const { extension, setup: setupTasks } = allTasks;

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -35,6 +35,7 @@ const taskDashboardSelect = ( select ) => {
 		getProductTypes,
 		getProfileItems,
 		getTasksStatus,
+		hasFinishedResolution: hasOnboardingStoreFinishedResolution,
 	} = select( ONBOARDING_STORE_NAME );
 	const { getSettings } = select( SETTINGS_STORE_NAME );
 	const { getOption, hasFinishedResolution } = select( OPTIONS_STORE_NAME );
@@ -116,13 +117,17 @@ const taskDashboardSelect = ( select ) => {
 			] ) ||
 			! hasFinishedResolution( 'getOption', [
 				'woocommerce_task_list_dismissed_tasks',
-			] ),
+			] ) ||
+			! hasOnboardingStoreFinishedResolution( 'getProductTypes' ),
 	};
 };
 
 const TaskDashboard = ( { userPreferences, query } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		ONBOARDING_STORE_NAME
+	);
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 	const {
 		trackedCompletedTasks,
@@ -153,6 +158,7 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 	useEffect( () => {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
+		invalidateResolutionForStoreSelector( 'getProductTypes' );
 	}, [] );
 
 	const getTaskStartedCount = ( taskName ) => {

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -60,6 +60,7 @@ export function getAllTasks( {
 	onTaskSelect,
 	hasCompleteAddress,
 	trackedCompletedActions,
+	productTypes,
 } ) {
 	const {
 		hasPaymentGateway,
@@ -81,6 +82,7 @@ export function getAllTasks( {
 	};
 
 	const groupedProducts = getCategorizedOnboardingProducts(
+		productTypes,
 		profileItems,
 		installedPlugins
 	);
@@ -92,7 +94,7 @@ export function getAllTasks( {
 		activePlugins.indexOf( 'woocommerce-services' ) !== -1;
 	const {
 		completed: profilerCompleted,
-		product_types: productTypes,
+		product_types: profileProductTypes,
 		business_extensions: businessExtensions,
 	} = profileItems;
 
@@ -335,7 +337,8 @@ export function getAllTasks( {
 			},
 			completed: shippingZonesCount > 0,
 			visible:
-				( productTypes && productTypes.includes( 'physical' ) ) ||
+				( profileProductTypes &&
+					profileProductTypes.includes( 'physical' ) ) ||
 				hasPhysicalProducts,
 			time: __( '1 minute', 'woocommerce-admin' ),
 			type: 'setup',

--- a/client/task-list/tasks/products/products.js
+++ b/client/task-list/tasks/products/products.js
@@ -12,7 +12,11 @@ import {
 	archive,
 	download,
 } from '@wordpress/icons';
-import { ONBOARDING_STORE_NAME, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import {
+	ONBOARDING_STORE_NAME,
+	PLUGINS_STORE_NAME,
+	SETTINGS_STORE_NAME,
+} from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 import { List, Pill } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
@@ -22,8 +26,9 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import ProductTemplateModal from './product-template-modal';
+import { getCountryCode } from '../../../dashboard/utils';
 
-const subTasks = [
+const getSubTasks = () => [
 	{
 		key: 'addProductTemplate',
 		title: (
@@ -92,10 +97,13 @@ const subTasks = [
 
 export default function Products() {
 	const [ selectTemplate, setSelectTemplate ] = useState( null );
-	const { profileItems } = useSelect( ( select ) => {
+	const { countryCode, profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
+		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { general: settings = {} } = getSettings( 'general' );
 
 		return {
+			countryCode: getCountryCode( settings.woocommerce_default_country ),
 			profileItems: getProfileItems(),
 		};
 	} );
@@ -107,9 +115,12 @@ export default function Products() {
 		};
 	} );
 
+	const subTasks = getSubTasks();
+
 	if (
 		window.wcAdminFeatures &&
 		window.wcAdminFeatures.subscriptions &&
+		countryCode === 'US' &&
 		profileItems.product_types.includes( 'subscriptions' ) &&
 		installedPlugins.includes( 'woocommerce-payments' )
 	) {

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -60,6 +60,7 @@ describe( 'TaskDashboard and TaskList', () => {
 			updateOptions,
 			createNotice,
 			installAndActivatePlugins: jest.fn(),
+			invalidateResolutionForStoreSelector: jest.fn(),
 		} ) );
 		Object.defineProperty( global.HTMLElement.prototype, 'clientHeight', {
 			configurable: true,


### PR DESCRIPTION
Fixes #7821

This PR adds country validation for Subscriptions to the old task list.

_The subscription inclusion was added before the old task list removal but not the country validation. This is why the country validation hasn't been added to the old task list._

**Do not merge this PR with `main`**.

(No changelog is necessary)

### Screenshots

### Detailed test instructions:

0. Checkout this branch and turn the new task-list off [here](https://github.com/woocommerce/woocommerce-admin/blob/release/2.8.0-rc.2/config/development.json#L20).
1. Deactivate and delete `WooCommerce Payments` if you have it installed.
2. Go to step one of the store profiler and select `France` (or any country other than the US) as the store `Country / Region`.
3. Go to step three of the store profiler (`Product Types`) and verify `Subscriptions` is shown as a paid extension (with a price chip).
5. Check `Subscriptions` and continue with the OBW.
6. Go back to the `Home` screen by pressing `Skip setup store details` in step one of the store profiler. Check that the task item `Add Subscriptions to my store` is visible in the setup task list.
7. Press `Add my products` in the setup task list.
8. Select `Start with a template`. Verify that the option `Subscription product` is not visible in the popup.
9. Go to step one of the store profiler and select `US` as the store `Country / Region`.
10. Verify `Subscriptions` is shown as free (without a price chip). Also, verify that the text

```
The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature
```

is visible at the bottom when `WooCommerce Payments` is not installed.

![screenshot-one wordpress test-2021 09 30-14_12_58](https://user-images.githubusercontent.com/1314156/135506696-b7812f7e-437f-4d89-956a-b73248f70f6b.png)

11. Check `Subscriptions` and  press`Continue` and verify that the `WooCommerce Payments` plugin is installed and activated and it's not shown in the `Free features` list

![screenshot-one wordpress test-2021 09 30-14_32_20](https://user-images.githubusercontent.com/1314156/135506727-d8888f2b-3424-4cf5-a4bf-b67a14a198b6.png)

12. Verify that the `WooCommerce Payments` plugin is being shown in the `Free features` list when the store country is other than the `US`.

13. Go back to the `Home` screen by pressing `Skip setup store details` in step one of the store profiler. Check that the task item `Add Subscriptions to my store` is not visible in the setup task list. It should be visible if the store is from any country other than the US.

14. Press `Add my products` in the setup task list.
15. Select `Start with a template`. Verify that the option `Subscription product` is visible in the popup (verify that this is not being shown when the store is from a country other than the US)

![screenshot-one wordpress test-2021 09 30-14_35_22](https://user-images.githubusercontent.com/1314156/135506748-0b7bdce5-b006-47f9-9289-03ed26e4950c.png)

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
