### PR TITLE
Fix variations table product filter

### DIFF
--- a/changelogs/fix-7768-variations-table-filter
+++ b/changelogs/fix-7768-variations-table-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix variations table product filter query. #8120

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -271,7 +271,7 @@ class VariationsReportTable extends Component {
 					orderby: query.orderby || 'items_sold',
 					order: query.order || 'desc',
 					extended_info: true,
-					product_includes: query.products,
+					product_includes: query.product_includes,
 					variations: query.variations,
 				} }
 				title={ __( 'Variations', 'woocommerce-admin' ) }


### PR DESCRIPTION
Fixes #7768

This PR fixes the wrong variations table product filter.

### Detailed test instructions:

1. Place orders for some variable products.
2. Go to **Analytics > Variations** screen.
3. Click on the **"All Variations"** dropdown and select the **"Advance Filter"** option.
4. Click on the **"+"** Add filter button.
5. Click on the "Product" option and select the **"include"** option.
6. Search for variation for which order is placed in step 5.
7. Observe that only variations of the searched product are displayed when the filter is applied for a single variation.

