### PR TITLE
Fix incorrectly selected column type in two-cols experiment

### DIFF
--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -69,15 +69,6 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		hideTaskList( id );
 	};
 
-	useEffect( () => {
-		// @todo Update this when all task lists have been hidden or completed.
-		const taskListsFinished = false;
-		updateOptions( {
-			woocommerce_task_list_prompt_shown: true,
-			woocommerce_default_homepage_layout: 'two_columns',
-		} );
-	}, [ taskLists, isResolving ] );
-
 	const currentTask = getCurrentTask();
 
 	if ( task && ! currentTask ) {

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -69,6 +69,12 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		hideTaskList( id );
 	};
 
+	useEffect( () => {
+		updateOptions( {
+			woocommerce_task_list_prompt_shown: true,
+		} );
+	}, [ taskLists, isResolving ] );
+
 	const currentTask = getCurrentTask();
 
 	if ( task && ! currentTask ) {


### PR DESCRIPTION
Fixes #8126

This PR fixes the issue by removing a code block where it updates `woocommerce_default_homepage_layout` to two_columns.

I actually don't know why we have this code block. It looks like it always updates the option to `two_columns` without any condition. I tested the workflow without the code block and everything worked as expected.

### Detailed test instructions:

1. Start with a fresh installation.
2. Navigate to WooCommerce -> Home
3. Open the inspector -> Application -> Local storage -> select your current site.
4. Select `explat-experiment--woocommerce_tasklist_progression_headercard_2022_01` and change `variationName` to `treatment`
5. Refresh
6. Click `Display` from the activity panel. The column should match your current layout/


no changelog