### PR TITLE
Move payments task to extended task list when WC Pay task is shown

### DIFF
--- a/changelogs/update-7720
+++ b/changelogs/update-7720
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Move payments task to extended task list when WC Pay task is shown #7980

--- a/src/Events.php
+++ b/src/Events.php
@@ -52,6 +52,7 @@ use \Automattic\WooCommerce\Admin\Notes\NavigationNudge;
 use Automattic\WooCommerce\Admin\Schedulers\MailchimpScheduler;
 use \Automattic\WooCommerce\Admin\Notes\CompleteStoreDetails;
 use \Automattic\WooCommerce\Admin\Notes\UpdateStoreDetails;
+use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
 
 /**
  * Events Class.
@@ -164,6 +165,7 @@ class Events {
 		NavigationNudge::delete_if_not_applicable();
 		NavigationFeedback::delete_if_not_applicable();
 		NavigationFeedbackFollowUp::delete_if_not_applicable();
+		SetUpAdditionalPaymentTypes::delete_if_not_applicable();
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Payments.php
+++ b/src/Features/OnboardingTasks/Tasks/Payments.php
@@ -25,7 +25,8 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_parent_id() {
-		return 'setup';
+		$woocommerce_payments = new WooCommercePayments();
+		return $woocommerce_payments->can_view() ? 'extended' : 'setup';
 	}
 
 	/**
@@ -34,7 +35,10 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Set up payments', 'woocommerce-admin' );
+		$woocommerce_payments = new WooCommercePayments();
+		return $woocommerce_payments->can_view()
+			? __( 'Set up additional payment providers', 'woocommerce-admin' )
+			: __( 'Set up payments', 'woocommerce-admin' );
 	}
 
 	/**
@@ -73,13 +77,7 @@ class Payments extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		return Features::is_enabled( 'payment-gateway-suggestions' ) &&
-		(
-			! WooCommercePayments::is_requested() ||
-			! WooCommercePayments::is_installed() ||
-			! WooCommercePayments::is_supported() ||
-			WooCommercePayments::is_connected()
-		);
+		return Features::is_enabled( 'payment-gateway-suggestions' );
 	}
 
 	/**
@@ -92,7 +90,7 @@ class Payments extends Task {
 		$enabled_gateways = array_filter(
 			$gateways,
 			function( $gateway ) {
-				return 'yes' === $gateway->enabled;
+				return 'yes' === $gateway->enabled && 'woocommerce_payments' !== $gateway->id;
 			}
 		);
 

--- a/src/Notes/SetUpAdditionalPaymentTypes.php
+++ b/src/Notes/SetUpAdditionalPaymentTypes.php
@@ -10,6 +10,8 @@ namespace Automattic\WooCommerce\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
+
 /**
  * Set_Up_Additional_Payment_Types
  */
@@ -71,6 +73,14 @@ class SetUpAdditionalPaymentTypes {
 	 */
 	public static function on_deactivate_wcpay() {
 		self::possibly_delete_note();
+	}
+
+	/**
+	 * Check if this note should exist.
+	 */
+	public static function is_applicable() {
+		$woocommerce_payments = new WooCommercePayments();
+		return ! $woocommerce_payments->can_view();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7720 

* Moves the payments task and updates the names when the WC Pay task is shown.
* Deletes the note for setting up additional payment gateways when WC Pay is active

Note that some existing logic in the note somewhat contradicts this new logic.  When WC Pay is deactivated, the note is deleted and when WC Pay is activated (from the business extensions step), the note gets added.  Our new logic overrides some of that by deleting the note daily when the WC Pay task is present.  cc @pmcpinto 

### Screenshots

![Screen Shot 2021-11-30 at 12 55 52 PM](https://user-images.githubusercontent.com/10561050/144102061-f379005c-194c-4a16-aa77-5513b7a4f69b.png)
 

### Detailed test instructions:

1.  Without WC Pay installed, visit the task list.
2. Check that the Payments task is shown without changes
3. Install/activate WC Pay via the business extensions during onboarding
4. Note the WC Pay task in the main setup task list and the payments task as "Set up additional payment providers" in the extended task list
5. Check that both tasks continue to function as expected
6. Disable all gateways in Settings->Payments
7. Complete the WC Pay task
8. Check that the payments task in the extended task list is not complete until setting up another gateway