### PR TITLE
Fix duplicated back button with two-cols experiment

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -195,7 +195,7 @@ export const Layout = ( {
 					/>
 					<TwoColumnTasksExtended
 						query={ query }
-						renderTask={ false }
+						shouldRenderTask={ false }
 					/>
 				</>
 			);

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -193,7 +193,10 @@ export const Layout = ( {
 						userPreferences={ userPrefs }
 						twoColumns={ twoColumns }
 					/>
-					<TwoColumnTasksExtended query={ query } />
+					<TwoColumnTasksExtended
+						query={ query }
+						renderTask={ false }
+					/>
 				</>
 			);
 		}

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -24,7 +24,10 @@ export type TasksProps = {
 	query: { task?: string };
 };
 
-const ExtendedTask: React.FC< TasksProps > = ( { query, renderTask } ) => {
+const ExtendedTask: React.FC< TasksProps > = ( {
+	query,
+	shouldRenderTask,
+} ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -88,7 +91,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query, renderTask } ) => {
 		return <TasksPlaceholder query={ query } />;
 	}
 
-	if ( currentTask && renderTask ) {
+	if ( currentTask && shouldRenderTask ) {
 		return (
 			<div className="woocommerce-task-dashboard__container">
 				<Task query={ query } task={ currentTask } />

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -24,7 +24,7 @@ export type TasksProps = {
 	query: { task?: string };
 };
 
-const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
+const ExtendedTask: React.FC< TasksProps > = ( { query, rednerTask } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -88,7 +88,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 		return <TasksPlaceholder query={ query } />;
 	}
 
-	if ( currentTask ) {
+	if ( currentTask && rednerTask ) {
 		return (
 			<div className="woocommerce-task-dashboard__container">
 				<Task query={ query } task={ currentTask } />

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -24,7 +24,7 @@ export type TasksProps = {
 	query: { task?: string };
 };
 
-const ExtendedTask: React.FC< TasksProps > = ( { query, rednerTask } ) => {
+const ExtendedTask: React.FC< TasksProps > = ( { query, renderTask } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -88,7 +88,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query, rednerTask } ) => {
 		return <TasksPlaceholder query={ query } />;
 	}
 
-	if ( currentTask && rednerTask ) {
+	if ( currentTask && renderTask ) {
 		return (
 			<div className="woocommerce-task-dashboard__container">
 				<Task query={ query } task={ currentTask } />


### PR DESCRIPTION
Fixes #8131 

This PR fixes the duplicated back button by making sure we render individual tasks only once in the two-cols experiment.

The issue only occurs when you're in a treatment group of `woocommerce_tasklist_progression_headercard_2022_01` experiment when you have both task and extended list.

### Detailed test instructions:

Let's reproduce the bug first.

1. Try with the latest `main`
2. Navigate to WooCommerce -> Home
3. Assign yourself to  `woocommerce_tasklist_progression_headercard_2022_01` experiment.
4. Refresh the page and confirm you're seeing the new tasklist with the header card design.
5. Click one of the tasks. 
6. You should see two back buttons.

Let's confirm the fix.

1. Clone this branch.
2. Repeat the steps.
3. Back button should be rendered correctly.

no changelog