### PR TITLE
Add tasklist_payment_setup track for WooCommerce Payments

### DIFF
--- a/changelogs/fix-7881_wcpay_setup_tracks
+++ b/changelogs/fix-7881_wcpay_setup_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Make sure WooCommerce Payments tasklist_payment_setup is triggered again. #8146

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
@@ -6,6 +6,10 @@ import { Button, Spinner } from '@wordpress/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { getPluginTrackKey } from '~/utils';
 
 export const Action = ( {
 	hasSetup = false,
@@ -32,6 +36,10 @@ export const Action = ( {
 
 	const handleClick = async () => {
 		onSetUp( id );
+
+		recordEvent( 'tasklist_payment_setup', {
+			selected: getPluginTrackKey( id ),
+		} );
 
 		if ( onSetupCallback ) {
 			setIsBusy( true );

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/List/Item.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/List/Item.js
@@ -5,14 +5,12 @@ import classnames from 'classnames';
 import { Fragment } from '@wordpress/element';
 import { CardBody, CardMedia, CardDivider } from '@wordpress/components';
 import { RecommendedRibbon, SetupRequired } from '@woocommerce/onboarding';
-import { recordEvent } from '@woocommerce/tracks';
 import { Text, useSlot } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import { Action } from '../Action';
-import { getPluginTrackKey } from '~/utils';
 import './List.scss';
 
 export const Item = ( { isRecommended, markConfigured, paymentGateway } ) => {
@@ -87,11 +85,6 @@ export const Item = ( { isRecommended, markConfigured, paymentGateway } ) => {
 						isRecommended={ isRecommended }
 						isLoading={ loading }
 						markConfigured={ markConfigured }
-						onSetUp={ () =>
-							recordEvent( 'tasklist_payment_setup', {
-								selected: getPluginTrackKey( id ),
-							} )
-						}
 					/>
 				</div>
 			</CardBody>

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
@@ -19,7 +19,6 @@ import {
  */
 
 import { Action } from '../Action';
-import { getPluginTrackKey } from '~/utils';
 
 const TosPrompt = () =>
 	interpolateComponents( {
@@ -83,11 +82,6 @@ export const Suggestion = ( { paymentGateway, onSetupCallback = null } ) => {
 							'woocommerce-admin'
 						) }
 						onSetupCallback={ onSetupCallback }
-						onSetUp={ () =>
-							recordEvent( 'tasklist_payment_setup', {
-								selected: getPluginTrackKey( id ),
-							} )
-						}
 					/>
 				</>
 			</WCPayCardFooter>


### PR DESCRIPTION
Fixes #7881 

This changes adds back the triggering of the `tasklist_payment_setup` track for wcpay in the payment method task.

### Detailed test instructions:

- Load this branch and make sure you have a store without WooCommerce Payments installed, but have a country selected that WC Pay supports
- Go to **WooCommerce > Home** and click on the **Set up payments** task
- Make sure you have your console open and the tracks output enabled (`localStorage.setItem( 'debug', 'wc-admin:*' );`)
- Click **Get started** for WC Pay, and it should output a `tasklist_payment_setup` track with the selected prop having `wcpay` as it's value.
- Go back to the  **Set up payments** task and click Set up for one of the other payment providers, make sure the track is still triggered with the correct property.