### PR TITLE
Revert experiment task titles back to original

### DIFF
--- a/changelogs/fix-7847-replace-experiment-task-titles-with-original
+++ b/changelogs/fix-7847-replace-experiment-task-titles-with-original
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Revert experiment task titles back to original #7853

--- a/client/two-column-tasks/task-list.js
+++ b/client/two-column-tasks/task-list.js
@@ -20,12 +20,6 @@ import taskHeaders from './task-headers';
 import DismissModal from './dissmiss-modal';
 import TaskListCompleted from './completed';
 
-// Temporary experiment titles which differs from current task titles.
-const experimentTaskTitles = {
-	marketing: __( 'Get more sales', 'woocommerce-admin' ),
-	'woocommerce-payments': __( 'Set up payments', 'woocommerce-admin' ),
-};
-
 export const TaskList = ( {
 	query,
 	taskListId,
@@ -248,10 +242,7 @@ export const TaskList = ( {
 								<TaskItem
 									key={ task.id }
 									className={ className }
-									title={
-										experimentTaskTitles[ task.id ] ??
-										task.title
-									}
+									title={ task.title }
 									completed={ task.isComplete }
 									content={ task.content }
 									onClick={ () => {


### PR DESCRIPTION
Fixes #7847

Revert experiment task titles back to default task titles from API.

### Screenshots
![image](https://user-images.githubusercontent.com/3747241/139034795-ac509888-582b-4cfb-b574-9bdc67588703.png)

### Detailed test instructions:

-  In setup wizard, go to Business Details step and make sure to select WooCommerce Payments in Free Features tab
- Make sure WCPay is not connected
- Go to WooCommerce > Home
- Observe the task 2 says "Get paid with WooCommerce Payments" and step 5 says "Set up marketing tools"