### PR TITLE
Sync WooCommerce Payments default gateway with WCCOM

### DIFF
--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -223,15 +223,29 @@ class DefaultPaymentGateways {
 					self::get_rules_for_countries( self::get_wcpay_countries() ),
 					(object) array(
 						'type'     => 'plugin_version',
-						'plugin'   => 'woocommerce-admin',
-						'version'  => '2.9.0-dev',
-						'operator' => '<',
-					),
-					(object) array(
-						'type'     => 'plugin_version',
 						'plugin'   => 'woocommerce',
 						'version'  => '5.10.0-dev',
 						'operator' => '<',
+					),
+					(object) array(
+						'type'     => 'or',
+						'operands' => (object) array(
+							(object) array(
+								'type'    => 'not',
+								'operand' => [
+									(object) array(
+										'type'    => 'plugins_activated',
+										'plugins' => [ 'woocommerce-admin' ],
+									),
+								],
+							),
+							(object) array(
+								'type'     => 'plugin_version',
+								'plugin'   => 'woocommerce-admin',
+								'version'  => '2.9.0-dev',
+								'operator' => '<',
+							),
+						),
 					),
 				),
 				'recommendation_priority' => 1,


### PR DESCRIPTION
Note that this PR is not strictly required for payment gateways to run, but purely to keep the default gateways in sync with the remote endpoint.

### Screenshots


![Screen Shot 2021-11-10 at 2 34 59 PM](https://user-images.githubusercontent.com/10561050/141181346-2abcad94-dfbe-4c89-9dc6-d680c7f64725.png)
![Screen Shot 2021-11-10 at 2 34 15 PM](https://user-images.githubusercontent.com/10561050/141181350-7be8056c-1c95-4630-b3b8-682265ffb7f5.png)
### Detailed test instructions:

Please see testing instructions in https://github.com/Automattic/woocommerce.com/pull/11555 and note that the rules match those in the WCCOM endpoint.