### PR TITLE
Make activity panel badges margin consistent

### DIFF
--- a/changelogs/tweak-8035-activity-panel-badges-margin
+++ b/changelogs/tweak-8035-activity-panel-badges-margin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Make activity panel badges margin consistent. #8152

--- a/client/homescreen/style.scss
+++ b/client/homescreen/style.scss
@@ -59,6 +59,10 @@
 		margin-bottom: $gap-large;
 	}
 
+	.components-text + .woocommerce-badge {
+		margin-left: 16px;
+	}
+
 	@include breakpoint( '<782px' ) {
 		width: 100%;
 		position: inherit;

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -36,12 +36,6 @@
 	transition: opacity 500ms, transform 500ms, max-height 500ms;
 }
 
-.wooocommerce-inbox-card__header {
-	.woocommerce-badge {
-		margin-left: 16px;
-	}
-}
-
 .woocommerce-inbox-dismiss-all-modal {
 	width: 565px;
 	max-width: 100%;

--- a/client/tasks/tasks.scss
+++ b/client/tasks/tasks.scss
@@ -23,10 +23,6 @@
 	.woocommerce-task-card {
 		.wooocommerce-task-card__header {
 			display: flex;
-
-			.woocommerce-badge {
-				margin-left: 16px;
-			}
 		}
 
 		.woocommerce-list__item-text {


### PR DESCRIPTION
Fixes #8035

This PR fixes the inconsistent margin style between Activity panel card titles and the badges.

I set the style in the parent component to ensure consistency.

### Screenshots

Before:
![screen1](https://user-images.githubusercontent.com/5121465/146105078-75ca953d-ee47-4a46-bccd-2b5467bd31f3.png)

After:
![Screen Shot 2022-01-12 at 15 07 43](https://user-images.githubusercontent.com/4344253/149081325-2bfc8bbf-181a-4f8a-a373-bb9de5bd9c7a.png)



### Detailed test instructions:

- Checkout to this branch
- Create some products or place some orders.
- Dismiss the task list to show the Activity panel
- Observe the margin between the Activity panel card titles and the badges is the same as other card titles.