### PR TITLE
Add Spain to Square suggestion country list

### DIFF
--- a/changelogs/add-8198-include-square-in-spain
+++ b/changelogs/add-8198-include-square-in-spain
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add Spain to Square country suggestion list. #8210

--- a/docs/features/payment-gateway-suggestions.md
+++ b/docs/features/payment-gateway-suggestions.md
@@ -16,7 +16,7 @@ This will create a new plugin that when activated will add two new gateway sugge
 
 ## Data Source Polling
 
-If a store is opted into marketplace suggestions via `woocommerce_show_marketplace_suggestions` the suggestions by default will be retrieved from `https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/payment-method/suggestions.json'`.
+If a store is opted into marketplace suggestions via `woocommerce_show_marketplace_suggestions` the suggestions by default will be retrieved from `https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json`.
 
 If a user is not opted into marketplace suggestions or polling fails, the gateway suggestions will fall back to the defaults in the `DefaultPaymentGateways` class.
 

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -374,7 +374,7 @@ class DefaultPaymentGateways {
 								self::get_rules_for_cbd( true ),
 							),
 							array(
-								self::get_rules_for_countries( array( 'US', 'CA', 'JP', 'GB', 'AU', 'IE', 'FR' ) ),
+								self::get_rules_for_countries( array( 'US', 'CA', 'JP', 'GB', 'AU', 'IE', 'FR', 'ES' ) ),
 								self::get_rules_for_selling_venues( array( 'brick-mortar', 'brick-mortar-other' ) ),
 							),
 						),


### PR DESCRIPTION
Fixes #8198

Include Square in Spain for #8198

Also fix the data URL in `docs/features/payment-gateway-suggestions.md`

### Screenshots
![Screen Shot 2022-01-24 at 18 21 11](https://user-images.githubusercontent.com/4344253/150765168-bde583d0-48b9-404a-9efa-e5e2014c97e1.png)


### Detailed test instructions:

1. Check out this branch
2. Run the setup wizard
3. Choose **Spain** as your location in the Store Details step 
4. Select one of the following options in the Business details to step - 'Currently selling elsewhere'
- Yes, in-person at physical stores and/or events
- Yes, on another platform and in person at physical stores and/or events
5. To make sure the fallback payment suggestions file is used, turn off `woocommerce_show_marketplace_suggestions` option **OR** break the connection between your local woocommerce-admin site and woocommerce.com
- `wp-env run cli wp option set woocommerce_show_marketplace_suggestions no`
- Delete the `woocommerce_admin_payment_gateway_suggestion_specs` transient, if any
 and change [this URL](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/PaymentGatewaySuggestions/PaymentGatewaySuggestionsDataSourcePoller.php#L18) to something that won't return json
6. Go to **WooCommerce > Home** and click the "Set up payments" task
7. Verify that Square is one of the options in the Set Up Payments interface.
