### PR TITLE
Fix Google Listings plugin is always shown in free features despite already activated

### DIFF
--- a/changelogs/fix-8327-google-listings-plugin-is-always-shown-in-free-features
+++ b/changelogs/fix-8327-google-listings-plugin-is-always-shown-in-free-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix Google Listings plugin is always shown in free features despite already activated. #8330

--- a/src-internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/src-internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -79,6 +79,17 @@ class DefaultFreeExtensions {
 				'image_url'      => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
+				'is_visible'     => [
+					[
+						'type'    => 'not',
+						'operand' => [
+							[
+								'type'    => 'plugins_activated',
+								'plugins' => [ 'google-listings-and-ads' ],
+							],
+						],
+					],
+				],
 			],
 			'google-listings-and-ads:alt'       => [
 				'name'           => __( 'Google Listings & Ads', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #8327

Add is_visible rule for google-listings-and-ads fallback to not display it if it's already activated

### Screenshots

![Screen Shot 2022-02-18 at 16 58 23](https://user-images.githubusercontent.com/4344253/154650962-830da7be-783b-478e-b335-eaf4694b1d22.png)


### Detailed test instructions:

1. Make sure the fallback payment suggestions file is used:
- turn off `woocommerce_show_marketplace_suggestions `option:
   - `wp-env run cli wp option set woocommerce_show_marketplace_suggestions no`
OR
   - Delete the `woocommerce_admin_payment_gateway_suggestion_specs` transient, if any
and change [this URL](https://github.com/woocommerce/woocommerce-admin/blob/main/src-internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13) to something that won't return json
2. Go to setup wizard's business details step -> free features tab
3. Observe that "Google Listings and Ads plugin" is displayed
2. Install and activate [Google Listings and Ads plugin](https://woocommerce.com/products/google-listings-and-ads/)
3. Go to setup wizard's business details step -> free features tab
4. Observe the plugin is **not** present

