### PR TITLE
Adding allowed plugins to composer configuration

### DIFF
--- a/changelogs/update-composer-add-allow-plugins
+++ b/changelogs/update-composer-add-allow-plugins
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Update
 
-Adding "allow-plugins" property for composer configuration
+Adding "allow-plugins" property for composer configuration. #8139

--- a/changelogs/update-composer-add-allow-plugins
+++ b/changelogs/update-composer-add-allow-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Adding "allow-plugins" property for composer configuration

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,12 @@
 	"config": {
 		"platform": {
 			"php": "7.1"
+		},
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true,
+			"bamarni/composer-bin-plugin": true,
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
This is a configuration tweak for composer to add the `allowed-plugins` property, used since version 2.2. I've added the plugins included in our current configuration, which without this change you would have to approve manually with each `composer install`: 

![image](https://user-images.githubusercontent.com/444632/148843688-fd404e89-54f3-4ffe-bfab-fa2fe90529a4.png)

Here are more details around the change: https://blog.packagist.com/composer-2-2/


### Detailed test instructions:

-  Update composer to >= 2.2
-   Checkout branch
- Run `composer install`, and you should _not_ be prompted to approve of each plugin manually.
- Checkout `main`, and notice that you are prompted when running the same command
