### PR TITLE
Fix payment task conflicts

### DIFF
--- a/changelogs/fix-8251_wc_pay_task_list_logic
+++ b/changelogs/fix-8251_wc_pay_task_list_logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Adjusted task list logic to fix conflict between current and experimental task list. #8321

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -116,12 +116,11 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		}
 		const hasMultiplePaymentTasks =
 			( taskList.tasks || [] ).filter(
-				( task ) =>
-					task.id === 'payments' || task.id === 'woocommerce-payments'
+				( t ) => t.id === 'payments' || t.id === 'woocommerce-payments'
 			).length > 1;
 		const tasks =
 			id === 'setup' && hasMultiplePaymentTasks && taskList.tasks
-				? taskList.tasks.filter( ( task ) => task.id !== 'payments' )
+				? taskList.tasks.filter( ( t ) => t.id !== 'payments' )
 				: taskList.tasks;
 
 		return (

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -109,12 +109,20 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 			isVisible,
 			isToggleable,
 			title,
-			tasks,
 		} = taskList;
 
 		if ( ! isVisible ) {
 			return null;
 		}
+		const hasMultiplePaymentTasks =
+			( taskList.tasks || [] ).filter(
+				( task ) =>
+					task.id === 'payments' || task.id === 'woocommerce-payments'
+			).length > 1;
+		const tasks =
+			id === 'setup' && hasMultiplePaymentTasks && taskList.tasks
+				? taskList.tasks.filter( ( task ) => task.id !== 'payments' )
+				: taskList.tasks;
 
 		return (
 			<Fragment key={ id }>

--- a/client/two-column-tasks/extended-task.tsx
+++ b/client/two-column-tasks/extended-task.tsx
@@ -71,17 +71,25 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 	const setupTaskList = taskLists.find( ( list ) => {
 		return list.id === 'setup';
 	} );
+	const hasSetupPaymentsTask = setupTaskList.tasks.find(
+		( t ) => t.id === 'payments'
+	);
 
 	extendedTaskList.tasks = [
 		...new Set(
-			extendedTaskList.tasks.concat(
-				setupTaskList?.tasks.filter( ( unallowedTask ) => {
-					return (
-						! allowedTasks.includes( unallowedTask.id ) &&
-						unallowedTask.id !== 'store_details'
-					);
-				} ) || []
-			)
+			// Filter out the additional payments task if it is already present in the setup tasks.
+			extendedTaskList.tasks
+				.filter(
+					( t ) => t.id !== 'payments' || ! hasSetupPaymentsTask
+				)
+				.concat(
+					setupTaskList?.tasks.filter( ( unallowedTask ) => {
+						return (
+							! allowedTasks.includes( unallowedTask.id ) &&
+							unallowedTask.id !== 'store_details'
+						);
+					} ) || []
+				)
 		),
 	];
 

--- a/client/two-column-tasks/index.js
+++ b/client/two-column-tasks/index.js
@@ -83,9 +83,13 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 	}
 	// List of task items to be shown on the main task list.
 	// Any other remaining tasks will be moved to the extended task list.
-	const setupTasks = taskLists[ 0 ].tasks.filter( ( setupTask ) =>
-		allowedTasks.includes( setupTask.id )
-	);
+	const setupTasks = taskLists[ 0 ].tasks.filter( ( setupTask ) => {
+		if ( setupTask.id === 'woocommerce-payments' && setupTask.isComplete ) {
+			// filter out woocommerce payments task if complete.
+			return false;
+		}
+		return allowedTasks.includes( setupTask.id );
+	} );
 
 	const completedTasks = setupTasks.filter(
 		( setupTask ) => setupTask.isComplete

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -49,7 +49,7 @@ class TaskLists {
 		'Shipping',
 		'Marketing',
 		'Appearance',
-		'AdditionalPayments'
+		'AdditionalPayments',
 	);
 
 	/**

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -49,6 +49,7 @@ class TaskLists {
 		'Shipping',
 		'Marketing',
 		'Appearance',
+		'AdditionalPayments'
 	);
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Payments;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
+
+/**
+ * Payments Task
+ */
+class AdditionalPayments extends Payments
+{
+	/**
+	 * Parent ID.
+	 *
+	 * @return string
+	 */
+	public function get_parent_id()
+	{
+		return 'extended';
+	}
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	public function get_title()
+	{
+		return __('Set up additional payment providers', 'woocommerce-admin');
+	}
+
+
+	/**
+	 * Task visibility.
+	 *
+	 * @return bool
+	 */
+	public function can_view()
+	{
+		$woocommerce_payments = new WooCommercePayments();
+		return Features::is_enabled('payment-gateway-suggestions') && $woocommerce_payments->can_view();
+	}
+}
+

--- a/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -10,15 +10,14 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayme
 /**
  * Payments Task
  */
-class AdditionalPayments extends Payments
-{
+class AdditionalPayments extends Payments {
+
 	/**
 	 * Parent ID.
 	 *
 	 * @return string
 	 */
-	public function get_parent_id()
-	{
+	public function get_parent_id() {
 		return 'extended';
 	}
 
@@ -27,9 +26,8 @@ class AdditionalPayments extends Payments
 	 *
 	 * @return string
 	 */
-	public function get_title()
-	{
-		return __('Set up additional payment providers', 'woocommerce-admin');
+	public function get_title() {
+		return __( 'Set up additional payment providers', 'woocommerce-admin' );
 	}
 
 
@@ -38,10 +36,9 @@ class AdditionalPayments extends Payments
 	 *
 	 * @return bool
 	 */
-	public function can_view()
-	{
+	public function can_view() {
 		$woocommerce_payments = new WooCommercePayments();
-		return Features::is_enabled('payment-gateway-suggestions') && $woocommerce_payments->can_view();
+		return Features::is_enabled( 'payment-gateway-suggestions' ) && $woocommerce_payments->can_view();
 	}
 }
 

--- a/src/Features/OnboardingTasks/Tasks/Payments.php
+++ b/src/Features/OnboardingTasks/Tasks/Payments.php
@@ -74,7 +74,7 @@ class Payments extends Task {
 	 */
 	public function can_view() {
 		$woocommerce_payments = new WooCommercePayments();
-		return (!$woocommerce_payments->can_view() || ($woocommerce_payments->can_view() && WooCommercePayments::is_connected())) && Features::is_enabled('payment-gateway-suggestions');
+		return ( ! $woocommerce_payments->can_view() || ( $woocommerce_payments->can_view() && WooCommercePayments::is_connected() ) ) && Features::is_enabled( 'payment-gateway-suggestions' );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/Payments.php
+++ b/src/Features/OnboardingTasks/Tasks/Payments.php
@@ -25,8 +25,7 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_parent_id() {
-		$woocommerce_payments = new WooCommercePayments();
-		return $woocommerce_payments->can_view() ? 'extended' : 'setup';
+		return 'setup';
 	}
 
 	/**
@@ -35,10 +34,7 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		$woocommerce_payments = new WooCommercePayments();
-		return $woocommerce_payments->can_view()
-			? __( 'Set up additional payment providers', 'woocommerce-admin' )
-			: __( 'Set up payments', 'woocommerce-admin' );
+		return __( 'Set up payments', 'woocommerce-admin' );
 	}
 
 	/**
@@ -77,7 +73,8 @@ class Payments extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		return Features::is_enabled( 'payment-gateway-suggestions' );
+		$woocommerce_payments = new WooCommercePayments();
+		return (!$woocommerce_payments->can_view() || ($woocommerce_payments->can_view() && WooCommercePayments::is_connected())) && Features::is_enabled('payment-gateway-suggestions');
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -96,8 +96,7 @@ class WooCommercePayments extends Task {
 	public function can_view() {
 		return self::is_requested() &&
 			self::is_installed() &&
-			self::is_supported() &&
-			! self::is_connected();
+			self::is_supported();
 	}
 
 	/**
@@ -106,6 +105,7 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_requested() {
+		return false;
 		$profiler_data       = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$business_extensions = isset( $profiler_data['business_extensions'] ) ? $profiler_data['business_extensions'] : array();
 		return in_array( 'woocommerce-payments', $business_extensions, true );
@@ -127,6 +127,7 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_connected() {
+		return true;
 		if ( class_exists( '\WC_Payments' ) ) {
 			$wc_payments_gateway = \WC_Payments::get_gateway();
 			return method_exists( $wc_payments_gateway, 'is_connected' )

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -105,7 +105,6 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_requested() {
-		return false;
 		$profiler_data       = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$business_extensions = isset( $profiler_data['business_extensions'] ) ? $profiler_data['business_extensions'] : array();
 		return in_array( 'woocommerce-payments', $business_extensions, true );
@@ -127,7 +126,6 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_connected() {
-		return true;
 		if ( class_exists( '\WC_Payments' ) ) {
 			$wc_payments_gateway = \WC_Payments::get_gateway();
 			return method_exists( $wc_payments_gateway, 'is_connected' )


### PR DESCRIPTION
Fixes #8251 

Fix payment logic of payment tasks between current task list and experimental one.

I am not overly happy with this approach, as it feels hacky, I have another PR on the way with a much nicer approach, but this required a huge amount of refactors. So for the sake of time and this needing to get into **3.2**, I proposed this fix.

### Screenshots
<img width="1248" alt="Screen Shot 2022-02-16 at 11 23 05 AM" src="https://user-images.githubusercontent.com/2240960/154296646-965edd41-e0d4-46b8-a812-23de5b77c111.png">

### Detailed test instructions:

Testing a couple scenarios
#### Finish onboarding with selecting WooCommerce Payments
**Non experiment**
- Make sure the task list shows **Get paid with WooCommerce Payments** in the main task list and **Set up additional payment providers** task in the extended task list
- Connect WooCommerce Payments (easiest on Jurassic with the dev mode using the [WC Pay test tools](https://github.com/Automattic/woocommerce-payments-dev-tools) (install this first before starting the WC Pay onboarding)
- Once connected it should still show the **Get paid with WooCommerce Payments** task in the main task list, but completed
- **Set up additional payment providers** task should still be present in the extended task list

**Experiment** (use the `woocommerce_tasklist_progression_headercard_2col_2022_02` treatment in Abacus and clear your local storage, that should show the experimental task list).
- If you still have the WC Pay connected, the **Get paid with WooCommerce Payments** task should **not** be present in the new task list, but an un completed **Set up payments** should be provided.
- Now make sure WC Pay isn't connected anymore (I think the WC Pay dev tools allows for this, or start a new site)
- It should show a uncompleted **Get paid with WooCommerce Payments** task in the set up tasks and **Set up additional payment providers** in the extended task list.

#### Finish onboarding WITHOUT selecting WooCommerce Payments
This should be the same for both the experiment and non-experiment
- Go to **WooCommerce > Home**
- The **Set up payments** task should be in the main set up task list
- **Set up additional payment providers** should not be present in the extended task list


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
