### PR TITLE
Set Task UI List number circle bg to transparent

### DIFF
--- a/client/two-column-tasks/style.scss
+++ b/client/two-column-tasks/style.scss
@@ -164,6 +164,7 @@
 	}
 	.woocommerce-task-list__item:not(.complete) .woocommerce-task__icon {
 		border: 1px solid var(--wp-admin-theme-color);
+		background: transparent;
 	}
 
 	.woocommerce-task-list__item-before {


### PR DESCRIPTION
Fixes #7845 

This PR sets the number circle bg to transparent on hover.

### Screenshots
![Screen Shot 2021-10-26 at 5 22 52 PM](https://user-images.githubusercontent.com/4723145/138979480-b4683df0-85f5-4c2f-93e3-440b40608888.jpg)

### Detailed test instructions:

1. Mouse however on one of the tasks.
2. Confirm the number circle's background is transparent.