### PR TITLE
Addressing blank screen displayed on products task

### DIFF
--- a/client/tasks/fills/products/product-template-modal.js
+++ b/client/tasks/fills/products/product-template-modal.js
@@ -124,7 +124,7 @@ export default function ProductTemplateModal( { onClose } ) {
 	const removeSubscriptions =
 		( window.wcAdminFeatures && ! window.wcAdminFeatures.subscriptions ) ||
 		countryCode !== 'US' ||
-		! profileItems.product_types.includes( 'subscriptions' ) ||
+		! profileItems.product_types?.includes( 'subscriptions' ) ||
 		! installedPlugins.includes( 'woocommerce-payments' );
 
 	const productTemplates = removeSubscriptions

--- a/client/tasks/fills/products/products.js
+++ b/client/tasks/fills/products/products.js
@@ -123,7 +123,7 @@ const Products = () => {
 		window.wcAdminFeatures &&
 		window.wcAdminFeatures.subscriptions &&
 		countryCode === 'US' &&
-		profileItems.product_types.includes( 'subscriptions' ) &&
+		profileItems.product_types?.includes( 'subscriptions' ) &&
 		installedPlugins.includes( 'woocommerce-payments' )
 	) {
 		const task = subTasks.find(


### PR DESCRIPTION
Fixes #7933 

The user has been encountering a blank screen when navigating to the Products task, after skipping the onboarding wizard. This is due to references to a null value, which is addressed in this PR.

### Detailed test instructions:

-   Checkout branch on fresh site
-   Skip onboarding wizard
- Navigate to Woocommerce -> Home
- Click on the "Add my products" task
- Confirm that behavior is as expected, with no blank screen or error thrown.
- Click on "Start with template" on the product creation modal, and ensure that no error is thrown.
