### PR TITLE
Adding unfulfilled order count badge to woo navigation

### DIFF
--- a/client/navigation/components/Item/index.js
+++ b/client/navigation/components/Item/index.js
@@ -35,7 +35,7 @@ const Item = ( { item } ) => {
 			key={ item.id }
 			item={ item.id }
 			title={ item.title }
-			badge={ item.badge }
+			badge={ item.badge ? item.badge : null }
 			href={ item.url }
 			navigateToMenu={ ! item.url && item.id }
 			onClick={ () => trackClick( item.id ) }

--- a/client/navigation/components/Item/index.js
+++ b/client/navigation/components/Item/index.js
@@ -35,6 +35,7 @@ const Item = ( { item } ) => {
 			key={ item.id }
 			item={ item.id }
 			title={ item.title }
+			badge={ item.badge }
 			href={ item.url }
 			navigateToMenu={ ! item.url && item.id }
 			onClick={ () => trackClick( item.id ) }

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -79,17 +79,8 @@ class CoreMenu {
 	 * @return array
 	 */
 	public static function get_shop_order_count() {
-		$query            = new \WC_Order_Query(
-			array(
-				'paginate' => true,
-				'return'   => 'ids',
-				'status'   => array( 'processing', 'on-hold' ),
-			)
-		);
-		$shop_orders      = $query->get_orders();
-		$shop_order_count = intval( $shop_orders->total );
-
-		return $shop_order_count;
+		$status_counts = array_map( 'wc_orders_count', array( 'processing', 'on-hold' ) );
+		return array_sum( $status_counts );
 	}
 
 	/**

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -74,6 +74,25 @@ class CoreMenu {
 	}
 
 	/**
+	 * Get unfulfilled order count
+	 *
+	 * @return array
+	 */
+	public static function get_shop_order_count() {
+		$query            = new \WC_Order_Query(
+			array(
+				'paginate' => true,
+				'return'   => 'ids',
+				'status'   => array( 'processing', 'on-hold' ),
+			)
+		);
+		$shop_orders      = $query->get_orders();
+		$shop_order_count = intval( $shop_orders->total );
+
+		return $shop_order_count;
+	}
+
+	/**
 	 * Get all menu categories.
 	 *
 	 * @return array
@@ -84,6 +103,7 @@ class CoreMenu {
 			array(
 				'title' => __( 'Orders', 'woocommerce-admin' ),
 				'id'    => 'woocommerce-orders',
+				'badge' => self::get_shop_order_count(),
 				'order' => 10,
 			),
 			array(
@@ -374,7 +394,7 @@ class CoreMenu {
 				) {
 					continue;
 				}
-	
+
 				// Use the link from the first item if it's a category.
 				if ( ! isset( $item['url'] ) ) {
 					$categoryMenuId = $menuId === 'favorites' ? 'plugins' : $menuId;
@@ -383,7 +403,7 @@ class CoreMenu {
 					if ( ! empty( $category_items ) ) {
 						$first_item = $category_items[0];
 
-	
+
 						$submenu['woocommerce'][] = array(
 							$item['title'],
 							$first_item['capability'],
@@ -391,10 +411,10 @@ class CoreMenu {
 							$item['title'],
 						);
 					}
-	
+
 					continue;
 				}
-	
+
 				// Show top-level items.
 				$submenu['woocommerce'][] = array(
 					$item['title'],


### PR DESCRIPTION
Fixes #7641

Adding order count badge to orders category item for woo navigation.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/138372959-7ee33e8c-5358-449f-b07e-d1f743dac6bc.png)

**Notes:**
- I'm not 100% confident of my method for fetching the order count on the back-end, since other places in WCAdmin use the `window.wcSettings.admin.orderCount` value, on the front-end.
- I'm assuming that we don't want to display the value `0`, and instead not show the badge. Is that correct @elizaan36 ?


### Detailed test instructions:

-   Checkout branch
-   Ensure that woo navigation is enabled (Woocommerce -> Settings -> Advanced -> Features)
- Make sure you have some test orders, including some in status `processing` or `on-hold`
- Confirm that order badge appears on orders category in navigation item (as pictured)
- Compare number to Activity Panel or `window.wcSettings.admin.orderCount`

