### PR TITLE
Only add product data on REST requests and task list

### DIFF
--- a/changelogs/fix-7884
+++ b/changelogs/fix-7884
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Only add product data on REST requests and task list #8235

--- a/src/API/OnboardingProductTypes.php
+++ b/src/API/OnboardingProductTypes.php
@@ -72,7 +72,7 @@ class OnboardingProductTypes extends \WC_REST_Data_Controller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_product_types( $request ) {
-		return Onboarding::get_allowed_product_types();
+		return Onboarding::get_product_data( Onboarding::get_allowed_product_types() );
 	}
 
 }

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -508,9 +508,8 @@ class Onboarding {
 		if ( ! Features::is_enabled( 'subscriptions' ) || 'US' !== $base_location['country'] ) {
 			$products['subscriptions']['product'] = 27147;
 		}
-		$product_types = self::append_product_data( $products );
 
-		return apply_filters( 'woocommerce_admin_onboarding_product_types', $product_types );
+		return apply_filters( 'woocommerce_admin_onboarding_product_types', $products );
 	}
 
 	/**
@@ -633,12 +632,12 @@ class Onboarding {
 	}
 
 	/**
-	 * Append dynamic product data from API.
+	 * Get dynamic product data from API.
 	 *
 	 * @param array $product_types Array of product types.
 	 * @return array
 	 */
-	public static function append_product_data( $product_types ) {
+	public static function get_product_data( $product_types ) {
 		$woocommerce_products = get_transient( self::PRODUCT_DATA_TRANSIENT );
 		if ( false === $woocommerce_products ) {
 			$woocommerce_products = wp_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/search' );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -648,12 +648,13 @@ class Onboarding {
 			set_transient( self::PRODUCT_DATA_TRANSIENT, $woocommerce_products, DAY_IN_SECONDS );
 		}
 
-		$product_data = json_decode( $woocommerce_products['body'] );
+		$data         = json_decode( $woocommerce_products['body'] );
 		$products     = array();
+		$product_data = array();
 
 		// Map product data by ID.
-		if ( isset( $product_data ) && isset( $product_data->products ) ) {
-			foreach ( $product_data->products as $product_datum ) {
+		if ( isset( $data ) && isset( $data->products ) ) {
+			foreach ( $data->products as $product_datum ) {
 				if ( isset( $product_datum->id ) ) {
 					$products[ $product_datum->id ] = $product_datum;
 				}
@@ -662,21 +663,23 @@ class Onboarding {
 
 		// Loop over product types and append data.
 		foreach ( $product_types as $key => $product_type ) {
+			$product_data[ $key ] = $product_types[ $key ];
+
 			if ( isset( $product_type['product'] ) && isset( $products[ $product_type['product'] ] ) ) {
 				$price        = html_entity_decode( $products[ $product_type['product'] ]->price );
 				$yearly_price = (float) str_replace( '$', '', $price );
 
-				$product_types[ $key ]['yearly_price'] = $yearly_price;
-				$product_types[ $key ]['description']  = $products[ $product_type['product'] ]->excerpt;
-				$product_types[ $key ]['more_url']     = $products[ $product_type['product'] ]->link;
-				$product_types[ $key ]['slug']         = strtolower( preg_replace( '~[^\pL\d]+~u', '-', $products[ $product_type['product'] ]->slug ) );
+				$product_data[ $key ]['yearly_price'] = $yearly_price;
+				$product_data[ $key ]['description']  = $products[ $product_type['product'] ]->excerpt;
+				$product_data[ $key ]['more_url']     = $products[ $product_type['product'] ]->link;
+				$product_data[ $key ]['slug']         = strtolower( preg_replace( '~[^\pL\d]+~u', '-', $products[ $product_type['product'] ]->slug ) );
 			} elseif ( isset( $product_type['product'] ) ) {
 				/* translators: site currency symbol (used to show that the product costs money) */
-				$product_types[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce-admin' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
+				$product_data[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce-admin' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
 			}
 		}
 
-		return $product_types;
+		return $product_data;
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/src/Features/OnboardingTasks/Tasks/Purchase.php
@@ -154,18 +154,18 @@ class Purchase extends Task {
 		$profiler_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$installed     = PluginsHelper::get_installed_plugin_slugs();
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
-		$allowed       = Onboarding::get_allowed_product_types();
+		$product_data  = Onboarding::get_product_data( Onboarding::get_allowed_product_types() );
 		$purchaseable  = array();
 		$remaining     = array();
 		foreach ( $product_types as $type ) {
-			if ( ! isset( $allowed[ $type ]['slug'] ) ) {
+			if ( ! isset( $product_data[ $type ]['slug'] ) ) {
 				continue;
 			}
 
-			$purchaseable[] = $allowed[ $type ];
+			$purchaseable[] = $product_data[ $type ];
 
-			if ( ! in_array( $allowed[ $type ]['slug'], $installed, true ) ) {
-				$remaining[] = $allowed[ $type ]['label'];
+			if ( ! in_array( $product_data[ $type ]['slug'], $installed, true ) ) {
+				$remaining[] = $product_data[ $type ]['label'];
 			}
 		}
 


### PR DESCRIPTION
Fixes #7884 

Removes the append data call for products so that data is only loaded on REST requests instead of every page load.

### Screenshots


<img width="687" alt="Screen Shot 2022-01-31 at 3 07 40 PM" src="https://user-images.githubusercontent.com/10561050/151867326-96fcc690-fa0e-4d68-aaed-9e32a6c13115.png">
<img width="588" alt="Screen Shot 2022-01-31 at 2 59 22 PM" src="https://user-images.githubusercontent.com/10561050/151867328-50887aff-c1b3-4031-a06b-1905106076ac.png">

### Detailed test instructions:

1. Smoke test the product types step of the profile wizard
2. Add a paid product type or two from the wizard
3. Visit the task list
4. Verify that the purchase task continues to work as expected
5. Using the below filter in a plugin, check that the data only includes local product type information and not data polled from WCCOM

```php
add_filter( 'woocommerce_admin_onboarding_product_types', function($types) {
    error_log(print_r($types,true));
    return $types;
} );
```