### PR TITLE
Add featured pill for MailPoet and Google Listings in marketing task

### DIFF
--- a/changelogs/add-7542
+++ b/changelogs/add-7542
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add featured pill for MailPoet and Google Listings in marketing task #8009

--- a/client/tasks/fills/Marketing/Plugin.scss
+++ b/client/tasks/fills/Marketing/Plugin.scss
@@ -32,6 +32,10 @@
 .woocommerce-plugin-list__plugin-text {
 	max-width: 370px;
 	margin-right: $gap;
+	.woocommerce-pill {
+		color: $studio-gray-50;
+		margin-left: $gap-small;
+	}
 }
 
 .woocommerce-plugin-list__plugin-action {

--- a/client/tasks/fills/Marketing/Plugin.tsx
+++ b/client/tasks/fills/Marketing/Plugin.tsx
@@ -6,6 +6,7 @@ import { Button } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
+import { Pill } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import './Plugin.scss';
 export type PluginProps = {
 	isActive: boolean;
 	isBusy?: boolean;
+	isBuiltByWC: boolean;
 	isDisabled?: boolean;
 	isInstalled: boolean;
 	description?: string;
@@ -31,6 +33,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 	installAndActivate = () => {},
 	isActive,
 	isBusy,
+	isBuiltByWC,
 	isDisabled,
 	isInstalled,
 	manageUrl,
@@ -54,6 +57,11 @@ export const Plugin: React.FC< PluginProps > = ( {
 			<div className="woocommerce-plugin-list__plugin-text">
 				<Text variant="subtitle.small" as="h4">
 					{ name }
+					{ isBuiltByWC && (
+						<Pill>
+							{ __( 'Built by WooCommerce', 'woocommerce-admin' ) }
+						</Pill>
+					) }
 				</Text>
 				<Text variant="subtitle.small">{ description }</Text>
 			</div>

--- a/client/tasks/fills/Marketing/Plugin.tsx
+++ b/client/tasks/fills/Marketing/Plugin.tsx
@@ -59,7 +59,10 @@ export const Plugin: React.FC< PluginProps > = ( {
 					{ name }
 					{ isBuiltByWC && (
 						<Pill>
-							{ __( 'Built by WooCommerce', 'woocommerce-admin' ) }
+							{ __(
+								'Built by WooCommerce',
+								'woocommerce-admin'
+							) }
 						</Pill>
 					) }
 				</Text>

--- a/client/tasks/fills/Marketing/PluginList.tsx
+++ b/client/tasks/fills/Marketing/PluginList.tsx
@@ -37,6 +37,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 					description,
 					imageUrl,
 					isActive,
+					isBuiltByWC,
 					isInstalled,
 					manageUrl,
 					slug,
@@ -51,6 +52,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 						imageUrl={ imageUrl }
 						installAndActivate={ installAndActivate }
 						isActive={ isActive }
+						isBuiltByWC={ isBuiltByWC }
 						isBusy={ currentPlugin === slug }
 						isDisabled={ !! currentPlugin }
 						isInstalled={ isInstalled }

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -6,7 +6,6 @@ import { Card, CardHeader, Spinner } from '@wordpress/components';
 import {
 	ONBOARDING_STORE_NAME,
 	PLUGINS_STORE_NAME,
-	OPTIONS_STORE_NAME,
 	WCDataSelector,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -45,7 +45,14 @@ export const transformExtensionToPlugin = (
 	activePlugins: string[],
 	installedPlugins: string[]
 ): PluginProps => {
-	const { description, image_url, is_built_by_wc, key, manage_url, name } = extension;
+	const {
+		description,
+		image_url,
+		is_built_by_wc,
+		key,
+		manage_url,
+		name,
+	} = extension;
 	const slug = key.split( ':' )[ 0 ];
 	return {
 		description,

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -24,7 +24,6 @@ import { PluginList, PluginListProps } from './PluginList';
 import { PluginProps } from './Plugin';
 
 const ALLOWED_PLUGIN_LISTS = [ 'task-list/reach', 'task-list/grow' ];
-const EMPTY_ARRAY = [];
 
 export type ExtensionList = {
 	key: string;

--- a/client/tasks/fills/Marketing/index.tsx
+++ b/client/tasks/fills/Marketing/index.tsx
@@ -37,6 +37,7 @@ export type Extension = {
 	description: string;
 	key: string;
 	image_url: string;
+	is_built_by_wc: boolean;
 	manage_url: string;
 	name: string;
 };
@@ -46,7 +47,7 @@ export const transformExtensionToPlugin = (
 	activePlugins: string[],
 	installedPlugins: string[]
 ): PluginProps => {
-	const { description, image_url, key, manage_url, name } = extension;
+	const { description, image_url, is_built_by_wc, key, manage_url, name } = extension;
 	const slug = key.split( ':' )[ 0 ];
 	return {
 		description,
@@ -54,6 +55,7 @@ export const transformExtensionToPlugin = (
 		imageUrl: image_url,
 		isActive: activePlugins.includes( slug ),
 		isInstalled: installedPlugins.includes( slug ),
+		isBuiltByWC: is_built_by_wc,
 		manageUrl: manage_url,
 		name,
 	};

--- a/client/tasks/fills/Marketing/test/index.tsx
+++ b/client/tasks/fills/Marketing/test/index.tsx
@@ -14,6 +14,7 @@ const basicPlugins: Extension[] = [
 		description: 'Basic plugin description',
 		manage_url: '#',
 		image_url: 'basic.jpeg',
+		is_built_by_wc: true,
 	},
 ];
 
@@ -71,6 +72,7 @@ describe( 'transformExtensionToPlugin', () => {
 			imageUrl: 'basic.jpeg',
 			isActive: false,
 			isInstalled: false,
+			isBuiltByWC: true,
 			manageUrl: '#',
 			name: 'Basic Plugin',
 		} );

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -70,48 +70,53 @@ class DefaultFreeExtensions {
 	public static function get_plugin( $slug ) {
 		$plugins = array(
 			'google-listings-and-ads'           => [
-				'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
-				'description' => sprintf(
+				'name'           => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/google-listings-and-ads" target="_blank">',
 					'</a>'
 				),
-				'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'image_url'      => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'is_built_by_wc' => true,
 			],
 			'google-listings-and-ads:alt'       => [
-				'name'        => __( 'Google Listings & Ads', 'woocommerce-admin' ),
-				'description' => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
-				'image_url'   => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'name'           => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+				'description'    => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
+				'image_url'      => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'is_built_by_wc' => true,
 			],
 			'mailpoet'                          => [
-				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
-				'description' => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
-				'image_url'   => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
+				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'image_url'      => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
+				'is_built_by_wc' => true,
 			],
 			'mailchimp-for-woocommerce'         => [
-				'name'        => __( 'Mailchimp', 'woocommerce-admin' ),
-				'description' => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce-admin' ),
-				'image_url'   => plugins_url( 'images/onboarding/mailchimp-for-woocommerce.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=mailchimp-woocommerce',
+				'name'           => __( 'Mailchimp', 'woocommerce-admin' ),
+				'description'    => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce-admin' ),
+				'image_url'      => plugins_url( 'images/onboarding/mailchimp-for-woocommerce.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=mailchimp-woocommerce',
+				'is_built_by_wc' => false,
 			],
 			'creative-mail-by-constant-contact' => [
-				'name'        => __( 'Creative Mail for WooCommerce', 'woocommerce-admin' ),
-				'description' => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce-admin' ),
-				'image_url'   => plugins_url( 'images/onboarding/creative-mail-by-constant-contact.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=creativemail',
+				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce-admin' ),
+				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce-admin' ),
+				'image_url'      => plugins_url( 'images/onboarding/creative-mail-by-constant-contact.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=creativemail',
+				'is_built_by_wc' => false,
 			],
 			'woocommerce-payments'              => [
-				'description' => sprintf(
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Accept credit cards with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
 					'</a>'
 				),
-				'is_visible'  => [
+				'is_visible'     => [
 					[
 						'type'     => 'or',
 						'operands' => [
@@ -240,15 +245,16 @@ class DefaultFreeExtensions {
 						],
 					],
 				],
+				'is_built_by_wc' => true,
 			],
 			'woocommerce-services:shipping'     => [
-				'description' => sprintf(
+				'description'    => sprintf(
 				/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
 					'</a>'
 				),
-				'is_visible'  => [
+				'is_visible'     => [
 					[
 						'type'      => 'base_location_country',
 						'value'     => 'US',
@@ -306,15 +312,16 @@ class DefaultFreeExtensions {
 						],
 					],
 				],
+				'is_built_by_wc' => true,
 			],
 			'woocommerce-services:tax'          => [
-				'description' => sprintf(
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/tax" target="_blank">',
 					'</a>'
 				),
-				'is_visible'  => [
+				'is_visible'     => [
 					[
 						'type'     => 'or',
 						'operands' => [
@@ -385,15 +392,16 @@ class DefaultFreeExtensions {
 						],
 					],
 				],
+				'is_built_by_wc' => true,
 			],
 			'jetpack'                           => [
-				'description' => sprintf(
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
 					'</a>'
 				),
-				'is_visible'  => [
+				'is_visible'     => [
 					[
 						'type'    => 'not',
 						'operand' => [
@@ -404,17 +412,18 @@ class DefaultFreeExtensions {
 						],
 					],
 				],
+				'is_built_by_wc' => false,
 			],
 			'mailpoet'                          => [
-				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
-				'description' => sprintf(
+				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
 					'</a>'
 				),
-				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
-				'is_visible'  => [
+				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
+				'is_visible'     => [
 					[
 						'type'    => 'not',
 						'operand' => [
@@ -425,12 +434,14 @@ class DefaultFreeExtensions {
 						],
 					],
 				],
+				'is_built_by_wc' => true,
 			],
 			'mailpoet:alt'                      => [
-				'name'        => __( 'MailPoet', 'woocommerce-admin' ),
-				'description' => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
-				'image_url'   => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
-				'manage_url'  => 'admin.php?page=mailpoet-newsletters',
+				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
+				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'image_url'      => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
+				'is_built_by_wc' => true,
 			],
 		);
 


### PR DESCRIPTION
Fixes #7542
This PR adds a featured pill for MailPoet and Google Listings in the marketing task. The pill will have the text: "Built by WooCommerce".


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-localhost_10003-2021 12 07-11_36_15](https://user-images.githubusercontent.com/1314156/145049039-141fa083-f1eb-404b-8388-fa976e75ce38.png)

### Detailed test instructions:

1. Checkout this branch `add/7542`.
2. Delete `_transient_woocommerce_admin_remote_free_extensions_specs` transient. You can use a [plugin like this](https://wordpress.org/plugins/wp-phpmyadmin-extension/) to add PHPMyAdmin and run a query like this:
```
DELETE FROM `wp_options` WHERE `option_name` = '_transient_woocommerce_admin_remote_free_extensions_specs';
```
3. Install [this plugin](https://gist.github.com/octaedro/7d9f83a4dec9f3fc1918404ad69c421f) to modify [this call](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13).
4. You'll need the WC.COM project ready and with the [branch `add/built_by_wc_data_spec` checked out](https://github.com/Automattic/woocommerce.com/pull/11953).
5. Go to the marketing task (`/wp-admin/admin.php?page=wc-admin&task=marketing`).
6. Verify that the MailPoet and Google Listings plugins have the pill "Built by WooCommerce".
7.  Go to the testing plugin that you just downloaded and set `$use_broken_url` as `true`  here. That will make the plugin use a broken URL instead of `woocommerce.test`. The fallback code should be used here and it should show the same list with the pills.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
