### PR TITLE
Avoid `get_notes` call in `CouponPageMoved`

### DIFF
--- a/changelogs/fix-7986-avoid-get_notes-in-CouponPageMoved
+++ b/changelogs/fix-7986-avoid-get_notes-in-CouponPageMoved
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Performance
+
+Avoid expensive get_notes() queries in CouponPageMoved admin_init actions by using new Notes::get_note_by_name() helper method. #8202

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -94,15 +94,16 @@ class CouponPageMoved {
 	 * @return bool
 	 */
 	protected static function has_unactioned_note() {
-		$notes = self::get_data_store()->get_notes(
-			[
-				'name'       => [ self::NOTE_NAME ],
-				'status'     => [ 'unactioned' ],
-				'is_deleted' => false,
-			]
+		global $wpdb;
+
+		$unactioned_note_count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE name = %s AND status = %s AND is_deleted = 0",
+				[ self::NOTE_NAME, 'unactioned' ]
+			)
 		);
 
-		return ! empty( $notes );
+		return $unactioned_note_count > 0;
 	}
 
 	/**
@@ -111,14 +112,16 @@ class CouponPageMoved {
 	 * @return bool
 	 */
 	protected static function has_dismissed_note() {
-		$notes = self::get_data_store()->get_notes(
-			[
-				'name'       => [ self::NOTE_NAME ],
-				'is_deleted' => true,
-			]
+		global $wpdb;
+
+		$dismissed_note_count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE name = %s AND is_deleted = 1",
+				[ self::NOTE_NAME ]
+			)
 		);
 
-		return ! empty( $notes );
+		return $dismissed_note_count > 0;
 	}
 
 	/**

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -109,16 +109,13 @@ class CouponPageMoved {
 	 * @return bool
 	 */
 	protected static function has_dismissed_note() {
-		global $wpdb;
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
 
-		$dismissed_note_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE name = %s AND is_deleted = 1",
-				[ self::NOTE_NAME ]
-			)
-		);
+		if ( ! $note ) {
+			return false;
+		}
 
-		return $dismissed_note_count > 0;
+		return ! $note->get_is_deleted();
 	}
 
 	/**

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -94,16 +94,13 @@ class CouponPageMoved {
 	 * @return bool
 	 */
 	protected static function has_unactioned_note() {
-		global $wpdb;
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
 
-		$unactioned_note_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE name = %s AND status = %s AND is_deleted = 0",
-				[ self::NOTE_NAME, 'unactioned' ]
-			)
-		);
+		if ( ! $note ) {
+			return false;
+		}
 
-		return $unactioned_note_count > 0;
+		return $note->get_status() === 'unactioned';
 	}
 
 	/**

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -316,14 +316,11 @@ class Notes {
 	 * @return string|bool The note status.
 	 */
 	public static function get_note_status( $note_name ) {
-		$data_store = self::load_data_store();
-		$note_ids   = $data_store->get_notes_with_name( $note_name );
+		$note = self::get_note_by_name( $note_name );
 
-		if ( empty( $note_ids ) ) {
+		if ( ! $note ) {
 			return false;
 		}
-
-		$note = self::get_note( $note_ids[0] );
 
 		return $note->get_status();
 	}

--- a/src/Notes/Notes.php
+++ b/src/Notes/Notes.php
@@ -83,6 +83,26 @@ class Notes {
 	}
 
 	/**
+	 * Get admin note using its name.
+	 *
+	 * This is a shortcut for the common pattern of looking up note ids by name and then passing the first id to get_note().
+	 * It will behave unpredictably when more than one note with the given name exists.
+	 *
+	 * @param string $note_name Note name.
+	 * @return Note|bool
+	 **/
+	public static function get_note_by_name( $note_name ) {
+		$data_store = self::load_data_store();
+		$note_ids   = $data_store->get_notes_with_name( $note_name );
+
+		if ( empty( $note_ids ) ) {
+			return false;
+		}
+
+		return self::get_note( $note_ids[0] );
+	}
+
+	/**
 	 * Get the total number of notes
 	 *
 	 * @param string $type Comma separated list of note types.


### PR DESCRIPTION
Fixes #7986 

`CouponPageMoved::possibly_add_note()` was potentially calling `get_notes()` from the data store twice, which can get expensive. I have changed both the called methods (`has_dismissed_note()` and `has_unactioned_note()`) to directly call `$wpdb` with simpler, less expensive queries.

### Detailed test instructions:

The relevant method runs as part of the [admin_init](https://developer.wordpress.org/reference/hooks/admin_init/) hook, so among other things it happens any time you load wp-admin. If coupons are enabled, legacy coupon menu is enabled, and there isn't already an unactioned or soft-deleted `wc-admin-coupon-page-moved` note in the database, one should be created.
<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
