### PR TITLE
Replace all docs.woocommerce.com links with woocommerce.com's

### DIFF
--- a/changelogs/fix-8096-doc-links
+++ b/changelogs/fix-8096-doc-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Replace all docs.woocommerce.com links with woocommerce.com/document. #8105

--- a/client/activity-panel/panels/help.js
+++ b/client/activity-panel/panels/help.js
@@ -36,27 +36,27 @@ function getHomeItems() {
 		{
 			title: __( 'Home Screen', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen?utm_medium=product',
+				'https://woocommerce.com/document/home-screen/?utm_medium=product',
 		},
 		{
 			title: __( 'Inbox', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-2',
+				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-2',
 		},
 		{
 			title: __( 'Stats Overview', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-4',
+				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-4',
 		},
 		{
 			title: __( 'Store Management', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/home-screen?utm_medium=product#section-5',
+				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-5',
 		},
 		{
 			title: __( 'Store Setup Checklist', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-setup-wizard?utm_medium=product#store-setup-checklist',
+				'https://woocommerce.com/document/woocommerce-setup-wizard?utm_medium=product#store-setup-checklist',
 		},
 	];
 }
@@ -69,7 +69,7 @@ function getAppearanceItems() {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __(
@@ -77,7 +77,7 @@ function getAppearanceItems() {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __(
@@ -85,7 +85,7 @@ function getAppearanceItems() {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/choose-change-theme/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/choose-change-theme/?utm_source=help_panel&utm_medium=product',
 		},
 	];
 }
@@ -101,7 +101,7 @@ function getMarketingItems( props ) {
 		activePlugins.includes( 'google-listings-and-ads' ) && {
 			title: __( 'Set up Google Listing & Ads', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/google-listings-and-ads/?utm_medium=product#get-started',
+				'https://woocommerce.com/document/google-listings-and-ads/?utm_medium=product#get-started',
 		},
 		activePlugins.includes( 'mailchimp-for-woocommerce' ) && {
 			title: __(
@@ -131,7 +131,7 @@ function getPaymentGatewaySuggestions( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.woocommerce_payments && {
 			title: __(
@@ -139,17 +139,17 @@ function getPaymentGatewaySuggestions( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/payments/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/payments/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.woocommerce_payments && {
 			title: __( 'WooCommerce Payments FAQs', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.stripe && {
 			title: __( 'Stripe Setup and Configuration', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/stripe/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/stripe/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions[ 'ppcp-gateway' ] && {
 			title: __(
@@ -157,42 +157,42 @@ function getPaymentGatewaySuggestions( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/2-0/woocommerce-paypal-payments/?utm_medium=product#section-3',
+				'https://woocommerce.com/document/2-0/woocommerce-paypal-payments/?utm_medium=product#section-3',
 		},
 		paymentGatewaySuggestions.square_credit_card && {
 			title: __( 'Square - Get started', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-square/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/woocommerce-square/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.kco && {
 			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/klarna-checkout/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/klarna-checkout/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.klarna_payments && {
 			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/klarna-payments/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/klarna-payments/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.payfast && {
 			title: __( 'PayFast Setup and Configuration', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.eway && {
 			title: __( 'Eway Setup and Configuration', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/eway/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/eway/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/bacs/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/bacs/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __( 'Cash on Delivery', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/cash-on-delivery/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/cash-on-delivery/?utm_source=help_panel&utm_medium=product',
 		},
 	].filter( Boolean );
 }
@@ -202,7 +202,7 @@ function getProductsItems() {
 		{
 			title: __( 'Adding and Managing Products', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __(
@@ -210,7 +210,7 @@ function getProductsItems() {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __(
@@ -226,7 +226,7 @@ function getProductsItems() {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel&utm_medium=product',
 		},
 	];
 }
@@ -239,17 +239,17 @@ function getShippingItems( { activePlugins, countryCode } ) {
 		{
 			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __( 'Core Shipping Options', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/product-shipping-classes/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/product-shipping-classes/?utm_source=help_panel&utm_medium=product',
 		},
 		showWCS && {
 			title: __(
@@ -257,7 +257,7 @@ function getShippingItems( { activePlugins, countryCode } ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-shipping-and-tax/?utm_source=help_panel&utm_medium=product#section-3',
+				'https://woocommerce.com/document/woocommerce-shipping-and-tax/?utm_source=help_panel&utm_medium=product#section-3',
 		},
 		{
 			title: __(
@@ -265,7 +265,7 @@ function getShippingItems( { activePlugins, countryCode } ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel&utm_medium=product',
 		},
 	].filter( Boolean );
 }
@@ -294,7 +294,7 @@ function getTaxItems( props ) {
 		{
 			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
 			link:
-				'https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel&utm_medium=product',
+				'https://woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel&utm_medium=product',
 		},
 		showWCS && {
 			title: __(
@@ -302,7 +302,7 @@ function getTaxItems( props ) {
 				'woocommerce-admin'
 			),
 			link:
-				'https://docs.woocommerce.com/document/woocommerce-services/?utm_source=help_panel&utm_medium=product#section-10',
+				'https://woocommerce.com/document/woocommerce-services/?utm_source=help_panel&utm_medium=product#section-10',
 		},
 	].filter( Boolean );
 }
@@ -347,7 +347,7 @@ function getListItems( props ) {
 	const genericDocsLink = {
 		title: __( 'WooCommerce Docs', 'woocommerce-admin' ),
 		link:
-			'https://docs.woocommerce.com/?utm_source=help_panel&utm_medium=product',
+			'https://woocommerce.com/documentation/?utm_source=help_panel&utm_medium=product',
 	};
 	itemsByType.push( genericDocsLink );
 

--- a/client/tasks/fills/tax/manual-configuration/configure.tsx
+++ b/client/tasks/fills/tax/manual-configuration/configure.tsx
@@ -53,7 +53,7 @@ export const Configure: React.FC< TaxChildProps > = ( {
 						components: {
 							link: (
 								<Link
-									href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_medium=product#section-1"
+									href="https://woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_medium=product#section-1"
 									target="_blank"
 									type="external"
 								/>

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -57,7 +57,7 @@ We also use existing options from WooCommerce Core or extensions like WooCommerc
 
 ## WooCommerce.com Connection
 
-During the profile wizard, merchants can select paid product type extensions (like WooCommerce Memberships) or a paid theme. To make installation easier and to finish purchasing, it is necessary to make a [WooCommerce.com connection](https://docs.woocommerce.com/document/managing-woocommerce-com-subscriptions/). We also prompt users to connect on the task list if they chose extensions in the profile wizard, but did not finish connecting.
+During the profile wizard, merchants can select paid product type extensions (like WooCommerce Memberships) or a paid theme. To make installation easier and to finish purchasing, it is necessary to make a [WooCommerce.com connection](https://woocommerce.com/document/managing-woocommerce-com-subscriptions/). We also prompt users to connect on the task list if they chose extensions in the profile wizard, but did not finish connecting.
 
 To make the connection from the new onboarding experience possible, we build our own connection endpoints [/wc-admin/plugins/request-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L298-L355) and [/wc-admin/plugins/finish-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L357-L417).
 

--- a/docs/woocommerce.com/activity-panels.md
+++ b/docs/woocommerce.com/activity-panels.md
@@ -42,7 +42,7 @@ For stores with Stock Management enabled, the Stock panel will be displayed.
 
 The Stock Panel will show Products that are either Low in Stock or Out of stock.
 
-"Low in Stock" status is determined by a combination of the store setting and individual product settings. Consult the [Managing Products](https://docs.woocommerce.com/document/managing-products/#inventory-tab) documentation to learn more about managing product stock settings.
+"Low in Stock" status is determined by a combination of the store setting and individual product settings. Consult the [Managing Products](https://woocommerce.com/document/managing-products/#inventory-tab) documentation to learn more about managing product stock settings.
  
 ![Updating Stock from Activity Panel](images/activity-panels-stock-update.png)
 

--- a/packages/components/src/dynamic-form/README.md
+++ b/packages/components/src/dynamic-form/README.md
@@ -23,7 +23,7 @@ const initialValues = { firstName: '' };
 
 | Name          | Type     | Default   | Description                                                                                                                                                             |
 | ------------- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fields`      | {} or [] | []        | An object to describe the structure and types of all fields, matching the structure returned by the [Settings API](https://docs.woocommerce.com/document/settings-api/) |
+| `fields`      | {} or [] | []        | An object to describe the structure and types of all fields, matching the structure returned by the [Settings API](https://woocommerce.com/document/settings-api/) |
 | `isBusy`      | Boolean  | false     | Boolean indicating busy state of submit button                                                                                                                          |
 | `onSubmit`    | Function | `noop`    | Function to call when a form is submitted with valid fields                                                                                                             |
 | `onChange`    | Function | `noop`    | Function to call when any values on the form are changed                                                                                                                |
@@ -32,7 +32,7 @@ const initialValues = { firstName: '' };
 
 ### Fields structure
 
-Please reference the [WordPress settings API documentation](https://docs.woocommerce.com/document/settings-api/) to better understand the structure expected for the fields property. This component accepts the object returned via the `settings` property when querying a gateway via the API, or simply the array provided by `Object.values(settings)`.
+Please reference the [WordPress settings API documentation](https://woocommerce.com/document/settings-api/) to better understand the structure expected for the fields property. This component accepts the object returned via the `settings` property when querying a gateway via the API, or simply the array provided by `Object.values(settings)`.
 
 ### Currently Supported Types
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ WooCommerce Admin also allows store owners to customize a new dashboard screen w
 * PHP version 7.0 or greater. PHP 7.2 or greater is recommended
 * MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended
 
-Visit the [WooCommerce server requirements documentation](https://docs.woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
+Visit the [WooCommerce server requirements documentation](https://woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
 
 = Automatic installation =
 

--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -174,7 +174,7 @@ class InstalledExtensions {
 		$data['icon'] = plugins_url( 'images/marketing/pinterest.svg', WC_ADMIN_PLUGIN_FILE );
 
 		// TODO: Finalise docs url.
-		$data['docsUrl'] = 'https://docs.woocommerce.com/document/pinterest-for-woocommerce/?utm_medium=product';
+		$data['docsUrl'] = 'https://woocommerce.com/document/pinterest-for-woocommerce/?utm_medium=product';
 
 		if ( 'activated' === $data['status'] && class_exists( 'Pinterest_For_Woocommerce' ) ) {
 			$pinterest_onboarding_completed = Pinterest_For_Woocommerce()::is_setup_complete();
@@ -215,7 +215,7 @@ class InstalledExtensions {
 				$data['settingsUrl'] = admin_url( 'admin.php?page=wc-admin&path=/google/start' );
 			}
 
-			$data['docsUrl'] = 'https://docs.woocommerce.com/document/google-listings-and-ads/?utm_medium=product';
+			$data['docsUrl'] = 'https://woocommerce.com/document/google-listings-and-ads/?utm_medium=product';
 		}
 
 		return $data;
@@ -275,7 +275,7 @@ class InstalledExtensions {
 			}
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=codisto-settings' );
-			$data['docsUrl']     = 'https://docs.woocommerce.com/document/getting-started-with-woocommerce-amazon-ebay-integration/?utm_medium=product';
+			$data['docsUrl']     = 'https://woocommerce.com/documentation/getting-started-with-woocommerce-amazon-ebay-integration/?utm_medium=product';
 		}
 
 		return $data;

--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -275,7 +275,7 @@ class InstalledExtensions {
 			}
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=codisto-settings' );
-			$data['docsUrl']     = 'https://woocommerce.com/documentation/getting-started-with-woocommerce-amazon-ebay-integration/?utm_medium=product';
+			$data['docsUrl']     = 'https://woocommerce.com/document/multichannel-for-woocommerce-google-amazon-ebay-walmart-integration/?utm_medium=product';
 		}
 
 		return $data;

--- a/src/Notes/AddFirstProduct.php
+++ b/src/Notes/AddFirstProduct.php
@@ -64,7 +64,7 @@ class AddFirstProduct {
 			sprintf( __( 'Nice one; you\'ve created a WooCommerce store! Now it\'s time to add your first product and get ready to start selling.%s', 'woocommerce-admin' ), '<br/><br/>' ),
 			__( 'There are three ways to add your products: you can <strong>create products manually, import them at once via CSV file</strong>, or <strong>migrate them from another service</strong>.<br/><br/>', 'woocommerce-admin' ),
 			/* translators: %1$s is an open anchor tag (<a>) and %2$s is a close link tag (</a>). */
-			sprintf( __( '%1$1sExplore our docs%2$2s for more information, or just get started!', 'woocommerce-admin' ), '<a href="https://docs.woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product">', '</a>' ),
+			sprintf( __( '%1$1sExplore our docs%2$2s for more information, or just get started!', 'woocommerce-admin' ), '<a href="https://woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product">', '</a>' ),
 		);
 
 		$additional_data = array(

--- a/src/Notes/AddingAndManangingProducts.php
+++ b/src/Notes/AddingAndManangingProducts.php
@@ -69,7 +69,7 @@ class AddingAndManangingProducts {
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://docs.woocommerce.com/document/managing-products/?utm_source=inbox&utm_medium=product'
+			'https://woocommerce.com/document/managing-products/?utm_source=inbox&utm_medium=product'
 		);
 
 		return $note;

--- a/src/Notes/CustomizingProductCatalog.php
+++ b/src/Notes/CustomizingProductCatalog.php
@@ -72,7 +72,7 @@ class CustomizingProductCatalog {
 		$note->add_action(
 			'day-after-first-product',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://docs.woocommerce.com/document/woocommerce-customizer/?utm_source=inbox&utm_medium=product'
+			'https://woocommerce.com/document/woocommerce-customizer/?utm_source=inbox&utm_medium=product'
 		);
 
 		return $note;

--- a/src/Notes/FirstDownlaodableProduct.php
+++ b/src/Notes/FirstDownlaodableProduct.php
@@ -60,7 +60,7 @@ class FirstDownlaodableProduct {
 		$note->add_action(
 			'first-downloadable-product-handling',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://docs.woocommerce.com/document/digital-downloadable-product-handling/?utm_source=inbox&utm_medium=product'
+			'https://woocommerce.com/document/digital-downloadable-product-handling/?utm_source=inbox&utm_medium=product'
 		);
 
 		return $note;

--- a/src/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/src/Notes/ManageStoreActivityFromHomeScreen.php
@@ -56,7 +56,7 @@ class ManageStoreActivityFromHomeScreen {
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://docs.woocommerce.com/document/home-screen/?utm_source=inbox&utm_medium=product',
+			'https://woocommerce.com/document/home-screen/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true
 		);

--- a/src/Notes/OrderMilestones.php
+++ b/src/Notes/OrderMilestones.php
@@ -237,7 +237,7 @@ class OrderMilestones {
 				return array(
 					'name'  => 'learn-more',
 					'label' => __( 'Learn more', 'woocommerce-admin' ),
-					'query' => 'https://docs.woocommerce.com/document/managing-orders/?utm_source=inbox&utm_medium=product',
+					'query' => 'https://woocommerce.com/document/managing-orders/?utm_source=inbox&utm_medium=product',
 				);
 			case 10:
 				return array(

--- a/src/Notes/UnsecuredReportFiles.php
+++ b/src/Notes/UnsecuredReportFiles.php
@@ -35,7 +35,7 @@ class UnsecuredReportFiles {
 			sprintf(
 				/* translators: 1: opening analytics docs link tag. 2: closing link tag */
 				__( 'Files that may contain %1$sstore analytics%2$s reports were found in your uploads directory - we recommend assessing and deleting any such files.', 'woocommerce-admin' ),
-				'<a href="https://docs.woocommerce.com/document/woocommerce-analytics/" target="_blank">',
+				'<a href="https://woocommerce.com/document/woocommerce-analytics/" target="_blank">',
 				'</a>'
 			)
 		);


### PR DESCRIPTION
Fixes #8096

This PR fixes the broken "WooCommerce Docs" link and replaces all old docs.woocommerce.com links with woocommerce.com's.

### Detailed test instructions:

1. Go to /wp-admin/admin.php
2. Click "Help menu" on the top-right corner and make sure all links work
3. Confirm the other links still work (You could use an editor like vscode to help you open the links without copy-and-paste)