### PR TITLE
Made email in OBW optional again

### DIFF
--- a/changelogs/fix-optional-email
+++ b/changelogs/fix-optional-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fixed email address not being optional in OBW #8263

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -206,7 +206,7 @@ export class StoreDetails extends Component {
 		const validateAddress = getStoreAddressValidator( locale );
 		const errors = validateAddress( values );
 
-		if ( ! isEmail( values.storeEmail ) ) {
+		if ( values.storeEmail && ! isEmail( values.storeEmail ) ) {
 			errors.storeEmail = __(
 				'Invalid email address',
 				'woocommerce-admin'

--- a/client/profile-wizard/steps/store-details/test/index.js
+++ b/client/profile-wizard/steps/store-details/test/index.js
@@ -79,5 +79,15 @@ describe( 'StoreDetails', () => {
 				container.queryByText( 'Invalid email address' )
 			).toBeNull();
 		} );
+
+		test( 'should pass email validation when field is empty', async () => {
+			const container = render( <StoreDetails { ...testProps } /> );
+			const emailInput = container.getByLabelText( 'Email address' );
+			await userEvent.clear( emailInput );
+			userEvent.tab();
+			expect(
+				container.queryByText( 'Invalid email address' )
+			).toBeNull();
+		} );
 	} );
 } );


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/8197 introduced a bug where email address in OBW wasn't optional anymore because an empty email address failed validation.

This PR fixes that by only running validation if there is an email to validate.

### Detailed test instructions:


1. Start with a fresh install of WooCommerce
2. Enter the "Store Details" task in the Onboarding Wizard
3. Clear email address from the email address field, with the "Get tips ... straight to your mailbox" checkbox unchecked
4. Should be able to continue with wizard next step
