### PR TITLE
Reset "install_timestamp" if it's not numeric to avoid TypeError

### DIFF
--- a/changelogs/fix-7891-uncaught-typeError-int-string
+++ b/changelogs/fix-7891-uncaught-typeError-int-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Reset "install_timestamp" if it's not numeric to avoid TypeError. #8100

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -48,7 +48,7 @@ class WCAdminHelper {
 	public static function get_wcadmin_active_for_in_seconds() {
 		$install_timestamp = get_option( self::WC_ADMIN_TIMESTAMP_OPTION );
 
-		if ( false === $install_timestamp ) {
+		if ( false === $install_timestamp || ! is_numeric( $install_timestamp ) ) {
 			$install_timestamp = time();
 			update_option( self::WC_ADMIN_TIMESTAMP_OPTION, $install_timestamp );
 		}

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -48,7 +48,7 @@ class WCAdminHelper {
 	public static function get_wcadmin_active_for_in_seconds() {
 		$install_timestamp = get_option( self::WC_ADMIN_TIMESTAMP_OPTION );
 
-		if ( false === $install_timestamp || ! is_numeric( $install_timestamp ) ) {
+		if ( ! is_numeric( $install_timestamp ) ) {
 			$install_timestamp = time();
 			update_option( self::WC_ADMIN_TIMESTAMP_OPTION, $install_timestamp );
 		}

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -15,6 +15,15 @@ use \Automattic\WooCommerce\Admin\WCAdminHelper;
 class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 
 	/**
+	 * Test get_wcadmin_active_for_in_seconds_with with invalid timestamp option.
+	 */
+	public function test_get_wcadmin_active_for_in_seconds_with_invalid_timestamp_option() {
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, 'invalid-time' );
+		$this->assertEquals( is_numeric( WCAdminHelper::get_wcadmin_active_for_in_seconds() ), true );
+	}
+
+
+	/**
 	 * Test wc_admin_active_for one hour
 	 */
 	public function test_is_wc_admin_active_for_one_hour() {


### PR DESCRIPTION
Fixes #7891

This PR should be able to avoid the ` Uncaught TypeError: Unsupported operand types: int - string in /wordpress/plugins/woocommerce/5.8.0/packages/woocommerce-admin/src/WCAdminHelper.php:56`

`return time() - $install_timestamp;` is line 56

Note that somehow I couldn't reproduce the error on my test site with PHP 8.0 and WooCommerce 5.8.0 in a normal way. But we can empty the `woocommerce_admin_install_timestamp` option or set it to a non-numeric string in the wp_options to get the same error. 

And I found that PHP 8.0 still can do the "int - string" operation safetly. I tested the code below on both [an online PHP sandbox](https://sandbox.onlinephpfunctions.com/) and my local PHP environment.

```php
echo time() - "123";
```

Therefore, I supposed something changes the "install_timestamp" to be non-numeric when using PHP8. So I updated the code to check if "install_timestamp" is a numeric string.

I didn't use `intval` to cast the typing because I think it might cause unexpected results. 

```php
echo intval("");   // 0
echo intval(array());
echo intval(array());                 // 0
echo intval(array('foo', 'bar'));     // 1
echo intval(false);                   // 0
echo intval(true);                    // 1
```

### Detailed test instructions:

1. Launch a new site with PHP 8.0 and WooCommerce 5.8.0
2. Install WooCommerce Payments and active it
3. Should not see the ["int - string" type error from the CLI](p9F6qB-7CT-p2)
4. Update `woocommerce_admin_install_timestamp` option in the table `wp_options` to be a non-numeric value.
5. Go to /wp-admin/admin.php.
6.  Should not see the "int - string" type error from the frontend page.
