### PR TITLE
OBW: Update WC Pay label on recommended extensions list

### DIFF
--- a/changelogs/tweak-7551
+++ b/changelogs/tweak-7551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+OBW: Update WC Pay label on recommended extensions list #8038

--- a/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src/Features/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -112,7 +112,7 @@ class DefaultFreeExtensions {
 			'woocommerce-payments'              => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Accept credit cards with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
+					__( 'Accept credit cards and other popular payment methods with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
 					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
 					'</a>'
 				),


### PR DESCRIPTION
Fixes #7551

This PR replaces the label `Accept credit cards with WooCommerce Payments` with `Accept credit cards and other popular payment methods with WooCommerce Payments` in step 4 (Business Details) of the OBW.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screenshot-localhost_10003-2021 12 15-13_02_09](https://user-images.githubusercontent.com/1314156/146240724-12c4a404-45df-495e-8973-9e77339b3f88.png)


### Detailed test instructions:

1. Checkout this branch `tweak/7551`.
2. Delete `_transient_woocommerce_admin_remote_free_extensions_specs` transient. You can use a [plugin like this](https://wordpress.org/plugins/wp-phpmyadmin-extension/) to add PHPMyAdmin and run a query like this:
```
DELETE FROM `wp_options` WHERE `option_name` = '_transient_woocommerce_admin_remote_free_extensions_specs';
```
3. Install [this plugin](https://gist.github.com/octaedro/7d9f83a4dec9f3fc1918404ad69c421f) to modify [this call](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13).
4. You'll need the WC.COM project ready and with the [branch `tweak/modify_wcpay_label` checked out](12021-gh-Automattic/woocommerce.com).
5. Go to step 4 (Business Details) of the OBW.
6. Verify that the copy under `Get the basics` for WooCommerce Payments says `Accept credit cards and other popular payment methods with WooCommerce Payments` instead of `Accept credit cards with WooCommerce Payments`.
7.  Go to the testing plugin that you just downloaded and set `$use_broken_url` as `true`  here. That will make the plugin use a broken URL instead of `woocommerce.test`. The fallback code should be used here and it should show the same text for WooCommerce Payments.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->