### PR TITLE
Fix incorrect date options when the "Default Date Range" is set from Analytics settings

### DIFF
--- a/changelogs/fix-7639-by-hour-option-not-displayed
+++ b/changelogs/fix-7639-by-hour-option-not-displayed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix incorrect date options when the "Default Date Range" is set from Analytics settings. #8189

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -86,12 +86,11 @@ export class ReportChart extends Component {
 			selectedChart,
 			defaultDateRange,
 		} = this.props;
-		const currentInterval = getIntervalForQuery( query );
+		const currentInterval = getIntervalForQuery( query, defaultDateRange );
 		const { primary, secondary } = getCurrentDates(
 			query,
 			defaultDateRange
 		);
-
 		const chartData = primaryData.data.intervals.map( function (
 			interval,
 			index
@@ -157,9 +156,13 @@ export class ReportChart extends Component {
 			selectedChart,
 			showHeaderControls,
 			primaryData,
+			defaultDateRange,
 		} = this.props;
-		const currentInterval = getIntervalForQuery( query );
-		const allowedIntervals = getAllowedIntervalsForQuery( query );
+		const currentInterval = getIntervalForQuery( query, defaultDateRange );
+		const allowedIntervals = getAllowedIntervalsForQuery(
+			query,
+			defaultDateRange
+		);
 		const formats = getDateFormatsForInterval(
 			currentInterval,
 			primaryData.data.intervals.length

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -271,6 +271,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 									section.key
 								) }
 								path={ path }
+								defaultDateRange={ defaultDateRange }
 								query={ query }
 								title={ section.title }
 								onMove={ partial( onMove, index ) }
@@ -310,10 +311,8 @@ export default compose(
 			SETTINGS_STORE_NAME
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
-		const withSelectData = {
+		return {
 			defaultDateRange,
 		};
-
-		return withSelectData;
 	} )
 )( CustomizableDashboard );

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -50,8 +50,16 @@ const renderChartToggles = ( { hiddenBlocks, onToggleHiddenBlock } ) => {
 	} );
 };
 
-const renderIntervalSelector = ( { chartInterval, setInterval, query } ) => {
-	const allowedIntervals = getAllowedIntervalsForQuery( query );
+const renderIntervalSelector = ( {
+	chartInterval,
+	setInterval,
+	query,
+	defaultDateRange,
+} ) => {
+	const allowedIntervals = getAllowedIntervalsForQuery(
+		query,
+		defaultDateRange
+	);
 	if ( ! allowedIntervals || allowedIntervals.length < 1 ) {
 		return null;
 	}
@@ -127,6 +135,7 @@ const DashboardCharts = ( props ) => {
 		title,
 		titleInput,
 		filters,
+		defaultDateRange,
 	} = props;
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 	const [ chartType, setChartType ] = useState(
@@ -198,6 +207,7 @@ const DashboardCharts = ( props ) => {
 					chartInterval,
 					setInterval,
 					query,
+					defaultDateRange,
 				} ) }
 				<NavigableMenu
 					className="woocommerce-chart__types"
@@ -247,6 +257,7 @@ const DashboardCharts = ( props ) => {
 DashboardCharts.propTypes = {
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
+	defaultDateRange: PropTypes.string.isRequired,
 };
 
 export default DashboardCharts;

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -6,7 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { getPersistedQuery } from '@woocommerce/navigation';
 import { withSelect } from '@wordpress/data';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import {
 	EllipsisMenu,
 	MenuItem,
@@ -201,15 +200,11 @@ export default compose(
 		const userIndicators = indicators.filter(
 			( indicator ) => ! hiddenBlocks.includes( indicator.stat )
 		);
-		const { woocommerce_default_date_range: defaultDateRange } = select(
-			SETTINGS_STORE_NAME
-		).getSetting( 'wc_admin', 'wcAdminSettings' );
 
 		const data = {
 			hiddenBlocks,
 			userIndicators,
 			indicators,
-			defaultDateRange,
 		};
 		if ( userIndicators.length === 0 ) {
 			return data;

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -195,9 +195,9 @@ export function isReportDataEmpty( report, endpoint ) {
  * @return {Object} data request query parameters.
  */
 function getRequestQuery( options ) {
-	const { endpoint, dataType, query, fields } = options;
-	const datesFromQuery = getCurrentDates( query, options.defaultDateRange );
-	const interval = getIntervalForQuery( query );
+	const { endpoint, dataType, query, fields, defaultDateRange } = options;
+	const datesFromQuery = getCurrentDates( query, defaultDateRange );
+	const interval = getIntervalForQuery( query, defaultDateRange );
 	const filterQuery = getFilterQuery( options );
 	const end = datesFromQuery[ dataType ].before;
 

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
+-   Add "defaultDateRange" argument to "getAllowedIntervalsForQuery" for default period value. #8189
 
 # 3.1.0
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -485,11 +485,16 @@ export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
  * Returns the allowed selectable intervals for a specific query.
  *
  * @param  {Object} query Current query
+ * @param {string} defaultDateRange - the store's default date range
  * @return {Array} Array containing allowed intervals.
  */
-export function getAllowedIntervalsForQuery( query ) {
+export function getAllowedIntervalsForQuery(
+	query,
+	defaultDateRange = 'period=&compare=previous_year'
+) {
+	const { period } = getDateParamsFromQuery( query, defaultDateRange );
 	let allowed = [];
-	if ( query.period === 'custom' ) {
+	if ( period === 'custom' ) {
 		const { primary } = getCurrentDates( query );
 		const differenceInDays = getDateDifferenceInDays(
 			primary.before,
@@ -509,7 +514,7 @@ export function getAllowedIntervalsForQuery( query ) {
 			allowed = [ 'hour', 'day' ];
 		}
 	} else {
-		switch ( query.period ) {
+		switch ( period ) {
 			case 'today':
 			case 'yesterday':
 				allowed = [ 'hour', 'day' ];
@@ -541,11 +546,15 @@ export function getAllowedIntervalsForQuery( query ) {
 /**
  * Returns the current interval to use.
  *
- * @param  {Object} query Current query
+ * @param {Object} query Current query
+ * @param {string} defaultDateRange - the store's default date range
  * @return {string} Current interval.
  */
-export function getIntervalForQuery( query ) {
-	const allowed = getAllowedIntervalsForQuery( query );
+export function getIntervalForQuery(
+	query,
+	defaultDateRange = 'period=&compare=previous_year'
+) {
+	const allowed = getAllowedIntervalsForQuery( query, defaultDateRange );
 	const defaultInterval = allowed[ 0 ];
 	let current = query.interval || defaultInterval;
 	if ( query.interval && ! allowed.includes( query.interval ) ) {

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -100,18 +100,43 @@ describe( 'toMoment', () => {
 
 describe( 'getAllowedIntervalsForQuery', () => {
 	it( 'should return days when query period is defined but empty', () => {
-		const allowedIntervals = getAllowedIntervalsForQuery( { period: '' } );
+		const allowedIntervals = getAllowedIntervalsForQuery( {
+			period: '',
+			compare: 'previous_year',
+		} );
 		expect( allowedIntervals ).toEqual( [ 'day' ] );
+	} );
+
+	it( 'should return days, hours when query period is empty but defaultDateRange is today and yesterday', () => {
+		const allowedIntervals = getAllowedIntervalsForQuery(
+			{
+				period: '',
+				compare: 'previous_year',
+			},
+			'period=today&compare=previous_year'
+		);
+		expect( allowedIntervals ).toEqual( [ 'hour', 'day' ] );
+
+		const allowedIntervalsYesterday = getAllowedIntervalsForQuery(
+			{
+				period: '',
+				compare: 'previous_year',
+			},
+			'period=yesterday&compare=previous_year'
+		);
+		expect( allowedIntervalsYesterday ).toEqual( [ 'hour', 'day' ] );
 	} );
 
 	it( 'should return days and hours for today and yesterday periods', () => {
 		const allowedIntervalsToday = getAllowedIntervalsForQuery( {
 			period: 'today',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsToday ).toEqual( [ 'hour', 'day' ] );
 
 		const allowedIntervalsYesterday = getAllowedIntervalsForQuery( {
 			period: 'yesterday',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsYesterday ).toEqual( [ 'hour', 'day' ] );
 	} );
@@ -119,11 +144,13 @@ describe( 'getAllowedIntervalsForQuery', () => {
 	it( 'should return day for week and last_week periods', () => {
 		const allowedIntervalsWeek = getAllowedIntervalsForQuery( {
 			period: 'week',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsWeek ).toEqual( [ 'day' ] );
 
 		const allowedIntervalsLastWeek = getAllowedIntervalsForQuery( {
 			period: 'last_week',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsLastWeek ).toEqual( [ 'day' ] );
 	} );
@@ -131,11 +158,13 @@ describe( 'getAllowedIntervalsForQuery', () => {
 	it( 'should return day, week for month and last_month periods', () => {
 		const allowedIntervalsMonth = getAllowedIntervalsForQuery( {
 			period: 'month',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsMonth ).toEqual( [ 'day', 'week' ] );
 
 		const allowedIntervalsLastMonth = getAllowedIntervalsForQuery( {
 			period: 'last_month',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsLastMonth ).toEqual( [ 'day', 'week' ] );
 	} );
@@ -143,11 +172,13 @@ describe( 'getAllowedIntervalsForQuery', () => {
 	it( 'should return day, week, month for quarter and last_quarter periods', () => {
 		const allowedIntervalsQuarter = getAllowedIntervalsForQuery( {
 			period: 'quarter',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsQuarter ).toEqual( [ 'day', 'week', 'month' ] );
 
 		const allowedIntervalsLastQuarter = getAllowedIntervalsForQuery( {
 			period: 'last_quarter',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsLastQuarter ).toEqual( [
 			'day',
@@ -159,6 +190,7 @@ describe( 'getAllowedIntervalsForQuery', () => {
 	it( 'should return day, week, month, quarter for year and last_year periods', () => {
 		const allowedIntervalsYear = getAllowedIntervalsForQuery( {
 			period: 'year',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsYear ).toEqual( [
 			'day',
@@ -169,6 +201,7 @@ describe( 'getAllowedIntervalsForQuery', () => {
 
 		const allowedIntervalsLastYear = getAllowedIntervalsForQuery( {
 			period: 'last_year',
+			compare: 'previous_year',
 		} );
 		expect( allowedIntervalsLastYear ).toEqual( [
 			'day',


### PR DESCRIPTION
Fixes #7639

This PR fixes incorrect Analytics "By hour/By week..." options displayed issue when the "Default Date Range" is set or the "period" from URL query is empty.

### Screenshots

Before:

https://user-images.githubusercontent.com/41110392/132547320-fabd41e4-18b0-4fab-95fa-9b8516f72939.mp4

After:

https://user-images.githubusercontent.com/4344253/149891688-af1eb40a-4901-41fc-bbff-c051ef9237ae.mov

### Detailed test instructions:

1. Create any test site using the JN site.
2. Complete the setup wizard.
3. Go to the 'Analytics > Settings' page.
4. Click the "Date Range" option in "Default Date Range".
5. Change it to "Today".
6. Navigate to the 'Analytics > Overview'''.
7. Observe that the 'By day' and 'By hour' options are displayed in "Charts".
