### PR TITLE
Updating woo navigation link colors for greater contrast

### DIFF
--- a/changelogs/update-7815-nav-contrast
+++ b/changelogs/update-7815-nav-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Updating navigation link colors

--- a/client/navigation/components/container/style.scss
+++ b/client/navigation/components/container/style.scss
@@ -28,12 +28,12 @@
 
 		&:not(:hover) {
 			.components-button {
-				color: #949494;
+				color: $gray-400;
 			}
 		}
 		&:hover {
 			.components-button {
-				color: #ddd;
+				color: $white;
 			}
 		}
 		&.is-active {
@@ -62,7 +62,7 @@
 		&:not(:hover) {
 			a.components-button {
 				// ${ G2.lightGray.ui };
-				color: #949494;
+				color: $gray-400;
 			}
 		}
 		&.is-active {
@@ -101,7 +101,7 @@
 	}
 
 	.components-navigation__back-button {
-		color: #949494;
+		color: $gray-400;
 		opacity: 1;
 
 		&,


### PR DESCRIPTION
Fixes #7815

Just updating the link colors for greater contrast and accessibility. 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/138360521-28250c06-d496-4bfe-9cde-8ceebce6bc3e.png)


### Detailed test instructions:

-   Checkout branch
-   Enable new navigation in Woocommerce -> Settings -> Advanced -> Features
- Check that the link colors match the screenshot and issue requirements
