### PR TITLE
Fix incorrectly displayed note created date

### DIFF
--- a/changelogs/fix-2006-notes-time-zone
+++ b/changelogs/fix-2006-notes-time-zone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix incorrectly displayed note created date. #8179

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 -	Make the Inbox note title clickable. #7975
+-   Fix incorrectly displayed note created date. #8179
 
 # 2.1.0
 

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -157,7 +157,6 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 	}
 
 	const unread = is_read === false;
-	const date = dateCreated;
 	const hasImage = layout === 'thumbnail';
 	const cardClassName = classnames(
 		'woocommerce-inbox-message',
@@ -188,9 +187,9 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 						{ unread && (
 							<div className="woocommerce-inbox-message__unread-indicator" />
 						) }
-						{ date && (
+						{ dateCreatedGmt && (
 							<span className="woocommerce-inbox-message__date">
-								{ moment.utc( date ).fromNow() }
+								{ moment.utc( dateCreatedGmt ).fromNow() }
 							</span>
 						) }
 						<H className="woocommerce-inbox-message__title">


### PR DESCRIPTION
Fixes #2006

This PR fixes the incorrectly displayed note "created date" issue when the store timezone is other than UTC.

### Screenshots

![Screen Shot 2022-01-17 at 11 49 37](https://user-images.githubusercontent.com/4344253/149705362-390a103d-baac-4c17-962d-837fa1de0a14.png)


### Detailed test instructions:

1. Use a new site and **main** branch
2. Go to **WooCommerce > Home**
3. Observe that notes created date show correctly with the UTC+0 store time. For example: "1 minus ago"
4. Go to **Settings > General**
5. Change the store timezone to other UTC times such as UTC+8
6. Go to **WooCommerce > Home**
7. Observe that the notes created date is incorrect. For example: "7 hours from now"
8. Checkout to this branch and refresh the page
9. Observe that the notes created date show correctly.