### PR TITLE
Sync changelog from 2.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-== 2.8.0 10/22/2021 ==
+== 2.8.0 11/02/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
 - Fix: Fix issue where stock activity panel was not rendering correctly. #7817
@@ -16,7 +16,9 @@
 - Update: Update back up copy of free extension for Google Listing & Ads plugin. #7798
 - Update: Update Eway payment gateway capitalization (was eWAY). #7678
 - Update: Enable Square in France. #7679
+- Update: Update WC pay supported country list for the default free extensions. #7873
 - Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. #7666
+- Performance: Only load tasks during rest api requests #7856
 
 == 2.7.2 10/11/2021 ==
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == 2.8.0 10/22/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
+- Fix: Fix issue where stock activity panel was not rendering correctly. #7817
 - Fix: Increase CSS specificity to avoid conflicts and broken panel styling. #7813
 - Fix: Updated link to WooCommerce Developers Blog in readme.txt #7824
 - Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == 2.8.0 10/22/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
+- Fix: Increase CSS specificity to avoid conflicts and broken panel styling. #7813
 - Fix: Updated link to WooCommerce Developers Blog in readme.txt #7824
 - Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771
 - Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
-== 2.8.0 10/14/2021 ==
+== 2.8.0 10/22/2021 ==
 
 - Add: Store Profiler and Product task - include Subscriptions #7734
+- Fix: Updated link to WooCommerce Developers Blog in readme.txt #7824
 - Fix: Fixed navigation menu text color after Gutenberg 11.6.0 #7771
 - Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. #7743
 - Fix: Allow already installed marketing extensions to be activated #7740

--- a/changelogs/fix-7812_activity_panel_styling
+++ b/changelogs/fix-7812_activity_panel_styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Increase CSS specificity to avoid conflicts and broken panel styling. #7813

--- a/changelogs/fix-7814-correct-link-to-wc-dev-blog
+++ b/changelogs/fix-7814-correct-link-to-wc-dev-blog
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Updated link to WooCommerce Developers Blog in readme.txt #7824

--- a/changelogs/fix-7816_stock_activity_panel
+++ b/changelogs/fix-7816_stock_activity_panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Fix
-
-Fix issue where stock activity panel was not rendering correctly. #7817

--- a/changelogs/update-7862_wc_pay_intl_expansion
+++ b/changelogs/update-7862_wc_pay_intl_expansion
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Update WC pay supported country list for the default free extensions. #7873


### PR DESCRIPTION
This PR syncs the changelog from `release/2.8.0` back to `main`.

## Testing instructions

1. Confidence check - make sure changelog changes look correct.

(no changelog is needed here)