### PR TITLE
Make sure WP_ENVIRONMENT_TYPE is defined before checking the value

### DIFF
--- a/src/Schedulers/MailchimpScheduler.php
+++ b/src/Schedulers/MailchimpScheduler.php
@@ -87,7 +87,7 @@ class MailchimpScheduler {
 	 * @return mixed
 	 */
 	public function make_request( $store_email ) {
-		if ( 'development' === constant( 'WP_ENVIRONMENT_TYPE' ) ) {
+		if ( true === defined( 'WP_ENVIRONMENT_TYPE' ) && 'development' === constant( 'WP_ENVIRONMENT_TYPE' ) ) {
 			$subscribe_endpoint = self::SUBSCRIBE_ENDPOINT_DEV;
 		} else {
 			$subscribe_endpoint = self::SUBSCRIBE_ENDPOINT;


### PR DESCRIPTION
Fixes #8060 

This PR makes sure `WP_ENVIRONMENT_TYPE` is defined before attempting to get the value to prevent error in PHP 8+

### Detailed test instructions:

Reproducing the error:

1. Start with the latest `main` without the change in this PR.
2. Use PHP 8+ version
3. Start OBW and check "Get tips, product updates and inspiration straight to your mailbox."
4. Finish OBW.
5. Install `WP Crontrol` plugin.
6. Navigate to `Tools -> Cron events` and run `wp_admin_daily`
7. Check `wp-content/debug.log`. 

Confirming the fix:

1. Repeat the same steps with this branch.
2. You should not see any errors related to constant.

no changelog
