### PR TITLE
Reduce padding around plugin list titles for marketing tools page.

### DIFF
--- a/changelogs/fix-8164-padding-reduction-reach-out-to-customers
+++ b/changelogs/fix-8164-padding-reduction-reach-out-to-customers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Tweak
+
+Padding tweak for marketing tools plugin list headings. #8171

--- a/client/tasks/fills/Marketing/PluginList.scss
+++ b/client/tasks/fills/Marketing/PluginList.scss
@@ -1,5 +1,5 @@
 .woocommerce-plugin-list__title {
-	padding: $gap 30px 0 30px;
+	padding: $gap-large 30px 0 30px;
 	position: relative;
 
 	h3 {

--- a/client/tasks/fills/Marketing/PluginList.scss
+++ b/client/tasks/fills/Marketing/PluginList.scss
@@ -1,5 +1,5 @@
 .woocommerce-plugin-list__title {
-	padding: $gap-larger 30px $gap 30px;
+	padding: $gap 30px 0 30px;
 	position: relative;
 
 	h3 {


### PR DESCRIPTION
Fixes #8164 

Reduce padding around plugin list titles for marketing tools page. (In the screenshots below, we're talking about "Reach out to customers" and "Grow your store".)

### Screenshots

Before:
![Screen Shot 2022-01-14 at 12 23 37](https://user-images.githubusercontent.com/890809/149566000-df9b6394-ddf0-4963-ad3b-762af5b95c81.png)

After:
![Screen Shot 2022-01-14 at 12 23 57](https://user-images.githubusercontent.com/890809/149566042-2cee4440-cac5-4a61-82cc-3a0ca93a3e5e.png)

### Detailed test instructions:

1. Go to WooCommerce > Home
2. In task list, click on Set up marketing tools
3. Observe the padding around "Reach out to customers" and "Grow your store".
