### PR TITLE
Deprecate WC_ADMIN_VERSION_NUMBER

### DIFF
--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -16,9 +16,6 @@ function replace_version( $filename, $package_json ) {
 		if ( stripos( $line, ' * Version: ' ) !== false ) {
 			$line = " * Version: {$package_json->version}\n";
 		}
-		if ( stripos( $line, ">define( 'WC_ADMIN_VERSION_NUMBER'," ) !== false ) {
-			$line = "\t\t\$this->define( 'WC_ADMIN_VERSION_NUMBER', '{$package_json->version}' );\n";
-		}
 		if ( stripos( $line, "const VERSION =" ) !== false ) {
 			$line = "\tconst VERSION = '{$package_json->version}';\n";
 		}

--- a/changelogs/update-8295-deprecate-wc-admin-version-number
+++ b/changelogs/update-8295-deprecate-wc-admin-version-number
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Deprecate WC_ADMIN_VERSION_NUMBET constant #8309

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -144,9 +144,14 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_DIST_JS_FOLDER', 'dist/' );
 		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'dist/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
-		// WARNING: Do not directly edit this version number constant.
-		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0-dev' );
+
+		/**
+		 * Constant used to fetch the connection owner token
+		 *
+		 * @deprecated 3.3.0
+		 * @var boolean
+		 */
+		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
 	}
 
 	/**

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -149,7 +149,7 @@ class FeaturePlugin {
 		 * Constant used to fetch the connection owner token
 		 *
 		 * @deprecated 3.3.0
-		 * @var boolean
+		 * @var string
 		 */
 		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
 	}


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32177 

This PR deprecate `WC_ADMIN_VERSION_NUMBER` constant as a part of The Merge. 

Please note that this **PR should be merged after releasing WCA** `3.3.0` as we still have `3.3.0-dev` in [woocommerce-admin.php](https://github.com/woocommerce/woocommerce-admin/blob/main/woocommerce-admin.php). Please also note that the Github tests are failing due to the version mismatch. 

I'm converting this PR as a draft for now, but it can be reviewed.

### Detailed test instructions:

1. Open [FeaturePlugin.php](https://github.com/woocommerce/woocommerce-admin/blob/main/src/FeaturePlugin.php) and update `WC_ADMIN_VERSION_NUMBER` constant to your local WCA version (most likely 3.3.0-dev) temporarily.  Otherwise, WCA won't be activated with the following error due to the version mismatch.
![Screen Shot 2022-02-14 at 12 53 25 PM](https://user-images.githubusercontent.com/4723145/153945319-c123b6f5-684e-4714-8155-16af40b26b3a.jpg)

2. Navigate WCA pages and make sure there are no errors.