### PR TITLE
Fix get_automated_tax_supported_countries doesn't include UK

### DIFF
--- a/changelogs/fix-5836-automated-tax-supported-countries-uk
+++ b/changelogs/fix-5836-automated-tax-supported-countries-uk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix get_automated_tax_supported_countries doesn't include UK. #8180

--- a/src/Features/OnboardingTasks/Tasks/Tax.php
+++ b/src/Features/OnboardingTasks/Tasks/Tax.php
@@ -155,7 +155,7 @@ class Tax extends Task {
 	public static function get_automated_support_countries() {
 		// https://developers.taxjar.com/api/reference/#countries .
 		$tax_supported_countries = array_merge(
-			array( 'US', 'CA', 'AU' ),
+			array( 'US', 'CA', 'AU', 'GB' ),
 			WC()->countries->get_european_union_countries()
 		);
 


### PR DESCRIPTION
Fixes #5836

This PR adds the 'GB' to the automated tax-supported countries list.

### Screenshots
![Screen Shot 2022-01-17 at 13 37 19](https://user-images.githubusercontent.com/4344253/149714010-84e07373-86ef-4ed2-a155-08bea0b4fc6c.png)



### Detailed test instructions:

1. Use a new store
2. Enter **'United Kingdom'** as Country in Store Details in the setup wizard
3. Go to WooCommerce > Home
4. Click the **'Set up tax'** task
5. Observe that **WooCommerce Tax** shows on the tax partner panels 
6. Click the 'Help' menu
7. Observe that "Automated Tax calculation using WooCommerce Tax" exists
