### PR TITLE
Make sure hidden fields are cleared when definition changes

### DIFF
--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -363,12 +363,7 @@ export function StoreAddress( {
 					.replace( /(address)Line([0-9])/, '$1$2' )
 					.toLowerCase();
 				const props = getInputProps( field );
-				if (
-					locale[ fieldKey ] &&
-					locale[ fieldKey ].hidden &&
-					props.value &&
-					props.value.length > 0
-				) {
+				if ( locale[ fieldKey ]?.hidden && props.value?.length > 0 ) {
 					// Clear hidden field.
 					setValue( field, '' );
 				}

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -16,6 +16,13 @@ import { useSelect } from '@wordpress/data';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
+const storeAddressFields = [
+	'addressLine1',
+	'addressLine2',
+	'city',
+	'countryState',
+	'postCode',
+];
 
 type Option = { key: string; label: string };
 
@@ -348,6 +355,26 @@ export function StoreAddress( {
 		countryState,
 		setValue
 	);
+
+	useEffect( () => {
+		if ( locale ) {
+			storeAddressFields.forEach( ( field ) => {
+				const fieldKey = field
+					.replace( /(address)Line([0-9])/, '$1$2' )
+					.toLowerCase();
+				const props = getInputProps( field );
+				if (
+					locale[ fieldKey ] &&
+					locale[ fieldKey ].hidden &&
+					props.value &&
+					props.value.length > 0
+				) {
+					// Clear hidden field.
+					setValue( field, '' );
+				}
+			} );
+		}
+	}, [ countryState, locale ] );
 	if ( ! hasFinishedResolution ) {
 		return <Spinner />;
 	}


### PR DESCRIPTION
Fixes #8249 

Makes sure that if a store address field is set to hidden, it is cleared if it was previously set.

### Screenshots

![clear-hidden-fields](https://user-images.githubusercontent.com/2240960/152233610-d7965a6b-6ced-4216-8ac1-74afb903a1b3.gif)

### Detailed test instructions:

1. On a fresh store go to the onboarding flow
2. Select United States as address and fill out all the required fields
3. Before hitting next, change the country to Guatemala
4. Notice how the postal code field is now hidden
5. Finish the onboarding flow
6. Go to **WooCommerce > Settings** and notice how the store address postal code is blank.

No changelog necessary given it's a new feature

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
