### PR TITLE
Enhance report chart i18n support

### DIFF
--- a/changelogs/enhancement-7827-report-i18n-translate
+++ b/changelogs/enhancement-7827-report-i18n-translate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Enhance report chart i18n support. #8129

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -29,7 +29,7 @@ import {
  */
 import { CurrencyContext } from '../../../lib/currency-context';
 import ReportError from '../report-error';
-import { getChartMode, getSelectedFilter } from './utils';
+import { getChartMode, getSelectedFilter, createDateFormatter } from './utils';
 
 /**
  * Component that renders the chart in reports.
@@ -165,7 +165,8 @@ export class ReportChart extends Component {
 		);
 		const formats = getDateFormatsForInterval(
 			currentInterval,
-			primaryData.data.intervals.length
+			primaryData.data.intervals.length,
+			{ type: 'php' }
 		);
 		const emptyMessage = emptySearchResults
 			? __( 'No data for the current search', 'woocommerce-admin' )
@@ -187,10 +188,14 @@ export class ReportChart extends Component {
 				mode={ mode }
 				path={ path }
 				query={ query }
-				screenReaderFormat={ formats.screenReaderFormat }
+				screenReaderFormat={ createDateFormatter(
+					formats.screenReaderFormat
+				) }
 				showHeaderControls={ showHeaderControls }
 				title={ selectedChart.label }
-				tooltipLabelFormat={ formats.tooltipLabelFormat }
+				tooltipLabelFormat={ createDateFormatter(
+					formats.tooltipLabelFormat
+				) }
 				tooltipTitle={
 					( mode === 'time-comparison' && selectedChart.label ) ||
 					null
@@ -201,8 +206,8 @@ export class ReportChart extends Component {
 				) }
 				chartType={ getChartTypeForQuery( query ) }
 				valueType={ selectedChart.type }
-				xFormat={ formats.xFormat }
-				x2Format={ formats.x2Format }
+				xFormat={ createDateFormatter( formats.xFormat ) }
+				x2Format={ createDateFormatter( formats.x2Format ) }
 				currency={ getCurrencyConfig() }
 			/>
 		);

--- a/client/analytics/components/report-chart/utils.js
+++ b/client/analytics/components/report-chart/utils.js
@@ -3,6 +3,7 @@
  */
 import { find, get } from 'lodash';
 import { flattenFilters } from '@woocommerce/navigation';
+import { format as formatDate } from '@wordpress/date';
 
 export const DEFAULT_FILTER = 'all';
 
@@ -42,4 +43,8 @@ export function getChartMode( selectedFilter, query ) {
 	}
 
 	return null;
+}
+
+export function createDateFormatter( format ) {
+	return ( date ) => formatDate( format, date );
 }

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
 -   Add "defaultDateRange" argument to "getAllowedIntervalsForQuery" for default period value. #8189
+-   Add type option to `getDateFormatsForInterval` to support `getDateFormatsForIntervalPhp` feature. #8129
 
 # 3.1.0
 

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -26,6 +26,9 @@
 		"moment": "2.29.1",
 		"qs": "6.9.6"
 	},
+	"devDependencies": {
+		"d3-time-format": "2.3.0"
+	},
 	"peerDependencies": {
 		"lodash": "^4.17.0"
 	},

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -584,13 +584,37 @@ export const defaultTableDateFormat = 'm/d/Y';
 
 /**
  * Returns date formats for the current interval.
+ *
+ * @param {string} interval Interval to get date formats for.
+ * @param {number} [ticks] Number of ticks the axis will have.
+ * @param {Object} [option] Options
+ * @param {string} [option.type] Date format type, d3 or php, defaults to d3.
+ * @return {string} Current interval.
+ */
+export function getDateFormatsForInterval(
+	interval,
+	ticks = 0,
+	option = { type: 'd3' }
+) {
+	switch ( option.type ) {
+		case 'php':
+			return getDateFormatsForIntervalPhp( interval, ticks );
+
+		case 'd3':
+		default:
+			return getDateFormatsForIntervalD3( interval, ticks );
+	}
+}
+
+/**
+ * Returns d3 date formats for the current interval.
  * See https://github.com/d3/d3-time-format for chart formats.
  *
  * @param  {string} interval Interval to get date formats for.
  * @param  {number}    [ticks] Number of ticks the axis will have.
  * @return {string} Current interval.
  */
-export function getDateFormatsForInterval( interval, ticks = 0 ) {
+export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
 	let screenReaderFormat = '%B %-d, %Y';
 	let tooltipLabelFormat = '%B %-d, %Y';
 	let xFormat = '%Y-%m-%d';
@@ -621,10 +645,12 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 				xFormat = '%b';
 				x2Format = '%Y';
 			}
+			// eslint-disable-next-line @wordpress/i18n-translator-comments
 			screenReaderFormat = __(
 				'Week of %B %-d, %Y',
 				'woocommerce-admin'
 			);
+			// eslint-disable-next-line @wordpress/i18n-translator-comments
 			tooltipLabelFormat = __(
 				'Week of %B %-d, %Y',
 				'woocommerce-admin'
@@ -641,6 +667,73 @@ export function getDateFormatsForInterval( interval, ticks = 0 ) {
 			screenReaderFormat = '%Y';
 			tooltipLabelFormat = '%Y';
 			xFormat = '%Y';
+			break;
+	}
+
+	return {
+		screenReaderFormat,
+		tooltipLabelFormat,
+		xFormat,
+		x2Format,
+		tableFormat,
+	};
+}
+
+/**
+ * Returns php date formats for the current interval.
+ * See see php.net/date.
+ *
+ * @param  {string} interval Interval to get date formats for.
+ * @param  {number}    [ticks] Number of ticks the axis will have.
+ * @return {string} Current interval.
+ */
+export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
+	let screenReaderFormat = 'F j, Y';
+	let tooltipLabelFormat = 'F j, Y';
+	let xFormat = 'Y-m-%d';
+	let x2Format = 'M Y';
+	let tableFormat = defaultTableDateFormat;
+
+	switch ( interval ) {
+		case 'hour':
+			screenReaderFormat = 'gA F j, Y';
+			tooltipLabelFormat = 'gA M j, Y';
+			xFormat = 'gA';
+			x2Format = 'M j, Y';
+			tableFormat = 'h A';
+			break;
+		case 'day':
+			if ( ticks < dayTicksThreshold ) {
+				xFormat = 'j';
+			} else {
+				xFormat = 'M';
+				x2Format = 'Y';
+			}
+			break;
+		case 'week':
+			if ( ticks < weekTicksThreshold ) {
+				xFormat = 'j';
+				x2Format = 'M Y';
+			} else {
+				xFormat = 'M';
+				x2Format = 'Y';
+			}
+			// eslint-disable-next-line @wordpress/i18n-translator-comments
+			screenReaderFormat = __( 'Week of F j, Y', 'woocommerce-admin' );
+			// eslint-disable-next-line @wordpress/i18n-translator-comments
+			tooltipLabelFormat = __( 'Week of F j, Y', 'woocommerce-admin' );
+			break;
+		case 'quarter':
+		case 'month':
+			screenReaderFormat = 'F Y';
+			tooltipLabelFormat = 'F Y';
+			xFormat = 'M';
+			x2Format = 'Y';
+			break;
+		case 'year':
+			screenReaderFormat = 'Y';
+			tooltipLabelFormat = 'Y';
+			xFormat = 'Y';
 			break;
 	}
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -718,14 +718,15 @@ export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
 				xFormat = 'M';
 				x2Format = 'Y';
 			}
-			screenReaderFormat = __(
-				'\\W\\e\\e\\k \\of F j, Y',
+
+			// Since some alphabet letters have php associated formats, we need to escape them first.
+			const escapedWeekOfStr = __(
+				'Week of',
 				'woocommerce-admin'
-			);
-			tooltipLabelFormat = __(
-				'\\W\\e\\e\\k \\of F j, Y',
-				'woocommerce-admin'
-			);
+			).replace( /(\w)/g, '\\$1' );
+
+			screenReaderFormat = `${ escapedWeekOfStr } F j, Y`;
+			tooltipLabelFormat = `${ escapedWeekOfStr } F j, Y`;
 			break;
 		case 'quarter':
 		case 'month':

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -681,7 +681,7 @@ export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
 
 /**
  * Returns php date formats for the current interval.
- * See see php.net/date.
+ * See see https://www.php.net/manual/en/datetime.format.php.
  *
  * @param  {string} interval Interval to get date formats for.
  * @param  {number}    [ticks] Number of ticks the axis will have.
@@ -690,7 +690,7 @@ export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
 export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
 	let screenReaderFormat = 'F j, Y';
 	let tooltipLabelFormat = 'F j, Y';
-	let xFormat = 'Y-m-%d';
+	let xFormat = 'Y-m-d';
 	let x2Format = 'M Y';
 	let tableFormat = defaultTableDateFormat;
 
@@ -718,10 +718,14 @@ export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
 				xFormat = 'M';
 				x2Format = 'Y';
 			}
-			// eslint-disable-next-line @wordpress/i18n-translator-comments
-			screenReaderFormat = __( 'Week of F j, Y', 'woocommerce-admin' );
-			// eslint-disable-next-line @wordpress/i18n-translator-comments
-			tooltipLabelFormat = __( 'Week of F j, Y', 'woocommerce-admin' );
+			screenReaderFormat = __(
+				'\\W\\e\\e\\k \\of F j, Y',
+				'woocommerce-admin'
+			);
+			tooltipLabelFormat = __(
+				'\\W\\e\\e\\k \\of F j, Y',
+				'woocommerce-admin'
+			);
 			break;
 		case 'quarter':
 		case 'month':

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import moment from 'moment';
-
+import { format as formatDate } from '@wordpress/date';
+import { timeFormat as d3TimeFormat } from 'd3-time-format';
 /**
  * Internal dependencies
  */
@@ -22,6 +23,9 @@ import {
 	getChartTypeForQuery,
 	getAllowedIntervalsForQuery,
 	getStoreTimeZoneMoment,
+	getDateFormatsForIntervalPhp,
+	getDateFormatsForIntervalD3,
+	dayTicksThreshold,
 } from '../';
 
 jest.mock( 'moment', () => {
@@ -1041,4 +1045,56 @@ describe( 'getStoreTimeZoneMoment', () => {
 		expect( mockTz ).not.toHaveBeenCalled();
 		expect( utcOffset ).toHaveBeenCalledWith( '-04:00' );
 	} );
+} );
+
+describe( 'getDateFormatsForIntervalPhp', () => {
+	const date = moment( '2022-01-01T13:00:00' ).tz( 'Asia/Taipei' );
+
+	test.each( [
+		{ interval: 'hour', ticks: 0 },
+		{ interval: 'day', ticks: dayTicksThreshold - 1 },
+		{ interval: 'day', ticks: dayTicksThreshold + 1 },
+		{ interval: 'week', ticks: dayTicksThreshold - 1 },
+		{ interval: 'week', ticks: dayTicksThreshold + 1 },
+		{ interval: 'quarter', ticks: 0 },
+		{ interval: 'month', ticks: 0 },
+		{ interval: 'year', ticks: 0 },
+		{ interval: 'default', ticks: 0 },
+	] )(
+		'should return formatted date same as getDateFormatsForIntervalD3 when interval is $interval and ticks is $ticks',
+		( { interval, ticks } ) => {
+			const dateFormatsPhp = getDateFormatsForIntervalPhp(
+				interval,
+				ticks
+			);
+			const dateFormatsD3 = getDateFormatsForIntervalD3(
+				interval,
+				ticks
+			);
+
+			expect(
+				formatDate( dateFormatsPhp.screenReaderFormat, date )
+			).toBe(
+				d3TimeFormat( dateFormatsD3.screenReaderFormat )(
+					date
+				).trimStart() // trim the leading space since d3.timeFormat adds it but it does not affect the UI
+			);
+
+			expect(
+				formatDate( dateFormatsPhp.tooltipLabelFormat, date )
+			).toBe(
+				d3TimeFormat( dateFormatsD3.tooltipLabelFormat )(
+					date
+				).trimStart()
+			);
+
+			expect( formatDate( dateFormatsPhp.xFormat, date ) ).toBe(
+				d3TimeFormat( dateFormatsD3.xFormat )( date ).trimStart()
+			);
+
+			expect( formatDate( dateFormatsPhp.x2Format, date ) ).toBe(
+				d3TimeFormat( dateFormatsD3.x2Format )( date ).trimStart()
+			);
+		}
+	);
 } );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -1048,8 +1048,6 @@ describe( 'getStoreTimeZoneMoment', () => {
 } );
 
 describe( 'getDateFormatsForIntervalPhp', () => {
-	const date = moment( '2022-01-01T13:00:00' ).tz( 'Asia/Taipei' );
-
 	test.each( [
 		{ interval: 'hour', ticks: 0 },
 		{ interval: 'day', ticks: dayTicksThreshold - 1 },
@@ -1063,6 +1061,8 @@ describe( 'getDateFormatsForIntervalPhp', () => {
 	] )(
 		'should return formatted date same as getDateFormatsForIntervalD3 when interval is $interval and ticks is $ticks',
 		( { interval, ticks } ) => {
+			const date = new Date();
+
 			const dateFormatsPhp = getDateFormatsForIntervalPhp(
 				interval,
 				ticks


### PR DESCRIPTION
Fixes #7827

This PR adds the i18n support for **the labels on the tooltip, screenReader, and x-axis** of the report chart.

Previously, all formatted texts are English only because we use `d3.timeFormat` to format the date string but we didn't load d3 locale files. If we keep using `d3.timeFormat`, we need to load its locales. 

However, I use `@wordpress/date` to handle this since we already use it in many places. I didn't remove the d3 format-related code to have the backward-compatible for other library users.

### Screenshots

English

![Screen Shot 2022-01-07 at 12 13 23](https://user-images.githubusercontent.com/4344253/148490486-7492c5ad-df68-4e0e-a331-1b14f335f31c.png)

Portuguese (Brazil)

![Screen Shot 2022-01-07 at 12 12 07](https://user-images.githubusercontent.com/4344253/148490407-6b7f4ce6-d4c6-4202-8002-3b3f98ec3114.png)


### Detailed test instructions:

1. Go to **Analytics > Overview**
2. Observe chart texts show normally in English/site language.
3. Select different "Date range" options, and repeat step 2 until all options are confirmed.
4. Go to **Settings > General** 
5. Change the "Site Language" to other languages like "Português do Brasil"
6. Repeat 1 ~ 3 steps
