### PR TITLE
Fix failing test-php (7.0, 5.5, latest, 6.5.9, 1.10.19) test

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -18,7 +18,7 @@ jobs:
                 composer: ['2.0.6']
                 include:
                     - php: '7.0'
-                      wordpress: '5.5'
+                      wordpress: '5.6'
                       woocommerce: 'latest'
                       phpunit: '6.5.9'
                       composer: '1.10.19'


### PR DESCRIPTION
Fixes #7842 

This PR fixes failing `test-php (7.0, 5.5, latest, 6.5.9, 1.10.19) test` test by updating WordPress version to 5.6.

Please see issue #7842 for the cause of the failure. 

no changelog

### Detailed test instructions.

Check `test-php (7.0, 5.6, latest, 6.5.9, 1.10.19)` from this PR and make sure it passes without an error.