### PR TITLE
Make use of the woocommerce_allow_marketplace_suggestions filter

### DIFF
--- a/changelogs/add-wc-pay-promotion-allow-suggestion-filter
+++ b/changelogs/add-wc-pay-promotion-allow-suggestion-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Add
+
+Add woocommerce_allow_marketplace_suggestions filter to WooCommerce Payments payment method promotion. #8117

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -102,6 +102,9 @@ class Init {
 		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
 			return false;
 		}
+		if ( ! apply_filters( 'woocommerce_allow_marketplace_suggestions', true ) ) {
+			return false;
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce/issues/31566

Make use of the `woocommerce_allow_marketplace_suggestions` filter in WooCommerce Payment promotion, so 3PDs are able to disable it using this filter as well.

See this thread for more context: p1641393911079700-slack-C2CM2ELTG

cc @pmcpinto (this would mean that this won't show up on Calypso site's either, as calypso sets `allow_marketplace_suggestions` to false, but this might be fine?)

### Detailed test instructions:

- Load this branch and make sure you have WC Pay **not** installed
- Go to **WooCommerce > Settings > Payments** and notice the WooCommerce Payments promotion with the Install button at the top of the payments table
- Add this filter to your `mu-plugin` -> `add_filter( 'woocommerce_allow_marketplace_suggestions', '__return_false' );`
- Reload the payments setting page, the WooCommerce Payment Promotion should be hidden now