### PR TITLE
Task List: Personalize your store / Import products - error message is not formatted correctly

### DIFF
--- a/changelogs/fix-4314-import-products-error-message-formatting
+++ b/changelogs/fix-4314-import-products-error-message-formatting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Fix product import error message formatting. #8173

--- a/changelogs/fix-4314-import-products-error-message-formatting
+++ b/changelogs/fix-4314-import-products-error-message-formatting
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Fix
 
-Fix product import error message formatting. #8173
+Preserve HTML markup in server-side error messages received from sample product import request. #8173

--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -4,7 +4,12 @@
 import { noop } from 'lodash';
 import classnames from 'classnames';
 import { speak } from '@wordpress/a11y';
-import { useEffect, forwardRef, renderToString } from '@wordpress/element';
+import {
+	RawHTML,
+	useEffect,
+	forwardRef,
+	renderToString,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import warning from '@wordpress/warning';
 import { Button } from '@wordpress/components';
@@ -45,6 +50,7 @@ function Snackbar(
 		// It is distinct from onRemove, which _looks_ like a callback but is
 		// actually the function to call to remove the snackbar from the UI.
 		onDismiss = null,
+		__unstableHTML = false,
 	},
 	ref
 ) {
@@ -101,6 +107,10 @@ function Snackbar(
 			'components-snackbar__content-with-icon': !! icon,
 		}
 	);
+
+	if ( __unstableHTML === true ) {
+		children = <RawHTML>{ children }</RawHTML>;
+	}
 
 	return (
 		<div

--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -137,13 +137,15 @@ class Appearance extends Component {
 				this.setState( { isPending: false } );
 				this.completeStep();
 			} )
-			.catch( () => {
+			.catch( ( { message } ) => {
 				createNotice(
 					'error',
-					__(
-						'There was an error importing the sample products',
-						'woocommerce-admin'
-					)
+					message ||
+						__(
+							'There was an error importing the sample products',
+							'woocommerce-admin'
+						),
+					{ __unstableHTML: true }
 				);
 				this.setState( { isPending: false } );
 			} );

--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -137,8 +137,14 @@ class Appearance extends Component {
 				this.setState( { isPending: false } );
 				this.completeStep();
 			} )
-			.catch( ( error ) => {
-				createNotice( 'error', error.message );
+			.catch( () => {
+				createNotice(
+					'error',
+					__(
+						'There was an error importing the sample products',
+						'woocommerce-admin'
+					)
+				);
 				this.setState( { isPending: false } );
 			} );
 	}


### PR DESCRIPTION
Fixes #4314 

When an error happens during sample item import, it's likely the error message that comes back from the server will contain HTML tags, which has up to now been just printed on the screen in the notice.

This PR uses the `__unstableHTML` option to preserve markup in messages received from the API when importing sample products. It also adds support for `__unstableHTML` to the `Snackbar` element.

### Screenshots

Before:
![9D6B7022-FEE5-47FE-BF7B-73C3688D2F2F_4_5005_c](https://user-images.githubusercontent.com/890809/149607323-266480b4-3804-45a1-a2ef-9574fac03b3e.jpeg)

After:

Default message if the error.message property is falsy:
![F5F4648F-820D-4E7D-A9CB-DE7D6EAA42D6_4_5005_c](https://user-images.githubusercontent.com/890809/149607315-3ce8ed2b-d569-4cf3-a7ed-0780236da4a3.jpeg)

A specific server-side error message with no markup:
![Screen Shot 2022-01-25 at 10 56 33](https://user-images.githubusercontent.com/890809/151022827-3b545d1f-8f5e-4606-a940-343153785c7f.png)

A specific server-side error message with markup:
![Screen Shot 2022-01-25 at 10 57 29](https://user-images.githubusercontent.com/890809/151022968-c1ff61ee-9fd2-42cf-8c73-6547e3f8d9d4.png)

### Detailed test instructions:

-  Go to the "Personalize my store" OBW task
- ...somehow arrange for an Exception to be thrown during the sample import...
- Click "Import Products"
- Verify the formatting of the error message that appears.
