### PR TITLE
Make src/Features/navigation/* internal

### DIFF
--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -9,7 +9,7 @@
  * Register the JS.
  */
 function add_navigation_items_register_script() {
-	if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) || ! \Automattic\WooCommerce\Admin\Features\Navigation\Screen::is_woocommerce_page() ) {
+	if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) || ! \Automattic\WooCommerce\Internal\Admin\Navigation\Screen::is_woocommerce_page() ) {
 		return;
 	}
 
@@ -37,7 +37,7 @@ function add_navigation_items_register_items() {
 		return;
 	}
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+	\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_item(
 		array(
 			'id'         => 'example-plugin',
 			'title'      => 'Example Plugin',
@@ -46,7 +46,7 @@ function add_navigation_items_register_items() {
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+	\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_category(
 		array(
 			'id'         => 'example-category',
 			'title'      => 'Example Category',
@@ -54,7 +54,7 @@ function add_navigation_items_register_items() {
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+	\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_item(
 		array(
 			'id'         => 'example-category-child-1',
 			'parent'     => 'example-category',
@@ -64,7 +64,7 @@ function add_navigation_items_register_items() {
 		)
 	);
 
-	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+	\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_item(
 		array(
 			'id'         => 'example-category-child-2',
 			'parent'     => 'example-category',

--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -9,7 +9,7 @@
  * Register the JS.
  */
 function add_navigation_items_register_script() {
-	if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) || ! \Automattic\WooCommerce\Internal\Admin\Navigation\Screen::is_woocommerce_page() ) {
+	if ( ! class_exists( '\Automattic\WooCommerce\Internal\Admin\Navigation\Screen' ) || ! \Automattic\WooCommerce\Internal\Admin\Navigation\Screen::is_woocommerce_page() ) {
 		return;
 	}
 
@@ -31,8 +31,8 @@ add_action( 'admin_enqueue_scripts', 'add_navigation_items_register_script' );
  */
 function add_navigation_items_register_items() {
 	if (
-		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_plugin_category' ) ||
-		! method_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu', 'add_plugin_item' )
+		! method_exists( '\Automattic\WooCommerce\Internal\Admin\Navigation\Menu', 'add_plugin_category' ) ||
+		! method_exists( '\Automattic\WooCommerce\Internal\Admin\Navigation\Menu', 'add_plugin_item' )
 	) {
 		return;
 	}

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -30,7 +30,7 @@ Clicking on a category will not navigate to a new page, but instead open the chi
 * `capability` - (string) Capability to view this menu item.
 
 ```php
-\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_category(
     array(
         'id'     => 'example-category',
         'title'  => 'Example Category',
@@ -41,7 +41,7 @@ Clicking on a category will not navigate to a new page, but instead open the chi
 Categories can also contain more categories by specifying the `parent` property for the child category.  There is no limit on the level of nesting.
 
 ```php
-\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_category(
+\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_category(
     array(
         'id'     => 'example-nested-category',
         'parent' => 'example-category',
@@ -63,7 +63,7 @@ Adding an item, much like a category, can be added directly to the menu or to an
 * `matchExpression` - (string) An optional regex string to compare against the current location and mark the item active.
 
 ```php
-\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+\Automattic\WooCommerce\Internal\Admin\Navigation\Menu::add_plugin_item(
     array(
         'id'         => 'example-plugin',
         'title'      => 'Example Plugin',
@@ -79,16 +79,15 @@ In order to show the new navigation in place of the traditional WordPress menu o
 
 When adding items, the navigation will automatically add support for the screen via the URL or callback provided with an item.  However, custom post types and taxonomies need to be registered with the navigation to work on the custom post type page.
 
-
 ```php
-\Automattic\WooCommerce\Admin\Features\Navigation\Screen::register_post_type( 'my-custom-post-type' );
-\Automattic\WooCommerce\Admin\Features\Navigation\Screen::register_taxonomy( 'my-custom-taxonomy' );
+\Automattic\WooCommerce\Internal\Admin\Navigation\Screen::register_post_type( 'my-custom-post-type' );
+\Automattic\WooCommerce\Internal\Admin\Navigation\Screen::register_taxonomy( 'my-custom-taxonomy' );
 ```
 
 You can also manually add a screen without registering an item.
 
 ```php
-\Automattic\WooCommerce\Admin\Features\Navigation\Screen::add_screen( 'my-plugin-page' );
+\Automattic\WooCommerce\Internal\Admin\Navigation\Screen::add_screen( 'my-plugin-page' );
 ```
 
 ### Slot/fill items

--- a/src-internal/Admin/Navigation/CoreMenu.php
+++ b/src-internal/Admin/Navigation/CoreMenu.php
@@ -5,11 +5,11 @@
  * @package Woocommerce Admin
  */
 
-namespace Automattic\WooCommerce\Admin\Features\Navigation;
+namespace Automattic\WooCommerce\Internal\Admin\Navigation;
 
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Menu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Screen;
 
 /**
  * CoreMenu class. Handles registering Core menu items.

--- a/src-internal/Admin/Navigation/Favorites.php
+++ b/src-internal/Admin/Navigation/Favorites.php
@@ -5,7 +5,7 @@
  * @package Woocommerce Navigation
  */
 
-namespace Automattic\WooCommerce\Admin\Features\Navigation;
+namespace Automattic\WooCommerce\Internal\Admin\Navigation;
 
 use Automattic\WooCommerce\Admin\Loader;
 

--- a/src-internal/Admin/Navigation/Init.php
+++ b/src-internal/Admin/Navigation/Init.php
@@ -5,14 +5,14 @@
  * @package Woocommerce Admin
  */
 
-namespace Automattic\WooCommerce\Admin\Features\Navigation;
+namespace Automattic\WooCommerce\Internal\Admin\Navigation;
 
 use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\Survey;
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
-use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Screen;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Menu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\CoreMenu;
 
 /**
  * Contains logic for the Navigation

--- a/src-internal/Admin/Navigation/Menu.php
+++ b/src-internal/Admin/Navigation/Menu.php
@@ -5,11 +5,11 @@
  * @package Woocommerce Navigation
  */
 
-namespace Automattic\WooCommerce\Admin\Features\Navigation;
+namespace Automattic\WooCommerce\Internal\Admin\Navigation;
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Favorites;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Favorites;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Screen;
+use Automattic\WooCommerce\Internal\Admin\Navigation\CoreMenu;
 
 /**
  * Contains logic for the WooCommerce Navigation menu.

--- a/src-internal/Admin/Navigation/Screen.php
+++ b/src-internal/Admin/Navigation/Screen.php
@@ -5,9 +5,9 @@
  * @package Woocommerce Navigation
  */
 
-namespace Automattic\WooCommerce\Admin\Features\Navigation;
+namespace Automattic\WooCommerce\Internal\Admin\Navigation;
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Menu;
 
 /**
  * Contains logic for the WooCommerce Navigation menu.

--- a/src/API/NavigationFavorites.php
+++ b/src/API/NavigationFavorites.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Favorites;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Favorites;
 
 /**
  * REST API Favorites controller class.

--- a/src/Features/Features.php
+++ b/src/Features/Features.php
@@ -402,6 +402,7 @@ class Features {
 			// new class => original class (this will be aliased).
 			'Automattic\WooCommerce\Internal\Admin\WcPayPromotion\Init' => 'Automattic\WooCommerce\Admin\Features\WcPayPromotion\Init',
 			'Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init' => 'Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\Init',
+			'Automattic\WooCommerce\Internal\Admin\Navigation\Init' => 'Automattic\WooCommerce\Admin\Features\Navigation\Init',
 		);
 		foreach ( $aliases as $new_class => $orig_class ) {
 			class_alias( $new_class, $orig_class );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -10,7 +10,7 @@ use \_WP_Dependency;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
 use Automattic\WooCommerce\Admin\API\Plugins;
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Screen;
 use WC_Marketplace_Suggestions;
 
 /**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -809,7 +809,7 @@ class Loader {
 	 * TODO: See usage in `admin.php`. This needs refactored and implemented properly in core.
 	 */
 	public static function is_embed_page() {
-		return wc_admin_is_connected_page() || ( ! self::is_admin_page() && class_exists( 'Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) && Screen::is_woocommerce_page() );
+		return wc_admin_is_connected_page() || ( ! self::is_admin_page() && class_exists( 'Automattic\WooCommerce\Internal\Admin\Navigation\Screen' ) && Screen::is_woocommerce_page() );
 	}
 
 	/**

--- a/src/Notes/NavigationNudge.php
+++ b/src/Notes/NavigationNudge.php
@@ -10,7 +10,7 @@ namespace Automattic\WooCommerce\Admin\Notes;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\Features\Navigation\Init as Navigation;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Init as Navigation;
 
 /**
  * Navigation Nudge.

--- a/tests/navigation/class-wc-favorites.php
+++ b/tests/navigation/class-wc-favorites.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Admin\Tests\Navigation
  */
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Favorites;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Favorites;
 
 
 /**

--- a/tests/navigation/class-wc-menu.php
+++ b/tests/navigation/class-wc-menu.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Admin\Tests\Navigation
  */
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Menu;
 
 
 /**

--- a/tests/navigation/class-wc-screen.php
+++ b/tests/navigation/class-wc-screen.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Admin\Tests\Navigation
  */
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Internal\Admin\Navigation\Screen;
 
 /*
  * This is required to allow manually setting of the screen during testing.


### PR DESCRIPTION
Fixes #8270

This PR is similar to #8311 that moves src `/Features/navigation/*` to `/src-internal/Admin/navigation` and add it to `register_internal_class_aliases` in `features.php` for backward compatibility.

### Screenshots
![Screen Shot 2022-02-15 at 15 49 28](https://user-images.githubusercontent.com/4344253/154016852-7c0a4017-2edf-4274-9687-9774534677c6.png)

![Screen Shot 2022-02-15 at 16 58 39](https://user-images.githubusercontent.com/4344253/154027569-cc7821ec-b4f0-4a8d-8620-587e2ee4fdff.png)



### Detailed test instructions:

1. Use a new site
2. Check out this branch and run composer install
3. cd to `docs/examples/extensions` and run `npm run example -- --ext=add-navigation-items`.
4. Observe that webpack is able to emit `../../../../add-navigation-items/woocommerce-admin-add-navigation-items-example.php`
5. Go to **WordPress > Installed Plugins** and activate the plugin
6. Skip or complete setup wizard
7. Go to **WooCommerce > Home**
8. Should see the `You now have access to the WooCommerce navigation` note in the inbox.
9. Go to /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features and enable the **Navigation** feature
10.  Navigate to WooCommerce and click **Example Category**
11. Click the **favorite icon** and make sure it works without an error.

no changelog