### PR TITLE
Add e2e tests for PR 7963

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -36,7 +36,6 @@ import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
 import { SelectiveExtensionsBundle } from './selective-extensions-bundle';
 import './style.scss';
-import input from '@woocommerce/components/build/calendar/input';
 
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
 const FREE_FEATURES_TAB_NAME = 'free-features';

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -303,7 +303,7 @@ class BusinessDetails extends Component {
 		return {
 			...props,
 			className: classnames(
-				`woocommerce-profile-wizard_${ name }`,
+				`woocommerce-profile-wizard__${ name.replace( /\_/g, '-' ) }`,
 				className
 			),
 		};

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -22,6 +22,7 @@ import {
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -35,6 +36,7 @@ import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
 import { SelectiveExtensionsBundle } from './selective-extensions-bundle';
 import './style.scss';
+import input from '@woocommerce/components/build/calendar/input';
 
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
 const FREE_FEATURES_TAB_NAME = 'free-features';
@@ -297,6 +299,17 @@ class BusinessDetails extends Component {
 		} );
 	}
 
+	getSelectControlProps( getInputProps, name ) {
+		const { className, ...props } = getInputProps( name );
+		return {
+			...props,
+			className: classnames(
+				`woocommerce-profile-wizard_${ name }`,
+				className
+			),
+		};
+	}
+
 	renderBusinessDetailsStep() {
 		const {
 			goToNextStep,
@@ -360,7 +373,10 @@ class BusinessDetails extends Component {
 										) }
 										options={ productCountOptions }
 										required
-										{ ...getInputProps( 'product_count' ) }
+										{ ...this.getSelectControlProps(
+											getInputProps,
+											'product_count'
+										) }
 									/>
 
 									<SelectControl
@@ -371,7 +387,10 @@ class BusinessDetails extends Component {
 										) }
 										options={ sellingVenueOptions }
 										required
-										{ ...getInputProps( 'selling_venues' ) }
+										{ ...this.getSelectControlProps(
+											getInputProps,
+											'selling_venues'
+										) }
 									/>
 
 									{ [
@@ -388,7 +407,8 @@ class BusinessDetails extends Component {
 											) }
 											options={ employeeOptions }
 											required
-											{ ...getInputProps(
+											{ ...this.getSelectControlProps(
+												getInputProps,
 												'number_employees'
 											) }
 										/>
@@ -413,7 +433,10 @@ class BusinessDetails extends Component {
 												formatAmount
 											) }
 											required
-											{ ...getInputProps( 'revenue' ) }
+											{ ...this.getSelectControlProps(
+												getInputProps,
+												'revenue'
+											) }
 										/>
 									) }
 
@@ -433,7 +456,8 @@ class BusinessDetails extends Component {
 													) }
 													options={ platformOptions }
 													required
-													{ ...getInputProps(
+													{ ...this.getSelectControlProps(
+														getInputProps,
 														'other_platform'
 													) }
 												/>
@@ -445,7 +469,8 @@ class BusinessDetails extends Component {
 															'woocommerce-admin'
 														) }
 														required
-														{ ...getInputProps(
+														{ ...this.getSelectControlProps(
+															getInputProps,
 															'other_platform_name'
 														) }
 													/>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -298,7 +298,7 @@ class BusinessDetails extends Component {
 		} );
 	}
 
-	getSelectControlProps( getInputProps, name ) {
+	getSelectControlProps( getInputProps, name = '' ) {
 		const { className, ...props } = getInputProps( name );
 		return {
 			...props,

--- a/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
@@ -24,7 +24,7 @@ export class BusinessSection extends BasePage {
 
 	async selectProductNumber( productLabel: string ) {
 		const howManyProductsDropdown = this.getDropdownField(
-			'.components-card__body > div:nth-child(1)'
+			'.woocommerce-profile-wizard_product_count'
 		);
 
 		await howManyProductsDropdown.select( productLabel );
@@ -32,28 +32,28 @@ export class BusinessSection extends BasePage {
 
 	async selectCurrentlySelling( currentlySelling: string ) {
 		const sellingElsewhereDropdown = this.getDropdownField(
-			'.components-card__body > div:nth-child(2)'
+			'.woocommerce-profile-wizard_selling_venues'
 		);
 
 		await sellingElsewhereDropdown.select( currentlySelling );
 	}
 	async selectEmployeesNumber( employeesNumber: string ) {
 		const employeesNumberDropdown = this.getDropdownField(
-			'.components-card__body > div:nth-child(3)'
+			'.woocommerce-profile-wizard_number_employees'
 		);
 
 		await employeesNumberDropdown.select( employeesNumber );
 	}
 	async selectRevenue( revenue: string ) {
 		const revenueDropdown = this.getDropdownField(
-			'.components-card__body > div:nth-child(4)'
+			'.woocommerce-profile-wizard_revenue'
 		);
 
 		await revenueDropdown.select( revenue );
 	}
 	async selectOtherPlatformName( otherPlatformName: string ) {
 		const otherPlatformNameDropdown = this.getDropdownField(
-			'.components-card__body > div:nth-child(5)'
+			'.woocommerce-profile-wizard_other_platform'
 		);
 
 		await otherPlatformNameDropdown.select( otherPlatformName );

--- a/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
@@ -24,7 +24,7 @@ export class BusinessSection extends BasePage {
 
 	async selectProductNumber( productLabel: string ) {
 		const howManyProductsDropdown = this.getDropdownField(
-			'.woocommerce-profile-wizard_product_count'
+			'.woocommerce-profile-wizard__product-count'
 		);
 
 		await howManyProductsDropdown.select( productLabel );
@@ -32,28 +32,28 @@ export class BusinessSection extends BasePage {
 
 	async selectCurrentlySelling( currentlySelling: string ) {
 		const sellingElsewhereDropdown = this.getDropdownField(
-			'.woocommerce-profile-wizard_selling_venues'
+			'.woocommerce-profile-wizard__selling-venues'
 		);
 
 		await sellingElsewhereDropdown.select( currentlySelling );
 	}
 	async selectEmployeesNumber( employeesNumber: string ) {
 		const employeesNumberDropdown = this.getDropdownField(
-			'.woocommerce-profile-wizard_number_employees'
+			'.woocommerce-profile-wizard__number-employees'
 		);
 
 		await employeesNumberDropdown.select( employeesNumber );
 	}
 	async selectRevenue( revenue: string ) {
 		const revenueDropdown = this.getDropdownField(
-			'.woocommerce-profile-wizard_revenue'
+			'.woocommerce-profile-wizard__revenue'
 		);
 
 		await revenueDropdown.select( revenue );
 	}
 	async selectOtherPlatformName( otherPlatformName: string ) {
 		const otherPlatformNameDropdown = this.getDropdownField(
-			'.woocommerce-profile-wizard_other_platform'
+			'.woocommerce-profile-wizard__other-platform'
 		);
 
 		await otherPlatformNameDropdown.select( otherPlatformName );

--- a/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
@@ -37,6 +37,27 @@ export class BusinessSection extends BasePage {
 
 		await sellingElsewhereDropdown.select( currentlySelling );
 	}
+	async selectEmployeesNumber( employeesNumber: string ) {
+		const employeesNumberDropdown = this.getDropdownField(
+			'.components-card__body > div:nth-child(3)'
+		);
+
+		await employeesNumberDropdown.select( employeesNumber );
+	}
+	async selectRevenue( revenue: string ) {
+		const revenueDropdown = this.getDropdownField(
+			'.components-card__body > div:nth-child(4)'
+		);
+
+		await revenueDropdown.select( revenue );
+	}
+	async selectOtherPlatformName( otherPlatformName: string ) {
+		const otherPlatformNameDropdown = this.getDropdownField(
+			'.components-card__body > div:nth-child(5)'
+		);
+
+		await otherPlatformNameDropdown.select( otherPlatformName );
+	}
 
 	async selectInstallFreeBusinessFeatures( select: boolean ) {
 		if ( select ) {

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -525,7 +525,7 @@ const testBusinessDetailsForm = () => {
 		beforeAll( async () => {
 			await login.login();
 		} );
-		
+
 		afterAll( async () => {
 			await deactivateAndDeleteExtension( 'woocommerce-payments' );
 			await login.logout();

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -517,9 +517,70 @@ const testSubscriptionsInclusion = () => {
 	} );
 };
 
+const testBusinessDetailsForm = () => {
+	describe( 'A store that is selling elsewhere will see the "Number of employees” dropdown menu', () => {
+		const profileWizard = new OnboardingWizard( page );
+		const login = new Login( page );
+
+		beforeAll( async () => {
+			await login.login();
+		} );
+		
+		afterAll( async () => {
+			await deactivateAndDeleteExtension( 'woocommerce-payments' );
+			await login.logout();
+		} );
+
+		it( 'can complete the store details and product types sections', async () => {
+			await profileWizard.navigate();
+
+			// Wait for "Continue" button to become active
+			await profileWizard.continue();
+
+			// Wait for usage tracking pop-up window to appear
+			await profileWizard.optionallySelectUsageTracking();
+
+			// Query for the industries checkboxes
+			await profileWizard.industry.isDisplayed();
+			await profileWizard.continue();
+			await profileWizard.productTypes.isDisplayed( 7 );
+
+			await profileWizard.continue();
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		} );
+
+		it( 'can complete the business details tab', async () => {
+			await profileWizard.business.isDisplayed();
+
+			expect( page ).toMatchElement( 'label', {
+				text: 'How many employees do you have?',
+			} );
+
+			await profileWizard.business.selectProductNumber(
+				config.get( 'onboardingwizard.numberofproducts' )
+			);
+			await profileWizard.business.selectCurrentlySelling(
+				config.get( 'onboardingwizard.sellingOnAnotherPlatform' )
+			);
+			await profileWizard.business.selectEmployeesNumber(
+				config.get( 'onboardingwizard.number_employees' )
+			);
+			await profileWizard.business.selectRevenue(
+				config.get( 'onboardingwizard.revenue' )
+			);
+			await profileWizard.business.selectOtherPlatformName(
+				config.get( 'onboardingwizard.other_platform_name' )
+			);
+
+			await profileWizard.continue();
+		} );
+	} );
+};
+
 module.exports = {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
 	testDifferentStoreCurrenciesWCPay,
 	testSubscriptionsInclusion,
+	testBusinessDetailsForm,
 };

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -578,6 +578,7 @@ const testBusinessDetailsForm = () => {
 			);
 
 			await profileWizard.continue();
+			await profileWizard.business.expandRecommendedBusinessFeatures();
 			await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
 			await profileWizard.continue();
 			await profileWizard.themes.isDisplayed();

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -544,6 +544,11 @@ const testBusinessDetailsForm = () => {
 			await profileWizard.industry.isDisplayed();
 			await profileWizard.continue();
 			await profileWizard.productTypes.isDisplayed( 7 );
+			await profileWizard.productTypes.uncheckProducts();
+			// Select Physical
+			await profileWizard.productTypes.selectProduct(
+				'Physical products'
+			);
 
 			await profileWizard.continue();
 			await page.waitForNavigation( { waitUntil: 'networkidle0' } );

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -573,6 +573,9 @@ const testBusinessDetailsForm = () => {
 			);
 
 			await profileWizard.continue();
+			await profileWizard.business.uncheckAllRecommendedBusinessFeatures();
+			await profileWizard.continue();
+			await profileWizard.themes.isDisplayed();
 		} );
 	} );
 };

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -65,7 +65,11 @@
   "onboardingwizard": {
     "industry": "Test industry",
     "numberofproducts": "1 - 10",
-    "sellingelsewhere": "No"
+    "sellingelsewhere": "No",
+    "sellingOnAnotherPlatform": "Yes, on another platform",
+    "number_employees": "< 10",
+    "revenue": "Up to $2,500.00",
+    "other_platform_name": "Etsy"
   },
   "settings": {
     "shipping": {

--- a/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
+++ b/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx
@@ -3,9 +3,11 @@ const {
 	testSelectiveBundleWCPay,
 	testDifferentStoreCurrenciesWCPay,
 	testSubscriptionsInclusion,
+	testBusinessDetailsForm,
 } = require( '@woocommerce/admin-e2e-tests' );
 
 testAdminOnboardingWizard();
 testSelectiveBundleWCPay();
 testDifferentStoreCurrenciesWCPay();
 testSubscriptionsInclusion();
+testBusinessDetailsForm();


### PR DESCRIPTION
This is a follow-up [for PR 7963](https://github.com/woocommerce/woocommerce-admin/pull/7963).
This PR adds e2e tests for the inclusion of the "Number of employees" dropdown menu in the OBW.

### Detailed test instructions:

-   Run e2e tests. You shouldn't see any errors.

No changelog

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
