### PR TITLE
Disallow whitespace as a platform name input

### DIFF
--- a/changelogs/fix-7907-disallow-white-space-platform-name-input
+++ b/changelogs/fix-7907-disallow-white-space-platform-name-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Disallow whitespace as the platform name input. #8090

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -226,9 +226,8 @@ class BusinessDetails extends Component {
 				'woocommerce-admin'
 			);
 		}
-
 		if (
-			! values.other_platform_name &&
+			! values.other_platform_name.trim().length &&
 			values.other_platform === 'other' &&
 			[ 'other', 'brick-mortar-other' ].includes( values.selling_venues )
 		) {


### PR DESCRIPTION
Fixes #7907

This PR fixed the issue that users can enter whitespaces as a valid platform name input.


### Screenshots
![Screen Shot 2021-12-28 at 16 16 12](https://user-images.githubusercontent.com/4344253/147544666-cd935ebc-4585-474e-9984-eaef6310839c.png)


### Testing Instructions

1. Go to setup wizard
2. Navigate to the **Business details** page.
3. Select **other** as an option for `'Which platform is the store using?'` field.
4. Enter a white space into the required field and attempt to submit the form again.
5. Note that it should disallow you to submit the form with a message "This field is required".
