### PR TITLE
Add inbox_note_view Tracks Event

### DIFF
--- a/changelogs/fix-inbox-panel-view-event
+++ b/changelogs/fix-inbox-panel-view-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Add inbox_panel_view tracks event. #8002

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -68,6 +68,10 @@ const renderNotes = ( {
 		return renderEmptyCard();
 	}
 
+	recordEvent( 'inbox_panel_view', {
+		total: notes.length,
+	} );
+
 	const screen = getScreenName();
 	const onNoteVisible = ( note ) => {
 		recordEvent( 'inbox_note_view', {

--- a/client/inbox-panel/test/index.js
+++ b/client/inbox-panel/test/index.js
@@ -1,7 +1,28 @@
 /**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
  * Internal dependencies
  */
 import { getUnreadNotesCount, hasValidNotes } from '../utils';
+import InboxPanel from '../';
+
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
 
 const notes = [
 	{
@@ -9,30 +30,35 @@ const notes = [
 		date_created_gmt: '2019-05-10T16:57:31',
 		is_deleted: false,
 		status: 'unactioned',
+		actions: [],
 	},
 	{
 		id: 2,
 		date_created_gmt: '2020-05-12T16:57:31',
 		is_deleted: false,
 		status: 'unactioned',
+		actions: [],
 	},
 	{
 		id: 3,
 		date_created_gmt: '2020-05-14T16:57:31',
 		is_deleted: false,
 		status: 'unactioned',
+		actions: [],
 	},
 	{
 		id: 4,
 		date_created_gmt: '2020-05-15T16:57:31',
 		is_deleted: false,
 		status: 'unactioned',
+		actions: [],
 	},
 	{
 		id: 5,
 		date_created_gmt: '2020-05-18T16:57:31',
 		is_deleted: false,
 		status: 'unactioned',
+		actions: [],
 	},
 ];
 
@@ -77,5 +103,21 @@ describe( 'hasValidNotes', () => {
 		notes[ 0 ].is_deleted = true;
 		notes[ 3 ].is_deleted = true;
 		expect( hasValidNotes( notes ) ).toBeTruthy();
+	} );
+} );
+
+describe( 'inbox_panel_view_event', () => {
+	test( 'should fire when panel rendered', () => {
+		useSelect.mockImplementation( () => ( {
+			notes,
+			isError: false,
+			isResolvingNotes: false,
+			isBatchUpdating: false,
+		} ) );
+		render( <InboxPanel /> );
+
+		expect( recordEvent ).toHaveBeenCalledWith( 'inbox_panel_view', {
+			total: 5,
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #7735

Adds a new tracks event `inbox_panel_view` containing a `total` prop, representing the total amount of notes in the panel. This is fired on every view of the inbox panel (Home Screen and activity menu).

### Detailed test instructions:

- Add the tracks debugger in browser console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
- Load the WooCommerce home screen
- See that a tracks event is made in the browser console, with the `total` value matching the total rendered in the header.

<img width="1033" alt="Screen Shot 2021-12-06 at 8 20 10 pm" src="https://user-images.githubusercontent.com/9312929/144845215-0ec4d380-2b52-4f37-b7a4-f9cb268c0202.png">

<img width="516" alt="Screen Shot 2021-12-06 at 8 23 54 pm" src="https://user-images.githubusercontent.com/9312929/144845580-5de26350-de60-4c0a-a726-7111d098793a.png">


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
