### PR TITLE
Syc 2.9.x changelog entries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,15 @@
 - Update: Load both actioned and unactioned notes. #7983
 - Tweak: Add inbox_panel_view tracks event. #8002
 
+== 2.9.3 12/15/2021 ==
+- Fix: Correctly match payment gateways by id #7994
+
+== 2.9.2 12/13/2021 ==
+- Fix: Fix shipping task completion status #8031
+
+== 2.9.1 12/07/2021 == 
+- Fix: Fix shipping task not offering step 3. #7985
+
 == 2.9.0 11/30/2021 ==
 
 - Fix: Do not clear `current` class from the entire page when updating wp-admin's menu. #7773

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,12 +25,15 @@
 - Tweak: Add inbox_panel_view tracks event. #8002
 
 == 2.9.3 12/15/2021 ==
+
 - Fix: Correctly match payment gateways by id #7994
 
 == 2.9.2 12/13/2021 ==
+
 - Fix: Fix shipping task completion status #8031
 
-== 2.9.1 12/07/2021 == 
+== 2.9.1 12/07/2021 ==
+
 - Fix: Fix shipping task not offering step 3. #7985
 
 == 2.9.0 11/30/2021 ==


### PR DESCRIPTION
This PR syncs `main` with the 2.9.x changelog entries.

No changelog