### PR TITLE
Check if WC Pay is supported before adding gateway

### DIFF
--- a/changelogs/fix-wcpay-promotion-non-supported-country
+++ b/changelogs/fix-wcpay-promotion-non-supported-country
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix blank payment gateway method in table when WooCommerce Payments is not supported. #8122

--- a/src/Features/WcPayPromotion/Init.php
+++ b/src/Features/WcPayPromotion/Init.php
@@ -106,6 +106,10 @@ class Init {
 			return false;
 		}
 
+		$wc_pay_spec = self::get_wc_pay_promotion_spec();
+		if ( ! $wc_pay_spec ) {
+			return false;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Fix issue where a blank payment gateway shows up when the experiment is enabled and WC Pay is not supported.

(See last item in the screenshot)
<img width="1248" alt="Screen Shot 2022-01-06 at 2 52 01 PM" src="https://user-images.githubusercontent.com/2240960/148435509-ed51835d-6898-4e9b-b05b-e8b5519680b6.png">

### Detailed test instructions:

- Load the main branch first with a store in a country not supported by WC Pay (Brazil).
- Go to **WooCommerce > Settings > Payments** and notice the blank option in the table (this might require at-least WC 6)
- Load this branch now
- Reload the payment setting page, it should now be gone
- Set your store address to a supported WC Pay country (Canada or USA)
- Go to the payment settings page and see if the promotion shows up now

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
