### PR TITLE
Allow content data note props to be passed from remote sources

### DIFF
--- a/changelogs/update-7915
+++ b/changelogs/update-7915
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Allow content data note props to be passed from remote sources #8047

--- a/src/RemoteInboxNotifications/SpecRunner.php
+++ b/src/RemoteInboxNotifications/SpecRunner.php
@@ -59,7 +59,7 @@ class SpecRunner {
 		// Set up the note.
 		$note->set_title( $locale->title );
 		$note->set_content( $locale->content );
-		$note->set_content_data( (object) array() );
+		$note->set_content_data( isset( $spec->content_data ) ? $spec->content_data : (object) array() );
 		$note->set_status( $status );
 		$note->set_type( $spec->type );
 		$note->set_name( $spec->slug );


### PR DESCRIPTION
Fixes #7915 

Use content data prop from remote sources to allow extra note meta data to be passed.

### Screenshots

<img width="419" alt="Screen Shot 2021-12-20 at 4 57 57 PM" src="https://user-images.githubusercontent.com/10561050/146838238-ee1cec89-372e-46d4-8be9-40d8bd6fe8f8.png">
<img width="702" alt="Screen Shot 2021-12-20 at 4 57 43 PM" src="https://user-images.githubusercontent.com/10561050/146838240-1c2cb8cc-21cc-44b8-b256-e7bc49381020.png">


### Detailed test instructions:

1. Add a note via a filter in a plugin:
```php
add_filter( 'data_source_poller_specs', function( $specs, $id ) {
	if ( $id !== 'remote_inbox_notifications' ) {
		return $specs;
	}

	$specs[] = (object) [
		'slug'         => 'test-content-data',
		'type'         => 'info',
		'status'       => 'unactioned',
		'is_snoozable' => 0,
		'source'       => 'local',
		'content_data' => (object) array(
			'test'  => true,
			'hello' => 'world',
		),
		'locales'      => [
			(object) [
				'locale'  => 'en_US',
				'title'   => 'Test note',
				'content' => 'This note should contain content data',
			],
		],
		'rules'        => [
			(object) [
				'type'      => 'wcadmin_active_for',
				'operation' => '>=',
				'days'      => 1,
			],
		],
	];
	return $specs;
}, 10, 2 );
```
2. Run the `wc_admin_daily` cron event using a plugin like Crontrol
3. Open your console's network tab
4. Navigate to the WC homepage
5. Note that the network request to `/notes` (typically the first request) contains the note data with `content_data` included