### PR TITLE
Fix undefined derived_currency value for the track 'wcadmin_storeprofiler_store_details_continue'

### DIFF
--- a/changelogs/fix-7569-undefined-currency-code
+++ b/changelogs/fix-7569-undefined-currency-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix undefined derived_currency value for the track 'wcadmin_storeprofiler_store_details_continue'. #8193

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -116,7 +116,7 @@ class StoreDetails extends Component {
 
 		recordEvent( 'storeprofiler_store_details_continue', {
 			store_country: getCountryCode( values.countryState ),
-			derived_currency: currencySettings.currency_code,
+			derived_currency: currencySettings.code,
 			email_signup: values.isAgreeMarketing,
 		} );
 


### PR DESCRIPTION
Fixes #7569

This PR fixes the undefined derived_currency prop value for the track `wcadmin_storeprofiler_store_details_continue`.

### Detailed test instructions:

1. Create a new store and activate the debug on the browser console.
2. Go to the setup wizard
3. Fill out the store details
4. Click the "Continue" button and 
5. See that `wcadmin_storeprofiler_store_details_continue` is fired with a non-null derived_currency value.