### PR TITLE
Add custom error for store details email and allow continue

### DIFF
--- a/changelogs/update-7923
+++ b/changelogs/update-7923
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Add custom error for store details email and allow continue #8110

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -201,15 +201,6 @@ class StoreDetails extends Component {
 		const errors = validateStoreAddress( values );
 
 		if (
-			values.isAgreeMarketing &&
-			( ! values.storeEmail || ! values.storeEmail.trim().length )
-		) {
-			errors.storeEmail = __(
-				'Please add an email address',
-				'woocommerce-admin'
-			);
-		}
-		if (
 			values.storeEmail &&
 			values.storeEmail.trim().length &&
 			values.storeEmail.indexOf( '@' ) === -1
@@ -342,14 +333,31 @@ class StoreDetails extends Component {
 								/>
 
 								<TextControl
-									label={ __(
-										'Email address',
-										'woocommerce-admin'
-									) }
-									required
+									label={
+										values.isAgreeMarketing
+											? __(
+													'Email address',
+													'woocommerce-admin'
+											  )
+											: __(
+													'Email address (Optional)',
+													'woocommerce-admin'
+											  )
+									}
+									required={ values.isAgreeMarketing }
 									autoComplete="email"
 									{ ...getInputProps( 'storeEmail' ) }
 								/>
+								{ values.isAgreeMarketing &&
+									( ! values.storeEmail ||
+										! values.storeEmail.trim().length ) && (
+										<div className="woocommerce-profile-wizard__store-details-error">
+											{ __(
+												'Please enter your email address to subscribe',
+												'woocommerce-admin'
+											) }
+										</div>
+									) }
 							</CardBody>
 
 							<CardFooter>

--- a/client/profile-wizard/steps/store-details/style.scss
+++ b/client/profile-wizard/steps/store-details/style.scss
@@ -19,3 +19,11 @@
 		color: $studio-gray-20;
 	}
 }
+
+.woocommerce-profile-wizard__store-details-error {
+	margin-top: -$gap-small;
+	font-size: 12px;
+	font-style: normal;
+	color: #d63638;
+	padding-left: $gap-small;
+}


### PR DESCRIPTION
Fixes #7923

* Updates the error message for email
* Adds the "Optional" text when not selecting the newsletter
* Allows continuing past the step, even with the error

### Screenshots
![Screen Shot 2022-01-04 at 2 26 11 PM](https://user-images.githubusercontent.com/10561050/148113275-41c8cdc3-b1c2-4856-8b67-2149fe812bf0.png)
![Screen Shot 2022-01-04 at 2 13 17 PM](https://user-images.githubusercontent.com/10561050/148113277-b638aef8-f24e-476e-835f-95375d919f27.png)

cc @elizaan36 @pmcpinto Note that this error does not have the outline around the input like other inputs have.  This was intentional to copy the design in the issue, but can be updated to match others if preferred.  Maybe this is a good thing though since this error doesn't actually prevent submission?

### Detailed test instructions:

1. Navigate to the store details step of the profiler
2. Fill in the email, make sure no errors appear
3. Uncheck the newsletter box
4. Make sure the error is gone
5. Use an invalid email
6. Make sure the error appears regardless of the newsletter opt in