### PR TITLE
Pass child props to partners card

### DIFF
--- a/client/tasks/fills/tax/avalara/card.tsx
+++ b/client/tasks/fills/tax/avalara/card.tsx
@@ -12,13 +12,12 @@ import { recordEvent } from '@woocommerce/tracks';
 import { PartnerCard } from '../components/partner-card';
 import logo from './logo.png';
 
-export const Card = ( { isPending, task } ) => {
+export const Card = ( { task } ) => {
 	const { avalaraActivated } = task.additionalData;
 
 	return (
 		<PartnerCard
 			name={ __( 'Avalara', 'woocommerce-admin' ) }
-			isPending={ isPending }
 			logo={ logo }
 			description={ __(
 				'Powerful all-in-one tax tool',

--- a/client/tasks/fills/tax/components/partner-card.tsx
+++ b/client/tasks/fills/tax/components/partner-card.tsx
@@ -18,7 +18,7 @@ export const PartnerCard: React.FC< {
 	terms: string;
 	actionText: string;
 	onClick: () => void;
-	isPending: boolean;
+	isBusy?: boolean;
 } > = ( {
 	name,
 	logo,
@@ -27,7 +27,7 @@ export const PartnerCard: React.FC< {
 	terms,
 	actionText,
 	onClick,
-	isPending,
+	isBusy,
 } ) => {
 	return (
 		<div className="woocommerce-tax-partner-card">
@@ -63,8 +63,8 @@ export const PartnerCard: React.FC< {
 				<Button
 					isSecondary
 					onClick={ onClick }
-					isBusy={ isPending }
-					disabled={ isPending }
+					isBusy={ isBusy }
+					disabled={ isBusy }
 				>
 					{ actionText }
 				</Button>

--- a/client/tasks/fills/tax/index.tsx
+++ b/client/tasks/fills/tax/index.tsx
@@ -238,7 +238,7 @@ const Tax = ( { onComplete, query, task } ) => {
 	}
 
 	return (
-		<Partners>
+		<Partners { ...childProps }>
 			{ partners.map( ( partner ) =>
 				createElement( partner.card, {
 					key: partner.id,

--- a/client/tasks/fills/tax/woocommerce-tax/card.tsx
+++ b/client/tasks/fills/tax/woocommerce-tax/card.tsx
@@ -14,11 +14,10 @@ import { PartnerCard } from '../components/partner-card';
 import logo from './logo.png';
 import { TaxChildProps } from '../utils';
 
-export const Card: React.FC< TaxChildProps > = ( { isPending } ) => {
+export const Card: React.FC< TaxChildProps > = () => {
 	return (
 		<PartnerCard
 			name={ __( 'WooCommerce Tax', 'woocommerce-admin' ) }
-			isPending={ isPending }
 			logo={ logo }
 			description={ __( 'Best for new stores', 'woocommerce-admin' ) }
 			benefits={ [


### PR DESCRIPTION
Fixes #7921 

Fixes an issue where childprops were not passed to the card to handle tax actions.

Also removes `isPending` state from partner cards that's irrelevant to their busy state.

### Detailed test instructions:

1. Make sure you're in a country that supports Avalara and WC Tax (ex., US)
1. Navigate to the tax task
1. Click on `Set up taxes manually` or `I don't charge sales tax`
2. Make sure they go the manual tax setup or disable taxes, respectively