### PR TITLE
Added a filter that allow to change the csv reports directory.

### DIFF
--- a/changelogs/dev-filter-reports-directory
+++ b/changelogs/dev-filter-reports-directory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Adds a filter that allow us to change the csv reports directory.

--- a/src/ReportCSVExporter.php
+++ b/src/ReportCSVExporter.php
@@ -105,7 +105,7 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	public static function get_reports_directory() {
 		$upload_dir  = wp_upload_dir();
 		$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'woocommerce_uploads/reports/';
-		return apply_filters( 'woocommerce_report_export_get_directory', $reports_dir );
+		return apply_filters( 'woocommerce_admin_report_export_get_directory', $reports_dir );
 	}
 
 	/**

--- a/src/ReportCSVExporter.php
+++ b/src/ReportCSVExporter.php
@@ -103,8 +103,9 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	 * @return string
 	 */
 	public static function get_reports_directory() {
-		$upload_dir = wp_upload_dir();
-		return trailingslashit( $upload_dir['basedir'] ) . 'woocommerce_uploads/reports/';
+		$upload_dir  = wp_upload_dir();
+		$reports_dir = trailingslashit( $upload_dir['basedir'] ) . 'woocommerce_uploads/reports/';
+		return apply_filters( 'woocommerce_report_export_get_directory', $reports_dir );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

I've added a filter that allow us to change the reports storage directory. With it we can solve conflicts between some plugins (eg. a plugin that changes the wordpress default upload directory) or change the default directory to a non-public/custom folder in the server. 
