### PR TITLE
Bump Minimum Versions for 2.9 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.6 or greater](https://wordpress.org/download/) and [WooCommerce 4.8.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.6 or greater](https://wordpress.org/download/) and [WooCommerce 5.7.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.4 or greater](https://wordpress.org/download/) and [WooCommerce 4.8.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.6 or greater](https://wordpress.org/download/) and [WooCommerce 4.8.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
  * Version: 2.9.0-dev
- * Requires at least: 5.4
+ * Requires at least: 5.6
  * Requires PHP: 7.0
  *
  * WC requires at least: 5.7.0


### PR DESCRIPTION
Bumps the minimum versions of WordPress and WooCommerce according to L-2 for the 2.9 release.

No changelog