### PR TITLE
Fix category report query returns invalid net sales

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Fix category report query returns invalid net sales
+
+1. Create a new store and finish the Onboarding flow
+2. Go to **Products > Add New** and create a product called **Hoodie with Pocket** with the price $35
+3. Create a new category called **Hoodie** with **Clothing** as the parent category in the **Product categories** on the right.
+4. Select **Clothing** and **Hoodie with Pocket** as well and click **Update**
+5. Create an order with a single item of **Hoodie with Pocket** (keep note of the total price)
+6. Run the action scheduler (make sure all are run)
+7. Go to **Analytics > Overview** and scroll down to the **Leaderboards**
+8. Observe that the **Clothing** category has only **1** items sold and net sales is $35
+9. Click on **Clothing** it will redirect to the Categories page and show the correct numbers
+10. Now click on **Analytics > Categories** again and scroll down to the table
+11. Observe that the **Clothing** category has only **1** items sold and net sales is $35
+
 ## 3.1.0
 
 ### Inbox - 320 character limit

--- a/changelogs/fix-7710-overview-category-report-query-invalid-net-sales
+++ b/changelogs/fix-7710-overview-category-report-query-invalid-net-sales
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix category report query returns invalid net sales. #8153

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -94,21 +94,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$wpdb->term_relationships} ON {$order_product_lookup_table}.product_id = {$wpdb->term_relationships}.object_id" );
 		// Adding this (inner) JOIN as a LEFT JOIN for ordering purposes. See comment in add_order_by_params().
 		$this->subquery->add_sql_clause( 'left_join', "JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.term_taxonomy_id = {$wpdb->term_relationships}.term_taxonomy_id" );
-		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$wpdb->wc_category_lookup} ON {$wpdb->term_taxonomy}.term_id = {$wpdb->wc_category_lookup}.category_id" );
 
 		$included_categories = $this->get_included_categories( $query_args );
 		if ( $included_categories ) {
-			$this->subquery->add_sql_clause( 'where', "AND {$wpdb->wc_category_lookup}.category_tree_id IN ({$included_categories})" );
+			$this->subquery->add_sql_clause( 'where', "AND {$wpdb->term_relationships}.term_taxonomy_id IN ({$included_categories})" );
 
 			// Limit is left out here so that the grouping in code by PHP can be applied correctly.
 			// This also needs to be put after the term_taxonomy JOIN so that we can match the correct term name.
 			$this->add_order_by_params( $query_args, 'outer', 'default_results.category_id' );
 		} else {
-			$this->add_order_by_params( $query_args, 'inner', "{$wpdb->wc_category_lookup}.category_tree_id" );
+			$this->add_order_by_params( $query_args, 'inner', "{$wpdb->term_relationships}.term_taxonomy_id" );
 		}
 
 		$this->add_order_status_clause( $query_args, $order_product_lookup_table, $this->subquery );
-		$this->subquery->add_sql_clause( 'where', "AND {$wpdb->wc_category_lookup}.category_tree_id IS NOT NULL" );
+		$this->subquery->add_sql_clause( 'where', "AND {$wpdb->term_taxonomy}.taxonomy = 'product_cat'" );
 	}
 
 	/**
@@ -125,7 +124,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->add_orderby_order_clause( $query_args, $this );
 
 		if ( false !== strpos( $order_by_clause, '_terms' ) ) {
-			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_id";
+			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_taxonomy_id";
 			if ( 'inner' === $from_arg ) {
 				// Even though this is an (inner) JOIN, we're adding it as a `left_join` to
 				// affect its order in the query statement. The SqlQuery::$sql_filters variable
@@ -263,9 +262,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$categories_query = $this->subquery->get_query_statement();
 			}
 			$categories_data = $wpdb->get_results(
-				$categories_query,
+				$categories_query, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				ARRAY_A
-			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+			);
 
 			if ( null === $categories_data ) {
 				return new \WP_Error( 'woocommerce_analytics_categories_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ), array( 'status' => 500 ) );
@@ -299,8 +298,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	protected function initialize_queries() {
 		global $wpdb;
 		$this->subquery = new SqlQuery( $this->context . '_subquery' );
-		$this->subquery->add_sql_clause( 'select', "{$wpdb->wc_category_lookup}.category_tree_id as category_id," );
+		$this->subquery->add_sql_clause( 'select', "{$wpdb->term_taxonomy}.term_taxonomy_id as category_id," );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
-		$this->subquery->add_sql_clause( 'group_by', "{$wpdb->wc_category_lookup}.category_tree_id" );
+		$this->subquery->add_sql_clause( 'group_by', "{$wpdb->term_taxonomy}.term_taxonomy_id" );
 	}
 }

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -124,7 +124,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->add_orderby_order_clause( $query_args, $this );
 
 		if ( false !== strpos( $order_by_clause, '_terms' ) ) {
-			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_taxonomy_id";
+			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_id";
 			if ( 'inner' === $from_arg ) {
 				// Even though this is an (inner) JOIN, we're adding it as a `left_join` to
 				// affect its order in the query statement. The SqlQuery::$sql_filters variable


### PR DESCRIPTION
Fixes #7710

This PR fixes the **"category report shows double the amount for the parent category"** by fixing the category query SQL query.

Old sql:

```sql
SELECT
    wp_wc_category_lookup.category_tree_id AS category_id,
    SUM(product_qty) AS items_sold,
    SUM(product_net_revenue) AS net_revenue,
    COUNT(
        DISTINCT wp_wc_order_product_lookup.order_id
    ) AS orders_count,
    COUNT(
        DISTINCT wp_wc_order_product_lookup.product_id
    ) AS products_count
FROM
    wp_wc_order_product_lookup
JOIN wp_wc_order_stats ON wp_wc_order_product_lookup.order_id = wp_wc_order_stats.order_id
LEFT JOIN wp_term_relationships ON wp_wc_order_product_lookup.product_id = wp_term_relationships.object_id
JOIN wp_term_taxonomy ON wp_term_taxonomy.term_taxonomy_id = wp_term_relationships.term_taxonomy_id
LEFT JOIN wp_wc_category_lookup ON wp_term_taxonomy.term_id = wp_wc_category_lookup.category_id
WHERE
    1 = 1 AND(
        wp_wc_order_stats.status NOT IN(
            'wc-trash',
            'wc-pending',
            'wc-failed',
            'wc-cancelled'
        )
    ) AND wp_wc_category_lookup.category_tree_id IS NOT NULL AND wp_wc_order_product_lookup.date_created <= '2021-09-24 23:59:59'  AND wp_wc_order_product_lookup.date_created >= '2022-01-12 00:00:00'
GROUP BY
    wp_wc_category_lookup.category_tree_id
ORDER BY
    items_sold
DESC
```

New sql:

```sql
SELECT
  wp_term_taxonomy.term_id as category_id,
  SUM(product_qty) as items_sold,
  SUM(product_net_revenue) AS net_revenue,
  COUNT(DISTINCT wp_wc_order_product_lookup.order_id) as orders_count,
  COUNT(DISTINCT wp_wc_order_product_lookup.product_id) as products_count
FROM
  wp_wc_order_product_lookup
  JOIN wp_wc_order_stats ON wp_wc_order_product_lookup.order_id = wp_wc_order_stats.order_id
  LEFT JOIN wp_term_relationships ON wp_wc_order_product_lookup.product_id = wp_term_relationships.object_id
  JOIN wp_term_taxonomy ON wp_term_taxonomy.term_taxonomy_id = wp_term_relationships.term_taxonomy_id
WHERE
  1=1
  AND ( wp_wc_order_stats.status NOT IN ( 'wc-trash','wc-pending','wc-failed','wc-cancelled' ) ) 
  AND wp_term_taxonomy.taxonomy = 'product_cat' 
  AND wp_wc_order_product_lookup.date_created >= '2022-01-12 00:00:00'
  GROUP BY
    wp_term_taxonomy.term_id
  ORDER BY
    items_sold desc
```

I basically removed the `wp_wc_category_lookup` left join statement because It's the main reason why we get invalid results. When we join it by the category_id/term_id, it might match multiple rows because the data in the table is like below.

```
// select * from wp_wc_category_lookup where category_id in ('113', '46');
// 46 is the parent category of 113
category_tree_id category_id
46   46
46	113
113	113
```

it seems that we used it to filter valid product taxonomies by checking if `terms` in the `wp_wc_category_lookup` table. But I think we don't really need it because we can use `wp_term_taxonomy.taxonomy = 'product_cat' ` to get valid product taxonomies.

You can use this SQL to see all `taxonomy = 'product_cat'` terms.

```sql
select * from wp_terms where term_id in (
	select term_id from wp_term_taxonomy where taxonomy = 'product_cat'
);
```

### Screenshots

Before:

![screen1](https://user-images.githubusercontent.com/2240960/134677303-82fb99c2-b326-43ce-8ac3-cc5c2429bb59.png)

After:
![Screen Shot 2022-01-12 at 17 26 14](https://user-images.githubusercontent.com/4344253/149103148-0d9c3457-ed62-4d28-80e5-2293aa382fc8.png)


### Detailed test instructions:

1. Create a new store and finish the Onboarding flow
2. Go to **Products > Add New** and create a product called **Hoodie with Pocket** with the price $35
3. Create a new category called **Hoodie** with **Clothing** as the parent category in the **Product categories** on the right.
4. Select **Clothing** and **Hoodie with Pocket** as well and click **Update**
5. Create an order with a single item of **Hoodie with Pocket** (keep note of the total price)
6. Run the action scheduler (make sure all are run)
7. Go to **Analytics > Overview** and scroll down to the **Leaderboards**
8. Observe that the **Clothing** category has only **1** items sold and net sales is $35
9. Click on **Clothing** it will redirect to the Categories page and show the correct numbers
10. Now click on **Analytics > Categories** again and scroll down to the table
11. Observe that the **Clothing** category has only **1** items sold and net sales is $35