### PR TITLE
Replace deprecated isPrimary, isSecondary, isTertiary, isLink Button props with variant

### DIFF
--- a/changelogs/dev-update-deprecated-button-props
+++ b/changelogs/dev-update-deprecated-button-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Replace deprecated isPrimary, isSecondary, isTertiary, isLink Button props with variant. #8340

--- a/client/activity-panel/activity-card/test/index.js
+++ b/client/activity-panel/activity-card/test/index.js
@@ -78,7 +78,7 @@ describe( 'ActivityCard', () => {
 			<ActivityCard
 				title="Inbox message"
 				actions={
-					<Button isSecondary onClick={ noop }>
+					<Button variant="secondary" onClick={ noop }>
 						Action
 					</Button>
 				}
@@ -95,10 +95,10 @@ describe( 'ActivityCard', () => {
 			<ActivityCard
 				title="Inbox message"
 				actions={ [
-					<Button key="action1" isPrimary onClick={ noop }>
+					<Button key="action1" variant="primary" onClick={ noop }>
 						Action 1
 					</Button>,
-					<Button key="action2" isSecondary onClick={ noop }>
+					<Button key="action2" variant="secondary" onClick={ noop }>
 						Action 2
 					</Button>,
 				] }

--- a/client/activity-panel/highlight-tooltip/index.js
+++ b/client/activity-panel/highlight-tooltip/index.js
@@ -165,7 +165,7 @@ function HighlightTooltip( {
 							<CardFooter isBorderless={ true }>
 								<Button
 									size="small"
-									isPrimary
+									variant="primary"
 									onClick={ triggerClose }
 								>
 									{ closeButtonText ||

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -103,7 +103,7 @@ function HistoricalDataActions( {
 				<Fragment>
 					<Button
 						className="woocommerce-settings-historical-data__action-button"
-						isPrimary
+						variant="primary"
 						onClick={ onStopImport }
 					>
 						{ __( 'Stop Import', 'woocommerce-admin' ) }
@@ -128,13 +128,16 @@ function HistoricalDataActions( {
 				return (
 					<Fragment>
 						<Button
-							isPrimary
+							variant="primary"
 							onClick={ onStartImport }
 							disabled={ importDisabled }
 						>
 							{ __( 'Start', 'woocommerce-admin' ) }
 						</Button>
-						<Button isSecondary onClick={ deletePreviousData }>
+						<Button
+							variant="secondary"
+							onClick={ deletePreviousData }
+						>
 							{ __(
 								'Delete Previously Imported Data',
 								'woocommerce-admin'
@@ -147,7 +150,7 @@ function HistoricalDataActions( {
 			return (
 				<Fragment>
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ onStartImport }
 						disabled={ importDisabled }
 					>
@@ -170,10 +173,10 @@ function HistoricalDataActions( {
 		// Has imported all possible data
 		return (
 			<Fragment>
-				<Button isSecondary onClick={ reimportData }>
+				<Button variant="secondary" onClick={ reimportData }>
 					{ __( 'Re-import Data', 'woocommerce-admin' ) }
 				</Button>
-				<Button isSecondary onClick={ deletePreviousData }>
+				<Button variant="secondary" onClick={ deletePreviousData }>
 					{ __(
 						'Delete Previously Imported Data',
 						'woocommerce-admin'

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -143,11 +143,11 @@ const Settings = ( { createNotice, query } ) => {
 					/>
 				) ) }
 				<div className="woocommerce-settings__actions">
-					<Button isSecondary onClick={ resetDefaults }>
+					<Button variant="secondary" onClick={ resetDefaults }>
 						{ __( 'Reset defaults', 'woocommerce-admin' ) }
 					</Button>
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ isRequesting }
 						onClick={ saveChanges }
 					>

--- a/client/analytics/settings/setting.js
+++ b/client/analytics/settings/setting.js
@@ -59,7 +59,7 @@ class Setting extends Component {
 			case 'button':
 				return (
 					<Button
-						isSecondary
+						variant="secondary"
 						onClick={ this.handleInputCallback }
 						disabled={ disabled }
 					>

--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -143,7 +143,7 @@ class CartModal extends Component {
 
 				<div className="woocommerce-cart-modal__actions">
 					<Button
-						isLink
+						variant="link"
 						isBusy={ purchaseLaterButtonBusy }
 						onClick={ () => this.onClickPurchaseLater() }
 					>
@@ -151,7 +151,7 @@ class CartModal extends Component {
 					</Button>
 
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ purchaseNowButtonBusy }
 						onClick={ () => this.onClickPurchaseNow() }
 					>

--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -71,7 +71,7 @@ export class Connect extends Component {
 			<Fragment>
 				{ hasErrors ? (
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ () => window.location.reload() }
 					>
 						{ __( 'Retry', 'woocommerce-admin' ) }
@@ -80,7 +80,7 @@ export class Connect extends Component {
 					<Button
 						disabled={ isRequesting }
 						isBusy={ this.state.isConnecting }
-						isPrimary
+						variant="primary"
 						onClick={ this.connectJetpack }
 					>
 						{ __( 'Connect', 'woocommerce-admin' ) }

--- a/client/homescreen/activity-panel/reviews/index.js
+++ b/client/homescreen/activity-panel/reviews/index.js
@@ -244,7 +244,7 @@ class ReviewsPanel extends Component {
 		const cardActions = [
 			<Button
 				key="approve-action"
-				isSecondary
+				variant="secondary"
 				onClick={ () => {
 					this.recordReviewEvent( 'approve', manageReviewEvent );
 					this.updateReviewStatus(
@@ -258,7 +258,7 @@ class ReviewsPanel extends Component {
 			</Button>,
 			<Button
 				key="spam-action"
-				isTertiary
+				variant="tertiary"
 				onClick={ () => {
 					this.recordReviewEvent( 'mark_as_spam', manageReviewEvent );
 					this.updateReviewStatus( review.id, 'spam', review.status );
@@ -269,7 +269,7 @@ class ReviewsPanel extends Component {
 			<Button
 				key="delete-action"
 				isDestructive
-				isTertiary
+				variant="tertiary"
 				onClick={ () => {
 					this.recordReviewEvent( 'delete', manageReviewEvent );
 					this.deleteReview( review.id );

--- a/client/homescreen/activity-panel/stock/card.js
+++ b/client/homescreen/activity-panel/stock/card.js
@@ -133,7 +133,7 @@ export class ProductStockCard extends Component {
 
 		if ( editing ) {
 			return [
-				<Button key="save" type="submit" isPrimary>
+				<Button key="save" type="submit" variant="primary">
 					{ __( 'Save', 'woocommerce-admin' ) }
 				</Button>,
 				<Button key="cancel" type="reset">
@@ -143,7 +143,7 @@ export class ProductStockCard extends Component {
 		}
 
 		return [
-			<Button key="update" isSecondary onClick={ this.beginEdit }>
+			<Button key="update" variant="secondary" onClick={ this.beginEdit }>
 				{ __( 'Update stock', 'woocommerce-admin' ) }
 			</Button>,
 		];

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -54,7 +54,7 @@ export const JetpackCTA = ( {
 			</div>
 			<footer>
 				<Button
-					isSecondary
+					variant="secondary"
 					onClick={ () => {
 						recordEvent( 'statsoverview_install_jetpack' );
 						onClickInstall();
@@ -65,7 +65,7 @@ export const JetpackCTA = ( {
 					{ getJetpackInstallText( jetpackInstallState ) }
 				</Button>
 				<Button
-					isTertiary
+					variant="tertiary"
 					onClick={ () => {
 						recordEvent( 'statsoverview_dismiss_install_jetpack' );
 						onClickDismiss();

--- a/client/inbox-panel/dismiss-all-modal.js
+++ b/client/inbox-panel/dismiss-all-modal.js
@@ -66,7 +66,7 @@ const DismissAllModal = ( { onClose } ) => {
 							{ __( 'Cancel', 'woocommerce-admin' ) }
 						</Button>
 						<Button
-							isPrimary
+							variant="primary"
 							onClick={ () => {
 								dismissAllNotes();
 								onClose();

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -71,8 +71,7 @@ export class StoreAlerts extends Component {
 			return (
 				<Button
 					key={ action.name }
-					isPrimary={ action.primary }
-					isSecondary={ ! action.primary }
+					variant={ action.primary ? 'primary' : 'secondary' }
 					href={ action.url || undefined }
 					onClick={ () => triggerNoteAction( alert.id, action.id ) }
 				>

--- a/client/layout/transient-notices/snackbar/index.js
+++ b/client/layout/transient-notices/snackbar/index.js
@@ -132,7 +132,7 @@ function Snackbar(
 						<Button
 							key={ index }
 							href={ url }
-							isTertiary
+							variant="tertiary"
 							onClick={ ( event ) =>
 								onActionClick( event, onClick )
 							}

--- a/client/marketing/components/button/README.md
+++ b/client/marketing/components/button/README.md
@@ -7,7 +7,7 @@ This component creates simple reusable html `<button></button>` element.
 
 ```jsx
 <Button
-	isSecondary
+	variant="secondary"
 	onClick={ this.onActivateClick }
 	disabled={ isLoading }
 >

--- a/client/marketing/overview/installed-extensions/row.js
+++ b/client/marketing/overview/installed-extensions/row.js
@@ -93,7 +93,7 @@ class InstalledExtensionRow extends Component {
 
 		return (
 			<Button
-				isSecondary
+				variant="secondary"
 				onClick={ this.onActivateClick }
 				disabled={ isLoading }
 			>
@@ -105,7 +105,7 @@ class InstalledExtensionRow extends Component {
 	getFinishSetupButton() {
 		return (
 			<Button
-				isSecondary
+				variant="secondary"
 				href={ this.props.settingsUrl }
 				onClick={ this.onFinishSetupClick }
 			>

--- a/client/mobile-banner/banner.js
+++ b/client/mobile-banner/banner.js
@@ -75,7 +75,7 @@ export const Banner = ( { onInstall, onDismiss } ) => {
 
 			<Button
 				href={ PLAY_STORE_LINK }
-				isSecondary
+				variant="secondary"
 				onClick={ () => {
 					onInstall();
 					setIsActioned( true );

--- a/client/navigation/components/favorite-button/index.js
+++ b/client/navigation/components/favorite-button/index.js
@@ -46,7 +46,7 @@ export const FavoriteButton = ( { id } ) => {
 		<Button
 			id="woocommerce-navigation-favorite-button"
 			className="woocommerce-navigation-favorite-button"
-			isTertiary
+			variant="tertiary"
 			onClick={ toggleFavorite }
 			aria-label={
 				isFavorited

--- a/client/payments-welcome/exit-survey-modal.tsx
+++ b/client/payments-welcome/exit-survey-modal.tsx
@@ -126,14 +126,18 @@ function ExitSurveyModal( {
 
 			<div className="wc-calypso-bridge-payments-welcome-survey__buttons">
 				<Button
-					isTertiary
+					variant="tertiary"
 					isDestructive
 					onClick={ removeWCPayMenu }
 					name="cancel"
 				>
 					{ strings.surveyCancelButton }
 				</Button>
-				<Button isSecondary onClick={ sendFeedback } name="send">
+				<Button
+					variant="secondary"
+					onClick={ sendFeedback }
+					name="send"
+				>
 					{ strings.surveySubmitButton }
 				</Button>
 			</div>

--- a/client/payments-welcome/index.tsx
+++ b/client/payments-welcome/index.tsx
@@ -173,7 +173,7 @@ const ConnectPageOnboarding = ( {
 				</div>
 				<div className="connect-account__action">
 					<Button
-						isSecondary
+						variant="secondary"
 						isBusy={ isNoThanksClicked && isExitSurveyModalOpen }
 						disabled={ isNoThanksClicked && isExitSurveyModalOpen }
 						onClick={ handleNoThanks }
@@ -182,7 +182,7 @@ const ConnectPageOnboarding = ( {
 						{ strings.nothanks }
 					</Button>
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ isSubmitted }
 						disabled={ isSubmitted }
 						onClick={ handleSetup }

--- a/client/payments/payment-recommendations.tsx
+++ b/client/payments/payment-recommendations.tsx
@@ -150,7 +150,7 @@ const PaymentRecommendations: React.FC = () => {
 				content: decodeEntities( plugin.content ),
 				after: (
 					<Button
-						isSecondary
+						variant="secondary"
 						onClick={ () => setupPlugin( plugin ) }
 						isBusy={ installingPlugin === plugin.id }
 						disabled={ !! installingPlugin }
@@ -210,7 +210,11 @@ const PaymentRecommendations: React.FC = () => {
 			</CardHeader>
 			<List items={ pluginsList } />
 			<CardFooter>
-				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
+				<Button
+					href={ SEE_MORE_LINK }
+					target="_blank"
+					variant="tertiary"
+				>
 					{ __( 'See more options', 'woocommerce-admin' ) }
 					<ExternalIcon size={ 18 } />
 				</Button>

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -597,7 +597,7 @@ class BusinessDetails extends Component {
 								</CardFooter>
 								<CardFooter justify="center">
 									<Button
-										isPrimary
+										variant="primary"
 										onClick={ async () => {
 											await handleSubmit();
 											this.persistProfileItems();

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -384,7 +384,7 @@ export const SelectiveExtensionsBundle = ( {
 						} }
 						isBusy={ isInstallingActivating || isResolving }
 						disabled={ isInstallingActivating || isResolving }
-						isPrimary
+						variant="primary"
 					>
 						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>

--- a/client/profile-wizard/steps/industry.js
+++ b/client/profile-wizard/steps/industry.js
@@ -265,7 +265,7 @@ class Industry extends Component {
 					</CardBody>
 					<CardFooter isBorderless justify="center">
 						<Button
-							isPrimary
+							variant="primary"
 							onClick={ () => {
 								this.onContinue().then(
 									this.props.goToNextStep

--- a/client/profile-wizard/steps/product-types/index.js
+++ b/client/profile-wizard/steps/product-types/index.js
@@ -280,7 +280,7 @@ export class ProductTypes extends Component {
 					</CardBody>
 					<CardFooter isBorderless justify="center">
 						<Button
-							isPrimary
+							variant="primary"
 							onClick={ () => {
 								this.onContinue( this.props.goToNextStep );
 							} }

--- a/client/profile-wizard/steps/product-types/label.js
+++ b/client/profile-wizard/steps/product-types/label.js
@@ -35,7 +35,7 @@ export default function ProductTypeLabel( {
 				{ label }
 			</span>
 			<Button
-				isTertiary
+				variant="tertiary"
 				label={ __(
 					'Learn more about recommended free business features',
 					'woocommerce-admin'

--- a/client/profile-wizard/steps/product-types/product-type.js
+++ b/client/profile-wizard/steps/product-types/product-type.js
@@ -33,7 +33,7 @@ export default function ProductType( {
 		<div className="woocommerce-product-type">
 			<span className="woocommerce-product-type__label">{ label }</span>
 			<Button
-				isTertiary
+				variant="tertiary"
 				label={ __(
 					'Learn more about recommended free business features',
 					'woocommerce-admin'

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -293,7 +293,7 @@ export class StoreDetails extends Component {
 						) }
 
 						<Button
-							isTertiary
+							variant="tertiary"
 							label={ __(
 								'Learn more about store details',
 								'woocommerce-admin'
@@ -416,7 +416,7 @@ export class StoreDetails extends Component {
 
 							<CardFooter justify="center">
 								<Button
-									isPrimary
+									variant="primary"
 									onClick={ handleSubmit }
 									isBusy={ isBusy }
 									disabled={ ! isValidForm || isBusy }
@@ -429,7 +429,7 @@ export class StoreDetails extends Component {
 				</Form>
 				<div className="woocommerce-profile-wizard__footer">
 					<Button
-						isLink
+						variant="link"
 						className="woocommerce-profile-wizard__footer-link"
 						onClick={ () => {
 							invalidateResolutionForStoreSelector(
@@ -448,7 +448,7 @@ export class StoreDetails extends Component {
 						) }
 					</Button>
 					<Button
-						isTertiary
+						variant="tertiary"
 						label={ skipSetupText }
 						onClick={ () =>
 							this.setState( { isSkipSetupPopoverVisible: true } )

--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -223,7 +223,7 @@ class Theme extends Component {
 				<CardFooter>
 					{ slug === activeTheme ? (
 						<Button
-							isPrimary
+							variant="primary"
 							onClick={ () => this.onChoose( theme, 'card' ) }
 							isBusy={ chosen === slug }
 							disabled={ chosen === slug }
@@ -235,7 +235,7 @@ class Theme extends Component {
 						</Button>
 					) : (
 						<Button
-							isSecondary
+							variant="secondary"
 							onClick={ () => this.onChoose( theme, 'card' ) }
 							isBusy={ chosen === slug }
 							disabled={ chosen === slug }
@@ -245,7 +245,7 @@ class Theme extends Component {
 					) }
 					{ demoUrl && (
 						<Button
-							isTertiary
+							variant="tertiary"
 							onClick={ () => this.openDemo( theme ) }
 						>
 							{ __( 'Live demo', 'woocommerce-admin' ) }
@@ -406,7 +406,7 @@ class Theme extends Component {
 				{ activeThemeSupportsWooCommerce && (
 					<p className="woocommerce-profile-wizard__themes-skip-this-step">
 						<Button
-							isLink
+							variant="link"
 							className="woocommerce-profile-wizard__skip"
 							onClick={ () => this.skipStep() }
 						>

--- a/client/profile-wizard/steps/theme/preview.js
+++ b/client/profile-wizard/steps/theme/preview.js
@@ -104,7 +104,7 @@ class ThemePreview extends Component {
 						} ) }
 					</div>
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ () => onChoose( slug, 'preview' ) }
 						isBusy={ isBusy }
 					>

--- a/client/profile-wizard/steps/usage-modal.js
+++ b/client/profile-wizard/steps/usage-modal.js
@@ -147,7 +147,7 @@ class UsageModal extends Component {
 					</div>
 					<div className="woocommerce-usage-modal__actions">
 						<Button
-							isSecondary
+							variant="secondary"
 							isBusy={ isBusy }
 							onClick={ () =>
 								this.updateTracking( { allowTracking: false } )
@@ -156,7 +156,7 @@ class UsageModal extends Component {
 							{ dismissActionText }
 						</Button>
 						<Button
-							isPrimary
+							variant="primary"
 							isBusy={ isBusy }
 							onClick={ () =>
 								this.updateTracking( { allowTracking: true } )

--- a/client/profile-wizard/unsaved-changes-modal.js
+++ b/client/profile-wizard/unsaved-changes-modal.js
@@ -27,7 +27,7 @@ const UnsavedChangesModal = ( { onClose, onSave } ) => {
 						<Button onClick={ () => onClose() }>
 							{ discardText }
 						</Button>
-						<Button isPrimary onClick={ onSave }>
+						<Button variant="primary" onClick={ onSave }>
 							{ saveText }
 						</Button>
 					</div>

--- a/client/shipping/shipping-recommendations.tsx
+++ b/client/shipping/shipping-recommendations.tsx
@@ -84,7 +84,7 @@ const ShippingRecommendationsList: React.FC = ( { children } ) => (
 				className="woocommerce-recommended-shipping-extensions__more_options_cta"
 				href="https://woocommerce.com/product-category/woocommerce-extensions/shipping-methods/?utm_source=shipping_recommendations"
 				target="_blank"
-				isTertiary
+				variant="tertiary"
 			>
 				{ __( 'See more options', 'woocommerce-admin' ) }
 				<VisuallyHidden>

--- a/client/shipping/woocommerce-services-item.tsx
+++ b/client/shipping/woocommerce-services-item.tsx
@@ -78,7 +78,7 @@ const WooCommerceServicesItem: React.FC< {
 			</div>
 			<div className="woocommerce-list__item-after">
 				<Button
-					isSecondary
+					variant="secondary"
 					onClick={ handleSetupClick }
 					isBusy={ pluginsBeingSetup.includes(
 						'woocommerce-services'

--- a/client/tasks/fills/Marketing/Plugin.tsx
+++ b/client/tasks/fills/Marketing/Plugin.tsx
@@ -73,7 +73,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 					<Button
 						disabled={ isDisabled }
 						isBusy={ isBusy }
-						isSecondary
+						variant="secondary"
 						href={ getAdminLink( manageUrl ) }
 						onClick={ () =>
 							recordEvent( 'marketing_manage', {
@@ -88,7 +88,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 					<Button
 						disabled={ isDisabled }
 						isBusy={ isBusy }
-						isSecondary
+						variant="secondary"
 						onClick={ () => installAndActivate( slug ) }
 					>
 						{ __( 'Activate', 'woocommmerce-admin' ) }
@@ -98,7 +98,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 					<Button
 						disabled={ isDisabled }
 						isBusy={ isBusy }
-						isSecondary
+						variant="secondary"
 						onClick={ () => installAndActivate( slug ) }
 					>
 						{ __( 'Get started', 'woocommmerce-admin' ) }

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
@@ -62,7 +62,7 @@ export const Action = ( {
 	const ManageButton = () => (
 		<Button
 			className={ classes }
-			isSecondary
+			variant="secondary"
 			role="button"
 			href={ manageUrl }
 			onClick={ () => recordEvent( 'tasklist_payment_manage', { id } ) }
@@ -74,8 +74,7 @@ export const Action = ( {
 	const SetupButton = () => (
 		<Button
 			className={ classes }
-			isPrimary={ isRecommended }
-			isSecondary={ ! isRecommended }
+			variant={ isRecommended ? 'primary' : 'secondary' }
 			isBusy={ isBusy }
 			disabled={ isBusy }
 			onClick={ () => handleClick() }
@@ -89,7 +88,7 @@ export const Action = ( {
 			return (
 				<Button
 					className={ classes }
-					isSecondary
+					variant="secondary"
 					onClick={ () => markConfigured( id ) }
 				>
 					{ __( 'Enable', 'woocommerce-admin' ) }
@@ -117,8 +116,7 @@ export const Action = ( {
 		return (
 			<Button
 				className={ classes }
-				isPrimary={ isRecommended }
-				isSecondary={ ! isRecommended }
+				variant={ isRecommended ? 'primary' : 'secondary' }
 				isBusy={ isBusy }
 				disabled={ isBusy }
 				onClick={ () => handleClick() }

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Configure.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Configure.js
@@ -125,7 +125,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 			<>
 				{ helpText }
 				<Button
-					isPrimary
+					variant="primary"
 					onClick={ () =>
 						recordEvent( 'tasklist_payment_connect_start', {
 							payment_method: id,
@@ -158,7 +158,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 					) }
 				</p>
 			) }
-			<Button isPrimary href={ settingsUrl }>
+			<Button variant="primary" href={ settingsUrl }>
 				{ __( 'Set up', 'woocommerce-admin' ) }
 			</Button>
 		</>

--- a/client/tasks/fills/PaymentGatewaySuggestions/plugins/Bacs.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/plugins/Bacs.js
@@ -153,7 +153,7 @@ const BacsPaymentGatewaySetup = () => {
 											/>
 										</div>
 										<Button
-											isPrimary
+											variant="primary"
 											isBusy={ isUpdating }
 											onClick={ handleSubmit }
 										>

--- a/client/tasks/fills/appearance.js
+++ b/client/tasks/fills/appearance.js
@@ -272,7 +272,7 @@ class Appearance extends Component {
 						<Button
 							onClick={ this.importProducts }
 							isBusy={ isPending }
-							isPrimary
+							variant="primary"
 						>
 							{ __( 'Import products', 'woocommerce-admin' ) }
 						</Button>
@@ -293,14 +293,14 @@ class Appearance extends Component {
 				content: (
 					<Fragment>
 						<Button
-							isPrimary
+							variant="primary"
 							isBusy={ isPending }
 							onClick={ this.createHomepage }
 						>
 							{ __( 'Create homepage', 'woocommerce-admin' ) }
 						</Button>
 						<Button
-							isTertiary
+							variant="tertiary"
 							onClick={ () => {
 								recordEvent(
 									'tasklist_appearance_create_homepage',
@@ -334,12 +334,12 @@ class Appearance extends Component {
 							disabled={ ! logo && ! isDirty }
 							onClick={ this.updateLogo }
 							isBusy={ isUpdatingLogo }
-							isPrimary
+							variant="primary"
 						>
 							{ __( 'Proceed', 'woocommerce-admin' ) }
 						</Button>
 						<Button
-							isTertiary
+							variant="tertiary"
 							onClick={ () => this.completeStep() }
 						>
 							{ __( 'Skip', 'woocommerce-admin' ) }
@@ -371,7 +371,7 @@ class Appearance extends Component {
 								this.setState( { storeNoticeText: value } )
 							}
 						/>
-						<Button onClick={ this.updateNotice } isPrimary>
+						<Button onClick={ this.updateNotice } variant="primary">
 							{ __( 'Complete task', 'woocommerce-admin' ) }
 						</Button>
 					</Fragment>

--- a/client/tasks/fills/products/product-template-modal.js
+++ b/client/tasks/fills/products/product-template-modal.js
@@ -184,7 +184,7 @@ export default function ProductTemplateModal( { onClose } ) {
 				</div>
 				<div className="woocommerce-product-template-modal__actions">
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ isRedirecting }
 						disabled={ ! selectedTemplate || isRedirecting }
 						onClick={ createTemplate }

--- a/client/tasks/fills/shipping/rates.js
+++ b/client/tasks/fills/shipping/rates.js
@@ -340,7 +340,7 @@ class ShippingRates extends Component {
 								) ) }
 							</div>
 
-							<Button isPrimary onClick={ handleSubmit }>
+							<Button variant="primary" onClick={ handleSubmit }>
 								{ buttonText ||
 									__( 'Update', 'woocommerce-admin' ) }
 							</Button>

--- a/client/tasks/fills/steps/location.js
+++ b/client/tasks/fills/steps/location.js
@@ -98,7 +98,7 @@ const StoreLocation = ( {
 						getInputProps={ getInputProps }
 						setValue={ setValue }
 					/>
-					<Button isPrimary onClick={ handleSubmit }>
+					<Button variant="primary" onClick={ handleSubmit }>
 						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
 				</Fragment>

--- a/client/tasks/fills/tax/components/partner-card.tsx
+++ b/client/tasks/fills/tax/components/partner-card.tsx
@@ -61,7 +61,7 @@ export const PartnerCard: React.FC< {
 					{ terms }
 				</div>
 				<Button
-					isSecondary
+					variant="secondary"
 					onClick={ onClick }
 					isBusy={ isBusy }
 					disabled={ isBusy }

--- a/client/tasks/fills/tax/components/partners.tsx
+++ b/client/tasks/fills/tax/components/partners.tsx
@@ -37,7 +37,7 @@ export const Partners: React.FC< TaxChildProps > = ( {
 				<ul className="woocommerce-tax-partners__other-actions">
 					<li>
 						<Button
-							isTertiary
+							variant="tertiary"
 							disabled={ isPending }
 							isBusy={ isPending }
 							onClick={ () => {
@@ -52,7 +52,7 @@ export const Partners: React.FC< TaxChildProps > = ( {
 					</li>
 					<li>
 						<Button
-							isTertiary
+							variant="tertiary"
 							disabled={ isPending }
 							isBusy={ isPending }
 							onClick={ () => {

--- a/client/tasks/fills/tax/manual-configuration/configure.tsx
+++ b/client/tasks/fills/tax/manual-configuration/configure.tsx
@@ -31,7 +31,7 @@ export const Configure: React.FC< TaxChildProps > = ( {
 	return (
 		<>
 			<Button
-				isPrimary
+				variant="primary"
 				disabled={ isPending }
 				isBusy={ isPending }
 				onClick={ () => {

--- a/client/tasks/fills/tax/woocommerce-tax/automated-taxes.tsx
+++ b/client/tasks/fills/tax/woocommerce-tax/automated-taxes.tsx
@@ -43,7 +43,7 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 				} ) }
 			</p>
 			<Button
-				isPrimary
+				variant="primary"
 				isBusy={ isPending }
 				onClick={ () => {
 					recordEvent( 'tasklist_tax_setup_automated_proceed', {
@@ -56,7 +56,7 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 			</Button>
 			<Button
 				disabled={ isPending }
-				isTertiary
+				variant="tertiary"
 				onClick={ () => {
 					recordEvent( 'tasklist_tax_setup_automated_proceed', {
 						setup_automatically: false,
@@ -66,7 +66,11 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 			>
 				{ __( "No thanks, I'll set up manually", 'woocommerce-admin' ) }
 			</Button>
-			<Button disabled={ isPending } isTertiary onClick={ onDisable }>
+			<Button
+				disabled={ isPending }
+				variant="tertiary"
+				onClick={ onDisable }
+			>
 				{ __( "I don't charge sales tax", 'woocommerce-admin' ) }
 			</Button>
 		</div>

--- a/client/two-column-tasks/completed.js
+++ b/client/two-column-tasks/completed.js
@@ -33,10 +33,10 @@ export const TaskListCompleted = ( { twoColumns, hideTasks, keepTasks } ) => {
 									'woocommerce-admin'
 								) }
 							</h2>
-							<Button isSecondary onClick={ keepTasks }>
+							<Button variant="secondary" onClick={ keepTasks }>
 								{ __( 'Keep list', 'woocommerce-admin' ) }
 							</Button>
-							<Button isPrimary onClick={ hideTasks }>
+							<Button variant="primary" onClick={ hideTasks }>
 								{ __( 'Hide this list', 'woocommerce-admin' ) }
 							</Button>
 						</div>

--- a/client/two-column-tasks/dismiss-modal.js
+++ b/client/two-column-tasks/dismiss-modal.js
@@ -39,7 +39,7 @@ const DismissModal = ( {
 								{ dismissActionText }
 							</Button>
 							<Button
-								isPrimary
+								variant="primary"
 								onClick={ () => {
 									hideTasks( 'remove_card' );
 									setShowDismissModal( false );

--- a/client/two-column-tasks/headers/appearance.js
+++ b/client/two-column-tasks/headers/appearance.js
@@ -23,8 +23,7 @@ const AppearanceHeader = ( { task, goToTask } ) => {
 					) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ task.isComplete

--- a/client/two-column-tasks/headers/marketing.js
+++ b/client/two-column-tasks/headers/marketing.js
@@ -23,8 +23,7 @@ const MarketingHeader = ( { task, goToTask } ) => {
 					) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ __( 'Add selling tools', 'woocommerce-admin' ) }

--- a/client/two-column-tasks/headers/payments.js
+++ b/client/two-column-tasks/headers/payments.js
@@ -23,8 +23,7 @@ const PaymentsHeader = ( { task, goToTask } ) => {
 					) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ __( 'Set up payments', 'woocommerce-admin' ) }

--- a/client/two-column-tasks/headers/products.js
+++ b/client/two-column-tasks/headers/products.js
@@ -22,8 +22,7 @@ const ProductsHeader = ( { task, goToTask } ) => {
 					) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ __( 'Add products', 'woocommerce-admin' ) }

--- a/client/two-column-tasks/headers/shipping.js
+++ b/client/two-column-tasks/headers/shipping.js
@@ -28,8 +28,7 @@ const ShippingHeader = ( { task, goToTask } ) => {
 					) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ __( 'Add shipping zones', 'woocommerce-admin' ) }

--- a/client/two-column-tasks/headers/tax.js
+++ b/client/two-column-tasks/headers/tax.js
@@ -20,8 +20,7 @@ const TaxHeader = ( { task, goToTask } ) => {
 				</h1>
 				<p>{ task.content }</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					onClick={ goToTask }
 				>
 					{ task.actionLabel }

--- a/client/two-column-tasks/headers/woocommerce-payments.js
+++ b/client/two-column-tasks/headers/woocommerce-payments.js
@@ -73,8 +73,7 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 					} ) }
 				</p>
 				<Button
-					isSecondary={ task.isComplete }
-					isPrimary={ ! task.isComplete }
+					variant={ task.isComplete ? 'primary' : 'secondary' }
 					isBusy={ isBusy }
 					disabled={ isBusy }
 					onClick={ onClick }

--- a/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -91,7 +91,7 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 			</div>
 			<div className="woocommerce-beta-features-tracking-modal__actions">
 				<Button
-					isPrimary
+					variant="primary"
 					onClick={ async () => {
 						if ( isChecked ) {
 							await setTracking( true );

--- a/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -38,7 +38,7 @@ export class NavigationOptOutContainer extends Component {
 
 				<div className="woocommerce-navigation-opt-out-modal__actions">
 					<Button
-						isDefault
+						variant="secondary"
 						onClick={ () =>
 							this.setState( { isModalOpen: false } )
 						}
@@ -47,7 +47,7 @@ export class NavigationOptOutContainer extends Component {
 					</Button>
 
 					<Button
-						isPrimary
+						variant="primary"
 						target="_blank"
 						href={ window.surveyData.url }
 						onClick={ () =>

--- a/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -186,7 +186,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 								<Button
 									className="button alignright"
 									onClick={ () => installPaymentGateway() }
-									isSecondary
+									variant="secondary"
 									isBusy={ installing }
 									aria-disabled={ installing }
 								>

--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -62,10 +62,16 @@ export class DismissModal extends Component {
 					) }
 				</p>
 				<div className="wc-admin-shipping-banner__dismiss-modal-actions">
-					<Button isSecondary onClick={ this.remindMeLaterClicked }>
+					<Button
+						variant="secondary"
+						onClick={ this.remindMeLaterClicked }
+					>
 						{ __( 'Remind me later', 'woocommerce-admin' ) }
 					</Button>
-					<Button isPrimary onClick={ this.closeForeverClicked }>
+					<Button
+						variant="primary"
+						onClick={ this.closeForeverClicked }
+					>
 						{ __( "I don't need this", 'woocommerce-admin' ) }
 					</Button>
 				</div>

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -441,7 +441,7 @@ export class ShippingBanner extends Component {
 					</div>
 					<Button
 						disabled={ isShippingLabelButtonBusy }
-						isPrimary
+						variant="primary"
 						isBusy={ isShippingLabelButtonBusy }
 						onClick={ this.createShippingLabelClicked }
 					>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Replace deprecated isPrimary, isSecondary, isTertiary, isLink Button props with variant. #8340
+
 # 9.0.0
 
 - Update line-height of SelectControl label to avoid truncated descenders in some typefaces and zoom levels. #8186

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -363,7 +363,7 @@ class AdvancedFilters extends Component {
 				<CardFooter align="center">
 					<div className="woocommerce-filters-advanced__controls">
 						{ updateDisabled && (
-							<Button isPrimary disabled>
+							<Button variant="primary" disabled>
 								{ __( 'Filter', 'woocommerce-admin' ) }
 							</Button>
 						) }

--- a/packages/components/src/compare-filter/button.js
+++ b/packages/components/src/compare-filter/button.js
@@ -32,7 +32,7 @@ const CompareButton = ( {
 				<Button
 					className="woocommerce-compare-button"
 					disabled={ true }
-					isSecondary
+					variant="secondary"
 				>
 					{ children }
 				</Button>
@@ -43,7 +43,7 @@ const CompareButton = ( {
 			className={ classnames( 'woocommerce-compare-button', className ) }
 			onClick={ onClick }
 			disabled={ disabled }
-			isSecondary
+			variant="secondary"
 		>
 			{ children }
 		</Button>

--- a/packages/components/src/compare-filter/index.js
+++ b/packages/components/src/compare-filter/index.js
@@ -125,7 +125,7 @@ export class CompareFilter extends Component {
 						{ labels.update }
 					</CompareButton>
 					{ selected.length > 0 && (
-						<Button isLink={ true } onClick={ this.clearQuery }>
+						<Button variant="link" onClick={ this.clearQuery }>
 							{ __( 'Clear all', 'woocommerce-admin' ) }
 						</Button>
 					) }

--- a/packages/components/src/date-range-filter-picker/content.js
+++ b/packages/components/src/date-range-filter-picker/content.js
@@ -143,7 +143,7 @@ class DatePickerContent extends Component {
 										{ selected.name === 'custom' && (
 											<Button
 												className="woocommerce-filters-date__button"
-												isSecondary
+												variant="secondary"
 												onClick={ resetCustomValues }
 												disabled={
 													! ( after || before )
@@ -162,7 +162,7 @@ class DatePickerContent extends Component {
 													selected.name,
 													onClose
 												) }
-												isPrimary
+												variant="primary"
 											>
 												{ __(
 													'Update',
@@ -172,7 +172,7 @@ class DatePickerContent extends Component {
 										) : (
 											<Button
 												className="woocommerce-filters-date__button"
-												isPrimary
+												variant="primary"
 												disabled
 											>
 												{ __(

--- a/packages/components/src/dynamic-form/dynamic-form.tsx
+++ b/packages/components/src/dynamic-form/dynamic-form.tsx
@@ -106,7 +106,7 @@ export const DynamicForm: React.FC< DynamicFormProps > = ( {
 						} ) }
 
 						<Button
-							isPrimary
+							variant="primary"
 							isBusy={ isBusy }
 							onClick={ () => {
 								handleSubmit();

--- a/packages/components/src/empty-content/index.js
+++ b/packages/components/src/empty-content/index.js
@@ -53,7 +53,7 @@ class EmptyContent extends Component {
 			return (
 				<Button
 					className="woocommerce-empty-content__action"
-					isPrimary={ isPrimary }
+					variant={ isPrimary ? 'primary' : 'secondary' }
 					onClick={ actionCallback }
 					href={ actionURL }
 				>
@@ -64,7 +64,7 @@ class EmptyContent extends Component {
 			return (
 				<Button
 					className="woocommerce-empty-content__action"
-					isPrimary={ isPrimary }
+					variant={ isPrimary ? 'primary' : 'secondary' }
 					href={ actionURL }
 				>
 					{ actionLabel }
@@ -74,7 +74,7 @@ class EmptyContent extends Component {
 			return (
 				<Button
 					className="woocommerce-empty-content__action"
-					isPrimary={ isPrimary }
+					variant={ isPrimary ? 'primary' : 'secondary' }
 					onClick={ actionCallback }
 				>
 					{ actionLabel }

--- a/packages/components/src/form/README.md
+++ b/packages/components/src/form/README.md
@@ -24,7 +24,7 @@ const initialValues = { firstName: '' };
 				{ ...getInputProps( 'firstName' ) }
 			/>
 			<Button
-				isPrimary
+				variant="primary"
 				onClick={ handleSubmit }
 				disabled={ Object.keys( errors ).length }
 			>

--- a/packages/components/src/form/stories/index.js
+++ b/packages/components/src/form/stories/index.js
@@ -70,7 +70,7 @@ export const Basic = () => (
 					{ ...getInputProps( 'radio' ) }
 				/>
 				<Button
-					isPrimary
+					variant="primary"
 					onClick={ handleSubmit }
 					disabled={ Object.keys( errors ).length }
 				>

--- a/packages/components/src/image-upload/index.js
+++ b/packages/components/src/image-upload/index.js
@@ -72,7 +72,7 @@ class ImageUpload extends Component {
 							<img src={ image.url } alt="" />
 						</div>
 						<Button
-							isSecondary
+							variant="secondary"
 							className="woocommerce-image-upload__remove-image"
 							onClick={ this.removeImage }
 						>
@@ -91,7 +91,7 @@ class ImageUpload extends Component {
 						<Button
 							className="woocommerce-image-upload__add-image"
 							onClick={ this.openModal }
-							isSecondary
+							variant="secondary"
 						>
 							<Icon icon={ upload } />
 							{ __( 'Add an image', 'woocommerce-admin' ) }

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -87,7 +87,7 @@ export class Plugins extends Component {
 			return (
 				<Fragment>
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ isRequesting }
 						onClick={ this.installAndActivate }
 					>
@@ -111,7 +111,7 @@ export class Plugins extends Component {
 			return (
 				<Fragment>
 					<Button
-						isPrimary
+						variant="primary"
 						isBusy={ isRequesting }
 						onClick={ this.skipInstaller }
 					>
@@ -125,16 +125,16 @@ export class Plugins extends Component {
 			<Fragment>
 				<Button
 					isBusy={ isRequesting }
-					isPrimary
+					variant="primary"
 					onClick={ this.installAndActivate }
 				>
 					{ __( 'Install & enable', 'woocommerce-admin' ) }
 				</Button>
-				<Button isTertiary onClick={ this.skipInstaller }>
+				<Button variant="tertiary" onClick={ this.skipInstaller }>
 					{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
 				</Button>
 				{ onAbort && (
-					<Button isTertiary onClick={ onAbort }>
+					<Button variant="tertiary" onClick={ onAbort }>
 						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
 					</Button>
 				) }

--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -200,7 +200,7 @@ export class SearchListControl extends Component {
 					<strong>{ messages.selected( selectedCount ) }</strong>
 					{ selectedCount > 0 ? (
 						<Button
-							isLink
+							variant="link"
 							isDestructive
 							onClick={ this.onClear }
 							aria-label={ messages.clear }

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -72,7 +72,7 @@ class Tags extends Component {
 				{ showClearButton && (
 					<Button
 						className="woocommerce-select-control__clear"
-						isLink
+						variant="link"
 						onClick={ this.removeAll }
 					>
 						<Icon

--- a/packages/customer-effort-score/CHANGELOG.md
+++ b/packages/customer-effort-score/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Replace deprecated isPrimary, isSecondary, isTertiary, isLink Button props with variant. #8340
+
 # 2.0.0
 
 - Update dependencies to support react 17 #8305

--- a/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -141,10 +141,10 @@ function CustomerFeedbackModal( {
 			) }
 
 			<div className="woocommerce-customer-effort-score__buttons">
-				<Button isTertiary onClick={ closeModal } name="cancel">
+				<Button variant="tertiary" onClick={ closeModal } name="cancel">
 					{ __( 'Cancel', 'woocommerce-admin' ) }
 				</Button>
-				<Button isPrimary onClick={ sendScore } name="send">
+				<Button variant="primary" onClick={ sendScore } name="send">
 					{ __( 'Send', 'woocommerce-admin' ) }
 				</Button>
 			</div>

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Replace deprecated isPrimary, isSecondary, isTertiary, isLink Button props with variant. #8340
+
 # 3.0.0
 
 ## Breaking changes

--- a/packages/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/experimental/src/experimental-list/task-item/index.tsx
@@ -202,7 +202,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 							{ ! completed && showActionButton && (
 								<Button
 									className="woocommerce-task-list__item-action"
-									isPrimary
+									variant="primary"
 									onClick={ (
 										event:
 											| React.MouseEvent

--- a/packages/experimental/src/inbox-note/action.tsx
+++ b/packages/experimental/src/inbox-note/action.tsx
@@ -53,7 +53,7 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 
 	return (
 		<Button
-			isLink={ true }
+			variant="link"
 			isBusy={ inAction }
 			disabled={ inAction }
 			href={ href }

--- a/packages/experimental/src/inbox-note/inbox-dismiss-confirmation-modal.tsx
+++ b/packages/experimental/src/inbox-note/inbox-dismiss-confirmation-modal.tsx
@@ -32,11 +32,11 @@ export const InboxDismissConfirmationModal: React.FC< ConfirmationModalProps > =
 					) }
 				</p>
 				<div className="woocommerce-inbox-dismiss-confirmation_buttons">
-					<Button isSecondary onClick={ () => onClose() }>
+					<Button variant="secondary" onClick={ () => onClose() }>
 						{ __( 'Cancel', 'woocommerce-admin' ) }
 					</Button>
 					<Button
-						isSecondary
+						variant="secondary"
 						isBusy={ inAction }
 						disabled={ inAction }
 						onClick={ () => {


### PR DESCRIPTION
Fixes #8313

This PR updates the deprecated isPrimary, isSecondary, isTertiary, isLink Button props.

> isPrimary, isSecondary, isTertiary and isLink props in Button have been deprecated. Use variant instead (https://github.com/WordPress/gutenberg/pull/31713).

Document Reference: https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/button#variant

### Screenshots

![Screen Shot 2022-02-22 at 14 57 27](https://user-images.githubusercontent.com/4344253/155079245-7478ce3c-c64d-454d-ba24-db9fcb336ad1.png)


primary, link

![Screen Shot 2022-02-22 at 14 40 39](https://user-images.githubusercontent.com/4344253/155078044-817aa8bb-3dc6-4396-b26e-06201bbfb85c.png)

primary, secondary, tertiary

### Detailed test instructions:

1. Checkout this branch
2. Go to the setup wizard
3. Oberse that the "Skip setup store details" button is shown as a link
2. Go to the Theme step
3. Observe that buttons are shown properly with the different variants

Review the other code changes