### PR TITLE
Fix misaligned rows per page dropdown

### DIFF
--- a/changelogs/fix-7863-misaligned-rows-per-page-dropdown
+++ b/changelogs/fix-7863-misaligned-rows-per-page-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix misaligned "Rows per page" dropdown. #8113

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982
 -   Fix select-control component label/value alignment. #8045
 -   Fix clicking the error message opens the dropdown. #8094
+-   Fix misaligned "Rows per page" dropdown. #8113
 
 # 8.1.1
 

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -182,6 +182,7 @@ class Pagination extends Component {
 			<div className="woocommerce-pagination__per-page-picker">
 				<SelectControl
 					label={ __( 'Rows per page', 'woocommerce-admin' ) }
+					labelPosition="side"
 					value={ this.props.perPage }
 					onChange={ this.perPageChange }
 					options={ pickerOptions }


### PR DESCRIPTION
Fixes #7863

This PR fixes the misaligned "Rows per page" dropdown on Analytics pages by adding the [`labelPosition="side"`](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/select-control#labelposition) attribute.


### Screenshots

Before:

![Before](https://user-images.githubusercontent.com/41110392/139287328-2f97ee70-72ee-449d-8405-26f6647d8e7a.png)

After:

![Screen Shot 2022-01-05 at 14 37 33](https://user-images.githubusercontent.com/4344253/148171959-6c2c676e-0ae9-46e9-994b-123848b936e7.png)


### Detailed test instructions:

1. Go to **Analytics > Revenue** page.
2. Select "Last month" as the "Date range".
2. Scroll down to the bottom section.
3. Observe that the "Rows per page" dropdown is aligned properly.
