### PR TITLE
Add missing dependency to onboarding package

### DIFF
--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Add missing dependency.
+
 # 3.0.0
 
 ## Breaking changes
@@ -9,14 +11,16 @@
 
 # 2.2.2
 
-- Retry fix for missing build-module folder
+-   Retry fix for missing build-module folder
 
 # 2.2.1
 
 -   Fix missing build-module folder
+
 # 2.2.0
 
 -   Update WCPayCard CSS to handle @wordpress/card updates. #7412
+
 # 2.1.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,12 +24,13 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@automattic/interpolate-components": "^1.2.0",
+		"@woocommerce/tracks": "file:../tracks",
 		"@wordpress/components": "19.4.0",
 		"@wordpress/element": "4.1.1",
 		"@wordpress/i18n": "^4.1.0",
 		"concurrently": "5.3.0",
-		"gridicons": "^3.3.1",
-		"@automattic/interpolate-components": "^1.2.0"
+		"gridicons": "^3.3.1"
 	},
 	"devDependencies": {
 		"@woocommerce/style-build": "file:../style-build"


### PR DESCRIPTION
Fixes #8351 

Adds missing dependency to the onboarding package.

No changelog necessary as it is within the individual package.