### PR TITLE
Fix WCPay in core texts and promo slug

### DIFF
--- a/changelogs/fix-wcpay-experiment-fix-text-and-promo-slug
+++ b/changelogs/fix-wcpay-experiment-fix-text-and-promo-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Tweak
+
+Fix WCPay in core texts and promo slug #8296

--- a/client/payments-welcome/index.tsx
+++ b/client/payments-welcome/index.tsx
@@ -50,7 +50,7 @@ interface activatePromoResponse {
 	success: boolean;
 }
 
-const PROMO_NAME = 'wcpay-promo-2021-6-incentive-2';
+const PROMO_NAME = 'wcpay-promo-2022-3-incentive-100-off';
 
 const LearnMore = () => {
 	const handleClick = () => {

--- a/client/payments-welcome/strings.tsx
+++ b/client/payments-welcome/strings.tsx
@@ -15,7 +15,7 @@ export default {
 		'woocommerce-admin'
 	),
 	bannerCopy: __(
-		'50% transaction fee discount for up to $125,000 in payments or six months',
+		'No transaction fees for up to 3 months (or $25,000 in payments)',
 		'woocommerce-admin'
 	),
 	discountCopy: __(
@@ -26,7 +26,7 @@ export default {
 
 	onboarding: {
 		description: __(
-			"Save 50% on transaction fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
+			"Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
 			'woocommerce-admin'
 		),
 	},

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -39,7 +39,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 * @var array
 	 */
 	protected $allowed_promo_notes = array(
-		'wcpay-promo-2021-6-incentive-2',
+		'wcpay-promo-2022-3-incentive-100-off',
 	);
 
 	/**

--- a/src/Notes/PaymentsRemindMeLater.php
+++ b/src/Notes/PaymentsRemindMeLater.php
@@ -66,7 +66,7 @@ class PaymentsRemindMeLater {
 		if ( ! self::should_display_note() ) {
 			return;
 		}
-		$content = __( 'Save up to 50% in fees by managing transactions in WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'woocommerce-admin' );
+		$content = __( 'Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'woocommerce-admin' );
 
 		$note = new Note();
 		$note->set_title( __( 'Save big with WooCommerce Payments', 'woocommerce-admin' ) );


### PR DESCRIPTION
This PR fixes promo texts to reflect the actual WCPay promo applied in backend (100% discount instead of 50%).

### Screenshots

<img width="811" alt="image" src="https://user-images.githubusercontent.com/3747241/153559942-03bf9fc3-9531-430c-a1fa-43d7dd765448.png">


### Detailed test instructions:

#### Testing the changed texts
- In your local, edit `should_add_the_menu` to return true in `src/Features/WcPayWelcomePage.php` to simulate treatment experiment (currently the experiment is disabled for February)
- Go to payments welcome page and observe the correct texts in banner and header card

#### Testing promo note action
- In payments welcome screen, click on "Install"
- Browse your database in `wp_wc_admin_notes` table, make sure a note with the name `wcpay-promo-2022-3-incentive-100-off` is created and its status is `actioned`
