### PR TITLE
Revert #7529 – remove Marketplace submenu items from new style nav

### DIFF
--- a/changelogs/update-revert-extensions-menu-split
+++ b/changelogs/update-revert-extensions-menu-split
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Reverts addition of Marketplace and My Subscriptions pages to the Marketplace menu. #7902

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -229,6 +229,15 @@ class CoreMenu {
 				),
 				array_merge( $product_items['new'], array( 'order' => 50 ) ),
 				$coupon_items['default'],
+				// Marketplace category.
+				array(
+					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
+					'capability' => 'manage_woocommerce',
+					'id'         => 'woocommerce-marketplace',
+					'url'        => 'wc-addons',
+					'menuId'     => 'secondary',
+					'order'      => 10,
+				),
 			),
 			// Tools category.
 			self::get_tool_items(),

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -121,12 +121,6 @@ class CoreMenu {
 				'order' => 40,
 			),
 			array(
-				'title'  => __( 'Marketplace', 'woocommerce-admin' ),
-				'id'     => 'woocommerce-marketplace',
-				'menuId' => 'secondary',
-				'order'  => 10,
-			),
-			array(
 				'title'  => __( 'Settings', 'woocommerce-admin' ),
 				'id'     => 'woocommerce-settings',
 				'menuId' => 'secondary',
@@ -236,8 +230,6 @@ class CoreMenu {
 				array_merge( $product_items['new'], array( 'order' => 50 ) ),
 				$coupon_items['default'],
 			),
-			// Marketplace category.
-			self::get_marketplace_items(),
 			// Tools category.
 			self::get_tool_items(),
 			// WooCommerce Admin items.
@@ -246,34 +238,6 @@ class CoreMenu {
 			$setting_items,
 			// Legacy report items.
 			self::get_legacy_report_items()
-		);
-	}
-
-	/**
-	 * Get marketplace menu items.
-	 *
-	 * @return array
-	 */
-	public static function get_marketplace_items() {
-		return array(
-			array(
-				'parent'     => 'woocommerce-marketplace',
-				'title'      => __( 'Browse', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'marketplace-browse',
-				'url'        => 'admin.php?page=wc-addons',
-				'migrate'    => false,
-				'order'      => 0,
-			),
-			array(
-				'parent'     => 'woocommerce-marketplace',
-				'title'      => __( 'My Subscriptions', 'woocommerce-admin' ),
-				'capability' => 'manage_woocommerce',
-				'id'         => 'marketplace-my-subscriptions',
-				'url'        => 'admin.php?page=wc-addons&section=helper',
-				'migrate'    => false,
-				'order'      => 1,
-			),
 		);
 	}
 
@@ -429,8 +393,6 @@ class CoreMenu {
 			'wc-reports',
 			'wc-settings',
 			'wc-status',
-			'wc-addons',
-			'wc-addons&section=helper',
 		);
 
 		return apply_filters( 'woocommerce_navigation_core_excluded_items', $excluded_items );


### PR DESCRIPTION
We are merging the Marketplace and My Subscriptions pages back into one Extensions page in WooCommerce core. As part of that change, we want to revert https://github.com/woocommerce/woocommerce-admin/pull/7529, which created items for these two pages in the Marketplace menu at the bottom of the new navigation.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="500" src="https://user-images.githubusercontent.com/1647564/140297682-fbb8c66f-d920-42e4-a490-a430984119e1.png">

### Detailed test instructions:

-   Check out this branch.
-   Add this snippet on your test site to enable the new navigation option:

```php
add_filter( 'woocommerce_admin_features', 'enable_new_woocommerce_navigation' );

function enable_new_woocommerce_navigation( $features ) {
	$features[] = 'navigation';
	return $features;
}
```

-  Select the new navigation in `WooCommerce > Settings > Advanced > Features` – enable `Adds the new WooCommerce navigation experience to the dashboard`.
-  View the WooCommerce home `/wp-admin/admin.php?page=wc-admin`. Check that the menu links for `My Subscriptions` and `Marketplace` appear as shown in the screenshot. Check that the two page links still work.
  - We will be merging the `My Subscriptions` page into `Marketplace` in WooCommerce core changes, at which point `My Subscriptions` should disappear from the `EXTENSIONS` menu.

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
