### PR TITLE
Add wc_version to store profiler view and complete tracks

### DIFF
--- a/changelogs/add-7919_wc_version_to_storeprofiler_tracks
+++ b/changelogs/add-7919_wc_version_to_storeprofiler_tracks
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Add
 
-wc_version property to the store profile onboarding tracks for view and complete steps. #8290
+Add wc_version property to the store profile onboarding tracks for view and complete steps. #8290

--- a/changelogs/add-7919_wc_version_to_storeprofiler_tracks
+++ b/changelogs/add-7919_wc_version_to_storeprofiler_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+wc_version property to the store profile onboarding tracks for view and complete steps. #8290

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -21,7 +21,7 @@ import {
 	QUERY_DEFAULTS,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { getAdminLink } from '@woocommerce/settings';
+import { getAdminLink, getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -70,6 +70,7 @@ class ProfileWizard extends Component {
 
 			recordEvent( 'storeprofiler_step_view', {
 				step: this.getCurrentStep().key,
+				wc_version: getSetting( 'wcVersion' ),
 			} );
 		}
 	}
@@ -82,6 +83,7 @@ class ProfileWizard extends Component {
 
 		recordEvent( 'storeprofiler_step_view', {
 			step: this.getCurrentStep().key,
+			wc_version: getSetting( 'wcVersion' ),
 		} );
 	}
 
@@ -162,6 +164,7 @@ class ProfileWizard extends Component {
 
 		recordEvent( 'storeprofiler_step_complete', {
 			step: currentStep.key,
+			wc_version: getSetting( 'wcVersion' ),
 			...tracksArgs,
 		} );
 

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -21,6 +21,7 @@ import {
 	PLUGINS_STORE_NAME,
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
+import { getSetting } from '@woocommerce/settings';
 import { recordEvent } from '@woocommerce/tracks';
 import classnames from 'classnames';
 
@@ -388,6 +389,7 @@ class BusinessDetails extends Component {
 		} );
 		recordEvent( 'storeprofiler_step_complete', {
 			step: BUSINESS_DETAILS_TAB_NAME,
+			wc_version: getSetting( 'wcVersion' ),
 		} );
 	}
 
@@ -429,6 +431,7 @@ class BusinessDetails extends Component {
 					this.trackBusinessDetailsStep( values );
 					recordEvent( 'storeprofiler_step_view', {
 						step: BUSINESS_FEATURES_TAB_NAME,
+						wc_version: getSetting( 'wcVersion' ),
 					} );
 				} }
 				onChange={ ( _, values, isValid ) => {
@@ -691,6 +694,7 @@ class BusinessDetails extends Component {
 						} );
 						recordEvent( 'storeprofiler_step_view', {
 							step: tabName,
+							wc_version: getSetting( 'wcVersion' ),
 						} );
 					}
 				} }


### PR DESCRIPTION
Fixes #7919 

Add's `wc_version` as a prop to the store profiler step view and complete tracks. As mentioned in #7919, this will help differentiate the funnels, given the business details step track has been changed a bit.

### Detailed test instructions:

1. Open your console and make sure you have tracks outputted ( `localStorage.setItem( 'debug', 'wc-admin:*' );` )
2. Go to the Onboarding wizard and step through until the business details `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details`
3. Look back at the `wcadmin_storeprofiler_step_view` and `_complete` tracks and make sure `wc_version` is included in the props.
4. A `storeprofiler_step_view` should be triggered with `business-details` as the step and containing `wc_version`.
5. Fill out the dropdowns and click continue
6. A `storeprofiler_step_complete` should of fired with a `step` prop of `business-details`. A new `storeprofiler_step_view` should of also fired with `business-features` as a step and containing `wc_version`. Now select some free features and click continue.
7. A `storeprofiler_step_complete` should of fired with a `step` prop of `business-features` and containing `wc_version`.
8. Check the general styling of the business features tab to make sure things look good still.
