### PR TITLE
Fix shipping task completion status

### DIFF
--- a/changelogs/fix-8026
+++ b/changelogs/fix-8026
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix shipping task completion status #8031

--- a/client/tasks/fills/shipping/index.js
+++ b/client/tasks/fills/shipping/index.js
@@ -172,7 +172,13 @@ export class Shipping extends Component {
 	}
 
 	getSteps() {
-		const { countryCode, isJetpackConnected, settings } = this.props;
+		const {
+			countryCode,
+			createNotice,
+			isJetpackConnected,
+			settings,
+			updateAndPersistSettingsForGroup,
+		} = this.props;
 		const pluginsToActivate = this.getPluginsToActivate();
 		const requiresJetpackConnection =
 			! isJetpackConnected && countryCode === 'US';
@@ -187,7 +193,11 @@ export class Shipping extends Component {
 				),
 				content: (
 					<StoreLocation
-						{ ...this.props }
+						createNotice={ createNotice }
+						updateAndPersistSettingsForGroup={
+							updateAndPersistSettingsForGroup
+						}
+						settings={ settings }
 						onComplete={ ( values ) => {
 							const country = getCountryCode(
 								values.countryState
@@ -275,9 +285,9 @@ export class Shipping extends Component {
 								plugins_to_activate: pluginsToActivate,
 							} );
 							getHistory().push( getNewPath( {}, '/', {} ) );
+							this.props.onComplete();
 						} }
 						pluginSlugs={ pluginsToActivate }
-						{ ...this.props }
 					/>
 				),
 				visible: pluginsToActivate.length,
@@ -295,7 +305,6 @@ export class Shipping extends Component {
 							'admin.php?page=wc-admin'
 						) }
 						completeStep={ this.completeStep }
-						{ ...this.props }
 						onConnect={ () => {
 							recordEvent( 'tasklist_shipping_connect_store' );
 						} }

--- a/client/tasks/fills/shipping/index.js
+++ b/client/tasks/fills/shipping/index.js
@@ -12,7 +12,11 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { Link, Stepper, Plugins } from '@woocommerce/components';
 import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
-import { SETTINGS_STORE_NAME, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import {
+	SETTINGS_STORE_NAME,
+	ONBOARDING_STORE_NAME,
+	PLUGINS_STORE_NAME,
+} from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
@@ -175,8 +179,12 @@ export class Shipping extends Component {
 		const {
 			countryCode,
 			createNotice,
+			invalidateResolutionForStoreSelector,
 			isJetpackConnected,
+			onComplete,
+			optimisticallyCompleteTask,
 			settings,
+			task,
 			updateAndPersistSettingsForGroup,
 		} = this.props;
 		const pluginsToActivate = this.getPluginsToActivate();
@@ -227,8 +235,13 @@ export class Shipping extends Component {
 								: __( 'Complete task', 'woocommerce-admin' )
 						}
 						shippingZones={ this.state.shippingZones }
-						onComplete={ this.completeStep }
-						createNotice={ this.props.createNotice }
+						onComplete={ () => {
+							const { id } = task;
+							optimisticallyCompleteTask( id );
+							invalidateResolutionForStoreSelector();
+							this.completeStep();
+						} }
+						createNotice={ createNotice }
 					/>
 				),
 				visible:
@@ -285,7 +298,7 @@ export class Shipping extends Component {
 								plugins_to_activate: pluginsToActivate,
 							} );
 							getHistory().push( getNewPath( {}, '/', {} ) );
-							this.props.onComplete();
+							onComplete();
 						} }
 						pluginSlugs={ pluginsToActivate }
 					/>
@@ -375,9 +388,15 @@ const ShippingWrapper = compose(
 		const { updateAndPersistSettingsForGroup } = dispatch(
 			SETTINGS_STORE_NAME
 		);
+		const {
+			invalidateResolutionForStoreSelector,
+			optimisticallyCompleteTask,
+		} = dispatch( ONBOARDING_STORE_NAME );
 
 		return {
 			createNotice,
+			invalidateResolutionForStoreSelector,
+			optimisticallyCompleteTask,
 			updateAndPersistSettingsForGroup,
 		};
 	} )
@@ -387,8 +406,10 @@ registerPlugin( 'wc-admin-onboarding-task-shipping', {
 	scope: 'woocommerce-tasks',
 	render: () => (
 		<WooOnboardingTask id="shipping">
-			{ ( { onComplete } ) => {
-				return <ShippingWrapper onComplete={ onComplete } />;
+			{ ( { onComplete, task } ) => {
+				return (
+					<ShippingWrapper onComplete={ onComplete } task={ task } />
+				);
 			} }
 		</WooOnboardingTask>
 	),


### PR DESCRIPTION
Fixes #8026 #8027 

Fixes destructured props that were prematurely completing the task and optimistically completes the task once rates are saved.

### Screenshots


<img width="696" alt="Screen Shot 2021-12-13 at 2 49 12 PM" src="https://user-images.githubusercontent.com/10561050/145879970-33838944-b72b-4b30-84ae-298493748ffa.png">

### Detailed test instructions:

**Task completion**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Delete WCS if active so that the plugins step appears.
2. Navigate to the shipping task.
3. On the plugin installation step, click "No thanks"
4. Note that you are redirected to the homescreen and the task is marked complete.

**Connection step**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Delete WCS if active so that the plugins step appears.
2. Navigate to the shipping task.
3. Continue installing the plugin.
4. Note that you land on the Connect step

**Task abandonment**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Navigate to the shipping task.
3. Complete the rates step.
4. Use the back button next to the page title to navigate back to the homescreen.
5. Note that the task is marked complete since rates are complete.
