### PR TITLE
Enable type definitions output for @woocommerce/components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/**/dist
 build
 build-module
 build-style
+build-types
 languages/*
 !languages/README.md
 woocommerce-admin.zip

--- a/changelogs/enhancement-8282-enable-typedefs-woocommerce-components
+++ b/changelogs/enhancement-8282-enable-typedefs-woocommerce-components
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Added Typescript type declarations to build for @woocommerce/components #8282

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.2.0-dev",
+	"version": "3.3.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9420,16 +9420,6 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
 			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
 		},
-		"@types/yauzl": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.22.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.1.tgz",
@@ -15657,6 +15647,18 @@
 						"debug": "^4.1.1",
 						"get-stream": "^5.1.0",
 						"yauzl": "^2.10.0"
+					},
+					"dependencies": {
+						"@types/yauzl": {
+							"version": "2.9.2",
+							"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+							"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"@types/node": "*"
+							}
+						}
 					}
 				},
 				"file-entry-cache": {
@@ -16828,6 +16830,36 @@
 						"tar-fs": "^2.0.0",
 						"unbzip2-stream": "^1.3.3",
 						"ws": "^7.2.3"
+					},
+					"dependencies": {
+						"chownr": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+							"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+							"dev": true
+						},
+						"tar-fs": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+							"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+							"dev": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"mkdirp-classic": "^0.5.2",
+								"pump": "^3.0.0",
+								"tar-stream": "^2.1.4"
+							}
+						},
+						"unbzip2-stream": {
+							"version": "1.4.3",
+							"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+							"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+							"dev": true,
+							"requires": {
+								"buffer": "^5.2.1",
+								"through": "^2.3.8"
+							}
+						}
 					}
 				},
 				"read-pkg": {
@@ -25760,9 +25792,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.4",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-			"integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+			"version": "1.14.7",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+			"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
 		},
 		"for-each": {
 			"version": "0.3.3",
@@ -42434,18 +42466,6 @@
 				}
 			}
 		},
-		"tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
 		"tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -43354,16 +43374,6 @@
 				"has-bigints": "^1.0.1",
 				"has-symbols": "^1.0.2",
 				"which-boxed-primitive": "^1.0.2"
-			}
-		},
-		"unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
 			}
 		},
 		"unc-path-regex": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Update line-height of SelectControl label to avoid truncated descenders in some typefaces and zoom levels. #8186
-
+- Added Typescript type declarations to build for @woocommerce/components #8282
 # 8.2.0
 
 -   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,7 @@
 		"build-style/**",
 		"src/**/*.scss"
 	],
+	"types": "build-types",
 	"dependencies": {
 		"@storybook/addon-knobs": "^6.3.0",
 		"@woocommerce/csv-export": "file:../csv-export",
@@ -85,7 +86,7 @@
 		"build:css": "webpack",
 		"clean": "npx rimraf tsconfig.tsbuildinfo build build-*",
 		"prepack": "npm run clean && npm run build",
-		"start": "concurrently \"tsc --build --watch\" \"webpack --watch\"",
+		"start": "concurrently \"tsc --build ./tsconfig.json --watch --verbose\" \"webpack --watch\"",
 		"test": "lerna run build && npm run test:nobuild",
 		"test:nobuild": "jest --config ./jest.config.json",
 		"test:update-snapshots": "npm run test:nobuild --updateSnapshot",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -86,7 +86,7 @@
 		"build:css": "webpack",
 		"clean": "npx rimraf tsconfig.tsbuildinfo build build-*",
 		"prepack": "npm run clean && npm run build",
-		"start": "concurrently \"tsc --build ./tsconfig.json --watch --verbose\" \"webpack --watch\"",
+		"start": "concurrently \"tsc --build ./tsconfig.json --watch\" \"webpack --watch\"",
 		"test": "lerna run build && npm run test:nobuild",
 		"test:nobuild": "jest --config ./jest.config.json",
 		"test:update-snapshots": "npm run test:nobuild --updateSnapshot",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,6 +2,9 @@
 	"extends": "../tsconfig",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build-module"
+		"outDir": "build-module",
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "./build-types",
 	}
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,6 +5,6 @@
 		"outDir": "build-module",
 		"declaration": true,
 		"declarationMap": true,
-		"declarationDir": "./build-types",
+		"declarationDir": "./build-types"
 	}
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -10,12 +10,14 @@
 		"jsx": "react",
 		"jsxFactory": "createElement",
 		"jsxFragmentFactory": "Fragment",
-		"incremental": true
+		"incremental": true,
 	},
 	"exclude": [
 		"node_modules",
+		"**/stories",
 		"**/build",
 		"**/build-module",
+		"**/build-types",
 		"**/test/*",
 		"**/jest.config.js",
 		"**/webpack.*.js"

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -10,7 +10,7 @@
 		"jsx": "react",
 		"jsxFactory": "createElement",
 		"jsxFragmentFactory": "Fragment",
-		"incremental": true,
+		"incremental": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
An attempt to make progress on https://github.com/woocommerce/woocommerce-admin/issues/6745

Added the configurations necessary in tsconfig to enable type definitions output for @woocommerce/components 
- output directory is at `build-types`, similarly to [Gutenberg packages](https://github.com/WordPress/gutenberg/commit/65520ef48b5861ed492116b74eb589bca27e42bc)
- package consumers know where to find the type definitions because its inside `package.json: { types }`
- type definitions are automatically generated and updated if you use `npm run start`

I'm not too confident of these modifications especially the npm package publishing steps, will require the reviewer to ensure that I haven't broken anything there (shouldn't have).

Note:

I had to add `**/stories` to the tsconfig excludes for two reasons:  
1. It was causing cyclic resolution issues during re-builds. This is caused by the `import { x } from '@woocommerce/components'` from within the storybook files. The other way to resolve this would be to change all the imports to relative imports, but this would have been messy as well due to imports from '@woocommerce/<others>', I suspect.
2. Type definitions were being generated and added to the output for storybook files which is unnecessary.

The unfortunate outcome of this would be that typechecking won't be performed on storybook .tsx files (none right now) by tsc CLI. You will still get type checking in your IDE, though.

### Detailed test instructions:

1. npm install
2. npm run build / npm run start

Should find the type definitions in `./packages/components/build-types`

Previously if a component from @woocommerce/components was imported in a .tsx file you would see:
![Pasted image 20220208171134](https://user-images.githubusercontent.com/27843274/153158837-51125de2-3bac-4fd8-b5e7-c1b1a021082b.png)

Now you should see:

![Pasted image 20220209142700](https://user-images.githubusercontent.com/27843274/153158902-a360282d-dae6-47b9-bc3e-975c1de41fcc.png)

Type checks should work too:

![image](https://user-images.githubusercontent.com/27843274/153159168-988ff349-b71d-41f1-a462-00f51749918e.png)

Bonuses: 

- "Right click -> Go to Definition" should bring you directly to the source code instead of the transpiled output now!
- Documentation should show up too

![image](https://user-images.githubusercontent.com/27843274/153163031-583fc014-0dd5-47a3-9fcc-942177a6f16c.png)
