### PR TITLE
Fix Uncaught TypeError count(NULL) for php8+ in Marketing.php

### DIFF
--- a/changelogs/fix-8211-marketing-overview-type-error
+++ b/changelogs/fix-8211-marketing-overview-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Uncaught TypeError count(NULL) for php8+ in Marketing.php. #8213

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -265,8 +265,7 @@ class Marketing {
 						'author_avatar' => isset( $raw_post['author_avatar_url'] ) ? $raw_post['author_avatar_url'] : '',
 					];
 
-					$featured_media = $raw_post['_embedded']['wp:featuredmedia'];
-
+					$featured_media = $raw_post['_embedded']['wp:featuredmedia'] ?? [];
 					if ( count( $featured_media ) > 0 ) {
 						$image         = current( $featured_media );
 						$post['image'] = add_query_arg(


### PR DESCRIPTION
Fixes #8211

This PR fixes a marketing page fatal error in PHP 8+:

```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, 
null given in /var/www/html/wp-content/plugins/woocommerce-admin/src/Features/Marketing.php:269
```

Note: count(NULL) is a warning in PHP 7 but becomes a fatal error in PHP 8+.

### Screenshots

Before:
![Screen Shot 2022-01-25 at 10 59 52](https://user-images.githubusercontent.com/4344253/150924384-da60ddee-742b-4be4-ae1d-1919c8660cf5.png)

After:
![Screen Shot 2022-01-25 at 14 37 30](https://user-images.githubusercontent.com/4344253/150924427-e324b6e7-53c8-4ad0-a385-2765843ee931.png)


### Detailed test instructions:

1. Checkout to the main branch
2. Start a new site with PHP 8+
3. Go to **"Marketing > Overview"**
4. You should see **"Oops, our posts aren't loading right now"** messages under "WooCommerce knowledge base"
4. View the debug logs and you should notice this error
5. Checkout this branch
6. Reload the **"Marketing > Overview"** page
7. You should see the contents under "WooCommerce knowledge base" and no errors in debug logs
