### PR TITLE
Rename some constants

### DIFF
--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -37,7 +37,7 @@ export const ActivityPanel = () => {
 		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
 		const manageStock = getAdminSetting( 'manageStock', 'no' );
 		const countLowStockProducts = getLowStockCount( select );
-		const countUnapprovedReviews = getUnapprovedReviews( select );
+		const unapprovedReviewsCount = getUnapprovedReviews( select );
 		const publishedProductCount = getAdminSetting(
 			'publishedProductCount',
 			0
@@ -46,7 +46,7 @@ export const ActivityPanel = () => {
 
 		return {
 			countLowStockProducts,
-			countUnapprovedReviews,
+			unapprovedReviewsCount,
 			countUnreadOrders,
 			manageStock,
 			isTaskListHidden: taskList?.isHidden,

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -34,7 +34,7 @@ export const ActivityPanel = () => {
 		const totalOrderCount = getAdminSetting( 'orderCount', 0 );
 		const orderStatuses = getOrderStatuses( select );
 		const reviewsEnabled = getAdminSetting( 'reviewsEnabled', 'no' );
-		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
+		const unreadOrdersCount = getUnreadOrders( select, orderStatuses );
 		const manageStock = getAdminSetting( 'manageStock', 'no' );
 		const lowStockProductsCount = getLowStockCount( select );
 		const unapprovedReviewsCount = getUnapprovedReviews( select );
@@ -47,7 +47,7 @@ export const ActivityPanel = () => {
 		return {
 			lowStockProductsCount,
 			unapprovedReviewsCount,
-			countUnreadOrders,
+			unreadOrdersCount,
 			manageStock,
 			isTaskListHidden: taskList?.isHidden,
 			publishedProductCount,

--- a/client/homescreen/activity-panel/index.js
+++ b/client/homescreen/activity-panel/index.js
@@ -36,7 +36,7 @@ export const ActivityPanel = () => {
 		const reviewsEnabled = getAdminSetting( 'reviewsEnabled', 'no' );
 		const countUnreadOrders = getUnreadOrders( select, orderStatuses );
 		const manageStock = getAdminSetting( 'manageStock', 'no' );
-		const countLowStockProducts = getLowStockCount( select );
+		const lowStockProductsCount = getLowStockCount( select );
 		const unapprovedReviewsCount = getUnapprovedReviews( select );
 		const publishedProductCount = getAdminSetting(
 			'publishedProductCount',
@@ -45,7 +45,7 @@ export const ActivityPanel = () => {
 		const taskList = select( ONBOARDING_STORE_NAME ).getTaskList( 'setup' );
 
 		return {
-			countLowStockProducts,
+			lowStockProductsCount,
 			unapprovedReviewsCount,
 			countUnreadOrders,
 			manageStock,

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -209,7 +209,7 @@ function renderOrders( orders ) {
 	);
 }
 
-function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
+function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 	const actionableOrdersQuery = useMemo(
 		() => ( {
 			page: 1,
@@ -233,7 +233,7 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 			ITEMS_STORE_NAME
 		);
 
-		if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
+		if ( ! orderStatuses.length && unreadOrdersCount === 0 ) {
 			return { isRequesting: false };
 		}
 
@@ -247,7 +247,7 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 
 		if (
 			isRequestingActionable ||
-			countUnreadOrders === null ||
+			unreadOrdersCount === null ||
 			orderItems === null
 		) {
 			return {
@@ -331,7 +331,7 @@ function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
 OrdersPanel.propTypes = {
 	isError: PropTypes.bool,
 	isRequesting: PropTypes.bool,
-	countUnreadOrders: PropTypes.number,
+	unreadOrdersCount: PropTypes.number,
 	orders: PropTypes.array.isRequired,
 	orderStatuses: PropTypes.array,
 };

--- a/client/homescreen/activity-panel/orders/test/index.js
+++ b/client/homescreen/activity-panel/orders/test/index.js
@@ -27,7 +27,7 @@ describe( 'OrdersPanel', () => {
 			isError: false,
 			isRequesting: false,
 		} );
-		render( <OrdersPanel orderStatuses={ [] } countUnreadOrders={ 0 } /> );
+		render( <OrdersPanel orderStatuses={ [] } unreadOrdersCount={ 0 } /> );
 		expect(
 			screen.queryByText( 'You’ve fulfilled all your orders' )
 		).toBeInTheDocument();

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -13,7 +13,7 @@ import ReviewsPanel from './reviews';
 export function getAllPanels( {
 	lowStockProductsCount,
 	unapprovedReviewsCount,
-	countUnreadOrders,
+	unreadOrdersCount,
 	manageStock,
 	isTaskListHidden,
 	orderStatuses,
@@ -28,13 +28,13 @@ export function getAllPanels( {
 	return [
 		totalOrderCount > 0 && {
 			className: 'woocommerce-homescreen-card',
-			count: countUnreadOrders,
+			count: unreadOrdersCount,
 			collapsible: true,
 			id: 'orders-panel',
 			initialOpen: false,
 			panel: (
 				<OrdersPanel
-					countUnreadOrders={ countUnreadOrders }
+					unreadOrdersCount={ unreadOrdersCount }
 					orderStatuses={ orderStatuses }
 				/>
 			),

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -12,7 +12,7 @@ import ReviewsPanel from './reviews';
 
 export function getAllPanels( {
 	countLowStockProducts,
-	countUnapprovedReviews,
+	unapprovedReviewsCount,
 	countUnreadOrders,
 	manageStock,
 	isTaskListHidden,
@@ -56,16 +56,16 @@ export function getAllPanels( {
 				title: __( 'Stock', 'woocommerce-admin' ),
 			},
 		publishedProductCount > 0 &&
-			countUnapprovedReviews > 0 &&
+			unapprovedReviewsCount > 0 &&
 			reviewsEnabled === 'yes' && {
 				className: 'woocommerce-homescreen-card',
 				id: 'reviews-panel',
-				count: countUnapprovedReviews,
+				count: unapprovedReviewsCount,
 				initialOpen: false,
-				collapsible: countUnapprovedReviews !== 0,
+				collapsible: unapprovedReviewsCount !== 0,
 				panel: (
 					<ReviewsPanel
-						hasUnapprovedReviews={ countUnapprovedReviews > 0 }
+						hasUnapprovedReviews={ unapprovedReviewsCount > 0 }
 					/>
 				),
 				title: __( 'Reviews', 'woocommerce-admin' ),

--- a/client/homescreen/activity-panel/panels.js
+++ b/client/homescreen/activity-panel/panels.js
@@ -11,7 +11,7 @@ import StockPanel from './stock';
 import ReviewsPanel from './reviews';
 
 export function getAllPanels( {
-	countLowStockProducts,
+	lowStockProductsCount,
 	unapprovedReviewsCount,
 	countUnreadOrders,
 	manageStock,
@@ -44,13 +44,13 @@ export function getAllPanels( {
 			publishedProductCount > 0 &&
 			manageStock === 'yes' && {
 				className: 'woocommerce-homescreen-card',
-				count: countLowStockProducts,
+				count: lowStockProductsCount,
 				id: 'stock-panel',
 				initialOpen: false,
-				collapsible: countLowStockProducts !== 0,
+				collapsible: lowStockProductsCount !== 0,
 				panel: (
 					<StockPanel
-						countLowStockProducts={ countLowStockProducts }
+						lowStockProductsCount={ lowStockProductsCount }
 					/>
 				),
 				title: __( 'Stock', 'woocommerce-admin' ),

--- a/client/homescreen/activity-panel/stock/index.js
+++ b/client/homescreen/activity-panel/stock/index.js
@@ -81,7 +81,7 @@ export class StockPanel extends Component {
 
 	render() {
 		const {
-			countLowStockProducts,
+			lowStockProductsCount,
 			isError,
 			isRequesting,
 			products,
@@ -110,7 +110,7 @@ export class StockPanel extends Component {
 
 		// Show placeholders only for the first products fetch.
 		if ( isRequesting || ! products.length ) {
-			const numPlaceholders = Math.min( 5, countLowStockProducts ?? 1 );
+			const numPlaceholders = Math.min( 5, lowStockProductsCount ?? 1 );
 			const placeholders = Array.from(
 				new Array( numPlaceholders )
 			).map( ( v, idx ) => (
@@ -130,7 +130,7 @@ export class StockPanel extends Component {
 }
 
 StockPanel.propTypes = {
-	countLowStockProducts: PropTypes.number,
+	lowStockProductsCount: PropTypes.number,
 	products: PropTypes.array.isRequired,
 	isError: PropTypes.bool,
 	isRequesting: PropTypes.bool,

--- a/client/homescreen/activity-panel/stock/test/index.js
+++ b/client/homescreen/activity-panel/stock/test/index.js
@@ -14,7 +14,7 @@ describe( 'StockPanel', () => {
 	it( 'should the correct number of placeholders', () => {
 		const { container } = render(
 			<StockPanel
-				countLowStockProducts={ 3 }
+				lowStockProductsCount={ 3 }
 				isError={ false }
 				isRequesting={ true }
 				products={ [] }
@@ -35,7 +35,7 @@ describe( 'StockPanel', () => {
 
 		const { getByRole } = render(
 			<StockPanel
-				countLowStockProducts={ 1 }
+				lowStockProductsCount={ 1 }
 				isError={ false }
 				isRequesting={ false }
 				products={ [

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -6,7 +6,7 @@ import { getAllPanels } from '../panels';
 describe( 'ActivityPanel', () => {
 	it( 'should exclude the orders and stock panels when there are no orders', () => {
 		const panels = getAllPanels( {
-			countUnreadOrders: 0,
+			unreadOrdersCount: 0,
 			orderStatuses: [],
 			totalOrderCount: 0,
 			publishedProductCount: 1,
@@ -28,7 +28,7 @@ describe( 'ActivityPanel', () => {
 
 	it( 'should exclude the reviews and stock panels when there are no published products', () => {
 		const panels = getAllPanels( {
-			countUnreadOrders: 0,
+			unreadOrdersCount: 0,
 			orderStatuses: [],
 			totalOrderCount: 1, // Yes, I realize this isn't "possible".
 			publishedProductCount: 0,
@@ -51,7 +51,7 @@ describe( 'ActivityPanel', () => {
 
 	it( 'should exclude any panel when the setup task list is visible', () => {
 		const panels = getAllPanels( {
-			countUnreadOrders: 0,
+			unreadOrdersCount: 0,
 			orderStatuses: [],
 			totalOrderCount: 1,
 			publishedProductCount: 0,
@@ -79,7 +79,7 @@ describe( 'ActivityPanel', () => {
 
 	it( 'should include the orders panel when there are orders', () => {
 		const panels = getAllPanels( {
-			countUnreadOrders: 1,
+			unreadOrdersCount: 1,
 			orderStatuses: [],
 			totalOrderCount: 10,
 			isTaskListHidden: 'yes',
@@ -94,7 +94,7 @@ describe( 'ActivityPanel', () => {
 
 	it( 'should include the stock panel when there are orders, products, and inventory management is enabled', () => {
 		const panels = getAllPanels( {
-			countUnreadOrders: 1,
+			unreadOrdersCount: 1,
 			orderStatuses: [],
 			totalOrderCount: 10,
 			publishedProductCount: 2,

--- a/client/homescreen/activity-panel/test/panels.js
+++ b/client/homescreen/activity-panel/test/panels.js
@@ -128,7 +128,7 @@ describe( 'ActivityPanel', () => {
 			publishedProductCount: 5,
 			reviewsEnabled: 'yes',
 			isTaskListHidden: 'yes',
-			countUnapprovedReviews: 3,
+			unapprovedReviewsCount: 3,
 		} );
 
 		expect( panels ).toEqual(


### PR DESCRIPTION
This is a follow-up for [PR 8147](https://github.com/woocommerce/woocommerce-admin/pull/8147) so this PR should be merged (to 8147) before merging `PR 8147` to `main`.

In this PR the const `countUnapprovedReviews` is renamed to `unapprovedReviewsCount` (reference [here](https://github.com/woocommerce/woocommerce-admin/pull/8147#discussion_r783417604)). `countUnreadOrders` and `countLowStockProducts` are renamed as well.

(no changelog)

### Screenshots

![screenshot-localhost_10003-2022 01 16-16_15_24](https://user-images.githubusercontent.com/1314156/149674505-e7294f6a-da20-414d-a7f6-4c567f13e2c7.png)

### Detailed test instructions:

1. Run js and e2e tests and verify that there aren't any errors.
2. Smoke test the Home screen activity panels (Orders, Stock and Reviews). 

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
