### PR TITLE
Fix a lot of pending "run_remote_notifications" scheduled actions

### DIFF
--- a/changelogs/fix-pending-run-remote-notifications-actions
+++ b/changelogs/fix-pending-run-remote-notifications-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix too many pending run_remote_notifications actions. #8285

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -115,7 +115,7 @@ class StoredStateSetupForProducts {
 	 * Enqueues an async action (using action-scheduler) to run remote
 	 * notifications.
 	 */
-	private static function update_stored_state_and_run_remote_notifications() {
+	private static function update_stored_state_and_possibly_run_remote_notifications() {
 		$stored_state = RemoteInboxNotificationsEngine::get_stored_state();
 		if ( true === $stored_state->there_are_now_products ) {
 			return;

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -117,6 +117,7 @@ class StoredStateSetupForProducts {
 	 */
 	private static function update_stored_state_and_possibly_run_remote_notifications() {
 		$stored_state = RemoteInboxNotificationsEngine::get_stored_state();
+		// If the stored_state is the same, we don't need to run remote notifications to avoid unnecessary action scheduling.
 		if ( true === $stored_state->there_are_now_products ) {
 			return;
 		}

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -89,7 +89,7 @@ class StoredStateSetupForProducts {
 		}
 		// phpcs:enable
 
-		self::update_stored_state_and_run_remote_notifications();
+		self::update_stored_state_and_possibly_run_remote_notifications();
 	}
 
 	/**
@@ -108,7 +108,7 @@ class StoredStateSetupForProducts {
 			return;
 		}
 
-		self::update_stored_state_and_run_remote_notifications();
+		self::update_stored_state_and_possibly_run_remote_notifications();
 	}
 
 	/**

--- a/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
+++ b/src/RemoteInboxNotifications/StoredStateSetupForProducts.php
@@ -89,11 +89,7 @@ class StoredStateSetupForProducts {
 		}
 		// phpcs:enable
 
-		$stored_state                         = RemoteInboxNotificationsEngine::get_stored_state();
-		$stored_state->there_are_now_products = true;
-		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
-
-		self::enqueue_async_run_remote_notifications();
+		self::update_stored_state_and_run_remote_notifications();
 	}
 
 	/**
@@ -112,19 +108,23 @@ class StoredStateSetupForProducts {
 			return;
 		}
 
-		$stored_state                         = RemoteInboxNotificationsEngine::get_stored_state();
-		$stored_state->there_are_now_products = true;
-
-		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
-
-		self::enqueue_async_run_remote_notifications();
+		self::update_stored_state_and_run_remote_notifications();
 	}
 
 	/**
 	 * Enqueues an async action (using action-scheduler) to run remote
 	 * notifications.
 	 */
-	private static function enqueue_async_run_remote_notifications() {
+	private static function update_stored_state_and_run_remote_notifications() {
+		$stored_state = RemoteInboxNotificationsEngine::get_stored_state();
+		if ( true === $stored_state->there_are_now_products ) {
+			return;
+		}
+
+		$stored_state->there_are_now_products = true;
+		RemoteInboxNotificationsEngine::update_stored_state( $stored_state );
+
+		// Run self::run_remote_notifications asynchronously.
 		as_enqueue_async_action( self::ASYNC_RUN_REMOTE_NOTIFICATIONS_ACTION_NAME );
 	}
 }


### PR DESCRIPTION
Fixes #7957

This PR adds a check before updating the store state to avoid many pending `woocommerce admin/stored_state_setup_for_products/async/run/remote_notifications_actions`.

### Detailed test instructions:

1. Use a fresh site
2. Go to **WooCommerce > Products**.
3. Import the [products sample data](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/sample-data/sample_products.csv)
4. Go to /wp-admin/tools.php?page=action-scheduler
5. Verify that only one pending `woocommerce_admin/stored_state_setup_for_products/async/run_remote_notifications` action is generated.
6. Wait a few minutes and refresh the page to confirm that the action is completed.
![Screen Shot 2022-02-09 at 15 45 50](https://user-images.githubusercontent.com/4344253/153144811-5bae59da-bd18-46ad-aea0-752680852be8.png)

