### PR TITLE
Adding google listings and ads back to basics in defaults

### DIFF
--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -313,6 +313,12 @@ class DefaultFreeExtensions {
 							],
 						],
 					],
+					[
+						'key'         => 'google-listings-and-ads',
+						'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+						'description' => __( 'Drive sales with Google Listings & Ads.', 'woocommerce-admin' ),
+						'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+					],
 				],
 			],
 			[


### PR DESCRIPTION
Fixes #7780 

Modifying the free extensions defaults to include "Google listings and ads" in basics list.

### Screenshots
![Screenshot from 2021-10-21 10-03-58](https://user-images.githubusercontent.com/444632/138342938-0c3d8099-4c1b-4e90-8f7d-03b7bb7594ed.png)

### Detailed test instructions:

-  Checkout branch & activate
-  Disable marketing suggestions opt-in in Woocommerce -> Settings -> Advanced -> Woocommerce.com
- Delete any existing transient option `_transient_woocommerce_admin_remote_free_extensions_specs` from your DB
- Refresh and navigate through OBW to Busness details step.
- Ensure that "Google listings and ads" is shown in the free extensions list, and enabled by default.