### PR TITLE
Add/8073 add action_click event to inbox 2.0

### DIFF
--- a/changelogs/add-8073-add-inbox2-click-event
+++ b/changelogs/add-8073-add-inbox2-click-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Add
+
+Add inbox_action_click track when a note gets clicked #8086

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -51,6 +51,8 @@ const onBodyLinkClick = ( note, innerLink ) => {
 	} );
 };
 
+let hasFiredPanelViewTrack = false;
+
 const renderNotes = ( {
 	hasNotes,
 	isBatchUpdating,
@@ -68,9 +70,12 @@ const renderNotes = ( {
 		return renderEmptyCard();
 	}
 
-	recordEvent( 'inbox_panel_view', {
-		total: notes.length,
-	} );
+	if ( ! hasFiredPanelViewTrack ) {
+		recordEvent( 'inbox_panel_view', {
+			total: notes.length,
+		} );
+		hasFiredPanelViewTrack = true;
+	}
 
 	const screen = getScreenName();
 	const onNoteVisible = ( note ) => {

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -274,6 +274,14 @@ const InboxPanel = ( { showHeader = true } ) => {
 
 	const onNoteActionClick = ( note, action ) => {
 		triggerNoteAction( note.id, action.id );
+		const screen = getScreenName();
+		recordEvent( 'inbox_action_click', {
+			note_content: note.content,
+			note_name: note.name,
+			note_title: note.title,
+			note_type: note.type,
+			screen,
+		} );
 	};
 
 	if ( isError ) {


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32205 

This PR has the following changes:

1. It prevents `inbox_panel_view` track from firing multiple times.
2. It adds`inbox_action_click` when a note gets clicked.

### Detailed test instructions:

1. Open browser inspector and enable logging.
2. Navigate to WooCommerce -> Home
3. Confirm `inbox_panel_view` track gets fired only once
4. Click one of the notes. Confirm `inbox_action_click` track gets fired. 
