### PR TITLE
Fix hidden notes in `admin/notes` when the user is not in tasklist experiment

### DIFF
--- a/changelogs/fix-admin_notes_tasklist_experiment
+++ b/changelogs/fix-admin_notes_tasklist_experiment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix hidden notes in `admin/notes` endpoint when the user is not in the tasklist experiment. #8329
+Fix hidden notes in `admin/notes` endpoint when the user is not in the tasklist experiment. #8328

--- a/changelogs/fix-admin_notes_tasklist_experiment
+++ b/changelogs/fix-admin_notes_tasklist_experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix hidden notes in `admin/notes` endpoint when the user is not in the tasklist experiment. #8329

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -199,20 +199,8 @@ class Notes extends \WC_REST_CRUD_Controller {
 
 		$notes = NotesRepository::get_notes( 'edit', $query_args );
 
-		$is_tasklist_experiment_assigned_treatment = $this->is_tasklist_experiment_assigned_treatment();
-
 		$data = array();
 		foreach ( (array) $notes as $note_obj ) {
-			// Hide selected notes for users not in experiment.
-			if ( ! $is_tasklist_experiment_assigned_treatment ) {
-				if ( 'wc-admin-complete-store-details' === $note_obj['name'] ) {
-					continue;
-				}
-
-				if ( 'wc-admin-update-store-details' === $note_obj['name'] ) {
-					continue;
-				}
-			}
 			$note   = $this->prepare_item_for_response( $note_obj, $request );
 			$note   = $this->prepare_response_for_collection( $note );
 			$data[] = $note;
@@ -276,6 +264,12 @@ class Notes extends \WC_REST_CRUD_Controller {
 
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date_created';
+		}
+
+		// Hide selected notes for users not in experiment.
+		$is_tasklist_experiment_assigned_treatment = $this->is_tasklist_experiment_assigned_treatment();
+		if ( false === $is_tasklist_experiment_assigned_treatment ) {
+			$args['excluded_name'] = array( 'wc-admin-complete-store-details', 'wc-admin-update-store-details' );
 		}
 
 		/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -418,14 +418,16 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$escaped_is_deleted = esc_sql( $args['is_deleted'] );
 		}
 
-		$where_name_array   = $this->get_escaped_arguments_array_by_key( $args, 'name' );
-		$where_source_array = $this->get_escaped_arguments_array_by_key( $args, 'source' );
+		$where_name_array          = $this->get_escaped_arguments_array_by_key( $args, 'name' );
+		$where_excluded_name_array = $this->get_escaped_arguments_array_by_key( $args, 'excluded_name' );
+		$where_source_array        = $this->get_escaped_arguments_array_by_key( $args, 'source' );
 
-		$escaped_where_types  = implode( ',', $where_type_array );
-		$escaped_where_status = implode( ',', $where_status_array );
-		$escaped_where_names  = implode( ',', $where_name_array );
-		$escaped_where_source = implode( ',', $where_source_array );
-		$where_clauses        = '';
+		$escaped_where_types          = implode( ',', $where_type_array );
+		$escaped_where_status         = implode( ',', $where_status_array );
+		$escaped_where_names          = implode( ',', $where_name_array );
+		$escaped_where_excluded_names = implode( ',', $where_excluded_name_array );
+		$escaped_where_source         = implode( ',', $where_source_array );
+		$where_clauses                = '';
 
 		if ( ! empty( $escaped_where_types ) ) {
 			$where_clauses .= " AND type IN ($escaped_where_types)";
@@ -437,6 +439,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		if ( ! empty( $escaped_where_names ) ) {
 			$where_clauses .= " AND name IN ($escaped_where_names)";
+		}
+
+		if ( ! empty( $escaped_where_excluded_names ) ) {
+			$where_clauses .= " AND name NOT IN ($escaped_where_excluded_names)";
 		}
 
 		if ( ! empty( $escaped_where_source ) ) {

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -217,6 +217,79 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting notes when the user is in tasklist experiment returns notes of size `per_page` without any filters.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_getting_notes_when_user_is_in_tasklist_experiment_returns_unfiltered_notes() {
+		// Given.
+		wp_set_current_user( $this->user );
+		WC_Helper_Admin_Notes::reset_notes_dbs();
+		// Notes of the following two names are hidden when the user is not in the task list experiment.
+		WC_Helper_Admin_Notes::add_note_for_test( 'wc-admin-complete-store-details' );
+		WC_Helper_Admin_Notes::add_note_for_test( 'wc-admin-update-store-details' );
+		// Other notes.
+		WC_Helper_Admin_Notes::add_note_for_test( 'winter-sales' );
+		WC_Helper_Admin_Notes::add_note_for_test( '2022-promo' );
+
+		$this->set_user_in_tasklist_experiment();
+
+		// When.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'page'     => '1',
+				'per_page' => '3',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		// Then.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, count( $notes ) );
+		$this->assertEquals( $notes[0]['name'], 'wc-admin-complete-store-details' );
+		$this->assertEquals( $notes[1]['name'], 'wc-admin-update-store-details' );
+		$this->assertEquals( $notes[2]['name'], 'winter-sales' );
+	}
+
+	/**
+	 * Test getting notes when the user is not in tasklist experiment excludes two notes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_getting_notes_when_user_is_not_in_tasklist_experiment_excludes_two_notes() {
+		// Given.
+		wp_set_current_user( $this->user );
+		WC_Helper_Admin_Notes::reset_notes_dbs();
+		// Notes of the following two names are hidden when the user is not in the task list experiment.
+		WC_Helper_Admin_Notes::add_note_for_test( 'wc-admin-complete-store-details' );
+		WC_Helper_Admin_Notes::add_note_for_test( 'wc-admin-update-store-details' );
+		// Other notes.
+		WC_Helper_Admin_Notes::add_note_for_test( 'summer-sales' );
+		WC_Helper_Admin_Notes::add_note_for_test( '2022-promo' );
+
+		$this->set_user_out_of_tasklist_experiment();
+
+		// When.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'page'     => '1',
+				'per_page' => '3',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		// Then.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( $notes[0]['name'], 'summer-sales' );
+		$this->assertEquals( $notes[1]['name'], '2022-promo' );
+	}
+
+	/**
 	 * Test getting notes of a certain type.
 	 *
 	 * @since 3.5.0
@@ -544,5 +617,31 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $notes ) );
+	}
+
+	/**
+	 * Simulates when the user is in tasklist experiment similar to `API/Notes` `is_tasklist_experiment_assigned_treatment` function.
+	 */
+	private function set_user_in_tasklist_experiment() {
+		// When the user is participating in either `wc-admin-complete-store-details` or `wc-admin-update-store-details` AB tests,
+		// the user is in tasklist experiment.
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		$date = new \DateTime();
+		$date->setTimeZone( new \DateTimeZone( 'UTC' ) );
+
+		$experiment_name = sprintf(
+			'woocommerce_tasklist_progression_headercard_%s_%s',
+			$date->format( 'Y' ),
+			$date->format( 'm' )
+		);
+		set_transient( 'abtest_variation_' . $experiment_name, 'treatment' );
+	}
+
+	/**
+	 * Simulates when the user is not in tasklist experiment similar to `API/Notes` `is_tasklist_experiment_assigned_treatment` function.
+	 */
+	private function set_user_out_of_tasklist_experiment() {
+		// Any experiment is off when `woocommerce_allow_tracking` option is false.
+		update_option( 'woocommerce_allow_tracking', false );
 	}
 }

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -132,4 +132,25 @@ class WC_Helper_Admin_Notes {
 		);
 		$note_5->save();
 	}
+
+	/**
+	 * Create a note that we can use for tests on `name` related filters
+	 *
+	 * @param string $name The name of the new note.
+	 */
+	public static function add_note_for_test( string $name = 'default_name' ) {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		$note = new Note();
+		$note->set_title( 'PHPUNIT_TEST_NOTE_TITLE' );
+		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
+
+		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( $name );
+		$note->set_source( 'PHPUNIT_TEST' );
+		$note->set_is_snoozable( false );
+		$note->set_layout( 'plain' );
+		$note->set_image( '' );
+		$note->save();
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/6147
Fixes #8329 

First noticed in pbIJXs-12m-p2#comment-3225, and I can reproduce consistently in Woo iOS app as we implement Inbox with `GET admin/notes` endpoint. The size of notes in the response is off by 1 from the requested page size. After some debugging, the missing note was one of the two hidden notes (`wc-admin-complete-store-details` and `wc-admin-update-store-details`) when the user is not in the tasklist experiment. Because the filtering is after the database query, the returned notes size might not be the same as the page size.

This PR moved the filtering to the database query by setting the two note names under `excluded_name` argument that is used to add a ` AND name NOT IN (excluded_name_array)` clause.

### Detailed test instructions:

I'm not sure how to turn on/off the AB test for a user/store, so far I can only reproduce the issue on a public site but not on local sites.

- Make an API request `wc-analytics/admin/notes?page=1&per_page=10` --> make sure there are 10 notes in the response

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->