### PR TITLE
Add localized validation to store address

### DIFF
--- a/changelogs/update-7782-store-details
+++ b/changelogs/update-7782-store-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add localized validation to store address #8123

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -17,36 +17,75 @@ import { getAdminSetting } from '~/utils/admin-settings';
 
 const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
 /**
+ * Check if a given address field is required for the locale.
+ *
+ * @param fieldName Name of the field to check.
+ * @param locale Locale data.
+ * @return boolean
+ */
+export function isAddressFieldRequired( fieldName, locale = {} ) {
+	if ( locale[ fieldName ]?.hasOwnProperty( 'required' ) ) {
+		return locale[ fieldName ]?.required;
+	}
+
+	if ( fieldName === 'address_2' ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Form validation.
  *
- * @param {Object} values Keyed values of all fields in the form.
- * @return {Object} Key value of fields and error messages, { myField: 'This field is required' }
+ * @param {Object} locale The store locale.
+ * @return {Function} Validator function.
  */
-export function validateStoreAddress( values ) {
-	const errors: {
-		[ key: string ]: string;
-	} = {};
+export function getStoreAddressValidator( locale = {} ) {
+	/**
+	 * Form validator.
+	 *
+	 * @param {Object} values Keyed values of all fields in the form.
+	 * @return {Object} Key value of fields and error messages, { myField: 'This field is required' }
+	 */
+	return ( values ) => {
+		const errors: {
+			[ key: string ]: string;
+		} = {};
 
-	if ( ! values.addressLine1.trim().length ) {
-		errors.addressLine1 = __(
-			'Please add an address',
-			'woocommerce-admin'
-		);
-	}
-	if ( ! values.countryState.trim().length ) {
-		errors.countryState = __(
-			'Please select a country / region',
-			'woocommerce-admin'
-		);
-	}
-	if ( ! values.city.trim().length ) {
-		errors.city = __( 'Please add a city', 'woocommerce-admin' );
-	}
-	if ( ! values.postCode.trim().length ) {
-		errors.postCode = __( 'Please add a post code', 'woocommerce-admin' );
-	}
+		if (
+			isAddressFieldRequired( 'address_1', locale ) &&
+			! values.addressLine1.trim().length
+		) {
+			errors.addressLine1 = __(
+				'Please add an address',
+				'woocommerce-admin'
+			);
+		}
+		if ( ! values.countryState.trim().length ) {
+			errors.countryState = __(
+				'Please select a country / region',
+				'woocommerce-admin'
+			);
+		}
+		if (
+			isAddressFieldRequired( 'city', locale ) &&
+			! values.city.trim().length
+		) {
+			errors.city = __( 'Please add a city', 'woocommerce-admin' );
+		}
+		if (
+			isAddressFieldRequired( 'postcode', locale ) &&
+			! values.postCode.trim().length
+		) {
+			errors.postCode = __(
+				'Please add a post code',
+				'woocommerce-admin'
+			);
+		}
 
-	return errors;
+		return errors;
+	};
 }
 
 /**
@@ -249,7 +288,7 @@ export function StoreAddress( props ) {
 					locale?.address_1?.label ||
 					__( 'Address line 1', 'woocommerce-admin' )
 				}
-				required
+				required={ isAddressFieldRequired( 'address_1', locale ) }
 				autoComplete="address-line1"
 				{ ...getInputProps( 'addressLine1' ) }
 			/>
@@ -259,7 +298,7 @@ export function StoreAddress( props ) {
 					locale?.address_2?.label ||
 					__( 'Address line 2 (optional)', 'woocommerce-admin' )
 				}
-				required
+				required={ isAddressFieldRequired( 'address_2', locale ) }
 				autoComplete="address-line2"
 				{ ...getInputProps( 'addressLine2' ) }
 			/>
@@ -282,7 +321,7 @@ export function StoreAddress( props ) {
 				label={
 					locale?.city?.label || __( 'City', 'woocommerce-admin' )
 				}
-				required
+				required={ isAddressFieldRequired( 'city', locale ) }
 				{ ...getInputProps( 'city' ) }
 				autoComplete="address-level2"
 			/>
@@ -292,7 +331,7 @@ export function StoreAddress( props ) {
 					locale?.postcode?.label ||
 					__( 'Post code', 'woocommerce-admin' )
 				}
-				required
+				required={ isAddressFieldRequired( 'postcode', locale ) }
 				autoComplete="postal-code"
 				{ ...getInputProps( 'postCode' ) }
 			/>

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -19,9 +19,9 @@ const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
 /**
  * Check if a given address field is required for the locale.
  *
- * @param fieldName Name of the field to check.
- * @param locale Locale data.
- * @return boolean
+ * @param {string} fieldName Name of the field to check.
+ * @param {Object} locale Locale data.
+ * @return {boolean} Field requirement.
  */
 export function isAddressFieldRequired( fieldName, locale = {} ) {
 	if ( locale[ fieldName ]?.hasOwnProperty( 'required' ) ) {
@@ -258,13 +258,11 @@ export function useGetCountryStateAutofill( options, countryState, setValue ) {
  * @return {Object} -
  */
 export function StoreAddress( props ) {
-	const { getInputProps, setValue } = props;
+	const { getInputProps, setValue, onChange } = props;
 	const countryState = getInputProps( 'countryState' ).value;
 	const { locale, hasFinishedResolution } = useSelect( ( select ) => {
 		return {
-			locale: select( COUNTRIES_STORE_NAME ).getLocale(
-				countryState?.split( ':' )[ 0 ] || 'US'
-			),
+			locale: select( COUNTRIES_STORE_NAME ).getLocale( countryState ),
 			hasFinishedResolution: select(
 				COUNTRIES_STORE_NAME
 			).hasFinishedResolution( 'getLocales' ),

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -17,6 +17,7 @@ import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Form, TextControl } from '@woocommerce/components';
 import {
+	COUNTRIES_STORE_NAME,
 	ONBOARDING_STORE_NAME,
 	OPTIONS_STORE_NAME,
 	SETTINGS_STORE_NAME,
@@ -31,7 +32,7 @@ import { Icon, info } from '@wordpress/icons';
 import { getCountryCode, getCurrencyRegion } from '../../../dashboard/utils';
 import {
 	StoreAddress,
-	validateStoreAddress,
+	getStoreAddressValidator,
 } from '../../../dashboard/components/settings/general/store-address';
 import UsageModal from '../usage-modal';
 import { CurrencyContext } from '../../../lib/currency-context';
@@ -68,6 +69,7 @@ class StoreDetails extends Component {
 
 		this.onContinue = this.onContinue.bind( this );
 		this.onSubmit = this.onSubmit.bind( this );
+		this.validateStoreDetails = this.validateStoreDetails.bind( this );
 	}
 
 	deriveCurrencySettings( countryState ) {
@@ -198,7 +200,9 @@ class StoreDetails extends Component {
 	}
 
 	validateStoreDetails( values ) {
-		const errors = validateStoreAddress( values );
+		const { locale } = this.props;
+		const validateAddress = getStoreAddressValidator( locale );
+		const errors = validateAddress( values );
 
 		if (
 			values.storeEmail &&
@@ -459,6 +463,10 @@ export default compose(
 			getEmailPrefill,
 			hasFinishedResolution: hasFinishedResolutionOnboarding,
 		} = select( ONBOARDING_STORE_NAME );
+		const {
+			getLocale,
+			hasFinishedResolution: hasFinishedResolutionCountries,
+		} = select( COUNTRIES_STORE_NAME );
 		const { isResolving } = select( OPTIONS_STORE_NAME );
 
 		const profileItems = getProfileItems();
@@ -471,7 +479,8 @@ export default compose(
 			isResolving( 'getOption', [ 'woocommerce_allow_tracking' ] );
 		const isLoading =
 			! hasFinishedResolutionOnboarding( 'getProfileItems' ) ||
-			! hasFinishedResolutionOnboarding( 'getEmailPrefill' );
+			! hasFinishedResolutionOnboarding( 'getEmailPrefill' ) ||
+			! hasFinishedResolutionCountries( 'getLocales' );
 		const errorsRef = useRef( {
 			settings: null,
 		} );
@@ -484,6 +493,7 @@ export default compose(
 			( settings.woocommerce_store_address &&
 				settings.woocommerce_default_country ) ||
 			'';
+		const locale = getLocale( countryState );
 
 		const initialValues = {
 			addressLine1: settings.woocommerce_store_address || '',
@@ -504,6 +514,7 @@ export default compose(
 		return {
 			initialValues,
 			isLoading,
+			locale,
 			profileItems,
 			isBusy,
 			settings,

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -200,7 +200,8 @@ class StoreDetails extends Component {
 	}
 
 	validateStoreDetails( values ) {
-		const { locale } = this.props;
+		const { getLocale } = this.props;
+		const locale = getLocale( values.countryState );
 		const validateAddress = getStoreAddressValidator( locale );
 		const errors = validateAddress( values );
 
@@ -465,6 +466,7 @@ export default compose(
 		} = select( ONBOARDING_STORE_NAME );
 		const {
 			getLocale,
+			getLocales,
 			hasFinishedResolution: hasFinishedResolutionCountries,
 		} = select( COUNTRIES_STORE_NAME );
 		const { isResolving } = select( OPTIONS_STORE_NAME );
@@ -493,7 +495,7 @@ export default compose(
 			( settings.woocommerce_store_address &&
 				settings.woocommerce_default_country ) ||
 			'';
-		const locale = getLocale( countryState );
+		getLocales();
 
 		const initialValues = {
 			addressLine1: settings.woocommerce_store_address || '',
@@ -512,9 +514,9 @@ export default compose(
 		};
 
 		return {
+			getLocale,
 			initialValues,
 			isLoading,
-			locale,
 			profileItems,
 			isBusy,
 			settings,

--- a/packages/data/src/countries/selectors.ts
+++ b/packages/data/src/countries/selectors.ts
@@ -7,6 +7,7 @@ export const getLocales = ( state: CountriesState ) => {
 	return state.locales;
 };
 
-export const getLocale = ( state: CountriesState, country: string ) => {
+export const getLocale = ( state: CountriesState, id: string ) => {
+	const country = id.split( ':' )[ 0 ];
 	return state.locales[ country ];
 };


### PR DESCRIPTION
Fixes #7782 

* Adds locale specific labels for address fields
* Updates required address fields and validation based on locale

Follow-ups:
* Ordering of fields based on priority
* Would be great to not have to pass `locale` back and forth to validation function, but not sure how we can both get the `locale` in the child `StoreAddress` and have validation from it go back to the parent

### Screenshots

<img width="533" alt="Screen Shot 2022-01-06 at 3 36 39 PM" src="https://user-images.githubusercontent.com/10561050/148448340-53ced110-5439-4f62-a14b-3fef8f355295.png">


### Detailed test instructions:

**Store details**
1. Navigate to the Store Details step of the profiler
2. Change the country/region to US.
3. Check that the address labels remain the same as they were before this PR
4. Check that all fields are still required
5. Change your country to Brazil
6. Make sure address labels 1 & 2 are updated
7. Change the country to HK
8. Check that zip/postal is no longer required

**Tasks**

1. Delete any shipping zones you might have
2. Delete the `woocommerce_store_address` option in your database so you're forced to re-enter your address
3. Visit the Shipping task in the task list
4. Note the same validation/labeling for the store location step as above