### PR TITLE
Change WCPay menu experiment check ordering

### DIFF
--- a/src/Features/WcPayWelcomePage.php
+++ b/src/Features/WcPayWelcomePage.php
@@ -23,10 +23,6 @@ class WcPayWelcomePage {
 	public function register_payments_welcome_page() {
 		global $menu;
 
-		if ( ! $this->should_add_the_menu() ) {
-			return;
-		}
-
 		// WC Payment must not be active.
 		if ( is_plugin_active( 'woocommerce-payments/woocommerce-payments.php' ) ) {
 			return;
@@ -39,6 +35,10 @@ class WcPayWelcomePage {
 		}
 
 		if ( 'yes' === get_option( 'wc_calypso_bridge_payments_dismissed', 'no' ) ) {
+			return;
+		}
+
+		if ( ! $this->should_add_the_menu() ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR changes the experiment to run **after** initial checking of WCPay plugin install status and country support.

This is because running the experiment first will include ineligible users into the experiment and will clutter the result data. Running it after the checks will only include eligible users. This is to address the concern [here](woocommerce/woocommerce#32219):

> Also, how do we ensure that new users and users who already have the extension installed or a wcpay account are not exposed to the experiment?

### Detailed test instructions:

Make sure things still works https://github.com/woocommerce/woocommerce-admin/pull/8083