### PR TITLE
Rename Inbox -> Activity from the activity header

### DIFF
--- a/changelogs/update-7248-update-inbox-link-to-activity
+++ b/changelogs/update-7248-update-inbox-link-to-activity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Rename Inbox to Activity from the activity header

--- a/changelogs/update-7248-update-inbox-link-to-activity
+++ b/changelogs/update-7248-update-inbox-link-to-activity
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Rename Inbox to Activity from the activity header
+Rename Inbox to Activity from the activity header #7879

--- a/client/header/activity-panel/icon-flag.js
+++ b/client/header/activity-panel/icon-flag.js
@@ -1,0 +1,28 @@
+export const IconFlag = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<mask
+			id="mask0_2915:6733"
+			maskUnits="userSpaceOnUse"
+			x="4"
+			y="3"
+			width="16"
+			height="18"
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M4.5 3.5H13.5L13.9 5.5H19.5V15.5H12.5L12.1 13.5H6.5V20.5H4.5V3.5ZM12.26 7.5L11.86 5.5H6.5V11.5H13.74L14.14 13.5H17.5V7.5H12.26Z"
+				fill="white"
+			/>
+		</mask>
+		<g mask="url(#mask0_2915:6733)">
+			<rect width="24" height="24" fill="#50575E" />
+		</g>
+	</svg>
+);

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -5,12 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { lazy, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
-import {
-	Icon,
-	help as helpIcon,
-	inbox as inboxIcon,
-	external,
-} from '@wordpress/icons';
+import { Icon, help as helpIcon, external } from '@wordpress/icons';
 import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import { H, Section } from '@woocommerce/components';
 import {
@@ -22,7 +17,6 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { applyFilters } from '@wordpress/hooks';
 import { useSlot } from '@woocommerce/experimental';
-
 /**
  * Internal dependencies
  */
@@ -31,6 +25,7 @@ import { isNotesPanelVisible } from './unread-indicators';
 import { isWCAdmin } from '../../dashboard/utils';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
+import { IconFlag } from './icon-flag';
 import { DisplayOptions } from './display-options';
 import { HighlightTooltip } from './highlight-tooltip';
 import { Panel } from './panel';
@@ -230,10 +225,10 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 
 	// @todo Pull in dynamic unread status/count
 	const getTabs = () => {
-		const inbox = {
-			name: 'inbox',
-			title: __( 'Inbox', 'woocommerce-admin' ),
-			icon: <Icon icon={ inboxIcon } />,
+		const activity = {
+			name: 'activity',
+			title: __( 'Activity', 'woocommerce-admin' ),
+			icon: <IconFlag />,
 			unread: hasUnreadNotes || hasAbbreviatedNotifications,
 			visible:
 				( isEmbedded || ! isHomescreen() ) && ! isPerformingSetupTask(),
@@ -307,7 +302,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 			},
 		};
 
-		return [ inbox, setup, previewSite, displayOptions, help ].filter(
+		return [ activity, setup, previewSite, displayOptions, help ].filter(
 			( tab ) => tab.visible
 		);
 	};
@@ -316,7 +311,7 @@ export const ActivityPanel = ( { isEmbedded, query, userPreferencesData } ) => {
 		const { task } = query;
 
 		switch ( tab ) {
-			case 'inbox':
+			case 'activity':
 				return (
 					<InboxPanel
 						hasAbbreviatedNotifications={

--- a/client/header/activity-panel/test/index.js
+++ b/client/header/activity-panel/test/index.js
@@ -70,7 +70,7 @@ describe( 'Activity Panel', () => {
 	it( 'should render inbox tab on embedded pages', () => {
 		render( <ActivityPanel isEmbedded query={ {} } /> );
 
-		expect( screen.getByText( 'Inbox' ) ).toBeDefined();
+		expect( screen.getByText( 'Activity' ) ).toBeDefined();
 	} );
 
 	it( 'should render inbox tab if not on home screen', () => {
@@ -78,7 +78,7 @@ describe( 'Activity Panel', () => {
 			<ActivityPanel query={ { page: 'wc-admin', path: '/customers' } } />
 		);
 
-		expect( screen.getByText( 'Inbox' ) ).toBeDefined();
+		expect( screen.getByText( 'Activity' ) ).toBeDefined();
 	} );
 
 	it( 'should not render inbox tab on home screen', () => {


### PR DESCRIPTION
Fixes #7248 

This PR renames `Inbox` to `Activity` from the activity header panel and uses the flag icon.

### Screenshots
![Screen Shot 2021-11-01 at 10 16 43 PM](https://user-images.githubusercontent.com/4723145/139790506-27f35959-7bbc-429b-a66e-a4af6d5b0b05.jpg)

### Detailed test instructions:

1. Navigate to WooCommerce -> Orders
2. Confirm the `Inbox` has been renamed to `Activity` and the icon is flag as shown on the screenshot.