### PR TITLE
Remove unused task styling classes

### DIFF
--- a/changelogs/fix-7693
+++ b/changelogs/fix-7693
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Remove unused task styling classes #8234

--- a/client/inbox-panel/dismiss-all-modal.js
+++ b/client/inbox-panel/dismiss-all-modal.js
@@ -7,7 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DissmissAllModal = ( { onClose } ) => {
+const DismissAllModal = ( { onClose } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	const { batchUpdateNotes, removeAllNotes } = useDispatch(
@@ -81,4 +81,4 @@ const DissmissAllModal = ( { onClose } ) => {
 	);
 };
 
-export default DissmissAllModal;
+export default DismissAllModal;

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -26,7 +26,7 @@ import moment from 'moment';
 import { ActivityCard } from '~/activity-panel/activity-card';
 import { hasValidNotes, truncateRenderableHTML } from './utils';
 import { getScreenName } from '../utils';
-import DismissAllModal from './dissmiss-all-modal';
+import DismissAllModal from './dismiss-all-modal';
 import './index.scss';
 
 const renderEmptyCard = () => (

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -76,7 +76,6 @@ class ProfileWizard extends Component {
 
 	componentDidMount() {
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );
-		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );
 		document.body.classList.add( 'woocommerce-admin-full-screen' );
 		document.body.classList.add( 'is-wp-toolbar-disabled' );
@@ -87,7 +86,6 @@ class ProfileWizard extends Component {
 	}
 
 	componentWillUnmount() {
-		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
 		document.body.classList.remove( 'woocommerce-admin-full-screen' );
 		document.body.classList.remove( 'is-wp-toolbar-disabled' );

--- a/client/two-column-tasks/dismiss-modal.js
+++ b/client/two-column-tasks/dismiss-modal.js
@@ -4,7 +4,7 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DissmissModal = ( {
+const DismissModal = ( {
 	showDismissModal,
 	setShowDismissModal,
 	hideTasks,
@@ -55,4 +55,4 @@ const DissmissModal = ( {
 	);
 };
 
-export default DissmissModal;
+export default DismissModal;

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 
@@ -34,11 +33,6 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 		keepCompletedTaskList,
 		isResolving: isResolvingOptions,
 	} = useSelect( taskDashboardSelect );
-
-	useEffect( () => {
-		document.body.classList.add( 'woocommerce-onboarding' );
-		document.body.classList.add( 'woocommerce-task-dashboard__body' );
-	}, [] );
 
 	const { task } = query;
 

--- a/client/two-column-tasks/style.scss
+++ b/client/two-column-tasks/style.scss
@@ -74,7 +74,7 @@
 	}
 }
 
-.woocommerce-task-dashboard__body .woocommerce-task-dashboard__container .woocommerce-task-card.completed {
+.woocommerce-task-dashboard__container .woocommerce-task-card.completed {
 	display: block;
 	.components-card__header {
 		display: block;

--- a/client/two-column-tasks/style.scss
+++ b/client/two-column-tasks/style.scss
@@ -273,7 +273,7 @@
 	}
 }
 
-.woocommerce-task-dashboard__body .woocommerce-task-dismiss-modal {
+.woocommerce-task-dismiss-modal {
 	width: 565px;
 	max-width: 100%;
 

--- a/client/two-column-tasks/task-list.js
+++ b/client/two-column-tasks/task-list.js
@@ -17,7 +17,7 @@ import classnames from 'classnames';
  */
 import '../tasks/task-list.scss';
 import taskHeaders from './task-headers';
-import DismissModal from './dissmiss-modal';
+import DismissModal from './dismiss-modal';
 import TaskListCompleted from './completed';
 
 export const TaskList = ( {


### PR DESCRIPTION
Fixes #7693 

Removes some unused selectors and simplifies some of our task list styling.

### Detailed test instructions:

Try the following with the new task list on/off by adding yourself to the treatment/control of the `woocommerce_tasklist_progression_headercard_2col_2022_02` experiment.

1. Smoke test the task list, making sure no styling is broken
2. Dismiss the new task list with some incomplete tasks
3. Make sure the dismiss modal styling is still as expected (cc @moon0326 would be great if you could give this a sanity check to make sure I didn't break any of your styling)
