### PR TITLE
Fix shipping task -- completing step 2 redirects users to Woo Home

### DIFF
--- a/client/tasks/fills/shipping/index.js
+++ b/client/tasks/fills/shipping/index.js
@@ -218,7 +218,7 @@ export class Shipping extends Component {
 						}
 						shippingZones={ this.state.shippingZones }
 						onComplete={ this.completeStep }
-						{ ...this.props }
+						createNotice={ this.props.createNotice }
 					/>
 				),
 				visible:


### PR DESCRIPTION
Fixes #7984 

This PR fixes shipping task step 2, where completing step 2 redirects users to Woo Home without offering step 3. 

This [line](https://github.com/woocommerce/woocommerce-admin/blob/main/client/tasks/fills/shipping/index.js#L221) overwrote `onComplete` prop with `onComplete` function from [task.tsx](https://github.com/woocommerce/woocommerce-admin/blob/main/client/tasks/task.tsx#L22)

This PR fixes the problem by setting required props explicitly.


### Detailed test instructions:

1. Complete the onboarding wizard without installing the recommended plugins.
2. Navigate to `WooCommerce -> Home` and click `Set up Shipping`
3. Click `Proceed` button on step 2
4. You should be offered to finish step 3.

no changelog