### PR TITLE
Hide InboxPanel header content in the sidebar

### DIFF
--- a/changelogs/update-7946-support-hiding-inbox-panel-header
+++ b/changelogs/update-7946-support-hiding-inbox-panel-header
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Hide InboxPanel header when it is rendered in the sidebar
+Hide InboxPanel header when it is rendered in the sidebar. #7952

--- a/changelogs/update-7946-support-hiding-inbox-panel-header
+++ b/changelogs/update-7946-support-hiding-inbox-panel-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Hide InboxPanel header when it is rendered in the sidebar

--- a/client/header/activity-panel/panels/inbox/inbox-panel.js
+++ b/client/header/activity-panel/panels/inbox/inbox-panel.js
@@ -16,7 +16,7 @@ export const InboxPanel = ( {
 					thingsToDoNextCount={ thingsToDoNextCount }
 				/>
 			) }
-			<NotesPanel />
+			<NotesPanel showHeader={ false } />
 		</div>
 	);
 };

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -58,6 +58,7 @@ const renderNotes = ( {
 	onDismiss,
 	onNoteActionClick,
 	setShowDismissAllModal: onDismissAll,
+	showHeader = true,
 } ) => {
 	if ( isBatchUpdating ) {
 		return;
@@ -82,29 +83,34 @@ const renderNotes = ( {
 
 	return (
 		<Card size="large">
-			<CardHeader size="medium">
-				<div className="wooocommerce-inbox-card__header">
-					<Text size="20" lineHeight="28px" variant="title.small">
-						{ __( 'Inbox', 'woocommerce-admin' ) }
-					</Text>
-					<Badge count={ notesArray.length } />
-				</div>
-				<EllipsisMenu
-					label={ __( 'Inbox Notes Options', 'woocommerce-admin' ) }
-					renderContent={ ( { onToggle } ) => (
-						<div className="woocommerce-inbox-card__section-controls">
-							<Button
-								onClick={ () => {
-									onDismissAll( true );
-									onToggle();
-								} }
-							>
-								{ __( 'Dismiss all', 'woocommerce-admin' ) }
-							</Button>
-						</div>
-					) }
-				/>
-			</CardHeader>
+			{ showHeader && (
+				<CardHeader size="medium">
+					<div className="wooocommerce-inbox-card__header">
+						<Text size="20" lineHeight="28px" variant="title.small">
+							{ __( 'Inbox', 'woocommerce-admin' ) }
+						</Text>
+						<Badge count={ notesArray.length } />
+					</div>
+					<EllipsisMenu
+						label={ __(
+							'Inbox Notes Options',
+							'woocommerce-admin'
+						) }
+						renderContent={ ( { onToggle } ) => (
+							<div className="woocommerce-inbox-card__section-controls">
+								<Button
+									onClick={ () => {
+										onDismissAll( true );
+										onToggle();
+									} }
+								>
+									{ __( 'Dismiss all', 'woocommerce-admin' ) }
+								</Button>
+							</div>
+						) }
+					/>
+				</CardHeader>
+			) }
 			<TransitionGroup role="menu">
 				{ notesArray.map( ( note ) => {
 					const { id: noteId, is_deleted: isDeleted } = note;
@@ -157,7 +163,7 @@ const INBOX_QUERY = {
 	],
 };
 
-const InboxPanel = () => {
+const InboxPanel = ( { showHeader = true } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { removeNote, updateNote, triggerNoteAction } = useDispatch(
 		NOTES_STORE_NAME
@@ -282,6 +288,7 @@ const InboxPanel = () => {
 							onDismiss,
 							onNoteActionClick,
 							setShowDismissAllModal,
+							showHeader,
 						} ) }
 				</Section>
 			</div>


### PR DESCRIPTION
Fixes #7946

This PR adds a new prop `showHeader` in the `InboxPanel` component to control the header visibility. We're hiding the InboxPanel header in the sidebar.

### Screenshots

**Home:**

![Screen Shot 2021-11-18 at 2 44 49 PM](https://user-images.githubusercontent.com/4723145/142508701-ff57c69e-1bbd-4391-bbb2-8d971d4e2eb1.jpg)


**Sidebar:**
![Screen Shot 2021-11-18 at 2 48 49 PM](https://user-images.githubusercontent.com/4723145/142509114-72ea9633-644f-4076-b45a-a0df97e652b6.jpg)


### Detailed test instructions:

1. Navigate to `WooCommerce -> Home` and confirm the InboxPanel has the header.
2. Navigate to any of the other WC pages and click `Activity` from the top right-hand corner.
3. The InboxPanel should not have the header.