### PR TITLE
Fix PHP ExPlat warning

### DIFF
--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -136,7 +136,7 @@ final class Experimental_Abtest {
 		}
 
 		// Store the variation in our internal cache.
-		$this->tests[ $test_name ] = $results['variations'][ $test_name ];
+		$this->tests[ $test_name ] = $results['variations'][ $test_name ] ?? null;
 
 		$variation = $results['variations'][ $test_name ] ?? 'control';
 


### PR DESCRIPTION
Fixes #8140

This PR fixes a PHP warning when it's trying to access an array with a non-existing key by null-coalescing it.

### Detailed test instructions:

1. Make sure `_transient_abtest_variation_woocommerce_payments_menu_promo_nz_ie_2022_01` option doesn't exist in `wp_options` table.
2. Enable PHP debugging to show warnings
3. Go to homescreen
4. Make sure no warning is displayed

no changelog