### PR TITLE
Task List UI - use single column placeholder

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -177,7 +177,11 @@ export const Layout = ( {
 	return (
 		<>
 			{ twoColumns && isRunningTwoColumnExperiment && (
-				<TwoColumnTasks query={ query } userPreferences={ userPrefs } />
+				<TwoColumnTasks
+					query={ query }
+					userPreferences={ userPrefs }
+					twoColumns={ twoColumns }
+				/>
 			) }
 			<div
 				className={ classnames( 'woocommerce-homescreen', {

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -78,7 +78,7 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 	}
 
 	if ( isResolving || isResolvingOptions ) {
-		return <TaskListPlaceholder />;
+		return <TaskListPlaceholder twoColumns={ twoColumns } />;
 	}
 
 	if ( currentTask ) {

--- a/client/two-column-tasks/placeholder.js
+++ b/client/two-column-tasks/placeholder.js
@@ -1,12 +1,23 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 
 const TaskListPlaceholder = ( props ) => {
-	const { numTasks = 5 } = props;
+	const { numTasks = 5, twoColumns = false } = props;
+
 	return (
-		<div className="woocommerce-task-dashboard__container two-column-experiment two-columns">
+		<div
+			className={ classnames( 'woocommerce-task-dashboard__container', {
+				'two-columns': twoColumns,
+				'two-column-experiment': true,
+			} ) }
+		>
 			<div className="components-card is-size-large woocommerce-task-card woocommerce-homescreen-card is-loading">
 				<div className="components-card__header is-size-medium">
 					<div className="wooocommerce-task-card__header">


### PR DESCRIPTION
Fixes #7877 

This PR uses the single column placeholder for the Task List UI when the layout mode is single column mode.

### Screenshots

**Before:**

![Screen Shot 2021-11-01 at 5 16 25 PM](https://user-images.githubusercontent.com/4723145/139760103-46d0b7cf-2129-4095-917e-5557620d6c72.jpg)

**After:**
![Screen Shot 2021-11-01 at 5 29 35 PM](https://user-images.githubusercontent.com/4723145/139760381-9c1e4f58-226e-4a83-af7f-905e4d98aaf3.jpg)


### Detailed test instructions:

1. Assign yourself to `woocommerce_tasklist_progression_headercard_2021_11` experiment.
2. Navigate to WooCommerce -> Home
3. If you're in the single column mode, confirm you're seeing the placeholder from the `After:` screenshot .

no changelog