### PR TITLE
Query against the `user_id` column when provided with user ID.

### DIFF
--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -122,7 +122,7 @@ class Orders extends \WC_REST_Orders_Controller {
 	/**
 	 * Get customer data from customer_id.
 	 *
-	 * @param array $customer_id ID of customer.
+	 * @param array $customer_id User ID of customer.
 	 * @return array
 	 */
 	protected function get_customer_by_id( $customer_id ) {
@@ -133,7 +133,7 @@ class Orders extends \WC_REST_Orders_Controller {
 		$customer = $wpdb->get_row(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT * FROM {$customer_lookup_table} WHERE customer_id = ( %d )",
+				"SELECT * FROM {$customer_lookup_table} WHERE user_id = ( %d )",
 				$customer_id
 			),
 			ARRAY_A


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32217.

We seem to be conflating user ID (in the WordPress sense) with customer ID (the corresponding but separate ID used in the customer lookup table).

As a result, the orders widget (not sure if that is the right terminology) in **WooCommerce ▸ Home** is prone to listing the wrong customer names next to each order (except in those cases where the lookup table customer ID happens to be 1:1 with the actual WordPress user ID).

### Screenshots

Borrowing from the [original issue](woocommerce/woocommerce#32217):

![Where the problem can be seen (the orders list within the WooCommerce dashboard)](https://user-images.githubusercontent.com/4162931/143382089-7e48d231-9caf-4384-b2a6-652c65c68582.png)

### Detailed test instructions:

Generate a set of customers, products and orders. I recommend using WC Smooth Generator for this, but per the original report you can probably use a few different means to get the same result. Example of using WC Smooth Generator via the command line:

```sh
wp wc generate products 100 ;\
wp wc generate customers 100 ;\
wp wc generate orders 25
```

Now navigate to **WooCommerce ▸ Home** and expand the list of orders per the above screenshot. If you look at each listed order and compare it to the customer details found in the order editor for the same order, you will likely see the discrepancy.

With this branch, the problem should be solved.

### Final notes :bulb:

- I wanted to transfer the original issue to this repo ... but couldn't. Temporary glitch with GitHub perhaps.
- I hope this PR helps, but I was really just doing the minimum to illustrate a pos fix and show where I think the problem is ... please do feel free to take over and/or close and follow an alternative strategy if preferred 😄 

