### PR TITLE
Update e2e-environment, so tests are run successfully locally.

### DIFF
--- a/changelogs/fix-e2e-tests
+++ b/changelogs/fix-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update @woocommerce/e2e-environment package to latest. #8000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.0.0-dev",
+	"version": "3.1.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -67,124 +67,6 @@
 				"puppeteer": "^2.0.0"
 			},
 			"dependencies": {
-				"@babel/cli": {
-					"version": "7.14.8",
-					"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.8.tgz",
-					"integrity": "sha512-lcy6Lymft9Rpfqmrqdd4oTDdUx9ZwaAhAfywVrHG4771Pa6PPT0danJ1kDHBXYqh4HHSmIdA+nlmfxfxSDPtBg==",
-					"requires": {
-						"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
-						"chokidar": "^3.4.0",
-						"commander": "^4.0.1",
-						"convert-source-map": "^1.1.0",
-						"fs-readdir-recursive": "^1.1.0",
-						"glob": "^7.0.0",
-						"make-dir": "^2.1.0",
-						"slash": "^2.0.0",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/core": {
-					"version": "7.15.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-					"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.15.0",
-						"@babel/helper-compilation-targets": "^7.15.0",
-						"@babel/helper-module-transforms": "^7.15.0",
-						"@babel/helpers": "^7.14.8",
-						"@babel/parser": "^7.15.0",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.15.0",
-						"@babel/types": "^7.15.0",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/preset-env": {
-					"version": "7.15.0",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.0.tgz",
-					"integrity": "sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==",
-					"requires": {
-						"@babel/compat-data": "^7.15.0",
-						"@babel/helper-compilation-targets": "^7.15.0",
-						"@babel/helper-plugin-utils": "^7.14.5",
-						"@babel/helper-validator-option": "^7.14.5",
-						"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-						"@babel/plugin-proposal-async-generator-functions": "^7.14.9",
-						"@babel/plugin-proposal-class-properties": "^7.14.5",
-						"@babel/plugin-proposal-class-static-block": "^7.14.5",
-						"@babel/plugin-proposal-dynamic-import": "^7.14.5",
-						"@babel/plugin-proposal-export-namespace-from": "^7.14.5",
-						"@babel/plugin-proposal-json-strings": "^7.14.5",
-						"@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-						"@babel/plugin-proposal-numeric-separator": "^7.14.5",
-						"@babel/plugin-proposal-object-rest-spread": "^7.14.7",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
-						"@babel/plugin-proposal-optional-chaining": "^7.14.5",
-						"@babel/plugin-proposal-private-methods": "^7.14.5",
-						"@babel/plugin-proposal-private-property-in-object": "^7.14.5",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
-						"@babel/plugin-syntax-async-generators": "^7.8.4",
-						"@babel/plugin-syntax-class-properties": "^7.12.13",
-						"@babel/plugin-syntax-class-static-block": "^7.14.5",
-						"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-						"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-						"@babel/plugin-syntax-json-strings": "^7.8.3",
-						"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-						"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-						"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-						"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-						"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-						"@babel/plugin-syntax-top-level-await": "^7.14.5",
-						"@babel/plugin-transform-arrow-functions": "^7.14.5",
-						"@babel/plugin-transform-async-to-generator": "^7.14.5",
-						"@babel/plugin-transform-block-scoped-functions": "^7.14.5",
-						"@babel/plugin-transform-block-scoping": "^7.14.5",
-						"@babel/plugin-transform-classes": "^7.14.9",
-						"@babel/plugin-transform-computed-properties": "^7.14.5",
-						"@babel/plugin-transform-destructuring": "^7.14.7",
-						"@babel/plugin-transform-dotall-regex": "^7.14.5",
-						"@babel/plugin-transform-duplicate-keys": "^7.14.5",
-						"@babel/plugin-transform-exponentiation-operator": "^7.14.5",
-						"@babel/plugin-transform-for-of": "^7.14.5",
-						"@babel/plugin-transform-function-name": "^7.14.5",
-						"@babel/plugin-transform-literals": "^7.14.5",
-						"@babel/plugin-transform-member-expression-literals": "^7.14.5",
-						"@babel/plugin-transform-modules-amd": "^7.14.5",
-						"@babel/plugin-transform-modules-commonjs": "^7.15.0",
-						"@babel/plugin-transform-modules-systemjs": "^7.14.5",
-						"@babel/plugin-transform-modules-umd": "^7.14.5",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
-						"@babel/plugin-transform-new-target": "^7.14.5",
-						"@babel/plugin-transform-object-super": "^7.14.5",
-						"@babel/plugin-transform-parameters": "^7.14.5",
-						"@babel/plugin-transform-property-literals": "^7.14.5",
-						"@babel/plugin-transform-regenerator": "^7.14.5",
-						"@babel/plugin-transform-reserved-words": "^7.14.5",
-						"@babel/plugin-transform-shorthand-properties": "^7.14.5",
-						"@babel/plugin-transform-spread": "^7.14.6",
-						"@babel/plugin-transform-sticky-regex": "^7.14.5",
-						"@babel/plugin-transform-template-literals": "^7.14.5",
-						"@babel/plugin-transform-typeof-symbol": "^7.14.5",
-						"@babel/plugin-transform-unicode-escapes": "^7.14.5",
-						"@babel/plugin-transform-unicode-regex": "^7.14.5",
-						"@babel/preset-modules": "^0.1.4",
-						"@babel/types": "^7.15.0",
-						"babel-plugin-polyfill-corejs2": "^0.2.2",
-						"babel-plugin-polyfill-corejs3": "^0.2.2",
-						"babel-plugin-polyfill-regenerator": "^0.2.2",
-						"core-js-compat": "^3.16.0",
-						"semver": "^6.3.0"
-					}
-				},
 				"@slack/web-api": {
 					"version": "5.15.0",
 					"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.15.0.tgz",
@@ -259,11 +141,6 @@
 					"version": "npm:wp-prettier@1.19.1",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
 					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -271,7 +148,6 @@
 			"version": "7.13.16",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.13.16.tgz",
 			"integrity": "sha512-cL9tllhqvsQ6r1+d9Invf7nNXg/3BlfL1vvvL/AdH9fZ2l5j0CeBcoq6UjsqHpvyN1v5nXSZgqJZoGeK+ZOAbw==",
-			"dev": true,
 			"requires": {
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
 				"chokidar": "^3.4.0",
@@ -288,7 +164,6 @@
 					"version": "2.1.8-no-fsevents",
 					"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
 					"integrity": "sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"anymatch": "^2.0.0",
@@ -308,7 +183,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-glob": "^3.1.0",
@@ -319,7 +193,6 @@
 							"version": "3.1.0",
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-extglob": "^2.1.0"
@@ -346,7 +219,6 @@
 			"version": "7.14.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
 			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
 				"@babel/generator": "^7.14.0",
@@ -368,8 +240,7 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -1382,7 +1253,6 @@
 			"version": "7.14.1",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.1.tgz",
 			"integrity": "sha512-0M4yL1l7V4l+j/UHvxcdvNfLB9pPtIooHTbEhgD/6UGyh8Hy3Bm1Mj0buzjDXATCSz3JFibVdnoJZCrlUCanrQ==",
-			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.14.0",
 				"@babel/helper-compilation-targets": "^7.13.16",
@@ -1462,8 +1332,7 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -3474,35 +3343,6 @@
 				"write-file-atomic": "2.4.1"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.15.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-					"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.15.0",
-						"@babel/helper-compilation-targets": "^7.15.0",
-						"@babel/helper-module-transforms": "^7.15.0",
-						"@babel/helpers": "^7.14.8",
-						"@babel/parser": "^7.15.0",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.15.0",
-						"@babel/types": "^7.15.0",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
-					}
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3512,11 +3352,6 @@
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -5350,25 +5185,6 @@
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
-		"@nicolo-ribaudo/chokidar-2": {
-			"version": "2.1.8-no-fsevents.2",
-			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.2.tgz",
-			"integrity": "sha512-Fb8WxUFOBQVl+CX4MWet5o7eCc6Pj04rXIwVKZ6h1NnqTo45eOQW6aWyhG25NIODvWFwTDMwBsYxrQ3imxpetg==",
-			"optional": true,
-			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.1",
-				"braces": "^2.3.2",
-				"glob-parent": "^5.1.2",
-				"inherits": "^2.0.3",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.2.1",
-				"upath": "^1.1.1"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5794,18 +5610,18 @@
 			"integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
 		},
 		"@slack/web-api": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.4.0.tgz",
-			"integrity": "sha512-Hi0pq60d/zCqn1UQvuSyrMcoLGNbKUBL/Tmk1b1RPTZdVYiRK8zp337glvhxTBwiaGOu+58uO5yflpK1AAuoRw==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.5.1.tgz",
+			"integrity": "sha512-W1PDIdHz/GtDpC8afpPUsXMfAQ+sZGwmfxx+Ug83uhRD8zECrypGTmIyCqrCSWzf2qVKT9XvMftZX3m0AmPY8A==",
 			"requires": {
 				"@slack/logger": "^3.0.0",
 				"@slack/types": "^2.0.0",
 				"@types/is-stream": "^1.1.0",
 				"@types/node": ">=12.0.0",
-				"axios": "^0.21.1",
+				"axios": "^0.24.0",
 				"eventemitter3": "^3.1.0",
 				"form-data": "^2.5.0",
-				"is-electron": "^2.2.0",
+				"is-electron": "2.2.0",
 				"is-stream": "^1.1.0",
 				"p-queue": "^6.6.1",
 				"p-retry": "^4.0.0"
@@ -5820,9 +5636,17 @@
 					}
 				},
 				"@slack/types": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/@slack/types/-/types-2.2.0.tgz",
-					"integrity": "sha512-/yHEFvgp0UY/lfFvQqbq9BocW/pM4xnGycqGAx+plRgYp96dZp1y50Whz7yzOgasEUsy5TyQfBK07cj0RwUyIg=="
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@slack/types/-/types-2.3.0.tgz",
+					"integrity": "sha512-oCP1mwWbI3HddvreY9tQW9JCzE7klKxbKtnsnH63UDlUL2HoDZbvbitN9IUkbbpJ8FitsP3z05yT9/EqRbFwaA=="
+				},
+				"axios": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+					"integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+					"requires": {
+						"follow-redirects": "^1.14.4"
+					}
 				}
 			}
 		},
@@ -10943,50 +10767,24 @@
 			}
 		},
 		"@woocommerce/e2e-environment": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@woocommerce/e2e-environment/-/e2e-environment-0.2.2.tgz",
-			"integrity": "sha512-1rDUhrMXt5mnTfe3k45WIB8wcKSTaCx4X/rKd38QIdr9FFH8Km54KlpfURkKNbx7W5e/iw9iKnyfPOqX6soVlQ==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@woocommerce/e2e-environment/-/e2e-environment-0.2.3.tgz",
+			"integrity": "sha512-Xvf8UbVS9KsN/LdD48u7wyWPNXkMCdsgj5YZvvdx035d/xDdmuF5L19byhJmj337hSubeyXM1AJlUlkdvbEVqA==",
 			"requires": {
 				"@automattic/puppeteer-utils": "github:Automattic/puppeteer-utils#0f3ec50",
 				"@jest/test-sequencer": "^25.5.4",
 				"@slack/web-api": "^6.1.0",
-				"@wordpress/e2e-test-utils": "^4.15.0",
+				"@woocommerce/api": "^0.2.0",
+				"@wordpress/e2e-test-utils": "^4.16.1",
 				"@wordpress/jest-preset-default": "^6.4.0",
 				"app-root-path": "^3.0.0",
 				"jest": "^25.1.0",
 				"jest-each": "25.5.0",
-				"jest-puppeteer": "^4.4.0"
+				"jest-puppeteer": "^4.4.0",
+				"node-stream-zip": "^1.13.6",
+				"request": "^2.88.2"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.15.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-					"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.15.0",
-						"@babel/helper-compilation-targets": "^7.15.0",
-						"@babel/helper-module-transforms": "^7.15.0",
-						"@babel/helpers": "^7.14.8",
-						"@babel/parser": "^7.15.0",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.15.0",
-						"@babel/types": "^7.15.0",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
-					}
-				},
 				"@jest/console": {
 					"version": "25.5.0",
 					"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
@@ -11034,12 +10832,17 @@
 						"strip-ansi": "^6.0.0"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+							"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^5.0.1"
 							}
 						}
 					}
@@ -11207,15 +11010,29 @@
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
-					"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+					"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0",
 						"@istanbuljs/load-nyc-config": "^1.0.0",
 						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-instrument": "^4.0.0",
+						"istanbul-lib-instrument": "^5.0.4",
 						"test-exclude": "^6.0.0"
+					},
+					"dependencies": {
+						"istanbul-lib-instrument": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
+							"integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+							"requires": {
+								"@babel/core": "^7.12.3",
+								"@babel/parser": "^7.14.7",
+								"@istanbuljs/schema": "^0.1.2",
+								"istanbul-lib-coverage": "^3.2.0",
+								"semver": "^6.3.0"
+							}
+						}
 					}
 				},
 				"babel-plugin-jest-hoist": {
@@ -11264,12 +11081,17 @@
 						"wrap-ansi": "^6.2.0"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+							"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^5.0.1"
 							}
 						}
 					}
@@ -11388,9 +11210,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"import-local": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+					"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
 					"requires": {
 						"pkg-dir": "^4.2.0",
 						"resolve-cwd": "^3.0.0"
@@ -11416,9 +11238,9 @@
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-					"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+					"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw=="
 				},
 				"istanbul-lib-instrument": {
 					"version": "4.0.3",
@@ -11442,9 +11264,9 @@
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-					"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+					"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
 					"requires": {
 						"debug": "^4.1.1",
 						"istanbul-lib-coverage": "^3.0.0",
@@ -11452,9 +11274,9 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.1.tgz",
+					"integrity": "sha512-q1kvhAXWSsXfMjCdNHNPKZZv94OlspKnoGv+R9RGbnqOOQ0VbNfLFgQDVgi7hHenKsndGq3/o0OBdzDXthWcNw==",
 					"requires": {
 						"html-escaper": "^2.0.0",
 						"istanbul-lib-report": "^3.0.0"
@@ -12148,12 +11970,17 @@
 						"strip-ansi": "^6.0.0"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+							"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+						},
 						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 							"requires": {
-								"ansi-regex": "^5.0.0"
+								"ansi-regex": "^5.0.1"
 							}
 						}
 					}
@@ -12170,9 +11997,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-					"integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg=="
+					"version": "7.5.6",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+					"integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
 				},
 				"yargs": {
 					"version": "15.4.1",
@@ -18371,11 +18198,11 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
 			"requires": {
-				"follow-redirects": "^1.10.0"
+				"follow-redirects": "^1.14.0"
 			}
 		},
 		"axobject-query": {
@@ -20240,7 +20067,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
 			"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -20250,7 +20076,6 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
@@ -20259,7 +20084,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -20267,20 +20091,17 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -25941,9 +25762,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
-			"integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
+			"version": "1.14.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+			"integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
 		},
 		"for-each": {
 			"version": "0.3.3",
@@ -28379,55 +28200,17 @@
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 				},
 				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
+						"ansi-regex": "^5.0.1"
 					}
 				}
 			}
@@ -31598,28 +31381,6 @@
 				"realpath-native": "^1.1.0"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.15.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-					"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.15.0",
-						"@babel/helper-compilation-targets": "^7.15.0",
-						"@babel/helper-module-transforms": "^7.15.0",
-						"@babel/helpers": "^7.14.8",
-						"@babel/parser": "^7.15.0",
-						"@babel/template": "^7.14.5",
-						"@babel/traverse": "^7.15.0",
-						"@babel/types": "^7.15.0",
-						"convert-source-map": "^1.7.0",
-						"debug": "^4.1.0",
-						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					}
-				},
 				"@jest/test-sequencer": {
 					"version": "24.9.0",
 					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
@@ -31679,11 +31440,6 @@
 						"jest-mock": "^24.9.0",
 						"jest-util": "^24.9.0"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -35920,6 +35676,11 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
 			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
 		},
+		"node-stream-zip": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+			"integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="
+		},
 		"node-watch": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
@@ -37106,8 +36867,7 @@
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@automattic/explat-client": "0.0.2",
 		"@automattic/explat-client-react-helpers": "0.0.2",
 		"@woocommerce/api": "0.2.0",
-		"@woocommerce/e2e-environment": "0.2.2",
+		"@woocommerce/e2e-environment": "0.2.3",
 		"@woocommerce/e2e-utils": "0.1.5",
 		"@wordpress/api-fetch": "2.2.8",
 		"@wordpress/base-styles": "3.3.0",


### PR DESCRIPTION
Fixes an issue where the container failed to build locally because it used WP 5.5, which WooCommerce didn't support. I updated the e2e-environment package as this will use the latest `5.8` now.

### Detailed test instructions:

- Load this branch locally
- Run `npm install` and `composer install`
- Run `npx wc-e2e docker:up`
- In a separate terminal run `npm run start` so it is build
- Run `npx wc-e2e test:e2e` this should run successfully and not get stuck in `Docker container is still being built`

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
