### PR TITLE
Make src/Features/RemoteFreeExtensions/* internal

### DIFF
--- a/src-internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src-internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -3,11 +3,10 @@
  * Gets a list of fallback methods if remote fetching is disabled.
  */
 
-namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
+namespace Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Init as OnboardingTasks;
 
 /**
  * Default Free Extensions

--- a/src-internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/src-internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -3,7 +3,7 @@
  * Evaluates the spec and returns a status.
  */
 
-namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
+namespace Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src-internal/Admin/RemoteFreeExtensions/Init.php
+++ b/src-internal/Admin/RemoteFreeExtensions/Init.php
@@ -3,12 +3,11 @@
  * Handles running payment method specs
  */
 
-namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
+namespace Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
-use Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\DefaultFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\DefaultFreeExtensions;
 
 /**
  * Remote Payment Methods engine.

--- a/src-internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php
+++ b/src-internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions;
+namespace Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions;
 
 /**
  * Specs data source poller class for remote free extensions.

--- a/src/API/OnboardingFreeExtensions.php
+++ b/src/API/OnboardingFreeExtensions.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\Init as RemoteFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFreeExtensions;
 
 /**
  * Onboarding Payments Controller.

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -401,6 +401,7 @@ class Features {
 		$aliases = array(
 			// new class => original class (this will be aliased).
 			'Automattic\WooCommerce\Internal\Admin\WcPayPromotion\Init' => 'Automattic\WooCommerce\Admin\Features\WcPayPromotion\Init',
+			'Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init' => 'Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\Init',
 		);
 		foreach ( $aliases as $new_class => $orig_class ) {
 			class_alias( $new_class, $orig_class );

--- a/src/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/src/Features/OnboardingTasks/Tasks/Marketing.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\Init as RemoteFreeExtensions;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFreeExtensions;
 
 /**
  * Marketing Task


### PR DESCRIPTION
Fixes #8272

This PR is similar to https://github.com/woocommerce/woocommerce-admin/pull/8307 that moves src `/Features/RemoteFreeExtensions/*` to `/src-internal/Admin/RemoteFreeExtensions` and add it to `register_internal_class_aliases` in `features.php` for backward compatibility.

### Screenshots
![Screen Shot 2022-02-15 at 15 22 16](https://user-images.githubusercontent.com/4344253/154013394-5a410e9c-0e5e-4351-8e58-23f7761c937e.png)


![Screen Shot 2022-02-15 at 15 29 48](https://user-images.githubusercontent.com/4344253/154013551-a0f28523-6aa8-4136-a9c4-713ae88fa635.png)

### Detailed test instructions:

1. Use a new site
2. Check out this branch and run `composer install`
3. Go to the setup wizard
4. Select a WCPay supported country
5. Go to "Business details" steps and select **"Free features"** tab
6. Observe that free extensions are displayed properly with the WCPay
7. Go to **Woocommerce > Home**
8. Select "Set up marketing tools" task
9. Should see the "Google Listings & Ads" and other recommended marketing extensions
10. Check no errors in debug logs

no changelog