### PR TITLE
Fix marketing task not displaying on Atomic sites.

### DIFF
--- a/changelogs/fix-8149
+++ b/changelogs/fix-8149
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fixing marketing task not displaying on Atomic sites #8150

--- a/src/Features/RemoteFreeExtensions/EvaluateExtension.php
+++ b/src/Features/RemoteFreeExtensions/EvaluateExtension.php
@@ -24,7 +24,7 @@ class EvaluateExtension {
 		$rule_evaluator = new RuleEvaluator();
 
 		if ( isset( $extension->is_visible ) ) {
-			$is_visible            = is_bool( $extension->is_visible ) ? $extension->is_visible : $rule_evaluator->evaluate( $extension->is_visible );
+			$is_visible            = $rule_evaluator->evaluate( $extension->is_visible );
 			$extension->is_visible = $is_visible;
 		} else {
 			$extension->is_visible = true;

--- a/src/Features/RemoteFreeExtensions/EvaluateExtension.php
+++ b/src/Features/RemoteFreeExtensions/EvaluateExtension.php
@@ -24,7 +24,7 @@ class EvaluateExtension {
 		$rule_evaluator = new RuleEvaluator();
 
 		if ( isset( $extension->is_visible ) ) {
-			$is_visible            = $rule_evaluator->evaluate( $extension->is_visible );
+			$is_visible            = is_bool( $extension->is_visible ) ? $extension->is_visible : $rule_evaluator->evaluate( $extension->is_visible );
 			$extension->is_visible = $is_visible;
 		} else {
 			$extension->is_visible = true;

--- a/src/RemoteInboxNotifications/RuleEvaluator.php
+++ b/src/RemoteInboxNotifications/RuleEvaluator.php
@@ -37,6 +37,11 @@ class RuleEvaluator {
 	 * @return bool The result of the operation.
 	 */
 	public function evaluate( $rules, $stored_state = null, $logger_args = array() ) {
+
+		if ( is_bool( $rules ) ) {
+			return $rules;
+		}
+
 		if ( ! is_array( $rules ) ) {
 			$rules = array( $rules );
 		}


### PR DESCRIPTION
Fixes #8149

This is an issue that surfaced on Atomic sites only, that resulted in the Marketing task not being shown. As I mentioned in the issue, this ultimately came down to incorrectly passing a boolean value to be evaluated as if it were a set of rules for the extensions spec. Instead we're simply accepting a boolean if provided, and only evaluating otherwise. 

### Detailed test instructions:
**Testing on Atomic Ephemeral**
- Checkout this branch locally
- Create a zip with `npm run test:zip` (but you won't use this just yet)
- Create an Atomic Ephemeral site [here](https://mc.a8c.com/atomic/ephemeral-sites/)
-  SSH into your new ephemeral site with the provided connection string
- Install/activate the latest woocommerce with `wp plugin install https://github.com/woocommerce/woocommerce/releases/download/6.1.0/woocommerce.zip --activate`
- Log into the admin panel and look at the Homescreen. You'll notice that the marketing task is missing in the "Get ready to start selling" task list. It would read "Set up marketing tools."
- Now go back to your local machine in the directory that you just build this branch into a zip file. Copy this file to your ephemeral instance with this command: `scp ./woocommerce-admin.zip YOUR_CONNECTION_STRING:/srv/htdocs`
_Note: Your connection string is simply the username@ssh.atomicsites.net string that you used to SSH, and you'll need to enter your password again_
- Go back to your SSH instance and notice that the `woocommerce-admin.zip` file is now located at `/srv/htdocs`, where your SSH session started. 
- Run `wp plugin install ./woocommerce-admin.zip --activate`
- Refresh the Homescreen on the admin page for your ephemeral instance and notice that the marketing task now appears:
![image](https://user-images.githubusercontent.com/444632/149220615-55d84cc6-fb3a-494f-bdbb-6beec8b58c4d.png)
