### PR TITLE
Revert #7471 – use "Extensions" as the page title for My Subscriptions and Marketplace pages

### DIFF
--- a/changelogs/update-7901-revert-page-title-to-extensions
+++ b/changelogs/update-7901-revert-page-title-to-extensions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Use page title Extensions for Marketplace and My Subscriptions pages. #7901

--- a/includes/connect-existing-pages.php
+++ b/includes/connect-existing-pages.php
@@ -23,7 +23,7 @@ function wc_admin_get_core_pages_to_connect() {
 
 	return array(
 		'wc-addons'   => array(
-			'title' => __( 'Marketplace', 'woocommerce-admin' ),
+			'title' => __( 'Extensions', 'woocommerce-admin' ),
 			'tabs'  => array(),
 		),
 		'wc-reports'  => array(
@@ -292,15 +292,5 @@ wc_admin_connect_page(
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_page_product_attribute-edit',
 		'title'     => __( 'Edit attribute', 'woocommerce-admin' ),
-	)
-);
-
-// WooCommerce > My Subscriptions.
-wc_admin_connect_page(
-	array(
-		'id'        => 'wc-subscriptions',
-		'screen_id' => 'woocommerce_page_wc-addons-browse-extensions-helper',
-		'title'     => __( 'My Subscriptions', 'woocommerce-admin' ),
-		'path'      => 'admin.php?page=wc-addons&section=helper',
 	)
 );


### PR DESCRIPTION
This change reverts https://github.com/woocommerce/woocommerce-admin/pull/7471, where we introduced two different page titles for the My Subscriptions and Marketplace pages. We'll be merging those pages back into one Extensions page in a change in WooCommerce core.

### Accessibility

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="500" src="https://user-images.githubusercontent.com/1647564/140288608-6caede19-e9b5-4375-a09a-a85f6cf81949.png">

<img width="500" src="https://user-images.githubusercontent.com/1647564/140288641-1a0937ee-0b5f-4476-a0e7-4368bd6573a8.png">

### Detailed test instructions:

-   Check out this branch.
-   View the My Subscriptions page `/wp-admin/admin.php?page=wc-addons&section=helper`. Check the page title in the white bar at the top is Extensions.
-  View the Marketplace page `/wp-admin/admin.php?page=wc-addons`. Check the page title is also Extensions.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
