### PR TITLE
Have free subscriptions adhere to cbd industry

### DIFF
--- a/changelogs/fix-8320_subscription_should_be_hidden_with_cbd_industry
+++ b/changelogs/fix-8320_subscription_should_be_hidden_with_cbd_industry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Make sure free subscriptions does not show when cbd industry is selected. #8323

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -112,6 +112,7 @@ export class ProductTypes extends Component {
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures.subscriptions &&
 			countryCode === 'US' &&
+			! productTypes[ 'subscriptions' ].yearly_price &&
 			! installedPlugins.includes( 'woocommerce-payments' ) &&
 			selected.includes( 'subscriptions' )
 		) {
@@ -305,6 +306,7 @@ export class ProductTypes extends Component {
 						window.wcAdminFeatures.subscriptions &&
 						countryCode === 'US' &&
 						! isWCPayInstalled &&
+						! productTypes[ 'subscriptions' ].yearly_price &&
 						selected.includes( 'subscriptions' ) && (
 							<Text
 								variant="body"

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -99,6 +99,7 @@ export class ProductTypes extends Component {
 			goToNextStep,
 			installAndActivatePlugins,
 			updateProfileItems,
+			productTypes,
 		} = this.props;
 
 		const eventProps = {

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -113,7 +113,8 @@ export class ProductTypes extends Component {
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures.subscriptions &&
 			countryCode === 'US' &&
-			! productTypes[ 'subscriptions' ].yearly_price &&
+			productTypes.subscriptions &&
+			! productTypes.subscriptions.yearly_price &&
 			! installedPlugins.includes( 'woocommerce-payments' ) &&
 			selected.includes( 'subscriptions' )
 		) {
@@ -307,7 +308,8 @@ export class ProductTypes extends Component {
 						window.wcAdminFeatures.subscriptions &&
 						countryCode === 'US' &&
 						! isWCPayInstalled &&
-						! productTypes[ 'subscriptions' ].yearly_price &&
+						productTypes.subscriptions &&
+						! productTypes.subscriptions.yearly_price &&
 						selected.includes( 'subscriptions' ) && (
 							<Text
 								variant="body"

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -491,7 +491,14 @@ class Onboarding {
 			),
 		);
 		$base_location = wc_get_base_location();
-		if ( ! Features::is_enabled( 'subscriptions' ) || 'US' !== $base_location['country'] ) {
+		$has_cbd_industry = false;
+		if ( 'US' === $base_location['country'] ) {
+			$profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+			if ( ! empty( $profile['industry'] ) ) {
+				$has_cbd_industry = in_array( 'cbd-other-hemp-derived-products', array_column( $profile['industry'], 'slug' ), true );
+			}
+		}
+		if ( ! Features::is_enabled( 'subscriptions' ) || 'US' !== $base_location['country'] || $has_cbd_industry ) {
 			$products['subscriptions']['product'] = 27147;
 		}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -462,7 +462,7 @@ class Onboarding {
 	 * @return array
 	 */
 	public static function get_allowed_product_types() {
-		$products      = array(
+		$products         = array(
 			'physical'        => array(
 				'label'   => __( 'Physical products', 'woocommerce-admin' ),
 				'default' => true,
@@ -490,10 +490,10 @@ class Onboarding {
 				'product' => 18618,
 			),
 		);
-		$base_location = wc_get_base_location();
+		$base_location    = wc_get_base_location();
 		$has_cbd_industry = false;
 		if ( 'US' === $base_location['country'] ) {
-			$profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+			$profile = get_option( self::PROFILE_DATA_OPTION, array() );
 			if ( ! empty( $profile['industry'] ) ) {
 				$has_cbd_industry = in_array( 'cbd-other-hemp-derived-products', array_column( $profile['industry'], 'slug' ), true );
 			}


### PR DESCRIPTION
Fixes #8320 

Make sure the free subscriptions does not show when cbd industry is selected

### Screenshots

![subscriptions-cbd](https://user-images.githubusercontent.com/2240960/154331123-68f85795-2b17-4819-af83-12a387705d4a.gif)

### Detailed test instructions:

- On a new WooCommerce store start the onboarding wizard
- Make sure the address is an american address
- Select "CBD and other hemp-derived products" for industry
- Notice in the "Product Types" step subscriptions has a price listed
- Select subscriptions, any footer text shouldn't appear, and click continue
- Go to installed plugins and make sure WooCommerce Payments isn't installed.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
