### PR TITLE
Fix marketing extensions tracks

### DIFF
--- a/changelogs/fix-7903
+++ b/changelogs/fix-7903
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix marketing extensions tracks #7908

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -92,7 +92,10 @@ class BusinessDetails extends Component {
 				extensionInstallationOptions[
 					'woocommerce-services:shipping'
 				] || extensionInstallationOptions[ 'woocommerce-services:tax' ],
+			install_google_listings_and_ads:
+				extensionInstallationOptions[ 'google-listings-and-ads' ],
 			install_jetpack: extensionInstallationOptions.jetpack,
+			install_mailpoet: extensionInstallationOptions.mailpoet,
 			install_wcpay:
 				extensionInstallationOptions[ 'woocommerce-payments' ],
 		} );


### PR DESCRIPTION
Fixes #7903

This PR fixes the marketing extensions tracks.

### Screenshots

![screenshot-one wordpress test-2021 11 07-17_11_45](https://user-images.githubusercontent.com/1314156/140660492-fbb1f0a6-53cc-4135-8a95-788850902bb8.png)

### Detailed test instructions:

1. Open the browser devtools, go to the `Console` and enable the debug messages, you can do it by following the steps detailed here(P90Yrv-1Wj-p2 #debug-devtools).
2. Go to the 4th step of the Onboarding wizard (Business Details) and click `Free features`.
3. Verify the event `wcadmin_storeprofiler_store_business_features_continue` is recorded with the props `install_google_listings_and_ads` and `install_mailpoet` after pressing `Continue`.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->