### PR TITLE
Fix/7938 navigation feedback follow up note should self delete when not relevant

### DIFF
--- a/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
+++ b/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Have NavigationFeedbackFollowUp note self-delete when navigation feature is not present, like the other Navigation notes do. #7939

--- a/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
+++ b/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Fix
 
-Have NavigationFeedbackFollowUp note self-delete when navigation feature is not present, like the other Navigation notes do. #7939
+Self-delete NavigationFeedbackFollowUp note when navigation feature is not present. #7939

--- a/src/Events.php
+++ b/src/Events.php
@@ -163,6 +163,7 @@ class Events {
 	protected function possibly_delete_notes() {
 		NavigationNudge::delete_if_not_applicable();
 		NavigationFeedback::delete_if_not_applicable();
+		NavigationFeedbackFollowUp::delete_if_not_applicable();
 	}
 
 	/**

--- a/src/Notes/NavigationFeedbackFollowUp.php
+++ b/src/Notes/NavigationFeedbackFollowUp.php
@@ -25,6 +25,13 @@ class NavigationFeedbackFollowUp {
 	const NOTE_NAME = 'wc-admin-navigation-feedback-follow-up';
 
 	/**
+	 * Should this note exist? (The navigation feature should exist.)
+	 */
+	public static function is_applicable() {
+		return Features::exists( 'navigation' );
+	}
+
+	/**
 	 * Get the note.
 	 *
 	 * @return Note


### PR DESCRIPTION
Fixes #7938

Applies the same changes we made to `NavigationNudge` and `NavigationFeedback` notes to `NavigationFeedbackFollowUp` note. I.e. it will delete itself as part of the daily wc admin cron if the navigation feature does not exist AND the note has not already been actioned.

### Detailed test instructions:

- Start with a clean WooCommerce site
- Install WooCommerce Admin from this branch and activate it
- Verify that the Navigation checkbox appears on the Settings / Advanced / Features page.
- If the `NavigationNudge` note ('You now have access to the WooCommerce navigation') doesn't show up immediately, run the `wc_admin_daily` cron event. I'm using the WP Crontrol plugin.
- Enable the navigation feature
- If the `NavigationFeedback` note ('You now have access to the new WooCommerce navigation') doesn't show up immediately, run the `wc_admin_daily` cron event.
- Either wait 432,001 seconds or back-date the `NavigationFeedback` note (see below)
- If the `NavigationFeedbackFollowUp` note ('Share your thoughts on the new WooCommerce navigation') doesn't show up immediately, run the `wc_admin_daily` cron event.
- Remove the navigation feature (see below)
- Verify that the `NavigationFeedbackFollowUp` note no longer appears (bonus points: check the database and verify that the only row in `wp_wc_admin_notes` with 'navigation' in its `name` is `wc-admin-navigation-nudge`).
- Reenable the navigation feature: Just undo whatever you did two steps ago.
- Run the `wc_admin_daily` cron event
- Verify that the `NavigationFeedback` note has been recreated
- Back-date the `NavigationFeedback` note
- Run the `wc_admin_daily` cron event
- Verify that the `NavigationFeedbackFollowUp` note has been recreated

#### Backdating the NavigationFeedback note

One way to backdate the `NavigationFeedback` note is to run this query in the database:
`UPDATE wp_wc_admin_notes SET date_created = DATE_ADD(date_created, INTERVAL -6 DAY) WHERE name LIKE 'wc-admin-navigation-%';`

(Yes, this will also backdate the nudge note, but we don't want the poor little fellas getting confused about cause and effect, do we?)

#### One way to remove the navigation feature:

Use the `'woocommerce_admin_features'` filter to remove the `'navigation'` filter like so (you can put this code anywhere it'll be executed--I'm using a custom plugin):

```
add_filter( 'woocommerce_admin_features', function ( $features ) {
	if (!empty($features)) {
		$features = array_filter($features, function ($feature) { return $feature !== 'navigation'; });
	}
	return $features;
} );
```

