### PR TITLE
Fix php unit test "test_deleted_coupons" for wc >= 6.1.0

### DIFF
--- a/tests/reports/class-wc-tests-reports-coupons.php
+++ b/tests/reports/class-wc-tests-reports-coupons.php
@@ -329,6 +329,14 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 	 * Test that calculations and querying works correctly when coupons are deleted.
 	 */
 	public function test_deleted_coupons() {
+		/**
+		 * In WC Core 6.1.0 Coupon Data is stored consistently in the order item meta.
+		 * see https://github.com/woocommerce/woocommerce/pull/31338.
+		 */
+		function is_wc_version_store_coupon_data_in_order_meta() {
+			return version_compare( WC_VERSION, '6.1.0', '>=' );
+		}
+
 		WC_Helper_Reports::reset_stats_dbs();
 
 		// Simple product.
@@ -343,11 +351,12 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 		$coupon_1->set_amount( $coupon_1_amount );
 		$coupon_1->save();
 
-		// Coupon that will be deleted.
+		// Coupon that will be deleted, but order item will have metadata that will preserve its ID if WC version >= 6.1.0.
 		$coupon_2_amount = 7;
 		$coupon_2        = WC_Helper_Coupon::create_coupon( 'coupon_2' );
 		$coupon_2->set_amount( $coupon_2_amount );
 		$coupon_2->save();
+		$coupon_2_id = $coupon_2->get_id();
 
 		// Coupon that will be deleted, but order item will have metadata that will preserve its ID.
 		$coupon_3_amount = 1;
@@ -402,7 +411,7 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 			'extended_info' => new ArrayObject(),
 		);
 		$coupon_2_response = array(
-			'coupon_id'     => -1, // coupon_2 was deleted, so a new ID was created.
+			'coupon_id'     => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_2_id : -1,
 			'amount'        => floatval( $coupon_2_amount ),
 			'orders_count'  => 1,
 			'extended_info' => new ArrayObject(),
@@ -421,10 +430,10 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 			'pages'   => 1,
 			'page_no' => 1,
 			'data'    => array(
-				// Order is 3, 1, 2 since query is sorted by coupon ID descending.
+				// Order query is sorted by coupon ID descending.
 				0 => $coupon_3_response,
-				1 => $coupon_1_response,
-				2 => $coupon_2_response,
+				1 => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_2_response : $coupon_1_response,
+				2 => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_1_response : $coupon_2_response,
 			),
 		);
 		$this->assertEquals( $expected_data, $data );
@@ -470,7 +479,7 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 		);
 
 		$coupon_2_response = array(
-			'coupon_id'     => -1,
+			'coupon_id'     => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_2_id : -1,
 			'amount'        => floatval( $coupon_2_amount ),
 			'orders_count'  => 1,
 			'extended_info' => array(
@@ -508,10 +517,10 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 			'pages'   => 1,
 			'page_no' => 1,
 			'data'    => array(
-				// Order is 3, 1, 2 since query is sorted by coupon ID descending.
+				// Order query is sorted by coupon ID descending.
 				0 => $coupon_3_response,
-				1 => $coupon_1_response,
-				2 => $coupon_2_response,
+				1 => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_2_response : $coupon_1_response,
+				2 => is_wc_version_store_coupon_data_in_order_meta() ? $coupon_1_response : $coupon_2_response,
 			),
 		);
 		$this->assertEquals( $expected_data, $data );


### PR DESCRIPTION
Fixes #8154

This PR fixes the failing `test-php (7.0, 5.6, latest, 6.5.9, 1.10.19)` CI. 

In WC Core 6.1.0 Coupon Data is stored consistently in the order item meta, which breaks our `WC_Tests_Reports_Coupons::test_deleted_coupons` test. 

- https://github.com/woocommerce/woocommerce/pull/31338
- [6.1.0 changelog.txt](https://github.com/woocommerce/woocommerce/blob/6.1.0/changelog.txt)

To test in local, I also fixed the `bin/install-wp-test.sh` as we did in https://github.com/woocommerce/woocommerce-admin/pull/8108.

### Detailed test instructions:

Please check the https://github.com/woocommerce/woocommerce-admin/runs/4798506778?check_suite_focus=true

To test manually:

1. Rebuild the php-test-suite docker image: `cd docker/wc-admin-php-test-suite && docker build . -t wc-admin-php-7-test-suite-phpunit:1.2.2`
2. Run php tests with wc 6.1.0: `WC_VERSION=6.1.0 npm run test:php` to verify the issue is fixed.
3. Run `docker-compose down -v` to make sure we can get a new db in the next step. 
4. Run php tests with wc 6.0.0: `WC_VERSION=6.0.0 npm run test:php` to verify old versions still work as epxected.

no changelog