### PR TITLE
Do not initialize WC Pay promotion if spec is empty

### DIFF
--- a/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
+++ b/src/Features/WcPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
@@ -24,7 +24,10 @@ class WCPaymentGatewayPreInstallWCPayPromotion extends \WC_Payment_Gateway {
 	 * Constructor
 	 */
 	public function __construct() {
-		$wc_pay_spec        = Init::get_wc_pay_promotion_spec();
+		$wc_pay_spec = Init::get_wc_pay_promotion_spec();
+		if ( ! $wc_pay_spec ) {
+			return;
+		}
 		$this->id           = static::GATEWAY_ID;
 		$this->method_title = $wc_pay_spec->title;
 		if ( property_exists( $wc_pay_spec, 'sub_title' ) ) {


### PR DESCRIPTION
Fixes #8080 

This PR fixes the critical error in PHP by making sure `get_wc_pay_promotion_spec` returns a value.

### Detailed test instructions:

1. Start **without** this branch to reproduce the error.
2. Start OBW and choose `CBD and other hemp-derived products` from the Industry tab.
3. Make sure not to install any payment plugins.
4. Navigate to WooCommerce -> Settings -> Payments. You should see some PHP errors related to `non-object`
5. Checkout this branch and refresh the page.
6. The errors should be gone.

no changelog