### PR TITLE
Enable wc-pay-welcome-page feature in the core config

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -19,6 +19,6 @@
 		"store-alerts": true,
 		"transient-notices": true,
 		"wc-pay-promotion": true,
-		"wc-pay-welcome-page": false
+		"wc-pay-welcome-page": true
 	}
 }


### PR DESCRIPTION
Fixes #8084

This PR enables `wc-pay-welcome-page` in the core config.

### Detailed test instructions:

1. Run `export WC_ADMIN_PHASE=core && npm run build:feature-config` 
2. Open `includes/feature-config.php` and confirm `wc-pay-welcome-page` is set to true.

no changelog