### PR TITLE
Fix setup wizard free features checkbox re-check itself

### DIFF
--- a/changelogs/fix-8163-setup-wizard-features-checkbox-recheck-itself
+++ b/changelogs/fix-8163-setup-wizard-features-checkbox-recheck-itself
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix setup wizard free features checkbox re-check itself. #8169

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -103,34 +103,31 @@ describe( 'BusinessDetails', () => {
 
 	describe( 'createInstallExtensionOptions', () => {
 		test( 'selected by default', () => {
-			const extensions = [
+			const installableExtensions = [
 				{
 					plugins: [
 						{
 							key: 'visible-and-not-selected',
-							selected: false,
 							isVisible: () => true,
 						},
 						{
 							key: 'visible-and-selected',
-							selected: true,
 							isVisible: () => true,
 						},
 						{
 							key: 'this-should-not-show-at-all',
-							selected: true,
 							isVisible: () => false,
 						},
 					],
 				},
 			];
 
-			const values = createInstallExtensionOptions(
-				extensions,
-				'US',
-				'',
-				[]
-			);
+			const values = createInstallExtensionOptions( {
+				installableExtensions,
+				prevInstallExtensionOptions: {
+					'visible-and-not-selected': false,
+				},
+			} );
 
 			expect( values ).toEqual(
 				expect.objectContaining( {


### PR DESCRIPTION
Fixes #8163

This PR fixes the unexpected setup wizard free features checkbox re-check issue.

### Screenshots

Issue:
<img src="https://cdn-std.droplr.net/files/acc_1119691/6SzAZY" width="600">

### Detailed test instructions:

1. Go to Business Features tab in Setup Wizard
2. Deselect all extensions and reselect only 1
3. Click continue
4. Observe the other extensions are **NOT** re-selected before it navigates to the next screen