### PR TITLE
Reintroduce CES 

### DIFF
--- a/changelogs/update-8170-reintroduce-the-ces
+++ b/changelogs/update-8170-reintroduce-the-ces
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Reintroduce CES on product add, product update, and order update.

--- a/changelogs/update-8170-reintroduce-the-ces
+++ b/changelogs/update-8170-reintroduce-the-ces
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Reintroduce CES on product add, product update, and order update.
+Reintroduce CES on product add, product update, and order update. #8238


### PR DESCRIPTION
Fixes #8170 

This PR reintroduce CES in the following actions:

* Add a product
* Update product
* Edit order


### Detailed test instructions:

Clear `woocommerce_ces_tracks_queue` and `woocommerce_clear_ces_tracks_queue_for_page` from `wp_options` table.

1. Navigate to Products -> Add new and add a new product.
2. You should see the CES notification on the next page.
3. Edit the product you just added. You should see the CES notification on the next page.
4. Add a new order and edit it. You should see the CES notification on the next page.

