### PR TITLE
Sync version and changelogs after 3.1.0 beta

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,14 +2,6 @@
 
 ## Unreleased
 
-### Fix PHP Warning on 'Add new product' page
-
-0. On a Jurassic Ninja site.
-1. Go to **WooCommerce** > **Home**.
-2. Press **Add my products** in the task list.
-3. Press **Add manually**.
-4. No PHP warning should be visible.
-
 ## 3.1.0
 
 ### Inbox - 320 character limit
@@ -18,6 +10,14 @@ On a new site, with English language settings:
 
 1. Go to WooCommerce home screen
 2. See that all Inbox notes are short in length (aproximately less than 320 characters). 
+
+### Fix PHP Warning on 'Add new product' page
+
+0. On a Jurassic Ninja site.
+1. Go to **WooCommerce** > **Home**.
+2. Press **Add my products** in the task list.
+3. Press **Add manually**.
+4. No PHP warning should be visible.
 
 ## 3.0.0
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,21 @@
+== 3.1.0 12/28/2021 ==
+
+- Fix: Fix Onboarding flow where extensions might not be selected and installed. #7979
+- Fix: Fix pagination issue with Analytics Coupons page. #8001
+- Fix: Fix select-control component label/value alignment. #8045
+- Fix: Fix unexpected analytics report table filter results. #8072
+- Fix: Prevent coupon move notice for new installs. #7995
+- Fix: Remove calls to read_meta_data in the Note DataStore. #7988
+- Add: Add featured pill for MailPoet and Google Listings in marketing task #8009
+- Add: Add inbox_action_click track when a note gets clicked #8086
+- Update: Allow content data note props to be passed from remote sources #8047
+- Update: Update @woocommerce/e2e-environment package to latest. #8000
+- Dev: Add payment gateway suggestion docs and example extensions #7966
+- Dev: Remove low performing inbox notes. #8054
+- Dev: Remove navigation feedback note. #8055
+- Tweak: OBW: Update WC Pay label on recommended extensions list #8038
+- Enhancement: Add SlotFill areas to header #7805
+
 == 3.0.0 12/14/2021 ==
 
 - Fix: Fix an issue with the code that makes use of an invalid parameter with a PHP function. The use of this invalid parameter causes PHP 8 to throw a Fatal Error. #7855

--- a/changelogs/add-7542
+++ b/changelogs/add-7542
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add featured pill for MailPoet and Google Listings in marketing task #8009

--- a/changelogs/add-7689
+++ b/changelogs/add-7689
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Enhancement
-
-Add SlotFill areas to header #7805

--- a/changelogs/add-7937
+++ b/changelogs/add-7937
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Add payment gateway suggestion docs and example extensions #7966

--- a/changelogs/add-8073-add-inbox2-click-event
+++ b/changelogs/add-8073-add-inbox2-click-event
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Add
-
-Add inbox_action_click track when a note gets clicked #8086

--- a/changelogs/fix-7321_free_extensions_list
+++ b/changelogs/fix-7321_free_extensions_list
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix Onboarding flow where extensions might not be selected and installed. #7979

--- a/changelogs/fix-7660-remove-note-read-meta-data-calls
+++ b/changelogs/fix-7660-remove-note-read-meta-data-calls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Remove calls to read_meta_data in the Note DataStore. #7988

--- a/changelogs/fix-7681_coupons_query
+++ b/changelogs/fix-7681_coupons_query
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix pagination issue with Analytics Coupons page. #8001

--- a/changelogs/fix-7786-searchable-select-control-label-alginment
+++ b/changelogs/fix-7786-searchable-select-control-label-alginment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix select-control component label/value alignment. #8045

--- a/changelogs/fix-7895-filter-customer-table
+++ b/changelogs/fix-7895-filter-customer-table
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix unexpected analytics report table filter results. #8072

--- a/changelogs/fix-e2e-tests
+++ b/changelogs/fix-e2e-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Update @woocommerce/e2e-environment package to latest. #8000

--- a/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
+++ b/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Prevent coupon move notice for new installs. #7995

--- a/changelogs/remove-5475-navigation-feedback-notes
+++ b/changelogs/remove-5475-navigation-feedback-notes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Remove navigation feedback note. #8055

--- a/changelogs/remove-7970-low-performing-inbox-notes
+++ b/changelogs/remove-7970-low-performing-inbox-notes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Remove low performing inbox notes. #8054

--- a/changelogs/tweak-7551
+++ b/changelogs/tweak-7551
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-OBW: Update WC Pay label on recommended extensions list #8038

--- a/changelogs/update-7915
+++ b/changelogs/update-7915
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Allow content data note props to be passed from remote sources #8047

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "3.1.0-dev",
+	"version": "3.2.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.1.0-dev",
+	"version": "3.2.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.8.1
 Requires PHP: 7.0
-Stable tag: 3.1.0-dev
+Stable tag: 3.2.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '3.1.0-dev';
+	const VERSION = '3.2.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -145,7 +145,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.1.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.2.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 3.1.0-dev
+ * Version: 3.2.0-dev
  * Requires at least: 5.6
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
Updating all version numbers to `3.2.0` after the `3.1.0` beta release. Also syncing changelog.txt file, testing instructions, and deleting all incorporated changelog files.

As per `#3` in **Post-beta release tasks** on P90Yrv-2p4-p2.

No changelog