### PR TITLE
Fix incorrect reader text generated for data points on charts table

### DIFF
--- a/changelogs/fix-6255-screen-reader-text-on-chart-table
+++ b/changelogs/fix-6255-screen-reader-text-on-chart-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix incorrect screen reader text generated for data points on charts table. #8181

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 -   Fix misaligned "Rows per page" dropdown. #8113
 -   Add `labelPositionToLeft` prop to the `OrderStatus` component. #8121
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
+-   Fix incorrect screen reader text generated for data points on charts table. #8181
 
 # 8.1.1
 

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -93,7 +93,10 @@ export const getLineData = ( data, orderedKeys ) =>
 		visible: row.visible,
 		label: row.label,
 		values: data.map( ( d ) => ( {
+			// To have the same X-axis scale, we use the same dates for all lines.
 			date: d.date,
+			// To have actual date for the screenReader, we need to use label date.
+			labelDate: d[ row.key ].labelDate,
 			focus: row.focus,
 			value: get( d, [ row.key, 'value' ], 0 ),
 			visible: row.visible,
@@ -144,7 +147,6 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'd', ( d ) => line( d.values ) );
 
 	const minDataPointSpacing = 36;
-
 	// eslint-disable-next-line no-unused-expressions
 	width / params.uniqueDates.length > minDataPointSpacing &&
 		series
@@ -173,7 +175,9 @@ export const drawLines = ( node, data, params, scales, formats, tooltip ) => {
 			.attr( 'role', 'graphics-symbol' )
 			.attr( 'aria-label', ( d ) => {
 				const label = formats.screenReaderFormat(
-					d.date instanceof Date ? d.date : moment( d.date ).toDate()
+					d.labelDate instanceof Date
+						? d.labelDate
+						: moment( d.labelDate ).toDate()
 				);
 				return `${ label } ${ tooltip.valueFormat( d.value ) }`;
 			} )


### PR DESCRIPTION
Fixes #6255

This PR fixes the incorrect `aria-label` value for data points on the charts table with comparison periods selected.

### Screenshots

![Screen Shot 2022-01-17 at 15 19 56](https://user-images.githubusercontent.com/4344253/149726448-b1b16489-f51d-4591-8bff-4b605fb411e7.png)


### Detailed test instructions:

1. Place some orders
2. Go to Analytics > Orders
3. Select a period that has some, but not too many data points
4. Ensure a comparison period is selected to be displayed.
5. Enable a screen reader 
6. Navigate to the chart via keyboard, and use the tab to focus the data points.
7. The screen reader will read out the date for the data point, which should match the date for the comparison period.
