### PR TITLE
Do not truncate notes created before WC 6.1 release

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -19,7 +19,7 @@ import {
 	InboxNotePlaceholder,
 	Text,
 } from '@woocommerce/experimental';
-
+import moment from 'moment';
 /**
  * Internal dependencies
  */
@@ -181,10 +181,24 @@ const InboxPanel = ( { showHeader = true } ) => {
 				isResolving,
 				isNotesRequesting,
 			} = select( NOTES_STORE_NAME );
+			const WC_VERSION_59_DATE = moment(
+				'2022-01-11',
+				'YYYY-MM-DD'
+			).valueOf();
 
 			return {
 				notes: getNotes( INBOX_QUERY ).map( ( note ) => {
-					note.content = truncateRenderableHTML( note.content, 320 );
+					const noteDate = moment(
+						note.date_created_gmt,
+						'YYYY-MM-DD'
+					).valueOf();
+
+					if ( noteDate >= WC_VERSION_59_DATE ) {
+						note.content = truncateRenderableHTML(
+							note.content,
+							320
+						);
+					}
 					return note;
 				} ),
 				isError: Boolean(

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -181,7 +181,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 				isResolving,
 				isNotesRequesting,
 			} = select( NOTES_STORE_NAME );
-			const WC_VERSION_59_DATE = moment(
+			const WC_VERSION_61_RELEASE_DATE = moment(
 				'2022-01-11',
 				'YYYY-MM-DD'
 			).valueOf();
@@ -193,7 +193,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 						'YYYY-MM-DD'
 					).valueOf();
 
-					if ( noteDate >= WC_VERSION_59_DATE ) {
+					if ( noteDate >= WC_VERSION_61_RELEASE_DATE ) {
 						note.content = truncateRenderableHTML(
 							note.content,
 							320


### PR DESCRIPTION
Fixes #8017 

This PR prevents notes created before WC 6.1 (scheduled for 2022-01-11) release from being truncated.

### Detailed test instructions:

1. Find a note with more than 320 chars.
2. Confirm the note is not truncated on `WooCommerce -> Home`
3. Change `created_date` field of the note to `2022-01-11`
4. Navigate to `WooCommerce->Home` and confirm the note is now truncated.

no changelog