### PR TITLE
Use ExPlat to render the WC Pay menu conditionally

### DIFF
--- a/src/Features/WCPayWelcomePage.php
+++ b/src/Features/WCPayWelcomePage.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\Features;
  */
 class WCPayWelcomePage {
 
-	const EXPERIMENT_NAME = 'test';
+	const EXPERIMENT_NAME_BASE = 'woocommerce_payments_menu_promo_nz_ie_:yyyy_:mm';
 
 	/**
 	 * WCPayWelcomePage constructor.
@@ -102,6 +102,15 @@ class WCPayWelcomePage {
 			$allow_tracking
 		);
 
-		return $abtest->get_variation( self::EXPERIMENT_NAME ) === 'treatment';
+		$date            = new \DateTime( 'now', wp_timezone() );
+		$experiment_name = strtr(
+			self::EXPERIMENT_NAME_BASE,
+			array(
+				':yyyy' => $date->format( 'Y' ),
+				':mm'   => $date->format( 'm' ),
+			)
+		);
+
+		return $abtest->get_variation( $experiment_name ) === 'treatment';
 	}
 }

--- a/src/Features/WCPayWelcomePage.php
+++ b/src/Features/WCPayWelcomePage.php
@@ -9,11 +9,12 @@ namespace Automattic\WooCommerce\Admin\Features;
  */
 class WCPayWelcomePage {
 
+	const EXPERIMENT_NAME = 'test';
+
 	/**
 	 * WCPayWelcomePage constructor.
 	 */
 	public function __construct() {
-
 		add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
 	}
 	/**
@@ -21,6 +22,10 @@ class WCPayWelcomePage {
 	 */
 	public function register_payments_welcome_page() {
 		global $menu;
+
+		if ( ! $this->should_add_the_menu() ) {
+			return;
+		}
 
 		// WC Payment must not be active.
 		if ( is_plugin_active( 'woocommerce-payments/woocommerce-payments.php' ) ) {
@@ -81,5 +86,22 @@ class WCPayWelcomePage {
 				$menu[ $index ][0] .= ' <span class="wcpay-menu-badge awaiting-mod count-1"><span class="plugin-count">1</span></span>';
 			}
 		}
+	}
+
+	/**
+	 * Checks if user is in the experiment.
+	 *
+	 * @return bool Whether the user is in the treatment group.
+	 */
+	private function should_add_the_menu() {
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
+			$anon_id,
+			'woocommerce',
+			$allow_tracking
+		);
+
+		return $abtest->get_variation( self::EXPERIMENT_NAME ) === 'treatment';
 	}
 }

--- a/src/Features/WcPayWelcomePage.php
+++ b/src/Features/WcPayWelcomePage.php
@@ -7,7 +7,7 @@ namespace Automattic\WooCommerce\Admin\Features;
  *
  * @package Automattic\WooCommerce\Admin\Features
  */
-class WCPayWelcomePage {
+class WcPayWelcomePage {
 
 	const EXPERIMENT_NAME_BASE = 'woocommerce_payments_menu_promo_nz_ie_:yyyy_:mm';
 


### PR DESCRIPTION
Fixes #8106

This PR uses ExPlat to render the WC Pay menu only when the current user is in a treatment group of `woocommerce_payments_menu_promo_nz_ie_:yyyy_:mm` experiment. 

### Detailed test instructions:

1. Start with a fresh installation of WC and WCA. 
2. Finish OBW as usual. 
2. At the time of opening this PR, the experiment is not ready. Add `return true;` at the first line of the `should_add_the_menu` function to fake it.
3. Navigate to WordPress admin area.
4. You should see the `Payments` menu.

no changelog
