### PR TITLE
dismiss note immediately upon clicking dismiss button

### DIFF
--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement, Fragment, useState, useRef } from '@wordpress/element';
-import { Button, Dropdown, Popover } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import VisibilitySensor from 'react-visibility-sensor';
 import moment from 'moment';
 import classnames from 'classnames';
@@ -51,16 +51,12 @@ type InboxNote = {
 type InboxNoteProps = {
 	note: InboxNote;
 	lastRead: number;
-	onDismiss?: ( note: InboxNote, type: 'all' | 'note' ) => void;
+	onDismiss?: ( note: InboxNote ) => void;
 	onNoteActionClick?: ( note: InboxNote, action: InboxNoteAction ) => void;
 	onBodyLinkClick?: ( note: InboxNote, link: string ) => void;
 	onNoteVisible?: ( note: InboxNote ) => void;
 	className?: string;
 };
-
-const DropdownWithPopoverProps = Dropdown as React.ComponentType<
-	Dropdown.Props & { popoverProps: Omit< Popover.Props, 'children' > }
->;
 
 const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 	note,
@@ -73,7 +69,6 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 } ) => {
 	const [ clickedActionText, setClickedActionText ] = useState( false );
 	const hasBeenSeen = useRef( false );
-	const toggleButtonRef = useRef< HTMLButtonElement >( null );
 	const linkCallbackRef = useCallbackOnLinkClick( ( innerLink ) => {
 		if ( onBodyLinkClick ) {
 			onBodyLinkClick( note, innerLink );
@@ -91,101 +86,18 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		}
 	};
 
-	const handleBlur = ( event: React.FocusEvent, onClose: () => void ) => {
-		const dropdownClasses = [
-			'woocommerce-admin-dismiss-notification',
-			'components-popover__content',
-			'components-dropdown__content',
-		];
-		// This line is for IE compatibility.
-		let relatedTarget: EventTarget | Element | null = null;
-		if ( event.relatedTarget ) {
-			relatedTarget = event.relatedTarget;
-		} else if ( toggleButtonRef.current ) {
-			const ownerDoc = toggleButtonRef.current.ownerDocument;
-			relatedTarget = ownerDoc ? ownerDoc.activeElement : null;
-		}
-		let isClickOutsideDropdown = false;
-		if ( relatedTarget && 'className' in relatedTarget ) {
-			const classNames = relatedTarget.className;
-			isClickOutsideDropdown = dropdownClasses.some( ( cName ) =>
-				classNames.includes( cName )
-			);
-		}
-		if ( isClickOutsideDropdown ) {
-			event.preventDefault();
-		} else {
-			onClose();
-		}
-	};
-
-	const onDropdownDismiss = (
-		type: 'note' | 'all',
-		onToggle: () => void
-	) => {
-		if ( onDismiss ) {
-			onDismiss( note, type );
-		}
-		onToggle();
-	};
-
 	const renderDismissButton = () => {
 		if ( clickedActionText ) {
 			return null;
 		}
 
 		return (
-			<DropdownWithPopoverProps
-				contentClassName="woocommerce-admin-dismiss-dropdown"
-				position="bottom right"
-				renderToggle={ ( { onClose, onToggle } ) => (
-					<Button
-						isTertiary
-						onClick={ ( event: React.MouseEvent ) => {
-							( event.target as HTMLElement ).focus();
-							onToggle();
-						} }
-						ref={ toggleButtonRef }
-						onBlur={ ( event: React.FocusEvent ) =>
-							handleBlur( event, onClose )
-						}
-					>
-						{ __( 'Dismiss', 'woocommerce-admin' ) }
-					</Button>
-				) }
-				focusOnMount={ false }
-				popoverProps={ { noArrow: true } }
-				renderContent={ ( { onToggle } ) => (
-					<ul>
-						<li>
-							<Button
-								className="woocommerce-admin-dismiss-notification"
-								onClick={ () =>
-									onDropdownDismiss( 'note', onToggle )
-								}
-							>
-								{ __(
-									'Dismiss this message',
-									'woocommerce-admin'
-								) }
-							</Button>
-						</li>
-						<li>
-							<Button
-								className="woocommerce-admin-dismiss-notification"
-								onClick={ () =>
-									onDropdownDismiss( 'all', onToggle )
-								}
-							>
-								{ __(
-									'Dismiss all messages',
-									'woocommerce-admin'
-								) }
-							</Button>
-						</li>
-					</ul>
-				) }
-			/>
+			<Button
+				className="woocommerce-admin-dismiss-notification"
+				onClick={ () => onDismiss && onDismiss( note ) }
+			>
+				{ __( 'Dismiss', 'woocommerce-admin' ) }
+			</Button>
 		);
 	};
 

--- a/packages/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/test/inbox-note.tsx
@@ -155,7 +155,7 @@ describe( 'InboxNoteCard', () => {
 	} );
 
 	describe( 'callbacks', () => {
-		it( 'should call onDismiss with note type when "Dismiss this message" is clicked', () => {
+		it( 'should call onDismiss with note when "Dismiss this message" is clicked', () => {
 			const onDismiss = jest.fn();
 			const { getByText } = render(
 				<InboxNoteCard
@@ -166,23 +166,7 @@ describe( 'InboxNoteCard', () => {
 				/>
 			);
 			userEvent.click( getByText( 'Dismiss' ) );
-			userEvent.click( getByText( 'Dismiss this message' ) );
-			expect( onDismiss ).toHaveBeenCalledWith( note, 'note' );
-		} );
-
-		it( 'should call onDismiss with all type when "Dismiss all messages" is clicked', () => {
-			const onDismiss = jest.fn();
-			const { getByText } = render(
-				<InboxNoteCard
-					key={ note.id }
-					note={ note }
-					lastRead={ lastRead }
-					onDismiss={ onDismiss }
-				/>
-			);
-			userEvent.click( getByText( 'Dismiss' ) );
-			userEvent.click( getByText( 'Dismiss all messages' ) );
-			expect( onDismiss ).toHaveBeenCalledWith( note, 'all' );
+			expect( onDismiss ).toHaveBeenCalledWith( note );
 		} );
 
 		it( 'should call onNoteActionClick with specific action when action is clicked', () => {


### PR DESCRIPTION
Fixes #7867 

This PR removes the dismiss confirmation popup and dismisses the note immediately.

### Detailed test instructions:

1. Navigate to WooCommerce -> Home
2. Click `dismiss` on a note.
3. Confirm the note dismissed without prompting the confirmation popup.
