### PR TITLE
Bump version to 3.3.0-dev and sync changelog from 3.2.0-beta.1

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Testing instructions
 
-## Unreleased
+## 3.2.0
 
 ### Fix category report query returns invalid net sales
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,41 @@
+== 3.2.0 01/25/2022 ==
+
+- Fix: changed email validation in Store Details onboarding task to more closely match PHP backend validation. #8197
+- Fix: Disallow whitespace as the platform name input. #8090
+- Fix: Ensure setup-wizard redirection on homescreen is stable. #8114
+- Fix: Fix category report query returns invalid net sales. #8153
+- Fix: Fix clicking the error message opens the dropdown. #8094
+- Fix: Fix get_automated_tax_supported_countries doesn't include UK. #8180
+- Fix: Fix incorrect date options when the "Default Date Range" is set from Analytics settings. #8189
+- Fix: Fix incorrectly displayed note created date. #8179
+- Fix: Fix incorrect screen reader text generated for data points on charts table. #8181
+- Fix: Fix incorrect total count of downloads on the analytics download report. #8182
+- Fix: Fix misaligned status column on order report. #8121
+- Fix: Fix shipping rate error message overlaps with the 'Proceed' button. #8165
+- Fix: Fix undefined derived_currency value for the track 'wcadmin_storeprofiler_store_details_continue'. #8193
+- Fix: Fix variations table product filter query. #8120
+- Fix: Preserve HTML markup in server-side error messages received from sample product import request. #8173
+- Fix: Remove border between email input and newsletter checkbox in OBW store details. #8148
+- Fix: Reset "install_timestamp" if it's not numeric to avoid TypeError. #8100
+- Fix: Truncate the long site title with an ellipses on the second line. #8112
+- Add: Add countries data store #8119
+- Add: Add extra tracking for plugin installation performance during onboarding. #8042
+- Add: Adding tooltip to describe the lack of refund deductions from revenue summaries. #8187
+- Add: Add localized validation to store address #8123
+- Add: Add Magento migration note #8145
+- Add: Add REST endpoint to retrieve address locales #8116
+- Add: Change the reviews empty state panels logic #8147
+- Update: Add custom error for store details email and allow continue #8110
+- Update: Adding "allow-plugins" property for composer configuration. #8139
+- Dev: Remove wc-admin-settings package and rename getSetting to getAdminSetting. #8057
+- Tweak: Grow and center buttons in all WooCommerce ellipsis menu popover containers. #8168
+- Tweak: Hide store address fields in regions that specify hidden #8172
+- Tweak: Make activity panel badges margin consistent. #8152
+- Tweak: Padding tweak for marketing tools plugin list headings. #8171
+- Performance: Speed up customer syncing action. #8021
+- Enhancement: Enhance report chart i18n support. #8129
+- Enhancement: Show MailPoet in Installed marketing extensions. #8091
+
 == 3.1.0 01/25/2022 ==
 
 - Fix: Fix Onboarding flow where extensions might not be selected and installed. #7979

--- a/changelogs/2022-01-17-08-56-31-701552
+++ b/changelogs/2022-01-17-08-56-31-701552
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix incorrect total count of downloads on the analytics download report. #8182

--- a/changelogs/add-7919_performance_tracks
+++ b/changelogs/add-7919_performance_tracks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add extra tracking for plugin installation performance during onboarding. #8042

--- a/changelogs/add-7971
+++ b/changelogs/add-7971
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add Magento migration note #8145

--- a/changelogs/add-7997-add-tooltip
+++ b/changelogs/add-7997-add-tooltip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Adding tooltip to describe the lack of refund deductions from revenue summaries. #8187

--- a/changelogs/add-8074
+++ b/changelogs/add-8074
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Change the reviews empty state panels logic #8147

--- a/changelogs/add-store-address-hidden
+++ b/changelogs/add-store-address-hidden
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Hide store address fields in regions that specify hidden #8172

--- a/changelogs/dev-wc-admin-settings
+++ b/changelogs/dev-wc-admin-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Dev
-
-Remove wc-admin-settings package and rename getSetting to getAdminSetting. #8057

--- a/changelogs/enhancement-7827-report-i18n-translate
+++ b/changelogs/enhancement-7827-report-i18n-translate
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Enhancement
-
-Enhance report chart i18n support. #8129

--- a/changelogs/enhancement-8091-mailpoet-in-installed-extensions
+++ b/changelogs/enhancement-8091-mailpoet-in-installed-extensions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Enhancement
-
-Show MailPoet in Installed marketing extensions. #8091

--- a/changelogs/fix-2006-notes-time-zone
+++ b/changelogs/fix-2006-notes-time-zone
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix incorrectly displayed note created date. #8179

--- a/changelogs/fix-26452-customers-sync-performance
+++ b/changelogs/fix-26452-customers-sync-performance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Performance
-
-Speed up customer syncing action. #8021

--- a/changelogs/fix-4314-import-products-error-message-formatting
+++ b/changelogs/fix-4314-import-products-error-message-formatting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Fix
-
-Preserve HTML markup in server-side error messages received from sample product import request. #8173

--- a/changelogs/fix-5836-automated-tax-supported-countries-uk
+++ b/changelogs/fix-5836-automated-tax-supported-countries-uk
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix get_automated_tax_supported_countries doesn't include UK. #8180

--- a/changelogs/fix-6255-screen-reader-text-on-chart-table
+++ b/changelogs/fix-6255-screen-reader-text-on-chart-table
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix incorrect screen reader text generated for data points on charts table. #8181

--- a/changelogs/fix-6389-shipping-error-message-overlaps
+++ b/changelogs/fix-6389-shipping-error-message-overlaps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix shipping rate error message overlaps with the 'Proceed' button. #8165

--- a/changelogs/fix-7174-dismiss-button-alignment
+++ b/changelogs/fix-7174-dismiss-button-alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Grow and center buttons in all WooCommerce ellipsis menu popover containers. #8168

--- a/changelogs/fix-7569-undefined-currency-code
+++ b/changelogs/fix-7569-undefined-currency-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix undefined derived_currency value for the track 'wcadmin_storeprofiler_store_details_continue'. #8193

--- a/changelogs/fix-7623-misaligned-status-column-on-orders-report
+++ b/changelogs/fix-7623-misaligned-status-column-on-orders-report
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix misaligned status column on order report. #8121

--- a/changelogs/fix-7639-by-hour-option-not-displayed
+++ b/changelogs/fix-7639-by-hour-option-not-displayed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix incorrect date options when the "Default Date Range" is set from Analytics settings. #8189

--- a/changelogs/fix-7710-overview-category-report-query-invalid-net-sales
+++ b/changelogs/fix-7710-overview-category-report-query-invalid-net-sales
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix category report query returns invalid net sales. #8153

--- a/changelogs/fix-7768-variations-table-filter
+++ b/changelogs/fix-7768-variations-table-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix variations table product filter query. #8120

--- a/changelogs/fix-7863-misaligned-rows-per-page-dropdown
+++ b/changelogs/fix-7863-misaligned-rows-per-page-dropdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix misaligned "Rows per page" dropdown. #8113

--- a/changelogs/fix-7891-uncaught-typeError-int-string
+++ b/changelogs/fix-7891-uncaught-typeError-int-string
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Reset "install_timestamp" if it's not numeric to avoid TypeError. #8100

--- a/changelogs/fix-7906-click-error-message-open-select-control
+++ b/changelogs/fix-7906-click-error-message-open-select-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix clicking the error message opens the dropdown. #8094

--- a/changelogs/fix-7907-disallow-white-space-platform-name-input
+++ b/changelogs/fix-7907-disallow-white-space-platform-name-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Disallow whitespace as the platform name input. #8090

--- a/changelogs/fix-8006-hide-header-if-no-plugin
+++ b/changelogs/fix-8006-hide-header-if-no-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Hide the extensions header when no available plugins in the category. #8089

--- a/changelogs/fix-8007-update-free-extensions-when-country-industry-changed
+++ b/changelogs/fix-8007-update-free-extensions-when-country-industry-changed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Fix free extensions list isn't updated after store location or industry is changed. #8099

--- a/changelogs/fix-8011-truncate-long-site-title
+++ b/changelogs/fix-8011-truncate-long-site-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Truncate the long site title with an ellipses on the second line. #8112

--- a/changelogs/fix-8029-ensure-redirect-to-setup-wizard-stably
+++ b/changelogs/fix-8029-ensure-redirect-to-setup-wizard-stably
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Ensure setup-wizard redirection on homescreen is stable. #8114

--- a/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
+++ b/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Remove border between email input and newsletter checkbox in OBW store details. #8148

--- a/changelogs/fix-8096-doc-links
+++ b/changelogs/fix-8096-doc-links
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Replace all docs.woocommerce.com links with woocommerce.com/document. #8105

--- a/changelogs/fix-8155-improve-frontend-email-validation
+++ b/changelogs/fix-8155-improve-frontend-email-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-changed email validation in Store Details onboarding task to more closely match PHP backend validation. #8197

--- a/changelogs/fix-8164-padding-reduction-reach-out-to-customers
+++ b/changelogs/fix-8164-padding-reduction-reach-out-to-customers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Tweak
-
-Padding tweak for marketing tools plugin list headings. #8171

--- a/changelogs/tweak-8035-activity-panel-badges-margin
+++ b/changelogs/tweak-8035-activity-panel-badges-margin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Tweak
-
-Make activity panel badges margin consistent. #8152

--- a/changelogs/update-7782
+++ b/changelogs/update-7782
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add REST endpoint to retrieve address locales #8116

--- a/changelogs/update-7782-data-store
+++ b/changelogs/update-7782-data-store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add countries data store #8119

--- a/changelogs/update-7782-store-details
+++ b/changelogs/update-7782-store-details
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add localized validation to store address #8123

--- a/changelogs/update-7923
+++ b/changelogs/update-7923
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Update
-
-Add custom error for store details email and allow continue #8110

--- a/changelogs/update-composer-add-allow-plugins
+++ b/changelogs/update-composer-add-allow-plugins
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Update
-
-Adding "allow-plugins" property for composer configuration. #8139

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "3.2.0-dev",
+	"version": "3.3.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.2.0-dev",
+	"version": "3.3.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.8.1
 Requires PHP: 7.0
-Stable tag: 3.2.0-dev
+Stable tag: 3.3.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activity, notices, insights, stats, woo commerce, woocommerce
 Requires at least: 5.4.0
-Tested up to: 5.8.1
+Tested up to: 5.9.0
 Requires PHP: 7.0
 Stable tag: 3.3.0-dev
 License: GPLv3

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '3.2.0-dev';
+	const VERSION = '3.3.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -146,7 +146,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.2.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 3.2.0-dev
+ * Version: 3.3.0-dev
  * Requires at least: 5.6
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
This PR bumps the version to `3.3.0-dev` and syncs the changelog and testing instructions from 3.2.0-beta.1.

## Testing instructions

1. Confidence check - make sure version bumps and changelog changes look correct.

(no changelog is needed here)
