### PR TITLE
Fix storybook cannot resolve '@woocommerce/settings' error

### DIFF
--- a/storybook/setting.mock.js
+++ b/storybook/setting.mock.js
@@ -1,0 +1,4 @@
+// @woocommerce/settings mocked module for storybook webpack resolve.alias config
+// see ./webpack.config.js
+
+export function getSetting() {}

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = ( storybookConfig ) => {
 
 	storybookConfig.resolve.alias[ '@woocommerce/settings' ] = path.resolve(
 		__dirname,
-		`../client/wc-admin-settings/index`
+		'./setting.mock.js'
 	);
 
 	storybookConfig.resolve.modules = [


### PR DESCRIPTION
Fixes #8127

This PR fixes the `@woocommerce/settings` import error during the storybook compiling to fix the failing publish docs CI.  

```
Module not found: Error: Can't resolve '@woocommerce/settings' in '/home/runner/work/woocommerce-admin/woocommerce-admin/packages/components/src/advanced-filters/stories'
```

### Detailed test instructions:

1. Checkout to this branch
2. Should be able to run `npm run storybook` and `npm run docs` without error


no changelog