### PR TITLE
Display actioned notes on Woo Home

### DIFF
--- a/changelogs/feature-7981-load-actioned-notes
+++ b/changelogs/feature-7981-load-actioned-notes
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Load both actioned and unactioned notes
+Load both actioned and unactioned notes #7983

--- a/changelogs/feature-7981-load-actioned-notes
+++ b/changelogs/feature-7981-load-actioned-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Load both actioned and unactioned notes

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -142,7 +142,7 @@ const renderNotes = ( {
 const INBOX_QUERY = {
 	page: 1,
 	per_page: QUERY_DEFAULTS.pageSize,
-	status: 'unactioned',
+	status: 'unactioned,actioned',
 	type: QUERY_DEFAULTS.noteTypes,
 	orderby: 'date',
 	order: 'desc',

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -30,7 +30,8 @@
 	}
 
 	&:not(.message-is-unread) {
-		h3, h4 {
+		h3,
+		h4 {
 			font-weight: normal;
 			a {
 				font-weight: normal;
@@ -85,7 +86,8 @@
 		}
 	}
 
-	h3, h4 {
+	h3,
+	h4 {
 		a {
 			@extend .woocommerce-inbox-message__title;
 			color: $gray-900 !important;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -30,8 +30,7 @@
 	}
 
 	&:not(.message-is-unread) {
-		h3,
-		h4 {
+		.woocommerce-inbox-message__title {
 			font-weight: normal;
 			a {
 				font-weight: normal;
@@ -84,10 +83,7 @@
 			}
 			margin-bottom: 10px;
 		}
-	}
 
-	h3,
-	h4 {
 		a {
 			@extend .woocommerce-inbox-message__title;
 			color: $gray-900 !important;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -31,7 +31,7 @@
 
 	&:not(.message-is-unread) {
 		h3,
-h4 {
+ h4 {
 			font-weight: normal;
 			a {
 				font-weight: normal;
@@ -87,7 +87,7 @@ h4 {
 	}
 
 	h3,
-h4 {
+ h4 {
 		a {
 			@extend .woocommerce-inbox-message__title;
 			color: $gray-900 !important;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -30,8 +30,7 @@
 	}
 
 	&:not(.message-is-unread) {
-		h3,
- h4 {
+		h3, h4 {
 			font-weight: normal;
 			a {
 				font-weight: normal;
@@ -86,8 +85,7 @@
 		}
 	}
 
-	h3,
- h4 {
+	h3, h4 {
 		a {
 			@extend .woocommerce-inbox-message__title;
 			color: $gray-900 !important;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -30,7 +30,8 @@
 	}
 
 	&:not(.message-is-unread) {
-		h3 {
+		h3,
+h4 {
 			font-weight: normal;
 			a {
 				font-weight: normal;
@@ -85,7 +86,8 @@
 		}
 	}
 
-	h3 {
+	h3,
+h4 {
 		a {
 			@extend .woocommerce-inbox-message__title;
 			color: $gray-900 !important;


### PR DESCRIPTION
Fixes #7981 

This PR queries both `actioned` and `unactioned` notes as per the new Inbox 2.0 design.

### Detailed test instructions:

1. Navigate to `WooCommerce -> Home`
2. Click a note to make it `actioned`
3. Reload the page.
4. Make sure the note you just clicked is still present.
