### PR TITLE
Truncate the site title with an ellipses on the second line

### DIFF
--- a/changelogs/fix-8011-truncate-long-site-title
+++ b/changelogs/fix-8011-truncate-long-site-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Truncate the long site title with an ellipses on the second line. #8112

--- a/client/navigation/components/header/index.js
+++ b/client/navigation/components/header/index.js
@@ -117,6 +117,7 @@ const Header = () => {
 				{ buttonIcon }
 			</Button>
 			<Button
+				title={ siteTitle }
 				href={ homeUrl }
 				className="woocommerce-navigation-header__site-title"
 				as="span"

--- a/client/navigation/components/header/style.scss
+++ b/client/navigation/components/header/style.scss
@@ -28,4 +28,12 @@
 			color: $gray-200;
 		}
 	}
+
+	.woocommerce-navigation-header__site-title {
+		padding-top: 0;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
 }


### PR DESCRIPTION
Fixes #8011

This PR truncates the long site title on the new WooCommerce navigation with ellipses on the second line.


### Screenshots

Before:

![screen1](https://user-images.githubusercontent.com/39308239/131832200-96a68459-2890-49f4-8506-aedfa8edeffd.png)

After:

![Screen Shot 2022-01-05 at 10 55 34](https://user-images.githubusercontent.com/4344253/148153577-07d21632-54ea-4461-b3a7-488e9263fa17.png)


### Detailed test instructions:

1. Ensure Woo Nav is enabled (WooCommerce -> Settings -> Advanced -> Features -> Check the checkbox next to Navigation)
2. Set a long site title (example: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.) in My Site → Settings → General → Site Title
3. Navigate to **WooCommerce** section
4. You should see the entire site title fit well in the top left corner with ellipses on the second line.

### Additional context

> The `-webkit-line-clamp` CSS property allows limiting of the contents of a block container to the specified number of lines.

> It only works in combination with the display property set to -webkit-box or -webkit-inline-box and the -webkit-box-orient property set to vertical.

> In most cases you will also want to set overflow to hidden, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines. --[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp)

[`line-clamp` CSS property browser support](https://caniuse.com/?search=line-clamp)