### PR TITLE
Redirect to the WC Pay onboarding when WC Pay is installed

### DIFF
--- a/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
@@ -50,7 +50,11 @@ export const Suggestion = ( { paymentGateway, onSetupCallback = null } ) => {
 	} = paymentGateway;
 
 	const { createNotice } = useDispatch( 'core/notices' );
-
+	// When the WC Pay is installed and onSetupCallback is null
+	// Overwrite onSetupCallback to redirect to the setup page
+	// when the user clicks on the "Finish setup" button.
+	// WC Pay doesn't need to be configured in WCA.
+	// It should be configured in its onboarding flow.
 	if ( installed && onSetupCallback === null ) {
 		onSetupCallback = () => {
 			connectWcpay( createNotice );

--- a/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
@@ -13,12 +13,14 @@ import {
 	WCPayCardBody,
 	SetupRequired,
 } from '@woocommerce/onboarding';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 
 import { Action } from '../Action';
+import { connectWcpay } from './utils';
 
 const TosPrompt = () =>
 	interpolateComponents( {
@@ -46,6 +48,14 @@ export const Suggestion = ( { paymentGateway, onSetupCallback = null } ) => {
 		enabled: isEnabled,
 		installed: isInstalled,
 	} = paymentGateway;
+
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	if ( installed && onSetupCallback === null ) {
+		onSetupCallback = () => {
+			connectWcpay( createNotice );
+		};
+	}
 
 	return (
 		<WCPayCard>


### PR DESCRIPTION
Fixes #8241 

This PR redirects customers to the WC Pay onboarding page without going through the standard payment task configuration step.


### Detailed test instructions:

1. Start with a fresh install.
2. Complete OBW without installing WC Pay from the `Business Details` step.
3. Navigate to `WooCommerce -> Home` and click `Set up payments` task.
4. You should see WooCommerce Payments instruction page.
5. Click `Get started` button.
6. Confirm it installs WooCommere Payments.
7. Do not click `Connect`. Navigate back to `WooCommerce -> Home` (do hard refresh)
8. You should see `Get paid with WooCommerce Payments` task.
9. Click `Set up additional payment providers` from the `Things to do next` list.
10. Click `Finish setup`
11. You should be redirected to the WC Pay onboarding page.

no changelog