### PR TITLE
Make Homescreen Default to Single Column Layout

### DIFF
--- a/changelogs/fix-default-layout
+++ b/changelogs/fix-default-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Ensure homescreen defaults to single column layout. #7969

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -76,7 +76,6 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		const taskListsFinished = false;
 		updateOptions( {
 			woocommerce_task_list_prompt_shown: true,
-			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	}, [ taskLists, isResolving ] );
 

--- a/client/tasks/test/tasks.test.tsx
+++ b/client/tasks/test/tasks.test.tsx
@@ -147,7 +147,6 @@ describe( 'Task', () => {
 		);
 		expect( updateOptions ).toHaveBeenCalledWith( {
 			woocommerce_task_list_prompt_shown: true,
-			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
 

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -119,16 +119,6 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 						'Get ready to start selling',
 						'woocommerce-admin'
 					) }
-					onComplete={ () =>
-						updateOptions( {
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
-					onHide={ () =>
-						updateOptions( {
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
 				/>
 			) }
 		</>

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -30,7 +30,6 @@ const taskDashboardSelect = ( select ) => {
 };
 
 const TaskDashboard = ( { query, twoColumns } ) => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const {
 		keepCompletedTaskList,
 		isResolving: isResolvingOptions,

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -311,6 +311,13 @@ function wc_admin_update_290_update_apperance_task_option() {
 }
 
 /**
+ * Delete the old woocommerce_default_homepage_layout option.
+ */
+function wc_admin_update_290_delete_default_homepage_layout_option() {
+	delete_option( 'woocommerce_default_homepage_layout' );
+}
+
+/**
  * Update DB Version.
  */
 function wc_admin_update_290_db_version() {

--- a/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
@@ -54,6 +54,5 @@ export class PaymentsSetup extends BasePage {
 	async enableCashOnDelivery() {
 		await this.page.waitForSelector( '.woocommerce-task-payment-cod' );
 		await this.clickButtonWithText( 'Enable' );
-		await waitForTimeout( 1000 );
 	}
 }

--- a/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
@@ -54,6 +54,6 @@ export class PaymentsSetup extends BasePage {
 	async enableCashOnDelivery() {
 		await this.page.waitForSelector( '.woocommerce-task-payment-cod' );
 		await this.clickButtonWithText( 'Enable' );
-		await waitForTimeout( 500 );
+		await waitForTimeout( 1000 );
 	}
 }

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -77,6 +77,9 @@ const testAdminPaymentSetupTask = () => {
 			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.enableCashOnDelivery();
+			await homeScreen.navigate();
+			await homeScreen.isDisplayed();
+			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.isDisplayed();
 			await paymentsSetup.methodHasBeenSetup( 'cod' );

--- a/src/Install.php
+++ b/src/Install.php
@@ -71,6 +71,7 @@ class Install {
 		),
 		'2.9.0'  => array(
 			'wc_admin_update_290_update_apperance_task_option',
+			'wc_admin_update_290_delete_default_homepage_layout_option',
 			'wc_admin_update_290_db_version',
 		),
 		'3.0.0'  => array(


### PR DESCRIPTION
Fixes #7967

By default, the homepage layout should use a single column layout. However, this can be overridden in various ways:

- By setting an option `woocommerce_default_homepage_layout`
- By changing a user preference using the Display Layout UI

<img width="240" alt="Screen Shot 2021-11-26 at 5 10 06 pm" src="https://user-images.githubusercontent.com/9312929/143555993-fe7d5039-8d54-4b4c-ab80-8f2e774652df.png">

This PR fixes a bug where WooCommerce Admin sets the value of `woocommerce_default_homepage_layout` to `two_columns` and causes the wrong layout to be rendered by default.

The previous use of the `woocommerce_default_homepage_layout` option caused ambiguity over what the default layout should be:

On the one hand, various parts of the code state it should be `single_column`. For example:

https://github.com/woocommerce/woocommerce-admin/blob/e9d94f6819f28827d9c9c49b934962908c3b05d8/client/homescreen/layout.js#L316-L318

On the other hand, parts of the code were explicitly updating the option value to be `two_columns`. For example:

https://github.com/woocommerce/woocommerce-admin/blob/c1f4ebfb7747584387be74f8a613e3726506b4d0/client/tasks/tasks.tsx#L74-L81

Furthermore, a previous install routine would set the value of the option to `two_columns`:

https://github.com/woocommerce/woocommerce-admin/blob/38f65f71f4b50997e39584c948ff71f296312934/includes/wc-admin-update-functions.php#L145-L150

This PR attempts to remove this ambiguity by deleting this option in the install routine, and removing the calls which explicitly set the value to `two_columns`. This results in the option being absent in a fresh install of Woo Admin, allowing the code-based default layout value of `single_column` to be passed through.

To keep this PR small, I have elected to keep the ability to override the default value with the `woocommerce_default_homepage_layout` option. A follow-up PR could remove this ability if it's thought to have little value.

### Testing Instructions

#### Installation Routine

1. To test the installation routine reliably, use the `trunk` development version of WooCommerce Admin Testing Tools and run the 2.9.0 callback:

<img width="970" alt="Screen Shot 2021-11-26 at 5 46 58 pm" src="https://user-images.githubusercontent.com/9312929/143561097-04ac9334-2ff8-4d40-b187-e2039fab15a8.png">

2. See that the `woocommerce_default_homepage_layout` option is not present.

#### Homescreen

1. View the WooCommerce Home Screen.
2. See that the single column layout is shown.

<img width="1501" alt="Screen Shot 2021-11-26 at 6 16 49 pm" src="https://user-images.githubusercontent.com/9312929/143565000-a70ebf77-0dd4-402d-b23e-e1858a3a97d8.png">

#### New Task List UI ExPlat Experiments (optional)

Additionally, ExPlat experiments for the Task List UI are currently in place.

Preparation:

1. Connect to a8c proxy.
2. Use the **treatment** bookmarklet for the `woocommerce_tasklist_progression_headercard_2021_11` experiment.

Note: ExPlat bookmarklets are not always reliable. You may need to clear browser localStorage prior to using a bookmarklet to have it apply correctly.

##### Single column experiment
1. Use the **control** bookmarklet for the `woocommerce_tasklist_progression_headercard_2coll_2021_11` experiment.
2. View the WooCommerce Home Screen.
3. See that the single column layout with new Task List UI is shown

<img width="700" alt="Screen Shot 2021-11-26 at 6 36 28 pm" src="https://user-images.githubusercontent.com/9312929/143567654-a9f3c23a-e050-4f77-b30e-3e5046dfe096.png">

##### Two column experiment
1. Use the **treatment** bookmarklet for the `woocommerce_tasklist_progression_headercard_2coll_2021_11` experiment.
2. View the WooCommerce Home Screen.
3. See that the two column layout with new Task List UI is shown

<img width="1058" alt="Screen Shot 2021-11-26 at 6 20 53 pm" src="https://user-images.githubusercontent.com/9312929/143566251-9562fcdf-ab37-4d58-98f5-90307d258d31.png">
