### PR TITLE
OBW: fix copy on Business Details when "WooCommerce Shipping" is not listed

### DIFF
--- a/changelogs/fix-6860
+++ b/changelogs/fix-6860
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+OBW: fix copy on Business Details when "WooCommerce Shipping" is not listed #8324

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -70,12 +70,27 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 
 	const installingJetpackOrWcShipping =
 		extensions.includes( 'jetpack' ) ||
-		extensions.includes( 'woocommerce-shipping' );
+		extensions.includes( 'woocommerce-services:shipping' );
 
 	const accountRequiredText = __(
 		'User accounts are required to use these features.',
 		'woocommerce-admin'
 	);
+
+	const isWCShippingAvailableToInstall = extensions.includes(
+		'woocommerce-services:shipping'
+	);
+
+	const installJetpackOrWcShippingText = isWCShippingAvailableToInstall
+		? __(
+				'By installing Jetpack and WooCommerce Shipping plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
+				'woocommerce-admin'
+		  )
+		: __(
+				'By installing Jetpack plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
+				'woocommerce-admin'
+		  );
+
 	return (
 		<div className="woocommerce-profile-wizard__footnote">
 			<Text variant="caption" as="p" size="12" lineHeight="16px">
@@ -94,10 +109,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 			{ installingJetpackOrWcShipping && (
 				<Text variant="caption" as="p" size="12" lineHeight="16px">
 					{ interpolateComponents( {
-						mixedString: __(
-							'By installing Jetpack and WooCommerce Shipping plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
-							'woocommerce-admin'
-						),
+						mixedString: installJetpackOrWcShippingText,
 						components: {
 							link: (
 								<Link

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -68,28 +68,36 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 		);
 	}
 
-	const installingJetpackOrWcShipping =
-		extensions.includes( 'jetpack' ) ||
-		extensions.includes( 'woocommerce-services:shipping' );
-
 	const accountRequiredText = __(
 		'User accounts are required to use these features.',
 		'woocommerce-admin'
 	);
 
-	const isWCShippingAvailableToInstall = extensions.includes(
-		'woocommerce-services:shipping'
+	const extensionsWithToS = extensions.filter(
+		( extension ) =>
+			extension === 'jetpack' ||
+			extension.includes( 'woocommerce-services' )
 	);
 
-	const installJetpackOrWcShippingText = isWCShippingAvailableToInstall
-		? __(
-				'By installing Jetpack and WooCommerce Shipping plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
-				'woocommerce-admin'
-		  )
-		: __(
-				'By installing Jetpack plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
-				'woocommerce-admin'
-		  );
+	const isInstallingJetpackAndWCServices =
+		extensionsWithToS.includes( 'jetpack' ) &&
+		( extensionsWithToS.includes( 'woocommerce-services:shipping' ) ||
+			extensionsWithToS.includes( 'woocommerce-services:tax' ) );
+
+	const extensionsListText = isInstallingJetpackAndWCServices
+		? 'Jetpack and WooCommerce Shipping & Tax'
+		: pluginNames[ extensionsWithToS[ 0 ] ];
+
+	const installingJetpackShippingTaxToS = sprintf(
+		/* translators: %s: a list of plugins, e.g. Jetpack */
+		_n(
+			'By installing %s plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
+			'By installing %s plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
+			extensionsWithToS.length,
+			'woocommerce-admin'
+		),
+		extensionsListText
+	);
 
 	return (
 		<div className="woocommerce-profile-wizard__footnote">
@@ -106,10 +114,10 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 					accountRequiredText
 				) }
 			</Text>
-			{ installingJetpackOrWcShipping && (
+			{ extensionsWithToS.length > 0 && (
 				<Text variant="caption" as="p" size="12" lineHeight="16px">
 					{ interpolateComponents( {
-						mixedString: installJetpackOrWcShippingText,
+						mixedString: installingJetpackShippingTaxToS,
 						components: {
 							link: (
 								<Link

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -203,26 +203,22 @@ export const ExtensionSection = ( {
 	);
 };
 
-export const createInstallExtensionOptions = ( {
-	installableExtensions,
-	prevInstallExtensionOptions,
-} ) => {
-	return installableExtensions.reduce( ( acc, curr ) => {
-		const plugins = curr.plugins.reduce( ( pluginAcc, plugin ) => {
-			// If the option exists in the previous state, use that so the option won't be reset.
-			if ( prevInstallExtensionOptions.hasOwnProperty( plugin.key ) ) {
-				return pluginAcc;
-			}
+export const createInstallExtensionOptions = ( installableExtensions ) => {
+	return installableExtensions.reduce(
+		( acc, curr ) => {
+			const plugins = curr.plugins.reduce( ( pluginAcc, plugin ) => {
+				return {
+					...pluginAcc,
+					[ plugin.key ]: true,
+				};
+			}, {} );
 			return {
-				...pluginAcc,
-				[ plugin.key ]: true,
+				...acc,
+				...plugins,
 			};
-		}, {} );
-		return {
-			...acc,
-			...plugins,
-		};
-	}, prevInstallExtensionOptions );
+		},
+		{ install_extensions: true }
+	);
 };
 
 export const SelectiveExtensionsBundle = ( {
@@ -280,11 +276,8 @@ export const SelectiveExtensionsBundle = ( {
 
 	useEffect( () => {
 		if ( ! isInstallingActivating ) {
-			setInstallExtensionOptions( ( currInstallExtensionOptions ) =>
-				createInstallExtensionOptions( {
-					installableExtensions,
-					prevInstallExtensionOptions: currInstallExtensionOptions,
-				} )
+			setInstallExtensionOptions( () =>
+				createInstallExtensionOptions( installableExtensions )
 			);
 		}
 		// Disable reason: This effect should only called when the installableExtensions are changed.

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -161,35 +161,25 @@ describe( 'BusinessDetails', () => {
 					plugins: [
 						{
 							key: 'visible-and-not-selected',
-							isVisible: () => true,
 						},
 						{
 							key: 'visible-and-selected',
-							isVisible: () => true,
-						},
-						{
-							key: 'this-should-not-show-at-all',
-							isVisible: () => false,
 						},
 					],
 				},
 			];
 
-			const values = createInstallExtensionOptions( {
-				installableExtensions,
-				prevInstallExtensionOptions: {
-					'visible-and-not-selected': false,
-				},
-			} );
+			const values = createInstallExtensionOptions(
+				installableExtensions
+			);
 
 			expect( values ).toEqual(
 				expect.objectContaining( {
-					'visible-and-not-selected': false,
+					install_extensions: true,
+					'visible-and-not-selected': true,
 					'visible-and-selected': true,
 				} )
 			);
-
-			expect( values ).not.toContain( 'this-should-not-show-at-all' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #6860

This PR fixes the `Bussiness details` copy in step 4 of OBW. Sometimes the WooCommerce Shipping wasn't available to install but the copy still mentioned the plugin. That was corrected here.  

It also corrects an issue refreshing data in step 4 of the OBW.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one local-2022 02 16-18_14_49](https://user-images.githubusercontent.com/1314156/154358398-8414ce52-d961-468c-9ab4-9760b94ec9df.png)

### Detailed test instructions:

1. Create a test site using JN.
2. Start OBW and enter an address that is not in the US.
3. Choose "food and drink" from the Industry
4. When you get to the "Business Details", click "Free features".
5. Note that "WooCommerce Shipping" is not listed.
6. Confirm that the copy under the plugin list says: `By installing Jetpack plugin for free you agree to our Terms of Service.`.

![screenshot-one local-2022 02 16-18_11_29](https://user-images.githubusercontent.com/1314156/154358103-53f33091-0673-4637-87f1-925b2aa4c1ca.png)

7. No go to the first step and select an address in the US.
8. Go back to the "Business Details" step and click "Free features".
9. The text now should say: `By installing Jetpack and WooCommerce Shipping plugins for free you agree to our Terms of Service.`

![screenshot-one local-2022 02 16-18_12_27](https://user-images.githubusercontent.com/1314156/154358164-532abca7-6d9d-4497-a216-4f62d3ca5580.png)

10. Run the tests and confirm that everything is working well.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
