### PR TITLE
Correctly match payment gateways by id

### DIFF
--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -56,8 +56,9 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		);
 
 		return paymentGatewaySuggestions.reduce( ( map, suggestion ) => {
-			const { id } = suggestion;
-			const installedGateway = mappedPaymentGateways[ suggestion.id ]
+			// A colon ':' is used sometimes to have multiple configs for the same gateway ex: woocommerce_payments:us.
+			const id = ( suggestion.id || '' ).split( ':' )[ 0 ];
+			const installedGateway = mappedPaymentGateways[ id ]
 				? mappedPaymentGateways[ id ]
 				: {};
 
@@ -81,7 +82,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 				...suggestion,
 			};
 
-			map.set( id, enrichedSuggestion );
+			map.set( suggestion.id, enrichedSuggestion );
 			return map;
 		}, new Map() );
 	};


### PR DESCRIPTION
Fixes #7992 

Fixes issue where a payment gateway id that has multiple configs differentiated by a colon in the id to still match the payment gateway correctly.
We use this for wc-pay to have different config for the us versus the rest of the world. Example of the id: `woocommerce_payments:us`. 

No changelog necessary.

cc @joshuatf if you know of any other places that this could be a problem?

### Screenshots

<img width="1432" alt="Screen Shot 2021-12-02 at 11 08 17 AM" src="https://user-images.githubusercontent.com/2240960/144448364-dfbca891-e1c8-4454-95c0-a58ea29a63be.png">

### Detailed test instructions:

1. Use fresh site, and ensure you select a country that is WCPay supported (USA)
2. Go through Onboarding wizard and select "WooCommerce Payments" in the free features (deselect everything else)
3. Click the "Setup payments" task (NOT the WCPay specific task)
4. Click "Get Started" button on the WCPay card.
5. Notice how the `Set up` button is now present on step 2
6. Try the same thing for the Paypal or Stripe gateways, step 2 should not be blank.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
