### PR TITLE
Remove the Spinner component while loading the store alerts

### DIFF
--- a/changelogs/update-7336-remove-loading-indicator
+++ b/changelogs/update-7336-remove-loading-indicator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Remove the Spinner component to prevent undesired page flickering.

--- a/changelogs/update-7336-remove-loading-indicator
+++ b/changelogs/update-7336-remove-loading-indicator
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Tweak
 
-Remove the Spinner component to prevent undesired page flickering.
+Remove the Spinner component to prevent undesired page flickering. #7886

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -50,7 +50,7 @@ export class PrimaryLayout extends Component {
 				id="woocommerce-layout__primary"
 			>
 				{ window.wcAdminFeatures[ 'store-alerts' ] && (
-					<Suspense fallback={ <div></div> }>
+					<Suspense fallback={ null }>
 						<StoreAlerts />
 					</Suspense>
 				) }

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -9,7 +9,6 @@ import { Router, Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { get, isFunction, identity } from 'lodash';
 import { parse } from 'qs';
-import { Spinner } from '@woocommerce/components';
 import { getHistory, getQuery } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import {
@@ -51,7 +50,7 @@ export class PrimaryLayout extends Component {
 				id="woocommerce-layout__primary"
 			>
 				{ window.wcAdminFeatures[ 'store-alerts' ] && (
-					<Suspense fallback={ <Spinner /> }>
+					<Suspense fallback={ <div></div> }>
 						<StoreAlerts />
 					</Suspense>
 				) }


### PR DESCRIPTION
Fixes #7336 

This PR removes the Spinner component while loading the store alerts to prevent undesired page flickering. 

P2: p90Yrv-2wh


### Detailed test instructions:

1. Navigate to one of the non-React pages such as WooCommerce -> Products or Order
2. Confirm there is no Spinner component and page flickering. 
