### PR TITLE
Enable the new navigation in core environment

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -8,7 +8,7 @@
 		"marketing": true,
 		"minified-js": false,
 		"mobile-app-banner": true,
-		"navigation": false,
+		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,


### PR DESCRIPTION
Fixes #8298 

This PR enables the new navigation in `core.json` as a part of The Merge. More details are in the issue.

### Detailed test instructions:

1. Run `export WC_ADMIN_PHASE=core && npm run build:feature-config`
2. Open `includes/feature-config.php`
3. Confirm `navigation` is set to true.

no changelog