### PR TITLE
Fix setup wizard title and flash of content

### DIFF
--- a/changelogs/fix-6598
+++ b/changelogs/fix-6598
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix setup wizard title and flash of content #8201

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -173,7 +173,7 @@ export const getPages = () => {
 			path: '/setup-wizard',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[ '/setup-wizard', __( 'Setup Wizard', 'woocommerce-admin' ) ],
+				__( 'Setup Wizard', 'woocommerce-admin' ),
 			],
 			capability: 'manage_woocommerce',
 		} );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -217,7 +217,7 @@ class Onboarding {
 		// New settings injection.
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
-		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
+		add_filter( 'admin_body_class', array( __CLASS__, 'add_loading_classes' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 	}
@@ -731,19 +731,24 @@ class Onboarding {
 	}
 
 	/**
-	 * Let the app know that we will be showing the onboarding route, so wp-admin elements should be hidden while loading.
+	 * Set the admin full screen class when loading to prevent flashes of unstyled content.
 	 *
-	 * @param bool $is_loading Indicates if the `woocommerce-admin-is-loading` should be appended or not.
-	 * @return bool
+	 * @param bool $classes Body classes.
+	 * @return array
 	 */
-	public function is_loading( $is_loading ) {
-		$show_profiler = self::should_show_profiler();
-
-		if ( $show_profiler ) {
-			return true;
+	public static function add_loading_classes( $classes ) {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if (
+			isset( $_GET['page'] ) &&
+			'wc-admin' === $_GET['page'] &&
+			isset( $_GET['path'] ) &&
+			'/setup-wizard' === $_GET['path']
+		) {
+			$classes .= ' woocommerce-admin-full-screen';
 		}
+		/* phpcs: enable */
 
-		return $is_loading;
+		return $classes;
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -109,6 +109,7 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_action( 'current_screen', array( $this, 'reset_extended_task_list' ) );
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
+		add_action( 'current_screen', array( $this, 'redirect_to_profiler' ) );
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
 	}
 
@@ -338,17 +339,31 @@ class Onboarding {
 	 * @return bool
 	 */
 	public static function should_show_profiler() {
-		/* phpcs:disable WordPress.Security.NonceVerification */
-		$is_current_page = isset( $_GET['page'] ) &&
-			'wc-admin' === $_GET['page'] &&
-			isset( $_GET['path'] ) &&
-			'/setup-wizard' === $_GET['path'];
-		/* phpcs: enable */
-
-		if ( $is_current_page ) {
+		if ( self::is_profile_wizard() ) {
 			return true;
 		}
 
+		return self::profiler_needs_completion();
+	}
+
+	/**
+	 * Redirect to the profiler on homepage if completion is needed.
+	 */
+	public static function redirect_to_profiler() {
+		if ( ! self::is_homepage() || ! self::profiler_needs_completion() ) {
+			return;
+		}
+
+		wp_safe_redirect( wc_admin_url( '&path=/setup-wizard' ) );
+		exit;
+	}
+
+	/**
+	 * Check if the profiler still needs to be completed.
+	 *
+	 * @return bool
+	 */
+	public static function profiler_needs_completion() {
 		$onboarding_data = get_option( self::PROFILE_DATA_OPTION, array() );
 
 		$is_completed = isset( $onboarding_data['completed'] ) && true === $onboarding_data['completed'];
@@ -357,6 +372,33 @@ class Onboarding {
 		// @todo When merging to WooCommerce Core, we should set the `completed` flag to true during the upgrade progress.
 		// https://github.com/woocommerce/woocommerce-admin/pull/2300#discussion_r287237498.
 		return ! $is_completed && ! $is_skipped;
+	}
+
+	/**
+	 * Check if the current page is the profile wizard.
+	 *
+	 * @return bool
+	 */
+	public static function is_profile_wizard() {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		return isset( $_GET['page'] ) &&
+			'wc-admin' === $_GET['page'] &&
+			isset( $_GET['path'] ) &&
+			'/setup-wizard' === $_GET['path'];
+		/* phpcs: enable */
+	}
+
+	/**
+	 * Check if the current page is the homepage.
+	 *
+	 * @return bool
+	 */
+	public static function is_homepage() {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		return isset( $_GET['page'] ) &&
+			'wc-admin' === $_GET['page'] &&
+			! isset( $_GET['path'] );
+		/* phpcs: enable */
 	}
 
 	/**
@@ -738,12 +780,7 @@ class Onboarding {
 	 */
 	public static function add_loading_classes( $classes ) {
 		/* phpcs:disable WordPress.Security.NonceVerification */
-		if (
-			isset( $_GET['page'] ) &&
-			'wc-admin' === $_GET['page'] &&
-			isset( $_GET['path'] ) &&
-			'/setup-wizard' === $_GET['path']
-		) {
+		if ( self::is_profile_wizard() ) {
 			$classes .= ' woocommerce-admin-full-screen';
 		}
 		/* phpcs: enable */


### PR DESCRIPTION
Fixes #6598 

* Fixes the setup wizard title
* Adds the full screen class to hide content while the page is loading

Note that the `woocommerce-admin-is-loading` class still works by adding a body class to the page.  However, since the chunks are now lazily loaded, `woocommerce-admin-is-loading` gets removed prior to the chunks loading causing the flash.

### Detailed test instructions:

1. Navigate to `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard` directly via your browser's address bar
2. Note that the page content underneath (header, menu, etc) is not shown while the profile wizard is loading
3. In your browser's console run `document.body.classList.remove('woocommerce-admin-full-screen');` 
4. This will result in a broken layout, but the important item to note here is that the header title is now "Store details" instead of "/setup-wizardStoreDetails"
3. Navigate to other pages to make sure no regressions have occurred