### PR TITLE
Remove unused data endpoints param

### DIFF
--- a/changelogs/fix-8373_dataendpoints_wc_v3_settings
+++ b/changelogs/fix-8373_dataendpoints_wc_v3_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Dev
+
+Remove unused pre loaded setting data displaying all the routes. #8379

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1020,7 +1020,7 @@ class Loader {
 			];
 		}
 
-		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array( '/wc/v3' ) );
+		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
 		if ( class_exists( 'Jetpack' ) ) {
 			$preload_data_endpoints['jetpackStatus'] = '/jetpack/v4/connection';
 		}


### PR DESCRIPTION
Partially addresses #8373 

Removes unused data endpoint used for the preload data in `wcSettings`. This will remove 182kB of data, and likely remove some delay on initial page load.

### Detailed test instructions:

- Search repo for any references of uses of `routes` from `wcSettings.dataEndpoints[0].routes` there shouldn't be any
- Do a quick smoke test of the app to make sure things still work as expected.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
