### PR TITLE
Remove limit from coupons query when getting the total count

### DIFF
--- a/changelogs/fix-7681_coupons_query
+++ b/changelogs/fix-7681_coupons_query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix pagination issue with Analytics Coupons page. #8001

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -283,7 +283,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$this->subquery->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
 				$coupons_query = $this->subquery->get_query_statement();
 
-				$this->subquery->clear_sql_clause( array( 'select', 'order_by' ) );
+				$this->subquery->clear_sql_clause( array( 'select', 'order_by', 'limit' ) );
 				$this->subquery->add_sql_clause( 'select', 'coupon_id' );
 				$coupon_subquery = "SELECT COUNT(*) FROM (
 					{$this->subquery->get_query_statement()}


### PR DESCRIPTION
Fixes #7681 

We were adding a limit clause to the coupons query but not removing it when we got the total count for the number of pages. This would always lead to a single page with max 25 coupons.
I made sure that we remove limit for the second 'count' query.

### Screenshots

<img width="1922" alt="Screen Shot 2021-12-03 at 3 01 11 PM" src="https://user-images.githubusercontent.com/2240960/144658262-1fbb0309-dac4-4778-8b46-91ec9babdb42.png">

### Detailed test instructions:

- Generate over 25 coupons with at-least one order (this is very tedious to do by hand so you could check out the `wc-smooth-generator` repo and the [add-coupons-generator](https://github.com/woocommerce/wc-smooth-generator/tree/add-coupons-generator) branch)
     - You can call it using `wp wc generate orders 30 --date-start=2021-09-01 --date-end=2021-11-01 --status=completed --coupons=true` which will generate 30 orders with random coupons attached.
- Make sure all the scheduled actions finished
- Go to **Analytics > Coupons** and notice how pagination is enabled as there are more then 25 coupons with orders
- Load `main` branch and notice how there is no pagination but the counts at the bottom of the table does mention more then 25 coupons.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
