### PR TITLE
Add business-details step complete track

### DIFF
--- a/changelogs/add-7919_business_details_track
+++ b/changelogs/add-7919_business_details_track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Add
+
+Add additional store profiler track for the business details tab. #8265

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -151,7 +151,7 @@ class ProfileWizard extends Component {
 	}
 
 	/**
-	 * @param {object} tracksArgs optional track arguments for the storeprofiler_step_complete track.
+	 * @param {Object} tracksArgs optional track arguments for the storeprofiler_step_complete track.
 	 */
 	async goToNextStep( tracksArgs = {} ) {
 		const { activePlugins } = this.props;

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -151,9 +151,9 @@ class ProfileWizard extends Component {
 	}
 
 	/**
-	 * @param {string} trackStepKey optional track key for steps that have multiple tabs containing their own steps.
+	 * @param {object} tracksArgs optional track arguments for the storeprofiler_step_complete track.
 	 */
-	async goToNextStep( trackStepKey = '' ) {
+	async goToNextStep( tracksArgs = {} ) {
 		const { activePlugins } = this.props;
 		const currentStep = this.getCurrentStep();
 		const currentStepIndex = this.getSteps().findIndex(
@@ -161,7 +161,8 @@ class ProfileWizard extends Component {
 		);
 
 		recordEvent( 'storeprofiler_step_complete', {
-			step: trackStepKey !== '' ? trackStepKey : currentStep.key,
+			step: currentStep.key,
+			...tracksArgs,
 		} );
 
 		// Update the activePlugins cache in case plugins were installed

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -150,6 +150,9 @@ class ProfileWizard extends Component {
 		return currentStep;
 	}
 
+	/**
+	 * @param string trackStepKey optional track key for steps that have multiple tabs containing their own steps.
+	 */
 	async goToNextStep( trackStepKey = '' ) {
 		const { activePlugins } = this.props;
 		const currentStep = this.getCurrentStep();

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -120,7 +120,7 @@ class ProfileWizard extends Component {
 				profileItems.product_types !== null,
 		} );
 		steps.push( {
-			key: 'business-features',
+			key: 'business-details',
 			container: BusinessDetailsStep,
 			label: __( 'Business Details', 'woocommerce-admin' ),
 			isComplete:
@@ -150,7 +150,7 @@ class ProfileWizard extends Component {
 		return currentStep;
 	}
 
-	async goToNextStep() {
+	async goToNextStep( trackStepKey = '' ) {
 		const { activePlugins } = this.props;
 		const currentStep = this.getCurrentStep();
 		const currentStepIndex = this.getSteps().findIndex(
@@ -158,7 +158,7 @@ class ProfileWizard extends Component {
 		);
 
 		recordEvent( 'storeprofiler_step_complete', {
-			step: currentStep.key,
+			step: trackStepKey !== '' ? trackStepKey : currentStep.key,
 		} );
 
 		// Update the activePlugins cache in case plugins were installed

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -151,7 +151,7 @@ class ProfileWizard extends Component {
 	}
 
 	/**
-	 * @param string trackStepKey optional track key for steps that have multiple tabs containing their own steps.
+	 * @param {string} trackStepKey optional track key for steps that have multiple tabs containing their own steps.
 	 */
 	async goToNextStep( trackStepKey = '' ) {
 		const { activePlugins } = this.props;

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -386,6 +386,9 @@ class BusinessDetails extends Component {
 			used_platform_name: otherPlatformName,
 			setup_client: isSetupClient,
 		} );
+		recordEvent( 'storeprofiler_step_complete', {
+			step: BUSINESS_DETAILS_TAB_NAME,
+		} );
 	}
 
 	getSelectControlProps( getInputProps, name = '' ) {

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -39,7 +39,7 @@ import { getPluginSlug, getPluginTrackKey } from '~/utils';
 import './style.scss';
 
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
-const FREE_FEATURES_TAB_NAME = 'free-features';
+const BUSINESS_FEATURES_TAB_NAME = 'business-features';
 
 export const filterBusinessExtensions = (
 	extensionInstallationOptions,
@@ -240,7 +240,7 @@ class BusinessDetails extends Component {
 
 		Promise.all( promises )
 			.then( () => {
-				goToNextStep();
+				goToNextStep( BUSINESS_FEATURES_TAB_NAME );
 			} )
 			.catch( () => {
 				createNotice(
@@ -423,10 +423,13 @@ class BusinessDetails extends Component {
 				onSubmit={ ( values ) => {
 					this.setState( {
 						savedValues: values,
-						currentTab: 'free-features',
+						currentTab: BUSINESS_FEATURES_TAB_NAME,
 					} );
 
 					this.trackBusinessDetailsStep( values );
+					recordEvent( 'storeprofiler_step_view', {
+						step: BUSINESS_FEATURES_TAB_NAME,
+					} );
 				} }
 				onChange={ ( _, values, isValid ) => {
 					this.setState( { savedValues: values, isValid } );
@@ -603,7 +606,9 @@ class BusinessDetails extends Component {
 										<Button
 											onClick={ () => {
 												this.persistProfileItems();
-												goToNextStep();
+												goToNextStep(
+													BUSINESS_FEATURES_TAB_NAME
+												);
 											} }
 										>
 											{ __(
@@ -684,6 +689,9 @@ class BusinessDetails extends Component {
 							savedValues:
 								this.state.savedValues || initialValues,
 						} );
+						recordEvent( 'storeprofiler_step_view', {
+							step: tabName,
+						} );
 					}
 				} }
 				tabs={ [
@@ -697,10 +705,10 @@ class BusinessDetails extends Component {
 					},
 					{
 						name:
-							this.state.currentTab === FREE_FEATURES_TAB_NAME
+							this.state.currentTab === BUSINESS_FEATURES_TAB_NAME
 								? 'current-tab'
-								: FREE_FEATURES_TAB_NAME,
-						id: FREE_FEATURES_TAB_NAME,
+								: BUSINESS_FEATURES_TAB_NAME,
+						id: BUSINESS_FEATURES_TAB_NAME,
 						title: __( 'Free features', 'woocommerce-admin' ),
 						className: this.state.isValid ? '' : 'is-disabled',
 					},

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -240,7 +240,7 @@ class BusinessDetails extends Component {
 
 		Promise.all( promises )
 			.then( () => {
-				goToNextStep( BUSINESS_FEATURES_TAB_NAME );
+				goToNextStep( { step: BUSINESS_FEATURES_TAB_NAME } );
 			} )
 			.catch( () => {
 				createNotice(
@@ -606,9 +606,9 @@ class BusinessDetails extends Component {
 										<Button
 											onClick={ () => {
 												this.persistProfileItems();
-												goToNextStep(
-													BUSINESS_FEATURES_TAB_NAME
-												);
+												goToNextStep( {
+													step: BUSINESS_FEATURES_TAB_NAME,
+												} );
 											} }
 										>
 											{ __(

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
@@ -1,4 +1,4 @@
-.woocommerce-profile-wizard__container.business-features {
+.woocommerce-profile-wizard__container.business-details {
 	.components-tab-panel__tabs {
 		.components-tab-panel__tabs-item {
 			&.is-disabled {

--- a/client/profile-wizard/steps/business-details/style.scss
+++ b/client/profile-wizard/steps/business-details/style.scss
@@ -1,5 +1,4 @@
-.business-details.woocommerce-profile-wizard__container,
-.business-features.woocommerce-profile-wizard__container {
+.business-details.woocommerce-profile-wizard__container {
 	.woocommerce-admin__business-details__spinner {
 		display: flex;
 		justify-content: center;


### PR DESCRIPTION
Fixes #7919 

Add extra step_complete track for the store profiler to more accurately figure out where people are dropping off during the onboarding flow.
This add's a `business-details` `storeprofiler_step_complete` track when a user finishes the business details step and moves on to the free features tab.

### Detailed test instructions:

- Open your console and make sure you have tracks outputted ( `localStorage.setItem( 'debug', 'wc-admin:*' );` )
- Go to the Onboarding wizard and step through until the business details `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details`
- A `storeprofiler_step_view` should be triggered with `business-details` as the step.
- Fill out the dropdowns and click continue
- A `storeprofiler_step_complete` should of fired with a `step` prop of `business-details`. A new `storeprofiler_step_view` should of also fired with `business-features` as a step. Now select some free features and click continue.
- A `storeprofiler_step_complete` should of fired with a `step` prop of `business-features`.
- Check the general styling of the business features tab to make sure things look good still.


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
