### PR TITLE
Add option to dismiss promotional payment gateway

### DIFF
--- a/changelogs/add-7951
+++ b/changelogs/add-7951
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add option to dismiss promotional payment gateway #7965

--- a/client/wp-admin-scripts/payment-method-promotions/index.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/index.tsx
@@ -12,7 +12,7 @@ const PAYMENT_METHOD_PROMOTIONS = [
 	{
 		gatewayId: 'pre_install_woocommerce_payments_promotion',
 		pluginSlug: 'woocommerce-payments',
-		link: 'https://woocommerce.com/payments/?utm_medium=product',
+		url: 'https://woocommerce.com/payments/?utm_medium=product',
 	},
 ];
 
@@ -37,9 +37,8 @@ PAYMENT_METHOD_PROMOTIONS.forEach( ( paymentMethod ) => {
 		render(
 			<PaymentPromotionRow
 				columns={ columns }
-				pluginSlug={ paymentMethod.pluginSlug }
+				paymentMethod={ paymentMethod }
 				title={ title.length === 1 ? title[ 0 ].innerHTML : undefined }
-				titleLink={ paymentMethod.link }
 				subTitleContent={
 					subTitle.length === 1 ? subTitle[ 0 ].innerHTML : undefined
 				}

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.scss
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.scss
@@ -28,10 +28,10 @@
 		}
 	}
 
-	.wc-payment-gateway-method_name {
+	.wc-payment-gateway-method__name {
 		display: flex;
 
-		.pre-install-payment-gateway_subtitle {
+		.pre-install-payment-gateway__subtitle {
 			margin-left: $gap;
 			> img {
 				height: 24px;
@@ -39,5 +39,17 @@
 				margin-left: 4px;
 			}
 		}
+	}
+
+	.pre-install-payment-gateway__actions {
+		display: flex;
+	}
+
+	.pre-install-payment-gateway__actions-menu {
+		margin-right: $gap;
+	}
+
+	.pre-install-payment-gateway__actions-menu-options {
+		text-align: center;
 	}
 }

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.scss
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.scss
@@ -46,7 +46,7 @@
 	}
 
 	.pre-install-payment-gateway__actions-menu {
-		margin-right: $gap;
+		margin-right: $gap-large;
 	}
 
 	.pre-install-payment-gateway__actions-menu-options {

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -117,6 +117,9 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 
 	const onDismiss = () => {
 		setIsVisible( false );
+		recordEvent( 'settings_payments_promotions_dismiss', {
+			id: gatewayId,
+		} );
 		updatePaymentGateway( gatewayId, {
 			settings: {
 				is_dismissed: 'yes',

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { EllipsisMenu, Link } from '@woocommerce/components';
+import { VerticalCSSTransition } from '@woocommerce/experimental';
 import { useState, useEffect } from '@wordpress/element';
 import {
 	PLUGINS_STORE_NAME,
@@ -52,12 +53,13 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 } ) => {
 	const { gatewayId, pluginSlug, url } = paymentMethod;
 	const [ installing, setInstalling ] = useState( false );
+	const [ isVisible, setIsVisible ] = useState( false );
 	const { installAndActivatePlugins }: PluginsStoreActions = useDispatch(
 		PLUGINS_STORE_NAME
 	);
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
-	const { gatewayIsActive, isDismissed, paymentGateway } = useSelect(
+	const { gatewayIsActive, paymentGateway, promotionGateway } = useSelect(
 		( select: WCDataSelector ) => {
 			const { getPaymentGateway } = select( PAYMENT_GATEWAYS_STORE_NAME );
 			const activePlugins: string[] = select(
@@ -71,12 +73,11 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 					pluginSlug.replace( /\-/g, '_' )
 				);
 			}
-			const promotion = getPaymentGateway( gatewayId );
 
 			return {
 				gatewayIsActive: isActive,
-				isDismissed: promotion?.settings?.is_dismissed?.value === 'yes',
 				paymentGateway: paymentGatewayData,
+				promotionGateway: getPaymentGateway( gatewayId ),
 			};
 		}
 	);
@@ -90,6 +91,12 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 			window.location.href = paymentGateway.settings_url;
 		}
 	}, [ gatewayIsActive, paymentGateway ] );
+
+	useEffect( () => {
+		if ( promotionGateway?.settings?.is_dismissed?.value === 'no' ) {
+			setIsVisible( true );
+		}
+	}, promotionGateway );
 
 	const installPaymentGateway = () => {
 		if ( installing ) {
@@ -110,6 +117,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 	};
 
 	const onDismiss = () => {
+		setIsVisible( false );
 		updatePaymentGateway( gatewayId, {
 			settings: {
 				is_dismissed: 'yes',
@@ -117,106 +125,97 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 		} );
 	};
 
-	if ( isDismissed ) {
-		return null;
-	}
-
 	return (
 		<>
-			{ columns.map( ( column ) => {
-				if ( column.className.includes( 'name' ) ) {
-					return (
-						<td className="name" key={ column.className }>
-							<div className="wc-payment-gateway-method__name">
-								<Link
-									target="_blank"
-									type="external"
-									rel="noreferrer"
-									href={ url }
-								>
-									{ title }
-								</Link>
-								{ subTitleContent ? (
-									<div
-										className="pre-install-payment-gateway__subtitle"
-										dangerouslySetInnerHTML={ sanitizeHTML(
-											subTitleContent
+			<VerticalCSSTransition timeout={ 500 } in={ isVisible }>
+				{ columns.map( ( column ) => {
+					if ( column.className.includes( 'name' ) ) {
+						return (
+							<td className="name" key={ column.className }>
+								<div className="wc-payment-gateway-method__name">
+									<Link
+										target="_blank"
+										type="external"
+										rel="noreferrer"
+										href={ url }
+									>
+										{ title }
+									</Link>
+									{ subTitleContent ? (
+										<div
+											className="pre-install-payment-gateway__subtitle"
+											dangerouslySetInnerHTML={ sanitizeHTML(
+												subTitleContent
+											) }
+										></div>
+									) : null }
+								</div>
+							</td>
+						);
+					} else if ( column.className.includes( 'status' ) ) {
+						return (
+							<td
+								className="pre-install-payment-gateway__status"
+								key={ column.className }
+							></td>
+						);
+					} else if ( column.className.includes( 'action' ) ) {
+						return (
+							<td className="action" key={ column.className }>
+								<div className="pre-install-payment-gateway__actions">
+									<EllipsisMenu
+										label={ __(
+											'Payment Promotion Options',
+											'woocommerce-admin'
 										) }
-									></div>
-								) : null }
-							</div>
-						</td>
-					);
-				} else if ( column.className.includes( 'status' ) ) {
+										className="pre-install-payment-gateway__actions-menu"
+										onToggle={ (
+											e:
+												| React.MouseEvent
+												| React.KeyboardEvent
+										) => e.stopPropagation() }
+										renderContent={ () => (
+											<div className="pre-install-payment-gateway__actions-menu-options">
+												<Button onClick={ onDismiss }>
+													{ __(
+														'Dismiss',
+														'woocommerce-admin'
+													) }
+												</Button>
+											</div>
+										) }
+									/>
+									<Button
+										className="button alignright"
+										onClick={ () =>
+											installPaymentGateway()
+										}
+										isSecondary
+										isBusy={ installing }
+										aria-disabled={ installing }
+									>
+										{ __( 'Install', 'woocommerce-admin' ) }
+									</Button>
+								</div>
+							</td>
+						);
+					}
 					return (
 						<td
-							className="pre-install-payment-gateway__status"
 							key={ column.className }
+							className={ column.className }
+							width={ column.width }
+							dangerouslySetInnerHTML={
+								column.className.includes( 'sort' )
+									? {
+											__html: column.html,
+									  }
+									: sanitizeHTML( column.html )
+							}
 						></td>
 					);
-				} else if ( column.className.includes( 'action' ) ) {
-					return (
-						<td className="action" key={ column.className }>
-							<div className="pre-install-payment-gateway__actions">
-								<EllipsisMenu
-									label={ __(
-										'Payment Promotion Options',
-										'woocommerce-admin'
-									) }
-									className="pre-install-payment-gateway__actions-menu"
-									onToggle={ (
-										e:
-											| React.MouseEvent
-											| React.KeyboardEvent
-									) => e.stopPropagation() }
-									renderContent={ () => (
-										<div className="pre-install-payment-gateway__actions-menu-options">
-											<Button
-												onClick={ (
-													e:
-														| React.MouseEvent
-														| React.KeyboardEvent
-												) => {
-													e.stopPropagation();
-													onDismiss();
-												} }
-											>
-												{ __(
-													'Dismiss',
-													'woocommerce-admin'
-												) }
-											</Button>
-										</div>
-									) }
-								/>
-								<Button
-									className="button alignright"
-									onClick={ () => installPaymentGateway() }
-									isSecondary
-									isBusy={ installing }
-									aria-disabled={ installing }
-								>
-									{ __( 'Install', 'woocommerce-admin' ) }
-								</Button>
-							</div>
-						</td>
-					);
-				}
-				return (
-					<td
-						key={ column.className }
-						className={ column.className }
-						width={ column.width }
-						dangerouslySetInnerHTML={
-							column.className.includes( 'sort' )
-								? {
-										__html: column.html,
-								  }
-								: sanitizeHTML( column.html )
-						}
-					></td>
-				);
-			} ) }
+				} ) }
+			</VerticalCSSTransition>
 		</>
 	);
 };

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -3,7 +3,6 @@
  */
 import { Button } from '@wordpress/components';
 import { EllipsisMenu, Link } from '@woocommerce/components';
-import { VerticalCSSTransition } from '@woocommerce/experimental';
 import { useState, useEffect } from '@wordpress/element';
 import {
 	PLUGINS_STORE_NAME,
@@ -125,97 +124,97 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 		} );
 	};
 
+	if ( ! isVisible ) {
+		return null;
+	}
+
 	return (
 		<>
-			<VerticalCSSTransition timeout={ 500 } in={ isVisible }>
-				{ columns.map( ( column ) => {
-					if ( column.className.includes( 'name' ) ) {
-						return (
-							<td className="name" key={ column.className }>
-								<div className="wc-payment-gateway-method__name">
-									<Link
-										target="_blank"
-										type="external"
-										rel="noreferrer"
-										href={ url }
-									>
-										{ title }
-									</Link>
-									{ subTitleContent ? (
-										<div
-											className="pre-install-payment-gateway__subtitle"
-											dangerouslySetInnerHTML={ sanitizeHTML(
-												subTitleContent
-											) }
-										></div>
-									) : null }
-								</div>
-							</td>
-						);
-					} else if ( column.className.includes( 'status' ) ) {
-						return (
-							<td
-								className="pre-install-payment-gateway__status"
-								key={ column.className }
-							></td>
-						);
-					} else if ( column.className.includes( 'action' ) ) {
-						return (
-							<td className="action" key={ column.className }>
-								<div className="pre-install-payment-gateway__actions">
-									<EllipsisMenu
-										label={ __(
-											'Payment Promotion Options',
-											'woocommerce-admin'
+			{ columns.map( ( column ) => {
+				if ( column.className.includes( 'name' ) ) {
+					return (
+						<td className="name" key={ column.className }>
+							<div className="wc-payment-gateway-method__name">
+								<Link
+									target="_blank"
+									type="external"
+									rel="noreferrer"
+									href={ url }
+								>
+									{ title }
+								</Link>
+								{ subTitleContent ? (
+									<div
+										className="pre-install-payment-gateway__subtitle"
+										dangerouslySetInnerHTML={ sanitizeHTML(
+											subTitleContent
 										) }
-										className="pre-install-payment-gateway__actions-menu"
-										onToggle={ (
-											e:
-												| React.MouseEvent
-												| React.KeyboardEvent
-										) => e.stopPropagation() }
-										renderContent={ () => (
-											<div className="pre-install-payment-gateway__actions-menu-options">
-												<Button onClick={ onDismiss }>
-													{ __(
-														'Dismiss',
-														'woocommerce-admin'
-													) }
-												</Button>
-											</div>
-										) }
-									/>
-									<Button
-										className="button alignright"
-										onClick={ () =>
-											installPaymentGateway()
-										}
-										isSecondary
-										isBusy={ installing }
-										aria-disabled={ installing }
-									>
-										{ __( 'Install', 'woocommerce-admin' ) }
-									</Button>
-								</div>
-							</td>
-						);
-					}
+									></div>
+								) : null }
+							</div>
+						</td>
+					);
+				} else if ( column.className.includes( 'status' ) ) {
 					return (
 						<td
+							className="pre-install-payment-gateway__status"
 							key={ column.className }
-							className={ column.className }
-							width={ column.width }
-							dangerouslySetInnerHTML={
-								column.className.includes( 'sort' )
-									? {
-											__html: column.html,
-									  }
-									: sanitizeHTML( column.html )
-							}
 						></td>
 					);
-				} ) }
-			</VerticalCSSTransition>
+				} else if ( column.className.includes( 'action' ) ) {
+					return (
+						<td className="action" key={ column.className }>
+							<div className="pre-install-payment-gateway__actions">
+								<EllipsisMenu
+									label={ __(
+										'Payment Promotion Options',
+										'woocommerce-admin'
+									) }
+									className="pre-install-payment-gateway__actions-menu"
+									onToggle={ (
+										e:
+											| React.MouseEvent
+											| React.KeyboardEvent
+									) => e.stopPropagation() }
+									renderContent={ () => (
+										<div className="pre-install-payment-gateway__actions-menu-options">
+											<Button onClick={ onDismiss }>
+												{ __(
+													'Dismiss',
+													'woocommerce-admin'
+												) }
+											</Button>
+										</div>
+									) }
+								/>
+								<Button
+									className="button alignright"
+									onClick={ () => installPaymentGateway() }
+									isSecondary
+									isBusy={ installing }
+									aria-disabled={ installing }
+								>
+									{ __( 'Install', 'woocommerce-admin' ) }
+								</Button>
+							</div>
+						</td>
+					);
+				}
+				return (
+					<td
+						key={ column.className }
+						className={ column.className }
+						width={ column.width }
+						dangerouslySetInnerHTML={
+							column.className.includes( 'sort' )
+								? {
+										__html: column.html,
+								  }
+								: sanitizeHTML( column.html )
+						}
+					></td>
+				);
+			} ) }
 		</>
 	);
 };

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { Link } from '@woocommerce/components';
 import { Button } from '@wordpress/components';
+import { EllipsisMenu, Link } from '@woocommerce/components';
 import { useState, useEffect } from '@wordpress/element';
 import {
 	PLUGINS_STORE_NAME,
@@ -103,13 +103,15 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 		);
 	};
 
+	const onDismiss = () => {};
+
 	return (
 		<>
 			{ columns.map( ( column ) => {
 				if ( column.className.includes( 'name' ) ) {
 					return (
 						<td className="name" key={ column.className }>
-							<div className="wc-payment-gateway-method_name">
+							<div className="wc-payment-gateway-method__name">
 								<Link
 									target="_blank"
 									type="external"
@@ -120,7 +122,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 								</Link>
 								{ subTitleContent ? (
 									<div
-										className="pre-install-payment-gateway_subtitle"
+										className="pre-install-payment-gateway__subtitle"
 										dangerouslySetInnerHTML={ sanitizeHTML(
 											subTitleContent
 										) }
@@ -132,22 +134,55 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 				} else if ( column.className.includes( 'status' ) ) {
 					return (
 						<td
-							className="pre-install-payment-gateway_status"
+							className="pre-install-payment-gateway__status"
 							key={ column.className }
 						></td>
 					);
 				} else if ( column.className.includes( 'action' ) ) {
 					return (
 						<td className="action" key={ column.className }>
-							<Button
-								className="button alignright"
-								onClick={ () => installPaymentGateway() }
-								isSecondary
-								isBusy={ installing }
-								aria-disabled={ installing }
-							>
-								{ __( 'Install', 'woocommerce-admin' ) }
-							</Button>
+							<div className="pre-install-payment-gateway__actions">
+								<EllipsisMenu
+									label={ __(
+										'Payment Promotion Options',
+										'woocommerce-admin'
+									) }
+									className="pre-install-payment-gateway__actions-menu"
+									onToggle={ (
+										e:
+											| React.MouseEvent
+											| React.KeyboardEvent
+									) => e.stopPropagation() }
+									renderContent={ () => (
+										<div className="pre-install-payment-gateway__actions-menu-options">
+											<Button
+												onClick={ (
+													e:
+														| React.MouseEvent
+														| React.KeyboardEvent
+												) => {
+													e.stopPropagation();
+													onDismiss();
+												} }
+											>
+												{ __(
+													'Dismiss',
+													'woocommerce-admin'
+												) }
+											</Button>
+										</div>
+									) }
+								/>
+								<Button
+									className="button alignright"
+									onClick={ () => installPaymentGateway() }
+									isSecondary
+									isBusy={ installing }
+									aria-disabled={ installing }
+								>
+									{ __( 'Install', 'woocommerce-admin' ) }
+								</Button>
+							</div>
 						</td>
 					);
 				}

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -52,13 +52,13 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 } ) => {
 	const { gatewayId, pluginSlug, url } = paymentMethod;
 	const [ installing, setInstalling ] = useState( false );
-	const [ isVisible, setIsVisible ] = useState( false );
+	const [ isVisible, setIsVisible ] = useState( true );
 	const { installAndActivatePlugins }: PluginsStoreActions = useDispatch(
 		PLUGINS_STORE_NAME
 	);
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
-	const { gatewayIsActive, paymentGateway, promotionGateway } = useSelect(
+	const { gatewayIsActive, paymentGateway } = useSelect(
 		( select: WCDataSelector ) => {
 			const { getPaymentGateway } = select( PAYMENT_GATEWAYS_STORE_NAME );
 			const activePlugins: string[] = select(
@@ -76,7 +76,6 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 			return {
 				gatewayIsActive: isActive,
 				paymentGateway: paymentGatewayData,
-				promotionGateway: getPaymentGateway( gatewayId ),
 			};
 		}
 	);
@@ -90,12 +89,6 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 			window.location.href = paymentGateway.settings_url;
 		}
 	}, [ gatewayIsActive, paymentGateway ] );
-
-	useEffect( () => {
-		if ( promotionGateway?.settings?.is_dismissed?.value === 'no' ) {
-			setIsVisible( true );
-		}
-	}, promotionGateway );
 
 	const installPaymentGateway = () => {
 		if ( installing ) {

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -64,7 +64,7 @@ class Init {
 	 * @return array list of gateway classes.
 	 */
 	public static function possibly_register_pre_install_wc_pay_promotion_gateway( $gateways ) {
-		if ( self::should_register_pre_install_wc_pay_promoted_gateway() ) {
+		if ( self::can_show_promotion() && ! WCPaymentGatewayPreInstallWCPayPromotion::is_dismissed() ) {
 			$gateways[] = 'Automattic\WooCommerce\Admin\Features\WCPayPromotion\WCPaymentGatewayPreInstallWCPayPromotion';
 		}
 		return $gateways;
@@ -78,7 +78,7 @@ class Init {
 	 * @return array list of payment method.
 	 */
 	public static function possibly_filter_recommended_payment_gateways( $specs, $datasource_poller_id ) {
-		if ( PaymentMethodSuggestionsDataSourcePoller::ID === $datasource_poller_id && self::should_register_pre_install_wc_pay_promoted_gateway() ) {
+		if ( PaymentMethodSuggestionsDataSourcePoller::ID === $datasource_poller_id && self::can_show_promotion() ) {
 			return array_filter(
 				$specs,
 				function( $spec ) {
@@ -90,11 +90,11 @@ class Init {
 	}
 
 	/**
-	 * Checks if promoted gateway should be registered.
+	 * Checks if promoted gateway can be registered.
 	 *
 	 * @return boolean if promoted gateway should be registered.
 	 */
-	public static function should_register_pre_install_wc_pay_promoted_gateway() {
+	public static function can_show_promotion() {
 		// Check if WC Pay is enabled.
 		if ( class_exists( '\WC_Payments' ) ) {
 			return false;

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -27,7 +27,8 @@ class Init {
 		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
 		add_filter( DataSourcePoller::FILTER_NAME_SPECS, array( __CLASS__, 'possibly_filter_recommended_payment_gateways' ), 10, 2 );
 
-		if ( ! isset( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] || ! isset( $_GET['tab'] ) || 'checkout' !== $_GET['tab'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+		$is_payments_page = isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab']; // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! wp_is_json_request() && ! $is_payments_page ) {
 			return;
 		}
 

--- a/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
+++ b/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
@@ -53,6 +53,15 @@ class WCPaymentGatewayPreInstallWCPayPromotion extends \WC_Payment_Gateway {
 				'default' => 'no',
 			),
 		);
+	}
 
+	/**
+	 * Check if the promotional gateaway has been dismissed.
+	 *
+	 * @return bool
+	 */
+	public static function is_dismissed() {
+		$settings = get_option( 'woocommerce_' . self::GATEWAY_ID . '_settings', array() );
+		return isset( $settings['is_dismissed'] ) && 'yes' === $settings['is_dismissed'];
 	}
 }

--- a/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
+++ b/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
@@ -35,5 +35,24 @@ class WCPaymentGatewayPreInstallWCPayPromotion extends \WC_Payment_Gateway {
 
 		// Get setting values.
 		$this->enabled = false;
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'is_dismissed' => array(
+				'title'   => __( 'Dismiss', 'woocommerce-admin' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Dismiss the gateway', 'woocommerce-admin' ),
+				'default' => 'no',
+			),
+		);
+
 	}
 }


### PR DESCRIPTION
Fixes #7951

Adds an option via the payment gateway API to dismiss the promotional gateway.

Note a couple of more stylistic items not handled in this PR:
* The transition group to slide in/out I removed in https://github.com/woocommerce/woocommerce-admin/commit/c67adcffeaee8b952980cc3d90e7ac4bb2b1c0d5 because of invalid HTML structure.  We'll need an `as` parameter to allow modifying the `VerticalCSSTransition` component and probably need to directly replace the `tr` tag instead of mounting React inside of it.  This is most likely going to create sorting issues with core's JS ui-sortable.
* The vertical alignment of action buttons.  It looks like this would need to apply to all gateways, not just the promotional ones (cc @elizaan36).  If that's the case, I think we should handle this directly in core instead of overriding styles.

### Screenshots

![Screen Shot 2021-11-24 at 12 45 57 PM](https://user-images.githubusercontent.com/10561050/143289975-39de2076-af5e-4f49-931a-faafe72e5465.png)

### Detailed test instructions:

1. Rebase this branch with https://github.com/woocommerce/woocommerce-admin/pull/7962
2. Navigate to WC Settings->Payments.
3. Note the item in the payment table and ellipsis drop-down menu.
4. Dismiss the payment method
5. Refresh to make sure settings persist
6. Delete the `woocommerce_pre_install_woocommerce_payments_promotion_settings` option to retest if necessary