### PR TITLE
Remove store setup from the things to do list in the Task List UI experiment

### DIFF
--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -109,7 +109,10 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		...new Set(
 			extendedTaskList.tasks.concat(
 				setupTaskList?.tasks.filter( ( unallowedTask ) => {
-					return ! allowedTasks.includes( unallowedTask.id );
+					return (
+						! allowedTasks.includes( unallowedTask.id ) &&
+						unallowedTask.id !== 'store_details'
+					);
 				} ) || []
 			)
 		),


### PR DESCRIPTION
Fixes #7875 

This PR removes `Store Setup` task from the `Things to do` list when the user is in the `treatment` group of the Task List UI experiment.


### Detailed test instructions:

1. Start with a fresh installation and skip the onboarding wizard.
2. Assign yourself to `woocommerce_tasklist_progression_headercard_2021_11` experiment.
3. Navigate to WooCommerce -> Home
4. You should see the horizontal task list without `Things to do` task list.

no changelog