### PR TITLE
Change CTA text for personalize store task after completion

### DIFF
--- a/changelogs/fix-7846-update-personalize-task-cta
+++ b/changelogs/fix-7846-update-personalize-task-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Change CTA text for personalize store task after completion #7852

--- a/client/two-column-tasks/headers/appearance.js
+++ b/client/two-column-tasks/headers/appearance.js
@@ -33,7 +33,9 @@ const AppearanceHeader = ( { task, goToTask } ) => {
 					isPrimary={ ! task.isComplete }
 					onClick={ goToTask }
 				>
-					{ __( 'Personalize', 'woocommerce-admin' ) }
+					{ task.isComplete
+						? __( 'Modify choices', 'woocommerce-admin' )
+						: __( 'Personalize', 'woocommerce-admin' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }


### PR DESCRIPTION
Fixes #7846

Change CTA for personalize store task:

![image](https://user-images.githubusercontent.com/3747241/138993816-1cc1e4ac-d89f-489e-b7b5-42b6eeeeb52b.png)

### Detailed test instructions:

1. In order to shortcut to the final task, you can remove [these lines](https://github.com/woocommerce/woocommerce-admin/blob/170d529417baad29a836957884db855f39052f1d/client/two-column-tasks/task-list.js#L147-L149) in your local
2. Complete personalize my task and navigate to Home
3. Observe `Modify choices` text for CTA button