### PR TITLE
Fix tax data not available on task render

### DIFF
--- a/client/tasks/fills/tax/avalara/card.tsx
+++ b/client/tasks/fills/tax/avalara/card.tsx
@@ -12,13 +12,12 @@ import { recordEvent } from '@woocommerce/tracks';
 import { PartnerCard } from '../components/partner-card';
 import logo from './logo.png';
 
-export const Card = ( { isPending, tasksStatus } ) => {
-	const { avalaraActivated } = tasksStatus;
+export const Card = ( { task } ) => {
+	const { avalaraActivated } = task;
 
 	return (
 		<PartnerCard
 			name={ __( 'Avalara', 'woocommerce-admin' ) }
-			isPending={ isPending }
 			logo={ logo }
 			description={ __(
 				'Powerful all-in-one tax tool',

--- a/client/tasks/fills/tax/avalara/card.tsx
+++ b/client/tasks/fills/tax/avalara/card.tsx
@@ -13,7 +13,7 @@ import { PartnerCard } from '../components/partner-card';
 import logo from './logo.png';
 
 export const Card = ( { task } ) => {
-	const { avalaraActivated } = task;
+	const { avalaraActivated } = task.additionalData;
 
 	return (
 		<PartnerCard

--- a/client/tasks/fills/tax/components/partner-card.tsx
+++ b/client/tasks/fills/tax/components/partner-card.tsx
@@ -18,7 +18,7 @@ export const PartnerCard: React.FC< {
 	terms: string;
 	actionText: string;
 	onClick: () => void;
-	isPending: boolean;
+	isBusy?: boolean;
 } > = ( {
 	name,
 	logo,
@@ -27,7 +27,7 @@ export const PartnerCard: React.FC< {
 	terms,
 	actionText,
 	onClick,
-	isPending,
+	isBusy,
 } ) => {
 	return (
 		<div className="woocommerce-tax-partner-card">
@@ -63,8 +63,8 @@ export const PartnerCard: React.FC< {
 				<Button
 					isSecondary
 					onClick={ onClick }
-					isBusy={ isPending }
-					disabled={ isPending }
+					isBusy={ isBusy }
+					disabled={ isBusy }
 				>
 					{ actionText }
 				</Button>

--- a/client/tasks/fills/tax/index.tsx
+++ b/client/tasks/fills/tax/index.tsx
@@ -45,35 +45,28 @@ const TaskCard = ( { children } ) => {
 	);
 };
 
-const Tax = ( { onComplete, query } ) => {
+const Tax = ( { onComplete, query, task } ) => {
 	const [ isPending, setIsPending ] = useState( false );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateAndPersistSettingsForGroup } = useDispatch(
 		SETTINGS_STORE_NAME
 	);
-	const {
-		generalSettings,
-		isResolving,
-		tasksStatus,
-		taxSettings,
-	} = useSelect( ( select ) => {
-		const { getSettings, hasFinishedResolution } = select(
-			SETTINGS_STORE_NAME
-		) as SettingsSelector;
+	const { generalSettings, isResolving, taxSettings } = useSelect(
+		( select ) => {
+			const { getSettings, hasFinishedResolution } = select(
+				SETTINGS_STORE_NAME
+			) as SettingsSelector;
 
-		return {
-			generalSettings: getSettings( 'general' ).general,
-			isResolving:
-				! hasFinishedResolution( 'getSettings', [ 'general' ] ) ||
-				! select( ONBOARDING_STORE_NAME ).hasFinishedResolution(
-					'getTasksStatus'
-				),
-			// @Todo this should be removed as soon as https://github.com/woocommerce/woocommerce-admin/pull/7841 is merged.
-			tasksStatus: select( ONBOARDING_STORE_NAME ).getTasksStatus(),
-			taxSettings: getSettings( 'tax' ).tax || {},
-		};
-	} );
+			return {
+				generalSettings: getSettings( 'general' ).general,
+				isResolving: ! hasFinishedResolution( 'getSettings', [
+					'general',
+				] ),
+				taxSettings: getSettings( 'tax' ).tax || {},
+			};
+		}
+	);
 
 	const onManual = useCallback( async () => {
 		setIsPending( true );
@@ -145,9 +138,9 @@ const Tax = ( { onComplete, query } ) => {
 			generalSettings?.woocommerce_default_country
 		);
 		const {
-			automatedTaxSupportedCountries = [],
+			woocommerceTaxCountries = [],
 			taxJarActivated,
-		} = tasksStatus;
+		} = task.additionalData;
 
 		const partners = [
 			{
@@ -156,7 +149,7 @@ const Tax = ( { onComplete, query } ) => {
 				component: WooCommerceTax,
 				isVisible:
 					! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
-					automatedTaxSupportedCountries.includes(
+					woocommerceTaxCountries.includes(
 						getCountryCode(
 							generalSettings?.woocommerce_default_country
 						)
@@ -219,7 +212,7 @@ const Tax = ( { onComplete, query } ) => {
 		onAutomate,
 		onManual,
 		onDisable,
-		tasksStatus,
+		task,
 	};
 
 	if ( isResolving ) {
@@ -260,8 +253,8 @@ registerPlugin( 'wc-admin-onboarding-task-tax', {
 	scope: 'woocommerce-tasks',
 	render: () => (
 		<WooOnboardingTask id="tax">
-			{ ( { onComplete, query } ) => (
-				<Tax onComplete={ onComplete } query={ query } />
+			{ ( { onComplete, query, task } ) => (
+				<Tax onComplete={ onComplete } query={ query } task={ task } />
 			) }
 		</WooOnboardingTask>
 	),

--- a/client/tasks/fills/tax/index.tsx
+++ b/client/tasks/fills/tax/index.tsx
@@ -245,7 +245,7 @@ const Tax = ( { onComplete, query } ) => {
 	}
 
 	return (
-		<Partners>
+		<Partners { ...childProps }>
 			{ partners.map( ( partner ) =>
 				createElement( partner.card, {
 					key: partner.id,

--- a/client/tasks/fills/tax/woocommerce-tax/card.tsx
+++ b/client/tasks/fills/tax/woocommerce-tax/card.tsx
@@ -14,11 +14,10 @@ import { PartnerCard } from '../components/partner-card';
 import logo from './logo.png';
 import { TaxChildProps } from '../utils';
 
-export const Card: React.FC< TaxChildProps > = ( { isPending } ) => {
+export const Card: React.FC< TaxChildProps > = () => {
 	return (
 		<PartnerCard
 			name={ __( 'WooCommerce Tax', 'woocommerce-admin' ) }
-			isPending={ isPending }
 			logo={ logo }
 			description={ __( 'Best for new stores', 'woocommerce-admin' ) }
 			benefits={ [

--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -68,7 +68,7 @@ class Init {
 				: false;
 		}
 
-		$settings['automatedTaxSupportedCountries'] = Tax::get_automated_tax_supported_countries();
+		$settings['automatedTaxSupportedCountries'] = Tax::get_automated_support_countries();
 		$settings['hasHomepage']                    = Appearance::has_homepage();
 		$settings['hasProducts']                    = Products::has_products();
 		$settings['stylesheet']                     = get_option( 'stylesheet' );

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -179,6 +179,7 @@ class Task {
 			'is_snoozeable'   => false,
 			'snoozed_until'   => null,
 			'additional_info' => '',
+			'additional_data' => (object) array(),
 		);
 
 		$data = wp_parse_args( $data, $defaults );
@@ -196,6 +197,7 @@ class Task {
 		$this->time            = (string) $data['time'];
 		$this->is_dismissable  = (bool) $data['is_dismissable'];
 		$this->is_snoozeable   = (bool) $data['is_snoozeable'];
+		$this->additional_data = (object) $data['additional_data'];
 
 		$snoozed_tasks = get_option( self::SNOOZED_OPTION, array() );
 		if ( isset( $snoozed_tasks[ $this->id ] ) ) {
@@ -395,7 +397,25 @@ class Task {
 			'isSnoozed'      => $this->is_snoozed(),
 			'isSnoozeable'   => $this->is_snoozeable,
 			'snoozedUntil'   => $this->snoozed_until,
+			'additionalData' => self::convert_object_to_camelcase( $this->additional_data ),
 		);
+	}
+
+	/**
+	 * Convert object keys to camelcase.
+	 *
+	 * @param object $object Object to convert.
+	 * @return object
+	 */
+	public static function convert_object_to_camelcase( $object ) {
+		$new_object = (object) array();
+
+		foreach ( $object as $key => $value ) {
+			$new_key              = lcfirst( implode( '', array_map( 'ucfirst', explode( '_', $key ) ) ) );
+			$new_object->$new_key = $value;
+		}
+
+		return $new_object;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Tax.php
+++ b/src/Features/OnboardingTasks/Tasks/Tax.php
@@ -54,9 +54,9 @@ class Tax {
 	 */
 	public static function get_task() {
 		return array(
-			'id'           => 'tax',
-			'title'        => __( 'Set up tax', 'woocommerce-admin' ),
-			'content'      => self::can_use_automated_taxes()
+			'id'              => 'tax',
+			'title'           => __( 'Set up tax', 'woocommerce-admin' ),
+			'content'         => self::can_use_automated_taxes()
 				? __(
 					'Good news! WooCommerce Services and Jetpack can automate your sales tax calculations for you.',
 					'woocommerce-admin'
@@ -65,15 +65,20 @@ class Tax {
 					'Set your store location and configure tax rate settings.',
 					'woocommerce-admin'
 				),
-			'action_label' => self::can_use_automated_taxes()
+			'action_label'    => self::can_use_automated_taxes()
 				? __( 'Yes please', 'woocommerce-admin' )
 				: __( "Let's go", 'woocommerce-admin' ),
-			'is_complete'  => get_option( 'wc_connect_taxes_enabled' ) ||
+			'is_complete'     => get_option( 'wc_connect_taxes_enabled' ) ||
 				count( TaxDataStore::get_taxes( array() ) ) > 0 ||
 				false !== get_option( 'woocommerce_no_sales_tax' ) ||
 				PluginsHelper::is_plugin_active( 'woocommerce-avatax' ),
-			'is_visible'   => true,
-			'time'         => __( '1 minute', 'woocommerce-admin' ),
+			'is_visible'      => true,
+			'time'            => __( '1 minute', 'woocommerce-admin' ),
+			'additional_data' => array(
+				'avalara_activated'         => PluginsHelper::is_plugin_active( 'woocommerce-avatax' ),
+				'tax_jar_activated'         => class_exists( 'WC_Taxjar' ),
+				'woocommerce_tax_countries' => self::get_automated_support_countries(),
+			),
 		);
 	}
 
@@ -87,7 +92,7 @@ class Tax {
 			return false;
 		}
 
-		return in_array( WC()->countries->get_base_country(), self::get_automated_tax_supported_countries(), true );
+		return in_array( WC()->countries->get_base_country(), self::get_automated_support_countries(), true );
 	}
 
 	/**
@@ -95,7 +100,7 @@ class Tax {
 	 *
 	 * @return array
 	 */
-	public static function get_automated_tax_supported_countries() {
+	public static function get_automated_support_countries() {
 		// https://developers.taxjar.com/api/reference/#countries .
 		$tax_supported_countries = array_merge(
 			array( 'US', 'CA', 'AU' ),


### PR DESCRIPTION
Fixes up the cherry pick of 7929 into 2.9.0 RC3.

Note that this incorporates some changes from https://github.com/woocommerce/woocommerce-admin/pull/7841 and cherry picking that PR as well as the original 7929 might be the better option, but this PR resolves the tax task issues.

Note that https://github.com/woocommerce/woocommerce-admin/issues/7910 is not resolved by this PR.

### Screenshots

![Screen Shot 2021-11-23 at 9 02 20 AM](https://user-images.githubusercontent.com/10561050/143038350-26ddc2c4-3c84-485d-b69a-a2f0528f785a.png)

### Detailed test instructions:

Follow the testing instructions in https://github.com/woocommerce/woocommerce-admin/pull/7874