### PR TITLE
Add dismiss all button for Inbox 2.0

### DIFF
--- a/changelogs/update-7243-action-to-dismiss-all-notes
+++ b/changelogs/update-7243-action-to-dismiss-all-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Added dismiss all button for inbox notes

--- a/client/inbox-panel/dissmiss-all-modal.js
+++ b/client/inbox-panel/dissmiss-all-modal.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const DissmissAllModal = ( { setShowDismissAllModal } ) => {
+	const title = __( 'Dismiss all messages', 'woocommerce-admin' );
+	const message = __(
+		'Are you sure? Inbox messages will be dismissed forever.',
+		'woocommerce-admin'
+	);
+	const dismissActionText = __( 'Cancel', 'woocommerce-admin' );
+	const acceptActionText = __( 'Yes, dismiss all', 'woocommerce-admin' );
+	return (
+		<>
+			<Modal
+				title={ title }
+				className="woocommerce-inbox-dismiss-all-modal"
+				onRequestClose={ () => {
+					setShowDismissAllModal( false );
+				} }
+			>
+				<div className="woocommerce-inbox-dismiss-all-modal__wrapper">
+					<div className="woocommerce-usage-modal__message">
+						{ message }
+					</div>
+					<div className="woocommerce-usage-modal__actions">
+						<Button
+							onClick={ () => setShowDismissAllModal( false ) }
+						>
+							{ dismissActionText }
+						</Button>
+						<Button
+							isPrimary
+							onClick={ () => {
+								setShowDismissAllModal( false );
+							} }
+						>
+							{ acceptActionText }
+						</Button>
+					</div>
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default DissmissAllModal;

--- a/client/inbox-panel/dissmiss-all-modal.js
+++ b/client/inbox-panel/dissmiss-all-modal.js
@@ -5,17 +5,10 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
-	const title = __( 'Dismiss all messages', 'woocommerce-admin' );
-	const message = __(
-		'Are you sure? Inbox messages will be dismissed forever.',
-		'woocommerce-admin'
-	);
-	const dismissActionText = __( 'Cancel', 'woocommerce-admin' );
-	const acceptActionText = __( 'Yes, dismiss all', 'woocommerce-admin' );
 	return (
 		<>
 			<Modal
-				title={ title }
+				title={ __( 'Dismiss all messages', 'woocommerce-admin' ) }
 				className="woocommerce-inbox-dismiss-all-modal"
 				onRequestClose={ () => {
 					setShowDismissAllModal( false );
@@ -23,13 +16,16 @@ const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
 			>
 				<div className="woocommerce-inbox-dismiss-all-modal__wrapper">
 					<div className="woocommerce-usage-modal__message">
-						{ message }
+						{ __(
+							'Are you sure? Inbox messages will be dismissed forever.',
+							'woocommerce-admin'
+						) }
 					</div>
 					<div className="woocommerce-usage-modal__actions">
 						<Button
 							onClick={ () => setShowDismissAllModal( false ) }
 						>
-							{ dismissActionText }
+							{ __( 'Cancel', 'woocommerce-admin' ) }
 						</Button>
 						<Button
 							isPrimary
@@ -38,7 +34,7 @@ const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
 								setShowDismissAllModal( false );
 							} }
 						>
-							{ acceptActionText }
+							{ __( 'Yes, dismiss all', 'woocommerce-admin' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/inbox-panel/dissmiss-all-modal.js
+++ b/client/inbox-panel/dissmiss-all-modal.js
@@ -4,15 +4,13 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
+const DissmissAllModal = ( { onClose, dismissAllNotes } ) => {
 	return (
 		<>
 			<Modal
 				title={ __( 'Dismiss all messages', 'woocommerce-admin' ) }
 				className="woocommerce-inbox-dismiss-all-modal"
-				onRequestClose={ () => {
-					setShowDismissAllModal( false );
-				} }
+				onRequestClose={ onClose }
 			>
 				<div className="woocommerce-inbox-dismiss-all-modal__wrapper">
 					<div className="woocommerce-usage-modal__message">
@@ -22,16 +20,14 @@ const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
 						) }
 					</div>
 					<div className="woocommerce-usage-modal__actions">
-						<Button
-							onClick={ () => setShowDismissAllModal( false ) }
-						>
+						<Button onClick={ onClose }>
 							{ __( 'Cancel', 'woocommerce-admin' ) }
 						</Button>
 						<Button
 							isPrimary
 							onClick={ () => {
 								dismissAllNotes();
-								setShowDismissAllModal( false );
+								onClose();
 							} }
 						>
 							{ __( 'Yes, dismiss all', 'woocommerce-admin' ) }

--- a/client/inbox-panel/dissmiss-all-modal.js
+++ b/client/inbox-panel/dissmiss-all-modal.js
@@ -4,7 +4,7 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DissmissAllModal = ( { setShowDismissAllModal } ) => {
+const DissmissAllModal = ( { setShowDismissAllModal, dismissAllNotes } ) => {
 	const title = __( 'Dismiss all messages', 'woocommerce-admin' );
 	const message = __(
 		'Are you sure? Inbox messages will be dismissed forever.',
@@ -34,6 +34,7 @@ const DissmissAllModal = ( { setShowDismissAllModal } ) => {
 						<Button
 							isPrimary
 							onClick={ () => {
+								dismissAllNotes();
 								setShowDismissAllModal( false );
 							} }
 						>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -62,7 +62,7 @@ const renderNotes = ( {
 	notes,
 	onDismiss,
 	onNoteActionClick,
-	setShowDismissAllModal,
+	setShowDismissAllModal: onDismissAll,
 } ) => {
 	if ( isBatchUpdating ) {
 		return;
@@ -100,7 +100,7 @@ const renderNotes = ( {
 						<div className="woocommerce-inbox-card__section-controls">
 							<Button
 								onClick={ () => {
-									setShowDismissAllModal( true );
+									onDismissAll( true );
 									onToggle();
 								} }
 							>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -318,7 +318,9 @@ const InboxPanel = () => {
 		<>
 			{ showDismissAllModal && (
 				<DismissAllModal
-					setShowDismissAllModal={ setShowDismissAllModal }
+					onClose={ () => {
+						setShowDismissAllModal( false );
+					} }
 					dismissAllNotes={ dismissAllNotes }
 				/>
 			) }

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -30,6 +30,7 @@ import {
 import { ActivityCard } from '../header/activity-panel/activity-card';
 import { hasValidNotes } from './utils';
 import { getScreenName } from '../utils';
+import DismissAllModal from './dissmiss-all-modal';
 import './index.scss';
 
 const renderEmptyCard = () => (
@@ -61,6 +62,7 @@ const renderNotes = ( {
 	notes,
 	dismissNote,
 	onNoteActionClick,
+	setShowDismissAllModal,
 } ) => {
 	if ( isBatchUpdating ) {
 		return;
@@ -94,10 +96,15 @@ const renderNotes = ( {
 				</div>
 				<EllipsisMenu
 					label={ __( 'Inbox Notes Options', 'woocommerce-admin' ) }
-					renderContent={ ( {} ) => (
+					renderContent={ ( { onToggle } ) => (
 						<div className="woocommerce-inbox-card__section-controls">
-							<Button>
-								{ __( 'Hide this', 'woocommerce-admin' ) }
+							<Button
+								onClick={ () => {
+									setShowDismissAllModal( true );
+									onToggle();
+								} }
+							>
+								{ __( 'Dismiss all', 'woocommerce-admin' ) }
 							</Button>
 						</div>
 					) }
@@ -181,6 +188,7 @@ const InboxPanel = () => {
 	);
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 	const [ lastRead ] = useState( userPrefs.activity_panel_inbox_last_read );
+	const [ showDismissAllModal, setShowDismissAllModal ] = useState( false );
 
 	useEffect( () => {
 		const mountTime = Date.now();
@@ -265,6 +273,11 @@ const InboxPanel = () => {
 	// the current one is only getting 25 notes and the count of unread notes only will refer to this 25 and not all the existing ones.
 	return (
 		<>
+			{ showDismissAllModal && (
+				<DismissAllModal
+					setShowDismissAllModal={ setShowDismissAllModal }
+				/>
+			) }
 			<div className="woocommerce-homepage-notes-wrapper">
 				{ ( isResolvingNotes || isBatchUpdating ) && (
 					<Section>
@@ -281,6 +294,7 @@ const InboxPanel = () => {
 							notes,
 							dismissNote,
 							onNoteActionClick,
+							setShowDismissAllModal,
 						} ) }
 				</Section>
 			</div>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -93,9 +93,9 @@ const renderNotes = ( {
 					<Badge count={ notesArray.length } />
 				</div>
 				<EllipsisMenu
-					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					label={ __( 'Inbox Notes Options', 'woocommerce-admin' ) }
 					renderContent={ ( {} ) => (
-						<div className="woocommerce-task-card__section-controls">
+						<div className="woocommerce-inbox-card__section-controls">
 							<Button>
 								{ __( 'Hide this', 'woocommerce-admin' ) }
 							</Button>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -60,7 +60,7 @@ const renderNotes = ( {
 	isBatchUpdating,
 	lastRead,
 	notes,
-	dismissNote,
+	onDismiss,
 	onNoteActionClick,
 	setShowDismissAllModal,
 } ) => {
@@ -126,7 +126,7 @@ const renderNotes = ( {
 								key={ noteId }
 								note={ note }
 								lastRead={ lastRead }
-								onDismiss={ dismissNote }
+								onDismiss={ onDismiss }
 								onNoteActionClick={ onNoteActionClick }
 								onBodyLinkClick={ onBodyLinkClick }
 								onNoteVisible={ onNoteVisible }
@@ -199,7 +199,7 @@ const InboxPanel = () => {
 		updateUserPreferences( userDataFields );
 	}, [] );
 
-	const dismissNote = ( note ) => {
+	const onDismiss = ( note ) => {
 		const screen = getScreenName();
 
 		recordEvent( 'inbox_action_dismiss', {
@@ -294,7 +294,7 @@ const InboxPanel = () => {
 							isBatchUpdating,
 							lastRead,
 							notes,
-							dismissNote,
+							onDismiss,
 							onNoteActionClick,
 							setShowDismissAllModal,
 						} ) }

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -93,9 +93,9 @@ const renderNotes = ( {
 					<Badge count={ notesArray.length } />
 				</div>
 				<EllipsisMenu
-					label={ __( 'Inbox Notes Options', 'woocommerce-admin' ) }
+					label={ __( 'Task List Options', 'woocommerce-admin' ) }
 					renderContent={ ( {} ) => (
-						<div className="woocommerce-inbox-card__section-controls">
+						<div className="woocommerce-task-card__section-controls">
 							<Button>
 								{ __( 'Hide this', 'woocommerce-admin' ) }
 							</Button>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -164,13 +164,9 @@ const INBOX_QUERY = {
 
 const InboxPanel = () => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const {
-		batchUpdateNotes,
-		removeAllNotes,
-		removeNote,
-		updateNote,
-		triggerNoteAction,
-	} = useDispatch( NOTES_STORE_NAME );
+	const { removeNote, updateNote, triggerNoteAction } = useDispatch(
+		NOTES_STORE_NAME
+	);
 	const { isError, isResolvingNotes, isBatchUpdating, notes } = useSelect(
 		( select ) => {
 			const {
@@ -246,45 +242,6 @@ const InboxPanel = () => {
 		}
 	};
 
-	const dismissAllNotes = async () => {
-		recordEvent( 'wcadmin_inbox_action_dismissall', {} );
-		try {
-			const notesRemoved = await removeAllNotes( {
-				status: INBOX_QUERY.status,
-			} );
-			createNotice(
-				'success',
-				__( 'All messages dismissed', 'woocommerce-admin' ),
-				{
-					actions: [
-						{
-							label: __( 'Undo', 'woocommerce-admin' ),
-							onClick: () => {
-								batchUpdateNotes(
-									notesRemoved.map( ( note ) => note.id ),
-									{
-										is_deleted: 0,
-									}
-								);
-							},
-						},
-					],
-				}
-			);
-		} catch ( e ) {
-			createNotice(
-				'error',
-				_n(
-					'Message could not be dismissed',
-					'Messages could not be dismissed',
-					notes.length,
-					'woocommerce-admin'
-				)
-			);
-			setShowDismissAllModal( false );
-		}
-	};
-
 	const onNoteActionClick = ( note, action ) => {
 		triggerNoteAction( note.id, action.id );
 	};
@@ -321,7 +278,6 @@ const InboxPanel = () => {
 					onClose={ () => {
 						setShowDismissAllModal( false );
 					} }
-					dismissAllNotes={ dismissAllNotes }
 				/>
 			) }
 			<div className="woocommerce-homepage-notes-wrapper">

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -45,6 +45,10 @@
 	width: 565px;
 	max-width: 100%;
 
+	.components-modal__content::before {
+		margin-bottom: 0;
+	}
+
 	.components-modal__header {
 		border-bottom: 1px solid #ddd !important;
 	}

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -63,7 +63,7 @@
 		position: relative;
 		position: sticky;
 		top: 0;
-		margin: 0 -32px 24px;
+		margin: 0 -#{$gap * 2} $gap-large;
 		font-size: 1.2em;
 	}
 

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -52,7 +52,7 @@
 	.woocommerce-usage-modal__message {
 		box-sizing: border-box;
 		border-bottom: 1px solid #ddd;
-		padding: 32px;
+		padding: $gap * 2;
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -1,6 +1,7 @@
 #activity-panel-inbox {
 	margin: 0 $gap-large;
 }
+
 .woocommerce-layout__inbox-panel-header {
 	padding: $gap-large;
 

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -40,3 +40,40 @@
 		margin-left: 16px;
 	}
 }
+
+.woocommerce-inbox-dismiss-all-modal {
+	width: 565px;
+	max-width: 100%;
+
+	.components-modal__header {
+		border-bottom: 1px solid #ddd;
+	}
+
+	.woocommerce-usage-modal__message {
+		box-sizing: border-box;
+		border-bottom: 1px solid #ddd;
+		padding: 0 32px;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		background: #fff;
+		align-items: center;
+		height: 60px;
+		z-index: 10;
+		position: relative;
+		position: sticky;
+		top: 0;
+		margin: 0 -32px 24px;
+		font-size: 1.2em;
+	}
+
+	.woocommerce-usage-modal__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: $gap;
+
+		button {
+			margin-left: $gap;
+		}
+	}
+}

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -46,13 +46,13 @@
 	max-width: 100%;
 
 	.components-modal__header {
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid #ddd !important;
 	}
 
 	.woocommerce-usage-modal__message {
 		box-sizing: border-box;
 		border-bottom: 1px solid #ddd;
-		padding: 0 32px;
+		padding: 32px;
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -35,7 +35,6 @@
 	}
 
 	&:not(.is-placeholder) {
-		border: 0;
 		border-bottom: 1px solid $gray-200;
 	}
 


### PR DESCRIPTION
Fixes #7243 

This PR adds `dismiss all` button and a modal when the button is clicked.

### Screenshots

![Screen Shot 2021-10-29 at 8 40 50 PM](https://user-images.githubusercontent.com/4723145/139519043-b01aa6cc-f629-4b8a-b065-e297cbd8dd1c.jpg)

### Detailed test instructions:

1. Navigate to WooCommerce -> Home
2. Click the ellipsis menu from the Inbox header.
3. Click `dismiss all`
4. Confirm the notes are all dismissed and a notice is displayed at the bottom left corner. 
5. Click `Undo` from the notice 
6. Confirm `wcadmin_inbox_action_dismissall` track even has been fired.

no changelog