### PR TITLE
Only run the version check for an admin request

### DIFF
--- a/src-internal/Admin/Install.php
+++ b/src-internal/Admin/Install.php
@@ -103,7 +103,9 @@ class Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
-		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
+		if ( ( is_admin() && ! wp_doing_ajax() ) || wp_doing_cron() ) {
+			add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
+		}
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 
 		// Add wc-admin report tables to list of WooCommerce tables.


### PR DESCRIPTION
Fixes #8381 

This PR adds the first change from #8257. As the other changes in #8257 need more testing (especially locking), I'm opening this PR to see if we can include it in the upcoming WC 6.3 release. The change in this PR is simple, easy to test, and relatively safe IMO.

Thanks to @WPprodigy for the original PR.

### Detailed test instructions:

1. Start with a fresh install.
2. Update `woocommerce_admin_version` from `wp_options` to a lower number.
3. Navigate to `/wp-admin` and login in.
4. Check `woocommerce_admin_version` back and confirm the value has been updated to the current version.
5. Open an incognito session and close all your admin sessions.
6. Update `woocommerce_admin_version` back to a lower number.
7. Navigate to `http://your-site` (not admin area).
8. Confirm `woocommerce_admin_version` value has not been updated.

no changelog