### PR TITLE
Fix race condition in data package's options module

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Fix the batch fetch logic for the options data store. #7587
 -   Add backwards compability for old function format. #7688
 -   Add console warning for inbox note contents exceeding 320 characters and add dompurify dependency. #7869
+-   Fix race condition in data package's options module. #7947
 
 # 1.4.0
 

--- a/packages/data/src/options/controls.js
+++ b/packages/data/src/options/controls.js
@@ -26,23 +26,28 @@ export const controls = {
 
 		return new Promise( ( resolve ) => {
 			setTimeout( function () {
-				const names = optionNames.join( ',' );
-				if ( fetches[ names ] ) {
-					return fetches[ names ].then( ( result ) => {
+				if ( fetches[ optionName ] ) {
+					return fetches[ optionName ].then( ( result ) => {
 						resolve( result );
 					} );
 				}
 
+				// Get unique option names.
+				const names = [ ...new Set( optionNames ) ].join( ',' );
+				// Send request for a group of options.
 				const url = WC_ADMIN_NAMESPACE + '/options?options=' + names;
-				fetches[ names ] = apiFetch( { path: url } );
-				fetches[ names ].then( ( result ) => resolve( result ) );
+				const fetch = apiFetch( { path: url } );
+				fetch.then( ( result ) => resolve( result ) );
+				optionNames.forEach( ( option ) => {
+					fetches[ option ] = fetch;
+					fetches[ option ].then( () => {
+						// Delete the fetch after to allow wp data to handle cache invalidation.
+						delete fetches[ option ];
+					} );
+				} );
 
-				// Clear option names after all resolved;
-				setTimeout( () => {
-					optionNames = [];
-					// Delete the fetch after to allow wp data to handle cache invalidation.
-					delete fetches[ names ];
-				}, 1 );
+				// Clear option names after we've sent the request for a group of options.
+				optionNames = [];
 			}, 1 );
 		} );
 	},


### PR DESCRIPTION
Fixes #7936, #7478

This PR fixes a race condition in options' control module. Previously, `optionNames` was deleted in another "thread" and there were cases where options did not get fetched due to it being deleted prematurely. More details:
- `fetches` object now stores individual option instead of a group of options. This is so that it's possible to get the reference of an option that's fetching.
- `optionNames` array is now deleted in the same execution "thread" after its use. This should guarantee that no option is accidentally deleted before it is fetched.

### Detailed test instructions:

- Make sure `woocommerce_navigation_intro_modal_dismissed` option is set to `yes`
- You need to use Safari browser since the bug is more apparent in the browser
- Open WooCommerce > Home, observe that "Welcome" modal did not appear after the page finishes loading
- Due to the bug's intermittent nature, repeat the check above at least 5 times and make sure the bug is truly fixed

No changelog required.