### PR TITLE
Add payments remind me later note

### DIFF
--- a/changelogs/add-8077-wcpay-payments-remind-me-later-note
+++ b/changelogs/add-8077-wcpay-payments-remind-me-later-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add payment remind me later note. #8085

--- a/src/Events.php
+++ b/src/Events.php
@@ -53,6 +53,7 @@ use Automattic\WooCommerce\Admin\Schedulers\MailchimpScheduler;
 use \Automattic\WooCommerce\Admin\Notes\CompleteStoreDetails;
 use \Automattic\WooCommerce\Admin\Notes\UpdateStoreDetails;
 use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
+use \Automattic\WooCommerce\Admin\Notes\PaymentsRemindMeLater;
 
 /**
  * Events Class.
@@ -156,6 +157,7 @@ class Events {
 		NavigationNudge::possibly_add_note();
 		CompleteStoreDetails::possibly_add_note();
 		UpdateStoreDetails::possibly_add_note();
+		PaymentsRemindMeLater::possibly_add_note()();
 	}
 
 	/**
@@ -166,6 +168,7 @@ class Events {
 		NavigationFeedback::delete_if_not_applicable();
 		NavigationFeedbackFollowUp::delete_if_not_applicable();
 		SetUpAdditionalPaymentTypes::delete_if_not_applicable();
+		PaymentsRemindMeLater::delete_if_not_applicable();
 	}
 
 	/**

--- a/src/Events.php
+++ b/src/Events.php
@@ -157,7 +157,7 @@ class Events {
 		NavigationNudge::possibly_add_note();
 		CompleteStoreDetails::possibly_add_note();
 		UpdateStoreDetails::possibly_add_note();
-		PaymentsRemindMeLater::possibly_add_note()();
+		PaymentsRemindMeLater::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/PaymentsRemindMeLater.php
+++ b/src/Notes/PaymentsRemindMeLater.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WooCommerce Admin Payment Reminder Me later
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\PluginsHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PaymentsRemindMeLater
+ */
+class PaymentsRemindMeLater {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-payments-remind-me-later';
+
+	/**
+	 * Should this note exist?
+	 */
+	public static function is_applicable() {
+		return self::should_display_note();
+	}
+
+	/**
+	 * Returns true if we should display the note.
+	 *
+	 * @return Boolean
+	 */
+	public static function should_display_note() {
+		// Installed WCPay.
+		$installed_plugins = PluginsHelper::get_installed_plugin_slugs();
+		if ( in_array( 'woocommerce-payments', $installed_plugins, true ) ) {
+			return false;
+		}
+		// Dismissed WCPay welcome page.
+		if ( 'yes' === get_option( 'wc_pay_welcome_page_dismissed', 'no' ) ) {
+			return false;
+		}
+
+		// Less than 3 days since viewing welcome page.
+		$view_timestamp = get_option( 'wc_pay_welcome_page_viewed_timestamp', false );
+		if ( ! $view_timestamp ||
+			( time() - $view_timestamp < 3 * DAY_IN_SECONDS )
+		) {
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		if ( ! self::should_display_note() ) {
+			return;
+		}
+		$content = __( 'Save up to 50% in fees by managing transactions in WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'woocommerce-admin' );
+
+		$note = new Note();
+		$note->set_title( __( 'Save big with WooCommerce Payments', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), admin_url( 'admin.php?page=wc-admin&path=/wc-pay-welcome-page' ) );
+		return $note;
+	}
+}

--- a/src/Notes/PaymentsRemindMeLater.php
+++ b/src/Notes/PaymentsRemindMeLater.php
@@ -33,7 +33,7 @@ class PaymentsRemindMeLater {
 	/**
 	 * Returns true if we should display the note.
 	 *
-	 * @return Boolean
+	 * @return bool
 	 */
 	public static function should_display_note() {
 		// Installed WCPay.


### PR DESCRIPTION
Fixes #8077

This PR is making the changes as https://github.com/Automattic/wc-calypso-bridge/pull/756 to show payments remind me later note based on the rules:

- Don't have WCPay installed
- Haven't dismissed welcome screen
- Timing: 3 days after viewing the WCPay welcome screen

### Testing Instructions

**Before starting, make sure of the following:**
1. Deactivate & uninstall WooCommerce Payments plugin
2. `wc_pay_welcome_page_dismissed` option is deleted or set to `No`
3. Install the plugin [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)

**Testing timestamp trigger**
1. Click on the payments menu
2. Check the option `wc_pay_welcome_page_viewed_timestamp`, it should contain a timestamp value
3. Open Tools > Cron Events
4. Look for `wc_admin_bridge_daily`, and click on "Run now"
5. Wait for it to finish running and navigate to WooCommerce homescreen
6. "Save big with WooCommerce Payments" note should **NOT** be displayed
7. Manually set the value `1632611715` to `wc_pay_welcome_page_viewed_timestamp` to pass the 3 day check
8. Re-run `wc_admin_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should be displayed

**Testing WCPay plugin installed**
1. Go to WP's database and delete `wc-admin-payments-remind-me-later` in the table `wp_wc_admin_notes`
2. Go to Payments screen and click on "No thanks" > "Just remove WooCommerce Payments" 
8. Re-run `wc_admin_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed

**Testing WCPay dismissed**
1. Delete the option `wc_admin_payments_dismissed`
1. Go to WP's database and delete `wc-admin-payments-remind-me-later` in the table `wp_wc_admin_notes`
2. Install WCPay plugin
8. Re-run `wc_admin_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed

**Testing note removal**
1. Get the note displayed (refer to steps above)
2. Either install WCPay plugin or dismiss the payments menu
8. Re-run `wc_admin_daily` event in Tools > Cron Events
9. Check WooCommerce homescreen, the note should **NOT** be displayed