### PR TITLE
Add support for filtering by changelog type for testing instructions

### DIFF
--- a/bin/changelogger/WCAdminFormatter.php
+++ b/bin/changelogger/WCAdminFormatter.php
@@ -103,12 +103,9 @@ class WCAdminFormatter extends KeepAChangelogParser implements FormatterPlugin {
 					$row = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
 					$row_segments = explode( ':', $row );
 
-					array_push(
-						$changes,
-						array(
-							'subheading' => trim( $row_segments[0] ),
-							'content'    => trim( $row_segments[1] ),
-						)
+					$changes[] = array(
+						'subheading' => trim($row_segments[0]),
+						'content' => count( $row_segments ) > 1 ? trim($row_segments[1]) : '',
 					);
 				}
 

--- a/bin/test-instruction-logger/README.md
+++ b/bin/test-instruction-logger/README.md
@@ -12,7 +12,7 @@ Test Instruction Logger requires Github username and a personal access token to 
 ## Writing to TESTING-INSTRUCTION.md
 
 1. Update the `changelog.txt` 
-2. Run `npm run test-instruction-logger -- :version`.
+2. Run `npm run test-instruction-logger -- write :version`.
 3. Verify `TESTING-INSTRUCTION.md`.
 
 ### Options
@@ -21,10 +21,10 @@ Test Instruction Logger requires Github username and a personal access token to 
 
 A comma seperated list of changelog types to retrieve the testing instructions from.
 
-`npm run test-instruction-logger -- :version --types=enhancement,add`
+`npm run test-instruction-logger -- write :version --types=enhancement,add`
 
 #### save-to
 
 Allows you to save the testing instructions to a different file. Default: TESTING-INSTRUCTIONS.md
 
-`npm run test-instruction-logger -- :version --save-to=instructions.md`
+`npm run test-instruction-logger -- write :version --save-to=instructions.md`

--- a/bin/test-instruction-logger/README.md
+++ b/bin/test-instruction-logger/README.md
@@ -1,6 +1,6 @@
 # Test Instruction Logger
 
-Test Instruction Logger retrives test instructions from the PRs in the `changelog.txt` and write them into TESTING-INSTRUCTION.md.
+Test Instruction Logger retrieves test instructions from the PRs in the `changelog.txt` and writes them into TESTING-INSTRUCTION.md.
 
 ## Prerequisites
 
@@ -12,5 +12,19 @@ Test Instruction Logger requires Github username and a personal access token to 
 ## Writing to TESTING-INSTRUCTION.md
 
 1. Update the `changelog.txt` 
-2. Run `npm run test-instruction-logger :version`.
+2. Run `npm run test-instruction-logger -- :version`.
 3. Verify `TESTING-INSTRUCTION.md`.
+
+### Options
+
+#### types
+
+A comma seperated list of changelog types to retrieve the testing instructions from.
+
+`npm run test-instruction-logger -- :version --types=enhancement,add`
+
+#### save-to
+
+Allows you to save the testing instructions to a different file. Default: TESTING-INSTRUCTIONS.md
+
+`npm run test-instruction-logger -- :version --save-to=instructions.md`

--- a/bin/test-instruction-logger/WriteCommand.php
+++ b/bin/test-instruction-logger/WriteCommand.php
@@ -84,7 +84,6 @@ class WriteCommand extends Command {
 		if ( null !== $types ) {
 			$changelog_types = explode( ',', strtolower( $types ) );
 		}
-		error_log( print_r( $changelog_types, true ) );
 
 		$changelog = $this->changeloggerFormatter->parse( file_get_contents( $this->config->getChangelogFilepath() ) );
 		$this->githubCredentials = $this->config->getGithubCredentials();

--- a/bin/test-instruction-logger/WriteCommand.php
+++ b/bin/test-instruction-logger/WriteCommand.php
@@ -60,7 +60,8 @@ class WriteCommand extends Command {
 	protected function configure() {
 		$this->setDescription( 'Generate test instructions from a given version.' )
 			->addArgument( 'version', InputArgument::REQUIRED, 'Release version from changelog.txt.' )
-			->addOption( 'save-to', null, InputOption::VALUE_REQUIRED, 'Specificity a file path to save the output.' );
+			->addOption( 'save-to', null, InputOption::VALUE_REQUIRED, 'Specificity a file path to save the output.' )
+			->addOption( 'types', null, InputOption::VALUE_REQUIRED, 'List of changelog types to use for testing instructions.' );
 	}
 
 	/**
@@ -78,6 +79,12 @@ class WriteCommand extends Command {
 		if ( null === $saveTo ) {
 			$saveTo = $this->config->getOutputFilePath();
 		}
+		$types = $input->getOption( 'types');
+		$changelog_types = array();
+		if ( null !== $types ) {
+			$changelog_types = explode( ',', strtolower( $types ) );
+		}
+		error_log( print_r( $changelog_types, true ) );
 
 		$changelog = $this->changeloggerFormatter->parse( file_get_contents( $this->config->getChangelogFilepath() ) );
 		$this->githubCredentials = $this->config->getGithubCredentials();
@@ -102,8 +109,8 @@ class WriteCommand extends Command {
 			$output->writeln( "<error>{$version} does not exist.</>" );
 			return 1;
 		}
-		
-		$prs = $this->extractPrNumbers( $entry->getChanges() );
+
+		$prs = $this->extractPrNumbers( $entry->getChanges(), $changelog_types );
 		$prContents = $this->getPrContents( $prs );
 
 		if ( count($prContents) === 0 ) {
@@ -137,30 +144,28 @@ class WriteCommand extends Command {
 		$output = array();
 
 		// Get the first line (heading) from the TESTING-INSTRUCTIONS.md.
-		array_push( $output, array_shift( $testingInstructions ) );
+		$output[] = array_shift( $testingInstructions );
 
 		// Put the version.
-		array_push( $output, '## '.$version );
+		$output[] = '## '.$version;
 
 		foreach ( $prContents as $pr => $prContent ) {
 			if ( empty( $prContent['testInstructions'] ) ) {
 				continue;
 			}
-			array_push( $output, '### '.$prContent[ 'title' ].' #'.$pr );
-			array_push( $output, $prContent[ 'testInstructions' ] );
+			$output[] = "\n### ".$prContent[ 'title' ].' #'.$pr."\n";
+			$output[] = rtrim( $prContent[ 'testInstructions' ] );
 		}
 
 		// Put the remaining contents from TESTING-INSTRUCTIONS.md.
-		foreach ( $testingInstructions as $testingInstruction ) {
-			array_push( $output, $testingInstruction );
-		}
+		$output[] = implode( '', $testingInstructions );
 
 		return implode( "\n", $output);
 	}
 
 	/**
 	 * Get ChangelogEntry by the given version.
-	 * 
+	 *
 	 * @param Changelog $changelog
 	 * @param $version
 	 *
@@ -212,9 +217,13 @@ class WriteCommand extends Command {
 	 * @return array
 	 * @throws Exception
 	 */
-	protected function extractPrNumbers( $changeEntires = [] ) {
+	protected function extractPrNumbers( $changeEntires = [], $changelogSubheadings = [] ) {
 		$prs = [];
 		foreach ( $changeEntires as $changeEntry ) {
+			$subheading = strtolower( $changeEntry->getSubheading() );
+			if ( 0 !== count( $changelogSubheadings ) && false === in_array( $subheading, $changelogSubheadings ) ) {
+				continue;
+			}
 			preg_match( "/#[0-9]+/", $changeEntry->getContent(), $matches );
 			if ( count( $matches ) ) {
 				array_push( $prs, str_replace( "#", "", $matches[0] ) );

--- a/changelogs/update-testing-instructions-script
+++ b/changelogs/update-testing-instructions-script
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Dev
+
+Fix formatting and add filter param for changelog types for the testing instructions script. #8256


### PR DESCRIPTION
Add support for filtering by changelog type for testing instructions as we usually don't want all of them.
There was also a couple PHP warnings that shouldn't show up anymore, and I updated the formatting a bit, so it shouldn't be adding extra new lines to the testing instructions file.

### Detailed test instructions:

- Make sure you have the Git credentials set up by running: `npm run test-instruction-logger github-credentials`
- Run `npm run test-instruction-logger -- write 3.2.0 --types=enhancement,add`
- Check TESTING-INSTRUCTIONS.md and see if only the changes for types enhancements and add are added. (you can try other types as well, like `fix`).
- Check the formatting to see if things look good.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
