### PR TITLE
Render the activity panel when the experimental tasklist is hidden

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -162,7 +162,7 @@ export const Layout = ( {
 							) }
 						/>
 					) }
-					{ ! isRunningTaskListExperiment && <ActivityPanel /> }
+					{ <ActivityPanel /> }
 					{ hasTaskList && renderTaskList() }
 					<InboxPanel />
 				</Column>


### PR DESCRIPTION
Fixes #8109

This PR renders the activity panel correctly when the experimental task is hidden.

### Detailed test instructions:

1. Assign yourself to `woocommerce_tasklist_progression_headercard_2022_01` experiment.
2. Make sure you're seeing the following tasklist on `WooCommerce -> Home`
![Screen Shot 2022-01-04 at 5 54 38 PM](https://user-images.githubusercontent.com/4723145/148148326-ab24e404-a200-4867-82f6-8915f817944b.jpg)
3. Click the ellipsis (three dots) and click `Hide this`
4. The activity panel should appear.

![Screen Shot 2022-01-04 at 5 56 13 PM](https://user-images.githubusercontent.com/4723145/148148449-c2b375cd-6763-4432-beef-c171e45f8137.jpg)

no changelog
