### PR TITLE
Fix country/region selection not preserved in store details task

### DIFF
--- a/changelogs/fix-8225-country-region-not-preserved
+++ b/changelogs/fix-8225-country-region-not-preserved
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix country/region selection not preserved in store details task. #8228

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -218,8 +218,9 @@ export function useGetCountryStateAutofill(
 			}
 		}
 		isAutofillChange.current = false;
+		// Disable reason: If we include autofillCountry/autofillState in the dependency array, we will have an unnecessary function call because we also update them in this function.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ countryState ] );
+	}, [ countryState, options ] );
 
 	// Sync the countryState value the autofill fields changes
 	useEffect( () => {
@@ -282,6 +283,7 @@ export function useGetCountryStateAutofill(
 			isAutofillChange.current = true;
 			setValue( 'countryState', filteredOptions[ 0 ].key );
 		}
+		// Disable reason: If we include countryState in the dependency array, we will have an unnecessary function call because we also update it in this function.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ autofillCountry, autofillState, options, setValue ] );
 
@@ -313,6 +315,7 @@ export function useGetCountryStateAutofill(
 }
 
 type StoreAddressProps = {
+	// Disable reason: The getInputProps type are not provided by the caller and source.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	getInputProps: any;
 	setValue: ( key: string, value: string ) => void;

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -238,8 +238,9 @@ export function useGetCountryStateAutofill(
 			escapeRegExp( autofillCountry ),
 			'i'
 		);
-		const isStateAbbreviation = autofillState.length < 3;
 		const isCountryAbbreviation = autofillCountry.length < 3;
+		const isStateAbbreviation =
+			autofillState.length < 3 && autofillState.match( /^[\w]+$/ );
 		let filteredOptions = [];
 
 		if ( autofillCountry.length && autofillState.length ) {

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -154,13 +154,13 @@ export const getStateFilter = (
 		? option.key.split( ':' )
 		: option.label.split( '—' );
 
-	// no region options in country
+	// No region options in the country
 	if ( countryStateArray.length <= 1 ) {
 		return false;
 	}
 
 	const state = countryStateArray[ 1 ];
-	// handle special case, for example: China — Beijing / 北京
+	// Handle special case, for example: China — Beijing / 北京
 	if ( state.includes( '/' ) ) {
 		const stateStrList = state.split( '/' );
 		return (
@@ -169,7 +169,7 @@ export const getStateFilter = (
 		);
 	}
 
-	// handle special case, for example: Iran — Alborz (البرز)
+	// Handle special case, for example: Iran — Alborz (البرز)
 	if ( state.includes( '(' ) && state.includes( ')' ) ) {
 		const stateStrList = state.replace( ')', '' ).split( '(' );
 		return (
@@ -200,7 +200,7 @@ export function useGetCountryStateAutofill(
 		current: boolean;
 	} = useRef();
 
-	// sync the autofill fields on first render and the countryState value changes.
+	// Sync the autofill fields on first render and the countryState value changes.
 	useEffect( () => {
 		if ( ! isAutofillChange.current ) {
 			const option = options.find( ( opt ) => opt.key === countryState );
@@ -222,14 +222,15 @@ export function useGetCountryStateAutofill(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ countryState ] );
 
-	// sync the countryState value the autofill fields changes
+	// Sync the countryState value the autofill fields changes
 	useEffect( () => {
-		// skip on first render since we only want to update the value when the autofill fields changes.
+		// Skip on first render since we only want to update the value when the autofill fields changes.
 		if ( isAutofillChange.current === undefined ) {
 			return;
 		}
 
 		if ( ! autofillCountry && ! autofillState && countryState ) {
+			// Clear form
 			isAutofillChange.current = true;
 			setValue( 'countryState', '' );
 			return;
@@ -240,7 +241,7 @@ export function useGetCountryStateAutofill(
 		);
 		const isCountryAbbreviation = autofillCountry.length < 3;
 		const isStateAbbreviation =
-			autofillState.length < 3 && autofillState.match( /^[\w]+$/ );
+			autofillState.length < 3 && !! autofillState.match( /^[\w]+$/ );
 		let filteredOptions = [];
 
 		if ( autofillCountry.length && autofillState.length ) {
@@ -249,7 +250,7 @@ export function useGetCountryStateAutofill(
 					isCountryAbbreviation ? option.key : option.label
 				)
 			);
-			// No country matches so use all options for state filter.
+			// no country matches so use all options for state filter.
 			if ( ! filteredOptions.length ) {
 				filteredOptions = [ ...options ];
 			}

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -28,11 +28,10 @@ type Option = { key: string; label: string };
  */
 export function isAddressFieldRequired(
 	fieldName: string,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	locale: any = {}
+	locale: unknown = {}
 ): boolean {
 	if ( locale[ fieldName ]?.hasOwnProperty( 'required' ) ) {
-		return locale[ fieldName ]?.required;
+		return locale[ fieldName ]?.required as boolean;
 	}
 
 	if ( fieldName === 'address_2' ) {

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -16,6 +16,9 @@ import { useSelect } from '@wordpress/data';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
+
+type Option = { key: string; label: string };
+
 /**
  * Check if a given address field is required for the locale.
  *
@@ -23,7 +26,11 @@ const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
  * @param {Object} locale Locale data.
  * @return {boolean} Field requirement.
  */
-export function isAddressFieldRequired( fieldName, locale = {} ) {
+export function isAddressFieldRequired(
+	fieldName: string,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	locale: any = {}
+): boolean {
 	if ( locale[ fieldName ]?.hasOwnProperty( 'required' ) ) {
 		return locale[ fieldName ]?.required;
 	}
@@ -123,6 +130,58 @@ export function getCountryStateOptions() {
 }
 
 /**
+ * Normalize state string for matching.
+ *
+ * @param {string} state The state to normalize.
+ * @return {Function} filter function.
+ */
+export const normalizeState = ( state: string ): string => {
+	return state.replace( /\s/g, '' ).toLowerCase();
+};
+
+/**
+ * Get state filter
+ *
+ * @param {string} isStateAbbreviation Whether to use state abbreviation or not.
+ * @param {string} normalizedAutofillState The value of the autofillState field.
+ * @return {Function} filter function.
+ */
+export const getStateFilter = (
+	isStateAbbreviation: boolean,
+	normalizedAutofillState: string
+): ( ( option: Option ) => boolean ) => ( option: Option ) => {
+	const countryStateArray = isStateAbbreviation
+		? option.key.split( ':' )
+		: option.label.split( '—' );
+
+	// no region options in country
+	if ( countryStateArray.length <= 1 ) {
+		return false;
+	}
+
+	const state = countryStateArray[ 1 ];
+	// handle special case, for example: China — Beijing / 北京
+	if ( state.includes( '/' ) ) {
+		const stateStrList = state.split( '/' );
+		return (
+			normalizeState( stateStrList[ 0 ] ) === normalizedAutofillState ||
+			normalizeState( stateStrList[ 1 ] ) === normalizedAutofillState
+		);
+	}
+
+	// handle special case, for example: Iran — Alborz (البرز)
+	if ( state.includes( '(' ) && state.includes( ')' ) ) {
+		const stateStrList = state.replace( ')', '' ).split( '(' );
+		return (
+			normalizeState( stateStrList[ 0 ] ) === normalizedAutofillState ||
+			normalizeState( stateStrList[ 1 ] ) === normalizedAutofillState
+		);
+	}
+
+	return normalizeState( state ) === normalizedAutofillState;
+};
+
+/**
  * Get the autofill countryState fields and set value from filtered options.
  *
  * @param {Array} options Array of filterable options.
@@ -130,91 +189,91 @@ export function getCountryStateOptions() {
  * @param {Function} setValue Set value of the countryState input.
  * @return {Object} React component.
  */
-export function useGetCountryStateAutofill( options, countryState, setValue ) {
+export function useGetCountryStateAutofill(
+	options: Option[],
+	countryState: string,
+	setValue: ( key: string, value: string ) => void
+): JSX.Element {
 	const [ autofillCountry, setAutofillCountry ] = useState( '' );
 	const [ autofillState, setAutofillState ] = useState( '' );
 	const isAutofillChange: {
 		current: boolean;
 	} = useRef();
 
+	// sync the autofill fields on first render and the countryState value changes.
 	useEffect( () => {
-		const option = options.find( ( opt ) => opt.key === countryState );
-		const labels = option ? option.label.split( /\u2013|\u2014|\-/ ) : [];
-		const newCountry = ( labels[ 0 ] || '' ).trim();
-		const newState = ( labels[ 1 ] || '' ).trim();
+		if ( ! isAutofillChange.current ) {
+			const option = options.find( ( opt ) => opt.key === countryState );
+			const labels = option
+				? option.label.split( /\u2013|\u2014|\-/ )
+				: [];
+			const newCountry = ( labels[ 0 ] || '' ).trim();
+			const newState = ( labels[ 1 ] || '' ).trim();
 
-		if (
-			! isAutofillChange.current &&
-			( newCountry !== autofillCountry || newState !== autofillState )
-		) {
-			setAutofillCountry( newCountry );
-			setAutofillState( newState );
+			if (
+				newCountry !== autofillCountry ||
+				newState !== autofillState
+			) {
+				setAutofillCountry( newCountry );
+				setAutofillState( newState );
+			}
 		}
 		isAutofillChange.current = false;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ countryState ] );
 
+	// sync the countryState value the autofill fields changes
 	useEffect( () => {
+		// skip on first render since we only want to update the value when the autofill fields changes.
+		if ( isAutofillChange.current === undefined ) {
+			return;
+		}
+
 		if ( ! autofillCountry && ! autofillState && countryState ) {
-			// Clear form.
 			isAutofillChange.current = true;
 			setValue( 'countryState', '' );
+			return;
 		}
-		let filteredOptions = [];
 		const countrySearch = new RegExp(
 			escapeRegExp( autofillCountry ),
 			'i'
 		);
-		const stateSearch = new RegExp(
-			escapeRegExp( autofillState.replace( /\s/g, '' ) ) + '$', // Always match the end of string for region.
-			'i'
-		);
-		if ( autofillState.length || autofillCountry.length ) {
-			filteredOptions = options.filter( ( option ) =>
-				( autofillCountry.length ? countrySearch : stateSearch ).test(
-					option.label
-				)
-			);
-		}
+		const isStateAbbreviation = autofillState.length < 3;
+		const isCountryAbbreviation = autofillCountry.length < 3;
+		let filteredOptions = [];
+
 		if ( autofillCountry.length && autofillState.length ) {
-			const isStateAbbreviation = autofillState.length < 3;
-			filteredOptions = filteredOptions.filter( ( option ) =>
-				stateSearch.test(
-					( isStateAbbreviation ? option.key : option.label )
-						.replace( '-', '' )
-						.replace( /\s/g, '' )
+			filteredOptions = options.filter( ( option ) =>
+				countrySearch.test(
+					isCountryAbbreviation ? option.key : option.label
 				)
 			);
-
-			const isCountryAbbreviation = autofillCountry.length < 3;
+			// No country matches so use all options for state filter.
+			if ( ! filteredOptions.length ) {
+				filteredOptions = [ ...options ];
+			}
 			if ( filteredOptions.length > 1 ) {
-				let countryKeyOptions = [];
-				countryKeyOptions = filteredOptions.filter( ( option ) =>
-					countrySearch.test(
-						isCountryAbbreviation ? option.key : option.label
+				filteredOptions = filteredOptions.filter(
+					getStateFilter(
+						isStateAbbreviation,
+						normalizeState( autofillState )
 					)
 				);
-
-				if ( countryKeyOptions.length > 0 ) {
-					filteredOptions = countryKeyOptions;
-				}
 			}
-
-			if ( filteredOptions.length > 1 ) {
-				let stateKeyOptions = [];
-				stateKeyOptions = filteredOptions.filter( ( option ) =>
-					stateSearch.test(
-						( isStateAbbreviation ? option.key : option.label )
-							.replace( '-', '' )
-							.replace( /\s/g, '' )
-					)
-				);
-
-				if ( stateKeyOptions.length === 1 ) {
-					filteredOptions = stateKeyOptions;
-				}
-			}
+		} else if ( autofillCountry.length ) {
+			filteredOptions = options.filter( ( option ) =>
+				countrySearch.test(
+					isCountryAbbreviation ? option.key : option.label
+				)
+			);
+		} else if ( autofillState.length ) {
+			filteredOptions = options.filter(
+				getStateFilter(
+					isStateAbbreviation,
+					normalizeState( autofillState )
+				)
+			);
 		}
-
 		if (
 			filteredOptions.length === 1 &&
 			countryState !== filteredOptions[ 0 ].key
@@ -222,6 +281,7 @@ export function useGetCountryStateAutofill( options, countryState, setValue ) {
 			isAutofillChange.current = true;
 			setValue( 'countryState', filteredOptions[ 0 ].key );
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ autofillCountry, autofillState, options, setValue ] );
 
 	return (
@@ -234,7 +294,7 @@ export function useGetCountryStateAutofill( options, countryState, setValue ) {
 				name="country"
 				type="text"
 				className="woocommerce-select-control__autofill-input"
-				tabIndex="-1"
+				tabIndex={ -1 }
 				autoComplete="country"
 			/>
 
@@ -244,21 +304,31 @@ export function useGetCountryStateAutofill( options, countryState, setValue ) {
 				name="state"
 				type="text"
 				className="woocommerce-select-control__autofill-input"
-				tabIndex="-1"
+				tabIndex={ -1 }
 				autoComplete="address-level1"
 			/>
 		</>
 	);
 }
 
+type StoreAddressProps = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	getInputProps: any;
+	setValue: ( key: string, value: string ) => void;
+};
+
 /**
  * Store address fields.
  *
  * @param {Object} props Props for input components.
+ * @param {Function} props.getInputProps Get input props.
+ * @param {Function} props.setValue Set value of the countryState input.
  * @return {Object} -
  */
-export function StoreAddress( props ) {
-	const { getInputProps, setValue, onChange } = props;
+export function StoreAddress( {
+	getInputProps,
+	setValue,
+}: StoreAddressProps ): JSX.Element {
 	const countryState = getInputProps( 'countryState' ).value;
 	const { locale, hasFinishedResolution } = useSelect( ( select ) => {
 		return {
@@ -274,7 +344,6 @@ export function StoreAddress( props ) {
 		countryState,
 		setValue
 	);
-
 	if ( ! hasFinishedResolution ) {
 		return <Spinner />;
 	}

--- a/client/dashboard/components/settings/general/test/store-address.js
+++ b/client/dashboard/components/settings/general/test/store-address.js
@@ -7,7 +7,7 @@ import { render, fireEvent } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { useGetCountryStateAutofill } from '../store-address';
+import { useGetCountryStateAutofill, getStateFilter } from '../store-address';
 
 const AutofillWrapper = ( { options, value, onChange } ) => {
 	const [ values, setValues ] = useState( { countryState: value || '' } );
@@ -41,7 +41,12 @@ const DEFAULT_OPTIONS = [
 	{ key: 'CA:BC', label: 'Canada — British Columbia' },
 	{ key: 'CA:MB', label: 'Canada — Manitoba' },
 	{ key: 'US:CA', label: 'United States - California' },
+	{ key: 'US:AR', label: 'United States (US) — Arkansas' },
+	{ key: 'US:KS', label: 'United States (US) — Kansas' },
+	{ key: 'CN:CN2', label: 'China — Beijing / 北京' },
+	{ key: 'IR:THR', label: 'Iran — Tehran (تهران)' },
 ];
+
 describe( 'useGetCountryStateAutofill', () => {
 	it( 'should render a country and state inputs with autoComplete', () => {
 		const { queryAllByRole } = render(
@@ -54,7 +59,23 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( inputs[ 1 ].autocomplete ).toEqual( 'address-level1' );
 	} );
 
-	it( 'should set autocomplete fields if a value is selected', () => {
+	it( 'should set countryState value if the value is provided', () => {
+		const onChange = jest.fn();
+		render(
+			<AutofillWrapper
+				options={ [ ...DEFAULT_OPTIONS ] }
+				value="US:KS"
+				onChange={ onChange }
+			/>
+		);
+
+		// check the most recent call values
+		expect( onChange.mock.calls.pop() ).toEqual( [
+			{ countryState: 'US:KS' },
+		] );
+	} );
+
+	it( 'should set autocomplete fields if a countryState has a value', () => {
 		const { queryAllByRole } = render(
 			<AutofillWrapper options={ [ ...DEFAULT_OPTIONS ] } value="CA:MB" />
 		);
@@ -65,7 +86,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( inputs[ 1 ].value ).toEqual( 'Manitoba' );
 	} );
 
-	it( 'should select region by key if abbreviation is used', () => {
+	it( 'should set countryState if auto complete fields are changed and abbreviation is used', () => {
 		const onChange = jest.fn();
 		const { queryAllByRole } = render(
 			<AutofillWrapper
@@ -81,7 +102,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( onChange ).toHaveBeenCalledWith( { countryState: 'US:CA' } );
 	} );
 
-	it( 'should update the value if the auto complete fields changed', () => {
+	it( 'should set countryState if auto complete fields are changed and abbreviation is not used', () => {
 		const onChange = jest.fn();
 		const { queryAllByRole } = render(
 			<AutofillWrapper
@@ -97,7 +118,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( onChange ).toHaveBeenCalledWith( { countryState: 'CA:BC' } );
 	} );
 
-	it( 'should update the value if the auto complete fields changed and value was already set', () => {
+	it( 'should update the countryState if the auto complete fields changed and countryState was already set', () => {
 		const onChange = jest.fn();
 		const { queryAllByRole } = render(
 			<AutofillWrapper
@@ -116,7 +137,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( onChange ).toHaveBeenCalledWith( { countryState: 'CA:BC' } );
 	} );
 
-	it( 'should update the auto complete inputs when value changed and inputs already set', () => {
+	it( 'should update the auto complete fields when countryState is changed and inputs already set', () => {
 		const onChange = jest.fn();
 		const options = [ ...DEFAULT_OPTIONS ];
 		const { rerender, queryAllByRole } = render(
@@ -139,4 +160,54 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( inputs[ 0 ].value ).toEqual( 'Cambodia' );
 		expect( inputs[ 1 ].value ).toEqual( '' );
 	} );
+} );
+
+describe( 'getStateFilter', () => {
+	test.each( [
+		{
+			isStateAbbreviation: false,
+			normalizedAutofillState: 'britishcolumbia',
+			expected: { key: 'CA:BC', label: 'Canada — British Columbia' },
+		},
+		{
+			isStateAbbreviation: true,
+			normalizedAutofillState: 'ks',
+			expected: {
+				key: 'US:KS',
+				label: 'United States (US) — Kansas',
+			},
+		},
+		{
+			isStateAbbreviation: false,
+			normalizedAutofillState: '北京',
+			expected: { key: 'CN:CN2', label: 'China — Beijing / 北京' },
+		},
+		{
+			isStateAbbreviation: false,
+			normalizedAutofillState: 'beijing',
+			expected: { key: 'CN:CN2', label: 'China — Beijing / 北京' },
+		},
+		{
+			isStateAbbreviation: false,
+			normalizedAutofillState: 'تهران',
+			expected: { key: 'IR:THR', label: 'Iran — Tehran (تهران)' },
+		},
+		{
+			isStateAbbreviation: false,
+			normalizedAutofillState: 'tehran',
+			expected: { key: 'IR:THR', label: 'Iran — Tehran (تهران)' },
+		},
+	] )(
+		'should filter state matches with isStateAbbreviation=$isStateAbbreviation and normalizedAutofillState=$normalizedAutofillState',
+		( { isStateAbbreviation, normalizedAutofillState, expected } ) => {
+			expect(
+				DEFAULT_OPTIONS.filter(
+					getStateFilter(
+						isStateAbbreviation,
+						normalizedAutofillState
+					)
+				)
+			).toEqual( [ expected ] );
+		}
+	);
 } );

--- a/client/dashboard/components/settings/general/test/store-address.js
+++ b/client/dashboard/components/settings/general/test/store-address.js
@@ -59,7 +59,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		expect( inputs[ 1 ].autocomplete ).toEqual( 'address-level1' );
 	} );
 
-	it( 'should set countryState value if the value is provided', () => {
+	it( 'should set countryState value if a value is provided', () => {
 		const onChange = jest.fn();
 		render(
 			<AutofillWrapper
@@ -75,7 +75,7 @@ describe( 'useGetCountryStateAutofill', () => {
 		] );
 	} );
 
-	it( 'should set autocomplete fields if a countryState has a value', () => {
+	it( 'should set autocomplete fields if the countryState is not empty', () => {
 		const { queryAllByRole } = render(
 			<AutofillWrapper options={ [ ...DEFAULT_OPTIONS ] } value="CA:MB" />
 		);


### PR DESCRIPTION
Fixes #8225

This PR fixes the country/region preserved issue with the following changes:

- Instead of using the regular expression to match the state label, compare the strings directly to avoid ambiguity.

This issue is that we used the regular expression to match state but the `/Kansas$/i` also matches "Arkansas".

https://github.com/woocommerce/woocommerce-admin/blob/281ae241d0c6d15f696c74cd6bd28294dee16a0f/client/dashboard/components/settings/general/store-address.tsx#L167-L170

And the`filteredOptions` length is two so `countryState` won't be updated.

https://github.com/woocommerce/woocommerce-admin/blob/281ae241d0c6d15f696c74cd6bd28294dee16a0f/client/dashboard/components/settings/general/store-address.tsx#L218-L224

- Handle the special region cases:  `China — Beijing / 北京`, `Iran — Tehran (تهران)`, etc.
- Simplify the logic of the functions in the `useEffect`.
- Update & add more tests
- Add typescript "typings" to function props.
- Fixed "tabIndex" string warning.

### Screenshots

Before:

https://user-images.githubusercontent.com/4344253/151507869-f64af582-43b9-460e-9cb2-b72667f2cff0.mov

After:

https://user-images.githubusercontent.com/4344253/151505034-15d46d98-a872-45e4-80a5-cdd2803865b0.mov




### Detailed test instructions:

1. Create a new store
2. Go to the setup wizard
3. Choose "United States (US) — Kansas" as the "Country/Region"
4. Complete the setup wizard
5. Go to **WooCommerce > Home** click the Store Details task again
6. "Country/Region" should be populated with "United States (US) -- Kansas"
7. Navigate to **WooCommerce > Settings > General**
8. Observe that the "Country / State" value under the Store Address section should be the same.


Since this PR also refactor the autocomplete parts, it would be great to test it as well:

Reference: https://github.com/woocommerce/woocommerce-admin/pull/7497

- Start a new WooCommerce store and go to **WooCommerce > Home** (make sure you have autofill enabled and some addresses configured) - [chrome settings](https://support.google.com/chrome/answer/142893?hl=en&co=GENIE.Platform%3DDesktop&oco=0)
- The onboarding flow should start, asking for the store address
- Do an autofill of the store address and make sure the Country/Region is correctly selected
- Now try each of these cases:
     - After using autocomplete, search for and select a country/region manually, it should change on click
     - Clear the fields and make sure one of your auto-complete addresses uses an abbreviated region (California -> CA) and see if it correctly selects the region with the country
- Feel free to try other things with the type ahead field and see if any odd behavior happens and in other browsers like Safari or Firefox
