### PR TITLE
wp-env - Update doc for the default mysql username and password

### DIFF
--- a/docker/wc-admin-wp-env/README.md
+++ b/docker/wc-admin-wp-env/README.md
@@ -103,13 +103,12 @@ You can get the current Mysql port with `npm run wp-env-mysql-port` command.
 
 1. Open your choice of Mysql tool.
 2. Use the following values to access the Mysql container.
-3. You can omit the username and password.
 
 | Name | Value |
 |--------|-----|
 |  Host  | 127.0.0.1 |
-| Username |  |
-| Password |  |
+| Username | root |
+| Password | password |
 | Port | Port from the command |
 
 ## HOWTOs


### PR DESCRIPTION
This PR updates the local env setup documentation for the default MySQL username and password.

no changelog