### PR TITLE
Activate promo note after WC Pay is activated

### DIFF
--- a/changelogs/add-8067-activate-promo-note
+++ b/changelogs/add-8067-activate-promo-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Activate promo note after WC Pay is activated. #8104

--- a/client/payments-welcome/index.tsx
+++ b/client/payments-welcome/index.tsx
@@ -128,7 +128,7 @@ const ConnectPageOnboarding = ( {
 
 	const activatePromo = async () => {
 		const activatePromoRequest: activatePromoResponse = await apiFetch( {
-			path: `/wc-analytics/admin/notes/activate-promo/${ PROMO_NAME }`,
+			path: `/wc-analytics/admin/notes/experimental-activate-promo/${ PROMO_NAME }`,
 			method: 'POST',
 		} );
 		if ( activatePromoRequest?.success ) {

--- a/client/payments-welcome/index.tsx
+++ b/client/payments-welcome/index.tsx
@@ -13,6 +13,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { OPTIONS_STORE_NAME, PluginsStoreActions } from '@woocommerce/data';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -48,6 +49,8 @@ declare global {
 interface activatePromoResponse {
 	success: boolean;
 }
+
+const PROMO_NAME = 'wcpay-promo-2021-6-incentive-2';
 
 const LearnMore = () => {
 	const handleClick = () => {
@@ -124,17 +127,12 @@ const ConnectPageOnboarding = ( {
 	};
 
 	const activatePromo = async () => {
-		try {
-			// const activatePromoRequest = ( await apiFetch( {
-			// 	path: '/wc-calypso-bridge/v1/payments/activate-promo',
-			// 	method: 'POST',
-			// } ) ) as activatePromoResponse;
-
-			// if ( activatePromoRequest?.success ) {
+		const activatePromoRequest: activatePromoResponse = await apiFetch( {
+			path: `/wc-analytics/admin/notes/activate-promo/${ PROMO_NAME }`,
+			method: 'POST',
+		} );
+		if ( activatePromoRequest?.success ) {
 			window.location.href = connectUrl;
-			// }
-		} catch ( e ) {
-			// renderErrorMessage( e.message );
 		}
 	};
 
@@ -149,11 +147,10 @@ const ConnectPageOnboarding = ( {
 			const installAndActivateResponse = await installAndActivatePlugins(
 				[ 'woocommerce-payments' ]
 			);
-
 			if ( installAndActivateResponse?.success ) {
-				activatePromo();
+				await activatePromo();
 			} else {
-				renderErrorMessage( installAndActivateResponse.message );
+				throw new Error( installAndActivateResponse.message );
 			}
 		} catch ( e ) {
 			renderErrorMessage( e.message );

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -138,6 +138,19 @@ class Notes extends \WC_REST_CRUD_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/activate-promo/(?P<promo_note_name>[\w-]+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'activate_promo_note' ),
+					'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -444,6 +457,42 @@ class Notes extends \WC_REST_CRUD_Controller {
 		$response = rest_ensure_response( $data );
 		$response->header( 'X-WP-Total', NotesRepository::get_notes_count( array( 'info', 'warning' ), array() ) );
 		return $response;
+	}
+
+	/**
+	 * Activate a promo note, create if not exist.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Request|WP_Error
+	 */
+	public function activate_promo_note( $request ) {
+		$promo_note_name = $request->get_param( 'promo_note_name' );
+		$data_store      = NotesRepository::load_data_store();
+		$note_ids        = $data_store->get_notes_with_name( $promo_note_name );
+
+		if ( empty( $note_ids ) ) {
+			// Promo note doesn't exist, this could happen in cases where
+			// user might have disabled RemoteInboxNotications via disabling
+			// marketing suggestions. Thus we'd have to manually add the note.
+			$note = new Note();
+			$note->set_name( $promo_note_name );
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$data_store->create( $note );
+		} else {
+			$note = NotesRepository::get_note( $note_ids[0] );
+			NotesRepository::update_note(
+				$note,
+				[
+					'status' => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				]
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8067

This PR calls activate promo REST API to activate the WC Pay incentive promotion.

### Screenshots

### Detailed test instructions:

1. Make sure you don't have `wcpay-promo-2021-6-incentive-2` note in your `wp_wc_admin_notes` table. If you have it already, make sure the status is unactioned
2. Navigate to the welcome page.
3. Click "Get started" button. You should be redirected.
4. Open `wp_wc_admin_notes` table and confirm that the `wcpay-promo-2021-6-incentive-2` status is now actioned
5. You can also finish the KYC and confirm your account has the promotion applied.


### Screenshots

![Screen Shot 2021-07-07 at 2 44 00 PM](https://user-images.githubusercontent.com/4723145/124833910-b8b30c00-df33-11eb-9f3d-8d4a5f13a9a9.jpg)

