### PR TITLE
Add Profile Notes

### DIFF
--- a/changelogs/add-profile-notes
+++ b/changelogs/add-profile-notes
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Add profile notes.
+Add profile notes. #7861

--- a/changelogs/add-profile-notes
+++ b/changelogs/add-profile-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Add profile notes.

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -17,8 +17,6 @@ import {
 	InboxDismissConfirmationModal,
 	InboxNotePlaceholder,
 } from '@woocommerce/experimental';
-import moment from 'moment';
-import { useExperiment } from '@woocommerce/explat';
 
 /**
  * Internal dependencies
@@ -57,7 +55,6 @@ const renderNotes = ( {
 	notes,
 	onDismiss,
 	onNoteActionClick,
-	isRunningExperiment,
 } ) => {
 	if ( isBatchUpdating ) {
 		return;
@@ -87,17 +84,6 @@ const renderNotes = ( {
 				if ( isDeleted ) {
 					return null;
 				}
-
-				if ( ! isRunningExperiment ) {
-					if ( note.name === 'wc-admin-complete-store-details' ) {
-						return null;
-					}
-
-					if ( note.name === 'wc-admin-update-store-details' ) {
-						return null;
-					}
-				}
-
 				return (
 					<CSSTransition
 						key={ noteId }
@@ -288,22 +274,6 @@ const InboxPanel = () => {
 
 	const hasNotes = hasValidNotes( notes );
 
-	const momentDate = moment().utc();
-
-	const [
-		isLoadingExperimentAssignment,
-		experimentAssignment,
-	] = useExperiment(
-		'woocommerce_tasklist_progression_headercard_' +
-			momentDate.format( 'YYYY' ) +
-			'_' +
-			momentDate.format( 'MM' )
-	);
-
-	const isRunningExperiment =
-		! isLoadingExperimentAssignment &&
-		experimentAssignment?.variationName === 'treatment';
-
 	// @todo After having a pagination implemented we should call the method "getNotes" with a different query since
 	// the current one is only getting 25 notes and the count of unread notes only will refer to this 25 and not all the existing ones.
 	return (
@@ -324,7 +294,6 @@ const InboxPanel = () => {
 							notes,
 							onDismiss,
 							onNoteActionClick,
-							isRunningExperiment,
 						} ) }
 				</Section>
 				{ dismiss && (

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -17,6 +17,8 @@ import {
 	InboxDismissConfirmationModal,
 	InboxNotePlaceholder,
 } from '@woocommerce/experimental';
+import moment from 'moment';
+import { useExperiment } from '@woocommerce/explat';
 
 /**
  * Internal dependencies
@@ -55,6 +57,7 @@ const renderNotes = ( {
 	notes,
 	onDismiss,
 	onNoteActionClick,
+	isRunningExperiment,
 } ) => {
 	if ( isBatchUpdating ) {
 		return;
@@ -84,6 +87,17 @@ const renderNotes = ( {
 				if ( isDeleted ) {
 					return null;
 				}
+
+				if ( ! isRunningExperiment ) {
+					if ( note.name === 'wc-admin-complete-store-details' ) {
+						return null;
+					}
+
+					if ( note.name === 'wc-admin-update-store-details' ) {
+						return null;
+					}
+				}
+
 				return (
 					<CSSTransition
 						key={ noteId }
@@ -274,6 +288,22 @@ const InboxPanel = () => {
 
 	const hasNotes = hasValidNotes( notes );
 
+	const momentDate = moment().utc();
+
+	const [
+		isLoadingExperimentAssignment,
+		experimentAssignment,
+	] = useExperiment(
+		'woocommerce_tasklist_progression_headercard_' +
+			momentDate.format( 'YYYY' ) +
+			'_' +
+			momentDate.format( 'MM' )
+	);
+
+	const isRunningExperiment =
+		! isLoadingExperimentAssignment &&
+		experimentAssignment?.variationName === 'treatment';
+
 	// @todo After having a pagination implemented we should call the method "getNotes" with a different query since
 	// the current one is only getting 25 notes and the count of unread notes only will refer to this 25 and not all the existing ones.
 	return (
@@ -294,6 +324,7 @@ const InboxPanel = () => {
 							notes,
 							onDismiss,
 							onNoteActionClick,
+							isRunningExperiment,
 						} ) }
 				</Section>
 				{ dismiss && (

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -130,8 +130,8 @@ final class Experimental_Abtest {
 		// Decode the results.
 		$results = json_decode( $response['body'], true );
 
-		// Bail if there were no results or there is no test variation returned.
-		if ( ! is_array( $results ) || empty( $results['variations'] ) ) {
+		// Bail if there were no resultsreturned.
+		if ( ! is_array( $results ) ) {
 			return new \WP_Error( 'unexpected_data_format', 'Data was not returned in the expected format.' );
 		}
 

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -179,15 +179,53 @@ class Notes extends \WC_REST_CRUD_Controller {
 
 		$data = array();
 		foreach ( (array) $notes as $note_obj ) {
+			// Hide selected notes for users not in experiment.
+			if ( ! $this->is_tasklist_experiment_assigned_treatment() ) {
+				if ( 'wc-admin-complete-store-details' === $note_obj['name'] ) {
+					continue;
+				}
+
+				if ( 'wc-admin-update-store-details' === $note_obj['name'] ) {
+					continue;
+				}
+			}
 			$note   = $this->prepare_item_for_response( $note_obj, $request );
 			$note   = $this->prepare_response_for_collection( $note );
 			$data[] = $note;
 		}
 
 		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', NotesRepository::get_notes_count( $query_args['type'], $query_args['status'] ) );
+		$response->header( 'X-WP-Total', count( $data ) );
 
 		return $response;
+	}
+
+	/**
+	 * Checks if user is in tasklist experiment.
+	 *
+	 * @return bool Whether remote inbox notifications are enabled.
+	 */
+	private function is_tasklist_experiment_assigned_treatment() {
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
+			$anon_id,
+			'woocommerce',
+			$allow_tracking
+		);
+
+		$date = new \DateTime();
+		$date->setTimeZone( new \DateTimeZone( 'UTC' ) );
+
+		$experiment_name = sprintf(
+			'woocommerce_tasklist_progression_headercard_%s_%s',
+			$date->format( 'Y' ),
+			$date->format( 'm' )
+		);
+
+		$variation_name = $abtest->get_variation( $experiment_name );
+
+		return $abtest->get_variation( $experiment_name ) === 'treatment';
 	}
 
 	/**

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -177,10 +177,12 @@ class Notes extends \WC_REST_CRUD_Controller {
 
 		$notes = NotesRepository::get_notes( 'edit', $query_args );
 
+		$is_tasklist_experiment_assigned_treatment = $this->is_tasklist_experiment_assigned_treatment();
+
 		$data = array();
 		foreach ( (array) $notes as $note_obj ) {
 			// Hide selected notes for users not in experiment.
-			if ( ! $this->is_tasklist_experiment_assigned_treatment() ) {
+			if ( ! $is_tasklist_experiment_assigned_treatment ) {
 				if ( 'wc-admin-complete-store-details' === $note_obj['name'] ) {
 					continue;
 				}

--- a/src/Events.php
+++ b/src/Events.php
@@ -50,6 +50,8 @@ use \Automattic\WooCommerce\Admin\Notes\DrawAttention;
 use \Automattic\WooCommerce\Admin\Notes\GettingStartedInEcommerceWebinar;
 use \Automattic\WooCommerce\Admin\Notes\NavigationNudge;
 use Automattic\WooCommerce\Admin\Schedulers\MailchimpScheduler;
+use \Automattic\WooCommerce\Admin\Notes\CompleteStoreDetails;
+use \Automattic\WooCommerce\Admin\Notes\UpdateStoreDetails;
 
 /**
  * Events Class.
@@ -151,6 +153,8 @@ class Events {
 		GettingStartedInEcommerceWebinar::possibly_add_note();
 		FirstDownlaodableProduct::possibly_add_note();
 		NavigationNudge::possibly_add_note();
+		CompleteStoreDetails::possibly_add_note();
+		UpdateStoreDetails::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/CompleteStoreDetails.php
+++ b/src/Notes/CompleteStoreDetails.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CompleteStoreDetails class
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds a note when the profiler was skipped.
+ */
+class CompleteStoreDetails {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-complete-store-details';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Bail when profile was set up by client.
+		if ( isset( $onboarding_profile['setup_client'] ) && $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// Bail when profile was not skipped.
+		if ( isset( $onboarding_profile['skipped'] ) && ! $onboarding_profile['skipped'] ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Add your store details to complete store setup', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Complete your store details with important information for setup such as your store’s base address', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'add-store-details',
+			__( 'Add store details', 'woocommerce-admin' ),
+			wc_admin_url( '&path=/setup-wizard' )
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/UpdateStoreDetails.php
+++ b/src/Notes/UpdateStoreDetails.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * UpdateStoreDetails class
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds a note when the profiler is completed.
+ */
+class UpdateStoreDetails {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-update-store-details';
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+
+		// Bail when profile was set up by client.
+		if ( isset( $onboarding_profile['setup_client'] ) && $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// Bail when profile is not yet completed.
+		if ( isset( $onboarding_profile['completed'] ) && ! $onboarding_profile['completed'] ) {
+			return;
+		}
+
+		$note = new Note();
+		$note->set_title( __( 'Edit your store details if you need to', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Nice work completing your store profile! You can always go back and edit the details you just shared, as needed.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'add-store-details',
+			__( 'Update store details', 'woocommerce-admin' ),
+			wc_admin_url( '&path=/setup-wizard' )
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #7715

Adds notes to prompt the store owner to update their store details, or complete it if it was previously skipped.

### Screenshots

<img width="519" alt="Screen Shot 2021-10-29 at 10 26 49 pm" src="https://user-images.githubusercontent.com/9312929/139452501-88bf68b3-accc-462d-b479-d94ca9399fc9.png">
<img width="521" alt="Screen Shot 2021-10-29 at 10 26 44 pm" src="https://user-images.githubusercontent.com/9312929/139452508-de22b1b7-54f0-4b2c-bac0-dfabdd420276.png">

### Detailed test instructions:

-   On a fresh install, skip the onboarding wizard.
-   Run the `wc_admin_daily` cron task.
-   Join the experiment treatment group using the `treatment - woocommerce_tasklist_progression_headercard_2021_10` bookmarklet.  Note this didn't work for me. An alternative approach is setting the transient option `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2021_10` value to `treatment`.
-   See that the "Add your store details to complete store setup" note appears.
-   Click "Add store details" on the note.
-   Complete the onboarding wizard.
-   Run the `wc_admin_daily` cron task.
-   See the "Edit your store details if you need to" note.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
