### PR TITLE
Do not truncate non-U.S notes.

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -164,6 +164,7 @@ const INBOX_QUERY = {
 		'image',
 		'is_deleted',
 		'is_read',
+		'locale',
 	],
 };
 

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -187,6 +187,14 @@ const InboxPanel = ( { showHeader = true } ) => {
 				'YYYY-MM-DD'
 			).valueOf();
 
+			const supportedLocales = [
+				'en_US',
+				'en_AU',
+				'en_CA',
+				'en_GB',
+				'en_ZA',
+			];
+
 			return {
 				notes: getNotes( INBOX_QUERY ).map( ( note ) => {
 					const noteDate = moment(
@@ -194,7 +202,10 @@ const InboxPanel = ( { showHeader = true } ) => {
 						'YYYY-MM-DD'
 					).valueOf();
 
-					if ( noteDate >= WC_VERSION_61_RELEASE_DATE ) {
+					if (
+						supportedLocales.includes( note.locale ) &&
+						noteDate >= WC_VERSION_61_RELEASE_DATE
+					) {
 						note.content = truncateRenderableHTML(
 							note.content,
 							320


### PR DESCRIPTION
Fixes #8018 

This PR prevents non-U.S notes from being truncated.

### Detailed test instructions:

1. Find a note with more than 320 chars.
2. Confirm the note's content gets truncated on `WooCommerce -> Home`
3. Update the note's locale to something else from the table.
4. Navigate to `WooCommerce -> Home` and confirm the note's content is not truncated.

no changelog