### PR TITLE
Change WCPay menu experiment pageview track

### DIFF
--- a/client/payments-welcome/index.tsx
+++ b/client/payments-welcome/index.tsx
@@ -258,7 +258,7 @@ const ConnectAccountPage = () => {
 	};
 	useEffect( () => {
 		recordEvent( 'page_view', {
-			path: 'payments_connect_dotcom_test',
+			path: 'payments_connect_core_test',
 		} );
 		storeViewWelcome();
 	}, [ hasViewedWelcomePage ] );


### PR DESCRIPTION
This PR updates the `path` prop in `page_view` track used in WCPay menu experiment.

### Detailed test instructions:

1. Open your browser console.
2. If you haven't enabled tracks debug, type in `localStorage.setItem( 'debug', 'wc-admin:tracks*' );` to enable it.
1. Navigate to the WCPay welcome page.
2. Note the track `wcadmin_page_view` is recorded with the prop `{path: "payments_connect_core_test"} 

No changelog