### PR TITLE
Add loading icon and disable continue until free extensions are loaded

### DIFF
--- a/changelogs/fix-7321_free_extensions_list
+++ b/changelogs/fix-7321_free_extensions_list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Onboarding flow where extensions might not be selected and installed. #7979

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -268,46 +268,43 @@ export const SelectiveExtensionsBundle = ( {
 				</div>
 				<div className="woocommerce-admin__business-details__selective-extensions-bundle">
 					<div className="woocommerce-admin__business-details__selective-extensions-bundle__extension">
-						{ isResolving ? (
-							<Spinner />
-						) : (
-							<CheckboxControl
-								checked={ values.install_extensions }
-								onChange={ ( checked ) => {
-									setValues(
-										setAllPropsToValue( values, checked )
-									);
-								} }
-							/>
-						) }
+						<CheckboxControl
+							checked={ values.install_extensions }
+							onChange={ ( checked ) => {
+								setValues(
+									setAllPropsToValue( values, checked )
+								);
+							} }
+						/>
 						<p className="woocommerce-admin__business-details__selective-extensions-bundle__description">
 							{ __(
 								'Add recommended business features to my site',
 								'woocommerce-admin'
 							) }
 						</p>
-						{ installableExtensions &&
-						installableExtensions.length > 0 ? (
-							<Button
-								className="woocommerce-admin__business-details__selective-extensions-bundle__expand"
-								onClick={ () => {
-									setShowExtensions( ! showExtensions );
+						<Button
+							className="woocommerce-admin__business-details__selective-extensions-bundle__expand"
+							disabled={
+								! installableExtensions ||
+								installableExtensions.length === 0
+							}
+							onClick={ () => {
+								setShowExtensions( ! showExtensions );
 
-									if ( ! showExtensions ) {
-										// only record the accordion click when the accordion is opened.
-										recordEvent(
-											'storeprofiler_store_business_features_accordion_click'
-										);
-									}
-								} }
-							>
-								<Icon
-									icon={
-										showExtensions ? chevronUp : chevronDown
-									}
-								/>
-							</Button>
-						) : null }
+								if ( ! showExtensions ) {
+									// only record the accordion click when the accordion is opened.
+									recordEvent(
+										'storeprofiler_store_business_features_accordion_click'
+									);
+								}
+							} }
+						>
+							<Icon
+								icon={
+									showExtensions ? chevronUp : chevronDown
+								}
+							/>
+						</Button>
 					</div>
 					{ showExtensions &&
 						installableExtensions.map(
@@ -347,7 +344,7 @@ export const SelectiveExtensionsBundle = ( {
 						onClick={ () => {
 							onSubmit( values );
 						} }
-						isBusy={ isInstallingActivating }
+						isBusy={ isInstallingActivating || isResolving }
 						disabled={ isInstallingActivating || isResolving }
 						isPrimary
 					>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -286,25 +286,28 @@ export const SelectiveExtensionsBundle = ( {
 								'woocommerce-admin'
 							) }
 						</p>
-						<Button
-							className="woocommerce-admin__business-details__selective-extensions-bundle__expand"
-							onClick={ () => {
-								setShowExtensions( ! showExtensions );
+						{ installableExtensions &&
+						installableExtensions.length > 0 ? (
+							<Button
+								className="woocommerce-admin__business-details__selective-extensions-bundle__expand"
+								onClick={ () => {
+									setShowExtensions( ! showExtensions );
 
-								if ( ! showExtensions ) {
-									// only record the accordion click when the accordion is opened.
-									recordEvent(
-										'storeprofiler_store_business_features_accordion_click'
-									);
-								}
-							} }
-						>
-							<Icon
-								icon={
-									showExtensions ? chevronUp : chevronDown
-								}
-							/>
-						</Button>
+									if ( ! showExtensions ) {
+										// only record the accordion click when the accordion is opened.
+										recordEvent(
+											'storeprofiler_store_business_features_accordion_click'
+										);
+									}
+								} }
+							>
+								<Icon
+									icon={
+										showExtensions ? chevronUp : chevronDown
+									}
+								/>
+							</Button>
+						) : null }
 					</div>
 					{ showExtensions &&
 						installableExtensions.map(

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -268,14 +268,18 @@ export const SelectiveExtensionsBundle = ( {
 				</div>
 				<div className="woocommerce-admin__business-details__selective-extensions-bundle">
 					<div className="woocommerce-admin__business-details__selective-extensions-bundle__extension">
-						<CheckboxControl
-							checked={ values.install_extensions }
-							onChange={ ( checked ) => {
-								setValues(
-									setAllPropsToValue( values, checked )
-								);
-							} }
-						/>
+						{ isResolving ? (
+							<Spinner />
+						) : (
+							<CheckboxControl
+								checked={ values.install_extensions }
+								onChange={ ( checked ) => {
+									setValues(
+										setAllPropsToValue( values, checked )
+									);
+								} }
+							/>
+						) }
 						<p className="woocommerce-admin__business-details__selective-extensions-bundle__description">
 							{ __(
 								'Add recommended business features to my site',
@@ -341,7 +345,7 @@ export const SelectiveExtensionsBundle = ( {
 							onSubmit( values );
 						} }
 						isBusy={ isInstallingActivating }
-						disabled={ isInstallingActivating }
+						disabled={ isInstallingActivating || isResolving }
 						isPrimary
 					>
 						{ __( 'Continue', 'woocommerce-admin' ) }

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
@@ -16,6 +16,12 @@
 			padding: $gap-large 30px;
 			border-bottom: 1px solid $gray-200;
 			align-items: center;
+
+			.components-spinner {
+				width: 20px;
+				height: 20px;
+				margin: 0 21px 0 0;
+			}
 		}
 
 		.woocommerce-admin__business-details__selective-extensions-bundle__description {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/style.scss
@@ -16,12 +16,6 @@
 			padding: $gap-large 30px;
 			border-bottom: 1px solid $gray-200;
 			align-items: center;
-
-			.components-spinner {
-				width: 20px;
-				height: 20px;
-				margin: 0 21px 0 0;
-			}
 		}
 
 		.woocommerce-admin__business-details__selective-extensions-bundle__description {

--- a/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
@@ -50,6 +50,9 @@ export class BusinessSection extends BasePage {
 		const expandButtonSelector =
 			'.woocommerce-admin__business-details__selective-extensions-bundle__expand';
 
+		await this.page.waitForSelector(
+			expandButtonSelector + ':not([disabled])'
+		);
 		await this.click( expandButtonSelector );
 
 		// Confirm that expanding the list shows all the extensions available to install.


### PR DESCRIPTION
Fixes #7321 

Make sure the free extensions are loaded before a user can hit continue.

### Screenshots


![Kapture 2021-12-01 at 10 36 39](https://user-images.githubusercontent.com/2240960/144254129-64fdf3a2-c639-4cfa-be9d-5076cd49153e.gif)

### Detailed test instructions:

- Delete the `woocommerce_admin_remote_free_extensions_specs` transient so the free extensions takes a little longer
- Start the Onboarding flow and continue to the Business details step
- Fill out the dropdown's and click continue so it goes to the free extension tab
- Notice how the `continue` button is disabled until the free extensions are loaded and there is a loading icon present

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
