### PR TITLE
Fix/8191 deleting products adds blank space to analytics data

### DIFF
--- a/changelogs/fix-8191-deleting-products-adds-blank-space-to-analytics-data
+++ b/changelogs/fix-8191-deleting-products-adds-blank-space-to-analytics-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix missing product name in variation analytic page for the deleted products. #8255

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -126,7 +126,7 @@ class VariationsReportTable extends Component {
 			return [
 				{
 					display: deleted ? (
-						name
+						name + ' ' + __( '(Deleted)', ' woocommerce-admin' )
 					) : (
 						<Link href={ editPostLink } type="wp-admin">
 							{ name }

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -107,6 +107,7 @@ class VariationsReportTable extends Component {
 				stock_status: stockStatus,
 				stock_quantity: stockQuantity,
 				low_stock_amount: lowStockAmount,
+				deleted,
 				sku,
 			} = extendedInfo;
 			const name = getFullVariationName( row );
@@ -124,7 +125,9 @@ class VariationsReportTable extends Component {
 
 			return [
 				{
-					display: (
+					display: deleted ? (
+						name
+					) : (
 						<Link href={ editPostLink } type="wp-admin">
 							{ name }
 						</Link>

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -350,7 +350,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$product   = $products[ $product_key ];
 			$index_key = $product['product_id'] . '_' . $product['variation_id'];
 			if ( isset( $index[ $index_key ] ) ) {
-				$products[ $product_key ]['extended_info']['name'] = $index[ $index_key ] . ' (' . __( 'deleted', 'woocommerce-admin' ) . ')';
+				$products[ $product_key ]['extended_info']['name'] = $index[ $index_key ];
 			}
 		}
 	}

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -375,7 +375,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		$cache_key = $this->get_cache_key( $query_args );
 		$data      = $this->get_cached_data( $cache_key );
-		$data      = false;
 
 		if ( false === $data ) {
 			$this->initialize_queries();

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -313,10 +313,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			array_map(
 				function( $ids ) {
 					return "(
-				product_lookup.product_id = {$ids['product_id']}
-				and
-				product_lookup.variation_id = {$ids['variation_id']}
-                )";
+						product_lookup.product_id = {$ids['product_id']}
+						and
+						product_lookup.variation_id = {$ids['variation_id']}
+                    )";
 				},
 				$product_variation_ids
 			)


### PR DESCRIPTION
Fixes #8191 

This PR adds the following changes

- Retrieve deleted product name from `woocommerce_order_items`
- Indicate product has been deleted by adding `(deleted)`
- Removes product link if it has been deleted.


### Screenshots
<img width="1182" alt="Screen Shot 2022-02-03 at 12 52 18 PM" src="https://user-images.githubusercontent.com/4723145/152426758-5679d088-c647-4534-bf37-1b6b4952dfc1.png">

### Detailed test instructions:

Please confirm the bug first by following the provided test instructions from #8191 

1. After performing the test instructions from #8191
2. Go to Analytics -> Variations
3. Confirm the deleted product name is shown with (deleted) suffix. 


