### PR TITLE
Only load tasks during rest api requests

### DIFF
--- a/changelogs/fix-task-list-performance
+++ b/changelogs/fix-task-list-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Only load tasks during rest api requests #7856

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -816,7 +816,7 @@ class Onboarding {
 		if ( $extended_list ) {
 			$help_tab['content'] .= '<h3>' . __( 'Extended task List', 'woocommerce-admin' ) . '</h3>';
 			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the extended task lists, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-			( $extended_task->is_hidden()
+			( $extended_list->is_hidden()
 				? '<p><a href="' . wc_admin_url( '&reset_extended_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
 				: '<p><a href="' . wc_admin_url( '&reset_extended_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
 			);

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -52,6 +52,7 @@ class Init {
 		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
 		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
 		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		TaskLists::init();
 
 		if ( ! is_admin() ) {
 			return;

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -45,6 +45,33 @@ class TaskLists {
 	}
 
 	/**
+	 * Initialize the task lists.
+	 */
+	public static function init() {
+		self::init_default_lists();
+		add_action( 'rest_api_init', array( __CLASS__, 'maybe_add_default_tasks' ) );
+	}
+
+	/**
+	 * Initialize default lists.
+	 */
+	public static function init_default_lists() {
+		self::add_list(
+			array(
+				'id'    => 'setup',
+				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
+			)
+		);
+
+		self::add_list(
+			array(
+				'id'    => 'extended',
+				'title' => __( 'Things to do next', 'woocommerce-admin' ),
+			)
+		);
+	}
+
+	/**
 	 * Add a task list.
 	 *
 	 * @param array $args Task list properties.
@@ -83,18 +110,15 @@ class TaskLists {
 	 * Add default task lists.
 	 */
 	public static function maybe_add_default_tasks() {
-		$added = isset( self::$lists['setup'] );
+		global $wp;
 
-		if ( ! apply_filters( 'woocommerce_admin_onboarding_tasks_add_default_tasks', ! $added ) ) {
+		if ( substr( $wp->request, 0, 34 ) !== 'wp-json/wc-admin/onboarding/tasks' ) {
 			return;
 		}
 
-		self::add_list(
-			array(
-				'id'    => 'setup',
-				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
-			)
-		);
+		if ( ! apply_filters( 'woocommerce_admin_onboarding_tasks_add_default_tasks', true ) ) {
+			return;
+		}
 
 		self::add_task( 'setup', StoreDetails::get_task() );
 		self::add_task( 'setup', Purchase::get_task() );
@@ -113,7 +137,6 @@ class TaskLists {
 	 * @return array
 	 */
 	public static function get_lists() {
-		self::maybe_add_default_tasks();
 		return self::$lists;
 	}
 


### PR DESCRIPTION
Only loads the task list tasks during REST API requests.

### Detailed test instructions:


**Smoke testing**
1. Build the production version of this branch
2. Make a `GET` request to `wp-json/wc-admin/onboarding/tasks`
2. Make sure the task lists and all tasks are returned as expected
3. Go to Products->Help (tab)->Setup Wizard
4. Attempt to Disable/Enable the task lists and make sure these actions work as expected
5. Optionally smoke test the task list (though this should have no relation to the changes in the PR given it does not rely on the task list REST API in this release).


**Performance testing**

1. Create a site with 1k+ products using WC Smooth Generator
2. Install the Query Monitor plugin - https://wordpress.org/plugins/query-monitor/
3. On the `release/2.8.0-rc.3` sort "Queries" by time to load
4. Navigate to a core WC page (like orders or products)
4. Note the highest is most likely the task list functions
5. Check out this branch
6. Note that this is no longer the case

Note that this issue still persists and has for quite some time on WooCommerce Admin pages, but will be resolved by the new task list REST API going forward.