### PR TITLE
Add Tracks prop when WCPay is installed in Product Types step of store profiler

### DIFF
--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -101,9 +101,10 @@ export class ProductTypes extends Component {
 			updateProfileItems,
 		} = this.props;
 
-		recordEvent( 'storeprofiler_store_product_type_continue', {
+		const eventProps = {
 			product_type: selected,
-		} );
+			wcpay_installed: false,
+		};
 
 		const promises = [ updateProfileItems( { product_types: selected } ) ];
 
@@ -117,6 +118,7 @@ export class ProductTypes extends Component {
 			promises.push(
 				installAndActivatePlugins( [ 'woocommerce-payments' ] )
 					.then( ( response ) => {
+						eventProps.wcpay_installed = true;
 						createNoticesFromResponse( response );
 					} )
 					.catch( ( error ) => {
@@ -127,7 +129,13 @@ export class ProductTypes extends Component {
 		}
 
 		Promise.all( promises )
-			.then( () => goToNextStep() )
+			.then( () => {
+				recordEvent(
+					'storeprofiler_store_product_type_continue',
+					eventProps
+				);
+				goToNextStep();
+			} )
 			.catch( () =>
 				createNotice(
 					'error',


### PR DESCRIPTION
Fixes #7916

This PR adds a new prop to the `wcadmin_storeprofiler_store_product_type_continue` Tracks event.

The new prop is: 
- `wcpay_installed`: true | false

No changelog is required.

### Screenshots

![screenshot-localhost_10013-2021 11 23-10_59_44](https://user-images.githubusercontent.com/1314156/143041916-07f2910a-4432-46aa-9419-4763b92ce08c.png)

### Detailed test instructions:

0. Checkout this branch. On a US store, be sure that [the Subscriptions feature](https://github.com/woocommerce/woocommerce-admin/blob/main/config/development.json#L18) is turned on and the `WooCommerce-Payments` plugin is not installed.
1. Open the browser devtools, go to the `Console` and enable the debug messages, you can do this by following the steps detailed here(P90Yrv-1Wj-p2 #debug-devtools).
3. Go to the step 3 of the Onboarding wizard (Product Types), select `Subscriptions`, and click `Continue`.
4. Verify that the event `wcadmin_storeprofiler_store_product_type_continue ` is recorded with the prop `wcpay_installed` after pressing `Continue`.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
