### PR TITLE
OBW: Hide the extensions header when no available plugins in the category

### DIFF
--- a/changelogs/fix-8006-hide-header-if-no-plugin
+++ b/changelogs/fix-8006-hide-header-if-no-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Hide the extensions header when no available plugins in the category. #8089

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -176,6 +176,42 @@ export const createInitialValues = ( extensions ) => {
 	}, baseValues );
 };
 
+const ExtensionSection = ( {
+	isResolving,
+	title,
+	plugins,
+	pluginState,
+	onCheckboxChange,
+} ) => {
+	if ( isResolving ) {
+		return (
+			<div>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( plugins.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<div className="woocommerce-admin__business-details__selective-extensions-bundle__category">
+				{ title }
+			</div>
+			{ plugins.map( ( { description, key } ) => (
+				<BundleExtensionCheckbox
+					key={ key }
+					description={ description }
+					isChecked={ pluginState[ key ] }
+					onChange={ onCheckboxChange( key ) }
+				/>
+			) ) }
+		</div>
+	);
+};
+
 export const SelectiveExtensionsBundle = ( {
 	isInstallingActivating,
 	onSubmit,
@@ -259,7 +295,6 @@ export const SelectiveExtensionsBundle = ( {
 			}
 		};
 	};
-
 	return (
 		<div className="woocommerce-profile-wizard__business-details__free-features">
 			<Card>
@@ -309,33 +344,15 @@ export const SelectiveExtensionsBundle = ( {
 					{ showExtensions &&
 						installableExtensions.map(
 							( { plugins, key: sectionKey, title } ) => (
-								<div key={ sectionKey }>
-									{ isResolving ? (
-										<Spinner />
-									) : (
-										<>
-											<div className="woocommerce-admin__business-details__selective-extensions-bundle__category">
-												{ title }
-											</div>
-											{ plugins.map(
-												( { description, key } ) => (
-													<BundleExtensionCheckbox
-														key={ key }
-														description={
-															description
-														}
-														isChecked={
-															values[ key ]
-														}
-														onChange={ getCheckboxChangeHandler(
-															key
-														) }
-													/>
-												)
-											) }
-										</>
-									) }
-								</div>
+								<ExtensionSection
+									key={ sectionKey }
+									title={ title }
+									plugins={ plugins }
+									pluginState={ values }
+									onCheckboxChange={
+										getCheckboxChangeHandler
+									}
+								/>
 							)
 						) }
 				</div>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -159,7 +159,7 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
 	);
 };
 
-const ExtensionSection = ( {
+export const ExtensionSection = ( {
 	isResolving,
 	title,
 	extensions,

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -159,8 +159,44 @@ const BundleExtensionCheckbox = ( { onChange, description, isChecked } ) => {
 	);
 };
 
-const baseValues = { install_extensions: true };
-export const createInitialValues = ( extensions ) => {
+const ExtensionSection = ( {
+	isResolving,
+	title,
+	extensions,
+	installExtensionOptions,
+	onCheckboxChange,
+} ) => {
+	if ( isResolving ) {
+		return (
+			<div>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( extensions.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<div className="woocommerce-admin__business-details__selective-extensions-bundle__category">
+				{ title }
+			</div>
+			{ extensions.map( ( { description, key } ) => (
+				<BundleExtensionCheckbox
+					key={ key }
+					description={ description }
+					isChecked={ installExtensionOptions[ key ] }
+					onChange={ onCheckboxChange( key ) }
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export const createInstallExtensionOptions = ( extensions = [] ) => {
+	const defaultInstallExtensionOptions = { install_extensions: true };
 	return extensions.reduce( ( acc, curr ) => {
 		const plugins = curr.plugins.reduce(
 			( pluginAcc, { key, selected } ) => {
@@ -173,43 +209,7 @@ export const createInitialValues = ( extensions ) => {
 			...acc,
 			...plugins,
 		};
-	}, baseValues );
-};
-
-const ExtensionSection = ( {
-	isResolving,
-	title,
-	plugins,
-	pluginState,
-	onCheckboxChange,
-} ) => {
-	if ( isResolving ) {
-		return (
-			<div>
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( plugins.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<div>
-			<div className="woocommerce-admin__business-details__selective-extensions-bundle__category">
-				{ title }
-			</div>
-			{ plugins.map( ( { description, key } ) => (
-				<BundleExtensionCheckbox
-					key={ key }
-					description={ description }
-					isChecked={ pluginState[ key ] }
-					onChange={ onCheckboxChange( key ) }
-				/>
-			) ) }
-		</div>
-	);
+	}, defaultInstallExtensionOptions );
 };
 
 export const SelectiveExtensionsBundle = ( {
@@ -217,7 +217,9 @@ export const SelectiveExtensionsBundle = ( {
 	onSubmit,
 } ) => {
 	const [ showExtensions, setShowExtensions ] = useState( false );
-	const [ values, setValues ] = useState( baseValues );
+	const [ installExtensionOptions, setInstallExtensionOptions ] = useState(
+		createInstallExtensionOptions()
+	);
 
 	const {
 		countryCode,
@@ -260,19 +262,20 @@ export const SelectiveExtensionsBundle = ( {
 			}
 			return ALLOWED_PLUGIN_LISTS.includes( list.key );
 		} );
-	}, [ freeExtensions, profileItems ] );
+	}, [ freeExtensions, profileItems, countryCode ] );
 
 	useEffect( () => {
 		if ( ! isInstallingActivating ) {
-			const initialValues = createInitialValues( installableExtensions );
-			setValues( initialValues );
+			setInstallExtensionOptions(
+				createInstallExtensionOptions( installableExtensions )
+			);
 		}
-	}, [ installableExtensions ] );
+	}, [ installableExtensions, isInstallingActivating ] );
 
 	const getCheckboxChangeHandler = ( key ) => {
 		return ( checked ) => {
 			const newState = {
-				...values,
+				...installExtensionOptions,
 				[ key ]: checked,
 			};
 
@@ -282,19 +285,20 @@ export const SelectiveExtensionsBundle = ( {
 
 			if ( allExtensionsDisabled ) {
 				// If all the extensions are disabled then disable the "Install Extensions" checkbox too
-				setValues( {
+				setInstallExtensionOptions( {
 					...newState,
 					install_extensions: false,
 				} );
 			} else {
-				setValues( {
-					...values,
+				setInstallExtensionOptions( {
+					...installExtensionOptions,
 					[ key ]: checked,
 					install_extensions: true,
 				} );
 			}
 		};
 	};
+
 	return (
 		<div className="woocommerce-profile-wizard__business-details__free-features">
 			<Card>
@@ -304,10 +308,15 @@ export const SelectiveExtensionsBundle = ( {
 				<div className="woocommerce-admin__business-details__selective-extensions-bundle">
 					<div className="woocommerce-admin__business-details__selective-extensions-bundle__extension">
 						<CheckboxControl
-							checked={ values.install_extensions }
+							checked={
+								installExtensionOptions.install_extensions
+							}
 							onChange={ ( checked ) => {
-								setValues(
-									setAllPropsToValue( values, checked )
+								setInstallExtensionOptions(
+									setAllPropsToValue(
+										installExtensionOptions,
+										checked
+									)
 								);
 							} }
 						/>
@@ -343,12 +352,14 @@ export const SelectiveExtensionsBundle = ( {
 					</div>
 					{ showExtensions &&
 						installableExtensions.map(
-							( { plugins, key: sectionKey, title } ) => (
+							( { plugins, key, title } ) => (
 								<ExtensionSection
-									key={ sectionKey }
+									key={ key }
 									title={ title }
-									plugins={ plugins }
-									pluginState={ values }
+									extensions={ plugins }
+									installExtensionOptions={
+										installExtensionOptions
+									}
 									onCheckboxChange={
 										getCheckboxChangeHandler
 									}
@@ -359,7 +370,7 @@ export const SelectiveExtensionsBundle = ( {
 				<div className="woocommerce-profile-wizard__business-details__free-features__action">
 					<Button
 						onClick={ () => {
-							onSubmit( values );
+							onSubmit( installExtensionOptions );
 						} }
 						isBusy={ isInstallingActivating || isResolving }
 						disabled={ isInstallingActivating || isResolving }
@@ -370,7 +381,7 @@ export const SelectiveExtensionsBundle = ( {
 				</div>
 			</Card>
 			{ renderBusinessExtensionHelpText(
-				values,
+				installExtensionOptions,
 				isInstallingActivating
 			) }
 		</div>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -9,7 +9,7 @@ import { pluginNames } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { SelectiveExtensionsBundle } from '../';
+import { SelectiveExtensionsBundle, ExtensionSection } from '../';
 
 jest.mock( '../../app-illustration', () => ( {
 	AppIllustration: jest.fn().mockReturnValue( '[illustration]' ),
@@ -128,5 +128,40 @@ describe( 'Selective extensions bundle', () => {
 		expect( getByText( 'Mailpoet Description' ) ).toBeInTheDocument();
 		expect( queryByText( 'Google Description' ) ).toBeInTheDocument();
 		expect( queryByText( 'Random Description' ) ).not.toBeInTheDocument();
+	} );
+
+	describe( '<ExtensionSection />', () => {
+		it( 'should render title and extensions', () => {
+			const title = 'This is title';
+			const { queryByText } = render(
+				<ExtensionSection
+					isResolving={ false }
+					title={ title }
+					extensions={ freeExtensions[ 0 ].plugins }
+					installExtensionOptions={ {} }
+					onCheckboxChange={ () => {} }
+				/>
+			);
+
+			expect( queryByText( title ) ).toBeInTheDocument();
+			freeExtensions[ 0 ].plugins.forEach( ( { description } ) => {
+				expect( queryByText( description ) ).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'should render not title when no plugins', () => {
+			const title = 'This is title';
+			const { queryByText } = render(
+				<ExtensionSection
+					isResolving={ false }
+					title={ title }
+					extensions={ [] }
+					installExtensionOptions={ {} }
+					onCheckboxChange={ () => {} }
+				/>
+			);
+
+			expect( queryByText( title ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -5,7 +5,7 @@ import {
 	filterBusinessExtensions,
 	prepareExtensionTrackingData,
 } from '../flows/selective-bundle';
-import { createInitialValues } from '../flows/selective-bundle/selective-extensions-bundle';
+import { createInstallExtensionOptions } from '../flows/selective-bundle/selective-extensions-bundle';
 
 describe( 'BusinessDetails', () => {
 	test( 'filtering extensions', () => {
@@ -101,7 +101,7 @@ describe( 'BusinessDetails', () => {
 		} );
 	} );
 
-	describe( 'createInitialValues', () => {
+	describe( 'createInstallExtensionOptions', () => {
 		test( 'selected by default', () => {
 			const extensions = [
 				{
@@ -125,7 +125,12 @@ describe( 'BusinessDetails', () => {
 				},
 			];
 
-			const values = createInitialValues( extensions, 'US', '', [] );
+			const values = createInstallExtensionOptions(
+				extensions,
+				'US',
+				'',
+				[]
+			);
 
 			expect( values ).toEqual(
 				expect.objectContaining( {


### PR DESCRIPTION
Fixes #8006

This PR is making the change to hide the extensions header if no available plugins in the category. 

I also made the following changes for the readability and maintenance:

- Moved extension section code out of nested logic and create a separated component for the feature.
- Renamed the state `values` -> `installExtensionOptions`.
- Fixed missing hook dependency warning.
- Added tests

### Screenshots

Before:


![https://user-images.githubusercontent.com/3747241/145002718-966d1d3f-b3e2-463f-870c-1cf7b2b4aaa9.png](https://user-images.githubusercontent.com/3747241/145002718-966d1d3f-b3e2-463f-870c-1cf7b2b4aaa9.png)


After:

![Screen Shot 2021-12-28 at 14 52 15](https://user-images.githubusercontent.com/4344253/147537228-3ece5745-25fa-4977-a168-9b49a9a63880.png)

### Test instructions:

1. In a new JN site with WooCommerce, install WCAdmin 3.0.0-beta.1 or WCAdmin on the main branch
2. Go to setup wizard
3. Choose "Johor - Malaysia" as store country
4. Go through all steps until "Business details"
5. Go to "Free features" tab
6. Observe the "GET THE BASICS" header is **NOT** shown without any plugins


