### PR TITLE
Implement MailChimp API request threshold for MailchimpScheduler

### DIFF
--- a/changelogs/fix-8322-mailchimp-too-many-request
+++ b/changelogs/fix-8322-mailchimp-too-many-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Implement MailChimp API request threshold for MailchimpScheduler. #8342

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -1015,7 +1015,7 @@ class Onboarding {
 	}
 
 	/**
-	 * Delete MailchimpScheduler::SUBSCRIBED_OPTION_NAME option if profile data is being updated with a new email.
+	 * Reset MailchimpScheduler if profile data is being updated with a new email.
 	 *
 	 * @param array $existing_data Existing option data.
 	 * @param array $updating_data Updating option data.
@@ -1026,7 +1026,7 @@ class Onboarding {
 			isset( $updating_data['store_email'] ) &&
 			$existing_data['store_email'] !== $updating_data['store_email']
 		) {
-			delete_option( MailchimpScheduler::SUBSCRIBED_OPTION_NAME );
+			MailchimpScheduler::reset();
 		}
 	}
 }

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -203,5 +203,6 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->server->dispatch( $request );
 
 		$this->assertFalse( get_option( MailchimpScheduler::SUBSCRIBED_OPTION_NAME, false ) );
+		$this->assertFalse( get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME, false ) );
 	}
 }

--- a/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
+++ b/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
@@ -99,7 +99,7 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 		// When.
 		update_option(
 			MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME,
-			MailchimpScheduler::MAX_ERROR_THRESHOLD,
+			MailchimpScheduler::MAX_ERROR_THRESHOLD
 		);
 
 		// Then.

--- a/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
+++ b/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
@@ -33,7 +33,7 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 								->setMethods( array( 'make_request' ) )
 								->getMock();
 
-		delete_option( MailchimpScheduler::SUBSCRIBED_OPTION_NAME );
+		MailchimpScheduler::reset();
 
 		parent::setUp();
 	}
@@ -83,10 +83,33 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 		$this->assertFalse( $this->instance->run() );
 	}
 
+
+	/**
+	 * When failed requests reaches the threshold.
+	 * Then it should abort.
+	 */
+	public function test_it_aborts_if_failed_requests_reaches_the_threshold() {
+		// Given.
+		$profile_data = array(
+			'is_agree_marketing' => true,
+			'store_email'        => 'test@test.com',
+		);
+		update_option( Onboarding::PROFILE_DATA_OPTION, $profile_data );
+
+		// When.
+		update_option(
+			MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME,
+			MailchimpScheduler::MAX_ERROR_THRESHOLD,
+		);
+
+		// Then.
+		$this->assertFalse( $this->instance->run() );
+	}
+
 	/**
 	 * Given is_agree_marketing and store_email values are set.
 	 * When the request to the API returns WP_Error.
-	 * Then it should log an error message.
+	 * Then it should log error message and error count.
 	 */
 	public function test_it_logs_error_when_wp_error_is_returned() {
 		// Given.
@@ -110,12 +133,15 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 		// Check for the missing 'body'.
 		$this->instance->method( 'make_request' )->willReturn( array() );
 		$this->instance->run();
+		$this->assertEquals( 1, get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME ) );
 	}
+
+
 
 	/**
 	 * Given is_agree_marketing and store_email values are set.
 	 * When the request to the API returns body without 'success'.
-	 * Then it should log an error message.
+	 * Then it should log error message and error count.
 	 */
 	public function test_it_logs_error_when_response_data_is_incorrect() {
 		// Given.
@@ -139,6 +165,7 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 						);
 
 		$this->instance->run();
+		$this->assertEquals( 1, get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME ) );
 	}
 
 	/**

--- a/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
+++ b/tests/schedulers/class-wc-tests-mailchimp-scheduler.php
@@ -129,11 +129,12 @@ class WC_Tests_Mailchimp_Scheduler extends WC_Unit_Test_Case {
 							->with( 'Error getting a response from Mailchimp API.', array( 'source' => MailchimpScheduler::LOGGER_CONTEXT ) );
 
 		$this->instance->run();
+		$this->assertEquals( 1, get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME ) );
 
 		// Check for the missing 'body'.
 		$this->instance->method( 'make_request' )->willReturn( array() );
 		$this->instance->run();
-		$this->assertEquals( 1, get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME ) );
+		$this->assertEquals( 2, get_option( MailchimpScheduler::SUBSCRIBED_ERROR_COUNT_OPTION_NAME ) );
 	}
 
 


### PR DESCRIPTION
Fixes #8322

This PR adds MailChimp API request threshold for MailchimpScheduler to stop requesting when failed requests reach the threshold.

### Detailed test instructions:

1. Start with a fresh install.
2. Start OBW.
3. Make sure to check to "Get tips, product updates, and inspiration straight to your mailbox".
3. Install and activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) plugin
4. Navigate to **Tools -> Cron Events**
5. Run `wc_admin_daily`
6. Navigate to WooCommerce -> Status -> Logs.
Select `mailchimp_scheduler-2022-MM-DD-:hash.log` file. MM-DD should be the current date.
You should see ERROR Incorrect response from Mailchimp API with: error message if you're not running local woocommerce.com.
7. Run `wc_admin_daily` three times
8. Confirm `mailchimp_scheduler-2022-MM-DD-:hash.log` should only contain three error logs
9. Check `woocommerce_onboarding_subscribed_to_mailchimp_error_count` option is `3` in the db option table.\
10. Go to OBW and use a new email
11. Repeat 4 ~ 6, you should see the new error logs