### PR TITLE
Hide store address fields in regions that specify hidden

### DIFF
--- a/changelogs/add-store-address-hidden
+++ b/changelogs/add-store-address-hidden
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Hide store address fields in regions that specify hidden #8172

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -281,25 +281,29 @@ export function StoreAddress( props ) {
 
 	return (
 		<div className="woocommerce-store-address-fields">
-			<TextControl
-				label={
-					locale?.address_1?.label ||
-					__( 'Address line 1', 'woocommerce-admin' )
-				}
-				required={ isAddressFieldRequired( 'address_1', locale ) }
-				autoComplete="address-line1"
-				{ ...getInputProps( 'addressLine1' ) }
-			/>
+			{ ! locale?.address_1?.hidden && (
+				<TextControl
+					label={
+						locale?.address_1?.label ||
+						__( 'Address line 1', 'woocommerce-admin' )
+					}
+					required={ isAddressFieldRequired( 'address_1', locale ) }
+					autoComplete="address-line1"
+					{ ...getInputProps( 'addressLine1' ) }
+				/>
+			) }
 
-			<TextControl
-				label={
-					locale?.address_2?.label ||
-					__( 'Address line 2 (optional)', 'woocommerce-admin' )
-				}
-				required={ isAddressFieldRequired( 'address_2', locale ) }
-				autoComplete="address-line2"
-				{ ...getInputProps( 'addressLine2' ) }
-			/>
+			{ ! locale?.address_2?.hidden && (
+				<TextControl
+					label={
+						locale?.address_2?.label ||
+						__( 'Address line 2 (optional)', 'woocommerce-admin' )
+					}
+					required={ isAddressFieldRequired( 'address_2', locale ) }
+					autoComplete="address-line2"
+					{ ...getInputProps( 'addressLine2' ) }
+				/>
+			) }
 
 			<SelectControl
 				label={ __( 'Country / Region', 'woocommerce-admin' ) }
@@ -315,24 +319,28 @@ export function StoreAddress( props ) {
 				{ countryStateAutofill }
 			</SelectControl>
 
-			<TextControl
-				label={
-					locale?.city?.label || __( 'City', 'woocommerce-admin' )
-				}
-				required={ isAddressFieldRequired( 'city', locale ) }
-				{ ...getInputProps( 'city' ) }
-				autoComplete="address-level2"
-			/>
+			{ ! locale?.city?.hidden && (
+				<TextControl
+					label={
+						locale?.city?.label || __( 'City', 'woocommerce-admin' )
+					}
+					required={ isAddressFieldRequired( 'city', locale ) }
+					{ ...getInputProps( 'city' ) }
+					autoComplete="address-level2"
+				/>
+			) }
 
-			<TextControl
-				label={
-					locale?.postcode?.label ||
-					__( 'Post code', 'woocommerce-admin' )
-				}
-				required={ isAddressFieldRequired( 'postcode', locale ) }
-				autoComplete="postal-code"
-				{ ...getInputProps( 'postCode' ) }
-			/>
+			{ ! locale?.postcode?.hidden && (
+				<TextControl
+					label={
+						locale?.postcode?.label ||
+						__( 'Post code', 'woocommerce-admin' )
+					}
+					required={ isAddressFieldRequired( 'postcode', locale ) }
+					autoComplete="postal-code"
+					{ ...getInputProps( 'postCode' ) }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Hides fields that are irrelevant for a given country/region.

Note that when the update occurs, it persists the existing postal code, even if it is hidden for the currently selected region.  I'm not sure if that's a good expectation or if we should empty it on regions that don't require it.

My gut feeling is keeping it would not be bad, but the UI differences between here and core may be slightly confusing.

### Screenshots

<img width="536" alt="Screen Shot 2022-01-14 at 3 17 28 PM" src="https://user-images.githubusercontent.com/10561050/149579590-bbb69ab2-26e8-497e-a024-1f00cbace24f.png">


### Detailed test instructions:

1. Go to the store setup wizard
2. Change to a country like Guatemala that hides the post code
3. Verify that the post code is hidden and "Continue" still works as expected
4. Switch to a different country with all fields shown and make sure things still work as expected