### PR TITLE
Bump versions for multiple WooCommerce packages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 8.2.0
+
 -   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982
 -   Fix select-control component label/value alignment. #8045
 -   Fix clicking the error message opens the dropdown. #8094

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "8.1.1",
+	"version": "8.2.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 3.2.1
+
 -   Tweak - Added `useCode` parameter to `formatAmount`, to render currency code instead of symbol. #7575
 
 # 3.2.0

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/currency",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"description": "WooCommerce currency utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,10 +1,42 @@
 # Unreleased
 
+# 2.0.0
+
+## Breaking changes
+
 -   Fix the batch fetch logic for the options data store. #7587
 -   Add backwards compability for old function format. #7688
 -   Add console warning for inbox note contents exceeding 320 characters and add dompurify dependency. #7869
 -   Fix race condition in data package's options module. #7947
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
+-   Update plugins data store actions #8042
+-   Add `defaultDateRange` parameter to `getRequestQuery` #8189
+-   Change `getLocale` selector parameter from country to id #8123
+-   Add countries data store #8119
+-   Rename `is_visible` to `can_view` #7918
+-   Replace old task list option calls with data store selectors #7820
+-   Remove task status endpoint #7841
+-   Add country validation to subscription inclusion #7777
+-   Move some of the deprecated tasks #7761
+-   Change how `getTasksFromDeprecatedFilter` works #7749
+-   Add query args for removeAllNotes #7743
+-   Removed some attributes from `TasksStatusState` #7736
+-   Add an endpoint and method for actioning tasks #7746
+-   Add show/hide behavior for task list API #7733
+-   Add optimistic task completion and cache invalidation #7722
+-   Add extended task list support to the new REST api task lists #7730
+-   Migrate tasks to task API #7699
+-   Revert `searchItemsByString` to use selector param again #7682
+-   Add hide task list endpoint and data actions #7578
+-   Add task list components to consume task list REST API #7556
+-   Add Newsletter Signup to onboarding data store #7601
+-   Add task selectors and actions to onboarding data store #7545
+-   Add super admin check to preloaded user data #7489
+-   Add free extensions data store #7420
+-   Add `isPluginsRequesting` selector #7383
+-   Add options and change selector param for `searchItemsByString`. #7385
+-   Change select to selector param for `searchItemsByString`. #7355
+-   Change item data store's `getItems` selector #7395
 
 # 1.4.0
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "1.4.0",
+	"version": "2.0.0",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Unreleased
 
+# 3.2.0
+
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
 -   Add "defaultDateRange" argument to "getAllowedIntervalsForQuery" for default period value. #8189
 -   Add type option to `getDateFormatsForInterval` to support `getDateFormatsForIntervalPhp` feature. #8129
+-   Sentence case all the things analytics #6501
+-   Fix end date for last periods #6584
 
 # 3.1.0
 

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/date",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "WooCommerce date utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
--	Make the Inbox note title clickable. #7975
+
+# 2.2.0
+-	  Make the Inbox note title clickable. #7975
 -   Fix incorrectly displayed note created date. #8179
+-   Fix inbox note css #7983
+-   Implement inbox note read state #7896
 
 # 2.1.0
 

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 # 2.2.0
--	  Make the Inbox note title clickable. #7975
+-   Make the Inbox note title clickable. #7975
 -   Fix incorrectly displayed note created date. #8179
 -   Fix inbox note css #7983
 -   Implement inbox note read state #7896

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+# 1.1.4
+
 - Fix an error when getting woocommerce_default_country value. #7600
 - Attempts to get the woocommerce_default_country value in wcSettings.preloadSettings.general first for the backward compatibility #7600
-# 1.1.3 
+
+# 1.1.3
 
 - Retry fix for missing build-module folder
 

--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/explat",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "WooCommerce component and utils for A/B testing.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR bumps versions for multiple `@woocommerce` packages ahead of publishing to npm. It seems we have missed updating these packages for some time now.

I skipped `admin-e2e-tests` in this update since I think it's more appropriate to address it in a separate PR. This is because I may only partially publish its updates since the tests are tightly tied to WooCommerce version releases.

**Patch version bump:**
- currency
- explat

**Minor version bump:**
- components
- date
- experimental

**Major version bump (with breaking changes):**
- data

No changelog.

