### PR TITLE
Fix/7563 improving admin search component

### DIFF
--- a/changelogs/fix-7563
+++ b/changelogs/fix-7563
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Fix
 
-Fix UX issue on search component #7855
+Fix UX issue on search component #7972

--- a/changelogs/fix-7563
+++ b/changelogs/fix-7563
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Fix UX issue on search component #7855

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -64,10 +64,11 @@
 		margin: 0;
 		padding-left: 10px;
 		display: flex;
-		width: 100%;
-		max-width: calc(100% - 60px);
+		width: 0;
+		flex-grow: 1;
 		overflow: hidden;
 		justify-content: flex-end;
+		align-items: center;
 		&::after {
 			content: '';
 			position: absolute;

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -63,11 +63,9 @@
 	.components-base-control .woocommerce-select-control__tags {
 		margin: 0;
 		display: flex;
-
-		width: -webkit-calc(100% - 60px);
-		width: -moz-calc(100% - 60px);
-		width: calc(100% - 60px);
-
+		max-width: -webkit-calc(100% - 60px);
+		max-width: -moz-calc(100% - 60px);
+		max-width: calc(100% - 60px);
 	}
 
 	.is-overflown {

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -71,6 +71,17 @@
 	.is-overflown {
 		overflow: hidden;
 		justify-content: flex-end;
+		&:after {
+			content: "";
+			position: absolute;
+			z-index: 1;
+			top: 0;
+			left: 0;
+			bottom: 0;
+			pointer-events: none;
+			background-image: linear-gradient(to right, white, transparent 40%);
+			width: 10%;
+		}
 	}
 
 

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -64,8 +64,7 @@
 		margin: 0;
 		padding-left: 10px;
 		display: flex;
-		max-width: -webkit-calc(100% - 60px);
-		max-width: -moz-calc(100% - 60px);
+		width: 100%;
 		max-width: calc(100% - 60px);
 		overflow: hidden;
 		justify-content: flex-end;
@@ -84,7 +83,6 @@
 
 
 	.components-base-control .woocommerce-tag {
-		flex-shrink: 0;
 		max-height: 24px;
 	}
 

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -62,25 +62,23 @@
 
 	.components-base-control .woocommerce-select-control__tags {
 		margin: 0;
+		padding-left: 10px;
 		display: flex;
 		max-width: -webkit-calc(100% - 60px);
 		max-width: -moz-calc(100% - 60px);
 		max-width: calc(100% - 60px);
-	}
-
-	.is-overflown {
 		overflow: hidden;
 		justify-content: flex-end;
-		&:after {
-			content: "";
+		&::after {
+			content: '';
 			position: absolute;
 			z-index: 1;
 			top: 0;
 			left: 0;
 			bottom: 0;
 			pointer-events: none;
-			background-image: linear-gradient(to right, white, transparent 40%);
-			width: 10%;
+			background-image: linear-gradient(to right, #fff, transparent 70%);
+			width: 20px;
 		}
 	}
 

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -62,9 +62,22 @@
 
 	.components-base-control .woocommerce-select-control__tags {
 		margin: 0;
+		display: flex;
+
+		width: -webkit-calc(100% - 60px);
+		width: -moz-calc(100% - 60px);
+		width: calc(100% - 60px);
+
 	}
 
+	.is-overflown {
+		overflow: hidden;
+		justify-content: flex-end;
+	}
+
+
 	.components-base-control .woocommerce-tag {
+		flex-shrink: 0;
 		max-height: 24px;
 	}
 

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -182,6 +182,39 @@ class Control extends Component {
 
 		const { isActive } = this.state;
 
+		const field = (
+			<div className="components-base-control__field">
+				{ !! label && (
+					<label
+						htmlFor={ `woocommerce-select-control-${ instanceId }__control-input` }
+						className="components-base-control__label"
+					>
+						{ label }
+					</label>
+				) }
+				{ this.renderInput() }
+				{ inlineTags && (
+					<span
+						id={ `search-inline-input-${ instanceId }` }
+						className="screen-reader-text"
+					>
+						{ __(
+							'Move backward for selected items',
+							'woocommerce-admin'
+						) }
+					</span>
+				) }
+				{ !! help && (
+					<p
+						id={ `woocommerce-select-control-${ instanceId }__help` }
+						className="components-base-control__help"
+					>
+						{ help }
+					</p>
+				) }
+			</div>
+		);
+
 		return (
 			// Disable reason: The div below visually simulates an input field. Its
 			// child input is the actual input and responds accordingly to all keyboard
@@ -214,42 +247,10 @@ class Control extends Component {
 					/>
 				) }
 				{ inlineTags ? (
-					<Tags
-						{ ...this.props }
-						searchInput={ this.renderInput() }
-					/>
+					<Tags { ...this.props } searchInput={ field } />
 				) : (
-					this.renderInput()
+					field
 				) }
-				<div className="components-base-control__field">
-					{ !! label && (
-						<label
-							htmlFor={ `woocommerce-select-control-${ instanceId }__control-input` }
-							className="components-base-control__label"
-						>
-							{ label }
-						</label>
-					) }
-					{ inlineTags && (
-						<span
-							id={ `search-inline-input-${ instanceId }` }
-							className="screen-reader-text"
-						>
-							{ __(
-								'Move backward for selected items',
-								'woocommerce-admin'
-							) }
-						</span>
-					) }
-					{ !! help && (
-						<p
-							id={ `woocommerce-select-control-${ instanceId }__help` }
-							className="components-base-control__help"
-						>
-							{ help }
-						</p>
-					) }
-				</div>
 			</div>
 			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		);

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -96,21 +96,6 @@ class Control extends Component {
 			event.stopPropagation();
 		}
 	}
-
-	renderButton() {
-		const { multiple, selected } = this.props;
-
-		if ( multiple || ! selected.length ) {
-			return null;
-		}
-
-		return (
-			<div className="woocommerce-select-control__control-value">
-				{ selected[ 0 ].label }
-			</div>
-		);
-	}
-
 	renderInput() {
 		const {
 			activeId,
@@ -194,6 +179,7 @@ class Control extends Component {
 			label,
 			query,
 		} = this.props;
+
 		const { isActive } = this.state;
 
 		return (
@@ -227,8 +213,14 @@ class Control extends Component {
 						icon={ search }
 					/>
 				) }
-				{ inlineTags && <Tags { ...this.props } /> }
-
+				{ inlineTags ? (
+					<Tags
+						{ ...this.props }
+						searchInput={ this.renderInput() }
+					/>
+				) : (
+					this.renderInput()
+				) }
 				<div className="components-base-control__field">
 					{ !! label && (
 						<label
@@ -238,7 +230,6 @@ class Control extends Component {
 							{ label }
 						</label>
 					) }
-					{ this.renderInput() }
 					{ inlineTags && (
 						<span
 							id={ `search-inline-input-${ instanceId }` }

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -44,7 +44,6 @@
 			padding-left: 0;
 			padding-right: 0;
 			width: 100%;
-			min-width: 20%;
 			line-height: 24px;
 			text-align: left;
 			letter-spacing: inherit;
@@ -56,9 +55,6 @@
 
 			&:focus {
 				outline: none;
-				@media only screen and (max-width: 600px) {
-					min-width: 80%;
-				}
 			}
 		}
 
@@ -87,6 +83,16 @@
 		}
 	}
 
+	.components-base-control__field {
+		min-width: 20%;
+	}
+
+	&.is-focused .components-base-control__field {
+		@media only screen and (max-width: 600px) {
+			min-width: 80%;
+		}
+	}
+
 	.woocommerce-select-control__autofill-input {
 		position: absolute;
 		z-index: -1;
@@ -106,10 +112,7 @@
 	}
 
 	.woocommerce-select-control__clear {
-		position: absolute;
-		right: 10px;
-		margin: 0;
-		padding: 0;
+		white-space: nowrap;
 		text-decoration: underline;
 		color: $gray-900;
 

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -44,6 +44,7 @@
 			padding-left: 0;
 			padding-right: 0;
 			width: 100%;
+			min-width: 20%;
 			line-height: 24px;
 			text-align: left;
 			letter-spacing: inherit;
@@ -55,6 +56,9 @@
 
 			&:focus {
 				outline: none;
+				@media only screen and (max-width: 600px) {
+					min-width: 80%;
+				}
 			}
 		}
 

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -104,7 +104,10 @@
 	.woocommerce-select-control__clear {
 		position: absolute;
 		right: 10px;
-		top: calc(50% - 10px);
+		margin: 0;
+		padding: 0;
+		text-decoration: underline;
+		color: $gray-900;
 
 		& > .clear-icon {
 			color: #c9c9c9;

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -28,6 +28,9 @@ class Tags extends Component {
 
 	isElementOverflown(e) {
 		// Calculate total width of all child elements
+		if (typeof e === 'undefined') {
+			return false;
+		}
 		const totalWidth = Object.values(e.childNodes).reduce((total, i) => total + i.clientWidth, 0);
 		return e.clientWidth < totalWidth;
 	}

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -75,10 +75,7 @@ class Tags extends Component {
 						isLink
 						onClick={ this.removeAll }
 					>
-						<Icon
-							icon={ cancelCircleFilled }
-							className="clear-icon"
-						/>
+						{ __( 'Clear all', 'woocommerce-admin' ) }
 						<span className="screen-reader-text">
 							{ __( 'Clear all', 'woocommerce-admin' ) }
 						</span>

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -21,6 +21,15 @@ class Tags extends Component {
 		super( props );
 		this.removeAll = this.removeAll.bind( this );
 		this.removeResult = this.removeResult.bind( this );
+		this.state = {
+			overflowActive: false
+		};
+	}
+
+	isElementOverflown(e) {
+		// Calculate total width of all child elements
+		const totalWidth = Object.values(e.childNodes).reduce((total, i) => total + i.clientWidth, 0);
+		return e.clientWidth < totalWidth;
 	}
 
 	removeAll() {
@@ -39,15 +48,20 @@ class Tags extends Component {
 		};
 	}
 
+	componentDidMount() {
+		this.setState({ overflowActive: this.isElementOverflown(this.tagsParent) });
+	}
+
 	render() {
 		const { selected, showClearButton } = this.props;
+		const { overflowActive } = this.state;
 		if ( ! selected.length ) {
 			return null;
 		}
 
 		return (
 			<Fragment>
-				<div className="woocommerce-select-control__tags">
+				<div ref={ ref => this.tagsParent = ref } className={`woocommerce-select-control__tags${overflowActive ? " is-overflown" : ""}`}>
 					{ selected.map( ( item, i ) => {
 						if ( ! item.label ) {
 							return null;
@@ -69,10 +83,10 @@ class Tags extends Component {
 						);
 					} ) }
 				</div>
-				{ showClearButton && (
+				{ showClearButton && selected.length > 1 && (
 					<Button
 						className="woocommerce-select-control__clear"
-						isLink
+						isLink={ false }
 						onClick={ this.removeAll }
 					>
 						{ __( 'Clear all', 'woocommerce-admin' ) }

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { Icon, cancelCircleFilled } from '@wordpress/icons';
 import { createElement, Component, Fragment } from '@wordpress/element';
 import { findIndex } from 'lodash';
 import PropTypes from 'prop-types';
@@ -21,18 +20,6 @@ class Tags extends Component {
 		super( props );
 		this.removeAll = this.removeAll.bind( this );
 		this.removeResult = this.removeResult.bind( this );
-		this.state = {
-			overflowActive: false
-		};
-	}
-
-	isElementOverflown(e) {
-		// Calculate total width of all child elements
-		if (typeof e === 'undefined') {
-			return false;
-		}
-		const totalWidth = Object.values(e.childNodes).reduce((total, i) => total + i.clientWidth, 0);
-		return e.clientWidth < totalWidth;
 	}
 
 	removeAll() {
@@ -51,20 +38,15 @@ class Tags extends Component {
 		};
 	}
 
-	componentDidMount() {
-		this.setState({ overflowActive: this.isElementOverflown(this.tagsParent) });
-	}
-
 	render() {
-		const { selected, showClearButton } = this.props;
-		const { overflowActive } = this.state;
+		const { selected, showClearButton, searchInput } = this.props;
 		if ( ! selected.length ) {
-			return null;
+			return searchInput;
 		}
 
 		return (
 			<Fragment>
-				<div ref={ ref => this.tagsParent = ref } className={`woocommerce-select-control__tags${overflowActive ? " is-overflown" : ""}`}>
+				<div className={ 'woocommerce-select-control__tags' }>
 					{ selected.map( ( item, i ) => {
 						if ( ! item.label ) {
 							return null;
@@ -85,6 +67,7 @@ class Tags extends Component {
 							/>
 						);
 					} ) }
+					{ searchInput }
 				</div>
 				{ showClearButton && selected.length > 1 && (
 					<Button

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -46,7 +46,7 @@ class Tags extends Component {
 
 		return (
 			<Fragment>
-				<div className={ 'woocommerce-select-control__tags' }>
+				<div className="woocommerce-select-control__tags">
 					{ selected.map( ( item, i ) => {
 						if ( ! item.label ) {
 							return null;

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -15,7 +15,7 @@
 		}
 
 		> div {
-			width: calc(100% - 50px);
+			flex-grow: 1;
 		}
 	}
 

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -15,7 +15,7 @@
 		}
 
 		> div {
-			width: 100%;
+			width: calc(100% - 50px);
 		}
 	}
 

--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -3,6 +3,7 @@
 	margin: 1px 4px 1px 0;
 	overflow: hidden;
 	vertical-align: middle;
+	flex-shrink: 0;
 
 	.woocommerce-tag__text,
 	.woocommerce-tag__remove {


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32239 

The search component has UX issues. When multiple tags are added, the component breaks apart. To fix this issue, the flex property is added to the parent element and gradient is added by using CSS after property to simulate diapering effect when tags can't be placed inside the search component.  The default property of shrinking column has been disabled and min width has been added to multiple elements to improve UI experience to the end user. 

### Screenshots

**Before**:

![image](https://user-images.githubusercontent.com/15913573/143605502-1ceb9b09-bfae-449e-8dff-a0c882ae870c.png)

<img width="421" alt="Screen Shot 2021-08-25 at 8 14 43 PM" src="https://user-images.githubusercontent.com/4500952/130895561-e2b845a1-e654-4e8d-9e11-8dc8dadc4cf2.png">

**After**:
Desktop screen when content can fit:

![image](https://user-images.githubusercontent.com/15913573/143602697-84b74448-4cf1-4159-97db-79db4e793b1c.png)

Mobile screen when content can't fit:

![image](https://user-images.githubusercontent.com/15913573/143603025-d25c87d5-c40a-4092-ada4-83fd88eaae4d.png)


### Detailed test instructions:

-   Open Customers page in WooCommerce or any page that uses this component
-   Enter multiple tags in search box
-   The input should handle multiple tags and scale them properly

Or take a look at testing instructions [here](woocommerce/woocommerce#32239).
