### PR TITLE
Fix shipping task step when store location isn't filled out

### DIFF
--- a/changelogs/fix-8239_shipping_task
+++ b/changelogs/fix-8239_shipping_task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Shipping task sometimes skipping the set shipping costs step. #8260

--- a/client/tasks/fills/shipping/index.js
+++ b/client/tasks/fills/shipping/index.js
@@ -214,7 +214,7 @@ export class Shipping extends Component {
 							recordEvent( 'tasklist_shipping_set_location', {
 								country,
 							} );
-							this.completeStep();
+							// Don't need to trigger completeStep here as it's triggered by the address updates in the componentDidUpdate function.
 						} }
 					/>
 				),


### PR DESCRIPTION
Fixes #8239 

Remove completeStep call in StoreLocation callback to avoid duplicate call, cause the shipping costs step to be skipped sometimes.

### Screenshots

https://user-images.githubusercontent.com/2240960/152561699-a4ac2703-1261-4cae-b042-45b27a10c396.mov

### Detailed test instructions:

1. On a fresh WooCommerce installation, skip setting up the store details (or clear your Store's address under **WooCommerce > Settings** and make sure you don't have any shipping zones)
3. Go to WooCommerce > Home
4. Click "Set up shipping"
5. Fill up the "Set store location" step and submit it.
6. "Set shipping costs" should load correctly

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
