### PR TITLE
Refactor `wcadmin_storeprofiler_store_business_features_continue`  Tracks event handling

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -58,6 +58,26 @@ export const filterBusinessExtensions = ( extensionInstallationOptions ) => {
 	);
 };
 
+export const prepareInstalledExtensionsForTracking = (
+	extensionInstallationOptions
+) => {
+	const installedExtensions = {};
+	for ( const [ fieldKey, value ] of Object.entries(
+		extensionInstallationOptions
+	) ) {
+		const key = `install_${ fieldKey
+			.replace( /-/g, '_' )
+			.split( ':', 1 ) }`;
+		if (
+			fieldKey !== 'install_extensions' &&
+			! installedExtensions[ key ]
+		) {
+			installedExtensions[ key ] = value;
+		}
+	}
+	return installedExtensions;
+};
+
 class BusinessDetails extends Component {
 	constructor() {
 		super();
@@ -84,26 +104,15 @@ class BusinessDetails extends Component {
 			extensionInstallationOptions
 		);
 
-		const isntalledExtensions = {};
-		for ( const [ fieldKey, value ] of Object.entries(
+		const installedExtensions = prepareInstalledExtensionsForTracking(
 			extensionInstallationOptions
-		) ) {
-			const key = `install_${ fieldKey
-				.replace( /-/g, '_' )
-				.split( ':', 1 ) }`;
-			if (
-				fieldKey !== 'install_extensions' &&
-				! isntalledExtensions[ key ]
-			) {
-				isntalledExtensions[ key ] = value;
-			}
-		}
+		);
 
 		recordEvent( 'storeprofiler_store_business_features_continue', {
 			all_extensions_installed: Object.values(
 				extensionInstallationOptions
 			).every( ( val ) => val ),
-			...isntalledExtensions,
+			...installedExtensions,
 		} );
 
 		const promises = [

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -58,7 +58,7 @@ export const filterBusinessExtensions = ( extensionInstallationOptions ) => {
 	);
 };
 
-export const prepareInstalledExtensionsForTracking = (
+export const prepareExtensionTrackingData = (
 	extensionInstallationOptions
 ) => {
 	const installedExtensions = {};
@@ -104,7 +104,7 @@ class BusinessDetails extends Component {
 			extensionInstallationOptions
 		);
 
-		const installedExtensions = prepareInstalledExtensionsForTracking(
+		const installedExtensions = prepareExtensionTrackingData(
 			extensionInstallationOptions
 		);
 

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -65,9 +65,10 @@ export const prepareExtensionTrackingData = (
 	for ( const [ fieldKey, value ] of Object.entries(
 		extensionInstallationOptions
 	) ) {
-		const key = `install_${ fieldKey
-			.replace( /-/g, '_' )
-			.split( ':', 1 ) }`;
+		const key =
+			fieldKey === 'woocommerce-payments'
+				? 'install_wcpay'
+				: `install_${ fieldKey.replace( /-/g, '_' ).split( ':', 1 ) }`;
 		if (
 			fieldKey !== 'install_extensions' &&
 			! installedExtensions[ key ]

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -84,20 +84,26 @@ class BusinessDetails extends Component {
 			extensionInstallationOptions
 		);
 
+		const isntalledExtensions = {};
+		for ( const [ fieldKey, value ] of Object.entries(
+			extensionInstallationOptions
+		) ) {
+			const key = `install_${ fieldKey
+				.replace( /-/g, '_' )
+				.split( ':', 1 ) }`;
+			if (
+				fieldKey !== 'install_extensions' &&
+				! isntalledExtensions[ key ]
+			) {
+				isntalledExtensions[ key ] = value;
+			}
+		}
+
 		recordEvent( 'storeprofiler_store_business_features_continue', {
 			all_extensions_installed: Object.values(
 				extensionInstallationOptions
 			).every( ( val ) => val ),
-			install_woocommerce_services:
-				extensionInstallationOptions[
-					'woocommerce-services:shipping'
-				] || extensionInstallationOptions[ 'woocommerce-services:tax' ],
-			install_google_listings_and_ads:
-				extensionInstallationOptions[ 'google-listings-and-ads' ],
-			install_jetpack: extensionInstallationOptions.jetpack,
-			install_mailpoet: extensionInstallationOptions.mailpoet,
-			install_wcpay:
-				extensionInstallationOptions[ 'woocommerce-payments' ],
+			...isntalledExtensions,
 		} );
 
 		const promises = [

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -3,7 +3,7 @@
  */
 import {
 	filterBusinessExtensions,
-	prepareInstalledExtensionsForTracking,
+	prepareExtensionTrackingData,
 } from '../flows/selective-bundle';
 import { createInitialValues } from '../flows/selective-bundle/selective-extensions-bundle';
 
@@ -36,7 +36,7 @@ describe( 'BusinessDetails', () => {
 		expect( filteredExtensions ).toEqual( expectedExtensions );
 	} );
 
-	describe( 'prepareInstalledExtensionsForTracking', () => {
+	describe( 'prepareExtensionTrackingData', () => {
 		test( 'preparing extensions for tracking', () => {
 			const extensions = {
 				'creative-mail-by-constant-contact': true,
@@ -57,7 +57,7 @@ describe( 'BusinessDetails', () => {
 				install_woocommerce_payments: true,
 			};
 
-			const installedExtensions = prepareInstalledExtensionsForTracking(
+			const installedExtensions = prepareExtensionTrackingData(
 				extensions
 			);
 
@@ -73,31 +73,31 @@ describe( 'BusinessDetails', () => {
 				install_woocommerce_services: true,
 			};
 
-			expect(
-				prepareInstalledExtensionsForTracking( extensions )
-			).toEqual( expectedExtensions );
+			expect( prepareExtensionTrackingData( extensions ) ).toEqual(
+				expectedExtensions
+			);
 
 			extensions[ 'woocommerce-services:shipping' ] = false;
 			extensions[ 'woocommerce-services:tax' ] = true;
 
-			expect(
-				prepareInstalledExtensionsForTracking( extensions )
-			).toEqual( expectedExtensions );
+			expect( prepareExtensionTrackingData( extensions ) ).toEqual(
+				expectedExtensions
+			);
 
 			extensions[ 'woocommerce-services:shipping' ] = true;
 			extensions[ 'woocommerce-services:tax' ] = false;
 
-			expect(
-				prepareInstalledExtensionsForTracking( extensions )
-			).toEqual( expectedExtensions );
+			expect( prepareExtensionTrackingData( extensions ) ).toEqual(
+				expectedExtensions
+			);
 
 			extensions[ 'woocommerce-services:shipping' ] = false;
 			extensions[ 'woocommerce-services:tax' ] = false;
 			expectedExtensions.install_woocommerce_services = false;
 
-			expect(
-				prepareInstalledExtensionsForTracking( extensions )
-			).toEqual( expectedExtensions );
+			expect( prepareExtensionTrackingData( extensions ) ).toEqual(
+				expectedExtensions
+			);
 		} );
 	} );
 

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -54,7 +54,7 @@ describe( 'BusinessDetails', () => {
 				install_jetpack: false,
 				install_google_listings_and_ads: true,
 				install_mailchimp_for_woocommerce: false,
-				install_woocommerce_payments: true,
+				install_wcpay: true,
 			};
 
 			const installedExtensions = prepareExtensionTrackingData(

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -37,7 +37,7 @@ describe( 'BusinessDetails', () => {
 	} );
 
 	describe( 'prepareInstalledExtensionsForTracking', () => {
-		test( 'prepareing extensions for tracking', () => {
+		test( 'preparing extensions for tracking', () => {
 			const extensions = {
 				'creative-mail-by-constant-contact': true,
 				'facebook-for-woocommerce': false,
@@ -63,7 +63,7 @@ describe( 'BusinessDetails', () => {
 
 			expect( installedExtensions ).toEqual( expectedExtensions );
 		} );
-		test( 'prepareing shipping and tax extensions for tracking', () => {
+		test( 'preparing shipping and tax extensions for tracking', () => {
 			const extensions = {
 				'woocommerce-services:shipping': true,
 				'woocommerce-services:tax': true,

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { filterBusinessExtensions } from '../flows/selective-bundle';
+import {
+	filterBusinessExtensions,
+	prepareInstalledExtensionsForTracking,
+} from '../flows/selective-bundle';
 import { createInitialValues } from '../flows/selective-bundle/selective-extensions-bundle';
 
 describe( 'BusinessDetails', () => {
@@ -31,6 +34,71 @@ describe( 'BusinessDetails', () => {
 		const filteredExtensions = filterBusinessExtensions( extensions );
 
 		expect( filteredExtensions ).toEqual( expectedExtensions );
+	} );
+
+	describe( 'prepareInstalledExtensionsForTracking', () => {
+		test( 'prepareing extensions for tracking', () => {
+			const extensions = {
+				'creative-mail-by-constant-contact': true,
+				'facebook-for-woocommerce': false,
+				install_extensions: true,
+				jetpack: false,
+				'google-listings-and-ads': true,
+				'mailchimp-for-woocommerce': false,
+				'woocommerce-payments': true,
+			};
+
+			const expectedExtensions = {
+				install_creative_mail_by_constant_contact: true,
+				install_facebook_for_woocommerce: false,
+				install_jetpack: false,
+				install_google_listings_and_ads: true,
+				install_mailchimp_for_woocommerce: false,
+				install_woocommerce_payments: true,
+			};
+
+			const installedExtensions = prepareInstalledExtensionsForTracking(
+				extensions
+			);
+
+			expect( installedExtensions ).toEqual( expectedExtensions );
+		} );
+		test( 'prepareing shipping and tax extensions for tracking', () => {
+			const extensions = {
+				'woocommerce-services:shipping': true,
+				'woocommerce-services:tax': true,
+			};
+
+			const expectedExtensions = {
+				install_woocommerce_services: true,
+			};
+
+			expect(
+				prepareInstalledExtensionsForTracking( extensions )
+			).toEqual( expectedExtensions );
+
+			extensions[ 'woocommerce-services:shipping' ] = false;
+			extensions[ 'woocommerce-services:tax' ] = true;
+
+			expect(
+				prepareInstalledExtensionsForTracking( extensions )
+			).toEqual( expectedExtensions );
+
+			extensions[ 'woocommerce-services:shipping' ] = true;
+			extensions[ 'woocommerce-services:tax' ] = false;
+
+			expect(
+				prepareInstalledExtensionsForTracking( extensions )
+			).toEqual( expectedExtensions );
+
+			extensions[ 'woocommerce-services:shipping' ] = false;
+			extensions[ 'woocommerce-services:tax' ] = false;
+			expectedExtensions.install_woocommerce_services = false;
+
+			expect(
+				prepareInstalledExtensionsForTracking( extensions )
+			).toEqual( expectedExtensions );
+		} );
 	} );
 
 	describe( 'createInitialValues', () => {


### PR DESCRIPTION
Fixes #7912

This PR refactors the `wcadmin_storeprofiler_store_business_features_continue` Tracks event handling to not hardcode the extensions' names..

This Tracks event will save the props `install_[extension name]` with a boolean value.

The prop `install_wcpay ` has been renamed for `install_woocommerce_payments`. //cc. @pmcpinto

No changelog required.

### Screenshots

![screenshot-one wordpress test-2021 11 07-17_11_45](https://user-images.githubusercontent.com/1314156/140660492-fbb1f0a6-53cc-4135-8a95-788850902bb8.png)

### Detailed test instructions:

1. Open the browser devtools, go to the `Console` and enable the debug messages, you can do this by following the steps detailed here(P90Yrv-1Wj-p2 #debug-devtools).
2. Go to 4th step of the Onboarding wizard (Business Details) and click `Free features`.
3. Verify that the event `wcadmin_storeprofiler_store_business_features_continue` is recorded with the selected extensions props (e.g.: `install_google_listings_and_ads`, `install_mailpoet`) after pressing `Continue`.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
