### PR TITLE
Add REST endpoint to retrieve address locales

### DIFF
--- a/changelogs/update-7782
+++ b/changelogs/update-7782
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add REST endpoint to retrieve address locales #8116

--- a/src/API/DataCountries.php
+++ b/src/API/DataCountries.php
@@ -22,4 +22,36 @@ class DataCountries extends \WC_REST_Data_Countries_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc-analytics';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/locales',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_locales' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		parent::register_routes();
+	}
+
+	/**
+	 * Get country fields.
+	 *
+	 * @return array
+	 */
+	public function get_locales() {
+		$locales = WC()->countries->get_country_locale();
+		return rest_ensure_response( $locales );
+	}
 }


### PR DESCRIPTION
Fixes (part of) #7782 

Adds an endpoint for retrieving locales.

Note that there's also a method in core `get_address_fields()` that retrieves filtered address fields based on a provided country.  The advantage to using that would be the filtering and sorting of fields, however it would mean a new request to the endpoint whenever the country is changed.

### Screenshots

<img width="412" alt="Screen Shot 2022-01-05 at 3 18 36 PM" src="https://user-images.githubusercontent.com/10561050/148283791-e81110e8-93be-46d8-88ef-be6b2fdafc7b.png">


### Detailed test instructions:

1. Make a GET request to `wp-json/wc-analytics/data/countries/locales`
2. Make sure that all locales are returned