### PR TITLE
Update/version 3.1.0 dev and changelogs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,27 @@
+== 3.0.0 11/30/2021 ==
+
+- Fix: Fix an issue with the code that makes use of an invalid parameter
+  with a PHP function. The use of this invalid parameter causes PHP 8 to
+  throw a Fatal Error. #7855
+- Fix: Fix TaskList UI experiment enablement logic. #7930
+- Fix: Navigation nudge note and navigation feedback notes will delete themselves if the navigation feature is not available. #7914
+- Fix: Replace old task list option calls with data store selectors. #7820
+- Fix: Self-delete NavigationFeedbackFollowUp note when navigation feature is not present. #7939
+- Add: Add option to dismiss promotional payment gateway. #7965
+- Add: OBW - Add number of employees field. #7963
+- Update: Ending wcpay promotion experiment and always displaying in payment methods table.
+- Update: Hide InboxPanel header when it is rendered in the sidebar. #7952
+- Update: Introduce a 320 character limit for inbox note contents. #7958
+- Update: Move payments task to extended task list when WC Pay task is shown. #7980
+- Update: Rename Inbox to Activity from the activity header. #7879
+- Dev: Explicitly sets the Node version to 14 in .nvmrc to prevent incompatible versions of Node from being used with nvm. #7932
+- Dev: Remove unused npm package @woocommerce/settings. #7949
+- Dev: Update payment method recommendation to new woocommerce.com endpoint. #7913
+- Dev: Use abstraction to add and retrieve task data. #7918
+- Tweak: Added dismiss all button for inbox notes.
+- Tweak: Implement note read state. #7896
+- Enhancement: Add tests to Subscriptions inclusion. #7804
+
 == 2.9.0 11/30/2021 ==
 
 - Fix: Do not clear `current` class from the entire page when updating wp-admin's menu. #7773
@@ -83,7 +107,7 @@
 - Update: Create task list REST API endpoint #7512
 - Update: Deleted OnboardingEmailMarketing note class #7595
 - Update: Removes the use of the depreciated woocommerce_shared_settings hook. #7480
-- Update: Removes non WooCommerce Admin specific settings from the `wc_admin` namespace in the `wc/data` settings store (ex: countries). #7480
+- Update: Removes non WooCommerce Admin specific settings from the `wc_admin` namespace in the `wc/data` settings store (ex
 - Update: Updating eway logo in payment suggestions defaults #7562
 - Update: Update marketing task completion logic. #7586
 - Dev: Add email address field to OBW #7552
@@ -104,7 +128,7 @@
 
 == 2.6.3 09/21/2021 ==
 
-- Fix unsecured reports
+- Fix unsecured reports. #7691
 - Fix fatal error and unrelated results in analytics. #7682
 
 == 2.6.2 09/14/2021 ==
@@ -220,20 +244,25 @@
 - Update: Remove facebook extension from onboarding extensions fallback list #7287
 - Performance: Add lazy loading by checking panel open status #7379
 
-== 2.4.4 7/21/2021 ==
+== 2.4.4 07/21/2021 ==
+
 - Fix: Fix homepage stock panel regression in 2.4.3. #7389
 
-== 2.4.3 7/21/2021 ==
+== 2.4.3 07/21/2021 ==
+
 - Fix: Add a new low stock products endpoint to improve the performance. #7377
 
-== 2.4.2 7/19/2021 ==
+== 2.4.2 07/19/2021 ==
+
 - Fix: Add lazy loading by checking panel open status #7376
 - Fix: Add cache-control header to low stock REST API response #7364
 
-== 2.4.1 7/1/2021 ==
+== 2.4.1 07/01/2021 ==
+
 - Fix: Fix and refactor explat polling to use setTimeout #7274
 
-== 2.4.0 6/29/2021 ==
+== 2.4.0 06/29/2021 ==
+
 - Add: SlotFill to Abbreviated Notification panel #7091
 - Add: Consume remote payment methods on frontend #6867
 - Add: Extend payment gateways REST endpoint #6919

--- a/changelog.txt
+++ b/changelog.txt
@@ -107,7 +107,7 @@
 - Update: Create task list REST API endpoint #7512
 - Update: Deleted OnboardingEmailMarketing note class #7595
 - Update: Removes the use of the depreciated woocommerce_shared_settings hook. #7480
-- Update: Removes non WooCommerce Admin specific settings from the `wc_admin` namespace in the `wc/data` settings store (ex
+- Update: Removes non WooCommerce Admin specific settings from the `wc_admin` namespace in the `wc/data` settings store (ex countries). #7480
 - Update: Updating eway logo in payment suggestions defaults #7562
 - Update: Update marketing task completion logic. #7586
 - Dev: Add email address field to OBW #7552

--- a/changelogs/7445_add_tests_to_subscriptions_inclusion
+++ b/changelogs/7445_add_tests_to_subscriptions_inclusion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Enhancement
-
-Add tests to Subscriptions inclusion #7804

--- a/changelogs/add-7854
+++ b/changelogs/add-7854
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-OBW - Add number of employees field #7963

--- a/changelogs/add-7951
+++ b/changelogs/add-7951
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add option to dismiss promotional payment gateway #7965

--- a/changelogs/dev-payment-method-suggestion-endpoint-change
+++ b/changelogs/dev-payment-method-suggestion-endpoint-change
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Update payment method recommendation to new woocommerce.com endpoint. #7913

--- a/changelogs/dev-remove_unused_package
+++ b/changelogs/dev-remove_unused_package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Remove unused npm package @woocommerce/settings. #7949

--- a/changelogs/fix-7758
+++ b/changelogs/fix-7758
@@ -1,6 +1,0 @@
-Significance: minor
-Type: Fix
-
-Fix an issue with the code that makes use of an invalid parameter
-with a PHP function. The use of this invalid parameter causes PHP 8 to 
-throw a Fatal Error. #7855

--- a/changelogs/fix-7807-navigation-nudge-shows-up-when-invalid
+++ b/changelogs/fix-7807-navigation-nudge-shows-up-when-invalid
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Navigation nudge note and navigation feedback notes will delete themselves if the navigation feature is not available. #7914

--- a/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
+++ b/changelogs/fix-7938-navigation-feedback-follow-up-note-should-self-delete-when-not-relevant
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Fix
-
-Self-delete NavigationFeedbackFollowUp note when navigation feature is not present. #7939

--- a/changelogs/fix-tasklist-ui-experiment-enablement-logic
+++ b/changelogs/fix-tasklist-ui-experiment-enablement-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix TaskList UI experiment enablement logic #7930

--- a/changelogs/update-7243-action-to-dismiss-all-notes
+++ b/changelogs/update-7243-action-to-dismiss-all-notes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Added dismiss all button for inbox notes

--- a/changelogs/update-7247-introduce-320-char-limit-for-inbox-notes
+++ b/changelogs/update-7247-introduce-320-char-limit-for-inbox-notes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Introduce a 320 character limit for inbox note contents #7958

--- a/changelogs/update-7248-update-inbox-link-to-activity
+++ b/changelogs/update-7248-update-inbox-link-to-activity
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Rename Inbox to Activity from the activity header #7879

--- a/changelogs/update-7720
+++ b/changelogs/update-7720
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Move payments task to extended task list when WC Pay task is shown #7980

--- a/changelogs/update-7751
+++ b/changelogs/update-7751
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Replace old task list option calls with data store selectors #7820

--- a/changelogs/update-7793-set-a-note-as-read-after-clicking-cta-buttons
+++ b/changelogs/update-7793-set-a-note-as-read-after-clicking-cta-buttons
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Implement note read state #7896

--- a/changelogs/update-7941
+++ b/changelogs/update-7941
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Ending wcpay promotion experiment and always displaying in payment methods table

--- a/changelogs/update-7946-support-hiding-inbox-panel-header
+++ b/changelogs/update-7946-support-hiding-inbox-panel-header
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Hide InboxPanel header when it is rendered in the sidebar. #7952

--- a/changelogs/update-pin-node-to-14-in-nvmrc
+++ b/changelogs/update-pin-node-to-14-in-nvmrc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Dev
-
-Explicitly sets the Node version to 14 in .nvmrc to prevent incompatible versions of Node from being used with nvm. #7932

--- a/changelogs/update-task-initialization
+++ b/changelogs/update-task-initialization
@@ -1,4 +1,0 @@
-Significance: major
-Type: Dev
-
-Use abstraction to add and retrieve task data #7918

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "3.0.0-dev",
+	"version": "3.1.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.0.0-dev",
+	"version": "3.1.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.8.1
 Requires PHP: 7.0
-Stable tag: 3.0.0-dev
+Stable tag: 3.1.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '3.0.0-dev';
+	const VERSION = '3.1.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -147,7 +147,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.0.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.1.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 3.0.0-dev
+ * Version: 3.1.0-dev
  * Requires at least: 5.6
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
Updating all version numbers to 3.1.0 after the 3.0.0 beta release. Also syncing changelog.txt file, and deleting all incorporated changelog files. 

As per `#3` in **Post-beta release tasks** on [this page](P90Yrv-2p4-p2).