### PR TITLE
Remove inbox_action_click event from onclick event

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -272,18 +272,6 @@ const InboxPanel = ( { showHeader = true } ) => {
 		}
 	};
 
-	const onNoteActionClick = ( note, action ) => {
-		triggerNoteAction( note.id, action.id );
-		const screen = getScreenName();
-		recordEvent( 'inbox_action_click', {
-			note_content: note.content,
-			note_name: note.name,
-			note_title: note.title,
-			note_type: note.type,
-			screen,
-		} );
-	};
-
 	if ( isError ) {
 		const title = __(
 			'There was an error getting your inbox. Please try again.',
@@ -332,7 +320,9 @@ const InboxPanel = ( { showHeader = true } ) => {
 							isBatchUpdating,
 							notes,
 							onDismiss,
-							onNoteActionClick,
+							onNoteActionClick: ( note, action ) => {
+								triggerNoteAction( note.id, action.id );
+							},
 							setShowDismissAllModal,
 							showHeader,
 						} ) }


### PR DESCRIPTION
Fixes #8374

This PR removes duplicated `inbox_action_click` action. The event is already being recorded from the backend.


### Detailed test instructions:

Follow test instructions from #8374, but make sure the event is fired only once.

no changelog 