### PR TITLE
Fix task ID class check and add tests around tracking

### DIFF
--- a/changelogs/fix-8183
+++ b/changelogs/fix-8183
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Fix task ID class check and add tests around tracking #8185

--- a/src/Features/OnboardingTasks/TaskTraits.php
+++ b/src/Features/OnboardingTasks/TaskTraits.php
@@ -38,10 +38,14 @@ trait TaskTraits {
 			return;
 		}
 
+		$prefixed_event_name = $this->prefix_event( $event_name );
+
 		wc_admin_record_tracks_event(
-			$this->prefix_event( $event_name ),
+			$prefixed_event_name,
 			$args
 		);
+
+		return $prefixed_event_name;
 	}
 
 	/**
@@ -51,7 +55,8 @@ trait TaskTraits {
 	 */
 	public function get_list_id() {
 		$namespaced_class = get_class( $this );
-		$short_class      = substr( $namespaced_class, strrpos( $namespaced_class, '\\' ) + 1 );
-		return 'Task' === $short_class ? $this->parent_id : $this->id;
+		return is_subclass_of( $namespaced_class, 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task' )
+			? $this->get_parent_id()
+			: $this->id;
 	}
 }

--- a/src/Features/OnboardingTasks/TaskTraits.php
+++ b/src/Features/OnboardingTasks/TaskTraits.php
@@ -32,6 +32,7 @@ trait TaskTraits {
 	 *
 	 * @param string $event_name Event name.
 	 * @param array  $args Array of tracks arguments.
+	 * @return string Prefixed event name.
 	 */
 	public function record_tracks_event( $event_name, $args = array() ) {
 		if ( ! $this->get_list_id() ) {

--- a/tests/features/onboarding-tasks/task-list.php
+++ b/tests/features/onboarding-tasks/task-list.php
@@ -349,4 +349,18 @@ class WC_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 		$json = $list->get_json();
 		$this->assertEquals( array_column( $json['tasks'], 'id' ), array( 'task-2', 'task-3', 'task-1', 'task-4' ) );
 	}
+
+	/**
+	 * Test that the list ID is retreived.
+	 */
+	public function test_get_list_id() {
+		$this->assertEquals( 'setup', $this->list->get_list_id() );
+	}
+
+	/**
+	 * Test that tracks events are recorded with the correct IDs.
+	 */
+	public function test_record_tracks_event() {
+		$this->assertEquals( 'tasklist_test_event', $this->list->record_tracks_event( 'test_event' ) );
+	}
 }

--- a/tests/features/onboarding-tasks/task.php
+++ b/tests/features/onboarding-tasks/task.php
@@ -365,5 +365,31 @@ class WC_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 		// Given levels are the same it should return the comparison of is_complete.
 		$this->assertEquals( 0, $result );
 	}
+
+	/**
+	 * Test that the parent list ID is retreived.
+	 */
+	public function test_get_list_id() {
+		$task = new TestTask(
+			array(
+				'id' => 'wc-unit-test-task',
+			)
+		);
+
+		$this->assertEquals( 'extended', $task->get_list_id() );
+	}
+
+	/**
+	 * Test that tracks events are recorded with the correct IDs.
+	 */
+	public function test_record_tracks_event() {
+		$task = new TestTask(
+			array(
+				'id' => 'wc-unit-test-task',
+			)
+		);
+
+		$this->assertEquals( 'extended_tasklist_test_event', $task->record_tracks_event( 'test_event' ) );
+	}
 }
 


### PR DESCRIPTION
Fixes #8183 

Since updating the task API to use child classes instead of directly implementing a `Task` class, the list ID check was failing and not recording tracks.  This PR
* Fixes the list ID retrieval
* Adds tests around the list ID and the tracks to prevent this from happening again

### Detailed test instructions:

1. Delete the `woocommerce_task_list_tracked_completed_tasks` option in your database
2. Visit the homepage to trigger task list retrieval and tracks
3. Check that no errors appear in the error log
4. Visit `https://mc.a8c.com/tracks/live/?eventname=%25tasklist_%25&user=joshuaflow&useragent=` with your username and make sure the tracks come through `tasklist_task_completed` (may take up to ~20 min)
5. Make sure all tests pass