### PR TITLE
Fix shipping rate error message overlaps with the 'Proceed' button

### DIFF
--- a/changelogs/fix-6389-shipping-error-message-overlaps
+++ b/changelogs/fix-6389-shipping-error-message-overlaps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix shipping rate error message overlaps with the 'Proceed' button. #8165


### PR DESCRIPTION
Fixes #6389

This PR fixes the issue that the shipping rate error message overlaps with the 'Proceed' button.

I also refactored the shipping rate component by splitting it into small components since the rendering part was too large to view.

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/4509348/108622237-5371e900-7472-11eb-856e-23f8f3c0a995.png)

After:

![Screen Shot 2022-01-13 at 14 55 58](https://user-images.githubusercontent.com/4344253/149281096-62554c76-f0b3-4424-9af4-0d427425905b.png)

### Detailed test instructions:

Use a new store and finish the 'Setup Wizard'.

1. Go to 'Home'
2. Click on 'Set up shipping'
3. Toggle the 'Rest of the world' on.
4. In the 'Shipping cost' input field inside the 'Rest of the world' section, enter '-4'.
5. Click anywhere outside the 'Shipping cost' input field.
6. Notice that the error message 'Shipping rates can not be negative numbers.' appears and it does **not** overlap with the 'Complete task' or 'Proceed' button