### PR TITLE
Add marketing extensions back to obw

### DIFF
--- a/changelogs/update-7823
+++ b/changelogs/update-7823
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Add marketing extensions back to onboarding wizard #7831

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -25,7 +25,7 @@ import sanitizeHTML from '~/lib/sanitize-html';
 import { setAllPropsToValue } from '~/lib/collections';
 import { getCountryCode } from '../../../../../../dashboard/utils';
 
-const ALLOWED_PLUGIN_LISTS = [ 'basics', 'grow' ];
+const ALLOWED_PLUGIN_LISTS = [ 'obw/basics', 'obw/grow' ];
 
 const FreeBadge = () => {
 	return (

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -25,7 +25,7 @@ import sanitizeHTML from '~/lib/sanitize-html';
 import { setAllPropsToValue } from '~/lib/collections';
 import { getCountryCode } from '../../../../../../dashboard/utils';
 
-const ALLOWED_PLUGIN_LISTS = [ 'basics' ];
+const ALLOWED_PLUGIN_LISTS = [ 'basics', 'grow' ];
 
 const FreeBadge = () => {
 	return (
@@ -304,23 +304,32 @@ export const SelectiveExtensionsBundle = ( {
 					</div>
 					{ showExtensions &&
 						installableExtensions.map(
-							( { plugins, key: sectionKey } ) => (
+							( { plugins, key: sectionKey, title } ) => (
 								<div key={ sectionKey }>
 									{ isResolving ? (
 										<Spinner />
 									) : (
-										plugins.map(
-											( { description, key } ) => (
-												<BundleExtensionCheckbox
-													key={ key }
-													description={ description }
-													isChecked={ values[ key ] }
-													onChange={ getCheckboxChangeHandler(
-														key
-													) }
-												/>
-											)
-										)
+										<>
+											<div className="woocommerce-admin__business-details__selective-extensions-bundle__category">
+												{ title }
+											</div>
+											{ plugins.map(
+												( { description, key } ) => (
+													<BundleExtensionCheckbox
+														key={ key }
+														description={
+															description
+														}
+														isChecked={
+															values[ key ]
+														}
+														onChange={ getCheckboxChangeHandler(
+															key
+														) }
+													/>
+												)
+											) }
+										</>
 									) }
 								</div>
 							)

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -35,7 +35,7 @@ jest.mock( '@woocommerce/data', () => ( {
 
 const freeExtensions = [
 	{
-		key: 'basics',
+		key: 'obw/basics',
 		title: 'Get the basics',
 		plugins: [
 			{
@@ -54,7 +54,7 @@ const freeExtensions = [
 		],
 	},
 	{
-		key: 'reach',
+		key: 'task-list/reach',
 		title: 'Reach out to customers',
 		plugins: [
 			{
@@ -68,7 +68,7 @@ const freeExtensions = [
 		],
 	},
 	{
-		key: 'grow',
+		key: 'obw/grow',
 		title: 'Grow your store',
 		plugins: [
 			{
@@ -86,7 +86,7 @@ const freeExtensions = [
 const profileItems = { product_types: [] };
 
 describe( 'Selective extensions bundle', () => {
-	it( 'should list installable free extensions in footer only basics', () => {
+	it( 'should list installable free extensions from obw/basics and obw/grow', () => {
 		useSelect.mockReturnValue( {
 			freeExtensions,
 			isResolving: false,
@@ -105,7 +105,7 @@ describe( 'Selective extensions bundle', () => {
 			queryByText(
 				new RegExp( pluginNames[ 'google-listings-and-ads' ] )
 			)
-		).not.toBeInTheDocument();
+		).toBeInTheDocument();
 		expect(
 			queryByText( new RegExp( pluginNames.random ) )
 		).not.toBeInTheDocument();
@@ -126,7 +126,7 @@ describe( 'Selective extensions bundle', () => {
 		userEvent.click( collapseButton );
 		expect( getByText( 'WC Pay Description' ) ).toBeInTheDocument();
 		expect( getByText( 'Mailpoet Description' ) ).toBeInTheDocument();
-		expect( queryByText( 'Google Description' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'Google Description' ) ).toBeInTheDocument();
 		expect( queryByText( 'Random Description' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -24,7 +24,7 @@ import { createNoticesFromResponse } from '~/lib/notices';
 import { PluginList, PluginListProps } from './PluginList';
 import { PluginProps } from './Plugin';
 
-const ALLOWED_PLUGIN_LISTS = [ 'reach', 'grow' ];
+const ALLOWED_PLUGIN_LISTS = [ 'task-list/reach', 'task-list/grow' ];
 const EMPTY_ARRAY = [];
 
 export type ExtensionList = {

--- a/client/tasks/fills/Marketing/test/index.tsx
+++ b/client/tasks/fills/Marketing/test/index.tsx
@@ -46,17 +46,17 @@ const growPlugins: Extension[] = [
 
 const extensionLists = [
 	{
-		key: 'basics',
+		key: 'obw/basics',
 		plugins: basicPlugins,
 		title: 'Basics',
 	},
 	{
-		key: 'reach',
+		key: 'task-list/reach',
 		plugins: reachPlugins,
 		title: 'Reach',
 	},
 	{
-		key: 'grow',
+		key: 'task-list/grow',
 		plugins: growPlugins,
 		title: 'Grow',
 	},
@@ -109,8 +109,8 @@ describe( 'getMarketingExtensionLists', () => {
 		);
 
 		expect( lists.length ).toBe( 2 );
-		expect( lists[ 0 ].key ).toBe( 'reach' );
-		expect( lists[ 1 ].key ).toBe( 'grow' );
+		expect( lists[ 0 ].key ).toBe( 'task-list/reach' );
+		expect( lists[ 1 ].key ).toBe( 'task-list/grow' );
 	} );
 
 	test( 'should separate installed plugins', () => {

--- a/src/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/src/Features/OnboardingTasks/Tasks/Marketing.php
@@ -37,8 +37,8 @@ class Marketing {
 	public static function get_plugins() {
 		$bundles = RemoteFreeExtensions::get_extensions(
 			array(
-				'reach',
-				'grow',
+				'task-list/reach',
+				'task-list/grow',
 			)
 		);
 

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -29,7 +29,6 @@ class DefaultFreeExtensions {
 					self::get_plugin( 'woocommerce-services:shipping' ),
 					self::get_plugin( 'woocommerce-services:tax' ),
 					self::get_plugin( 'jetpack' ),
-					self::get_plugin( 'mailpoet' ),
 				],
 			],
 			[

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -22,342 +22,382 @@ class DefaultFreeExtensions {
 	public static function get_all() {
 		$bundles = [
 			[
-				'key'     => 'basics',
+				'key'     => 'obw/basics',
 				'title'   => __( 'Get the basics', 'woocommerce-admin' ),
 				'plugins' => [
-					[
-						'key'         => 'woocommerce-payments',
-						'description' => sprintf(
-							/* translators: 1: opening product link tag. 2: closing link tag */
-							__( 'Accept credit cards with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
-							'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
-							'</a>'
-						),
-						'is_visible'  => [
-							[
-								'type'     => 'or',
-								'operands' => [
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'US',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'PR',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'AU',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'CA',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'DE',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'ES',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'FR',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'GB',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'IE',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'IT',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'NZ',
-										'operation' => '=',
-									],
-								],
-							],
-							[
-								'type'         => 'option',
-								'transformers' => [
-									[
-										'use'       => 'dot_notation',
-										'arguments' => [
-											'path' => 'industry',
-										],
-									],
-									[
-										'use'       => 'array_column',
-										'arguments' => [
-											'key' => 'slug',
-										],
-									],
-									[
-										'use'       => 'array_search',
-										'arguments' => [
-											'value' => 'cbd-other-hemp-derived-products',
-										],
-									],
-								],
-								'option_name'  => 'woocommerce_onboarding_profile',
-								'value'        => 'cbd-other-hemp-derived-products',
-								'default'      => '',
-								'operation'    => '!=',
-							],
-						],
-					],
-					[
-						'key'         => 'woocommerce-services:shipping',
-						'description' => sprintf(
-							/* translators: 1: opening product link tag. 2: closing link tag */
-							__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
-							'<a href="https://woocommerce.com/products/shipping" target="_blank">',
-							'</a>'
-						),
-						'is_visible'  => [
-							[
-								'type'      => 'base_location_country',
-								'value'     => 'US',
-								'operation' => '=',
-							],
-							[
-								'type'    => 'not',
-								'operand' => [
-									[
-										'type'    => 'plugins_activated',
-										'plugins' => [ 'woocommerce-services' ],
-									],
-								],
-							],
-							[
-								'type'     => 'or',
-								'operands' => [
-									[
-										[
-											'type'         => 'option',
-											'transformers' => [
-												[
-													'use' => 'dot_notation',
-													'arguments' => [
-														'path' => 'product_types',
-													],
-												],
-												[
-													'use' => 'count',
-												],
-											],
-											'option_name'  => 'woocommerce_onboarding_profile',
-											'value'        => 1,
-											'default'      => '',
-											'operation'    => '!=',
-										],
-									],
-									[
-										[
-											'type'         => 'option',
-											'transformers' => [
-												[
-													'use' => 'dot_notation',
-													'arguments' => [
-														'path' => 'product_types.0',
-													],
-												],
-											],
-											'option_name'  => 'woocommerce_onboarding_profile',
-											'value'        => 'downloads',
-											'default'      => '',
-											'operation'    => '!=',
-										],
-									],
-								],
-							],
-						],
-					],
-					[
-						'key'         => 'woocommerce-services:tax',
-						'description' => sprintf(
-							/* translators: 1: opening product link tag. 2: closing link tag */
-							__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce-admin' ),
-							'<a href="https://woocommerce.com/products/tax" target="_blank">',
-							'</a>'
-						),
-						'is_visible'  => [
-							[
-								'type'     => 'or',
-								'operands' => [
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'US',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'FR',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'GB',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'DE',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'CA',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'AU',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'GR',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'BE',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'PT',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'DK',
-										'operation' => '=',
-									],
-									[
-										'type'      => 'base_location_country',
-										'value'     => 'SE',
-										'operation' => '=',
-									],
-								],
-							],
-							[
-								'type'    => 'not',
-								'operand' => [
-									[
-										'type'    => 'plugins_activated',
-										'plugins' => [ 'woocommerce-services' ],
-									],
-								],
-							],
-						],
-					],
-					[
-						'key'         => 'jetpack',
-						'description' => sprintf(
-							/* translators: 1: opening product link tag. 2: closing link tag */
-							__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce-admin' ),
-							'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
-							'</a>'
-						),
-						'is_visible'  => [
-							[
-								'type'    => 'not',
-								'operand' => [
-									[
-										'type'    => 'plugins_activated',
-										'plugins' => [ 'jetpack' ],
-									],
-								],
-							],
-						],
-					],
-					[
-						'key'         => 'mailpoet',
-						'name'        => __( 'MailPoet', 'woocommerce-admin' ),
-						'description' => __( 'Level up your email marketing with {{link}}MailPoet{{/link}}', 'woocommerce-admin' ),
-						'description' => sprintf(
-							/* translators: 1: opening product link tag. 2: closing link tag */
-							__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce-admin' ),
-							'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
-							'</a>'
-						),
-						'manage_url'  => 'admin.php?page=mailpoet-newsletters',
-						'is_visible'  => [
-							[
-								'type'    => 'not',
-								'operand' => [
-									[
-										'type'    => 'plugins_activated',
-										'plugins' => [ 'mailpoet' ],
-									],
-								],
-							],
-						],
-					],
+					self::get_plugin( 'woocommerce-payments' ),
+					self::get_plugin( 'woocommerce-services:shipping' ),
+					self::get_plugin( 'woocommerce-services:tax' ),
+					self::get_plugin( 'jetpack' ),
+					self::get_plugin( 'mailpoet' ),
 				],
 			],
 			[
-				'key'     => 'reach',
-				'title'   => __( 'Reach out to customers', 'woocommerce-admin' ),
-				'plugins' => [
-					[
-						'key'         => 'mailpoet',
-						'name'        => __( 'MailPoet', 'woocommerce-admin' ),
-						'description' => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
-						'image_url'   => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
-						'manage_url'  => 'admin.php?page=mailpoet-newsletters',
-					],
-					[
-						'key'         => 'mailchimp-for-woocommerce',
-						'name'        => __( 'Mailchimp', 'woocommerce-admin' ),
-						'description' => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce-admin' ),
-						'image_url'   => plugins_url( 'images/onboarding/mailchimp-for-woocommerce.png', WC_ADMIN_PLUGIN_FILE ),
-						'manage_url'  => 'admin.php?page=mailchimp-woocommerce',
-					],
-					[
-						'key'         => 'creative-mail-by-constant-contact',
-						'name'        => __( 'Creative Mail for WooCommerce', 'woocommerce-admin' ),
-						'description' => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce-admin' ),
-						'image_url'   => plugins_url( 'images/onboarding/creative-mail-by-constant-contact.png', WC_ADMIN_PLUGIN_FILE ),
-						'manage_url'  => 'admin.php?page=creativemail',
-					],
-				],
-			],
-			[
-				'key'     => 'grow',
+				'key'     => 'obw/grow',
 				'title'   => __( 'Grow your store', 'woocommerce-admin' ),
 				'plugins' => [
-					[
-						'key'         => 'google-listings-and-ads',
-						'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
-						'description' => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
-						'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
-						'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
-					],
+					self::get_plugin( 'mailpoet' ),
+					self::get_plugin( 'google-listings-and-ads' ),
+				],
+			],
+			[
+				'key'     => 'task-list/reach',
+				'title'   => __( 'Reach out to customers', 'woocommerce-admin' ),
+				'plugins' => [
+					self::get_plugin( 'mailpoet:alt' ),
+					self::get_plugin( 'mailchimp-for-woocommerce' ),
+					self::get_plugin( 'creative-mail-by-constant-contact' ),
+				],
+			],
+			[
+				'key'     => 'task-list/grow',
+				'title'   => __( 'Grow your store', 'woocommerce-admin' ),
+				'plugins' => [
+					self::get_plugin( 'google-listings-and-ads:alt' ),
 				],
 			],
 		];
 
 		$bundles = wp_json_encode( $bundles );
 		return json_decode( $bundles );
+	}
+
+	/**
+	 * Get the plugin arguments by slug.
+	 *
+	 * @param string $slug Slug.
+	 * @return array
+	 */
+	public static function get_plugin( $slug ) {
+		$plugins = array(
+			'google-listings-and-ads'           => [
+				'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/google-listings-and-ads" target="_blank">',
+					'</a>'
+				),
+				'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+			],
+			'google-listings-and-ads:alt'       => [
+				'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+				'description' => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
+				'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+			],
+			'mailpoet'                          => [
+				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
+				'description' => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'image_url'   => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+			],
+			'mailchimp-for-woocommerce'         => [
+				'name'        => __( 'Mailchimp', 'woocommerce-admin' ),
+				'description' => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce-admin' ),
+				'image_url'   => plugins_url( 'images/onboarding/mailchimp-for-woocommerce.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=mailchimp-woocommerce',
+			],
+			'creative-mail-by-constant-contact' => [
+				'name'        => __( 'Creative Mail for WooCommerce', 'woocommerce-admin' ),
+				'description' => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce-admin' ),
+				'image_url'   => plugins_url( 'images/onboarding/creative-mail-by-constant-contact.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=creativemail',
+			],
+			'woocommerce-payments'              => [
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Accept credit cards with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
+					'</a>'
+				),
+				'is_visible'  => [
+					[
+						'type'     => 'or',
+						'operands' => [
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'US',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'PR',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'AU',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'CA',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'DE',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'ES',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'FR',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'GB',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'IE',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'IT',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'NZ',
+								'operation' => '=',
+							],
+						],
+					],
+					[
+						'type'         => 'option',
+						'transformers' => [
+							[
+								'use'       => 'dot_notation',
+								'arguments' => [
+									'path' => 'industry',
+								],
+							],
+							[
+								'use'       => 'array_column',
+								'arguments' => [
+									'key' => 'slug',
+								],
+							],
+							[
+								'use'       => 'array_search',
+								'arguments' => [
+									'value' => 'cbd-other-hemp-derived-products',
+								],
+							],
+						],
+						'option_name'  => 'woocommerce_onboarding_profile',
+						'value'        => 'cbd-other-hemp-derived-products',
+						'default'      => '',
+						'operation'    => '!=',
+					],
+				],
+			],
+			'woocommerce-services:shipping'     => [
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
+					'</a>'
+				),
+				'is_visible'  => [
+					[
+						'type'      => 'base_location_country',
+						'value'     => 'US',
+						'operation' => '=',
+					],
+					[
+						'type'    => 'not',
+						'operand' => [
+							[
+								'type'    => 'plugins_activated',
+								'plugins' => [ 'woocommerce-services' ],
+							],
+						],
+					],
+					[
+						'type'     => 'or',
+						'operands' => [
+							[
+								[
+									'type'         => 'option',
+									'transformers' => [
+										[
+											'use'       => 'dot_notation',
+											'arguments' => [
+												'path' => 'product_types',
+											],
+										],
+										[
+											'use' => 'count',
+										],
+									],
+									'option_name'  => 'woocommerce_onboarding_profile',
+									'value'        => 1,
+									'default'      => '',
+									'operation'    => '!=',
+								],
+							],
+							[
+								[
+									'type'         => 'option',
+									'transformers' => [
+										[
+											'use'       => 'dot_notation',
+											'arguments' => [
+												'path' => 'product_types.0',
+											],
+										],
+									],
+									'option_name'  => 'woocommerce_onboarding_profile',
+									'value'        => 'downloads',
+									'default'      => '',
+									'operation'    => '!=',
+								],
+							],
+						],
+					],
+				],
+			],
+			'woocommerce-services:tax'          => [
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/tax" target="_blank">',
+					'</a>'
+				),
+				'is_visible'  => [
+					[
+						'type'     => 'or',
+						'operands' => [
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'US',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'FR',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'GB',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'DE',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'CA',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'AU',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'GR',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'BE',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'PT',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'DK',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'SE',
+								'operation' => '=',
+							],
+						],
+					],
+					[
+						'type'    => 'not',
+						'operand' => [
+							[
+								'type'    => 'plugins_activated',
+								'plugins' => [ 'woocommerce-services' ],
+							],
+						],
+					],
+				],
+			],
+			'jetpack'                           => [
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
+					'</a>'
+				),
+				'is_visible'  => [
+					[
+						'type'    => 'not',
+						'operand' => [
+							[
+								'type'    => 'plugins_activated',
+								'plugins' => [ 'jetpack' ],
+							],
+						],
+					],
+				],
+			],
+			'mailpoet'                          => [
+				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
+				'description' => sprintf(
+					/* translators: 1: opening product link tag. 2: closing link tag */
+					__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce-admin' ),
+					'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
+					'</a>'
+				),
+				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+				'is_visible'  => [
+					[
+						'type'    => 'not',
+						'operand' => [
+							[
+								'type'    => 'plugins_activated',
+								'plugins' => [ 'mailpoet' ],
+							],
+						],
+					],
+				],
+			],
+			'mailpoet:alt'                      => [
+				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
+				'description' => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'image_url'   => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+			],
+		);
+
+		$plugin        = $plugins[ $slug ];
+		$plugin['key'] = $slug;
+
+		return $plugin;
 	}
 }

--- a/src/Features/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php
+++ b/src/Features/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php
@@ -10,7 +10,7 @@ class RemoteFreeExtensionsDataSourcePoller extends \Automattic\WooCommerce\Admin
 	const ID = 'remote_free_extensions';
 
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/obw-free-extensions/2.0/extensions.json',
+		'https://woocommerce.com/wp-json/wccom/obw-free-extensions/3.0/extensions.json',
 	);
 
 	/**


### PR DESCRIPTION
Fixes #7823 

* Adds back in the marketing extensions into the OBW
* Separates bundle list keys for future-proofing

### Screenshots


![Screen Shot 2021-10-21 at 11 42 22 AM](https://user-images.githubusercontent.com/10561050/138321235-35b91b5c-f059-43f3-96ab-b8da2d891d86.png)

### Detailed test instructions:

1. Checkout the WCCOM PR - https://github.com/Automattic/woocommerce.com/pull/11551
2. Turn off marketing suggestions under WC -> Settings -> WooCommerce.com
3. Delete the transient `woocommerce_admin_remote_free_extensions_specs`
4. Go to the "Business details" step under the obw
5. Click the dropdown on the list and make sure the correct extensions are shown as in the screenshot above (cc @pmcpinto to make sure these are the correct extensions under marketing)
6. Enable marketing suggestions
7. Make sure the transient `woocommerce_admin_remote_free_extensions_specs` is filled in with the respective data (will be identical to the above, but `wocommerce.test` URLs in place of image fields)
8. Make sure the "Business details" step still loads the correct extensions