### PR TITLE
Show single success message for theme install and activation

### DIFF
--- a/changelogs/update-6599
+++ b/changelogs/update-6599
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Tweak
+
+Show single success message for theme install and activation #8236

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -110,17 +110,7 @@ class Theme extends Component {
 			path: '/wc-admin/onboarding/themes/install?theme=' + slug,
 			method: 'POST',
 		} )
-			.then( ( response ) => {
-				createNotice(
-					'success',
-					sprintf(
-						__(
-							'%s was installed on your site',
-							'woocommerce-admin'
-						),
-						response.name
-					)
-				);
+			.then( () => {
 				this.activateTheme( slug );
 			} )
 			.catch( ( response ) => {
@@ -140,8 +130,9 @@ class Theme extends Component {
 				createNotice(
 					'success',
 					sprintf(
+						/* translators: The name of the theme that was installed and activated */
 						__(
-							'%s was activated on your site',
+							'%s was installed and activated on your site',
 							'woocommerce-admin'
 						),
 						response.name


### PR DESCRIPTION
Fixes #6599

Shows a single install/activation notice instead of multiple notices on theme install.

### Screenshots

#### Before
<img width="466" alt="Screen Shot 2022-01-31 at 4 02 36 PM" src="https://user-images.githubusercontent.com/10561050/151872678-98ef1abd-7605-4712-a25d-d925509cd7b7.png">


#### After
<img width="422" alt="Screen Shot 2022-01-31 at 3 53 26 PM" src="https://user-images.githubusercontent.com/10561050/151872687-4bd9abdf-8909-464e-9b9a-e315add03e3c.png">

### Detailed test instructions:

1. Navigate to the store setup wizard theme step
2. Choose a new theme
3. Note the single success toast notice