### PR TITLE
Two columns experiment - move paid extensions to extended task list  

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -50,6 +50,12 @@ const TwoColumnTasks = lazy( () =>
 	import( /* webpackChunkName: "two-column-tasks" */ '../two-column-tasks' )
 );
 
+const TwoColumnTasksExtended = lazy( () =>
+	import(
+		/* webpackChunkName: "two-column-tasks-extended" */ '../two-column-tasks/extended-task'
+	)
+);
+
 export const Layout = ( {
 	defaultHomescreenLayout,
 	isBatchUpdating,
@@ -134,18 +140,25 @@ export const Layout = ( {
 
 	const renderTaskList = () => {
 		if ( twoColumns && isRunningTwoColumnExperiment ) {
-			return '';
+			return (
+				// When running the two-column experiment, we still need to render
+				// the component in the left column for the extended task list.
+				<TwoColumnTasksExtended query={ query } />
+			);
 		} else if (
 			! twoColumns &&
 			isRunningTwoColumnExperiment &&
 			! isLoadingExperimentAssignment
 		) {
 			return (
-				<TwoColumnTasks
-					query={ query }
-					userPreferences={ userPrefs }
-					twoColumns={ twoColumns }
-				/>
+				<>
+					<TwoColumnTasks
+						query={ query }
+						userPreferences={ userPrefs }
+						twoColumns={ twoColumns }
+					/>
+					<TwoColumnTasksExtended query={ query } />
+				</>
 			);
 		}
 

--- a/client/two-column-tasks/allowed-tasks.js
+++ b/client/two-column-tasks/allowed-tasks.js
@@ -1,0 +1,9 @@
+export default [
+	'products',
+	'payments',
+	'woocommerce-payments',
+	'tax',
+	'shipping',
+	'marketing',
+	'appearance',
+];

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -132,7 +132,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		}
 	);
 
-	// Use custom isComplete since we're manusally adding tasks
+	// Use custom isComplete since we're manually adding tasks
 	// to the extended task list.
 	const isComplete = completedTasks.length === extendedTaskList.tasks.length;
 

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import { Fragment, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useExperiment } from '@woocommerce/explat';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { DisplayOption } from '../header/activity-panel/display-options';
+import { Task } from '../tasks/task';
+import { TaskList } from '../tasks/task-list';
+import { TasksPlaceholder } from '../tasks/placeholder';
+import '../tasks/tasks.scss';
+import allowedTasks from './allowed-tasks';
+
+export type TasksProps = {
+	query: { task?: string };
+};
+
+const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
+	const { task } = query;
+	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'woocommerce_tasklist_progression'
+	);
+
+	const { isResolving, taskLists } = useSelect( ( select ) => {
+		return {
+			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
+				'getTaskLists'
+			),
+			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
+		};
+	} );
+
+	const getCurrentTask = () => {
+		if ( ! task ) {
+			return null;
+		}
+
+		const tasks = taskLists.reduce(
+			( acc, taskList ) => [ ...acc, ...taskList.tasks ],
+			[]
+		);
+
+		const currentTask = tasks.find( ( t ) => t.id === task );
+
+		if ( ! currentTask ) {
+			return null;
+		}
+
+		return currentTask;
+	};
+
+	const toggleTaskList = ( taskList ) => {
+		const { id, isHidden } = taskList;
+		const newValue = ! isHidden;
+
+		recordEvent(
+			newValue ? `${ id }_tasklist_hide` : `${ id }_tasklist_show`,
+			{}
+		);
+
+		hideTaskList( id );
+	};
+
+	useEffect( () => {
+		// @todo Update this when all task lists have been hidden or completed.
+		const taskListsFinished = false;
+		updateOptions( {
+			woocommerce_task_list_prompt_shown: true,
+			woocommerce_default_homepage_layout: 'two_columns',
+		} );
+	}, [ taskLists, isResolving ] );
+
+	const currentTask = getCurrentTask();
+
+	if ( task && ! currentTask ) {
+		return null;
+	}
+
+	if ( isResolving ) {
+		return <TasksPlaceholder query={ query } />;
+	}
+
+	if ( currentTask ) {
+		return (
+			<div className="woocommerce-task-dashboard__container">
+				<Task query={ query } task={ currentTask } />
+			</div>
+		);
+	}
+
+	if ( isLoadingExperiment ) {
+		return <TasksPlaceholder query={ query } />;
+	}
+
+	const extendedTaskList = taskLists.find( ( list ) => {
+		return list.id === 'extended';
+	} );
+
+	// See if we need to move any of the main tasks to the extended task list
+	const setupTaskList = taskLists.find( ( list ) => {
+		return list.id === 'setup';
+	} );
+
+	const unallowedTasks =
+		setupTaskList?.tasks.filter( ( unallowedTask ) => {
+			return (
+				! allowedTasks.includes( unallowedTask.id ) &&
+				unallowedTask.id !== 'store_details'
+			);
+		} ) || [];
+
+	extendedTaskList.tasks = extendedTaskList.tasks.concat( unallowedTasks );
+
+	if ( extendedTaskList.tasks.length === 0 ) {
+		return null;
+	}
+
+	const completedTasks = extendedTaskList.tasks.filter(
+		( extendedTaskListTask ) => {
+			return extendedTaskListTask.completed;
+		}
+	);
+
+	// Use custom isComplete since we're manusally adding tasks
+	// to the extended task list.
+	const isComplete = completedTasks.length === extendedTaskList.tasks.length;
+
+	const {
+		id,
+		isHidden,
+		isVisible,
+		isToggleable,
+		title,
+		tasks,
+	} = extendedTaskList;
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	return (
+		<Fragment key={ id }>
+			<TaskList
+				id={ id }
+				isComplete={ isComplete }
+				isExpandable={
+					experimentAssignment?.variationName === 'treatment'
+				}
+				query={ query }
+				tasks={ tasks }
+				title={ title }
+			/>
+			{ isToggleable && (
+				<DisplayOption>
+					<MenuGroup
+						className="woocommerce-layout__homescreen-display-options"
+						label={ __( 'Display', 'woocommerce-admin' ) }
+					>
+						<MenuItem
+							className="woocommerce-layout__homescreen-extension-tasklist-toggle"
+							icon={ ! isHidden && check }
+							isSelected={ ! isHidden }
+							role="menuitemcheckbox"
+							onClick={ () => toggleTaskList( extendedTaskList ) }
+						>
+							{ __(
+								'Show things to do next',
+								'woocommerce-admin'
+							) }
+						</MenuItem>
+					</MenuGroup>
+				</DisplayOption>
+			) }
+		</Fragment>
+	);
+};
+
+export default ExtendedTask;

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -105,14 +105,18 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		return list.id === 'setup';
 	} );
 
-	extendedTaskList.tasks = extendedTaskList.tasks.concat(
-		setupTaskList?.tasks.filter( ( unallowedTask ) => {
-			return (
-				! allowedTasks.includes( unallowedTask.id ) &&
-				unallowedTask.id !== 'store_details'
-			);
-		} ) || []
-	);
+	extendedTaskList.tasks = [
+		...new Set(
+			extendedTaskList.tasks.concat(
+				setupTaskList?.tasks.filter( ( unallowedTask ) => {
+					return (
+						! allowedTasks.includes( unallowedTask.id ) &&
+						unallowedTask.id !== 'store_details'
+					);
+				} ) || []
+			)
+		),
+	];
 
 	if ( extendedTaskList.tasks.length === 0 ) {
 		return null;

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -28,9 +28,6 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-		'woocommerce_tasklist_progression'
-	);
 
 	const { isResolving, taskLists } = useSelect( ( select ) => {
 		return {
@@ -99,10 +96,6 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		);
 	}
 
-	if ( isLoadingExperiment ) {
-		return <TasksPlaceholder query={ query } />;
-	}
-
 	const extendedTaskList = taskLists.find( ( list ) => {
 		return list.id === 'extended';
 	} );
@@ -153,9 +146,6 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 			<TaskList
 				id={ id }
 				isComplete={ isComplete }
-				isExpandable={
-					experimentAssignment?.variationName === 'treatment'
-				}
 				query={ query }
 				tasks={ tasks }
 				title={ title }

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -109,10 +109,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		...new Set(
 			extendedTaskList.tasks.concat(
 				setupTaskList?.tasks.filter( ( unallowedTask ) => {
-					return (
-						! allowedTasks.includes( unallowedTask.id ) &&
-						unallowedTask.id !== 'store_details'
-					);
+					return ! allowedTasks.includes( unallowedTask.id );
 				} ) || []
 			)
 		),

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -112,15 +112,14 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		return list.id === 'setup';
 	} );
 
-	const unallowedTasks =
+	extendedTaskList.tasks = extendedTaskList.tasks.concat(
 		setupTaskList?.tasks.filter( ( unallowedTask ) => {
 			return (
 				! allowedTasks.includes( unallowedTask.id ) &&
 				unallowedTask.id !== 'store_details'
 			);
-		} ) || [];
-
-	extendedTaskList.tasks = extendedTaskList.tasks.concat( unallowedTasks );
+		} ) || []
+	);
 
 	if ( extendedTaskList.tasks.length === 0 ) {
 		return null;

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -105,36 +105,32 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 
 	return (
 		<>
-			{ setupTasks &&
-				taskLists[ 0 ].isVisible &&
-				( ! taskLists[ 0 ].isHidden || task ) && (
-					<TaskList
-						taskListId={ taskLists[ 0 ].id }
-						eventName="tasklist"
-						twoColumns={ twoColumns }
-						keepCompletedTaskList={ keepCompletedTaskList }
-						dismissedTasks={ dismissedTasks || [] }
-						isComplete={ isTaskListComplete }
-						query={ query }
-						tasks={ setupTasks }
-						title={ __(
-							'Get ready to start selling',
-							'woocommerce-admin'
-						) }
-						onComplete={ () =>
-							updateOptions( {
-								woocommerce_default_homepage_layout:
-									'two_columns',
-							} )
-						}
-						onHide={ () =>
-							updateOptions( {
-								woocommerce_default_homepage_layout:
-									'two_columns',
-							} )
-						}
-					/>
-				) }
+			{ setupTasks && ( ! taskLists[ 0 ].isHidden || task ) && (
+				<TaskList
+					taskListId={ taskLists[ 0 ].id }
+					eventName="tasklist"
+					twoColumns={ twoColumns }
+					keepCompletedTaskList={ keepCompletedTaskList }
+					dismissedTasks={ dismissedTasks || [] }
+					isComplete={ isTaskListComplete }
+					query={ query }
+					tasks={ setupTasks }
+					title={ __(
+						'Get ready to start selling',
+						'woocommerce-admin'
+					) }
+					onComplete={ () =>
+						updateOptions( {
+							woocommerce_default_homepage_layout: 'two_columns',
+						} )
+					}
+					onHide={ () =>
+						updateOptions( {
+							woocommerce_default_homepage_layout: 'two_columns',
+						} )
+					}
+				/>
+			) }
 		</>
 	);
 };

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -14,6 +14,7 @@ import './style.scss';
 import TaskList from './task-list';
 import TaskListPlaceholder from './placeholder';
 import { Task } from '../tasks/task';
+import allowedTasks from './allowed-tasks';
 
 const taskDashboardSelect = ( select ) => {
 	const { getOption, hasFinishedResolution } = select( OPTIONS_STORE_NAME );
@@ -80,10 +81,19 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 		return <TaskListPlaceholder />;
 	}
 
-	const isSetupTaskListHidden = taskLists[ 0 ].isHidden;
-	const setupTasks = taskLists[ 0 ].tasks.filter(
-		( setupTask ) => setupTask.id !== 'store_details'
+	if ( currentTask ) {
+		return (
+			<div className="woocommerce-task-dashboard__container">
+				<Task query={ query } task={ currentTask } />
+			</div>
+		);
+	}
+	// List of task items to be shown on the main task list.
+	// Any other remaining tasks will be moved to the extended task list.
+	const setupTasks = taskLists[ 0 ].tasks.filter( ( setupTask ) =>
+		allowedTasks.includes( setupTask.id )
 	);
+
 	const completedTasks = setupTasks.filter(
 		( setupTask ) => setupTask.isComplete
 	);
@@ -93,46 +103,38 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 		( setupTask ) => setupTask.isDismissed
 	);
 
-	if ( currentTask ) {
-		return (
-			<div className="woocommerce-task-dashboard__container">
-				<Task query={ query } task={ currentTask } />
-			</div>
-		);
-	}
-
-	if ( ! taskLists[ 0 ].isVisible ) {
-		return null;
-	}
-
 	return (
 		<>
-			{ setupTasks && ( ! isSetupTaskListHidden || task ) && (
-				<TaskList
-					taskListId={ taskLists[ 0 ].id }
-					eventName="tasklist"
-					twoColumns={ twoColumns }
-					keepCompletedTaskList={ keepCompletedTaskList }
-					dismissedTasks={ dismissedTasks || [] }
-					isComplete={ isTaskListComplete }
-					query={ query }
-					tasks={ setupTasks }
-					title={ __(
-						'Get ready to start selling',
-						'woocommerce-admin'
-					) }
-					onComplete={ () =>
-						updateOptions( {
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
-					onHide={ () =>
-						updateOptions( {
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
-				/>
-			) }
+			{ setupTasks &&
+				taskLists[ 0 ].isVisible &&
+				( ! taskLists[ 0 ].isHidden || task ) && (
+					<TaskList
+						taskListId={ taskLists[ 0 ].id }
+						eventName="tasklist"
+						twoColumns={ twoColumns }
+						keepCompletedTaskList={ keepCompletedTaskList }
+						dismissedTasks={ dismissedTasks || [] }
+						isComplete={ isTaskListComplete }
+						query={ query }
+						tasks={ setupTasks }
+						title={ __(
+							'Get ready to start selling',
+							'woocommerce-admin'
+						) }
+						onComplete={ () =>
+							updateOptions( {
+								woocommerce_default_homepage_layout:
+									'two_columns',
+							} )
+						}
+						onHide={ () =>
+							updateOptions( {
+								woocommerce_default_homepage_layout:
+									'two_columns',
+							} )
+						}
+					/>
+				) }
 		</>
 	);
 };

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -105,7 +105,7 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 
 	return (
 		<>
-			{ setupTasks && ( ! taskLists[ 0 ].isHidden || task ) && (
+			{ setupTasks && ( taskLists[ 0 ].isVisible || task ) && (
 				<TaskList
 					taskListId={ taskLists[ 0 ].id }
 					eventName="tasklist"

--- a/client/two-column-tasks/style.scss
+++ b/client/two-column-tasks/style.scss
@@ -1,3 +1,7 @@
+.woocommerce-homescreen .woocommerce-task-dashboard__container:empty {
+	margin-bottom: 0;
+}
+
 .woocommerce-task-dashboard__container {
 	.woocommerce-homescreen-card {
 		max-width: none;


### PR DESCRIPTION
Fixes #7716 

This PR adds the extended task list to the two columns experiment and moves tasks that are not one of  `products, payments, woocommerce-payments, tax, shipping, marketing, and appearance` to it.

I copied [tasks.tsx](https://github.com/woocommerce/woocommerce-admin/blob/main/client/tasks/tasks.tsx) file as `extendedt-task.tsx` and modified it to add additional logics required. The additional changes start at [here](https://github.com/woocommerce/woocommerce-admin/compare/main...update/7716-move-paid-exts-to-extended-task-list#diff-0efef046575b085349dfc62186b02e5bb1fee30258a41a9e7e77ca73c7a0cf7bR106).

### Screenshots

Two columns: 
![Screen Shot 2021-10-24 at 11 48 40 AM](https://user-images.githubusercontent.com/4723145/138608378-53cb74e7-9d81-4b44-a163-7bf50e3cba30.jpg)

Single column:

![Screen Shot 2021-10-24 at 11 48 49 AM](https://user-images.githubusercontent.com/4723145/138608384-174b34ae-e0c7-43a8-b7c4-b191c635a602.jpg)

### Detailed test instructions:

1. Assign yourself to `explat-experiment--woocommerce_tasklist_progression_headercard_10` experiment's treatment group.
2. Install a fresh WooCommerce and WooCommerce Admin
3. Start OBW. Choose `Memberships` in the `Product Types` step. This will give us `Add Memberships to my store` in the `Things to do next` (extended) task list .
4. Go to the `Marketing`. Install and activate `Google Listings an Ads`. This will give us one more extended task list item.
5. Go to WooCommerce -> Home and confirm you have two items under the `Things to do` task.

no changelog