### PR TITLE
Fix WC pay promotion ordering

### DIFF
--- a/changelogs/fix-7942_wc_pay_promotion
+++ b/changelogs/fix-7942_wc_pay_promotion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix ordering and styling issue with WooCommerce Payments payment method promotion. #7943

--- a/client/wp-admin-scripts/payment-method-promotions/index.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/index.tsx
@@ -22,8 +22,13 @@ PAYMENT_METHOD_PROMOTIONS.forEach( ( paymentMethod ) => {
 	);
 
 	if ( container ) {
-		const sortColumn = container.children[ 0 ].innerHTML;
-		const descriptionColumn = container.children[ 3 ].innerHTML;
+		const columns = [ ...container.children ].map( ( child ) => {
+			return {
+				className: child.className,
+				html: child.innerHTML,
+				width: child.getAttribute( 'width' ),
+			};
+		} );
 		const title = container.getElementsByClassName(
 			'wc-payment-gateway-method-title'
 		);
@@ -31,9 +36,8 @@ PAYMENT_METHOD_PROMOTIONS.forEach( ( paymentMethod ) => {
 
 		render(
 			<PaymentPromotionRow
+				columns={ columns }
 				pluginSlug={ paymentMethod.pluginSlug }
-				sortColumnContent={ sortColumn }
-				descriptionColumnContent={ descriptionColumn }
 				title={ title.length === 1 ? title[ 0 ].innerHTML : undefined }
 				titleLink={ paymentMethod.link }
 				subTitleContent={

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -14,7 +14,6 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { sanitize } from 'dompurify';
 import { __ } from '@wordpress/i18n';
-import _ from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,20 +31,22 @@ function sanitizeHTML( html: string ) {
 
 type PaymentPromotionRowProps = {
 	pluginSlug: string;
-	sortColumnContent: string;
-	descriptionColumnContent: string;
 	titleLink: string;
 	title: string;
+	columns: {
+		className: string;
+		html: string;
+		width: string;
+	}[];
 	subTitleContent?: string;
 };
 
 export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 	pluginSlug,
-	sortColumnContent,
-	descriptionColumnContent,
 	title,
 	titleLink,
 	subTitleContent,
+	columns,
 } ) => {
 	const [ installing, setInstalling ] = useState( false );
 	const { installAndActivatePlugins }: PluginsStoreActions = useDispatch(
@@ -104,51 +105,67 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 
 	return (
 		<>
-			<td
-				className="sort ui-sortable-handle"
-				width="1%"
-				dangerouslySetInnerHTML={ {
-					__html: sortColumnContent,
-				} }
-			></td>
-			<td className="name">
-				<div className="wc-payment-gateway-method_name">
-					<Link
-						target="_blank"
-						type="external"
-						rel="noreferrer"
-						href={ titleLink }
-					>
-						{ title }
-					</Link>
-					{ subTitleContent ? (
-						<div
-							className="pre-install-payment-gateway_subtitle"
-							dangerouslySetInnerHTML={ sanitizeHTML(
-								subTitleContent
-							) }
-						></div>
-					) : null }
-				</div>
-			</td>
-			<td className="pre-install-payment-gateway_status"></td>
-			<td
-				className="description"
-				dangerouslySetInnerHTML={ sanitizeHTML(
-					descriptionColumnContent
-				) }
-			></td>
-			<td className="action">
-				<Button
-					className="button alignright"
-					onClick={ () => installPaymentGateway() }
-					isSecondary
-					isBusy={ installing }
-					aria-disabled={ installing }
-				>
-					{ __( 'Install', 'woocommerce-admin' ) }
-				</Button>
-			</td>
+			{ columns.map( ( column ) => {
+				if ( column.className.includes( 'name' ) ) {
+					return (
+						<td className="name" key={ column.className }>
+							<div className="wc-payment-gateway-method_name">
+								<Link
+									target="_blank"
+									type="external"
+									rel="noreferrer"
+									href={ titleLink }
+								>
+									{ title }
+								</Link>
+								{ subTitleContent ? (
+									<div
+										className="pre-install-payment-gateway_subtitle"
+										dangerouslySetInnerHTML={ sanitizeHTML(
+											subTitleContent
+										) }
+									></div>
+								) : null }
+							</div>
+						</td>
+					);
+				} else if ( column.className.includes( 'status' ) ) {
+					return (
+						<td
+							className="pre-install-payment-gateway_status"
+							key={ column.className }
+						></td>
+					);
+				} else if ( column.className.includes( 'action' ) ) {
+					return (
+						<td className="action" key={ column.className }>
+							<Button
+								className="button alignright"
+								onClick={ () => installPaymentGateway() }
+								isSecondary
+								isBusy={ installing }
+								aria-disabled={ installing }
+							>
+								{ __( 'Install', 'woocommerce-admin' ) }
+							</Button>
+						</td>
+					);
+				}
+				return (
+					<td
+						key={ column.className }
+						className={ column.className }
+						width={ column.width }
+						dangerouslySetInnerHTML={
+							column.className.includes( 'sort' )
+								? {
+										__html: column.html,
+								  }
+								: sanitizeHTML( column.html )
+						}
+					></td>
+				);
+			} ) }
 		</>
 	);
 };

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -137,7 +137,7 @@ class Init {
 		$id       = WCPaymentGatewayPreInstallWCPayPromotion::GATEWAY_ID;
 		// Only tweak the ordering if the list hasn't been reordered with WooCommerce Payments in it already.
 		if ( ! isset( $ordering[ $id ] ) || ! is_numeric( $ordering[ $id ] ) ) {
-			$is_empty        = empty( $ordering ) || empty( $ordering[0] );
+			$is_empty        = empty( $ordering ) || ( 1 === count( $ordering ) && false === $ordering[0] );
 			$ordering[ $id ] = $is_empty ? 0 : ( min( $ordering ) - 1 );
 		}
 		return $ordering;


### PR DESCRIPTION
Partially fixes #7942 

Fixes two issues:
- Issue where the top gateway wasn't listed when a user had a custom order and the WC Pay Promotion was displayed
- Styling issue when extra columns are displayed in the payment gateway table

### Screenshots

<img width="1452" alt="Screen Shot 2021-11-17 at 12 35 04 PM" src="https://user-images.githubusercontent.com/2240960/142242134-bd865a6a-da12-46f1-b9c4-efc14795eded.png">

### Detailed test instructions:

- Make sure you have tracking enabled and Woocommerce.com suggestions (under Advanced > Woocommerce.com settings) and WooCommerce Payments isn't installed, but have a supported country.
- Go to **WooCommerce > Settings > Payments** see if you have the treatment experiment running (WooCommerce Payments shows in the table with an Install button (see screenshot for example) )
     - If not you can run the treatment bookmarklet which you can get under the Audience > Variations table [here](https://experiments.a8c.com/experiments/20342-woocommerce-wc-pay-promotion-payment-methods-table-v2/overview)
- Before loading this branch reproduce the bug by:
     - Disable the **Show marketplace suggestions** (for now)
     - Go to **WooCommerce > Settings > Payments** and move the **Cash on delivery** to the top and click **Save Changes**
     - **Cash on delivery** should be on top, now enable the **Marketplace suggestions** again and go back to the Payments settings page
     - Notice how **Cash on delivery** isn't showing anymore, but the WC Pay promotion is
- Load this branch
- Notice how **Cash on delivery** is visible again
- Update the order and click **Save changes**, the order should persist correctly
- Now delete the `woocommerce_gateway_order` option and refresh the page
- Update the order and click **Save changes**, the order should persist correctly

Test extra column styling:
- Install the **WooCommerce Subscriptions** plugin, it can be found under https://woocommerce.com/my-account/downloads/
- Go to the payment settings page and notice how an extra column is present - **Automatic Recurring Payments**
- This column should also be shown for the Payment method promotion row

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
