### PR TITLE
Add WC Pay in person text

### DIFF
--- a/changelogs/update-7719
+++ b/changelogs/update-7719
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update WC Pay card to include in-person information #7830

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
@@ -107,18 +107,16 @@ export const Action = ( {
 
 	if ( isInstalled && hasPlugins ) {
 		return (
-			<div>
-				<Button
-					className={ classes }
-					isPrimary={ isRecommended }
-					isSecondary={ ! isRecommended }
-					isBusy={ isBusy }
-					disabled={ isBusy }
-					onClick={ () => handleClick() }
-				>
-					{ __( 'Finish setup', 'woocommerce-admin' ) }
-				</Button>
-			</div>
+			<Button
+				className={ classes }
+				isPrimary={ isRecommended }
+				isSecondary={ ! isRecommended }
+				isBusy={ isBusy }
+				disabled={ isBusy }
+				onClick={ () => handleClick() }
+			>
+				{ __( 'Finish setup', 'woocommerce-admin' ) }
+			</Button>
 		);
 	}
 

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -169,7 +169,8 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 
 					// WCPay is handled separately when not installed and configured
 					if (
-						gateway.id === 'woocommerce_payments' &&
+						gateway.plugins?.length === 1 &&
+						gateway.plugins[ 0 ] === 'woocommerce-payments' &&
 						! ( gateway.installed && ! gateway.needsSetup )
 					) {
 						wcPay.push( gateway );

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -224,7 +224,7 @@ class DefaultPaymentGateways {
 					(object) array(
 						'type'     => 'plugin_version',
 						'plugin'   => 'woocommerce-admin',
-						'version'  => '2.9.0',
+						'version'  => '2.9.0-dev',
 						'operator' => '<',
 					),
 					(object) array(
@@ -256,7 +256,7 @@ class DefaultPaymentGateways {
 							(object) array(
 								'type'     => 'plugin_version',
 								'plugin'   => 'woocommerce-admin',
-								'version'  => '2.9.0',
+								'version'  => '2.9.0-dev',
 								'operator' => '>=',
 							),
 							(object) array(
@@ -290,7 +290,7 @@ class DefaultPaymentGateways {
 							(object) array(
 								'type'     => 'plugin_version',
 								'plugin'   => 'woocommerce-admin',
-								'version'  => '2.9.0',
+								'version'  => '2.9.0-dev',
 								'operator' => '>=',
 							),
 							(object) array(

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -225,7 +225,7 @@ class DefaultPaymentGateways {
 				'recommendation_priority' => 1,
 			),
 			array(
-				'id'                      => 'woocommerce_payments',
+				'id'                      => 'woocommerce_payments:us',
 				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
 				'content'                 => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -217,10 +217,26 @@ class DefaultPaymentGateways {
 				),
 				'image'                   => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
 				'plugins'                 => array( 'woocommerce-payments' ),
+				'description'             => 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.',
+				'is_visible'              => array(
+					self::get_rules_for_cbd( false ),
+					self::get_rules_for_countries( array_diff( self::get_wcpay_countries(), array( 'US' ) ) ),
+				),
+				'recommendation_priority' => 1,
+			),
+			array(
+				'id'                      => 'woocommerce_payments',
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'content'                 => __(
+					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
+					'woocommerce-admin'
+				),
+				'image'                   => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'                 => array( 'woocommerce-payments' ),
 				'description'             => 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.',
 				'is_visible'              => array(
 					self::get_rules_for_cbd( false ),
-					self::get_rules_for_countries( self::get_wcpay_countries() ),
+					self::get_rules_for_countries( array( 'US' ) ),
 				),
 				'recommendation_priority' => 1,
 			),

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -217,7 +217,7 @@ class DefaultPaymentGateways {
 				),
 				'image'                   => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
 				'plugins'                 => array( 'woocommerce-payments' ),
-				'description'             => 'Try the new way to get paid. Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.',
+				'description'             => 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.',
 				'is_visible'              => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( self::get_wcpay_countries() ),

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -220,7 +220,53 @@ class DefaultPaymentGateways {
 				'description'             => 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.',
 				'is_visible'              => array(
 					self::get_rules_for_cbd( false ),
+					self::get_rules_for_countries( self::get_wcpay_countries() ),
+					(object) array(
+						'type'     => 'plugin_version',
+						'plugin'   => 'woocommerce-admin',
+						'version'  => '2.9.0',
+						'operator' => '<',
+					),
+					(object) array(
+						'type'     => 'plugin_version',
+						'plugin'   => 'woocommerce',
+						'version'  => '5.10.0',
+						'operator' => '<',
+					),
+				),
+				'recommendation_priority' => 1,
+			),
+			array(
+				'id'                      => 'woocommerce_payments:non-us',
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'content'                 => __(
+					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
+					'woocommerce-admin'
+				),
+				'image'                   => plugins_url( 'images/onboarding/wcpay.svg', WC_ADMIN_PLUGIN_FILE ),
+				'plugins'                 => array( 'woocommerce-payments' ),
+				'description'             => 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.',
+				'is_visible'              => array(
+					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( array_diff( self::get_wcpay_countries(), array( 'US' ) ) ),
+					(object) array(
+						'type'     => 'or',
+						// Older versions of WooCommerce Admin require the ID to be `woocommerce-payments` to show the suggestion card.
+						'operands' => (object) array(
+							(object) array(
+								'type'     => 'plugin_version',
+								'plugin'   => 'woocommerce-admin',
+								'version'  => '2.9.0',
+								'operator' => '>=',
+							),
+							(object) array(
+								'type'     => 'plugin_version',
+								'plugin'   => 'woocommerce',
+								'version'  => '5.10.0',
+								'operator' => '>=',
+							),
+						),
+					),
 				),
 				'recommendation_priority' => 1,
 			),
@@ -237,6 +283,24 @@ class DefaultPaymentGateways {
 				'is_visible'              => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( array( 'US' ) ),
+					(object) array(
+						'type'     => 'or',
+						// Older versions of WooCommerce Admin require the ID to be `woocommerce-payments` to show the suggestion card.
+						'operands' => (object) array(
+							(object) array(
+								'type'     => 'plugin_version',
+								'plugin'   => 'woocommerce-admin',
+								'version'  => '2.9.0',
+								'operator' => '>=',
+							),
+							(object) array(
+								'type'     => 'plugin_version',
+								'plugin'   => 'woocommerce',
+								'version'  => '5.10.0',
+								'operator' => '>=',
+							),
+						),
+					),
 				),
 				'recommendation_priority' => 1,
 			),

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -230,7 +230,7 @@ class DefaultPaymentGateways {
 					(object) array(
 						'type'     => 'plugin_version',
 						'plugin'   => 'woocommerce',
-						'version'  => '5.10.0',
+						'version'  => '5.10.0-dev',
 						'operator' => '<',
 					),
 				),
@@ -262,7 +262,7 @@ class DefaultPaymentGateways {
 							(object) array(
 								'type'     => 'plugin_version',
 								'plugin'   => 'woocommerce',
-								'version'  => '5.10.0',
+								'version'  => '5.10.0-dev',
 								'operator' => '>=',
 							),
 						),
@@ -296,7 +296,7 @@ class DefaultPaymentGateways {
 							(object) array(
 								'type'     => 'plugin_version',
 								'plugin'   => 'woocommerce',
-								'version'  => '5.10.0',
+								'version'  => '5.10.0-dev',
 								'operator' => '>=',
 							),
 						),


### PR DESCRIPTION
Fixes (part of) #7719 

Updates the WC Pay card text and button alignment.

### Screenshots

#### Before
<img width="224" alt="Screen Shot 2021-10-20 at 3 39 14 PM" src="https://user-images.githubusercontent.com/10561050/138161955-d121b5c3-790e-4576-82be-51afa4c30082.png">


#### After

<img width="266" alt="Screen Shot 2021-10-20 at 3 46 09 PM" src="https://user-images.githubusercontent.com/10561050/138161948-6ab40791-fdf0-44c7-a6ca-c2acf3c3f09f.png">

<img width="763" alt="Screen Shot 2021-10-21 at 4 13 40 PM" src="https://user-images.githubusercontent.com/10561050/138350617-7e9af501-d1e1-467f-9379-e2f92bad4534.png">

### Detailed test instructions:

1. Set your store location to US
2. Set your store to NOT allow marketplace suggestions
3. Delete the `woocommerce_admin_payment_gateway_suggestions_specs` option if it exists
2. Delete the `woocommerce_onboarding_profile` option (or don't select WC Pay in the free extensions step)
3. Deactivate WC Pay if active
3. Visit the payments task
4. Note the copy change
5. Activate WC Pay
6. Note the "Finish Setup" button aligment
7. Set your store to a non-US location and note the text
8. Repeat this process with marketplace suggestion on using this PR - https://github.com/Automattic/woocommerce.com/pull/11555
