### PR TITLE
Fix incorrect total count of downloads on the analytics download report

### DIFF
--- a/changelogs/2022-01-17-08-56-31-701552
+++ b/changelogs/2022-01-17-08-56-31-701552
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix incorrect total count of downloads on the analytics download report. #8182

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -85,7 +85,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			$this->initialize_queries();
 			$selections = $this->selected_columns( $query_args );
 			$this->add_sql_query_params( $query_args );
-			$this->add_time_period_sql_params( $query_args, $table_name );
+			$where_time = $this->add_time_period_sql_params( $query_args, $table_name );
 			$this->add_intervals_sql_params( $query_args, $table_name );
 
 			$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
@@ -94,7 +94,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 
 			$db_intervals = $wpdb->get_col(
 				$this->interval_query->get_query_statement()
-			); // WPCS: cache ok, DB call ok, , unprepared SQL ok.
+			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 
 			$db_records_count = count( $db_intervals );
 
@@ -109,11 +109,13 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			$this->interval_query->str_replace_clause( 'where_time', 'date_created', 'timestamp' );
 			$this->total_query->add_sql_clause( 'select', $selections );
 			$this->total_query->add_sql_clause( 'where', $this->interval_query->get_sql_clause( 'where' ) );
+			if ( $where_time ) {
+				$this->total_query->add_sql_clause( 'where_time', $where_time );
+			}
 			$totals = $wpdb->get_results(
 				$this->total_query->get_query_statement(),
 				ARRAY_A
-			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
-
+			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
 				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
 			}
@@ -128,7 +130,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			$intervals = $wpdb->get_results(
 				$this->interval_query->get_query_statement(),
 				ARRAY_A
-			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
 				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );


### PR DESCRIPTION
Fixes #6326

This PR adds the where time clause to the total query to fix the incorrect total count of downloads query:

```sql
# original query
SELECT
  COUNT(DISTINCT download_log_id) as download_count
FROM
  wp_wc_download_log
WHERE
  1=1
```

### Screenshots

Before:
![Screen Shot 2022-01-17 at 16 53 36](https://user-images.githubusercontent.com/4344253/149738097-8e8f6eb5-81b6-4cea-b67f-cbf36c463133.png)

After:
![Screen Shot 2022-01-17 at 16 43 55](https://user-images.githubusercontent.com/4344253/149736564-883f5380-bf48-43a1-9669-b925b883e028.png)

### Detailed test instructions:

1. [Create a downloadable product](https://woocommerce.com/document/digital-downloadable-product-handling/#creating-downloadable-products)
2. Place a fake order with the downloadable product and a fake customer
3. Go to **WooCommerce > Orders** and edit the fake order
4. Update the order with 'Completed' status and **'Regenerate download permissions'** action.
5. Scroll to the bottom and toggle the item on the **"Downloadable product permissions"** panel 
6. Click "Copy link" button of the "Customer download link".
7. Use the copied link to download a few times
8. To ensure there are downloads under the comparison period (within the Chart), you can alter one of the timestamps in the **wp_wc_download_log** table.
9. Go to **Analytics->Reports->Downloads**
10. Observe that the count for the comparison period is correct.


