### PR TITLE
Update headercard to use filter to add ExPlat parameter

### DIFF
--- a/changelogs/update-8227-add-headercard-experiment-hook
+++ b/changelogs/update-8227-add-headercard-experiment-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Update headercard to use filter to add ExPlat parameter #8233

--- a/changelogs/update-8227-add-install-timestamp-to-explat
+++ b/changelogs/update-8227-add-install-timestamp-to-explat
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Enhancement
-
-Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter. #8231

--- a/changelogs/update-8227-add-install-timestamp-to-explat
+++ b/changelogs/update-8227-add-install-timestamp-to-explat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter. #8231

--- a/client/homescreen/constants.js
+++ b/client/homescreen/constants.js
@@ -9,3 +9,9 @@ export const WELCOME_MODAL_DISMISSED_OPTION_NAME =
  */
 export const WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME =
 	'woocommerce_welcome_from_calypso_modal_dismissed';
+
+/**
+ * WooCommerce Admin installation timestamp option name.
+ */
+export const WOOCOMMERCE_ADMIN_INSTALL_TIMESTAMP_OPTION_NAME =
+	'woocommerce_admin_install_timestamp';

--- a/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
+++ b/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useHeadercardExperimentHook } from '../use-headercard-experiment-hook';
+
+jest.mock( '@woocommerce/explat', () => {
+	return {
+		...jest.requireActual( '@woocommerce/explat' ),
+		loadExperimentAssignment: jest.fn().mockResolvedValue( {
+			variationName: 'treatment',
+		} ),
+	};
+} );
+
+describe( 'useHeadercardExperimentHook', () => {
+	it( 'should return default values before installTimestampHasResolved', () => {
+		const { result } = renderHook( () =>
+			useHeadercardExperimentHook( false, null )
+		);
+		return expect( result.current ).toEqual( {
+			isLoadingExperimentAssignment: true,
+			isLoadingTwoColExperimentAssignment: true,
+			experimentAssignment: null,
+			twoColExperimentAssignment: null,
+		} );
+	} );
+
+	it( 'should not stay in loading state when installTimestampHasResolved is true but installTimestamp is null', () => {
+		const { result } = renderHook( () =>
+			useHeadercardExperimentHook( true, null )
+		);
+		return expect( result.current ).toEqual( {
+			isLoadingExperimentAssignment: false,
+			isLoadingTwoColExperimentAssignment: false,
+			experimentAssignment: null,
+			twoColExperimentAssignment: null,
+		} );
+	} );
+
+	it( 'should add install_timestamp to woocommerce_explat_request_args filter', async () => {
+		const { waitForNextUpdate } = renderHook( () =>
+			useHeadercardExperimentHook( true, 12345678 )
+		);
+		await waitForNextUpdate();
+		return expect(
+			applyFilters( 'woocommerce_explat_request_args', {} )
+		).toEqual( {
+			install_timestamp: 12345678,
+		} );
+	} );
+
+	it( 'should receive experiment results from explat when installTimestamp is provided', async () => {
+		const { result, waitForNextUpdate } = renderHook( () =>
+			useHeadercardExperimentHook( true, 12345678 )
+		);
+		await waitForNextUpdate();
+		return expect( result.current ).toEqual( {
+			isLoadingExperimentAssignment: false,
+			isLoadingTwoColExperimentAssignment: false,
+			experimentAssignment: { variationName: 'treatment' },
+			twoColExperimentAssignment: { variationName: 'treatment' },
+		} );
+	} );
+} );

--- a/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
+++ b/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { renderHook } from '@testing-library/react-hooks';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -44,15 +44,29 @@ describe( 'useHeadercardExperimentHook', () => {
 	} );
 
 	it( 'should add install_timestamp to woocommerce_explat_request_args filter', async () => {
+		// Set the experiment name via filter to pass its experiment name check.
+		addFilter(
+			'woocommerce_explat_request_args',
+			'woocommerce-admin',
+			( args ) => {
+				return {
+					...args,
+					experiment_name:
+						'woocommerce_tasklist_progression_headercard_',
+				};
+			}
+		);
 		const { waitForNextUpdate } = renderHook( () =>
 			useHeadercardExperimentHook( true, 12345678 )
 		);
 		await waitForNextUpdate();
 		return expect(
 			applyFilters( 'woocommerce_explat_request_args', {} )
-		).toEqual( {
-			install_timestamp: 12345678,
-		} );
+		).toEqual(
+			expect.objectContaining( {
+				install_timestamp: 12345678,
+			} )
+		);
 	} );
 
 	it( 'should receive experiment results from explat when installTimestamp is provided', async () => {

--- a/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
+++ b/client/homescreen/hooks/test/use-headercard-experiment-hook.test.js
@@ -64,7 +64,7 @@ describe( 'useHeadercardExperimentHook', () => {
 			applyFilters( 'woocommerce_explat_request_args', {} )
 		).toEqual(
 			expect.objectContaining( {
-				install_timestamp: 12345678,
+				woo_wcadmin_install_timestamp: 12345678,
 			} )
 		);
 	} );

--- a/client/homescreen/hooks/use-headercard-experiment-hook.js
+++ b/client/homescreen/hooks/use-headercard-experiment-hook.js
@@ -33,7 +33,7 @@ export const useHeadercardExperimentHook = (
 					if (
 						args.experiment_name?.indexOf(
 							'woocommerce_tasklist_progression_headercard_'
-						) !== -1
+						) > -1
 					) {
 						args.install_timestamp = installTimestamp;
 					}

--- a/client/homescreen/hooks/use-headercard-experiment-hook.js
+++ b/client/homescreen/hooks/use-headercard-experiment-hook.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { loadExperimentAssignment } from '@woocommerce/explat';
+import { addFilter } from '@wordpress/hooks';
+import moment from 'moment';
+
+export const useHeadercardExperimentHook = (
+	installTimestampHasResolved,
+	installTimestamp
+) => {
+	const [
+		isLoadingExperimentAssignment,
+		setIsLoadingExperimentAssignment,
+	] = useState( true );
+	const [
+		isLoadingTwoColExperimentAssignment,
+		setIsLoadingTwoColExperimentAssignment,
+	] = useState( true );
+	const [ experimentAssignment, setExperimentAssignment ] = useState( null );
+	const [
+		twoColExperimentAssignment,
+		setTwoColExperimentAssignment,
+	] = useState( null );
+
+	useEffect( () => {
+		if ( installTimestampHasResolved && installTimestamp ) {
+			addFilter(
+				'woocommerce_explat_request_args',
+				'woocommerce-admin',
+				function ( args ) {
+					if (
+						args.experiment_name?.indexOf(
+							'woocommerce_tasklist_progression_headercard_'
+						) !== -1
+					) {
+						args.install_timestamp = installTimestamp;
+					}
+					return args;
+				}
+			);
+
+			const momentDate = moment().utc();
+			const year = momentDate.format( 'YYYY' );
+			const month = momentDate.format( 'MM' );
+			loadExperimentAssignment(
+				`woocommerce_tasklist_progression_headercard_${ year }_${ month }`
+			).then( ( assignment ) => {
+				setExperimentAssignment( assignment );
+				setIsLoadingExperimentAssignment( false );
+			} );
+			loadExperimentAssignment(
+				`woocommerce_tasklist_progression_headercard_2col_${ year }_${ month }`
+			).then( ( assignment ) => {
+				setTwoColExperimentAssignment( assignment );
+				setIsLoadingTwoColExperimentAssignment( false );
+			} );
+		} else if ( installTimestampHasResolved ) {
+			// Cases when install timestamp is resolved but it's null. Should be impossible.
+			// Set loading to false so that we don't wait indefinitely.
+			setIsLoadingExperimentAssignment( false );
+			setIsLoadingTwoColExperimentAssignment( false );
+		}
+	}, [ installTimestampHasResolved, installTimestamp ] );
+	return {
+		isLoadingExperimentAssignment,
+		isLoadingTwoColExperimentAssignment,
+		experimentAssignment,
+		twoColExperimentAssignment,
+	};
+};

--- a/client/homescreen/hooks/use-headercard-experiment-hook.js
+++ b/client/homescreen/hooks/use-headercard-experiment-hook.js
@@ -35,7 +35,7 @@ export const useHeadercardExperimentHook = (
 							'woocommerce_tasklist_progression_headercard_'
 						) > -1
 					) {
-						args.install_timestamp = installTimestamp;
+						args.woo_wcadmin_install_timestamp = installTimestamp;
 					}
 					return args;
 				}

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -185,10 +185,7 @@ export const Layout = ( {
 							userPreferences={ userPrefs }
 							twoColumns={ twoColumns }
 						/>
-						<TwoColumnTasksExtended
-							query={ query }
-							shouldRenderTask={ false }
-						/>
+						<TwoColumnTasksExtended query={ query } />
 					</>
 				</Suspense>
 			);

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -261,6 +261,14 @@ Layout.propTypes = {
 	 */
 	shouldShowWelcomeFromCalypsoModal: PropTypes.bool,
 	/**
+	 * Timestamp of WooCommerce Admin installation.
+	 */
+	installTimestamp: PropTypes.string,
+	/**
+	 * Resolution of WooCommerce Admin installation timetsamp.
+	 */
+	installTimestampHasResolved: PropTypes.bool,
+	/**
 	 * Dispatch an action to update an option
 	 */
 	updateOptions: PropTypes.func.isRequired,

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -168,7 +168,9 @@ export const Layout = ( {
 			return (
 				// When running the two-column experiment, we still need to render
 				// the component in the left column for the extended task list.
-				<TwoColumnTasksExtended query={ query } />
+				<Suspense fallback={ null }>
+					<TwoColumnTasksExtended query={ query } />
+				</Suspense>
 			);
 		} else if (
 			! twoColumns &&
@@ -176,17 +178,19 @@ export const Layout = ( {
 			! isLoadingExperimentAssignment
 		) {
 			return (
-				<>
-					<TwoColumnTasks
-						query={ query }
-						userPreferences={ userPrefs }
-						twoColumns={ twoColumns }
-					/>
-					<TwoColumnTasksExtended
-						query={ query }
-						shouldRenderTask={ false }
-					/>
-				</>
+				<Suspense fallback={ null }>
+					<>
+						<TwoColumnTasks
+							query={ query }
+							userPreferences={ userPrefs }
+							twoColumns={ twoColumns }
+						/>
+						<TwoColumnTasksExtended
+							query={ query }
+							shouldRenderTask={ false }
+						/>
+					</>
+				</Suspense>
 			);
 		}
 

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -138,19 +138,21 @@ export const Layout = ( {
 		return (
 			<>
 				<Column shouldStick={ shouldStickColumns }>
-					{ ! isRunningTaskListExperiment && (
-						<ActivityHeader
-							className="your-store-today"
-							title={ __(
-								'Your store today',
-								'woocommerce-admin'
-							) }
-							subtitle={ __(
-								"To do's, tips, and insights for your business",
-								'woocommerce-admin'
-							) }
-						/>
-					) }
+					{ ! isLoadingExperimentAssignment &&
+						! isLoadingTwoColExperimentAssignment &&
+						! isRunningTaskListExperiment && (
+							<ActivityHeader
+								className="your-store-today"
+								title={ __(
+									'Your store today',
+									'woocommerce-admin'
+								) }
+								subtitle={ __(
+									"To do's, tips, and insights for your business",
+									'woocommerce-admin'
+								) }
+							/>
+						) }
 					{ <ActivityPanel /> }
 					{ hasTaskList && renderTaskList() }
 					<InboxPanel />
@@ -201,11 +203,13 @@ export const Layout = ( {
 	return (
 		<>
 			{ twoColumns && isRunningTaskListExperiment && (
-				<TwoColumnTasks
-					query={ query }
-					userPreferences={ userPrefs }
-					twoColumns={ twoColumns }
-				/>
+				<Suspense fallback={ null }>
+					<TwoColumnTasks
+						query={ query }
+						userPreferences={ userPrefs }
+						twoColumns={ twoColumns }
+					/>
+				</Suspense>
 			) }
 			<div
 				className={ classnames( 'woocommerce-homescreen', {

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -7,14 +7,12 @@ import { check } from '@wordpress/icons';
 import { Fragment, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
-import { useExperiment } from '@woocommerce/explat';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
 import { DisplayOption } from '~/activity-panel/display-options';
-import { Task } from '../tasks/task';
 import { TaskList } from '../tasks/task-list';
 import { TasksPlaceholder } from '../tasks/placeholder';
 import '../tasks/tasks.scss';
@@ -24,13 +22,10 @@ export type TasksProps = {
 	query: { task?: string };
 };
 
-const ExtendedTask: React.FC< TasksProps > = ( {
-	query,
-	shouldRenderTask,
-} ) => {
-	const { task } = query;
+const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { task } = query;
 
 	const { isResolving, taskLists } = useSelect( ( select ) => {
 		return {
@@ -40,25 +35,6 @@ const ExtendedTask: React.FC< TasksProps > = ( {
 			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
 		};
 	} );
-
-	const getCurrentTask = () => {
-		if ( ! task ) {
-			return null;
-		}
-
-		const tasks = taskLists.reduce(
-			( acc, taskList ) => [ ...acc, ...taskList.tasks ],
-			[]
-		);
-
-		const currentTask = tasks.find( ( t ) => t.id === task );
-
-		if ( ! currentTask ) {
-			return null;
-		}
-
-		return currentTask;
-	};
 
 	const toggleTaskList = ( taskList ) => {
 		const { id, isHidden } = taskList;
@@ -78,22 +54,13 @@ const ExtendedTask: React.FC< TasksProps > = ( {
 		} );
 	}, [ taskLists, isResolving ] );
 
-	const currentTask = getCurrentTask();
-
-	if ( task && ! currentTask ) {
+	// If a task detail is being shown, we shouldn't show the extended tasklist.
+	if ( task ) {
 		return null;
 	}
 
 	if ( isResolving ) {
 		return <TasksPlaceholder query={ query } />;
-	}
-
-	if ( currentTask && shouldRenderTask ) {
-		return (
-			<div className="woocommerce-task-dashboard__container">
-				<Task query={ query } task={ currentTask } />
-			</div>
-		);
 	}
 
 	const extendedTaskList = taskLists.find( ( list ) => {

--- a/client/two-column-tasks/headers/appearance.js
+++ b/client/two-column-tasks/headers/appearance.js
@@ -13,7 +13,7 @@ import PersonalizeMyStore from './illustrations/personalize-my-store.js';
 const AppearanceHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<PersonalizeMyStore class="svg-background" />
+			<PersonalizeMyStore className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( 'Personalize my store', 'woocommerce-admin' ) }</h1>
 				<p>

--- a/client/two-column-tasks/headers/marketing.js
+++ b/client/two-column-tasks/headers/marketing.js
@@ -13,7 +13,7 @@ import GetMoreSales from './illustrations/get-more-sales.js';
 const MarketingHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<GetMoreSales class="svg-background" />
+			<GetMoreSales className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( 'Get more sales', 'woocommerce-admin' ) }</h1>
 				<p>

--- a/client/two-column-tasks/headers/products.js
+++ b/client/two-column-tasks/headers/products.js
@@ -13,7 +13,7 @@ import AddProducts from './illustrations/add-products.js';
 const ProductsHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<AddProducts class="svg-background" />
+			<AddProducts className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( 'Add products to start selling' ) }</h1>
 				<p>

--- a/client/two-column-tasks/headers/shipping.js
+++ b/client/two-column-tasks/headers/shipping.js
@@ -13,7 +13,7 @@ import Shipping from './illustrations/shipping.js';
 const ShippingHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<Shipping class="svg-background" />
+			<Shipping className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>
 					{ __(

--- a/client/two-column-tasks/headers/tax.js
+++ b/client/two-column-tasks/headers/tax.js
@@ -13,7 +13,7 @@ import AddTaxRates from './illustrations/add-tax-rates.js';
 const TaxHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<AddTaxRates class="svg-background" />
+			<AddTaxRates className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>
 					{ __( 'Next up, add your tax rates', 'woocommerce-admin' ) }

--- a/client/two-column-tasks/headers/woocommerce-payments.js
+++ b/client/two-column-tasks/headers/woocommerce-payments.js
@@ -45,7 +45,7 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<GetPaid class="svg-background" />
+			<GetPaid className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( "It's time to get paid", 'woocommerce-admin' ) }</h1>
 				<p>

--- a/src/Features/Homescreen.php
+++ b/src/Features/Homescreen.php
@@ -165,6 +165,7 @@ class Homescreen {
 	 */
 	public function preload_options( $options ) {
 		$options[] = 'woocommerce_default_homepage_layout';
+		$options[] = 'woocommerce_admin_install_timestamp';
 
 		return $options;
 	}


### PR DESCRIPTION
Fixes #8227

This PR:
1. Adds the capability for tasklist progression experiments to append WCA's install timestamp to ExPlat API request
2. Changes the way experiment is called. Instead of using `useExperiment`, we're using a custom hook since we need to conditionally load the experiment after the required option is loaded

After a while of testing, I observed a noticeable delay in my local for the experiment tasklist to be displayed since it's not preloaded. We may need to consider preloading `woocommerce_admin_install_timestamp` option and hydrate if this is proven to be a problem.

### Detailed test instructions:

1. Since we're using dynamic experiments name, this needs to be tested anywhen in February 2022. Alternatively, hardcode the month [here](https://github.com/woocommerce/woocommerce-admin/blob/6824e721c21d01f9f635fe0c9359f0046fe4ba13/client/homescreen/hooks/use-headercard-experiment-hook.js#L46) to `'02'`
1. Use the treatment bookmarklet for experiment `woocommerce_tasklist_progression_headercard_2col_2022_02`
2. Open your browser's console network tab
3. Go to WooCommerce > Home
4. Observe the network request for `https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?experiment_name=woocommerce_tasklist_progression_headercard_2col_2022_02` contains the payload `woo_wcadmin_install_timestamp` and the value is a timestamp
5. If you received treatment variation, you should see the two column tasklist experiment 


