### PR TITLE
Bump experimental version

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.1.0
+
 -   Renaming remindMeLater() to onSnooze() for consistency. #7616
 -   Applied new Inbox 2.0 design to the inbox-note component. #7864
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "2.0.3",
+	"version": "2.1.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bumps version number for the experimental package ahead of publishing to npm.

No changelog.