### PR TITLE
Add extra intl countries to WC Pay support

### DIFF
--- a/changelogs/update-7862_wc_pay_intl_expansion
+++ b/changelogs/update-7862_wc_pay_intl_expansion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update WC pay supported country list for the default free extensions. #7873

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -170,40 +170,80 @@ class DefaultFreeExtensions {
 								'value'     => 'NZ',
 								'operation' => '=',
 							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'AT',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'BE',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'NL',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'PL',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'PT',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'CH',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'HK',
+								'operation' => '=',
+							],
+							[
+								'type'      => 'base_location_country',
+								'value'     => 'SG',
+								'operation' => '=',
+							],
 						],
-					],
-					[
-						'type'         => 'option',
-						'transformers' => [
-							[
-								'use'       => 'dot_notation',
-								'arguments' => [
-									'path' => 'industry',
+						[
+							'type'         => 'option',
+							'transformers' => [
+								[
+									'use'       => 'dot_notation',
+									'arguments' => [
+										'path' => 'industry',
+									],
+								],
+								[
+									'use'       => 'array_column',
+									'arguments' => [
+										'key' => 'slug',
+									],
+								],
+								[
+									'use'       => 'array_search',
+									'arguments' => [
+										'value' => 'cbd-other-hemp-derived-products',
+									],
 								],
 							],
-							[
-								'use'       => 'array_column',
-								'arguments' => [
-									'key' => 'slug',
-								],
-							],
-							[
-								'use'       => 'array_search',
-								'arguments' => [
-									'value' => 'cbd-other-hemp-derived-products',
-								],
-							],
+							'option_name'  => 'woocommerce_onboarding_profile',
+							'value'        => 'cbd-other-hemp-derived-products',
+							'default'      => '',
+							'operation'    => '!=',
 						],
-						'option_name'  => 'woocommerce_onboarding_profile',
-						'value'        => 'cbd-other-hemp-derived-products',
-						'default'      => '',
-						'operation'    => '!=',
 					],
 				],
 			],
 			'woocommerce-services:shipping'     => [
 				'description' => sprintf(
-					/* translators: 1: opening product link tag. 2: closing link tag */
+				/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
 					'</a>'


### PR DESCRIPTION
Fixes #7862 

Adds AT, BE, PT, PL, NL, CH to the free extensions support list of wc pay.


### Detailed test instructions:

- On a new store without WC Pay installed make sure that Marketing suggestions is turned off under **WooCommerce > Settings > Advanced > WooCommerce.com**
- Start the Onboarding flow and re-start this for each new country in the above list
- Step through until the Free features tab under Business details
- Make sure **WooCommerce Payments** is part of this list

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
