### PR TITLE
Task List UI - Update experiment name

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -79,11 +79,16 @@ export const Layout = ( {
 	const isTaskListEnabled = bothTaskListsHidden === false;
 	const isDashboardShown = ! query.task;
 
+	const momentDate = moment().utc();
+
 	const [
 		isLoadingExperimentAssignment,
 		experimentAssignment,
 	] = useExperiment(
-		'woocommerce_tasklist_progression_headercard_' + moment().format( 'MM' )
+		'woocommerce_tasklist_progression_headercard_' +
+			momentDate.format( 'YYYY' ) +
+			'_' +
+			momentDate.format( 'MM' )
 	);
 
 	const isRunningTwoColumnExperiment =


### PR DESCRIPTION
Fixes #7850 

This PR updates the experiment name used in Task List UI.

- Uses `woocommerce_tasklist_progression_headercard_$YYY_MM` format
- Uses UTC timezone

### Detailed test instructions:

1. Clear experiment cache by clearing local storage in Console -> Application -> Local Storage (Chrome)
2. Refresh WooCommerce -> Home
3. Go back to Console -> Application -> Local Storage and confirm you have `explat-experiment--woocommerce_tasklist_progression_headercard_2021_10` key.
