### PR TITLE
Fix PHP Warning on 'Add new product' page

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,5 +1,15 @@
 # Testing instructions
 
+## Unreleased
+
+### Fix PHP Warning on 'Add new product' page
+
+0. On a Jurassic Ninja site.
+1. Go to **WooCommerce** > **Home**.
+2. Press **Add my products** in the task list.
+3. Press **Add manually**.
+4. No PHP warning should be visible.
+
 ## 3.0.0
 
 ### Onboarding Workflow - Add number of employees field

--- a/changelogs/fix-7956
+++ b/changelogs/fix-7956
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix PHP Warning on 'Add new product' page #7989

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -318,7 +318,7 @@ abstract class Task {
 	 * Set this as the active task across page loads.
 	 */
 	public function set_active() {
-		if ( $this->is_complete ) {
+		if ( $this->is_complete() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #7956

This PR fixes a PHP Warning on the `Add new product` page.
We had an error in the class _Task_, the method `is_complete` [was treated](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/OnboardingTasks/Task.php#L321) as an attribute.

### Screenshots

**Before**
![screenshot-localhost_10013-2021 11 19-16_04_15](https://user-images.githubusercontent.com/1314156/142677640-d78a32af-1901-40a7-b3c1-8cac11405927.png)

**After**
![screenshot-two local-2021 12 01-13_55_16](https://user-images.githubusercontent.com/1314156/144278458-3a1821fb-ca3a-4005-9ca2-813a6a003142.png)


### Detailed test instructions:

1. Go to **WooCommerce** > **Home**.
2. Press **Add my products** in the task list.
3. Press **Add manually**.
4. No PHP warning should be visible.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
