### PR TITLE
Ending wcpay promotion experiment and always displaying in payment methods table

### DIFF
--- a/changelogs/update-7941
+++ b/changelogs/update-7941
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Ending wcpay promotion experiment and always displaying in payment methods table

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -101,27 +101,8 @@ class Init {
 		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
 			return false;
 		}
-		$wc_pay_spec = self::get_wc_pay_promotion_spec();
 
-		if ( ! $wc_pay_spec || ! isset( $wc_pay_spec->additional_info ) || ! isset( $wc_pay_spec->additional_info->experiment_version ) ) {
-			return false;
-		}
-
-		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
-		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
-		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
-			$anon_id,
-			'woocommerce',
-			$allow_tracking
-		);
-
-		$variation_name = $abtest->get_variation( self::EXPLAT_VARIATION_PREFIX . $wc_pay_spec->additional_info->experiment_version );
-
-		if ( 'treatment' === $variation_name ) {
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7941 

Ending the [wcpay promotion in payment methods experiment](https://github.com/woocommerce/woocommerce-admin/pull/7554), and switching to always favor the treatment option, which will always display the WCPay promotion within the payment methods table.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/143135699-a88e2c22-1e1a-4fc8-ab36-15a87b7e6ec1.png)

### Detailed test instructions:

-   Checkout branch
- Ensure the transient `abtest_variation_explat_test_v3_woocommerce_wc_pay_promotion_payment_methods_table_v1` does not exist any more.
-   Navigate to WooCommcerce -> Settings -> Payments
- You should see the WCPay promotion in the table (as pictured), and not in the card below. 
