### PR TITLE
Skip opening the dropdown if the click event is from the error message

### DIFF
--- a/changelogs/fix-7906-click-error-message-open-select-control
+++ b/changelogs/fix-7906-click-error-message-open-select-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix clicking the error message opens the dropdown. #8094

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982
 -   Fix select-control component label/value alignment. #8045
+-   Fix clicking the error message opens the dropdown. #8094
 
 # 8.1.1
 

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -217,8 +217,14 @@ class Control extends Component {
 						'is-disabled': disabled,
 					}
 				) }
-				onClick={ () => {
-					this.input.current.focus();
+				onClick={ ( event ) => {
+					// Don't focus the input if the click event is from the error message.
+					if (
+						event.target.className !==
+						'components-base-control__help'
+					) {
+						this.input.current.focus();
+					}
 				} }
 			>
 				{ isSearchable && (


### PR DESCRIPTION
Fixes #7906

This PR fixed the issue that clicking the error message unexpectedly opens the dropdown.

### Screenshots

Before

https://user-images.githubusercontent.com/19307354/140600433-20da0277-b191-4722-8bd7-3134fceb0471.mp4

After

https://user-images.githubusercontent.com/4344253/147631930-f8c71692-0c10-4870-844a-5b38c2044bfe.mov



### Detailed test instructions:

1. Use a new site or empty the `woocommerce_default_country` option from 'wp_options' table 
2. Go to Setup Wizard flow
3. On the store profile page, Keep the **'Country/Region'** field empty and click on continue.
4. Look for validation error message displayed for empty Country/Region field-> Please select a country / region
5. Click on the Error message and **it shouldn't open the dropdown**.

