### PR TITLE
Make ExPlat request URL args filterable

### DIFF
--- a/changelogs/update-8227-add-install-timestamp-to-explat
+++ b/changelogs/update-8227-add-install-timestamp-to-explat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter. #8231

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -161,6 +161,8 @@ final class Experimental_Abtest {
 			'woo_country_code' => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
 		);
 
+		$args = apply_filters( 'woocommerce_explat_request_args', $args );
+
 		$url = add_query_arg(
 			$args,
 			sprintf(

--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter #8231
+
 # 1.1.4
 
 - Fix an error when getting woocommerce_default_country value. #7600

--- a/packages/explat/jest.config.json
+++ b/packages/explat/jest.config.json
@@ -1,0 +1,4 @@
+{
+	"rootDir": "./src",
+	"preset": "../../js-tests/jest.config.js"
+}

--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -37,6 +37,9 @@
 		"clean": "npx rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"start": "tsc --build --watch",
-		"prepack": "npm run clean && npm run build"
+		"prepack": "npm run clean && npm run build",
+		"test": "lerna run build && npm run test:nobuild",
+		"test:nobuild": "jest --config ./jest.config.json",
+		"test-staged": "jest --bail --config ./jest.config.json --findRelatedTests"		
 	}
 }

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -30,8 +30,8 @@ export const fetchExperimentAssignment = async ( {
 	 * ( args ) => {
 	 * 	args.experimentName = 'my-experiment';
 	 * 	return args;
-	 * }
-	 * }
+	 * });
+	 *
 	 */
 	const params = applyFilters( 'woocommerce_explat_request_args', {
 		experiment_name: experimentName,

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -19,6 +19,20 @@ export const fetchExperimentAssignment = async ( {
 		);
 	}
 
+	/**
+	 * List of URL query parameters to be sent to the server.
+	 *
+	 * @filter woocommerce_explat_request_args
+	 * @example
+	 * addFilter(
+	 * 	'woocommerce_explat_request_args',
+	 * 	'woocommerce_explat_request_args',
+	 * ( args ) => {
+	 * 	args.experimentName = 'my-experiment';
+	 * 	return args;
+	 * }
+	 * }
+	 */
 	const params = applyFilters( 'woocommerce_explat_request_args', {
 		experiment_name: experimentName,
 		anon_id: anonId ?? undefined,

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { stringify } from 'qs';
+import { applyFilters } from '@wordpress/hooks';
 
 const EXPLAT_VERSION = '0.1.0';
 
@@ -18,7 +19,7 @@ export const fetchExperimentAssignment = async ( {
 		);
 	}
 
-	const params = stringify( {
+	const params = applyFilters( 'woocommerce_explat_request_args', {
 		experiment_name: experimentName,
 		anon_id: anonId ?? undefined,
 		woo_country_code:
@@ -29,7 +30,9 @@ export const fetchExperimentAssignment = async ( {
 	} );
 
 	const response = await window.fetch(
-		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ params }`
+		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ stringify(
+			params
+		) }`
 	);
 
 	return await response.json();

--- a/packages/explat/src/test/assignment-test.js
+++ b/packages/explat/src/test/assignment-test.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { fetchExperimentAssignment } from '../assignment';
+global.fetch = jest
+	.fn()
+	.mockImplementation( () =>
+		Promise.resolve( { json: () => Promise.resolve( [] ) } )
+	);
+global.wcTracks.isEnabled = true;
+
+const fetchMock = jest.spyOn( global, 'fetch' );
+
+describe( 'fetchExperimentAssignment', () => {
+	it( 'applies woocommerce_explat_request_args before constructing the full URL', () => {
+		addFilter(
+			'woocommerce_explat_request_args',
+			'test',
+			function ( args ) {
+				args.test = 'test';
+				return args;
+			}
+		);
+
+		const fetchPromise = fetchExperimentAssignment( {
+			experimentId: '123',
+			anonId: 'abc',
+		} );
+		Promise.resolve( fetchPromise );
+
+		expect( fetchMock ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test'
+		);
+	} );
+} );

--- a/tests/includes/class-experimental-abtest-test.php
+++ b/tests/includes/class-experimental-abtest-test.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Experimental_Abtest Tests
+ *
+ * @package WooCommerce\Admin
+ */
+
+use WooCommerce\Admin\Experimental_Abtest;
+
+
+/**
+ * Experimental_Abtest Tests
+ *
+ * @package WooCommerce\Admin
+ */
+class Experimental_Abtest_Test extends WP_UnitTestCase {
+
+	/**
+	 * Tests woocommerce_explat_request_args filter is used to construct
+	 * the request URL.
+	 */
+	public function test_it_applies_filters_to_construct_request_args() {
+		delete_transient( 'abtest_variation_control' );
+		add_filter(
+			'pre_http_request',
+			function( $arg1, $arg2, $url ) {
+				$this->assertTrue( false !== strpos( $url, 'test=test' ) );
+				return array(
+					'response'    => 200,
+					'status_code' => 200,
+					'success'     => 1,
+					'body'        => '{}',
+				);
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'woocommerce_explat_request_args',
+			function( $args ) {
+				$args['test'] = 'test';
+				return $args;
+			},
+			10,
+			1
+		);
+
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$exp->get_variation( 'control' );
+	}
+}


### PR DESCRIPTION
Fixes #8227 

This PR adds `woocommerce_explat_request_args` filter to make the ExPlat request URL filterable.

### Detailed test instructions:

Inspect test cases and make sure they make sense.

1. Run PHP test `npm run test:php -- --filter=Experimental_Abtest_Test`
2. Run Jest test `npm run test:packages -- --scope @woocommerce/explat`

