### PR TITLE
Try: Fetch hook data from REST endpoint for use in client

### DIFF
--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -1,3 +1,44 @@
-export default ( {} ) => {
-	return <div>Settings page</div>;
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import sanitizeHTML from '~/lib/sanitize-html';
+
+const SettingsPage = () => {
+	const [ actions, setActions ] = useState( {} );
+
+	useEffect( () => {
+		apiFetch( {
+			path: addQueryArgs( 'wc-admin/hooks', {
+				actions: 'woocommerce_settings_start',
+			} ),
+		} ).then( ( data ) => setActions( data ) );
+	}, [] );
+
+	return (
+		<div>
+			<div className="woocommerce-settings__start">
+				<h2>Settings start section</h2>
+				{ actions.woocommerce_settings_start && (
+					<div
+						dangerouslySetInnerHTML={ sanitizeHTML(
+							actions.woocommerce_settings_start
+						) }
+					/>
+				) }
+			</div>
+
+			<div className="woocommerce-settings_settings">
+				<h2>Settings get looped over here</h2>
+			</div>
+		</div>
+	);
 };
+
+export default SettingsPage;

--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,7 @@
 		"payment-gateway-suggestions": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
-		"settings": false,
+		"settings": true,
 		"shipping-label-banner": true,
 		"subscriptions": true,
 		"store-alerts": true,

--- a/src/API/Hooks.php
+++ b/src/API/Hooks.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * REST API Hooks Controller
+ *
+ * Handles requests to /hooks
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Hooks Controller.
+ *
+ * @extends WC_REST_Data_Controller
+ */
+class Hooks extends \WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'hooks';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_hook_data' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check whether a given request has permission to read hook data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		// @todo This should probably be limited by the given filter/hook.
+		return true;
+	}
+
+	/**
+	 * Return available hook data.
+	 *
+	 * @param \WP_REST_Request $request Request data.
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function get_hook_data( $request ) {
+		if ( ! isset( $request['actions'] ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of actions.', 'woocommerce-admin' ), 500 );
+		}
+
+		$hooks        = array();
+		$action_names = explode( ',', $request['actions'] );
+
+		foreach ( $action_names as $action_name ) {
+			ob_start();
+			do_action( $action_name );
+			$data = ob_get_contents();
+			ob_end_clean();
+			$hooks[] = array(
+				'name' => $action_name,
+				'data' => $data,
+				'type' => 'action',
+			);
+		}
+
+		return $hooks;
+	}
+
+}

--- a/src/API/Hooks.php
+++ b/src/API/Hooks.php
@@ -79,11 +79,7 @@ class Hooks extends \WC_REST_Data_Controller {
 			do_action( $action_name );
 			$data = ob_get_contents();
 			ob_end_clean();
-			$hooks[] = array(
-				'name' => $action_name,
-				'data' => $data,
-				'type' => 'action',
-			);
+			$hooks[ $action_name ] = $data;
 		}
 
 		return $hooks;

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -59,6 +59,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Data',
 			'Automattic\WooCommerce\Admin\API\DataCountries',
 			'Automattic\WooCommerce\Admin\API\DataDownloadIPs',
+			'Automattic\WooCommerce\Admin\API\Hooks',
 			'Automattic\WooCommerce\Admin\API\Marketing',
 			'Automattic\WooCommerce\Admin\API\MarketingOverview',
 			'Automattic\WooCommerce\Admin\API\Options',


### PR DESCRIPTION
Fixes #7925 

This is part of an initial spike to use plugin data from existing hooks in the new Reactified pages.  This PR fetches the registered hook data from a REST endpoint and injects that into the page.

I may take a stab at an alternative approach listed below in a follow-up to see what that would look like.

## Rest approach (this PR)

**Benefits**

* Actions and filters are readily available on any page
* Very performant and no preloading of data/pages required

**Disadvantages**

* Hooks and respective scripts may be registered under `admin_init` or checking a `$_GET` param which does not get triggered under this REST route
* We may need to pass params back with the hook names to get the correct data (`do_action( 'my_hook', $some_var, $some_other_var );`)
* We need to sanitize HTML before injecting (though this is probably true of all approaches)

**Things to improve with this method**

* The endpoint should allow for filters to be retrieved (easy)
* The endpoint should allow for params to be passed to actions/filters (technically easy, potentially difficult to gather all the correct data to pass back to the server)
* Need a way to catch form data and submit (moderate difficulty if the WC hooks are correctly used, impossible if they are not being used).  This may even be possible async; capture form data, on submit post to the save hook filter, invalidate cache on success, render new action hook content.

## Alternative approaches

### Overwrite WC Settings pages

**Advantages**

* Existing hooks are guaranteed to work and scripts don't need to be updated
* URLs don't change

**Disadvantages**

* Breaks React routing (I don't believe we can transition between the `wc-admin` and `wc-settings` namespace, can we?
* Not very performant given we'll probably be loading all the data from the original settings pages on top of the new data we add

### Render content to a hidden div

**Advantages**

* No fetching involved

**Disadvantages**

* Data has to be preloaded for all WCA pages which makes it a deal breaker IMO

### Screenshots

<img width="598" alt="Screen Shot 2021-12-15 at 4 37 29 PM" src="https://user-images.githubusercontent.com/10561050/146270193-f670e766-e880-4add-bad1-c47cc15eb314.png">


### Detailed test instructions:


1. Add a plugin that adds data to the settings start hook:
```php
add_action( 'woocommerce_settings_start', function() {
	echo '<div>This is content generated from the <strong>server-side</strong> hook</div>';
} );
```
2. Make sure you re-run the build to trigger feature config update (`settings => true`)
2. Enable the settings feature under `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Navigate to general settings `wp-admin/admin.php?page=wc-admin&path=%2Fsettings%2Fgeneral`
4. Note the custom hook content is shown