### PR TITLE
Fix unexpected analytics report table filter results

### DIFF
--- a/changelogs/fix-7895-filter-customer-table
+++ b/changelogs/fix-7895-filter-customer-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix unexpected analytics report table filter results. #8072

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -598,7 +598,9 @@ export default compose(
 			SETTINGS_STORE_NAME
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
-		if ( isRequesting ) {
+		const noSearchResultsFound =
+			query.search && ! ( query[ endpoint ] && query[ endpoint ].length );
+		if ( isRequesting || noSearchResultsFound ) {
 			return EMPTY_OBJECT;
 		}
 


### PR DESCRIPTION
Fixes #7895

Fix the report table logic to show `No data to display` UI when it has no results [as it did previously](https://github.com/woocommerce/woocommerce-admin/blob/0f6c86313f4f8ca27320f93553ff0de116a123e4/client/analytics/components/report-table/index.js#L588-L594).

### Screenshots

non-existing customer name 
![Screen Shot 2021-12-22 at 16 22 27](https://user-images.githubusercontent.com/4344253/147059988-382f0b47-d8fc-4ff5-a9e3-814f4e20e313.png)

existing customer name 
![Screen Shot 2021-12-22 at 16 22 38](https://user-images.githubusercontent.com/4344253/147060018-3565c0a9-1f55-4328-be06-077f85eb41d9.png)


### Detailed test instructions:

1. Go to WooCommerce > Customer
2. In the filter bar, enter a non-existing customer name and press enter
3. You should see the `No data to display` message.
