### PR TITLE
Add resolution check to ensure setup-wizard redirection on homescreen is stable

### DIFF
--- a/changelogs/fix-8029-ensure-redirect-to-setup-wizard-stably
+++ b/changelogs/fix-8029-ensure-redirect-to-setup-wizard-stably
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Ensure setup-wizard redirection on homescreen is stable. #8114

--- a/client/homescreen/index.tsx
+++ b/client/homescreen/index.tsx
@@ -18,13 +18,19 @@ import type { History } from 'history';
 import Layout from './layout';
 
 type HomescreenProps = ReturnType< typeof withSelectHandler > & {
+	hasFinishedResolution: boolean;
 	query: Record< string, string >;
 };
 
-const Homescreen = ( { profileItems, query }: HomescreenProps ) => {
-	const { completed: profilerCompleted, skipped: profilerSkipped } =
-		profileItems || {};
-	if ( ! profilerCompleted && ! profilerSkipped ) {
+const Homescreen = ( {
+	profileItems: {
+		completed: profilerCompleted,
+		skipped: profilerSkipped,
+	} = {},
+	hasFinishedResolution,
+	query,
+}: HomescreenProps ) => {
+	if ( hasFinishedResolution && ! profilerCompleted && ! profilerSkipped ) {
 		( getHistory() as History ).push(
 			getNewPath( {}, '/setup-wizard', {} )
 		);
@@ -36,10 +42,14 @@ const Homescreen = ( { profileItems, query }: HomescreenProps ) => {
 const onboardingData = getSetting( 'onboarding', {} );
 
 const withSelectHandler = ( select: WCDataSelector ) => {
-	const { getProfileItems } = select( ONBOARDING_STORE_NAME );
-	const profileItems = getProfileItems();
+	const { getProfileItems, hasFinishedResolution } = select(
+		ONBOARDING_STORE_NAME
+	);
 
-	return { profileItems };
+	return {
+		profileItems: getProfileItems(),
+		hasFinishedResolution: hasFinishedResolution( 'getProfileItems', [] ),
+	};
 };
 
 export default compose(


### PR DESCRIPTION
Fixes #8029 

This PR fixes the `Redirected to setup wizard from Home even after skipped setup` issue. This should make sure the setup-wizard redirection on homescreen is stable by checking the `hasFinishedResolution`.

### Detailed test instructions:

1. Use **Safari** browser as it's the only browser where this issue can be observed
2. Open developer console and go to Network tab. Disable cache. (This may help to reproduce the issue better)
3. In a fresh JN site
4. Skip setup wizard
5. Go to WooCommerce > Home
6. Retry step 5 by refreshing may be up to 50 times. You should **NOT** be redirected to the setup wizard.


