### PR TITLE
Help limit concurrency issues during db install

### DIFF
--- a/src/Features/OnboardingTasks/DeprecatedOptions.php
+++ b/src/Features/OnboardingTasks/DeprecatedOptions.php
@@ -30,7 +30,7 @@ class DeprecatedOptions {
 	 * @return string
 	 */
 	public static function get_deprecated_options( $pre_option, $option ) {
-		if ( Install::is_installing() ) {
+		if ( defined( 'WC_ADMIN_MIGRATING_OPTIONS' ) && WC_ADMIN_MIGRATING_OPTIONS ) {
 			return $pre_option;
 		};
 


### PR DESCRIPTION
This helps prevent some pretty nasty concurrency issues that exist with the current db install/update process.

Adds the following mitigations:

1) Only try to run the db install/update process on either an admin request or during cron. Running on `init` without any other limitations is very dangerous for actions like this as you are potentially introducing very high levels of concurrency concerns.

2) Instead of using transients (which are basically just options when there is no object cache), using the wp_cache_* api directly when possible. Of note, this allows us to use `wp_cache_add()` directly which is a much more proper defender against concurrency.

3) Since the only true way to know if you are actually installing or not is to attempt to claim the lock from the object cache with a memcached->add(),  it is better to just avoid needing to do so unless you are wanting to claim it. So I deprecated the `is_installing()` public method and I believe found a feasible workaround for the external location it was being used - but could use more eyes on that.

4) In `update_db_version ()`, I swapped to `update_option()` instead of the delete()->add(). As the latter was causing some horrible race conditions along w/ the alloptions cache, making it nearly impossible to even manually add or update the option due to all the frontend requests racing against each other as they deleted it followed by usually the add() failing as other requests were busy incrementally increasing the version.

Caveats: I haven't actually tested this, but showing some code felt easier than writing this all up in an issue :)

____

For context, here are some graphs showing the # of queries per second after a site updated WC today and ran into the problem 😬 :

![issue](https://user-images.githubusercontent.com/8536129/152483365-1ee58a3c-e8f8-403e-afe3-cac8d96969b6.png)