### PR TITLE
OBW - Add number of employees field

### DIFF
--- a/changelogs/add-7854
+++ b/changelogs/add-7854
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+OBW - Add number of employees field #7963

--- a/client/profile-wizard/steps/business-details/data/employee-options.js
+++ b/client/profile-wizard/steps/business-details/data/employee-options.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const employeeOptions = [
+	{
+		key: '1',
+		label: __( "It's just me", 'woocommerce-admin' ),
+	},
+	{
+		key: '<10',
+		label: __( '< 10', 'woocommerce-admin' ),
+	},
+	{
+		key: '10-50',
+		label: '10 - 50',
+	},
+	{
+		key: '50-250',
+		label: '50 - 250',
+	},
+	{
+		key: '+250',
+		label: __( '+250', 'woocommerce-admin' ),
+	},
+	{
+		key: 'not specified',
+		label: __( "I'd rather not say", 'woocommerce-admin' ),
+	},
+];

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -180,10 +180,7 @@ class BusinessDetails extends Component {
 		const finalUpdates = Object.entries( updates ).reduce(
 			( acc, [ key, val ] ) => {
 				if ( val !== '' ) {
-					return {
-						...acc,
-						[ key ]: val,
-					};
+					acc[ key ] = val;
 				}
 
 				return acc;

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -29,6 +29,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { CurrencyContext } from '~/lib/currency-context';
 import { createNoticesFromResponse } from '~/lib/notices';
 import { platformOptions } from '../../data/platform-options';
+import { employeeOptions } from '../../data/employee-options';
 import { sellingVenueOptions } from '../../data/selling-venue-options';
 import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
@@ -154,6 +155,7 @@ class BusinessDetails extends Component {
 		const { updateProfileItems, createNotice } = this.props;
 
 		const {
+			number_employees: numberEmployees,
 			other_platform: otherPlatform,
 			other_platform_name: otherPlatformName,
 			product_count: productCount,
@@ -163,6 +165,7 @@ class BusinessDetails extends Component {
 		} = this.state.savedValues;
 
 		const updates = {
+			number_employees: numberEmployees,
 			other_platform: otherPlatform,
 			other_platform_name:
 				otherPlatform === 'other' ? otherPlatformName : '',
@@ -238,6 +241,21 @@ class BusinessDetails extends Component {
 		}
 
 		if (
+			! values.number_employees.length &&
+			[
+				'other',
+				'brick-mortar',
+				'brick-mortar-other',
+				'other-woocommerce',
+			].includes( values.selling_venues )
+		) {
+			errors.number_employees = __(
+				'This field is required',
+				'woocommerce-admin'
+			);
+		}
+
+		if (
 			! values.revenue.length &&
 			[
 				'other',
@@ -260,6 +278,7 @@ class BusinessDetails extends Component {
 	}
 
 	trackBusinessDetailsStep( {
+		number_employees: numberEmployees,
 		other_platform: otherPlatform,
 		other_platform_name: otherPlatformName,
 		product_count: productCount,
@@ -270,6 +289,7 @@ class BusinessDetails extends Component {
 		const { getCurrencyConfig } = this.context;
 
 		recordEvent( 'storeprofiler_store_business_details_continue_variant', {
+			number_employees: numberEmployees,
 			already_selling: sellingVenues,
 			currency: getCurrencyConfig().code,
 			product_number: productCount,
@@ -356,6 +376,26 @@ class BusinessDetails extends Component {
 										required
 										{ ...getInputProps( 'selling_venues' ) }
 									/>
+
+									{ [
+										'other',
+										'brick-mortar',
+										'brick-mortar-other',
+										'other-woocommerce',
+									].includes( values.selling_venues ) && (
+										<SelectControl
+											excludeSelectedOptions={ false }
+											label={ __(
+												'How many employees do you have?',
+												'woocommerce-admin'
+											) }
+											options={ employeeOptions }
+											required
+											{ ...getInputProps(
+												'number_employees'
+											) }
+										/>
+									) }
 
 									{ [
 										'other',

--- a/client/profile-wizard/steps/business-details/index.js
+++ b/client/profile-wizard/steps/business-details/index.js
@@ -34,6 +34,7 @@ export const BusinessDetailsStep = ( props ) => {
 	}
 
 	const initialValues = {
+		number_employees: profileItems.number_employees || '',
 		other_platform: profileItems.other_platform || '',
 		other_platform_name: profileItems.other_platform_name || '',
 		product_count: profileItems.product_count || '',

--- a/packages/data/src/onboarding/reducer.js
+++ b/packages/data/src/onboarding/reducer.js
@@ -10,6 +10,7 @@ export const defaultState = {
 		business_extensions: null,
 		completed: null,
 		industry: null,
+		number_employees: null,
 		other_platform: null,
 		other_platform_name: null,
 		product_count: null,

--- a/packages/data/src/onboarding/selectors.ts
+++ b/packages/data/src/onboarding/selectors.ts
@@ -130,6 +130,7 @@ export type ProfileItemsState = {
 	business_extensions: [  ] | null;
 	completed: boolean | null;
 	industry: Industry[] | null;
+	number_employees: string | null;
 	other_platform: OtherPlatformSlug | null;
 	other_platform_name: string | null;
 	product_count: ProductCount | null;

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -323,6 +323,21 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other-woocommerce',
 				),
 			),
+			'number_employees'    => array(
+				'type'              => 'string',
+				'description'       => __( 'Number of employees of the store.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'1',
+					'<10',
+					'10-50',
+					'50-250',
+					'+250',
+					'not specified',
+				),
+			),
 			'revenue'             => array(
 				'type'              => 'string',
 				'description'       => __( 'Current annual revenue of the store.', 'woocommerce-admin' ),

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -262,6 +262,7 @@ class Onboarding {
 			'product_types'       => array(),
 			'product_count'       => '0',
 			'selling_venues'      => 'no',
+			'number_employees'    => '1',
 			'revenue'             => 'none',
 			'other_platform'      => 'none',
 			'business_extensions' => array(),

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -106,13 +106,14 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 15, $properties );
+		$this->assertCount( 16, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
 		$this->assertArrayHasKey( 'product_types', $properties );
 		$this->assertArrayHasKey( 'product_count', $properties );
 		$this->assertArrayHasKey( 'selling_venues', $properties );
+		$this->assertArrayHasKey( 'number_employees', $properties );
 		$this->assertArrayHasKey( 'revenue', $properties );
 		$this->assertArrayHasKey( 'other_platform', $properties );
 		$this->assertArrayHasKey( 'other_platform_name', $properties );


### PR DESCRIPTION
Fixes #7854

This PR adds a field to the `Business Details` step of the store profiler (OBW), to ask about the number of employees.
It also sets the `number_employees` prop on the `wcadmin_storeprofiler_store_business_details_continue_variant` Tracks event.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-one local-2021 11 29-13_30_05](https://user-images.githubusercontent.com/1314156/143906390-496d23bc-0f31-419d-bbd8-33a223fffb2e.png)

### Detailed test instructions:

- Go to step 4 of the OBW (Business details).
- Under `Currently selling elsewhere?` select any option other than "No".
- A drop-down list with the following options should be visible:
```
It's just me
<10
10-50
50-250
+250
I'd rather not say
```
- Select one of those options and fill out the rest of the options.
- Open the browser devtools, go to the `Console` and enable the debug messages. You can do this by following the steps detailed here(P90Yrv-1Wj-p2 #debug-devtools).
- Verify that the event `wcadmin_storeprofiler_store_business_details_continue_variant` is recorded with the prop `number_employees` after pressing `Continue`.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
