### PR TITLE
Use WC_VERSION as cache buster for assets

### DIFF
--- a/changelogs/update-8294-use-wc-version-as-cache-buster
+++ b/changelogs/update-8294-use-wc-version-as-cache-buster
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Use WC_VERSION as cache buster for assets #8308

--- a/src/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/src/Features/OnboardingTasks/Tasks/Appearance.php
@@ -115,7 +115,7 @@ class Appearance extends Task {
 			'onboarding-homepage-notice',
 			Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ),
 			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_ADMIN_VERSION_NUMBER,
+			WC_VERSION,
 			true
 		);
 	}

--- a/src/Features/OnboardingTasks/Tasks/Products.php
+++ b/src/Features/OnboardingTasks/Tasks/Products.php
@@ -108,7 +108,7 @@ class Products extends Task {
 			'onboarding-product-notice',
 			Loader::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ),
 			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_ADMIN_VERSION_NUMBER,
+			WC_VERSION,
 			true
 		);
 	}
@@ -136,7 +136,7 @@ class Products extends Task {
 			'onboarding-product-import-notice',
 			Loader::get_url( 'wp-admin-scripts/onboarding-product-import-notice', 'js' ),
 			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_ADMIN_VERSION_NUMBER,
+			WC_VERSION,
 			true
 		);
 	}

--- a/src/Features/OnboardingTasks/Tasks/Tax.php
+++ b/src/Features/OnboardingTasks/Tasks/Tax.php
@@ -41,7 +41,7 @@ class Tax extends Task {
 			'onboarding-tax-notice',
 			Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice', 'js' ),
 			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_ADMIN_VERSION_NUMBER,
+			WC_VERSION,
 			true
 		);
 	}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -291,7 +291,7 @@ class Loader {
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 			return filemtime( WC_ADMIN_ABSPATH . self::get_path( $ext ) );
 		}
-		return WC_ADMIN_VERSION_NUMBER;
+		return WC_VERSION;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8294 

This PR replaces `WC_ADMIN_VERSION_NUMBER` with `WC_VERSION` as a part of The Merge process. More details are in the original issue.

### Detailed test instructions:

Please make a note of your WooCommerce version.
Please open your browser inspector.

Testing `src/Loader.php` change.

1. Make sure to turn off [SCRIPT_DEBUG](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) constant.
2. Open browser inspector and navigate to any WCA pages.
3. Go to `Network` tab and select `JS`
4. Search for `woocommerce-admin`.
5. Confirm the scripts have `?ver={your WC version}` at the end.

Testing `Tax.php` change.

1. Start with a fresh install.
2. Complete OBW.
3. Navigate to `WooCommerce -> Home` and choose `Set up tax` task.
4. Click `Continue setup`
5. Click `Set up manually` on the next page.
6. Open browser inspector -> Network and search for `onboarding-tax-notice`.
7. Confirm the script has  `?ver={your WC version}` at the end.

Testing `Products.php` change

1. Start with a fresh install
2. Complete OBW.
3. Navigate to `WooCommerce -> Home` and click `Add my products` task.
4. Click `Add manually`
5. You're redirected to `Add new product` page. Enter product name and click `Save draft` 
6. Navigate to `Products -> All Products` and click the product you just saved.
7. Open browser inspector -> Network and search for `onboarding-product-notice.min.js`
8. Confirm the script has  `?ver={your WC version}` at the end.

Note: I wasn't able to find a way to confirm the change with [Appearance.php](https://github.com/woocommerce/woocommerce-admin/pull/8308/files#diff-1e9f928c39bc46eaf736019d043000136f74a86156469d121340d7da622a217b)

