### PR TITLE
Fix wc_admin_daily from a missed change

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -97,7 +97,6 @@ class Events {
 		$this->possibly_add_notes();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
-			DataSourcePoller::get_instance()->delete_specs_transient();
 			DataSourcePoller::get_instance()->read_specs_from_data_sources();
 			RemoteInboxNotificationsEngine::run();
 		}

--- a/src/Events.php
+++ b/src/Events.php
@@ -97,8 +97,8 @@ class Events {
 		$this->possibly_add_notes();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
-			$data_source_poller = RemoteInboxNotificationsEngine::get_data_source_poller_instance();
-			$data_source_poller->read_specs_from_data_sources();
+			DataSourcePoller::get_instance()->delete_specs_transient();
+			DataSourcePoller::get_instance()->read_specs_from_data_sources();
 			RemoteInboxNotificationsEngine::run();
 		}
 

--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -31,7 +31,10 @@ class DataSourcePoller extends \Automattic\WooCommerce\Admin\DataSourcePoller {
 		if ( ! self::$instance ) {
 			self::$instance = new self(
 				self::ID,
-				self::DATA_SOURCES
+				self::DATA_SOURCES,
+				array(
+					'spec_key' => 'slug',
+				)
 			);
 		}
 		return self::$instance;

--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class DataSourcePoller extends \Automattic\WooCommerce\Admin\DataSourcePoller {
 	const ID           = 'remote_inbox_notifications';
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
+		'http://woocommerce.test/wp-json/wccom/inbox-notifications/1.0/notifications.json',
 	);
 	/**
 	 * Class instance.

--- a/src/RemoteInboxNotifications/DataSourcePoller.php
+++ b/src/RemoteInboxNotifications/DataSourcePoller.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class DataSourcePoller extends \Automattic\WooCommerce\Admin\DataSourcePoller {
 	const ID           = 'remote_inbox_notifications';
 	const DATA_SOURCES = array(
-		'http://woocommerce.test/wp-json/wccom/inbox-notifications/1.0/notifications.json',
+		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
 	);
 	/**
 	 * Class instance.


### PR DESCRIPTION
Fixes the wc_admin_daily cron from a change that was missed in this PR https://github.com/woocommerce/woocommerce-admin/pull/7671

Fixes: #7885

No changelog necessary.

### Detailed test instructions:

-   Install [WC Admin test helper](https://github.com/woocommerce/woocommerce-admin-test-helper)
- Delete all the notes within the `wp_wc_admin_notes` table using phpMyAdmin.
-  Trigger the `wc_admin_daily` under **Tools > WCA Test Helper > Tools**
- It should succeed correctly, and likely show some new notes on **WooCommerce > Home**
- Look at the `wp_wc_admin_notes` table, it should contain most of the notes from [this data feed](https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json), slugs should match the name in the table.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
