### PR TITLE
Add payment gateway suggestion docs and example extensions

### DIFF
--- a/changelogs/add-7937
+++ b/changelogs/add-7937
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Dev
+
+Add payment gateway suggestion docs and example extensions #7966

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -108,7 +108,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 
 		const gateway = getPaymentGateway( id );
 
-		if ( ! gateway || gateway.enabled ) {
+		if ( ! gateway ) {
 			return;
 		}
 

--- a/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
@@ -21,6 +21,8 @@ class My_Simple_Gateway extends WC_Payment_Gateway {
 		// Load the settings.
 		$this->init_form_fields();
 		$this->init_settings();
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 	}
 
 	/**

--- a/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class My_Simple_Gateway
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * Class My_Simple_Gateway
+ */
+class My_Simple_Gateway extends WC_Payment_Gateway {
+	/**
+	 * Constructor for the gateway.
+	 */
+	public function __construct() {
+		$this->id                 = 'simple-gateway';
+		$this->has_fields         = false;
+		$this->method_title       = __( 'Simple gateway', 'woocommerce-admin' );
+		$this->method_description = __( 'A simple gateway to show extension of gateway installation during onboarding.', 'woocommerce-admin' );
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+	}
+
+	/**
+	 * Init settings for gateways.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		$this->enabled = ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'] ? 'yes' : 'no';
+	}
+
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => __( 'Enabled', 'woocommerce-admin' ),
+				'type'    => 'checkbox',
+				'label'   => '',
+				'default' => 'no',
+			),
+			'api_key' => array(
+				'title'   => __( 'API Key', 'woocommerce-admin' ),
+				'type'    => 'text',
+				'default' => '',
+			),
+		);
+	}
+
+	/**
+	 * Determine if the gateway requires further setup.
+	 */
+	public function needs_setup() {
+		$settings = get_option( 'woocommerce_simple-gateway_settings', array() );
+		return ! isset( $settings['api_key'] ) || empty( $settings['api_key'] );
+	}
+
+	/**
+	 * Get setup help text.
+	 *
+	 * @return string
+	 */
+	public function get_setup_help_text() {
+		return __( 'Help text displayed beneath the configuration form.', 'woocommerce-admin' );
+	}
+
+	/**
+	 * Get required settings keys.
+	 *
+	 * @return array
+	 */
+	public function get_required_settings_keys() {
+		return array( 'api_key' );
+	}
+}
+

--- a/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/class-my-simple-gateway.php
@@ -13,7 +13,7 @@ class My_Simple_Gateway extends WC_Payment_Gateway {
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {
-		$this->id                 = 'simple-gateway';
+		$this->id                 = 'my-simple-gateway';
 		$this->has_fields         = false;
 		$this->method_title       = __( 'Simple gateway', 'woocommerce-admin' );
 		$this->method_description = __( 'A simple gateway to show extension of gateway installation during onboarding.', 'woocommerce-admin' );
@@ -55,7 +55,7 @@ class My_Simple_Gateway extends WC_Payment_Gateway {
 	 * Determine if the gateway requires further setup.
 	 */
 	public function needs_setup() {
-		$settings = get_option( 'woocommerce_simple-gateway_settings', array() );
+		$settings = get_option( 'woocommerce_my-simple-gateway_settings', array() );
 		return ! isset( $settings['api_key'] ) || empty( $settings['api_key'] );
 	}
 

--- a/docs/examples/extensions/payment-gateway-suggestions/class-my-slot-filled-gateway.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/class-my-slot-filled-gateway.php
@@ -21,6 +21,8 @@ class My_Slot_Filled_Gateway extends WC_Payment_Gateway {
 		// Load the settings.
 		$this->init_form_fields();
 		$this->init_settings();
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 	}
 
 	/**

--- a/docs/examples/extensions/payment-gateway-suggestions/class-my-slot-filled-gateway.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/class-my-slot-filled-gateway.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Class My_Slot_Filled_Gateway
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * Class My_Simple_Gateway
+ */
+class My_Slot_Filled_Gateway extends WC_Payment_Gateway {
+	/**
+	 * Constructor for the gateway.
+	 */
+	public function __construct() {
+		$this->id                 = 'my-slot-filled-gateway';
+		$this->has_fields         = false;
+		$this->method_title       = __( 'Slot filled gateway', 'woocommerce-admin' );
+		$this->method_description = __( 'A gateway demonstrating the use of slot fill for custom configuration screens.', 'woocommerce-admin' );
+
+		// Load the settings.
+		$this->init_form_fields();
+		$this->init_settings();
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled'    => array(
+				'title'   => __( 'Enabled', 'woocommerce-admin' ),
+				'type'    => 'checkbox',
+				'label'   => '',
+				'default' => 'no',
+			),
+			'my_setting' => array(
+				'title'   => __( 'My setting', 'woocommerce-admin' ),
+				'type'    => 'text',
+				'default' => '',
+			),
+		);
+	}
+
+	/**
+	 * Determine if the gateway requires further setup.
+	 */
+	public function needs_setup() {
+		$settings = get_option( 'woocommerce_my-slot-filled-gateway_settings', array() );
+		return ! isset( $settings['my_setting'] ) || empty( $settings['my_setting'] );
+	}
+
+	/**
+	 * Get post install script handles.
+	 *
+	 * @return array
+	 */
+	public function get_post_install_script_handles() {
+		$asset_file = require __DIR__ . '/dist/index.asset.php';
+		wp_register_script(
+			'payment-gateway-suggestion-slot-fill',
+			plugins_url( '/dist/index.js', __FILE__ ),
+			$asset_file['dependencies'],
+			$asset_file['version'],
+			true
+		);
+
+		return array(
+			'payment-gateway-suggestion-slot-fill',
+		);
+	}
+}
+

--- a/docs/examples/extensions/payment-gateway-suggestions/js/index.js
+++ b/docs/examples/extensions/payment-gateway-suggestions/js/index.js
@@ -42,7 +42,7 @@ const MyPaymentGatewaySuggestion = () => {
 	);
 };
 
-registerPlugin( 'my-payment-gateway-suggestion', {
+export default registerPlugin( 'my-payment-gateway-suggestion', {
 	render: MyPaymentGatewaySuggestion,
 	scope: 'woocommerce-tasks',
 } );

--- a/docs/examples/extensions/payment-gateway-suggestions/js/index.js
+++ b/docs/examples/extensions/payment-gateway-suggestions/js/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createElement } from '@wordpress/element';
+import { PAYMENT_GATEWAYS_STORE_NAME } from '@woocommerce/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { useDispatch } from '@wordpress/data';
+import { WooPaymentGatewayConfigure } from '@woocommerce/onboarding';
+
+const MyPaymentGatewaySuggestion = () => {
+	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
+
+	return (
+		<WooPaymentGatewayConfigure id={ 'my-slot-filled-gateway' }>
+			{ ( { markConfigured, paymentGateway } ) => {
+				const completeSetup = () => {
+					updatePaymentGateway( paymentGateway.id, {
+						settings: {
+							my_setting: 123,
+						},
+					} ).then( () => {
+						markConfigured();
+					} );
+				};
+
+				return (
+					<>
+						<p>
+							{ __(
+								"This payment's configuration screen can be slot filled with any custom content.",
+								'woocommerce-admin'
+							) }
+						</p>
+						<button onClick={ completeSetup }>
+							{ __( 'Complete', 'woocommerce-admin' ) }
+						</button>
+					</>
+				);
+			} }
+		</WooPaymentGatewayConfigure>
+	);
+};
+
+registerPlugin( 'my-payment-gateway-suggestion', {
+	render: MyPaymentGatewaySuggestion,
+	scope: 'woocommerce-tasks',
+} );

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions-mock-installer.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions-mock-installer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file includes functions that bypass the typical install process for the sake of the example.
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * This is a workaround to bypass intalling the gateway plugins from WP.org.
+ * This is not necessary provided your suggestion is a valid WP.org plugin.
+ *
+ * @param array      $response Response data.
+ * @param array      $handler Matched handler.
+ * @param WP_Request $request Request data.
+ * @return array
+ */
+function payment_gateway_suggestions_mock_install_activate_response( $response, $handler, $request ) {
+	$plugins          = array( 'slot-filled-gateway-wporg-slug', 'simple-gateway-wporg-slug' );
+	$params           = $request->get_params();
+	$requested_plugin = isset( $params['plugins'] ) ? $params['plugins'] : null;
+
+	if ( '/wc-admin/plugins/install' === $request->get_route() && in_array( $requested_plugin, $plugins, true ) ) {
+		$response['data']    = array(
+			'installed' => array( $requested_plugin ),
+		);
+		$response['errors']  = array(
+			'errors' => array(),
+		);
+		$response['success'] = true;
+		$response['message'] = __( 'Plugins were successfully installed.', 'woocommerce-admin' );
+	}
+
+	if ( '/wc-admin/plugins/activate' === $request->get_route() && in_array( $requested_plugin, $plugins, true ) ) {
+		$response['data']['activated'] = array( $requested_plugin );
+		$response['data']['active']    = array_merge( $response['data']['active'], array( $requested_plugin ) );
+		$response['errors']            = array(
+			'errors' => array(),
+		);
+		$response['success']           = true;
+		$response['message']           = __( 'Plugins were successfully activated.', 'woocommerce-admin' );
+	}
+	return $response;
+}
+add_filter( 'rest_request_after_callbacks', 'payment_gateway_suggestions_mock_install_activate_response', 10, 3 );
+
+/**
+ * This is a workaround to fake the installation check for the plugins.
+ * This is not necessary when a plugin with the matching slug has been installed from WP.org.
+ *
+ * @param array $active_plugins Active plugins.
+ * @return array
+ */
+function payment_gateway_suggestions_mock_installed_gateway( $active_plugins ) {
+	if ( 'yes' === get_option( 'slot_filled_gateway_installed' ) ) {
+		$active_plugins[] = 'slot-filled-gateway-wporg-slug';
+	}
+
+	if ( 'yes' === get_option( 'simple-gateway-wporg-slug' ) ) {
+		$active_plugins[] = 'simple-gateway-wporg-slug';
+	}
+
+	return $active_plugins;
+}
+add_filter( 'option_active_plugins', 'payment_gateway_suggestions_mock_installed_gateway' );

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions-mock-installer.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions-mock-installer.php
@@ -15,7 +15,7 @@
  * @return array
  */
 function payment_gateway_suggestions_mock_install_activate_response( $response, $handler, $request ) {
-	$plugins          = array( 'slot-filled-gateway-wporg-slug', 'simple-gateway-wporg-slug' );
+	$plugins          = array( 'my-slot-filled-gateway-wporg-slug', 'my-simple-gateway-wporg-slug' );
 	$params           = $request->get_params();
 	$requested_plugin = isset( $params['plugins'] ) ? $params['plugins'] : null;
 
@@ -52,11 +52,11 @@ add_filter( 'rest_request_after_callbacks', 'payment_gateway_suggestions_mock_in
  */
 function payment_gateway_suggestions_mock_installed_gateway( $active_plugins ) {
 	if ( 'yes' === get_option( 'slot_filled_gateway_installed' ) ) {
-		$active_plugins[] = 'slot-filled-gateway-wporg-slug';
+		$active_plugins[] = 'my-slot-filled-gateway-wporg-slug';
 	}
 
-	if ( 'yes' === get_option( 'simple-gateway-wporg-slug' ) ) {
-		$active_plugins[] = 'simple-gateway-wporg-slug';
+	if ( 'yes' === get_option( 'my-simple-gateway-wporg-slug' ) ) {
+		$active_plugins[] = 'my-simple-gateway-wporg-slug';
 	}
 
 	return $active_plugins;

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
@@ -11,7 +11,7 @@
 function payment_gateway_suggestions_includes() {
 	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-mock-installer.php';
 	include_once __DIR__ . '/class-my-simple-gateway.php';
-	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-slot-filled-gateway.php';
+	include_once __DIR__ . '/class-my-slot-filled-gateway.php';
 }
 add_action( 'plugins_loaded', 'payment_gateway_suggestions_includes' );
 
@@ -38,11 +38,11 @@ add_filter( 'woocommerce_payment_gateways', 'payment_gateway_suggestions_registe
  */
 function payment_gateway_suggestions_add_suggestions( $specs ) {
 	$specs[] = array(
-		'id'         => 'simple-gateway',
+		'id'         => 'my-simple-gateway',
 		'title'      => __( 'Simple Gateway', 'woocommerce-admin' ),
 		'content'    => __( "This is a simple gateway that pulls its configuration fields from the gateway's class.", 'woocommerce-admin' ),
 		'image'      => WC()->plugin_url() . '/assets/images/placeholder.png',
-		'plugins'    => array( 'simple-gateway-wporg-slug' ),
+		'plugins'    => array( 'my-simple-gateway-wporg-slug' ),
 		'is_visible' => array(
 			(object) array(
 				'type'      => 'base_location_country',
@@ -53,11 +53,11 @@ function payment_gateway_suggestions_add_suggestions( $specs ) {
 	);
 
 	$specs[] = array(
-		'id'      => 'slot-filled-gateway',
+		'id'      => 'my-slot-filled-gateway',
 		'title'   => __( 'Slot Filled Gateway', 'woocommerce-admin' ),
 		'content' => __( 'This gateway makes use of registered SlotFill scripts to show its content.', 'woocommerce-admin' ),
 		'image'   => WC()->plugin_url() . '/assets/images/placeholder.png',
-		'plugins' => array( 'slot-filled-gateway-wporg-slug' ),
+		'plugins' => array( 'my-slot-filled-gateway-wporg-slug' ),
 	);
 
 	return $specs;

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
@@ -10,7 +10,7 @@
  */
 function payment_gateway_suggestions_includes() {
 	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-mock-installer.php';
-	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-simple-gateway.php';
+	include_once __DIR__ . '/class-my-simple-gateway.php';
 	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-slot-filled-gateway.php';
 }
 add_action( 'plugins_loaded', 'payment_gateway_suggestions_includes' );

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
@@ -63,24 +63,3 @@ function payment_gateway_suggestions_add_suggestions( $specs ) {
 	return $specs;
 }
 add_filter( 'woocommerce_admin_payment_gateway_suggestion_specs', 'payment_gateway_suggestions_add_suggestions' );
-
-/**
- * Register the JS.
- */
-function payment_gateway_suggestions_register_scripts() {
-	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
-		return;
-	}
-
-	$asset_file = require __DIR__ . '/dist/index.asset.php';
-	wp_register_script(
-		'payment-gateway-suggestion-slot-fill',
-		plugins_url( '/dist/index.js', __FILE__ ),
-		$asset_file['dependencies'],
-		$asset_file['version'],
-		true
-	);
-
-	wp_enqueue_script( 'payment-gateway-suggestion-slot-fill' );
-}
-add_action( 'admin_enqueue_scripts', 'payment_gateway_suggestions_register_scripts' );

--- a/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
+++ b/docs/examples/extensions/payment-gateway-suggestions/woocommerce-admin-payment-gateway-suggestions.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Admin Payment Gateway Suggestions
+ *
+ * @package WooCommerce\Admin
+ */
+
+/**
+ * Include files.
+ */
+function payment_gateway_suggestions_includes() {
+	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-mock-installer.php';
+	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-simple-gateway.php';
+	include_once __DIR__ . '/woocommerce-admin-payment-gateway-suggestions-slot-filled-gateway.php';
+}
+add_action( 'plugins_loaded', 'payment_gateway_suggestions_includes' );
+
+
+/**
+ * Register the gateways with WooCommerce.
+ *
+ * @param array $gateways Gateways.
+ * @return array
+ */
+function payment_gateway_suggestions_register_gateways( $gateways ) {
+	$gateways[] = 'My_Simple_Gateway';
+	$gateways[] = 'My_Slot_Filled_Gateway';
+
+	return $gateways;
+}
+add_filter( 'woocommerce_payment_gateways', 'payment_gateway_suggestions_register_gateways' );
+
+/**
+ * Add examples to the data sources.
+ *
+ * @param array $specs Specs.
+ * @return array
+ */
+function payment_gateway_suggestions_add_suggestions( $specs ) {
+	$specs[] = array(
+		'id'         => 'simple-gateway',
+		'title'      => __( 'Simple Gateway', 'woocommerce-admin' ),
+		'content'    => __( "This is a simple gateway that pulls its configuration fields from the gateway's class.", 'woocommerce-admin' ),
+		'image'      => WC()->plugin_url() . '/assets/images/placeholder.png',
+		'plugins'    => array( 'simple-gateway-wporg-slug' ),
+		'is_visible' => array(
+			(object) array(
+				'type'      => 'base_location_country',
+				'value'     => 'US',
+				'operation' => '=',
+			),
+		),
+	);
+
+	$specs[] = array(
+		'id'      => 'slot-filled-gateway',
+		'title'   => __( 'Slot Filled Gateway', 'woocommerce-admin' ),
+		'content' => __( 'This gateway makes use of registered SlotFill scripts to show its content.', 'woocommerce-admin' ),
+		'image'   => WC()->plugin_url() . '/assets/images/placeholder.png',
+		'plugins' => array( 'slot-filled-gateway-wporg-slug' ),
+	);
+
+	return $specs;
+}
+add_filter( 'woocommerce_admin_payment_gateway_suggestion_specs', 'payment_gateway_suggestions_add_suggestions' );
+
+/**
+ * Register the JS.
+ */
+function payment_gateway_suggestions_register_scripts() {
+	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
+		return;
+	}
+
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
+	wp_register_script(
+		'payment-gateway-suggestion-slot-fill',
+		plugins_url( '/dist/index.js', __FILE__ ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+
+	wp_enqueue_script( 'payment-gateway-suggestion-slot-fill' );
+}
+add_action( 'admin_enqueue_scripts', 'payment_gateway_suggestions_register_scripts' );

--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -4,6 +4,16 @@ This feature uses JSON to retrieve the currently recommended payment gateways. T
 
 After merchants click on a recommendation, plugins from this source will then walk through an installer step, followed by a connection step with the minimum required fields for setup defined by the downloaded plugin.
 
+### Quick start
+
+Gateway suggestions are retreived from a REST API and can be added via a remote JSON data source or filtered with the `woocommerce_admin_payment_gateway_suggestion_specs` filter.
+
+To quickly get started with an example plugin, run the following from your `woocommerce-admin` directory:
+
+`npm run example -- --ext=payment-gateway-suggestions`
+
+This will create a new plugin that when activated will add two new gateway suggestions.  The first is a simple gateway demonstrating how configuration fields can be pulled from the gateway class to create a configuration form.  The second gateway shows a more customized approach via SlotFill.
+
 ## Data Source Polling
 
 If a store is opted into marketplace suggestions via `woocommerce_show_marketplace_suggestions` the suggestions by default will be retrieved from `https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/payment-method/suggestions.json'`.

--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -4,11 +4,11 @@ This feature uses JSON to retrieve the currently recommended payment gateways. T
 
 After merchants click on a recommendation, plugins from this source will then walk through an installer step, followed by a connection step with the minimum required fields for setup defined by the downloaded plugin.
 
-## Enabling Payment Gateway Suggestions
+## Data Source Polling
 
-This feature is behind a feature flag. In order for it to run, the `payment-gateway-suggestions` must be set to `true` in `~/config/{environment}.json` and the plugin must be rebuilt either using `npm start` or `npm run build`.
+If a store is opted into marketplace suggestions via `woocommerce_show_marketplace_suggestions` the suggestions by default will be retrieved from `https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/payment-method/suggestions.json'`.
 
-Currently there is no working remote data source. For testing purposes, [this plugin](https://github.com/joshuatf/woocommerce-admin-remote-tester) can be used which adds a data source and removes the transient cache so the data source is re-fetched on each subsequent page load.
+If a user is not opted into marketplace suggestions or polling fails, the gateway suggestions will fall back to the defaults in the `DefaultPaymentGateways` class.
 
 ## Remote Data Source Schema
 

--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -47,10 +47,23 @@ Additional information is added to the existing payment gateway in the WooCommer
 | `get_post_install_script_handles()` | array   | `[]`    | An array of script handles previously registered with `wp_register_script` to enqueue after the payment gateway has been installed. This is primarily used to `SlotFill` the payment connection step, but can allow any script to be added to assist in payment gateway setup. |
 | `get_setup_help_text()`             | string  | `null`  | Help text to be shown above the connection step's submit button.                                                                                                                                                                                                               |
 
+
 ## SlotFill
 
-Payment gateway tasks can be SlotFilled to provide custom experiences. This is useful if a gateway cannot follow the generic payment steps to be fully set up.
+By default, the client will generate a payment gateway setup form from the settings fields registered in `get_required_settings_keys()`.  However, payment gateway tasks can be SlotFilled to provide custom experiences. This is useful if a gateway cannot follow the generic payment steps to be fully set up.
 
-The entire payment gateway card can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewaySetup) or simply SlotFill [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewayConfigure) to leave the default installation and stepper in place.
+### WooPaymentGatewayConfigure
 
-Note that since plugin installation happens asynchronously, a full page reload will not occur between gateway installation and configuration. This renders functions like `wp_enqueue_script` ineffective. To solve this issue and allow `SlotFill` to work on a newly installed plugin, the gateway can provide a URL to be loaded immediately after installation using `get_post_install_script_handles()`.
+To customize the configuration form used in the payment setup, you can use [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewayConfigure). 
+
+This will leave the default gateway installation and stepper in place, but allow the form to be customized as needed.
+
+### WooPaymentGatewaySetup
+
+To completely override the stepper and default installation behavior, the gateway can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewaySetup).
+
+## Post install setup
+
+Since plugin installation happens asynchronously, a full page reload will not occur between gateway installation and configuration. This renders functions like `wp_enqueue_script` ineffective.
+
+To allow for interaction with the newly registered gateway and allow `SlotFill` to work on a newly installed plugin, the gateway can provide a URL to be loaded immediately after installation using `get_post_install_script_handles()`.  Registered scripts in this handler will automatically be injected into the page after the gateway has been installed.

--- a/src/Features/PaymentGatewaySuggestions/Init.php
+++ b/src/Features/PaymentGatewaySuggestions/Init.php
@@ -59,15 +59,15 @@ class Init {
 	 */
 	public static function get_specs() {
 		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
-			return DefaultPaymentGateways::get_all();
+			return apply_filters( 'woocommerce_admin_payment_gateway_suggestion_specs', DefaultPaymentGateways::get_all() );
 		}
 		$specs = PaymentGatewaySuggestionsDataSourcePoller::get_instance()->get_specs_from_data_sources();
 
 		// Fetch specs if they don't yet exist.
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
-			return DefaultPaymentGateways::get_all();
+			return apply_filters( 'woocommerce_admin_payment_gateway_suggestion_specs', DefaultPaymentGateways::get_all() );
 		}
 
-		return $specs;
+		return apply_filters( 'woocommerce_admin_payment_gateway_suggestion_specs', $specs );
 	}
 }


### PR DESCRIPTION
Fixes #7937 

* Improves documentation around payment gateway suggestions, removing outdated references.
* Adds a simple server-side only gateway suggestion
* Adds a more complex slot filled gateway suggestion

### Screenshots

![Screen Shot 2021-11-29 at 5 33 29 PM](https://user-images.githubusercontent.com/10561050/144071756-f79ccc2b-4bfb-4ecc-84ad-bbe6f1a99876.png)

![Screen Shot 2021-11-30 at 9 49 14 AM](https://user-images.githubusercontent.com/10561050/144071751-93a92baf-24f9-4bc3-a3f5-fe9188c3157f.png)

### Detailed test instructions:

1. Run `npm run example -- --ext=payment-gateway-suggestions`
2. Activate the plugin
3. Navigate to the payments task
4. Note the two plugins
5. Check that they work and demonstrate the feature thoroughly
6. Check that the docs are accurate