### PR TITLE
Add a new update callback for the 3.0 version to update is_read column

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -322,11 +322,17 @@ function wc_admin_update_290_db_version() {
  */
 function wc_admin_update_300_update_is_read_from_last_read() {
 	global $wpdb;
-	$user      = wp_get_current_user();
-	$last_read = get_user_meta( $user->ID, 'woocommerce_admin_activity_panel_inbox_last_read', true );
+	$last_read = $wpdb->get_results(
+		"
+		select meta_value from {$wpdb->usermeta} 
+		where meta_key='woocommerce_admin_activity_panel_inbox_last_read' 
+		order by meta_value desc
+	"
+	);
 
-	if ( $last_read ) {
-		$date_in_utc = gmdate( 'Y-m-d H:i:s', $last_read );
+	if ( count( $last_read ) ) {
+		$last_read_value = $last_read[0]->meta_value;
+		$date_in_utc     = gmdate( 'Y-m-d H:i:s', $last_read_value );
 		$wpdb->query(
 			$wpdb->prepare(
 				"

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -322,12 +322,16 @@ function wc_admin_update_290_db_version() {
  */
 function wc_admin_update_300_update_is_read_from_last_read() {
 	global $wpdb;
+	$meta_key  = 'woocommerce_admin_activity_panel_inbox_last_read';
 	$last_read = $wpdb->get_results(
-		"
+		$wpdb->prepare(
+			"
 		select meta_value from {$wpdb->usermeta} 
-		where meta_key='woocommerce_admin_activity_panel_inbox_last_read' 
+		where meta_key=%s
 		order by meta_value desc
-	"
+	",
+			$meta_key
+		)
 	);
 
 	if ( count( $last_read ) ) {
@@ -342,6 +346,7 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 				$date_in_utc
 			)
 		);
+		$wpdb->query( $wpdb->prepare( "delete from {$wpdb->usermeta} where meta_key=%s", $meta_key ) );
 	}
 }
 /**

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -335,7 +335,7 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 	);
 
 	if ( count( $last_read ) ) {
-		$date_in_utc = gmdate( 'Y-m-d H:i:s', $last_read[0]->meta_value );
+		$date_in_utc = gmdate( 'Y-m-d H:i:s', intval( $last_read[0]->meta_value ) / 1000 );
 		$wpdb->query(
 			$wpdb->prepare(
 				"

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -325,18 +325,7 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 	$user      = wp_get_current_user();
 	$last_read = get_user_meta( $user->ID, 'woocommerce_admin_activity_panel_inbox_last_read', true );
 
-	// make sure is_read col has been added successfully.
-	$notes_table_cols = $wpdb->get_results( "show columns from {$wpdb->prefix}wc_admin_notes" );
-	$notes_table_cols = array_filter(
-		$notes_table_cols,
-		function( $row ) {
-			// phpcs:ignore
-			return 'is_read' === $row->Field;
-		}
-	);
-	$has_is_read_col  = count( $notes_table_cols ) > 0;
-
-	if ( $last_read && $has_is_read_col ) {
+	if ( $last_read ) {
 		$date_in_utc = gmdate( 'Y-m-d H:i:s', $last_read );
 		$wpdb->query(
 			$wpdb->prepare(

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -322,20 +322,13 @@ function wc_admin_update_290_db_version() {
  */
 function wc_admin_update_300_update_is_read_from_last_read() {
 	global $wpdb;
-	$meta_key  = 'woocommerce_admin_activity_panel_inbox_last_read';
-	$last_read = $wpdb->get_results(
-		$wpdb->prepare(
-			"
-		select meta_value from {$wpdb->usermeta} 
-		where meta_key=%s
-		order by meta_value desc
-	",
-			$meta_key
-		)
-	);
+	$meta_key = 'woocommerce_admin_activity_panel_inbox_last_read';
+	// phpcs:ignore
+	$users    = get_users( "meta_key={$meta_key}&orderby={$meta_key}&fields=all_with_meta&number=1" );
 
-	if ( count( $last_read ) ) {
-		$date_in_utc = gmdate( 'Y-m-d H:i:s', intval( $last_read[0]->meta_value ) / 1000 );
+	if ( count( $users ) ) {
+		$last_read   = current( $users )->{$meta_key};
+		$date_in_utc = gmdate( 'Y-m-d H:i:s', intval( $last_read ) / 1000 );
 		$wpdb->query(
 			$wpdb->prepare(
 				"
@@ -348,6 +341,7 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 		$wpdb->query( $wpdb->prepare( "delete from {$wpdb->usermeta} where meta_key=%s", $meta_key ) );
 	}
 }
+
 /**
  * Update DB Version.
  */

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -335,8 +335,7 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 	);
 
 	if ( count( $last_read ) ) {
-		$last_read_value = $last_read[0]->meta_value;
-		$date_in_utc     = gmdate( 'Y-m-d H:i:s', $last_read_value );
+		$date_in_utc = gmdate( 'Y-m-d H:i:s', $last_read[0]->meta_value );
 		$wpdb->query(
 			$wpdb->prepare(
 				"

--- a/src/Install.php
+++ b/src/Install.php
@@ -73,6 +73,10 @@ class Install {
 			'wc_admin_update_290_update_apperance_task_option',
 			'wc_admin_update_290_db_version',
 		),
+		'3.0.0'  => array(
+			'wc_admin_update_300_update_is_read_from_last_read',
+			'wc_admin_update_300_db_version',
+		),
 	);
 
 	/**

--- a/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
+++ b/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
@@ -18,38 +18,11 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 	 */
 	public function setUp() {
 		parent::setUp();
-
-		$this->add_is_read_col();
 		$this->user = $this->factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
 		);
-	}
-
-	/**
-	 * Adds is_read col to the notes table.
-	 */
-	protected function add_is_read_col() {
-		global $wpdb;
-		// make sure is_read col has been added successfully.
-		$notes_table_cols = $wpdb->get_results( "show columns from {$wpdb->prefix}wc_admin_notes" );
-		$notes_table_cols = array_filter(
-			$notes_table_cols,
-			function( $row ) {
-				// phpcs:ignore
-				return 'is_read' === $row->Field;
-			}
-		);
-		$has_is_read_col  = count( $notes_table_cols ) > 0;
-
-		if ( ! $has_is_read_col ) {
-			$wpdb->query(
-				"
-			alter table {$wpdb->prefix}wc_admin_notes add column is_read tinyint(1)
-		"
-			);
-		}
 	}
 
 	/**

--- a/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
+++ b/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
@@ -58,6 +58,8 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 		global $wpdb;
 		$time = time();
 
+		$meta_key = 'woocommerce_admin_activity_panel_inbox_last_read';
+
 		wp_set_current_user( $this->user );
 		$wpdb->query( "delete from {$wpdb->prefix}wc_admin_notes" );
 
@@ -82,7 +84,7 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 		// phpcs:ignore
 		$wpdb->query( "update {$wpdb->prefix}wc_admin_notes set date_created = '{$date_created_2}' where name='test2'" );
 
-		update_user_meta( $this->user, 'woocommerce_admin_activity_panel_inbox_last_read', $time );
+		update_user_meta( $this->user, $meta_key, $time );
 
 		wc_admin_update_300_update_is_read_from_last_read();
 
@@ -92,5 +94,9 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 		);
 
 		$this->assertTrue( '1' === $notes_with_is_read );
+
+		// phpcs:ignore
+		$last_read_count = $wpdb->get_var("select count(*) from {$wpdb->usermeta} where meta_key='{$meta_key}'");
+		$this->assertTrue( '0' === $last_read_count );
 	}
 }

--- a/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
+++ b/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
@@ -84,7 +84,7 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 		// phpcs:ignore
 		$wpdb->query( "update {$wpdb->prefix}wc_admin_notes set date_created = '{$date_created_2}' where name='test2'" );
 
-		update_user_meta( $this->user, $meta_key, $time );
+		update_user_meta( $this->user, $meta_key, $time * 1000 );
 
 		wc_admin_update_300_update_is_read_from_last_read();
 

--- a/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
+++ b/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
@@ -60,17 +60,14 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 	public function test_update_does_not_run_when_usermeta_does_not_exist() {
 		global $wpdb;
 
-		// Given.
 		$wpdb->query(
 			"
 			delete from {$wpdb->prefix}usermeta where meta_key = 'woocommerce_admin_activity_panel_inbox_last_read' 
 		"
 		);
 
-		// When.
 		wc_admin_update_300_update_is_read_from_last_read();
 
-		// Then.
 		$notes_with_is_read = $wpdb->get_var(
 			"select count(*) from {$wpdb->prefix}wc_admin_notes where is_read = 1
 		"
@@ -112,13 +109,10 @@ class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
 		// phpcs:ignore
 		$wpdb->query( "update {$wpdb->prefix}wc_admin_notes set date_created = '{$date_created_2}' where name='test2'" );
 
-		// Given.
 		update_user_meta( $this->user, 'woocommerce_admin_activity_panel_inbox_last_read', $time );
 
-		// When.
 		wc_admin_update_300_update_is_read_from_last_read();
 
-		// Then.
 		$notes_with_is_read = $wpdb->get_var(
 			"select count(*) from {$wpdb->prefix}wc_admin_notes where is_read = 1
 		"

--- a/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
+++ b/tests/db-updates/class-wc-tests-update-is-read-from-last-read.php
@@ -1,0 +1,129 @@
+<?php
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+/**
+ * DB Update test for wc_admin_update_300_update_is_read_from_last_read()
+ *
+ * @package WooCommerce\Admin\Tests\DBUpdates
+ */
+class WC_Tests_Update_Is_Read_From_Last_Read extends WC_Unit_Test_Case {
+	/**
+	 * @var object current user
+	 */
+	private $user;
+
+	/**
+	 * setUp
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->add_is_read_col();
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Adds is_read col to the notes table.
+	 */
+	protected function add_is_read_col() {
+		global $wpdb;
+		// make sure is_read col has been added successfully.
+		$notes_table_cols = $wpdb->get_results( "show columns from {$wpdb->prefix}wc_admin_notes" );
+		$notes_table_cols = array_filter(
+			$notes_table_cols,
+			function( $row ) {
+				// phpcs:ignore
+				return 'is_read' === $row->Field;
+			}
+		);
+		$has_is_read_col  = count( $notes_table_cols ) > 0;
+
+		if ( ! $has_is_read_col ) {
+			$wpdb->query(
+				"
+			alter table {$wpdb->prefix}wc_admin_notes add column is_read tinyint(1)
+		"
+			);
+		}
+	}
+
+	/**
+	 * Given woocommerce_admin_activity_panel_inbox_last_read does not exist
+	 * When the update runs
+	 * Then it should not update is_read col
+	 */
+	public function test_update_does_not_run_when_usermeta_does_not_exist() {
+		global $wpdb;
+
+		// Given.
+		$wpdb->query(
+			"
+			delete from {$wpdb->prefix}usermeta where meta_key = 'woocommerce_admin_activity_panel_inbox_last_read' 
+		"
+		);
+
+		// When.
+		wc_admin_update_300_update_is_read_from_last_read();
+
+		// Then.
+		$notes_with_is_read = $wpdb->get_var(
+			"select count(*) from {$wpdb->prefix}wc_admin_notes where is_read = 1
+		"
+		);
+
+		$this->assertTrue( '0' === $notes_with_is_read );
+	}
+
+	/**
+	 * Give woocommerce_admin_activity_panel_inbox_last_read
+	 * When the update runs
+	 * Then it should update notes where date_created value is less than woocommerce_admin_activity_panel_inbox_last_read
+	 */
+	public function test_it_updates_is_read_when_date_created_value_is_less_than_last_read() {
+		global $wpdb;
+		$time = time();
+
+		wp_set_current_user( $this->user );
+		$wpdb->query( "delete from {$wpdb->prefix}wc_admin_notes" );
+
+		// Note with date_created less than woocommerce_admin_activity_panel_inbox_last_read.
+		$note = new Note();
+		$note->set_title( 'test1' );
+		$note->set_content( 'test1' );
+		$note->set_name( 'test1' );
+		$note->save();
+		$date_created_1 = gmdate( 'Y-m-d H:i:s', $time - 3600 );
+
+		// Note with date_created greater than woocommerce_admin_activity_panel_inbox_last_read.
+		$note = new Note();
+		$note->set_title( 'test2' );
+		$note->set_content( 'test2' );
+		$note->set_name( 'test2' );
+		$note->save();
+		$date_created_2 = gmdate( 'Y-m-d H:i:s', $time + 3600 );
+
+		// phpcs:ignore
+		$wpdb->query( "update {$wpdb->prefix}wc_admin_notes set date_created = '{$date_created_1}' where name='test1'" );
+		// phpcs:ignore
+		$wpdb->query( "update {$wpdb->prefix}wc_admin_notes set date_created = '{$date_created_2}' where name='test2'" );
+
+		// Given.
+		update_user_meta( $this->user, 'woocommerce_admin_activity_panel_inbox_last_read', $time );
+
+		// When.
+		wc_admin_update_300_update_is_read_from_last_read();
+
+		// Then.
+		$notes_with_is_read = $wpdb->get_var(
+			"select count(*) from {$wpdb->prefix}wc_admin_notes where is_read = 1
+		"
+		);
+
+		$this->assertTrue( '1' === $notes_with_is_read );
+	}
+}


### PR DESCRIPTION
Fixes woocommerce/woocommerce-admin#7944 

This PR adds a new update callback for the 3.0 version to update `is_read` column by using `woocommerce_admin_activity_panel_inbox_last_read` user preference.

### Detailed test instructions:

1. Lower `woocommerce_admin_version` option value.
2. Reload a WC Admin page to trigger the update function.
3. Open `wp_wc_admin_notes` table and confirm `is_read` column has been added.

no changelog