### PR TITLE
Small change to WCPay welcome page banner

### DIFF
--- a/client/payments-welcome/strings.tsx
+++ b/client/payments-welcome/strings.tsx
@@ -15,7 +15,7 @@ export default {
 		'woocommerce-admin'
 	),
 	bannerCopy: __(
-		'No transaction fees for up to 3 months (or $25,000 in payments)',
+		'No card transaction fees for up to 3 months (or $25,000 in payments)',
 		'woocommerce-admin'
 	),
 	discountCopy: __(


### PR DESCRIPTION
Add "Card" to text. p1644989070127579/1644834294.855319-slack-C01SFMVEYAK

### Screenshots

<img width="815" alt="image" src="https://user-images.githubusercontent.com/3747241/154235268-a2bc4040-0413-4a34-a805-037d290c010c.png">



### Detailed test instructions:

#### Testing the changed texts
- In your local, edit `should_add_the_menu` to return true in `src/Features/WcPayWelcomePage.php` to simulate treatment experiment (currently the experiment is disabled for February)
- Go to payments welcome page and observe the text `No card transaction fees for up to 3 months (or $25,000 in payments)` in banner

No changelog