### PR TITLE
Use $id instance property in DataSourcePoller instead of ID const defined in child classes

### DIFF
--- a/src/DataSourcePoller.php
+++ b/src/DataSourcePoller.php
@@ -115,7 +115,7 @@ abstract class DataSourcePoller {
 	 */
 	public function read_specs_from_data_sources() {
 		$specs        = array();
-		$data_sources = apply_filters( self::FILTER_NAME, $this->data_sources, $this::ID );
+		$data_sources = apply_filters( self::FILTER_NAME, $this->data_sources, $this->id );
 
 		// Note that this merges the specs from the data sources based on the
 		// id - last one wins.


### PR DESCRIPTION
Fixes #7860

This PR improves the implementation of DataSourcePoller to not rely on a specific `ID` const being defined in child classes.

### Detailed test instructions:

1. Delete `woocommerce_admin_remote_free_extensions_specs` transient.

```
wp transient delete woocommerce_admin_remote_free_extensions_specs
```

2. Add a filter for `data_source_poller_data_sources` in a plugin:

```
add_filter(
	'data_source_poller_data_sources',
	function( $data_sources, $data_source_id ) {

		if ( $data_source_id === 'remote_free_extensions' ) {
			return array( 'http://10.0.2.2/wp-json/wccom/obw-free-extensions/2.0/extensions.json' );
		}

		return $data_sources;
	}, 10, 2
);
```

3. Reload the WC home screen.

4. Verify that the `woocommerce_admin_remote_free_extensions_specs` transient contains the data from the sources specified by the filter used above.


No changelog required, as this is a fix to the DataSourcePoller refactor introduced in #7671 (and not yet released).