### PR TITLE
Add Magento migration note

### DIFF
--- a/changelogs/add-7971
+++ b/changelogs/add-7971
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add Magento migration note #8145

--- a/src/Events.php
+++ b/src/Events.php
@@ -45,6 +45,7 @@ use \Automattic\WooCommerce\Admin\Notes\CompleteStoreDetails;
 use \Automattic\WooCommerce\Admin\Notes\UpdateStoreDetails;
 use \Automattic\WooCommerce\Admin\Notes\SetUpAdditionalPaymentTypes;
 use \Automattic\WooCommerce\Admin\Notes\PaymentsRemindMeLater;
+use \Automattic\WooCommerce\Admin\Notes\MagentoMigration;
 
 /**
  * Events Class.
@@ -140,6 +141,7 @@ class Events {
 		CompleteStoreDetails::possibly_add_note();
 		UpdateStoreDetails::possibly_add_note();
 		PaymentsRemindMeLater::possibly_add_note();
+		MagentoMigration::possibly_add_note();
 	}
 
 	/**

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -20,6 +20,7 @@ use \Automattic\WooCommerce\Admin\Notes\MerchantEmailNotifications\MerchantEmail
 use \Automattic\WooCommerce\Admin\Notes\WelcomeToWooCommerceForStoreUsers;
 use \Automattic\WooCommerce\Admin\Notes\ManageStoreActivityFromHomeScreen;
 use \Automattic\WooCommerce\Admin\Notes\NavigationNudge;
+use \Automattic\WooCommerce\Admin\Notes\MagentoMigration;
 use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
@@ -192,6 +193,7 @@ class FeaturePlugin {
 		new WelcomeToWooCommerceForStoreUsers();
 		new ManageStoreActivityFromHomeScreen();
 		new NavigationNudge();
+		new MagentoMigration();
 
 		// Initialize MerchantEmailNotifications.
 		MerchantEmailNotifications::init();

--- a/src/Notes/MagentoMigration.php
+++ b/src/Notes/MagentoMigration.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WooCommerce Admin note on how to migrate from Magento.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * MagentoMigration
+ */
+class MagentoMigration {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-magento-migration';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'update_option_' . Onboarding::PROFILE_DATA_OPTION, array( __CLASS__, 'possibly_add_note' ) );
+		add_action( 'woocommerce_admin_magento_migration_note', array( __CLASS__, 'save_note' ) );
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 */
+	public static function possibly_add_note() {
+		$onboarding_profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+
+		if ( empty( $onboarding_profile ) ) {
+			return;
+		}
+
+		if (
+			! isset( $onboarding_profile['other_platform'] ) ||
+			'magento' !== $onboarding_profile['other_platform']
+		) {
+			return;
+		}
+
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			$onboarding_profile['setup_client']
+		) {
+			return;
+		}
+
+		WC()->queue()->schedule_single( time() + ( 5 * MINUTE_IN_SECONDS ), 'woocommerce_admin_magento_migration_note' );
+	}
+
+	/**
+	 * Save the note to the database.
+	 */
+	public static function save_note() {
+		$note = self::get_note();
+
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		$note->save();
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$note = new Note();
+
+		$note->set_title( __( 'How to Migrate from Magento to WooCommerce', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Changing platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/how-migrate-from-magento-to-woocommerce/?utm_source=inbox'
+		);
+
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #7971 

Add note about migration from Magento 5 minutes after profiler settings update.

### Screenshots
<img width="722" alt="Screen Shot 2022-01-11 at 1 40 49 PM" src="https://user-images.githubusercontent.com/10561050/149002157-97f42063-5e61-45d8-a881-74bf3756ece4.png">


### Detailed test instructions:

1. Do not select `Magento` as another platform and/or checked `I'm setting up a store for a client` during the setup profiler
2. Walk through the profiler
3. Make sure the note is not created
4. Make sure the action `woocommerce_admin_magento_migration_note` is not created under Tools->Scheduled actions
5. Repeat these steps, selecting `Magento` and unchecking `I'm setting up a store for a client`
6. Note that an action is created under Tools->Scheduled actions
7. In 5 minutes, note a note is created
8. Delete the note
9. Run `wc_admin_daily` cron event
10. Note the note is recreated after 5 minutes (as it would be for sites not going through the profiler again)
