### PR TITLE
Place the offline gateways at the bottom

### DIFF
--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -23,6 +23,8 @@ import { getPluginSlug } from '~/utils';
 import './plugins/Bacs';
 import './payment-gateway-suggestions.scss';
 
+const OFFLINE_GATEWAYS = [ 'cod', 'cheque', 'bacs' ];
+
 export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 	const { updatePaymentGateway } = useDispatch( PAYMENT_GATEWAYS_STORE_NAME );
 	const {
@@ -67,6 +69,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 				installed: !! mappedPaymentGateways[ id ],
 				postInstallScripts: installedGateway.post_install_scripts,
 				enabled: installedGateway.enabled || false,
+				offlineOnly: OFFLINE_GATEWAYS.includes( id ),
 				needsSetup: installedGateway.needs_setup,
 				settingsUrl: installedGateway.settings_url,
 				connectionUrl: installedGateway.connection_url,
@@ -228,8 +231,8 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 						'woocommerce-admin'
 					) }
 					recommendation={ recommendation }
-					paymentGateways={ additionalGateways.sort( ( gateway ) => {
-						return gateway.needsSetup === false ? 1 : -1;
+					paymentGateways={ additionalGateways.sort( ( a, b ) => {
+						return a.offlineOnly - b.offlineOnly;
 					} ) }
 					markConfigured={ markConfigured }
 				/>

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -228,7 +228,9 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 						'woocommerce-admin'
 					) }
 					recommendation={ recommendation }
-					paymentGateways={ additionalGateways }
+					paymentGateways={ additionalGateways.sort( ( gateway ) => {
+						return gateway.needsSetup === false ? 1 : -1;
+					} ) }
 					markConfigured={ markConfigured }
 				/>
 			) }


### PR DESCRIPTION
Fixes #8232 

This PR defines `OFFLINE_GATEWAYS` constant to sort the offline gateways and place them at the bottom.

I'm open to suggestions if we have a better way to sort the offline-only payment gateways.


### Screenshots

**Before**
![Screen Shot 2022-02-01 at 4 11 51 PM](https://user-images.githubusercontent.com/4723145/152072676-bba5a565-a056-4151-a113-76899d83d4fc.jpg)

**After**

![Screen Shot 2022-02-01 at 4 13 44 PM](https://user-images.githubusercontent.com/4723145/152072681-94ca8763-c1db-4a4c-9e70-7d0c8074bbcc.jpg)

### Detailed test instructions:

1. Start with a fresh install 
2. Start OBW and choose India.
3. Navigate to WooCommerce -> Home and choose the payment task
4. Confirm the offline payment gateways are listed at the bottom.

no changelog