### PR TITLE
OBW: Fix free extensions list isn't updated after store location or industry is changed

### DIFF
--- a/changelogs/fix-8007-update-free-extensions-when-country-industry-changed
+++ b/changelogs/fix-8007-update-free-extensions-when-country-industry-changed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix free extensions list isn't updated after store location or industry is changed. #8099

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -10,7 +10,7 @@ import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
 import { pluginNames, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -213,6 +213,7 @@ export const SelectiveExtensionsBundle = ( {
 	onSubmit,
 	country,
 	productTypes,
+	industry,
 } ) => {
 	const [ showExtensions, setShowExtensions ] = useState( false );
 	const [ installExtensionOptions, setInstallExtensionOptions ] = useState(
@@ -230,6 +231,15 @@ export const SelectiveExtensionsBundle = ( {
 			isResolving: ! hasFinishedResolution( 'getFreeExtensions' ),
 		};
 	} );
+
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		ONBOARDING_STORE_NAME
+	);
+
+	useEffect( () => {
+		invalidateResolutionForStoreSelector( 'getFreeExtensions' );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ country, industry ] );
 
 	const installableExtensions = useMemo( () => {
 		return freeExtensionBundleByCategory.filter( ( extensionBundle ) => {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -8,11 +8,7 @@ import { Link } from '@woocommerce/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
-import {
-	pluginNames,
-	ONBOARDING_STORE_NAME,
-	SETTINGS_STORE_NAME,
-} from '@woocommerce/data';
+import { pluginNames, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSelect } from '@wordpress/data';
 
@@ -25,7 +21,7 @@ import sanitizeHTML from '~/lib/sanitize-html';
 import { setAllPropsToValue } from '~/lib/collections';
 import { getCountryCode } from '../../../../../../dashboard/utils';
 
-const ALLOWED_PLUGIN_LISTS = [ 'obw/basics', 'obw/grow' ];
+const ALLOWED_PLUGIN_CATEGORIES = [ 'obw/basics', 'obw/grow' ];
 
 const FreeBadge = () => {
 	return (
@@ -215,44 +211,35 @@ export const createInstallExtensionOptions = ( extensions = [] ) => {
 export const SelectiveExtensionsBundle = ( {
 	isInstallingActivating,
 	onSubmit,
+	country,
+	productTypes,
 } ) => {
 	const [ showExtensions, setShowExtensions ] = useState( false );
 	const [ installExtensionOptions, setInstallExtensionOptions ] = useState(
 		createInstallExtensionOptions()
 	);
-
 	const {
-		countryCode,
-		freeExtensions,
+		freeExtensions: freeExtensionBundleByCategory,
 		isResolving,
-		profileItems,
 	} = useSelect( ( select ) => {
-		const {
-			getFreeExtensions,
-			getProfileItems,
-			hasFinishedResolution,
-		} = select( ONBOARDING_STORE_NAME );
-		const { getSettings } = select( SETTINGS_STORE_NAME );
-		const { general: settings = {} } = getSettings( 'general' );
-
+		const { getFreeExtensions, hasFinishedResolution } = select(
+			ONBOARDING_STORE_NAME
+		);
 		return {
-			countryCode: getCountryCode( settings.woocommerce_default_country ),
 			freeExtensions: getFreeExtensions(),
 			isResolving: ! hasFinishedResolution( 'getFreeExtensions' ),
-			profileItems: getProfileItems(),
 		};
 	} );
 
 	const installableExtensions = useMemo( () => {
-		const { product_types: productTypes } = profileItems;
-		return freeExtensions.filter( ( list ) => {
+		return freeExtensionBundleByCategory.filter( ( extensionBundle ) => {
 			if (
 				window.wcAdminFeatures &&
 				window.wcAdminFeatures.subscriptions &&
-				countryCode === 'US'
+				getCountryCode( country ) === 'US'
 			) {
 				if ( productTypes.includes( 'subscriptions' ) ) {
-					list.plugins = list.plugins.filter(
+					extensionBundle.plugins = extensionBundle.plugins.filter(
 						( extension ) =>
 							extension.key !== 'woocommerce-payments' ||
 							( extension.key === 'woocommerce-payments' &&
@@ -260,9 +247,9 @@ export const SelectiveExtensionsBundle = ( {
 					);
 				}
 			}
-			return ALLOWED_PLUGIN_LISTS.includes( list.key );
+			return ALLOWED_PLUGIN_CATEGORIES.includes( extensionBundle.key );
 		} );
-	}, [ freeExtensions, profileItems, countryCode ] );
+	}, [ freeExtensionBundleByCategory, productTypes, country ] );
 
 	useEffect( () => {
 		if ( ! isInstallingActivating ) {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import userEvent from '@testing-library/user-event';
 import { pluginNames } from '@woocommerce/data';
 
@@ -83,15 +83,19 @@ const freeExtensions = [
 	},
 ];
 
-const profileItems = { product_types: [] };
-
 describe( 'Selective extensions bundle', () => {
-	it( 'should list installable free extensions from obw/basics and obw/grow', () => {
+	beforeAll( () => {
 		useSelect.mockReturnValue( {
 			freeExtensions,
 			isResolving: false,
-			profileItems,
 		} );
+
+		useDispatch.mockReturnValue( {
+			invalidateResolutionForStoreSelector: () => {},
+		} );
+	} );
+
+	it( 'should list installable free extensions from obw/basics and obw/grow', () => {
 		const { getByText, queryByText } = render(
 			<SelectiveExtensionsBundle isInstallingActivating={ false } />
 		);
@@ -112,11 +116,6 @@ describe( 'Selective extensions bundle', () => {
 	} );
 
 	it( 'should list installable extensions when dropdown is clicked', () => {
-		useSelect.mockReturnValue( {
-			freeExtensions,
-			isResolving: false,
-			profileItems,
-		} );
 		const { getAllByRole, getByText, queryByText } = render(
 			<SelectiveExtensionsBundle isInstallingActivating={ false } />
 		);

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -148,7 +148,7 @@ describe( 'Selective extensions bundle', () => {
 			} );
 		} );
 
-		it( 'should render not title when no plugins', () => {
+		it( 'should not render title when no plugins', () => {
 			const title = 'This is title';
 			const { queryByText } = render(
 				<ExtensionSection


### PR DESCRIPTION
Fixes #8007

This PR makes sure the free extensions are updated whenever the store location or industry is changed. (lines 235-242)

Besides, I refactored the code with the following changes:

1. To easier to understand, I renamed the `freeExtensions ` -> `freeExtensionBundleByCategory` and `ALLOWED_PLUGIN_LISTS` -> `ALLOWED_PLUGIN_CATEGORIES`.
2. I removed the `getSettings` from the `useSelect` since we already have them in the `"props"`.

### Detailed test instructions:

**change store Industry**

1. Checkout to this branch
2. Go to the setup wizard
3. Choose any store location that supports WCPay, such as any state in the US
4. In the Industry step, make sure to not select CBD
5. Proceed through the setup until the Business Details step
6. Go to the "Free features" tab
7. Observe **WooCommerce Payments** is displayed in the suggested extensions
8. Without refreshing, go back to the **Industry** step
9. Select **CBD industry** and click on continue until Business Details step again
10. In the extension list, observe that WooCommerce Payments is **NOT** displayed.

**change store country**

11. Repeat steps 3~7
12. Without refreshing, go back to the **Store Details** step
13. Choose any store location that **doesn't** supports WCPay, such as United Kingdom (UK)
14. Go to Business Details step again
15. In the extension list, observe that WooCommerce Payments is **NOT** displayed.