### PR TITLE
Update WooCommerce Payment note action callback logic

### DIFF
--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -309,6 +309,7 @@ class Note extends \WC_Data {
 		foreach ( $actions as $i => $action ) {
 			if ( $action->name === $action_name ) {
 				$matching_action =& $actions[ $i ];
+				break;
 			}
 		}
 		return $matching_action;

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -183,9 +183,9 @@ class WooCommercePayments {
 			return;
 		}
 
-		$note_id = array_pop($note_ids);
-		$note = Notes::get_note($note_id);
-		if (false === $note) {
+		$note_id = array_pop( $note_ids );
+		$note    = Notes::get_note( $note_id );
+		if ( false === $note ) {
 			return;
 		}
 		$action = $note->get_action( 'get-started' );

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -175,7 +175,19 @@ class WooCommercePayments {
 			return;
 		}
 
-		$note   = self::get_note();
+		$data_store = Notes::load_data_store();
+
+		// We already have this note? Then mark the note as actioned.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		$note_id = array_pop($note_ids);
+		$note = Notes::get_note($note_id);
+		if (false === $note) {
+			return;
+		}
 		$action = $note->get_action( 'get-started' );
 		if ( ! $action ||
 			( isset( $action->nonce_action ) &&


### PR DESCRIPTION
Follow up PR of some suggested changes.

No changelog necessary.

### Detailed test instructions:

- Have a store in America that is at-least 1 week old
- Run the daily cron job so the Note is present, and look for the `Try the new way to get paid` note
- Click the **Get started** button
- It should work like before and install and redirect to the WC Pay setup screen.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
